### PR TITLE
MaxBidMinAsk

### DIFF
--- a/nautilus_trader/indicators/max_bid_min_ask.pxd
+++ b/nautilus_trader/indicators/max_bid_min_ask.pxd
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------------------
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from cpython.datetime cimport datetime
+from cpython.datetime cimport timedelta
+
+from nautilus_trader.indicators.base.indicator cimport Indicator
+from nautilus_trader.model.identifiers cimport Symbol
+from nautilus_trader.model.objects cimport Price
+from nautilus_trader.model.tick cimport QuoteTick
+
+
+cdef class MaxBidMinAsk(Indicator):
+
+    cdef readonly Symbol symbol
+    cdef readonly timedelta lookback
+
+    cdef readonly Price max_bid
+    cdef readonly Price min_ask
+
+    cdef object _bid_prices
+    cdef object _ask_prices
+
+    cpdef void handle_quote_tick(self, QuoteTick tick) except *
+
+    cpdef void reset(self)
+
+    cdef inline void _handle_bid_and_ask(self, Price bid, Price ask, datetime timestamp)
+    cdef inline void _prune_by_datetime_cutoff(self, object ts_prices, datetime cutoff)
+    cdef inline void _append_bid(self, Price bid, datetime timestamp)
+    cdef inline void _append_ask(self, Price ask, datetime timestamp)

--- a/nautilus_trader/indicators/max_bid_min_ask.pyx
+++ b/nautilus_trader/indicators/max_bid_min_ask.pyx
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------------------------------------
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from collections import deque
+
+from cpython.datetime cimport datetime
+from cpython.datetime cimport timedelta
+
+from nautilus_trader.core.correctness cimport Condition
+from nautilus_trader.core.datetime cimport is_datetime_utc
+from nautilus_trader.indicators.base.indicator cimport Indicator
+from nautilus_trader.model.identifiers cimport Symbol
+from nautilus_trader.model.objects cimport Price
+from nautilus_trader.model.tick cimport QuoteTick
+
+
+cdef class MaxBidMinAsk(Indicator):
+
+    def __init__(self, Symbol symbol not None, timedelta lookback):
+        self.symbol = symbol
+        self.lookback = lookback
+
+        self.max_bid = None
+        self.min_ask = None
+
+        self._bid_prices = deque()
+        self._ask_prices = deque()
+
+    cpdef void handle_quote_tick(self, QuoteTick tick) except *:
+        self._handle_bid_and_ask(tick.bid, tick.ask, tick.timestamp)
+
+    cpdef void reset(self):
+        self.max_bid = None
+        self.min_ask = None
+        self._bid_prices.clear()
+        self._ask_prices.clear()
+
+    cdef inline void _handle_bid_and_ask(self, Price bid, Price ask, datetime timestamp):
+        Condition.true(is_datetime_utc(timestamp), "utc_now is tz aware UTC")
+
+        cdef datetime cutoff = timestamp - self.lookback
+
+        # Bids
+        self._prune_by_datetime_cutoff(self._bid_prices, cutoff)
+        self._append_bid(bid, timestamp)
+
+        # Asks
+        self._prune_by_datetime_cutoff(self._ask_prices, cutoff)
+        self._append_ask(ask, timestamp)
+
+        # Pull out the min/max
+        self.max_bid = max([p[1] for p in self._bid_prices])
+        self.min_ask = min([p[1] for p in self._ask_prices])
+
+        self._set_has_inputs(True)
+        self._set_initialized(True)
+
+    cdef inline void _prune_by_datetime_cutoff(self, object ts_prices, datetime cutoff):
+        """Drop items that are older than the cutoff"""
+        while ts_prices and ts_prices[0][0] < cutoff:
+            ts_prices.popleft()
+
+    cdef inline void _append_bid(self, Price bid, datetime timestamp):
+        """Handle bids"""
+        # Pop front elements that are less than or equal (since we want the max bid)
+        while self._bid_prices and self._bid_prices[-1][1] <= bid:
+            self._bid_prices.pop()
+
+        # Pop back elements that are less than or equal to the new bid
+        while self._bid_prices and self._bid_prices[0][1] <= bid:
+            self._bid_prices.popleft()
+
+        self._bid_prices.append((timestamp, bid))
+
+    cdef inline void _append_ask(self, Price ask, datetime timestamp):
+        """Handle asks"""
+        # Pop front elements that are less than or equal (since we want the max ask)
+        while self._ask_prices and self._ask_prices[-1][1] <= ask:
+            self._ask_prices.pop()
+
+        # Pop back elements that are less than or equal to the new ask
+        while self._ask_prices and self._ask_prices[0][1] <= ask:
+            self._ask_prices.popleft()
+
+        self._ask_prices.append((timestamp, ask))

--- a/tests/unit_tests/indicators/test_max_bid_min_ask.py
+++ b/tests/unit_tests/indicators/test_max_bid_min_ask.py
@@ -1,0 +1,84 @@
+# -------------------------------------------------------------------------------------------------
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from datetime import datetime
+from datetime import timedelta
+import unittest
+
+import pytz
+
+from nautilus_trader.indicators.max_bid_min_ask import MaxBidMinAsk
+from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.tick import QuoteTick
+
+
+class MaxBidMinAskTests(unittest.TestCase):
+    symbol = Symbol('SPY', Venue('TD Ameritrade'))
+
+    def test_can_instantiate(self):
+        # Arrange
+        indicator = MaxBidMinAsk(self.symbol, timedelta(minutes=5))
+
+        # Act
+        # Assert
+        self.assertEqual(None, indicator.max_bid)
+        self.assertEqual(None, indicator.min_ask)
+        self.assertEqual(False, indicator.initialized)
+
+    def test_can_expire_items(self):
+        # Arrange
+        indicator = MaxBidMinAsk(self.symbol, timedelta(minutes=5))
+
+        # Act + Assert
+        indicator.handle_quote_tick(
+            QuoteTick(
+                self.symbol,
+                Price(1.0, 0),
+                Price(2.0, 0),
+                Quantity(1),
+                Quantity(1),
+                datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+            )
+        )
+        self.assertEqual(Price(1.0, 0), indicator.max_bid)
+        self.assertEqual(Price(2.0, 0), indicator.min_ask)
+
+        # 5 min later (still in the window)
+        indicator.handle_quote_tick(
+            QuoteTick(
+                self.symbol,
+                Price(0.9, 0),
+                Price(2.1, 0),
+                Quantity(1),
+                Quantity(1),
+                datetime(2020, 1, 1, 0, 5, 0, tzinfo=pytz.utc),
+            )
+        )
+        self.assertEqual(Price(1.0, 0), indicator.max_bid)
+        self.assertEqual(Price(2.0, 0), indicator.min_ask)
+
+        # Allow the first item to expire out
+        # This also tests that the new tick is the new min/max
+        indicator.handle_quote_tick(
+            QuoteTick(
+                self.symbol,
+                Price(0.95, 0),
+                Price(2.05, 0),
+                Quantity(1),
+                Quantity(1),
+                datetime(2020, 1, 1, 0, 5, 1, tzinfo=pytz.utc),
+            )
+        )
+        self.assertEqual(Price(0.95, 0), indicator.max_bid)
+        self.assertEqual(Price(2.05, 0), indicator.min_ask)


### PR DESCRIPTION
Indicator that tracks the max bid and min ask within a recent time window.
Uses deques to prune the collection as aggressively as possible.

I tried using `libcpp.deque` but ran afoul of trying to put cdef Python classes into it. In retrospect, of course that wouldn't work. Will keep it in my back pocket if there's a time where I need a deque that only has C primitives in it.