### PR TITLE
Build cleanup

### DIFF
--- a/.github/workflows/test-tag-publish.yml
+++ b/.github/workflows/test-tag-publish.yml
@@ -7,9 +7,64 @@ on:
     branches: [ master ]
 
 jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    name: test - Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
-  test-tag-publish:
+    steps:
+      - uses: actions/checkout@v2
 
+      # Python setup
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install build dependencies
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip setuptools wheel poetry nox --use-feature=2020-resolver
+
+      # Setup Poetry caching
+      - name: Get Poetry cache dir
+        id: poetry-cache
+        run: echo "::set-output name=dir::$(poetry config cache-dir)"
+
+      - name: Poetry/Nox cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.poetry-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-test-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-test-
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-
+
+      # Run tests
+      - name: Install Redis (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install redis-server
+      - name: Install Redis (macOS)
+        if: runner.os == 'macOS'
+        run: brew install redis
+
+      - name: Run tests (with integrations test suite) [Linux/macOS]
+        if: (runner.os == 'Linux') || (runner.os == 'macOS')
+        run: |
+          redis-server --daemonize yes
+          nox -s tests_with_integration --reuse-existing-virtualenvs
+          redis-cli shutdown
+
+      - name: Run tests (without integrations test suite) [Windows]
+        if: runner.os == 'Windows'
+        run: nox -s tests_without_integration --reuse-existing-virtualenvs
+
+
+  tag:
+    needs: [ test ]
     strategy:
       fail-fast: false
       matrix:
@@ -42,24 +97,64 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.poetry-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-tag-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-tag-
             ${{ runner.os }}-${{ matrix.python-version }}-poetry-
 
       # Install
       - name: Install
         run: poetry install
 
-      # Build
-      - name: Build
-        run: poetry build
-
       # Tag the commit with the library version
       - name: Create git tag
         uses: salsify/action-detect-and-tag-new-version@v2
         with:
           version-command: poetry version --short
+
+
+  publish:
+    needs: [ tag ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    name: test - Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Python setup
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install build dependencies
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip setuptools wheel poetry --use-feature=2020-resolver
+
+      # Setup Poetry caching
+      - name: Get Poetry cache dir
+        id: poetry-cache
+        run: echo "::set-output name=dir::$(poetry config cache-dir)"
+
+      - name: Poetry/Nox cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.poetry-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-
+
+      # Install / Build
+      - name: Install / Build
+        run: |
+          poetry install
+          poetry build
 
       # Publish
       - name: Publish to production PyPi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,15 @@
 name: test
 
-# Test pushes on the develop branch
+# Test pushes on non-master branch
 
 on:
   push:
-    branches: [ develop ]
+    branches-ignore:
+      - "master"
+      - "dependabot/**"
 
 jobs:
-
   test:
-
     strategy:
       fail-fast: false
       matrix:

--- a/docs/source/developer_guide/overview.rst
+++ b/docs/source/developer_guide/overview.rst
@@ -8,9 +8,8 @@ Unfortunately the Community edition will not interpret Cython syntax.
 
 To run code or tests from the source code, first compile the C extensions for the package.
 
-    $ python setup.py build_ext --inplace
+    $ poetry install
 
-All tests can be run via the `run_tests.sh` script, or through pytest.
 
 Packaging for PyPI
 ------------------
@@ -23,16 +22,16 @@ for historical reasons.
 ### Manually Packaging
 Ensure version has been bumped and not pre-release.
 
-Create the distribution package tar.gz
+Create the distribution package wheel and sdist tar.gz.
 
-    python setup.py sdist
+    poetry install && poetry build
 
 
 Ensure this is the only distribution in the /dist directory
 
 Push package to PyPI using twine;
 
-    twine upload --repository pypi dist/*
+    poetry publish
 
 Username is \__token__
 

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -1,6 +1,16 @@
 Testing
 =======
 
+To run tests:
+
+    nox -s tests
+
+
+If you have `redis-server` up you can run integration tests:
+
+    nox -s integration_tests
+
+
 - Philosophy
 - Unit Tests
 - Integration Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nautilus_trader"
-version = "1.91.0"
+version = "1.91.1"
 description = "A high-performance algorithmic trading platform and event-driven backtester"
 authors = ["Nautech Systems <info@nautechsystems.io>"]
 license = "LGPL-3.0-or-later"
@@ -19,15 +19,15 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 packages = [
-    { include = "docs", format = "sdist" },
     { include = "examples", format = "sdist" },
     { include = "nautilus_trader" },
-    { include = "scripts", format = "sdist" },
-    { include = "tests", format = "sdist" },
 ]
 include = [
     # Compiled extensions must be included in the wheel distributions
     { path = "nautilus_trader/**/*.so", format = "wheel" },
+]
+exclude = [
+    "nautilus_trader/_internal",
 ]
 
 [tool.poetry.build]


### PR DESCRIPTION
1. Attempts to fix the test-tag-publish flow for master.
2. Enables `test` workflows for non-develop branches
3. Trims the size of the published sdist from 15mb to 200kb (by dropping docs/scripts/tests and nautilus_trader/_internal from the package).
4. Trims the size of the published MacOS wheel by 800kb (7.5mb -> 6.7mb).

I noticed that the linux wheels are much larger. Guessing it's just a byproduct of how manylinux2014 works.

I'm up for debating whether _internal should stay as part of the core shipped artifact. I'd argue that it's really big, and almost alway stale. It's really just one sliver of data that should belong in a user database. Getting it into that database probably shouldn't involve storing it in git.