### PR TITLE
Fix incorrect row sorting of order and position reports

### DIFF
--- a/nautilus_trader/analysis/reports.pyx
+++ b/nautilus_trader/analysis/reports.pyx
@@ -56,9 +56,7 @@ cdef class ReportProvider:
 
         cdef list orders_all = [self._order_to_dict(o) for o in orders]
 
-        report = pd.DataFrame(data=orders_all).set_index("cl_ord_id")
-        report.sort_values("timestamp", inplace=True)
-        return report
+        return pd.DataFrame(data=orders_all).set_index("cl_ord_id").sort_index()
 
     cpdef object generate_order_fills_report(self, list orders):
         """
@@ -86,9 +84,7 @@ cdef class ReportProvider:
         if not filled_orders:
             return pd.DataFrame()
 
-        report = pd.DataFrame(data=filled_orders).set_index("cl_ord_id")
-        report.sort_values("timestamp", inplace=True)
-        return report
+        return pd.DataFrame(data=filled_orders).set_index("cl_ord_id").sort_index()
 
     cpdef object generate_positions_report(self, list positions):
         """
@@ -113,9 +109,8 @@ cdef class ReportProvider:
         if not trades:
             return pd.DataFrame()
 
-        report = pd.DataFrame(data=trades).set_index("position_id")
-        report.sort_values("opened_time", inplace=True)
-        return report
+        return pd.DataFrame(data=trades).set_index("position_id").sort_values(
+            ['opened_time', 'closed_time', 'position_id'])
 
     cpdef object generate_account_report(self, Account account):
         """
@@ -143,9 +138,7 @@ cdef class ReportProvider:
         if not account_events:
             return pd.DataFrame()
 
-        report = pd.DataFrame(data=account_events).set_index("timestamp")
-        report.sort_index(inplace=True)
-        return report
+        return pd.DataFrame(data=account_events).set_index("timestamp").sort_index()
 
     cdef dict _order_to_dict(self, Order order):
         return {


### PR DESCRIPTION
Includes optional changes to condense code. I profiled changes and it makes no noticeable performance difference. Feel free to revert back to original style if preferred.
1) chaining of method calls
2) returns called function

Note TODO in code below. I haven't investigated fully to determine if this could cause a hard to diagnose bug later on.

### account_report

sorted correctly

### order_report & order_fills_report

Current sorting method:
```
        >>> order_report = pd.DataFrame(data=orders_all).set_index("cl_ord_id")
        >>> order_report.sort_values("timestamp", inplace=True)
       
        >>> order_report.index.is_monotonic_increasing
        False
    
        >>> order_report[['order_id', 'timestamp']][:10]
                                             order_id                 timestamp
        cl_ord_id                                                              
        O-20080201-014000-000-GBPUSD-1    B-GBP/USD-1 2008-02-01 01:40:00+00:00
        O-20080201-032000-000-GBPUSD-3    B-GBP/USD-3 2008-02-01 03:20:00+00:00
        O-20080201-032000-000-GBPUSD-2    B-GBP/USD-2 2008-02-01 03:20:00+00:00
        O-20080201-072500-000-GBPUSD-5    B-GBP/USD-5 2008-02-01 07:25:00+00:00
        O-20080201-072500-000-GBPUSD-4    B-GBP/USD-4 2008-02-01 07:25:00+00:00
        O-20080201-092000-000-GBPUSD-7    B-GBP/USD-7 2008-02-01 09:20:00+00:00
        O-20080201-092000-000-GBPUSD-6    B-GBP/USD-6 2008-02-01 09:20:00+00:00
        O-20080201-095500-000-GBPUSD-9    B-GBP/USD-9 2008-02-01 09:55:00+00:00
        O-20080201-095500-000-GBPUSD-8    B-GBP/USD-8 2008-02-01 09:55:00+00:00
        O-20080201-103000-000-GBPUSD-11  B-GBP/USD-11 2008-02-01 10:30:00+00:00
```

Improved sorting method:
```
        >>> order_report2 = pd.DataFrame(data=orders_all).set_index("cl_ord_id").sort_index()
       
        >>> order_report2.index.is_monotonic_increasing
        True
        
        >>> order_report2[['order_id', 'timestamp']][:10]
                                             order_id                 timestamp
        cl_ord_id                                                              
        O-20080201-014000-000-GBPUSD-1    B-GBP/USD-1 2008-02-01 01:40:00+00:00
        O-20080201-032000-000-GBPUSD-2    B-GBP/USD-2 2008-02-01 03:20:00+00:00
        O-20080201-032000-000-GBPUSD-3    B-GBP/USD-3 2008-02-01 03:20:00+00:00
        O-20080201-072500-000-GBPUSD-4    B-GBP/USD-4 2008-02-01 07:25:00+00:00
        O-20080201-072500-000-GBPUSD-5    B-GBP/USD-5 2008-02-01 07:25:00+00:00
        O-20080201-092000-000-GBPUSD-6    B-GBP/USD-6 2008-02-01 09:20:00+00:00
        O-20080201-092000-000-GBPUSD-7    B-GBP/USD-7 2008-02-01 09:20:00+00:00
        O-20080201-095500-000-GBPUSD-8    B-GBP/USD-8 2008-02-01 09:55:00+00:00
        O-20080201-095500-000-GBPUSD-9    B-GBP/USD-9 2008-02-01 09:55:00+00:00
        O-20080201-103000-000-GBPUSD-10  B-GBP/USD-10 2008-02-01 10:30:00+00:00
```

### positions_report

Current sorting method:
```
        >>> positions_report = pd.DataFrame(data=trades).set_index("position_id")
        >>> positions_report.sort_values("opened_time", inplace=True)
        
        >>> positions_report.index.is_monotonic_increasing
        False
    
        # first 10 rows appear to be sorted correctly...
        >>> positions_report[['opened_time', 'closed_time']][:10]
                                   opened_time                      closed_time
        position_id                                                            
        B-GBP/USD-1  2008-02-01 01:40:00+00:00        2008-02-01 03:20:00+00:00
        B-GBP/USD-2  2008-02-01 03:20:00+00:00        2008-02-01 07:25:00+00:00
        B-GBP/USD-3  2008-02-01 07:25:00+00:00        2008-02-01 09:20:00+00:00
        B-GBP/USD-4  2008-02-01 09:20:00+00:00        2008-02-01 09:55:00+00:00
        B-GBP/USD-5  2008-02-01 09:55:00+00:00        2008-02-01 10:30:00+00:00
        B-GBP/USD-6  2008-02-01 10:30:00+00:00        2008-02-01 11:40:00+00:00
        B-GBP/USD-7  2008-02-01 11:40:00+00:00        2008-02-01 12:15:00+00:00
        B-GBP/USD-8  2008-02-01 12:15:00+00:00        2008-02-01 19:35:00+00:00
        B-GBP/USD-9  2008-02-01 19:35:00+00:00        2008-02-01 20:05:00+00:00
        B-GBP/USD-10 2008-02-01 20:05:00+00:00 2008-02-03 22:11:59.900000+00:00
        
        # out of order positions appear further down
        >>> positions_report[['opened_time', 'closed_time']][25:35]
                                          opened_time                      closed_time
        position_id                                                                   
        B-GBP/USD-26        2008-02-03 22:32:00+00:00 2008-02-03 22:44:59.900000+00:00
        B-GBP/USD-27 2008-02-03 22:44:59.900000+00:00 2008-02-03 22:45:59.900000+00:00
        B-GBP/USD-28 2008-02-03 22:45:59.900000+00:00 2008-02-03 22:45:59.900000+00:00
        B-GBP/USD-29 2008-02-03 22:45:59.900000+00:00        2008-02-03 22:48:00+00:00
        B-GBP/USD-30        2008-02-03 22:48:00+00:00 2008-02-03 22:48:59.900000+00:00
        B-GBP/USD-33 2008-02-03 22:48:59.900000+00:00        2008-02-03 22:56:00+00:00
        B-GBP/USD-31 2008-02-03 22:48:59.900000+00:00 2008-02-03 22:48:59.900000+00:00
        B-GBP/USD-32 2008-02-03 22:48:59.900000+00:00 2008-02-03 22:48:59.900000+00:00
        B-GBP/USD-34        2008-02-03 22:56:00+00:00 2008-02-03 22:56:59.900000+00:00
        B-GBP/USD-35 2008-02-03 22:56:59.900000+00:00        2008-02-03 22:57:00+00:00
        
        # FYI sort_index() does not work since string indices are sorted lexicographically
        >>> positions_report.sort_index()[['opened_time', 'closed_time']][:15]
                                           opened_time                      closed_time
        position_id                                                                    
        B-GBP/USD-1          2008-02-01 01:40:00+00:00        2008-02-01 03:20:00+00:00
        B-GBP/USD-10         2008-02-01 20:05:00+00:00 2008-02-03 22:11:59.900000+00:00
        B-GBP/USD-100        2008-02-07 15:45:00+00:00        2008-02-07 19:55:00+00:00
        B-GBP/USD-101        2008-02-07 19:55:00+00:00        2008-02-07 20:00:00+00:00
        B-GBP/USD-102        2008-02-07 20:00:00+00:00        2008-02-07 20:35:00+00:00
        B-GBP/USD-103        2008-02-07 20:35:00+00:00        2008-02-07 23:35:00+00:00
        B-GBP/USD-104        2008-02-07 23:35:00+00:00        2008-02-08 00:40:00+00:00
        B-GBP/USD-105        2008-02-08 00:40:00+00:00        2008-02-08 02:40:00+00:00
        B-GBP/USD-106        2008-02-08 02:40:00+00:00        2008-02-08 03:10:00+00:00
        B-GBP/USD-107        2008-02-08 03:10:00+00:00        2008-02-08 04:40:00+00:00
        B-GBP/USD-108        2008-02-08 04:40:00+00:00        2008-02-08 06:45:00+00:00
        B-GBP/USD-109        2008-02-08 06:45:00+00:00        2008-02-08 07:25:00+00:00
        B-GBP/USD-11  2008-02-03 22:11:59.900000+00:00 2008-02-03 22:22:59.900000+00:00
        B-GBP/USD-110        2008-02-08 07:25:00+00:00        2008-02-08 08:20:00+00:00
        B-GBP/USD-111        2008-02-08 08:20:00+00:00        2008-02-08 11:20:00+00:00
```

Improved sorting method:
```
        # TODO: this seems it could fail in rare cases if position_id is used as tiebreaker for certain position_ids
        >>> positions_report2 = pd.DataFrame(data=trades).set_index("position_id").sort_values(
        ['opened_time', 'closed_time', 'position_id'])

        # This returns False since it is expected lexicographically sorted index but it is sorted numerically.
        >>> positions_report2.index.is_monotonic_increasing
        False
        
        >>> positions_report2[['opened_time', 'closed_time']][:10]
                                   opened_time                      closed_time
        position_id                                                            
        B-GBP/USD-1  2008-02-01 01:40:00+00:00        2008-02-01 03:20:00+00:00
        B-GBP/USD-2  2008-02-01 03:20:00+00:00        2008-02-01 07:25:00+00:00
        B-GBP/USD-3  2008-02-01 07:25:00+00:00        2008-02-01 09:20:00+00:00
        B-GBP/USD-4  2008-02-01 09:20:00+00:00        2008-02-01 09:55:00+00:00
        B-GBP/USD-5  2008-02-01 09:55:00+00:00        2008-02-01 10:30:00+00:00
        B-GBP/USD-6  2008-02-01 10:30:00+00:00        2008-02-01 11:40:00+00:00
        B-GBP/USD-7  2008-02-01 11:40:00+00:00        2008-02-01 12:15:00+00:00
        B-GBP/USD-8  2008-02-01 12:15:00+00:00        2008-02-01 19:35:00+00:00
        B-GBP/USD-9  2008-02-01 19:35:00+00:00        2008-02-01 20:05:00+00:00
        B-GBP/USD-10 2008-02-01 20:05:00+00:00 2008-02-03 22:11:59.900000+00:00
        
        # since we can't rely on is_monotonic_increasing this splits integer from end of order_id's 
        # and confirms they are correctly ordered
        >>> position_ids_as_ints = [int(pos_id.split('-')[-1]) for pos_id in positions_report2.index.to_list()]
        >>> position_ids_as_ints == sorted(position_ids_as_ints)
        True
 ```