### PR TITLE
Remove public declaration from .pxd

### DIFF
--- a/nautilus_trader/adapters/betfair/execution.pxd
+++ b/nautilus_trader/adapters/betfair/execution.pxd
@@ -22,8 +22,8 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
     cdef object _client
     cdef object _stream
     cdef str _account_currency
-    cpdef public dict venue_order_id_to_client_order_id
-    cpdef public set pending_update_order_client_ids
+    cpdef dict venue_order_id_to_client_order_id
+    cpdef set pending_update_order_client_ids
 
 # -- INTERNAL --------------------------------------------------------------------------------------
 

--- a/nautilus_trader/adapters/betfair/providers.pxd
+++ b/nautilus_trader/adapters/betfair/providers.pxd
@@ -35,6 +35,6 @@ cdef class BetfairInstrumentProvider(InstrumentProvider):
     cpdef list search_markets(self, dict market_filter=*)
     cpdef list search_instruments(self, dict instrument_filter=*, bint load=*)
     cpdef list list_instruments(self)
-    cpdef public BettingInstrument get_betting_instrument(self, str market_id, str selection_id, str handicap)
+    cpdef BettingInstrument get_betting_instrument(self, str market_id, str selection_id, str handicap)
     cpdef str get_account_currency(self)
     cpdef void set_instruments(self, list instruments) except *


### PR DESCRIPTION
I removed unnecessary public declaration.

Note You don’t need to (and shouldn’t) declare anything in a declaration file public in order to make it available to other Cython modules; its mere presence in a definition file does that. You only need a public declaration if you want to make something available to external C code.

https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#the-definition-file