### PR TITLE
add raw unix_timestamp

### DIFF
--- a/nautilus_trader/model/tick.pxd
+++ b/nautilus_trader/model/tick.pxd
@@ -28,6 +28,8 @@ cdef class Tick:
     """The ticks symbol.\n\n:returns: `Symbol`"""
     cdef readonly datetime timestamp
     """The ticks timestamp (UTC).\n\n:returns: `datetime`"""
+    cdef long double unix_timestamp
+    """The ticks unix timestamp (UTC).\n\n:returns: `double`"""
 
 
 cdef class QuoteTick(Tick):

--- a/nautilus_trader/model/tick.pyx
+++ b/nautilus_trader/model/tick.pyx
@@ -40,6 +40,7 @@ cdef class Tick:
         self,
         Symbol symbol not None,
         datetime timestamp not None,
+        long double unix_timestamp
     ):
         """
         Initialize a new instance of the `QuoteTick` class.
@@ -54,24 +55,25 @@ cdef class Tick:
         """
         self.symbol = symbol
         self.timestamp = timestamp
+        self.unix_timestamp = unix_timestamp
 
     def __eq__(self, Tick other) -> bool:
-        return self.timestamp == other.timestamp
+        return self.unix_timestamp == other.unix_timestamp
 
     def __ne__(self, Tick other) -> bool:
-        return self.timestamp != other.timestamp
+        return self.unix_timestamp != other.unix_timestamp
 
     def __lt__(self, Tick other) -> bool:
-        return self.timestamp < other.timestamp
+        return self.unix_timestamp < other.unix_timestamp
 
     def __le__(self, Tick other) -> bool:
-        return self.timestamp <= other.timestamp
+        return self.unix_timestamp <= other.unix_timestamp
 
     def __gt__(self, Tick other) -> bool:
-        return self.timestamp > other.timestamp
+        return self.unix_timestamp > other.unix_timestamp
 
     def __ge__(self, Tick other) -> bool:
-        return self.timestamp >= other.timestamp
+        return self.unix_timestamp >= other.unix_timestamp
 
 
 cdef class QuoteTick(Tick):
@@ -87,6 +89,7 @@ cdef class QuoteTick(Tick):
         Quantity bid_size not None,
         Quantity ask_size not None,
         datetime timestamp not None,
+        long double unix_timestamp=0
     ):
         """
         Initialize a new instance of the `QuoteTick` class.
@@ -107,7 +110,10 @@ cdef class QuoteTick(Tick):
             The tick timestamp (UTC).
 
         """
-        super().__init__(symbol, timestamp)
+        if unix_timestamp == 0:
+            unix_timestamp = timestamp.timestamp()
+
+        super().__init__(symbol, timestamp, unix_timestamp)
 
         self.bid = bid
         self.ask = ask
@@ -239,6 +245,7 @@ cdef class TradeTick(Tick):
         OrderSide side,
         TradeMatchId match_id not None,
         datetime timestamp not None,
+        long double unix_timestamp=0
     ):
         """
         Initialize a new instance of the `TradeTick` class.
@@ -265,7 +272,11 @@ cdef class TradeTick(Tick):
 
         """
         Condition.not_equal(side, OrderSide.UNDEFINED, "side", "UNDEFINED")
-        super().__init__(symbol, timestamp)
+
+        if unix_timestamp == 0:
+            unix_timestamp = timestamp.timestamp()
+
+        super().__init__(symbol, timestamp, unix_timestamp)
 
         self.price = price
         self.size = size

--- a/nautilus_trader/model/tick.pyx
+++ b/nautilus_trader/model/tick.pyx
@@ -51,6 +51,8 @@ cdef class Tick:
             The ticker symbol.
         timestamp : datetime
             The tick timestamp (UTC).
+        unix_timestamp: long double
+            The tick unix_timestamp.
 
         """
         self.symbol = symbol
@@ -108,6 +110,8 @@ cdef class QuoteTick(Tick):
             The size at the best ask.
         timestamp : datetime
             The tick timestamp (UTC).
+        unix_timestamp: long double
+            The tick unix_timestamp (optional)
 
         """
         if unix_timestamp == 0:
@@ -264,6 +268,8 @@ cdef class TradeTick(Tick):
             The trade match identifier.
         timestamp : datetime
             The tick timestamp (UTC).
+        unix_timestamp: long double
+            The tick unix_timestamp (optional)
 
         Raises
         ------

--- a/nautilus_trader/model/tick.pyx
+++ b/nautilus_trader/model/tick.pyx
@@ -51,7 +51,7 @@ cdef class Tick:
             The ticker symbol.
         timestamp : datetime
             The tick timestamp (UTC).
-        unix_timestamp: long double
+        unix_timestamp : long double
             The tick unix_timestamp.
 
         """
@@ -110,7 +110,7 @@ cdef class QuoteTick(Tick):
             The size at the best ask.
         timestamp : datetime
             The tick timestamp (UTC).
-        unix_timestamp: long double
+        unix_timestamp : long double
             The tick unix_timestamp (optional)
 
         """
@@ -268,7 +268,7 @@ cdef class TradeTick(Tick):
             The trade match identifier.
         timestamp : datetime
             The tick timestamp (UTC).
-        unix_timestamp: long double
+        unix_timestamp : long double
             The tick unix_timestamp (optional)
 
         Raises


### PR DESCRIPTION
I think that the ability to work with a datetime without calling python methods in base classes will further add performance for calculating indicators and aggregators 

Using raw format to work with  time speeds up >  2X for simple test`s 
in more sophisticated methods, faster up to 4 X

```
%%cython --annotate

from cpython.datetime cimport datetime
from cpython.datetime cimport timedelta
from nautilus_trader.model.tick cimport Tick
from nautilus_trader.model.objects cimport Price
from nautilus_trader.model.objects cimport Quantity
from nautilus_trader.model.identifiers cimport Symbol
from nautilus_trader.model.tick cimport QuoteTick

from nautilus_trader.core.datetime cimport from_posix_ms
from nautilus_trader.core.datetime cimport to_posix_ms


from tests.test_kit.stubs import UNIX_EPOCH
from tests.test_kit.providers import TestInstrumentProvider
from tests.test_kit.stubs import TestStubs
AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy(TestStubs.symbol_audusd())

from collections import deque
 

cpdef list create_ticks():
    cdef datetime clock = datetime.now()
    
    cdef list ticks = []
    for i in range(1_000_000):
        clock += timedelta(seconds=1)
        tick = QuoteTick(
            symbol=AUDUSD_SIM.symbol,
            bid=Price("1.00001"),
            ask=Price("1.00004"),
            bid_size=Quantity(3000),
            ask_size=Quantity(2000),
            timestamp=clock,
        )
        ticks.append(tick)
    return ticks
             
        
cdef class uts_SimpleRollingWindow:
    cdef long interval
    cdef object deque
    cdef int _len
    
    def __init__(self, int seconds):
        self.interval = seconds
        self.deque = deque()
        self._len = 0
    
    cdef void process(self, QuoteTick event):
        self.deque.append(event)
        self._len += 1
        while self._has_expired():
            self.deque.popleft()
            self._len -= 1
    
    cdef bint _has_expired(self):
        if self._len == 0:
            return False
        
        cdef QuoteTick first_tick = self.deque[0]
        cdef QuoteTick last_tick = self.deque[-1]
        
        cdef long double first_dt = first_tick.unix_timestamp
        cdef long  double last_dt = last_tick.unix_timestamp
        
        return  first_dt <= (last_dt - self.interval)
            
    cdef int get_result(self):
        return self._len

    
cdef class cSimpleRollingWindow:
    cdef timedelta interval
    cdef object deque
    cdef int _len
    
    def __init__(self, int seconds):
        self.interval = timedelta(seconds=(1 * seconds))
        self.deque = deque()
        self._len = 0
    
    cdef void process(self, QuoteTick event):
        self.deque.append(event)
        self._len += 1
        while self._has_expired():
            self.deque.popleft()
            self._len -= 1
    
    cdef bint _has_expired(self):
        if self._len == 0:
            return False
        
        cdef QuoteTick first_tick = self.deque[0]
        cdef QuoteTick last_tick = self.deque[-1]
        
        cdef datetime first_dt = first_tick.timestamp
        cdef datetime last_dt = last_tick.timestamp
        
        return  first_dt <= (last_dt - self.interval)
            
    cdef int get_result(self):
        return self._len


    

ticks = create_ticks()
    
def run_time_unix_ts_window():
    cdef QuoteTick t  
    w = uts_SimpleRollingWindow(60)
    for t in ticks:
        w.process(t)
    print(w.get_result())
    

def run_time_py_ts_window():
    cdef QuoteTick t  
    w = cSimpleRollingWindow(60)
    for t in ticks:
        w.process(t)
    print(w.get_result())

time run_time_unix_ts_window()
==
60
CPU times: user 151 ms, sys: 1.08 ms, total: 152 ms
Wall time: 152 ms

time run_time_py_ts_window()
==
60
CPU times: user 351 ms, sys: 1.67 ms, total: 353 ms
Wall time: 353 ms

```