### PR TITLE
changed TAKE_PROFIT to STOP_LOSS in BinanceCCXTExecutionCleint

### DIFF
--- a/nautilus_trader/adapters/ccxt/execution.pyx
+++ b/nautilus_trader/adapters/ccxt/execution.pyx
@@ -819,7 +819,7 @@ cdef class BinanceCCXTExecutionClient(CCXTExecutionClient):
             if order.side == OrderSide.BUY:
                 order_type = "STOP_LOSS"
             elif order.side == OrderSide.SELL:
-                order_type = "TAKE_PROFIT"
+                order_type = "STOP_LOSS"
             params["stopPrice"] = str(order.price)
         else:
             raise ValueError(f"Invalid OrderType, "


### PR DESCRIPTION
Changed line 822 in CCXT Adapter to resolve binance error in issue #346. The block of code pertains to the sell order side of a stop market order.