### PR TITLE
separate sdist and wheel publishing

### DIFF
--- a/.github/workflows/test-tag-publish.yml
+++ b/.github/workflows/test-tag-publish.yml
@@ -113,14 +113,14 @@ jobs:
           version-command: poetry version --short
 
 
-  publish:
+  publish_sdist:
     needs: [ tag ]
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
-    name: test - Python ${{ matrix.python-version }} (${{ matrix.os }})
+        os: [ ubuntu-latest ]
+        python-version: [ 3.9 ]
+    name: publish_sdist - Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -154,7 +154,58 @@ jobs:
       - name: Install / Build
         run: |
           poetry install
-          poetry build
+          poetry build --format sdist
+
+      # Publish
+      - name: Publish to production PyPi
+        env:
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish
+
+
+  publish_wheels:
+    needs: [ tag ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+    name: publish_wheels - Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Python setup
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install build dependencies
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip setuptools wheel poetry --use-feature=2020-resolver
+
+      # Setup Poetry caching
+      - name: Get Poetry cache dir
+        id: poetry-cache
+        run: echo "::set-output name=dir::$(poetry config cache-dir)"
+
+      - name: Poetry/Nox cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.poetry-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-publish-
+            ${{ runner.os }}-${{ matrix.python-version }}-poetry-
+
+      # Install / Build
+      - name: Install / Build
+        run: |
+          poetry install
+          poetry build --format wheel
 
       # Publish
       - name: Publish to production PyPi


### PR DESCRIPTION
Fix the duplicate publish issue.
One publish for the sdist.
One wheel publish for each os/pythonV.