### PR TITLE
Cleanup delete path, void _process_order in L2Orderbook

### DIFF
--- a/nautilus_trader/adapters/betfair/common.py
+++ b/nautilus_trader/adapters/betfair/common.py
@@ -110,7 +110,9 @@ all_prices = np.asarray(np.asarray(list(price_probability_map)) / 100.0)
 
 
 def round_probability(probability, side):
-    """ If we have a probability in between two prices, round to the better price """
+    """
+    If we have a probability in between two prices, round to the better price
+    """
     if probability in all_probabilities:
         return probability
     idx = all_probabilities.searchsorted(probability)
@@ -125,7 +127,9 @@ def round_probability(probability, side):
 
 
 def round_price(price, side):
-    """ If we have a probability in between two prices, round to the better price """
+    """
+    If we have a probability in between two prices, round to the better price
+    """
     if price in all_prices:
         return price
     else:

--- a/nautilus_trader/adapters/betfair/parsing.py
+++ b/nautilus_trader/adapters/betfair/parsing.py
@@ -77,7 +77,9 @@ uuid_factory = UUIDFactory()
 
 
 def order_submit_to_betfair(command: SubmitOrder, instrument: BettingInstrument):
-    """ Convert a SubmitOrder command into the data required by betfairlightweight """
+    """
+    Convert a SubmitOrder command into the data required by betfairlightweight
+    """
 
     order = command.order  # type: LimitOrder
     return {
@@ -118,7 +120,9 @@ def order_update_to_betfair(
     side: OrderSide,
     instrument: BettingInstrument,
 ):
-    """ Convert an UpdateOrder command into the data required by betfairlightweight """
+    """
+    Convert an UpdateOrder command into the data required by betfairlightweight
+    """
     return {
         "market_id": instrument.market_id,
         "customer_ref": command.id.value.replace("-", ""),
@@ -134,7 +138,9 @@ def order_update_to_betfair(
 
 
 def order_cancel_to_betfair(command: CancelOrder, instrument: BettingInstrument):
-    """ Convert a SubmitOrder command into the data required by betfairlightweight """
+    """
+    Convert a SubmitOrder command into the data required by betfairlightweight
+    """
     return {
         "market_id": instrument.market_id,
         "customer_ref": command.id.value.replace("-", ""),

--- a/nautilus_trader/adapters/betfair/util.py
+++ b/nautilus_trader/adapters/betfair/util.py
@@ -62,7 +62,9 @@ def flatten_tree(y: Dict, **filters):
 
 
 def chunk(list_like, n):
-    """ Yield successive n-sized chunks from l."""
+    """
+    Yield successive n-sized chunks from l.
+    """
     for i in range(0, len(list_like), n):
         yield list_like[i : i + n]
 
@@ -73,7 +75,9 @@ def hash_json(data):
 
 
 def one(iterable):
-    """ Stolen from more_itertools.one() """
+    """
+    Stolen from more_itertools.one()
+    """
     it = iter(iterable)
 
     try:

--- a/nautilus_trader/data/socket.py
+++ b/nautilus_trader/data/socket.py
@@ -73,7 +73,9 @@ class SocketClient:
         await self.connect()
 
     async def post_connection(self):
-        """ Overridable hook for any post-connection duties, i.e. sending further connection messages """
+        """
+        Overridable hook for any post-connection duties, i.e. sending further connection messages
+        """
         await asyncio.sleep(0)
 
     async def send(self, raw):

--- a/nautilus_trader/model/orderbook/book.pxd
+++ b/nautilus_trader/model/orderbook/book.pxd
@@ -79,7 +79,7 @@ cdef class L3OrderBook(OrderBook):
 
 
 cdef class L2OrderBook(OrderBook):
-    cdef inline Order _process_order(self, Order order)
+    cdef inline void _process_order(self, Order order)
     cdef inline void _remove_if_exists(self, Order order) except *
 
 

--- a/nautilus_trader/model/orderbook/book.pyx
+++ b/nautilus_trader/model/orderbook/book.pyx
@@ -721,20 +721,19 @@ cdef class L2OrderBook(OrderBook):
         for level in self.bids.levels + self.asks.levels:
             assert len(level.orders) == 1, f"Number of orders on {level} > 1"
 
-    cdef inline Order _process_order(self, Order order):
+    cdef inline void _process_order(self, Order order):
         # Because a L2OrderBook only has one order per level, we replace the
         # order.id with a price level, which will let us easily process the
         # order in the base class.
         order.id = f"{order.price:.{self.price_precision}f}"
-        return order
 
     cdef inline void _remove_if_exists(self, Order order) except *:
         # For a L2OrderBook, an order update means a whole level update. If this
         # level exists, remove it so we can insert the new level.
         if order.side == OrderSide.BUY and order.price in self.bids.prices():
-            self.delete(order)
+            self._delete(order)
         elif order.side == OrderSide.SELL and order.price in self.asks.prices():
-            self.delete(order)
+            self._delete(order)
 
 
 cdef class L1OrderBook(OrderBook):

--- a/tests/integration_tests/adapters/betfair/test_betfair_data.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_data.py
@@ -43,7 +43,9 @@ from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 @pytest.mark.asyncio
 @pytest.mark.skip  # Only runs locally, comment to run
 async def test_betfair_data_client(betfair_data_client, data_engine):
-    """ Local test only, ensure we can connect to betfair and receive some market data """
+    """
+    Local test only, ensure we can connect to betfair and receive some market data
+    """
     betfair_client = betfairlightweight.APIClient(
         username=os.environ["BETFAIR_USERNAME"],
         password=os.environ["BETFAIR_PW"],


### PR DESCRIPTION
Tiny PR:
- ensure we don't double `_process_order` in `_remove_if_exists`
- return `void` in L2OrderBook  `_process_order` to make it clear we need the functionality separate 

PR to `flake8_BLK100` branch temporarily just to ensure compare works