### PR TITLE
Fix incorrect type error in performance analyzer.

### DIFF
--- a/nautilus_trader/analysis/performance.pyx
+++ b/nautilus_trader/analysis/performance.pyx
@@ -245,7 +245,7 @@ cdef class PerformanceAnalyzer:
         double
 
         """
-        if self._account_starting_balance == 0:  # Protect divide by zero
+        if self._account_starting_balance.as_double() == 0:  # Protect divide by zero
             return 0.0
         cdef double current = self._account_balance
         cdef double starting = self._account_starting_balance.as_double()
@@ -610,7 +610,7 @@ cdef class PerformanceAnalyzer:
         """
         return [
             f"PNL:               {round(self.total_pnl(), 2):,} {self._account_currency}",
-            f"PNL %:             {round(self.total_pnl_percentage(), 2)}%",
+            f"PNL %:             {self.total_pnl_percentage()}",
             f"Max Winner:        {round(self.max_winner(), 2):,} {self._account_currency}",
             f"Avg Winner:        {round(self.avg_winner(), 2):,} {self._account_currency}",
             f"Min Winner:        {round(self.min_winner(), 2):,} {self._account_currency}",

--- a/nautilus_trader/analysis/performance.pyx
+++ b/nautilus_trader/analysis/performance.pyx
@@ -610,7 +610,7 @@ cdef class PerformanceAnalyzer:
         """
         return [
             f"PNL:               {round(self.total_pnl(), 2):,} {self._account_currency}",
-            f"PNL %:             {self.total_pnl_percentage()}",
+            f"PNL %:             {round(self.total_pnl_percentage(), 2)}%",
             f"Max Winner:        {round(self.max_winner(), 2):,} {self._account_currency}",
             f"Avg Winner:        {round(self.avg_winner(), 2):,} {self._account_currency}",
             f"Min Winner:        {round(self.min_winner(), 2):,} {self._account_currency}",


### PR DESCRIPTION
```
TypeError: Argument 'other' has incorrect type (expected nautilus_trader.model.objects.Money, got int)
Exception ignored in: 'nautilus_trader.analysis.performance.PerformanceAnalyzer.total_pnl_percentage'
Traceback (most recent call last):
  File "/Users/youngminbae/PycharmProjects/nautilus_trader/tests/acceptance_tests/test_backtest_acceptance.py", line 81, in test_run_empty_strategy
    self.engine.run(start, stop)
TypeError: Argument 'other' has incorrect type (expected nautilus_trader.model.objects.Money, got int)
```