### PR TITLE
Enhancements to strategy wire up and backtest execution

### DIFF
--- a/examples/strategies/ema_cross.py
+++ b/examples/strategies/ema_cross.py
@@ -15,9 +15,6 @@
 
 from datetime import timedelta
 
-from nautilus_trader.backtest.clock import TestClock
-from nautilus_trader.backtest.logging import TestLogger
-from nautilus_trader.backtest.uuid import TestUUIDFactory
 from nautilus_trader.indicators.atr import AverageTrueRange
 from nautilus_trader.indicators.average.ema import ExponentialMovingAverage
 from nautilus_trader.model.bar import Bar
@@ -63,12 +60,7 @@ class EMACross(TradingStrategy):
         :param sl_atr_multiple: The ATR multiple for stop-loss prices.
         :param extra_id_tag: An optional extra tag to append to order ids.
         """
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
+        super().__init__(order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
 
         # Custom strategy variables
         self.symbol = symbol
@@ -344,7 +336,6 @@ class EMACross(TradingStrategy):
 
         Cleanup any resources used by the strategy here.
         """
-        # Put custom code to be run on a strategy disposal here (or pass)
         self.unsubscribe_instrument(self.symbol)
         self.unsubscribe_bars(self.bar_type)
         self.unsubscribe_quote_ticks(self.symbol)

--- a/examples/strategies/ema_cross_filtered.py
+++ b/examples/strategies/ema_cross_filtered.py
@@ -18,9 +18,6 @@ from datetime import timedelta
 
 import pytz
 
-from nautilus_trader.backtest.clock import TestClock
-from nautilus_trader.backtest.logging import TestLogger
-from nautilus_trader.backtest.uuid import TestUUIDFactory
 from nautilus_trader.common.timer import TimeEvent
 from nautilus_trader.indicators.atr import AverageTrueRange
 from nautilus_trader.indicators.average.ema import ExponentialMovingAverage
@@ -77,12 +74,7 @@ class EMACrossFiltered(TradingStrategy):
         :param sl_atr_multiple: The ATR multiple for stop-loss prices.
         :param extra_id_tag: An optional extra tag to append to order ids.
         """
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
+        super().__init__(order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
 
         if news_currencies is None:
             news_currencies = []
@@ -270,7 +262,6 @@ class EMACrossFiltered(TradingStrategy):
         """
         Actions to be performed when the strategy is stopped.
         """
-        # Put custom code to be run on strategy stop here (or pass)
         pass
 
     def on_reset(self):
@@ -313,7 +304,6 @@ class EMACrossFiltered(TradingStrategy):
 
         Cleanup any resources used by the strategy here.
         """
-        # Put custom code to be run on a strategy disposal here (or pass)
         self.unsubscribe_instrument(self.symbol)
         self.unsubscribe_bars(self.bar_type)
         self.unsubscribe_quote_ticks(self.symbol)

--- a/nautilus_trader/__init__.py
+++ b/nautilus_trader/__init__.py
@@ -24,8 +24,8 @@ __author__ = "Nautech Systems"
 
 # Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = 1
-_MINOR_VERSION = 53
-_PATCH_VERSION = 1
+_MINOR_VERSION = 54
+_PATCH_VERSION = 0
 _PRE_RELEASE = ''
 
 __version__ = '.'.join([

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -64,4 +64,3 @@ cdef class BacktestEngine:
     cdef void _backtest_memory(self) except *
     cdef void _backtest_header(self, datetime run_started, datetime start, datetime stop) except *
     cdef void _backtest_footer(self, datetime run_started, datetime run_finished, datetime start, datetime stop) except *
-    cdef void _change_clocks_and_loggers(self, list strategies) except *

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -184,7 +184,6 @@ cdef class BacktestEngine:
             uuid_factory=self.uuid_factory,
             logger=self.test_logger)
 
-        self._change_clocks_and_loggers(strategies)
         self.test_clock.set_time(self.clock.time_now())  # For logging consistency
 
         self.iteration = 0
@@ -264,7 +263,6 @@ cdef class BacktestEngine:
         # Setup new strategies
         if strategies is not None:
             self.trader.initialize_strategies(strategies)
-            self._change_clocks_and_loggers(strategies)
 
         # Run the backtest
         self.log.info(f"Running backtest...")
@@ -435,11 +433,3 @@ cdef class BacktestEngine:
 
         for statistic in self.analyzer.get_performance_stats_formatted(self.exec_engine.account.currency):
             self.log.info(statistic)
-
-    cdef void _change_clocks_and_loggers(self, list strategies) except *:
-        # Replace the clocks and loggers for every strategy in the given list
-        for strategy in strategies:
-            # Separate test clocks to iterate independently
-            strategy.change_clock(TestClock(initial_time=self.test_clock.time_now()))
-            # Replace the strategies logger with the engines test logger
-            strategy.change_logger(self.test_logger)

--- a/nautilus_trader/backtest/execution.pxd
+++ b/nautilus_trader/backtest/execution.pxd
@@ -94,6 +94,7 @@ cdef class BacktestExecClient(ExecutionClient):
     cdef bint _is_marginal_buy_limit_fill(self, Price order_price, QuoteTick current_market)
     cdef bint _is_marginal_sell_stop_fill(self, Price order_price, QuoteTick current_market)
     cdef bint _is_marginal_sell_limit_fill(self, Price order_price, QuoteTick current_market)
+    cdef void _submit_order(self, Order order) except *
     cdef void _accept_order(self, Order order) except *
     cdef void _reject_order(self, Order order, str reason) except *
     cdef void _cancel_reject_order(self, OrderId order_id, str response, str reason) except *

--- a/nautilus_trader/common/data.pyx
+++ b/nautilus_trader/common/data.pyx
@@ -186,7 +186,7 @@ cdef class DataClient:
 
         strategy.register_data_client(self)
 
-        self._log.debug(f"Registered {strategy}.")
+        self._log.info(f"Registered {strategy}.")
 
 
 # -- HANDLER METHODS ----------------------------------------------------------------------------- #

--- a/nautilus_trader/common/execution.pyx
+++ b/nautilus_trader/common/execution.pyx
@@ -1038,9 +1038,8 @@ cdef class ExecutionEngine:
         Condition.not_none(strategy, "strategy")
         Condition.not_in(strategy.id, self._registered_strategies, "strategy.id", "registered_strategies")
 
-        self._registered_strategies[strategy.id] = strategy
-        strategy.register_trader(self.trader_id)
         strategy.register_execution_engine(self)
+        self._registered_strategies[strategy.id] = strategy
         self._log.info(f"Registered strategy {strategy}.")
 
     cpdef void deregister_strategy(self, TradingStrategy strategy) except *:

--- a/nautilus_trader/common/factories.pxd
+++ b/nautilus_trader/common/factories.pxd
@@ -28,7 +28,6 @@ from nautilus_trader.model.order cimport BracketOrder
 from nautilus_trader.model.order cimport MarketOrder
 from nautilus_trader.model.order cimport LimitOrder
 from nautilus_trader.model.order cimport StopOrder
-from nautilus_trader.model.order cimport StopLimitOrder
 
 
 cdef class OrderFactory:
@@ -57,15 +56,6 @@ cdef class OrderFactory:
         datetime expire_time=*)
 
     cpdef StopOrder stop(
-        self,
-        Symbol symbol,
-        OrderSide order_side,
-        Quantity quantity,
-        Price price,
-        TimeInForce time_in_force=*,
-        datetime expire_time=*)
-
-    cpdef StopLimitOrder stop_limit(
         self,
         Symbol symbol,
         OrderSide order_side,

--- a/nautilus_trader/common/factories.pyx
+++ b/nautilus_trader/common/factories.pyx
@@ -177,40 +177,6 @@ cdef class OrderFactory:
             init_id=self._uuid_factory.generate(),
             timestamp=self._clock.time_now())
 
-    cpdef StopLimitOrder stop_limit(
-            self,
-            Symbol symbol,
-            OrderSide order_side,
-            Quantity quantity,
-            Price price,
-            TimeInForce time_in_force=TimeInForce.DAY,
-            datetime expire_time=None):
-        """
-        Return a stop-limit order.
-        Note: If the time in force is GTD then a valid expire time must be given.
-
-        :param symbol: The orders symbol.
-        :param order_side: The orders side.
-        :param quantity: The orders quantity (> 0).
-        :param price: The orders price.
-        :param time_in_force: The orders time in force (default=DAY).
-        :param expire_time: The optional order expire time (for GTD orders).
-        :raises ValueError: If quantity is not positive (> 0).
-        :raises ValueError: If time_in_force is GTD and the expire_time is None.
-        :return Order.
-        """
-        return StopLimitOrder(
-            self._id_generator.generate(),
-            symbol,
-            order_side,
-            quantity,
-            price=price,
-            time_in_force=time_in_force,
-            expire_time=expire_time,
-            init_id=self._uuid_factory.generate(),
-            timestamp=self._clock.time_now())
-
-
     cpdef BracketOrder bracket(
             self,
             Order entry_order,

--- a/nautilus_trader/live/execution_engine.pyx
+++ b/nautilus_trader/live/execution_engine.pyx
@@ -43,7 +43,6 @@ from nautilus_trader.model.identifiers cimport TraderId
 from nautilus_trader.model.order cimport LimitOrder
 from nautilus_trader.model.order cimport MarketOrder
 from nautilus_trader.model.order cimport Order
-from nautilus_trader.model.order cimport StopLimitOrder
 from nautilus_trader.model.order cimport StopOrder
 from nautilus_trader.model.position cimport Position
 from nautilus_trader.serialization.base cimport CommandSerializer
@@ -459,8 +458,6 @@ cdef class RedisExecutionDatabase(ExecutionDatabase):
             order = LimitOrder.create(event=initial)
         elif initial.order_type == OrderType.STOP:
             order = StopOrder.create(event=initial)
-        elif initial.order_type == OrderType.STOP_LIMIT:
-            order = StopLimitOrder.create(event=initial)
         else:
             raise RuntimeError("Invalid order type")
 

--- a/nautilus_trader/live/node.pyx
+++ b/nautilus_trader/live/node.pyx
@@ -249,10 +249,6 @@ cdef class TradingNode:
             uuid_factory=self._uuid_factory,
             logger=self._logger)
 
-        for strategy in self.trader.strategies:
-            if not isinstance(strategy.clock, LiveClock):
-                strategy.change_clock(LiveClock())
-
         Condition.equal(self.trader_id, self.trader.id, "trader_id", "trader.id")
 
         self._check_residuals_delay = 2.0  # Hard coded delay to await system spool up (refactor)

--- a/nautilus_trader/model/c_enums/order_type.pxd
+++ b/nautilus_trader/model/c_enums/order_type.pxd
@@ -19,7 +19,6 @@ cpdef enum OrderType:
     MARKET = 1,
     LIMIT = 2,
     STOP = 3,
-    STOP_LIMIT = 4,
 
 
 cdef inline str order_type_to_string(int value):
@@ -29,8 +28,6 @@ cdef inline str order_type_to_string(int value):
         return 'LIMIT'
     elif value == 3:
         return 'STOP'
-    elif value == 4:
-        return 'STOP_LIMIT'
     else:
         return 'UNDEFINED'
 
@@ -42,7 +39,5 @@ cdef inline OrderType order_type_from_string(str value):
         return OrderType.LIMIT
     elif value == 'STOP':
         return OrderType.STOP
-    elif value == 'STOP_LIMIT':
-        return OrderType.STOP_LIMIT
     else:
         return OrderType.UNDEFINED

--- a/nautilus_trader/model/order.pxd
+++ b/nautilus_trader/model/order.pxd
@@ -110,11 +110,6 @@ cdef class StopOrder(PassiveOrder):
     cdef StopOrder create(OrderInitialized event)
 
 
-cdef class StopLimitOrder(PassiveOrder):
-    @staticmethod
-    cdef StopLimitOrder create(OrderInitialized event)
-
-
 cdef class LimitOrder(PassiveOrder):
     @staticmethod
     cdef LimitOrder create(OrderInitialized event)

--- a/nautilus_trader/serialization/serializers.pyx
+++ b/nautilus_trader/serialization/serializers.pyx
@@ -72,7 +72,6 @@ from nautilus_trader.model.order cimport LimitOrder
 from nautilus_trader.model.order cimport MarketOrder
 from nautilus_trader.model.order cimport Order
 from nautilus_trader.model.order cimport PassiveOrder
-from nautilus_trader.model.order cimport StopLimitOrder
 from nautilus_trader.model.order cimport StopOrder
 from nautilus_trader.network.identifiers cimport ClientId
 from nautilus_trader.network.identifiers cimport ServerId
@@ -257,18 +256,6 @@ cdef class MsgPackOrderSerializer(OrderSerializer):
 
         if order_type == OrderType.STOP:
             return StopOrder(
-                order_id=order_id,
-                symbol=symbol,
-                order_side=order_side,
-                quantity=quantity,
-                price=convert_string_to_price(unpacked[PRICE].decode(UTF8)),
-                time_in_force=time_in_force,
-                expire_time=convert_string_to_datetime(unpacked[EXPIRE_TIME].decode(UTF8)),
-                init_id=init_id,
-                timestamp=timestamp)
-
-        if order_type == OrderType.STOP_LIMIT:
-            return StopLimitOrder(
                 order_id=order_id,
                 symbol=symbol,
                 order_side=order_side,

--- a/nautilus_trader/trading/strategy.pxd
+++ b/nautilus_trader/trading/strategy.pxd
@@ -59,14 +59,15 @@ cdef class TradingStrategy:
     cdef readonly TraderId trader_id
 
     cdef readonly bint flatten_on_stop
-    cdef readonly bint flatten_on_sl_reject
+    cdef readonly bint flatten_on_reject
     cdef readonly bint cancel_all_orders_on_stop
     cdef readonly bint reraise_exceptions
 
     cdef readonly OrderFactory order_factory
     cdef readonly PositionIdGenerator position_id_generator
-    cdef dict _stop_loss_orders
-    cdef dict _take_profit_orders
+    cdef set _flattening_ids
+    cdef set _stop_loss_ids
+    cdef set _take_profit_ids
 
     cdef list _indicators
     cdef dict _indicator_updaters
@@ -94,7 +95,7 @@ cdef class TradingStrategy:
     cpdef void on_dispose(self) except *
 
 # -- REGISTRATION METHODS -------------------------------------------------------------------------#
-    cpdef void register_trader(self, TraderId trader_id) except *
+    cpdef void register_trader(self, TraderId trader_id, Clock clock, UUIDFactory uuid_factory, Logger logger) except *
     cpdef void register_data_client(self, DataClient client) except *
     cpdef void register_execution_engine(self, ExecutionEngine engine) except *
     cpdef void register_indicator(self, data_source, Indicator indicator, update_method=*) except *
@@ -160,8 +161,8 @@ cdef class TradingStrategy:
     cpdef Order order(self, OrderId order_id)
     cpdef dict orders(self)
     cpdef dict orders_working(self)
-    cpdef dict orders_stop_loss(self)
-    cpdef dict orders_take_profit(self)
+    cpdef set stop_loss_ids(self)
+    cpdef set take_profit_ids(self)
     cpdef dict orders_completed(self)
     cpdef Position position(self, PositionId position_id)
     cpdef Position position_for_order(self, OrderId order_id)
@@ -201,9 +202,4 @@ cdef class TradingStrategy:
     cpdef void flatten_position(self, PositionId position_id) except *
     cpdef void flatten_all_positions(self) except *
 
-    cdef void _flatten_on_sl_reject(self, OrderRejected event) except *
-
-# -- BACKTEST METHODS -----------------------------------------------------------------------------#
-    cpdef void change_clock(self, Clock clock) except *
-    cpdef void change_uuid_factory(self, UUIDFactory uuid_factory) except *
-    cpdef void change_logger(self, Logger logger) except *
+    cdef void _flatten_on_reject(self, OrderRejected event) except *

--- a/nautilus_trader/trading/trader.pxd
+++ b/nautilus_trader/trading/trader.pxd
@@ -41,6 +41,7 @@ cdef class Trader:
     cdef readonly Portfolio portfolio
     cdef readonly PerformanceAnalyzer analyzer
     cdef readonly list strategies
+    cdef readonly set strategy_ids
 
     cpdef void initialize_strategies(self, list strategies) except *
     cpdef void start(self) except *

--- a/tests/integration_tests/test_live_execution.py
+++ b/tests/integration_tests/test_live_execution.py
@@ -19,6 +19,7 @@ import redis
 
 from nautilus_trader.backtest.clock import TestClock
 from nautilus_trader.backtest.logging import TestLogger
+from nautilus_trader.backtest.uuid import TestUUIDFactory
 from nautilus_trader.common.account import Account
 from nautilus_trader.live.execution_engine import RedisExecutionDatabase
 from nautilus_trader.model.enums import OrderSide
@@ -46,14 +47,17 @@ class RedisExecutionDatabaseTests(unittest.TestCase):
     def setUp(self):
         # Fixture Setup
         clock = TestClock()
+        uuid_factory = TestUUIDFactory()
         logger = TestLogger(clock)
 
         self.trader_id = TraderId("TESTER", "000")
 
         self.strategy = EmptyStrategy(order_id_tag="001")
-        self.strategy.register_trader(TraderId("TESTER", "000"))
-        self.strategy.change_clock(clock)
-        self.strategy.change_logger(logger)
+        self.strategy.register_trader(
+            TraderId("TESTER", "000"),
+            clock,
+            uuid_factory,
+            logger)
 
         self.database = RedisExecutionDatabase(
             trader_id=self.trader_id,

--- a/tests/test_kit/strategies.py
+++ b/tests/test_kit/strategies.py
@@ -15,9 +15,6 @@
 
 from datetime import timedelta
 
-from nautilus_trader.backtest.clock import TestClock
-from nautilus_trader.backtest.logging import TestLogger
-from nautilus_trader.backtest.uuid import TestUUIDFactory
 from nautilus_trader.core.types import Label
 from nautilus_trader.indicators.atr import AverageTrueRange
 from nautilus_trader.indicators.average.ema import ExponentialMovingAverage
@@ -70,12 +67,7 @@ class EmptyStrategy(TradingStrategy):
 
         :param order_id_tag: The order_id tag for the strategy (should be unique at trader level).
         """
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag=order_id_tag)
+        super().__init__(order_id_tag=order_id_tag)
 
 
 class TickTock(TradingStrategy):
@@ -85,12 +77,7 @@ class TickTock(TradingStrategy):
 
     def __init__(self, instrument, bar_type):
         """Initialize a new instance of the TickTock class."""
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag="000")
+        super().__init__(order_id_tag="000")
 
         self.instrument = instrument
         self.bar_type = bar_type
@@ -136,12 +123,7 @@ class TestStrategy1(TradingStrategy):
 
     def __init__(self, bar_type, id_tag_strategy="001"):
         """Initialize a new instance of the TestStrategy1 class."""
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag=id_tag_strategy)
+        super().__init__(order_id_tag=id_tag_strategy)
 
         self.object_storer = ObjectStorer()
         self.bar_type = bar_type
@@ -236,12 +218,7 @@ class EMACross(TradingStrategy):
         :param sl_atr_multiple: The ATR multiple for stop-loss prices.
         :param extra_id_tag: An optional extra tag to append to order ids.
         """
-        clock = TestClock()
-        super().__init__(
-            clock=clock,
-            uuid_factory=TestUUIDFactory(),
-            logger=TestLogger(clock),
-            order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
+        super().__init__(order_id_tag=symbol.code.replace('/', '') + extra_id_tag)
 
         # Custom strategy variables
         self.symbol = symbol
@@ -517,7 +494,6 @@ class EMACross(TradingStrategy):
 
         Cleanup any resources used by the strategy here.
         """
-        # Put custom code to be run on a strategy disposal here (or pass)
         self.unsubscribe_instrument(self.symbol)
         self.unsubscribe_bars(self.bar_type)
         self.unsubscribe_quote_ticks(self.symbol)

--- a/tests/unit_tests/backtest/test_backtest_execution.py
+++ b/tests/unit_tests/backtest/test_backtest_execution.py
@@ -76,14 +76,14 @@ class BacktestExecClientTests(unittest.TestCase):
 
         self.analyzer = PerformanceAnalyzer()
 
-        trader_id = TraderId("TESTER", "000")
+        self.trader_id = TraderId("TESTER", "000")
         account_id = TestStubs.account_id()
 
         self.exec_db = InMemoryExecutionDatabase(
-            trader_id=trader_id,
+            trader_id=self.trader_id,
             logger=self.logger)
         self.exec_engine = ExecutionEngine(
-            trader_id=trader_id,
+            trader_id=self.trader_id,
             account_id=account_id,
             database=self.exec_db,
             portfolio=self.portfolio,
@@ -104,6 +104,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_can_account_collateral_inquiry(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.exec_engine.register_strategy(strategy)
 
         # Act
@@ -115,6 +120,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_can_submit_market_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -136,6 +146,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_can_submit_limit_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -158,6 +173,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_can_submit_bracket_market_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -177,13 +197,18 @@ class BacktestExecClientTests(unittest.TestCase):
         strategy.submit_bracket_order(bracket_order, strategy.position_id_generator.generate())
 
         # Assert
-        self.assertEqual(7, strategy.object_storer.count)
-        self.assertTrue(isinstance(strategy.object_storer.get_store()[3], OrderFilled))
+        self.assertEqual(8, strategy.object_storer.count)
+        self.assertTrue(isinstance(strategy.object_storer.get_store()[4], OrderFilled))
         self.assertEqual(Price(80.000, 3), bracket_order.stop_loss.price)
 
     def test_can_submit_bracket_stop_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -205,12 +230,18 @@ class BacktestExecClientTests(unittest.TestCase):
         strategy.submit_bracket_order(bracket_order, strategy.position_id_generator.generate())
 
         # Assert
-        self.assertEqual(4, strategy.object_storer.count)
-        self.assertTrue(isinstance(strategy.object_storer.get_store()[3], OrderWorking))
+        self.assertEqual(6, strategy.object_storer.count)
+        print(strategy.object_storer.get_store())
+        self.assertTrue(isinstance(strategy.object_storer.get_store()[5], OrderWorking))
 
     def test_can_modify_stop_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -235,6 +266,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_can_modify_bracket_order_working_stop_loss(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -257,8 +293,8 @@ class BacktestExecClientTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(Price(85.100, 3), strategy.order(bracket_order.stop_loss.id).price)
-        self.assertEqual(8, strategy.object_storer.count)
-        self.assertTrue(isinstance(strategy.object_storer.get_store()[7], OrderModified))
+        self.assertEqual(9, strategy.object_storer.count)
+        self.assertTrue(isinstance(strategy.object_storer.get_store()[8], OrderModified))
 
     # TODO: Fix failing test - market not updating inside BacktestExecution Client
     # def test_submit_market_order_with_slippage_fill_model_slips_order(self):
@@ -302,6 +338,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_submit_order_with_no_market_rejects_order(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()
@@ -322,6 +363,11 @@ class BacktestExecClientTests(unittest.TestCase):
     def test_submit_order_with_invalid_price_gets_rejected(self):
         # Arrange
         strategy = TestStrategy1(bar_type=TestStubs.bartype_usdjpy_1min_bid())
+        strategy.register_trader(
+            self.trader_id,
+            self.clock,
+            self.uuid_factory,
+            self.logger)
         self.data_client.register_strategy(strategy)
         self.exec_engine.register_strategy(strategy)
         strategy.start()

--- a/tests/unit_tests/common/test_common_execution.py
+++ b/tests/unit_tests/common/test_common_execution.py
@@ -58,14 +58,12 @@ class InMemoryExecutionDatabaseTests(unittest.TestCase):
         self.trader_id = TraderId("TESTER", "000")
         self.account_id = TestStubs.account_id()
 
-        self.strategy = TradingStrategy(
+        self.strategy = TradingStrategy(order_id_tag="001")
+        self.strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=clock,
             uuid_factory=TestUUIDFactory(),
-            logger=logger,
-            order_id_tag="001")
-        self.strategy.register_trader(TraderId("TESTER", "000"))
-        self.strategy.change_clock(clock)
-        self.strategy.change_logger(logger)
+            logger=logger)
 
         self.database = InMemoryExecutionDatabase(trader_id=self.trader_id, logger=logger)
 
@@ -505,11 +503,12 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_register_strategy(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         # Act
         self.exec_engine.register_strategy(strategy)
@@ -519,11 +518,12 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_deregister_strategy(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)
 
@@ -535,11 +535,12 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_is_flat_when_strategy_registered_returns_true(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         # Act
         self.exec_engine.register_strategy(strategy)
@@ -555,11 +556,12 @@ class ExecutionEngineTests(unittest.TestCase):
         self.assertTrue(self.exec_engine.is_flat())
 
     def test_can_reset_execution_engine(self):
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)  # Also registers with portfolio
 
@@ -571,14 +573,14 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_submit_order(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)
-        strategy.change_clock(self.clock)
 
         position_id = strategy.position_id_generator.generate()
         order = strategy.order_factory.market(
@@ -605,14 +607,14 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_handle_order_fill_event(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)
-        strategy.change_clock(self.clock)
 
         position_id = strategy.position_id_generator.generate()
         order = strategy.order_factory.market(
@@ -632,6 +634,7 @@ class ExecutionEngineTests(unittest.TestCase):
         self.exec_engine.execute_command(submit_order)
 
         # Act
+        self.exec_engine.handle_event(TestStubs.event_order_submitted(order))
         self.exec_engine.handle_event(TestStubs.event_order_accepted(order))
         self.exec_engine.handle_event(TestStubs.event_order_filled(order))
 
@@ -655,14 +658,14 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_add_to_existing_position_on_order_fill(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)
-        strategy.change_clock(self.clock)
 
         position_id = strategy.position_id_generator.generate()
         order1 = strategy.order_factory.market(
@@ -721,14 +724,14 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_can_close_position_on_order_fill(self):
         # Arrange
-        strategy = TradingStrategy(
+        strategy = TradingStrategy(order_id_tag="001")
+        strategy.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy)
-        strategy.change_clock(self.clock)
 
         position_id = strategy.position_id_generator.generate()
 
@@ -794,17 +797,19 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_multiple_strategy_positions_opened(self):
         # Arrange
-        strategy1 = TradingStrategy(
+        strategy1 = TradingStrategy(order_id_tag="001")
+        strategy1.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
-        strategy2 = TradingStrategy(
+        strategy2 = TradingStrategy(order_id_tag="002")
+        strategy2.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="002")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy1)
         self.exec_engine.register_strategy(strategy2)
@@ -886,17 +891,19 @@ class ExecutionEngineTests(unittest.TestCase):
 
     def test_multiple_strategy_positions_one_active_one_closed(self):
         # Arrange
-        strategy1 = TradingStrategy(
+        strategy1 = TradingStrategy(order_id_tag="001")
+        strategy1.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="001")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
-        strategy2 = TradingStrategy(
+        strategy2 = TradingStrategy(order_id_tag="002")
+        strategy2.register_trader(
+            TraderId("TESTER", "000"),
             clock=self.clock,
-            uuid_factory=self.uuid_factory,
-            logger=self.logger,
-            order_id_tag="002")
+            uuid_factory=TestUUIDFactory(),
+            logger=self.logger)
 
         self.exec_engine.register_strategy(strategy1)
         self.exec_engine.register_strategy(strategy2)

--- a/tests/unit_tests/live/test_live_execution.py
+++ b/tests/unit_tests/live/test_live_execution.py
@@ -135,8 +135,11 @@ class LiveExecutionTests(unittest.TestCase):
 
         self.bar_type = TestStubs.bartype_audusd_1min_bid()
         self.strategy = TestStrategy1(self.bar_type, id_tag_strategy="001")
-        self.strategy.register_trader(TraderId("TESTER", "000"))
-        self.strategy.change_logger(logger)
+        self.strategy.register_trader(
+            TraderId("TESTER", "000"),
+            clock,
+            uuid_factory,
+            logger)
         self.exec_engine.register_strategy(self.strategy)
 
     def tearDown(self):

--- a/tests/unit_tests/model/test_model_order.py
+++ b/tests/unit_tests/model/test_model_order.py
@@ -254,20 +254,6 @@ class OrderTests(unittest.TestCase):
         self.assertEqual(TimeInForce.DAY, order.time_in_force)
         self.assertFalse(order.is_completed())
 
-    def test_can_initialize_stop_limit_order(self):
-        # Arrange
-        # Act
-        order = self.order_factory.stop_limit(
-            AUDUSD_FXCM,
-            OrderSide.BUY,
-            Quantity(100000),
-            Price(1.00000, 5))
-
-        # Assert
-        self.assertEqual(OrderType.STOP_LIMIT, order.type)
-        self.assertEqual(OrderState.INITIALIZED, order.state())
-        self.assertFalse(order.is_completed())
-
     def test_can_initialize_bracket_order_market_with_no_take_profit(self):
         # Arrange
         entry_order = self.order_factory.market(

--- a/tests/unit_tests/serialization/test_serialization_serializers.py
+++ b/tests/unit_tests/serialization/test_serialization_serializers.py
@@ -66,7 +66,6 @@ from nautilus_trader.model.instrument import Instrument
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.model.order import LimitOrder
-from nautilus_trader.model.order import StopLimitOrder
 from nautilus_trader.model.order import StopOrder
 from nautilus_trader.network.identifiers import ClientId
 from nautilus_trader.network.identifiers import ServerId
@@ -201,28 +200,6 @@ class MsgPackOrderSerializerTests(unittest.TestCase):
             price=Price(1.00000, 5),
             time_in_force=TimeInForce.GTD,
             expire_time=UNIX_EPOCH,
-            init_id=uuid4(),
-            timestamp=UNIX_EPOCH)
-
-        # Act
-        serialized = self.serializer.serialize(order)
-        deserialized = self.serializer.deserialize(serialized)
-
-        # Assert
-        self.assertEqual(order, deserialized)
-        print(b64encode(serialized))
-        print(order)
-
-    def test_can_serialize_and_deserialize_stop_limit_orders(self):
-        # Arrange
-        order = StopLimitOrder(
-            OrderId("O-123456"),
-            AUDUSD_FXCM,
-            OrderSide.BUY,
-            Quantity(100000),
-            price=Price(1.00000, 5),
-            time_in_force=TimeInForce.GTC,
-            expire_time=None,
             init_id=uuid4(),
             timestamp=UNIX_EPOCH)
 
@@ -494,7 +471,7 @@ class MsgPackEventSerializerTests(unittest.TestCase):
             OrderId("O-123456"),
             AUDUSD_FXCM,
             OrderSide.SELL,
-            OrderType.STOP_LIMIT,
+            OrderType.STOP,
             Quantity(100000),
             Price(1.50000, 5),
             TimeInForce.DAY,
@@ -597,7 +574,7 @@ class MsgPackEventSerializerTests(unittest.TestCase):
             OrderIdBroker("B-123456"),
             AUDUSD_FXCM,
             OrderSide.SELL,
-            OrderType.STOP_LIMIT,
+            OrderType.STOP,
             Quantity(100000),
             Price(1.50000, 5),
             TimeInForce.DAY,
@@ -621,7 +598,7 @@ class MsgPackEventSerializerTests(unittest.TestCase):
             OrderIdBroker("B-123456"),
             AUDUSD_FXCM,
             OrderSide.SELL,
-            OrderType.STOP_LIMIT,
+            OrderType.STOP,
             Quantity(100000),
             Price(1.50000, 5),
             TimeInForce.DAY,


### PR DESCRIPTION
- Central method for wiring up strategy
- Refactoring of various backtest execution methods
- Better handling of OCO orders
- Above fixed invalid order events
- Enhance flattening of strategy positions
- Remove StopLimitOrder (for now)
- Bump version