### PR TITLE
fix syntax of .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-src_paths = ["examples", "nautilus_trader", "scripts", "tests", "tools"]
+src_paths = examples,nautilus_trader,scripts,tests,tools
 combine_as_imports = true
 ensure_newline_before_comments = true
 force_grid_wrap = false
@@ -8,8 +8,8 @@ force_sort_within_sections = true
 include_trailing_comma = true
 lexicographical = true
 line_length = 88
-known_first_party = ["examples", "nautilus_trader", "tests"]
-known_third_party = []
+known_first_party = examples,nautilus_trader,tests
+known_third_party =
 multi_line_output = 3
-single_line_exclusions = ["typing"]
+single_line_exclusions = typing
 use_parentheses = true


### PR DESCRIPTION
@cjdsellers 

Stupid syntax error on my part. I wrote it in the syntax of `pyproject.toml`. Didn't realize that `.isort.cfg` has its own format.
Discovered when I was running `isort` directly. Not sure why it wasn't throwing errors during the pre-commit run.

As an aside, I've done some testing around on this and it seems to work fine for Cython.
Will definitely create a chunderous PR if you let it run across all files though.