### PR TITLE
Convert unittest tests to pytest (tests/unit_tests/trading)

### DIFF
--- a/tests/unit_tests/model/test_model_position.py
+++ b/tests/unit_tests/model/test_model_position.py
@@ -14,9 +14,9 @@
 # -------------------------------------------------------------------------------------------------
 
 from decimal import Decimal
-import unittest
 
 from parameterized import parameterized
+import pytest
 
 from nautilus_trader.common.clock import TestClock
 from nautilus_trader.common.factories import OrderFactory
@@ -50,8 +50,8 @@ XBTUSD_BITMEX = TestInstrumentProvider.xbtusd_bitmex()
 ETHUSD_BITMEX = TestInstrumentProvider.ethusd_bitmex()
 
 
-class PositionTests(unittest.TestCase):
-    def setUp(self):
+class TestPosition:
+    def setup(self):
         # Fixture Setup
         self.account_id = TestStubs.account_id()
         self.order_factory = OrderFactory(
@@ -63,7 +63,8 @@ class PositionTests(unittest.TestCase):
     def test_side_from_order_side_given_invalid_value_returns_none(self):
         # Arrange
         # Act
-        self.assertRaises(ValueError, Position.side_from_order_side, 0)
+        with pytest.raises(ValueError):
+            Position.side_from_order_side(0)
 
     @parameterized.expand(
         [
@@ -79,7 +80,7 @@ class PositionTests(unittest.TestCase):
         position_side = Position.side_from_order_side(order_side)
 
         # Assert
-        self.assertEqual(expected, position_side)
+        assert position_side == expected
 
     def test_position_hash_str_repr(self):
         # Arrange
@@ -176,33 +177,33 @@ class PositionTests(unittest.TestCase):
         assert position.symbol == AUDUSD_SIM.id.symbol
         assert position.venue == AUDUSD_SIM.id.venue
         assert not position.is_opposite_side(fill.order_side)
-        self.assertFalse(position != position)  # Equality operator test
-        self.assertEqual(ClientOrderId("O-19700101-000000-000-001-1"), position.from_order)
-        self.assertEqual(Quantity.from_int(100000), position.quantity)
-        self.assertEqual(Quantity.from_int(100000), position.peak_qty)
-        self.assertEqual(OrderSide.BUY, position.entry)
-        self.assertEqual(PositionSide.LONG, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(0, position.duration_ns)
-        self.assertEqual(Decimal("1.00001"), position.avg_px_open)
-        self.assertEqual(1, position.event_count)
-        self.assertEqual([order.client_order_id], position.client_order_ids)
-        self.assertEqual([VenueOrderId("1")], position.venue_order_ids)
-        self.assertEqual([ExecutionId("E-19700101-000000-000-001-1")], position.execution_ids)
-        self.assertEqual(ExecutionId("E-19700101-000000-000-001-1"), position.last_execution_id)
-        self.assertEqual(PositionId("P-123456"), position.id)
-        self.assertEqual(1, len(position.events))
-        self.assertTrue(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertTrue(position.is_open)
-        self.assertFalse(position.is_closed)
-        self.assertEqual(0, position.realized_points)
-        self.assertEqual(0, position.realized_return)
-        self.assertEqual(Money(-2.00, USD), position.realized_pnl)
-        self.assertEqual(Money(49.00, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(47.00, USD), position.total_pnl(last))
-        self.assertEqual([Money(2.00, USD)], position.commissions())
-        self.assertEqual("Position(LONG 100_000 AUD/USD.SIM, id=P-123456)", repr(position))
+        assert not position != position  # Equality operator test
+        assert position.from_order == ClientOrderId("O-19700101-000000-000-001-1")
+        assert position.quantity == Quantity.from_int(100000)
+        assert position.peak_qty == Quantity.from_int(100000)
+        assert position.entry == OrderSide.BUY
+        assert position.side == PositionSide.LONG
+        assert position.ts_opened_ns == 0
+        assert position.duration_ns == 0
+        assert position.avg_px_open == Decimal("1.00001")
+        assert position.event_count == 1
+        assert position.client_order_ids == [order.client_order_id]
+        assert position.venue_order_ids == [VenueOrderId("1")]
+        assert position.execution_ids == [ExecutionId("E-19700101-000000-000-001-1")]
+        assert position.last_execution_id == ExecutionId("E-19700101-000000-000-001-1")
+        assert position.id == PositionId("P-123456")
+        assert len(position.events) == 1
+        assert position.is_long
+        assert not position.is_short
+        assert position.is_open
+        assert not position.is_closed
+        assert position.realized_points == 0
+        assert position.realized_return == 0
+        assert position.realized_pnl == Money(-2.00, USD)
+        assert position.unrealized_pnl(last) == Money(49.00, USD)
+        assert position.total_pnl(last) == Money(47.00, USD)
+        assert position.commissions() == [Money(2.00, USD)]
+        assert repr(position) == "Position(LONG 100_000 AUD/USD.SIM, id=P-123456)"
 
     def test_position_filled_with_sell_order_returns_expected_attributes(self):
         # Arrange
@@ -226,26 +227,26 @@ class PositionTests(unittest.TestCase):
         position = Position(instrument=AUDUSD_SIM, fill=fill)
 
         # Assert
-        self.assertEqual(Quantity.from_int(100000), position.quantity)
-        self.assertEqual(Quantity.from_int(100000), position.peak_qty)
-        self.assertEqual(PositionSide.SHORT, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.00001"), position.avg_px_open)
-        self.assertEqual(1, position.event_count)
-        self.assertEqual([ExecutionId("E-19700101-000000-000-001-1")], position.execution_ids)
-        self.assertEqual(ExecutionId("E-19700101-000000-000-001-1"), position.last_execution_id)
-        self.assertEqual(PositionId("P-123456"), position.id)
-        self.assertFalse(position.is_long)
-        self.assertTrue(position.is_short)
-        self.assertTrue(position.is_open)
-        self.assertFalse(position.is_closed)
-        self.assertEqual(0, position.realized_points)
-        self.assertEqual(0, position.realized_return)
-        self.assertEqual(Money(-2.00, USD), position.realized_pnl)
-        self.assertEqual(Money(-49.00, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(-51.00, USD), position.total_pnl(last))
-        self.assertEqual([Money(2.00, USD)], position.commissions())
-        self.assertEqual("Position(SHORT 100_000 AUD/USD.SIM, id=P-123456)", repr(position))
+        assert position.quantity == Quantity.from_int(100000)
+        assert position.peak_qty == Quantity.from_int(100000)
+        assert position.side == PositionSide.SHORT
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.00001")
+        assert position.event_count == 1
+        assert position.execution_ids == [ExecutionId("E-19700101-000000-000-001-1")]
+        assert position.last_execution_id == ExecutionId("E-19700101-000000-000-001-1")
+        assert position.id == PositionId("P-123456")
+        assert not position.is_long
+        assert position.is_short
+        assert position.is_open
+        assert not position.is_closed
+        assert position.realized_points == 0
+        assert position.realized_return == 0
+        assert position.realized_pnl == Money(-2.00, USD)
+        assert position.unrealized_pnl(last) == Money(-49.00, USD)
+        assert position.total_pnl(last) == Money(-51.00, USD)
+        assert position.commissions() == [Money(2.00, USD)]
+        assert repr(position) == "Position(SHORT 100_000 AUD/USD.SIM, id=P-123456)"
 
     def test_position_partial_fills_with_buy_order_returns_expected_attributes(self):
         # Arrange
@@ -270,23 +271,23 @@ class PositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(Quantity.from_int(50000), position.quantity)
-        self.assertEqual(Quantity.from_int(50000), position.peak_qty)
-        self.assertEqual(PositionSide.LONG, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.00001"), position.avg_px_open)
-        self.assertEqual(1, position.event_count)
-        self.assertTrue(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertTrue(position.is_open)
-        self.assertFalse(position.is_closed)
-        self.assertEqual(0, position.realized_points)
-        self.assertEqual(0, position.realized_return)
-        self.assertEqual(Money(-2.00, USD), position.realized_pnl)
-        self.assertEqual(Money(23.50, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(21.50, USD), position.total_pnl(last))
-        self.assertEqual([Money(2.00, USD)], position.commissions())
-        self.assertEqual("Position(LONG 50_000 AUD/USD.SIM, id=P-123456)", repr(position))
+        assert position.quantity == Quantity.from_int(50000)
+        assert position.peak_qty == Quantity.from_int(50000)
+        assert position.side == PositionSide.LONG
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.00001")
+        assert position.event_count == 1
+        assert position.is_long
+        assert not position.is_short
+        assert position.is_open
+        assert not position.is_closed
+        assert position.realized_points == 0
+        assert position.realized_return == 0
+        assert position.realized_pnl == Money(-2.00, USD)
+        assert position.unrealized_pnl(last) == Money(23.50, USD)
+        assert position.total_pnl(last) == Money(21.50, USD)
+        assert position.commissions() == [Money(2.00, USD)]
+        assert repr(position) == "Position(LONG 50_000 AUD/USD.SIM, id=P-123456)"
 
     def test_position_partial_fills_with_sell_order_returns_expected_attributes(self):
         # Arrange
@@ -324,22 +325,22 @@ class PositionTests(unittest.TestCase):
         position.apply(fill2)
 
         # Assert
-        self.assertEqual(Quantity.from_int(100000), position.quantity)
-        self.assertEqual(PositionSide.SHORT, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.000015"), position.avg_px_open)
-        self.assertEqual(2, position.event_count)
-        self.assertFalse(position.is_long)
-        self.assertTrue(position.is_short)
-        self.assertTrue(position.is_open)
-        self.assertFalse(position.is_closed)
-        self.assertEqual(0, position.realized_points)
-        self.assertEqual(0, position.realized_return)
-        self.assertEqual(Money(-4.00, USD), position.realized_pnl)
-        self.assertEqual(Money(-48.50, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(-52.50, USD), position.total_pnl(last))
-        self.assertEqual([Money(4.00, USD)], position.commissions())
-        self.assertEqual("Position(SHORT 100_000 AUD/USD.SIM, id=P-123456)", repr(position))
+        assert position.quantity == Quantity.from_int(100000)
+        assert position.side == PositionSide.SHORT
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.000015")
+        assert position.event_count == 2
+        assert not position.is_long
+        assert position.is_short
+        assert position.is_open
+        assert not position.is_closed
+        assert position.realized_points == 0
+        assert position.realized_return == 0
+        assert position.realized_pnl == Money(-4.00, USD)
+        assert position.unrealized_pnl(last) == Money(-48.50, USD)
+        assert position.total_pnl(last) == Money(-52.50, USD)
+        assert position.commissions() == [Money(4.00, USD)]
+        assert repr(position) == "Position(SHORT 100_000 AUD/USD.SIM, id=P-123456)"
 
     def test_position_filled_with_buy_order_then_sell_order_returns_expected_attributes(
         self,
@@ -388,25 +389,25 @@ class PositionTests(unittest.TestCase):
 
         # Assert
         assert position.is_opposite_side(fill2.order_side)
-        self.assertEqual(Quantity.zero(), position.quantity)
-        self.assertEqual(PositionSide.FLAT, position.side)
-        self.assertEqual(1_000_000_000, position.ts_opened_ns)
-        self.assertEqual(1_000_000_000, position.duration_ns)
-        self.assertEqual(Decimal("1.00001"), position.avg_px_open)
-        self.assertEqual(2, position.event_count)
-        self.assertEqual(2_000_000_000, position.ts_closed_ns)
-        self.assertEqual(Decimal("1.00011"), position.avg_px_close)
-        self.assertFalse(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertFalse(position.is_open)
-        self.assertTrue(position.is_closed)
-        self.assertEqual(Decimal("0.00010"), position.realized_points)
-        self.assertEqual(Decimal("0.00009999900000999990000099999000"), position.realized_return)
-        self.assertEqual(Money(12.00, USD), position.realized_pnl)
-        self.assertEqual(Money(0, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(12.00, USD), position.total_pnl(last))
-        self.assertEqual([Money(3.00, USD)], position.commissions())
-        self.assertEqual("Position(FLAT AUD/USD.SIM, id=P-123456)", repr(position))
+        assert position.quantity == Quantity.zero()
+        assert position.side == PositionSide.FLAT
+        assert position.ts_opened_ns == 1_000_000_000
+        assert position.duration_ns == 1_000_000_000
+        assert position.avg_px_open == Decimal("1.00001")
+        assert position.event_count == 2
+        assert position.ts_closed_ns == 2_000_000_000
+        assert position.avg_px_close == Decimal("1.00011")
+        assert not position.is_long
+        assert not position.is_short
+        assert not position.is_open
+        assert position.is_closed
+        assert position.realized_points == Decimal("0.00010")
+        assert position.realized_return == Decimal("0.00009999900000999990000099999000")
+        assert position.realized_pnl == Money(12.00, USD)
+        assert position.unrealized_pnl(last) == Money(0, USD)
+        assert position.total_pnl(last) == Money(12.00, USD)
+        assert position.commissions() == [Money(3.00, USD)]
+        assert repr(position) == "Position(FLAT AUD/USD.SIM, id=P-123456)"
 
     def test_position_filled_with_sell_order_then_buy_order_returns_expected_attributes(
         self,
@@ -459,27 +460,23 @@ class PositionTests(unittest.TestCase):
         position.apply(fill3)
 
         # Assert
-        self.assertEqual(Quantity.zero(), position.quantity)
-        self.assertEqual(PositionSide.FLAT, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.0"), position.avg_px_open)
-        self.assertEqual(3, position.event_count)
-        self.assertEqual(
-            [order1.client_order_id, order2.client_order_id], position.client_order_ids
-        )
-        self.assertEqual(0, position.ts_closed_ns)
-        self.assertEqual(Decimal("1.00002"), position.avg_px_close)
-        self.assertFalse(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertFalse(position.is_open)
-        self.assertTrue(position.is_closed)
-        self.assertEqual(Money(-8.00, USD), position.realized_pnl)
-        self.assertEqual(Money(0, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(-8.000, USD), position.total_pnl(last))
-        self.assertEqual([Money(6.00, USD)], position.commissions())
-        self.assertEqual(
-            "Position(FLAT AUD/USD.SIM, id=P-19700101-000000-000-001-1)", repr(position)
-        )
+        assert position.quantity == Quantity.zero()
+        assert position.side == PositionSide.FLAT
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.0")
+        assert position.event_count == 3
+        assert position.client_order_ids == [order1.client_order_id, order2.client_order_id]
+        assert position.ts_closed_ns == 0
+        assert position.avg_px_close == Decimal("1.00002")
+        assert not position.is_long
+        assert not position.is_short
+        assert not position.is_open
+        assert position.is_closed
+        assert position.realized_pnl == Money(-8.00, USD)
+        assert position.unrealized_pnl(last) == Money(0, USD)
+        assert position.total_pnl(last) == Money(-8.000, USD)
+        assert position.commissions() == [Money(6.00, USD)]
+        assert repr(position) == "Position(FLAT AUD/USD.SIM, id=P-19700101-000000-000-001-1)"
 
     def test_position_filled_with_no_change_returns_expected_attributes(self):
         # Arrange
@@ -517,36 +514,29 @@ class PositionTests(unittest.TestCase):
         position.apply(fill2)
 
         # Assert
-        self.assertEqual(Quantity.zero(), position.quantity)
-        self.assertEqual(PositionSide.FLAT, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.0"), position.avg_px_open)
-        self.assertEqual(2, position.event_count)
-        self.assertEqual(
-            [order1.client_order_id, order2.client_order_id], position.client_order_ids
-        )
-        self.assertEqual(
-            [
-                ExecutionId("E-19700101-000000-000-001-1"),
-                ExecutionId("E-19700101-000000-000-001-2"),
-            ],
-            position.execution_ids,
-        )
-        self.assertEqual(0, position.ts_closed_ns)
-        self.assertEqual(Decimal("1.0"), position.avg_px_close)
-        self.assertFalse(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertFalse(position.is_open)
-        self.assertTrue(position.is_closed)
-        self.assertEqual(0, position.realized_points)
-        self.assertEqual(0, position.realized_return)
-        self.assertEqual(Money(-4.00, USD), position.realized_pnl)
-        self.assertEqual(Money(0, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(-4.00, USD), position.total_pnl(last))
-        self.assertEqual([Money(4.00, USD)], position.commissions())
-        self.assertEqual(
-            "Position(FLAT AUD/USD.SIM, id=P-19700101-000000-000-001-1)", repr(position)
-        )
+        assert position.quantity == Quantity.zero()
+        assert position.side == PositionSide.FLAT
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.0")
+        assert position.event_count == 2
+        assert position.client_order_ids == [order1.client_order_id, order2.client_order_id]
+        assert position.execution_ids == [
+            ExecutionId("E-19700101-000000-000-001-1"),
+            ExecutionId("E-19700101-000000-000-001-2"),
+        ]
+        assert position.ts_closed_ns == 0
+        assert position.avg_px_close == Decimal("1.0")
+        assert not position.is_long
+        assert not position.is_short
+        assert not position.is_open
+        assert position.is_closed
+        assert position.realized_points == 0
+        assert position.realized_return == 0
+        assert position.realized_pnl == Money(-4.00, USD)
+        assert position.unrealized_pnl(last) == Money(0, USD)
+        assert position.total_pnl(last) == Money(-4.00, USD)
+        assert position.commissions() == [Money(4.00, USD)]
+        assert repr(position) == "Position(FLAT AUD/USD.SIM, id=P-19700101-000000-000-001-1)"
 
     def test_position_long_with_multiple_filled_orders_returns_expected_attributes(
         self,
@@ -601,26 +591,27 @@ class PositionTests(unittest.TestCase):
         position.apply(fill3)
 
         # Assert
-        self.assertEqual(Quantity.zero(), position.quantity)
-        self.assertEqual(PositionSide.FLAT, position.side)
-        self.assertEqual(0, position.ts_opened_ns)
-        self.assertEqual(Decimal("1.000005"), position.avg_px_open)
-        self.assertEqual(3, position.event_count)
-        self.assertEqual(
-            [order1.client_order_id, order2.client_order_id, order3.client_order_id],
-            position.client_order_ids,
-        )
-        self.assertEqual(0, position.ts_closed_ns)
-        self.assertEqual(Decimal("1.0001"), position.avg_px_close)
-        self.assertFalse(position.is_long)
-        self.assertFalse(position.is_short)
-        self.assertFalse(position.is_open)
-        self.assertTrue(position.is_closed)
-        self.assertEqual(Money(11.00, USD), position.realized_pnl)
-        self.assertEqual(Money(0, USD), position.unrealized_pnl(last))
-        self.assertEqual(Money(11.00, USD), position.total_pnl(last))
-        self.assertEqual([Money(8.00, USD)], position.commissions())
-        self.assertEqual("Position(FLAT AUD/USD.SIM, id=P-123456)", repr(position))
+        assert position.quantity == Quantity.zero()
+        assert position.side == PositionSide.FLAT
+        assert position.ts_opened_ns == 0
+        assert position.avg_px_open == Decimal("1.000005")
+        assert position.event_count == 3
+        assert position.client_order_ids == [
+            order1.client_order_id,
+            order2.client_order_id,
+            order3.client_order_id,
+        ]
+        assert position.ts_closed_ns == 0
+        assert position.avg_px_close == Decimal("1.0001")
+        assert not position.is_long
+        assert not position.is_short
+        assert not position.is_open
+        assert position.is_closed
+        assert position.realized_pnl == Money(11.00, USD)
+        assert position.unrealized_pnl(last) == Money(0, USD)
+        assert position.total_pnl(last) == Money(11.00, USD)
+        assert position.commissions() == [Money(8.00, USD)]
+        assert repr(position) == "Position(FLAT AUD/USD.SIM, id=P-123456)"
 
     def test_pnl_calculation_from_trading_technologies_example(self):
         # https://www.tradingtechnologies.com/xtrader-help/fix-adapter-reference/pl-calculation-algorithm/understanding-pl-calculations/  # noqa
@@ -674,9 +665,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill2)
-        self.assertEqual(Quantity.from_int(29), position.quantity)
-        self.assertEqual(Money(-0.28830000, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("99.41379310344827586206896552"), position.avg_px_open)
+        assert position.quantity == Quantity.from_int(29)
+        assert position.realized_pnl == Money(-0.28830000, USDT)
+        assert position.avg_px_open == Decimal("99.41379310344827586206896552")
 
         fill3 = TestStubs.event_order_filled(
             order3,
@@ -687,9 +678,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill3)
-        self.assertEqual(Quantity.from_int(20), position.quantity)
-        self.assertEqual(Money(13.89666207, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("99.41379310344827586206896552"), position.avg_px_open)
+        assert position.quantity == Quantity.from_int(20)
+        assert position.realized_pnl == Money(13.89666207, USDT)
+        assert position.avg_px_open == Decimal("99.41379310344827586206896552")
 
         fill4 = TestStubs.event_order_filled(
             order4,
@@ -700,9 +691,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill4)
-        self.assertEqual(Quantity.from_int(16), position.quantity)
-        self.assertEqual(Money(36.19948966, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("99.41379310344827586206896552"), position.avg_px_open)
+        assert position.quantity == Quantity.from_int(16)
+        assert position.realized_pnl == Money(36.19948966, USDT)
+        assert position.avg_px_open == Decimal("99.41379310344827586206896552")
 
         fill5 = TestStubs.event_order_filled(
             order5,
@@ -713,12 +704,12 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill5)
-        self.assertEqual(Quantity.from_int(19), position.quantity)
-        self.assertEqual(Money(36.16858966, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("99.98003629764065335753176042"), position.avg_px_open)
-        self.assertEqual(
-            "Position(LONG 19.00000 ETH/USDT.BINANCE, id=P-19700101-000000-000-001-1)",
-            repr(position),
+        assert position.quantity == Quantity.from_int(19)
+        assert position.realized_pnl == Money(36.16858966, USDT)
+        assert position.avg_px_open == Decimal("99.98003629764065335753176042")
+        assert (
+            repr(position)
+            == "Position(LONG 19.00000 ETH/USDT.BINANCE, id=P-19700101-000000-000-001-1)"
         )
 
     def test_position_realised_pnl_with_interleaved_order_sides(self):
@@ -771,9 +762,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill2)
-        self.assertEqual(Quantity.from_str("29.000000"), position.quantity)
-        self.assertEqual(Money(-289.98300000, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("9999.413793103448275862068966"), position.avg_px_open)
+        assert position.quantity == Quantity.from_str("29.000000")
+        assert position.realized_pnl == Money(-289.98300000, USDT)
+        assert position.avg_px_open == Decimal("9999.413793103448275862068966")
 
         fill3 = TestStubs.event_order_filled(
             order3,
@@ -784,9 +775,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill3)
-        self.assertEqual(Quantity.from_int(20), position.quantity)
-        self.assertEqual(Money(-365.71613793, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("9999.413793103448275862068966"), position.avg_px_open)
+        assert position.quantity == Quantity.from_int(20)
+        assert position.realized_pnl == Money(-365.71613793, USDT)
+        assert position.avg_px_open == Decimal("9999.413793103448275862068966")
 
         fill4 = TestStubs.event_order_filled(
             order4,
@@ -797,9 +788,9 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill4)
-        self.assertEqual(Quantity.from_int(23), position.quantity)
-        self.assertEqual(Money(-395.72513793, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("9999.881559220389805097451274"), position.avg_px_open)
+        assert position.quantity == Quantity.from_int(23)
+        assert position.realized_pnl == Money(-395.72513793, USDT)
+        assert position.avg_px_open == Decimal("9999.881559220389805097451274")
 
         fill5 = TestStubs.event_order_filled(
             order5,
@@ -810,12 +801,12 @@ class PositionTests(unittest.TestCase):
         )
 
         position.apply(fill5)
-        self.assertEqual(Quantity.from_int(19), position.quantity)
-        self.assertEqual(Money(-415.27137481, USDT), position.realized_pnl)
-        self.assertEqual(Decimal("9999.881559220389805097451274"), position.avg_px_open)
-        self.assertEqual(
-            "Position(LONG 19.000000 BTC/USDT.BINANCE, id=P-19700101-000000-000-001-1)",
-            repr(position),
+        assert position.quantity == Quantity.from_int(19)
+        assert position.realized_pnl == Money(-415.27137481, USDT)
+        assert position.avg_px_open == Decimal("9999.881559220389805097451274")
+        assert (
+            repr(position)
+            == "Position(LONG 19.000000 BTC/USDT.BINANCE, id=P-19700101-000000-000-001-1)"
         )
 
     def test_calculate_pnl_when_given_position_side_flat_returns_zero(self):
@@ -844,7 +835,7 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(0, USDT), result)
+        assert result == Money(0, USDT)
 
     def test_calculate_pnl_for_long_position_win(self):
         # Arrange
@@ -872,14 +863,11 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(120.00000000, USDT), pnl)
-        self.assertEqual(Money(-126.00000000, USDT), position.realized_pnl)
-        self.assertEqual(
-            Money(120.00000000, USDT),
-            position.unrealized_pnl(Price.from_str("10510.00")),
-        )
-        self.assertEqual(Money(-6.00000000, USDT), position.total_pnl(Price.from_str("10510.00")))
-        self.assertEqual([Money(126.00000000, USDT)], position.commissions())
+        assert pnl == Money(120.00000000, USDT)
+        assert position.realized_pnl == Money(-126.00000000, USDT)
+        assert position.unrealized_pnl(Price.from_str("10510.00")) == Money(120.00000000, USDT)
+        assert position.total_pnl(Price.from_str("10510.00")) == Money(-6.00000000, USDT)
+        assert position.commissions() == [Money(126.00000000, USDT)]
 
     def test_calculate_pnl_for_long_position_loss(self):
         # Arrange
@@ -907,14 +895,11 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(-195.00000000, USDT), pnl)
-        self.assertEqual(Money(-126.00000000, USDT), position.realized_pnl)
-        self.assertEqual(
-            Money(-234.00000000, USDT),
-            position.unrealized_pnl(Price.from_str("10480.50")),
-        )
-        self.assertEqual(Money(-360.00000000, USDT), position.total_pnl(Price.from_str("10480.50")))
-        self.assertEqual([Money(126.00000000, USDT)], position.commissions())
+        assert pnl == Money(-195.00000000, USDT)
+        assert position.realized_pnl == Money(-126.00000000, USDT)
+        assert position.unrealized_pnl(Price.from_str("10480.50")) == Money(-234.00000000, USDT)
+        assert position.total_pnl(Price.from_str("10480.50")) == Money(-360.00000000, USDT)
+        assert position.commissions() == [Money(126.00000000, USDT)]
 
     def test_calculate_pnl_for_short_position_winning(self):
         # Arrange
@@ -942,17 +927,11 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(1116.50000000, USDT), pnl)
-        self.assertEqual(
-            Money(1116.50000000, USDT),
-            position.unrealized_pnl(Price.from_str("10390.00")),
-        )
-        self.assertEqual(Money(-106.57500000, USDT), position.realized_pnl)
-        self.assertEqual([Money(106.57500000, USDT)], position.commissions())
-        self.assertEqual(
-            Money(105458.50000000, USDT),
-            position.notional_value(Price.from_str("10390.00")),
-        )
+        assert pnl == Money(1116.50000000, USDT)
+        assert position.unrealized_pnl(Price.from_str("10390.00")) == Money(1116.50000000, USDT)
+        assert position.realized_pnl == Money(-106.57500000, USDT)
+        assert position.commissions() == [Money(106.57500000, USDT)]
+        assert position.notional_value(Price.from_str("10390.00")) == Money(105458.50000000, USDT)
 
     def test_calculate_pnl_for_short_position_loss(self):
         # Arrange
@@ -980,17 +959,11 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(-1705.00000000, USDT), pnl)
-        self.assertEqual(
-            Money(-1705.00000000, USDT),
-            position.unrealized_pnl(Price.from_str("10670.50")),
-        )
-        self.assertEqual(Money(-105.00000000, USDT), position.realized_pnl)
-        self.assertEqual([Money(105.00000000, USDT)], position.commissions())
-        self.assertEqual(
-            Money(106705.00000000, USDT),
-            position.notional_value(Price.from_str("10670.50")),
-        )
+        assert pnl == Money(-1705.00000000, USDT)
+        assert position.unrealized_pnl(Price.from_str("10670.50")) == Money(-1705.00000000, USDT)
+        assert position.realized_pnl == Money(-105.00000000, USDT)
+        assert position.commissions() == [Money(105.00000000, USDT)]
+        assert position.notional_value(Price.from_str("10670.50")) == Money(106705.00000000, USDT)
 
     def test_calculate_pnl_for_inverse1(self):
         # Arrange
@@ -1018,14 +991,10 @@ class PositionTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Money(-0.90909091, BTC), pnl)
-        self.assertEqual(
-            Money(-0.90909091, BTC), position.unrealized_pnl(Price.from_str("11000.00"))
-        )
-        self.assertEqual(Money(-0.00750000, BTC), position.realized_pnl)
-        self.assertEqual(
-            Money(9.09090909, BTC), position.notional_value(Price.from_str("11000.00"))
-        )
+        assert pnl == Money(-0.90909091, BTC)
+        assert position.unrealized_pnl(Price.from_str("11000.00")) == Money(-0.90909091, BTC)
+        assert position.realized_pnl == Money(-0.00750000, BTC)
+        assert position.notional_value(Price.from_str("11000.00")) == Money(9.09090909, BTC)
 
     def test_calculate_pnl_for_inverse2(self):
         # Arrange
@@ -1046,10 +1015,8 @@ class PositionTests(unittest.TestCase):
         position = Position(instrument=ETHUSD_BITMEX, fill=fill)
 
         # Act, Assert
-        self.assertEqual(Money(4.27745208, ETH), position.unrealized_pnl(Price.from_str("370.00")))
-        self.assertEqual(
-            Money(270.27027027, ETH), position.notional_value(Price.from_str("370.00"))
-        )
+        assert position.unrealized_pnl(Price.from_str("370.00")) == Money(4.27745208, ETH)
+        assert position.notional_value(Price.from_str("370.00")) == Money(270.27027027, ETH)
 
     def test_calculate_unrealized_pnl_for_long(self):
         # Arrange
@@ -1088,9 +1055,9 @@ class PositionTests(unittest.TestCase):
         pnl = position.unrealized_pnl(Price.from_str("11505.60"))
 
         # Assert
-        self.assertEqual(Money(4022.40000000, USDT), pnl)
-        self.assertEqual(Money(-42.00000000, USDT), position.realized_pnl)
-        self.assertEqual([Money(42.00000000, USDT)], position.commissions())
+        assert pnl == Money(4022.40000000, USDT)
+        assert position.realized_pnl == Money(-42.00000000, USDT)
+        assert position.commissions() == [Money(42.00000000, USDT)]
 
     def test_calculate_unrealized_pnl_for_short(self):
         # Arrange
@@ -1113,9 +1080,9 @@ class PositionTests(unittest.TestCase):
         pnl = position.unrealized_pnl(Price.from_str("10407.15"))
 
         # Assert
-        self.assertEqual(Money(582.03640000, USDT), pnl)
-        self.assertEqual(Money(-62.10910720, USDT), position.realized_pnl)
-        self.assertEqual([Money(62.10910720, USDT)], position.commissions())
+        assert pnl == Money(582.03640000, USDT)
+        assert position.realized_pnl == Money(-62.10910720, USDT)
+        assert position.commissions() == [Money(62.10910720, USDT)]
 
     def test_calculate_unrealized_pnl_for_long_inverse(self):
         # Arrange
@@ -1140,9 +1107,9 @@ class PositionTests(unittest.TestCase):
         pnl = position.unrealized_pnl(Price.from_str("11505.60"))
 
         # Assert
-        self.assertEqual(Money(0.83238969, BTC), pnl)
-        self.assertEqual(Money(-0.00714286, BTC), position.realized_pnl)
-        self.assertEqual([Money(0.00714286, BTC)], position.commissions())
+        assert pnl == Money(0.83238969, BTC)
+        assert position.realized_pnl == Money(-0.00714286, BTC)
+        assert position.commissions() == [Money(0.00714286, BTC)]
 
     def test_calculate_unrealized_pnl_for_short_inverse(self):
         # Arrange
@@ -1167,6 +1134,6 @@ class PositionTests(unittest.TestCase):
         pnl = position.unrealized_pnl(Price.from_str("12506.65"))
 
         # Assert
-        self.assertEqual(Money(19.30166700, BTC), pnl)
-        self.assertEqual(Money(-0.06048387, BTC), position.realized_pnl)
-        self.assertEqual([Money(0.06048387, BTC)], position.commissions())
+        assert pnl == Money(19.30166700, BTC)
+        assert position.realized_pnl == Money(-0.06048387, BTC)
+        assert position.commissions() == [Money(0.06048387, BTC)]

--- a/tests/unit_tests/trading/test_trading_account.py
+++ b/tests/unit_tests/trading/test_trading_account.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.cache.cache import Cache
 from nautilus_trader.cache.database import BypassCacheDatabase
 from nautilus_trader.common.clock import TestClock
@@ -52,8 +50,8 @@ ADABTC_BINANCE = TestInstrumentProvider.adabtc_binance()
 BTCUSDT_BINANCE = TestInstrumentProvider.btcusdt_binance()
 
 
-class AccountTests(unittest.TestCase):
-    def setUp(self):
+class TestAccount:
+    def setup(self):
         # Fixture Setup
         clock = TestClock()
         logger = Logger(clock)
@@ -116,12 +114,12 @@ class AccountTests(unittest.TestCase):
         self.portfolio.register_account(account)
 
         # Assert
-        self.assertEqual(AccountId("SIM", "001"), account.id)
-        self.assertEqual("Account(id=SIM-001)", str(account))
-        self.assertEqual("Account(id=SIM-001)", repr(account))
-        self.assertEqual(int, type(hash(account)))
-        self.assertTrue(account == account)
-        self.assertFalse(account != account)
+        assert account.id == AccountId("SIM", "001")
+        assert str(account) == "Account(id=SIM-001)"
+        assert repr(account) == "Account(id=SIM-001)"
+        assert type(hash(account)) == int
+        assert account == account
+        assert not account != account
 
     def test_instantiate_single_asset_account(self):
         # Arrange
@@ -152,22 +150,22 @@ class AccountTests(unittest.TestCase):
         self.portfolio.register_account(account)
 
         # Assert
-        self.assertEqual(USD, account.base_currency)
-        self.assertEqual(event, account.last_event)
-        self.assertEqual([event], account.events)
-        self.assertEqual(1, account.event_count)
-        self.assertEqual(Money(1_000_000, USD), account.balance_total())
-        self.assertEqual(Money(1_000_000, USD), account.balance_free())
-        self.assertEqual(Money(0, USD), account.balance_locked())
-        self.assertEqual({USD: Money(1_000_000, USD)}, account.balances_total())
-        self.assertEqual({USD: Money(1_000_000, USD)}, account.balances_free())
-        self.assertEqual({USD: Money(0, USD)}, account.balances_locked())
-        self.assertEqual(Money(0, USD), account.unrealized_pnl())
-        self.assertEqual(Money(1_000_000, USD), account.equity())
-        self.assertEqual({}, account.initial_margins())
-        self.assertEqual({}, account.maint_margins())
-        self.assertEqual(None, account.initial_margin())
-        self.assertEqual(None, account.maint_margin())
+        assert account.base_currency == USD
+        assert account.last_event == event
+        assert account.events == [event]
+        assert account.event_count == 1
+        assert account.balance_total() == Money(1_000_000, USD)
+        assert account.balance_free() == Money(1_000_000, USD)
+        assert account.balance_locked() == Money(0, USD)
+        assert account.balances_total() == {USD: Money(1_000_000, USD)}
+        assert account.balances_free() == {USD: Money(1_000_000, USD)}
+        assert account.balances_locked() == {USD: Money(0, USD)}
+        assert account.unrealized_pnl() == Money(0, USD)
+        assert account.equity() == Money(1_000_000, USD)
+        assert account.initial_margins() == {}
+        assert account.maint_margins() == {}
+        assert account.initial_margin() is None
+        assert account.maint_margin() is None
 
     def test_instantiate_multi_asset_account(self):
         # Arrange
@@ -204,39 +202,39 @@ class AccountTests(unittest.TestCase):
         self.portfolio.register_account(account)
 
         # Assert
-        self.assertEqual(AccountId("SIM", "001"), account.id)
-        self.assertEqual(None, account.base_currency)
-        self.assertEqual(event, account.last_event)
-        self.assertEqual([event], account.events)
-        self.assertEqual(1, account.event_count)
-        self.assertEqual(Money(10.00000000, BTC), account.balance_total(BTC))
-        self.assertEqual(Money(20.00000000, ETH), account.balance_total(ETH))
-        self.assertEqual(Money(10.00000000, BTC), account.balance_free(BTC))
-        self.assertEqual(Money(20.00000000, ETH), account.balance_free(ETH))
-        self.assertEqual(Money(0.00000000, BTC), account.balance_locked(BTC))
-        self.assertEqual(Money(0.00000000, ETH), account.balance_locked(ETH))
-        self.assertEqual(
-            {BTC: Money(10.00000000, BTC), ETH: Money(20.00000000, ETH)},
-            account.balances_total(),
-        )
-        self.assertEqual(
-            {BTC: Money(10.00000000, BTC), ETH: Money(20.00000000, ETH)},
-            account.balances_free(),
-        )
-        self.assertEqual(
-            {BTC: Money(0.00000000, BTC), ETH: Money(0.00000000, ETH)},
-            account.balances_locked(),
-        )
-        self.assertEqual(Money(0.00000000, BTC), account.unrealized_pnl(BTC))
-        self.assertEqual(Money(0.00000000, ETH), account.unrealized_pnl(ETH))
-        self.assertEqual(Money(10.00000000, BTC), account.equity(BTC))
-        self.assertEqual(Money(20.00000000, ETH), account.equity(ETH))
-        self.assertEqual({}, account.initial_margins())
-        self.assertEqual({}, account.maint_margins())
-        self.assertEqual(None, account.initial_margin(BTC))
-        self.assertEqual(None, account.initial_margin(ETH))
-        self.assertEqual(None, account.maint_margin(BTC))
-        self.assertEqual(None, account.maint_margin(ETH))
+        assert account.id == AccountId("SIM", "001")
+        assert account.base_currency is None
+        assert account.last_event == event
+        assert account.events == [event]
+        assert account.event_count == 1
+        assert account.balance_total(BTC) == Money(10.00000000, BTC)
+        assert account.balance_total(ETH) == Money(20.00000000, ETH)
+        assert account.balance_free(BTC) == Money(10.00000000, BTC)
+        assert account.balance_free(ETH) == Money(20.00000000, ETH)
+        assert account.balance_locked(BTC) == Money(0.00000000, BTC)
+        assert account.balance_locked(ETH) == Money(0.00000000, ETH)
+        assert {
+            BTC: Money(10.00000000, BTC),
+            ETH: Money(20.00000000, ETH),
+        } == account.balances_total()
+        assert {
+            BTC: Money(10.00000000, BTC),
+            ETH: Money(20.00000000, ETH),
+        } == account.balances_free()
+        assert {
+            BTC: Money(0.00000000, BTC),
+            ETH: Money(0.00000000, ETH),
+        } == account.balances_locked()
+        assert account.unrealized_pnl(BTC) == Money(0.00000000, BTC)
+        assert account.unrealized_pnl(ETH) == Money(0.00000000, ETH)
+        assert account.equity(BTC) == Money(10.00000000, BTC)
+        assert account.equity(ETH) == Money(20.00000000, ETH)
+        assert account.initial_margins() == {}
+        assert account.maint_margins() == {}
+        assert account.initial_margin(BTC) is None
+        assert account.initial_margin(ETH) is None
+        assert account.maint_margin(BTC) is None
+        assert account.maint_margin(ETH) is None
 
     def test_apply_given_new_state_event_updates_correctly(self):
         # Arrange
@@ -301,15 +299,15 @@ class AccountTests(unittest.TestCase):
         account.apply(event=event2)
 
         # Assert
-        self.assertEqual(event2, account.last_event)
-        self.assertEqual([event1, event2], account.events)
-        self.assertEqual(2, account.event_count)
-        self.assertEqual(Money(9.00000000, BTC), account.balance_total(BTC))
-        self.assertEqual(Money(8.50000000, BTC), account.balance_free(BTC))
-        self.assertEqual(Money(0.50000000, BTC), account.balance_locked(BTC))
-        self.assertEqual(Money(20.00000000, ETH), account.balance_total(ETH))
-        self.assertEqual(Money(20.00000000, ETH), account.balance_free(ETH))
-        self.assertEqual(Money(0.00000000, ETH), account.balance_locked(ETH))
+        assert account.last_event == event2
+        assert account.events == [event1, event2]
+        assert account.event_count == 2
+        assert account.balance_total(BTC) == Money(9.00000000, BTC)
+        assert account.balance_free(BTC) == Money(8.50000000, BTC)
+        assert account.balance_locked(BTC) == Money(0.50000000, BTC)
+        assert account.balance_total(ETH) == Money(20.00000000, ETH)
+        assert account.balance_free(ETH) == Money(20.00000000, ETH)
+        assert account.balance_locked(ETH) == Money(0.00000000, ETH)
 
     def test_update_initial_margin(self):
         # Arrange
@@ -351,8 +349,8 @@ class AccountTests(unittest.TestCase):
         account.update_initial_margin(margin)
 
         # Assert
-        self.assertEqual(margin, account.initial_margin(BTC))
-        self.assertEqual({BTC: margin}, account.initial_margins())
+        assert account.initial_margin(BTC) == margin
+        assert account.initial_margins() == {BTC: margin}
 
     def test_update_maint_margin(self):
         # Arrange
@@ -394,8 +392,8 @@ class AccountTests(unittest.TestCase):
         account.update_maint_margin(margin)
 
         # Assert
-        self.assertEqual(margin, account.maint_margin(BTC))
-        self.assertEqual({BTC: margin}, account.maint_margins())
+        assert account.maint_margin(BTC) == margin
+        assert account.maint_margins() == {BTC: margin}
 
     def test_unrealized_pnl_with_single_asset_account_when_no_open_positions_returns_zero(
         self,
@@ -430,7 +428,7 @@ class AccountTests(unittest.TestCase):
         result = account.unrealized_pnl()
 
         # Assert
-        self.assertEqual(Money(0, USD), result)
+        assert result == Money(0, USD)
 
     def test_unrealized_pnl_with_multi_asset_account_when_no_open_positions_returns_zero(
         self,
@@ -471,7 +469,7 @@ class AccountTests(unittest.TestCase):
         result = account.unrealized_pnl(BTC)
 
         # Assert
-        self.assertEqual(Money(0.00000000, BTC), result)
+        assert result == Money(0.00000000, BTC)
 
     def test_equity_with_single_asset_account_no_default_returns_none(self):
         # Arrange
@@ -504,7 +502,7 @@ class AccountTests(unittest.TestCase):
         result = account.equity(BTC)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_equity_with_single_asset_account_returns_expected_money(self):
         # Arrange
@@ -537,7 +535,7 @@ class AccountTests(unittest.TestCase):
         result = account.equity()
 
         # Assert
-        self.assertEqual(Money(100000.00, USD), result)
+        assert result == Money(100000.00, USD)
 
     def test_equity_with_multi_asset_account_returns_expected_money(self):
         # Arrange
@@ -576,7 +574,7 @@ class AccountTests(unittest.TestCase):
         result = account.equity(BTC)
 
         # Assert
-        self.assertEqual(Money(10.00000000, BTC), result)
+        assert result == Money(10.00000000, BTC)
 
     def test_margin_available_for_single_asset_account(self):
         # Arrange
@@ -613,9 +611,9 @@ class AccountTests(unittest.TestCase):
         result3 = account.margin_available()
 
         # Assert
-        self.assertEqual(Money(100000.00, USD), result1)
-        self.assertEqual(Money(99500.00, USD), result2)
-        self.assertEqual(Money(98500.00, USD), result3)
+        assert result1 == Money(100000.00, USD)
+        assert result2 == Money(99500.00, USD)
+        assert result3 == Money(98500.00, USD)
 
     def test_margin_available_for_multi_asset_account(self):
         # Arrange
@@ -659,10 +657,10 @@ class AccountTests(unittest.TestCase):
         result4 = account.margin_available(ETH)
 
         # Assert
-        self.assertEqual(Money(10.00000000, BTC), result1)
-        self.assertEqual(Money(9.99990000, BTC), result2)
-        self.assertEqual(Money(9.99970000, BTC), result3)
-        self.assertEqual(Money(20.00000000, ETH), result4)
+        assert result1 == Money(10.00000000, BTC)
+        assert result2 == Money(9.99990000, BTC)
+        assert result3 == Money(9.99970000, BTC)
+        assert result4 == Money(20.00000000, ETH)
 
     def test_calculate_pnls_for_single_currency_cash_account(self):
         # Arrange

--- a/tests/unit_tests/trading/test_trading_account.py
+++ b/tests/unit_tests/trading/test_trading_account.py
@@ -213,18 +213,18 @@ class TestAccount:
         assert account.balance_free(ETH) == Money(20.00000000, ETH)
         assert account.balance_locked(BTC) == Money(0.00000000, BTC)
         assert account.balance_locked(ETH) == Money(0.00000000, ETH)
-        assert {
+        assert account.balances_total() == {
             BTC: Money(10.00000000, BTC),
             ETH: Money(20.00000000, ETH),
-        } == account.balances_total()
-        assert {
+        }
+        assert account.balances_free() == {
             BTC: Money(10.00000000, BTC),
             ETH: Money(20.00000000, ETH),
-        } == account.balances_free()
-        assert {
+        }
+        assert account.balances_locked() == {
             BTC: Money(0.00000000, BTC),
             ETH: Money(0.00000000, ETH),
-        } == account.balances_locked()
+        }
         assert account.unrealized_pnl(BTC) == Money(0.00000000, BTC)
         assert account.unrealized_pnl(ETH) == Money(0.00000000, ETH)
         assert account.equity(BTC) == Money(10.00000000, BTC)

--- a/tests/unit_tests/trading/test_trading_calculators.py
+++ b/tests/unit_tests/trading/test_trading_calculators.py
@@ -16,9 +16,9 @@
 import datetime
 from decimal import Decimal
 import os
-import unittest
 
 import pandas as pd
+import pytest
 
 from nautilus_trader.model.currencies import AUD
 from nautilus_trader.model.currencies import BTC
@@ -37,7 +37,7 @@ GBPUSD_SIM = TestStubs.gbpusd_id()
 USDJPY_SIM = TestStubs.usdjpy_id()
 
 
-class ExchangeRateCalculatorTests(unittest.TestCase):
+class TestExchangeRateCalculator:
     def test_get_rate_when_price_type_last_raises_value_error(self):
         # Arrange
         converter = ExchangeRateCalculator()
@@ -46,15 +46,8 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(
-            ValueError,
-            converter.get_rate,
-            USD,
-            JPY,
-            PriceType.LAST,
-            bid_rates,
-            ask_rates,
-        )
+        with pytest.raises(ValueError):
+            converter.get_rate(USD, JPY, PriceType.LAST, bid_rates, ask_rates)
 
     def test_get_rate_when_from_currency_equals_to_currency_returns_one(self):
         # Arrange
@@ -72,7 +65,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(1, result)
+        assert result == 1
 
     def test_get_rate_when_no_currency_rate_returns_zero(self):
         # Arrange
@@ -90,7 +83,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(0, result)
+        assert result == 0
 
     def test_get_rate(self):
         # Arrange
@@ -108,7 +101,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Decimal("0.80000"), result)
+        assert result == Decimal("0.80000")
 
     def test_get_rate_when_symbol_has_slash(self):
         # Arrange
@@ -126,7 +119,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Decimal("0.80000"), result)
+        assert result == Decimal("0.80000")
 
     def test_get_rate_for_inverse1(self):
         # Arrange
@@ -144,7 +137,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Decimal("0.00009522449173927534161786411465"), result)
+        assert result == Decimal("0.00009522449173927534161786411465")
 
     def test_get_rate_for_inverse2(self):
         # Arrange
@@ -162,7 +155,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertAlmostEqual(Decimal("0.009082652"), result)
+        assert Decimal("0.009082652") == pytest.approx(result)
 
     def test_calculate_exchange_rate_by_inference(self):
         # Arrange
@@ -194,8 +187,8 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertAlmostEqual(Decimal("0.01135331516802906448683015441"), result1)  # JPYAUD
-        self.assertAlmostEqual(Decimal("88.11501299999999999999999997"), result2)  # AUDJPY
+        assert Decimal("0.01135331516802906448683015441") == pytest.approx(result1)  # JPYAUD
+        assert Decimal("88.11501299999999999999999997") == pytest.approx(result2)  # AUDJPY
 
     def test_calculate_exchange_rate_for_mid_price_type(self):
         # Arrange
@@ -213,7 +206,7 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Decimal("0.009081414884438995595513781047"), result)
+        assert result == Decimal("0.009081414884438995595513781047")
 
     def test_calculate_exchange_rate_for_mid_price_type2(self):
         # Arrange
@@ -231,11 +224,11 @@ class ExchangeRateCalculatorTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Decimal("110.115"), result)
+        assert result == Decimal("110.115")
 
 
-class RolloverInterestCalculatorTests(unittest.TestCase):
-    def setUp(self):
+class TestRolloverInterestCalculator:
+    def setup(self):
         # Fixture Setup
         self.data = pd.read_csv(os.path.join(PACKAGE_ROOT, "data", "short-term-interest.csv"))
 
@@ -247,7 +240,7 @@ class RolloverInterestCalculatorTests(unittest.TestCase):
         rate_data = calculator.get_rate_data()
 
         # Assert
-        self.assertEqual(dict, type(rate_data))
+        assert type(rate_data) == dict
 
     def test_calc_overnight_fx_rate_with_audusd_on_unix_epoch_returns_correct_rate(
         self,
@@ -259,7 +252,7 @@ class RolloverInterestCalculatorTests(unittest.TestCase):
         rate = calculator.calc_overnight_rate(AUDUSD_SIM, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(-8.52054794520548e-05, rate)
+        assert rate == -8.52054794520548e-05
 
     def test_calc_overnight_fx_rate_with_audusd_on_later_date_returns_correct_rate(
         self,
@@ -271,7 +264,7 @@ class RolloverInterestCalculatorTests(unittest.TestCase):
         rate = calculator.calc_overnight_rate(AUDUSD_SIM, datetime.date(2018, 2, 1))
 
         # Assert
-        self.assertEqual(-2.739726027397263e-07, rate)
+        assert rate == -2.739726027397263e-07
 
     def test_calc_overnight_fx_rate_with_audusd_on_impossible_dates_returns_zero(self):
         # Arrange
@@ -279,15 +272,8 @@ class RolloverInterestCalculatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(
-            RuntimeError,
-            calculator.calc_overnight_rate,
-            AUDUSD_SIM,
-            datetime.date(1900, 1, 1),
-        )
-        self.assertRaises(
-            RuntimeError,
-            calculator.calc_overnight_rate,
-            AUDUSD_SIM,
-            datetime.date(3000, 1, 1),
-        )
+        with pytest.raises(RuntimeError):
+            calculator.calc_overnight_rate(AUDUSD_SIM, datetime.date(1900, 1, 1))
+
+        with pytest.raises(RuntimeError):
+            calculator.calc_overnight_rate(AUDUSD_SIM, datetime.date(3000, 1, 1))

--- a/tests/unit_tests/trading/test_trading_filters.py
+++ b/tests/unit_tests/trading/test_trading_filters.py
@@ -15,10 +15,10 @@
 
 from datetime import datetime
 import os
-import unittest
 
 import pandas as pd
 from parameterized import parameterized
+import pytest
 import pytz
 
 from nautilus_trader.core.datetime import as_utc_index
@@ -29,8 +29,8 @@ from tests.test_kit import PACKAGE_ROOT
 from tests.test_kit.stubs import UNIX_EPOCH
 
 
-class ForexSessionFilterTests(unittest.TestCase):
-    def setUp(self):
+class TestForexSessionFilter:
+    def setup(self):
         # Fixture Setup
         self.session_filter = ForexSessionFilter()
 
@@ -50,7 +50,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.local_from_utc(session, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(expected, str(result))
+        assert str(result) == expected
 
     @parameterized.expand(
         [
@@ -66,7 +66,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.next_start(session, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(expected, result)
+        assert result == expected
 
     def test_next_start_on_weekend_returns_expected_datetime_monday(self):
         # Arrange
@@ -75,7 +75,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.next_start(ForexSession.TOKYO, time_now)
 
         # Assert
-        self.assertEqual(datetime(2020, 7, 13, 0, 0, tzinfo=pytz.utc), result)
+        assert result == datetime(2020, 7, 13, 0, 0, tzinfo=pytz.utc)
 
     def test_next_in_session_returns_expected_datetime_next_day(self):
         # Arrange
@@ -84,7 +84,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.next_start(ForexSession.TOKYO, time_now)
 
         # Assert
-        self.assertEqual(datetime(2020, 7, 14, 0, 0, tzinfo=pytz.utc), result)
+        assert result == datetime(2020, 7, 14, 0, 0, tzinfo=pytz.utc)
 
     @parameterized.expand(
         [
@@ -100,7 +100,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.prev_start(session, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(expected, result)
+        assert result == expected
 
     @parameterized.expand(
         [
@@ -116,7 +116,7 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.next_end(session, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(expected, result)
+        assert result == expected
 
     @parameterized.expand(
         [
@@ -132,11 +132,11 @@ class ForexSessionFilterTests(unittest.TestCase):
         result = self.session_filter.prev_end(session, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(expected, result)
+        assert result == expected
 
 
-class EconomicNewsEventFilterTests(unittest.TestCase):
-    def setUp(self):
+class TestEconomicNewsEventFilter:
+    def setup(self):
         # Fixture Setup
         news_csv_path = os.path.join(PACKAGE_ROOT, "data", "news_events.csv")
         self.news_data = as_utc_index(pd.read_csv(news_csv_path, parse_dates=True, index_col=0))
@@ -153,16 +153,12 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(
-            pd.Timestamp("2008-01-01 10:00:00+0000", tz="UTC"),
-            news_filter.unfiltered_data_start,
+        assert (
+            pd.Timestamp("2008-01-01 10:00:00+0000", tz="UTC") == news_filter.unfiltered_data_start
         )
-        self.assertEqual(
-            pd.Timestamp("2020-12-31 23:00:00+0000", tz="UTC"),
-            news_filter.unfiltered_data_end,
-        )
-        self.assertEqual(currencies, news_filter.currencies)
-        self.assertEqual(impacts, news_filter.impacts)
+        assert pd.Timestamp("2020-12-31 23:00:00+0000", tz="UTC") == news_filter.unfiltered_data_end
+        assert news_filter.currencies == currencies
+        assert news_filter.impacts == impacts
 
     def test_initialize_filter_with_no_currencies_or_impacts_returns_none(self):
         # Arrange
@@ -179,8 +175,8 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
         event_prev = news_filter.next_event(datetime(2012, 3, 15, 12, 0, tzinfo=pytz.utc))
 
         # Assert
-        self.assertIsNone(event_next)
-        self.assertIsNone(event_prev)
+        assert event_next is None
+        assert event_prev is None
 
     def test_next_event_given_time_now_before_data_raises_value_error(self):
         # Arrange
@@ -192,7 +188,8 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(ValueError, news_filter.next_event, UNIX_EPOCH)
+        with pytest.raises(ValueError):
+            news_filter.next_event(UNIX_EPOCH)
 
     def test_next_event_given_time_now_after_data_raises_value_error(self):
         # Arrange
@@ -204,11 +201,8 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(
-            ValueError,
-            news_filter.next_event,
-            datetime(2050, 1, 1, 1, 1, tzinfo=pytz.utc),
-        )
+        with pytest.raises(ValueError):
+            news_filter.next_event(datetime(2050, 1, 1, 1, 1, tzinfo=pytz.utc))
 
     def test_prev_event_given_time_now_before_data_raises_value_error(self):
         # Arrange
@@ -220,7 +214,8 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(ValueError, news_filter.prev_event, UNIX_EPOCH)
+        with pytest.raises(ValueError):
+            news_filter.prev_event(UNIX_EPOCH)
 
     def test_prev_event_given_time_now_after_data_raises_value_error(self):
         # Arrange
@@ -232,11 +227,8 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(
-            ValueError,
-            news_filter.prev_event,
-            datetime(2050, 1, 1, 1, 1, tzinfo=pytz.utc),
-        )
+        with pytest.raises(ValueError):
+            news_filter.prev_event(datetime(2050, 1, 1, 1, 1, tzinfo=pytz.utc))
 
     def test_next_event_given_valid_date_returns_expected_news_event(self):
         # Arrange
@@ -248,7 +240,7 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         event = news_filter.prev_event(datetime(2015, 5, 10, 12, 0, tzinfo=pytz.utc))
-        self.assertEqual(1431088200000000000, event.ts_event_ns)
+        assert event.ts_event_ns == 1431088200000000000
 
     def test_prev_event_given_valid_date_returns_expected_news_event(self):
         # Arrange
@@ -260,4 +252,4 @@ class EconomicNewsEventFilterTests(unittest.TestCase):
 
         # Act
         event = news_filter.prev_event(datetime(2017, 8, 10, 15, 0, tzinfo=pytz.utc))
-        self.assertEqual(1501849800000000000, event.ts_event_ns)
+        assert event.ts_event_ns == 1501849800000000000

--- a/tests/unit_tests/trading/test_trading_portfolio.py
+++ b/tests/unit_tests/trading/test_trading_portfolio.py
@@ -14,7 +14,8 @@
 # -------------------------------------------------------------------------------------------------
 
 from decimal import Decimal
-import unittest
+
+import pytest
 
 from nautilus_trader.cache.cache import Cache
 from nautilus_trader.cache.database import BypassCacheDatabase
@@ -61,14 +62,15 @@ BTCUSD_BITMEX = TestInstrumentProvider.xbtusd_bitmex()
 ETHUSD_BITMEX = TestInstrumentProvider.ethusd_bitmex()
 
 
-class PortfolioFacadeTests(unittest.TestCase):
+class TestPortfolioFacade:
     def test_account_raises_not_implemented_error(self):
         # Arrange
         portfolio = PortfolioFacade()
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.account, SIM)
+        with pytest.raises(NotImplementedError):
+            portfolio.account(SIM)
 
     def test_order_margin_raises_not_implemented_error(self):
         # Arrange
@@ -76,7 +78,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.initial_margins, SIM)
+        with pytest.raises(NotImplementedError):
+            portfolio.initial_margins(SIM)
 
     def test_position_margin_raises_not_implemented_error(self):
         # Arrange
@@ -84,7 +87,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.maint_margins, SIM)
+        with pytest.raises(NotImplementedError):
+            portfolio.maint_margins(SIM)
 
     def test_unrealized_pnl_for_venue_raises_not_implemented_error(self):
         # Arrange
@@ -92,7 +96,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.unrealized_pnls, SIM)
+        with pytest.raises(NotImplementedError):
+            portfolio.unrealized_pnls(SIM)
 
     def test_unrealized_pnl_for_instrument_raises_not_implemented_error(self):
         # Arrange
@@ -100,7 +105,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.unrealized_pnl, BTCUSDT_BINANCE.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.unrealized_pnl(BTCUSDT_BINANCE.id)
 
     def test_market_value_raises_not_implemented_error(self):
         # Arrange
@@ -108,7 +114,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.net_exposure, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.net_exposure(AUDUSD_SIM.id)
 
     def test_market_values_raises_not_implemented_error(self):
         # Arrange
@@ -116,7 +123,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.net_exposures, BITMEX)
+        with pytest.raises(NotImplementedError):
+            portfolio.net_exposures(BITMEX)
 
     def test_net_position_raises_not_implemented_error(self):
         # Arrange
@@ -124,7 +132,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.net_position, GBPUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.net_position(GBPUSD_SIM.id)
 
     def test_is_net_long_raises_not_implemented_error(self):
         # Arrange
@@ -132,7 +141,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.is_net_long, GBPUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.is_net_long(GBPUSD_SIM.id)
 
     def test_is_net_short_raises_not_implemented_error(self):
         # Arrange
@@ -140,7 +150,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.is_net_short, GBPUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.is_net_short(GBPUSD_SIM.id)
 
     def test_is_flat_raises_not_implemented_error(self):
         # Arrange
@@ -148,7 +159,8 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.is_flat, GBPUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            portfolio.is_flat(GBPUSD_SIM.id)
 
     def test_is_completely_flat_raises_not_implemented_error(self):
         # Arrange
@@ -156,11 +168,12 @@ class PortfolioFacadeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, portfolio.is_completely_flat)
+        with pytest.raises(NotImplementedError):
+            portfolio.is_completely_flat()
 
 
-class PortfolioTests(unittest.TestCase):
-    def setUp(self):
+class TestPortfolio:
+    def setup(self):
         # Fixture Setup
         clock = TestClock()
         logger = Logger(clock, level_stdout=LogLevel.DEBUG)
@@ -217,7 +230,7 @@ class PortfolioTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.portfolio.account(SIM))
+        assert self.portfolio.account(SIM) is None
 
     def test_account_when_account_returns_the_account_facade(self):
         # Arrange
@@ -245,67 +258,67 @@ class PortfolioTests(unittest.TestCase):
         result = self.portfolio.account(BINANCE)
 
         # Assert
-        self.assertEqual("BINANCE", result.id.issuer)
+        assert result.id.issuer == "BINANCE"
 
     def test_net_position_when_no_positions_returns_zero(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(Decimal(0), self.portfolio.net_position(AUDUSD_SIM.id))
+        assert self.portfolio.net_position(AUDUSD_SIM.id) == Decimal(0)
 
     def test_is_net_long_when_no_positions_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.portfolio.is_net_long(AUDUSD_SIM.id))
+        assert self.portfolio.is_net_long(AUDUSD_SIM.id) is False
 
     def test_is_net_short_when_no_positions_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.portfolio.is_net_short(AUDUSD_SIM.id))
+        assert self.portfolio.is_net_short(AUDUSD_SIM.id) is False
 
     def test_is_flat_when_no_positions_returns_true(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(True, self.portfolio.is_flat(AUDUSD_SIM.id))
+        assert self.portfolio.is_flat(AUDUSD_SIM.id) is True
 
     def test_is_completely_flat_when_no_positions_returns_true(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(True, self.portfolio.is_flat(AUDUSD_SIM.id))
+        assert self.portfolio.is_flat(AUDUSD_SIM.id) is True
 
     def test_unrealized_pnl_for_instrument_when_no_instrument_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.portfolio.unrealized_pnl(USDJPY_SIM.id))
+        assert self.portfolio.unrealized_pnl(USDJPY_SIM.id) is None
 
     def test_unrealized_pnl_for_venue_when_no_account_returns_empty_dict(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual({}, self.portfolio.unrealized_pnls(SIM))
+        assert self.portfolio.unrealized_pnls(SIM) == {}
 
     def test_initial_margins_when_no_account_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(None, self.portfolio.initial_margins(SIM))
+        assert self.portfolio.initial_margins(SIM) is None
 
     def test_maint_margins_when_no_account_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(None, self.portfolio.maint_margins(SIM))
+        assert self.portfolio.maint_margins(SIM) is None
 
     def test_open_value_when_no_account_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(None, self.portfolio.net_exposures(SIM))
+        assert self.portfolio.net_exposures(SIM) is None
 
     def test_update_tick(self):
         # Arrange
@@ -315,7 +328,7 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_tick(tick)
 
         # Assert
-        self.assertIsNone(self.portfolio.unrealized_pnl(GBPUSD_SIM.id))
+        assert self.portfolio.unrealized_pnl(GBPUSD_SIM.id) is None
 
     def test_update_orders_working(self):
         # Arrange
@@ -395,7 +408,7 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.initialize_orders()
 
         # Assert
-        self.assertEqual({}, self.portfolio.initial_margins(BINANCE))
+        assert self.portfolio.initial_margins(BINANCE) == {}
 
     def test_update_positions(self):
         # Arrange
@@ -501,7 +514,7 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_tick(last)
 
         # Assert
-        self.assertTrue(self.portfolio.is_net_long(BTCUSDT_BINANCE.id))
+        assert self.portfolio.is_net_long(BTCUSDT_BINANCE.id)
 
     def test_opening_one_long_position_updates_portfolio(self):
         # Arrange
@@ -566,34 +579,16 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_opened(position))
 
         # Assert
-        self.assertEqual(
-            {USDT: Money(105100.00000000, USDT)},
-            self.portfolio.net_exposures(BINANCE),
-        )
-        self.assertEqual(
-            {USDT: Money(100.00000000, USDT)},
-            self.portfolio.unrealized_pnls(BINANCE),
-        )
-        self.assertEqual(
-            {USDT: Money(105.10000000, USDT)},
-            self.portfolio.maint_margins(BINANCE),
-        )
-        self.assertEqual(
-            Money(105100.00000000, USDT),
-            self.portfolio.net_exposure(BTCUSDT_BINANCE.id),
-        )
-        self.assertEqual(
-            Money(100.00000000, USDT),
-            self.portfolio.unrealized_pnl(BTCUSDT_BINANCE.id),
-        )
-        self.assertEqual(
-            Decimal("10.00000000"),
-            self.portfolio.net_position(order.instrument_id),
-        )
-        self.assertTrue(self.portfolio.is_net_long(order.instrument_id))
-        self.assertFalse(self.portfolio.is_net_short(order.instrument_id))
-        self.assertFalse(self.portfolio.is_flat(order.instrument_id))
-        self.assertFalse(self.portfolio.is_completely_flat())
+        assert self.portfolio.net_exposures(BINANCE) == {USDT: Money(105100.00000000, USDT)}
+        assert self.portfolio.unrealized_pnls(BINANCE) == {USDT: Money(100.00000000, USDT)}
+        assert self.portfolio.maint_margins(BINANCE) == {USDT: Money(105.10000000, USDT)}
+        assert self.portfolio.net_exposure(BTCUSDT_BINANCE.id) == Money(105100.00000000, USDT)
+        assert self.portfolio.unrealized_pnl(BTCUSDT_BINANCE.id) == Money(100.00000000, USDT)
+        assert self.portfolio.net_position(order.instrument_id) == Decimal("10.00000000")
+        assert self.portfolio.is_net_long(order.instrument_id)
+        assert not self.portfolio.is_net_short(order.instrument_id)
+        assert not self.portfolio.is_flat(order.instrument_id)
+        assert not self.portfolio.is_completely_flat()
 
     def test_opening_one_short_position_updates_portfolio(self):
         # Arrange
@@ -658,34 +653,16 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_opened(position))
 
         # Assert
-        self.assertEqual(
-            {USDT: Money(7987.77875000, USDT)},
-            self.portfolio.net_exposures(BINANCE),
-        )
-        self.assertEqual(
-            {USDT: Money(-262.77875000, USDT)},
-            self.portfolio.unrealized_pnls(BINANCE),
-        )
-        self.assertEqual(
-            {USDT: Money(7.98777875, USDT)},
-            self.portfolio.maint_margins(BINANCE),
-        )
-        self.assertEqual(
-            Money(7987.77875000, USDT),
-            self.portfolio.net_exposure(BTCUSDT_BINANCE.id),
-        )
-        self.assertEqual(
-            Money(-262.77875000, USDT),
-            self.portfolio.unrealized_pnl(BTCUSDT_BINANCE.id),
-        )
-        self.assertEqual(
-            Decimal("-0.515"),
-            self.portfolio.net_position(order.instrument_id),
-        )
-        self.assertFalse(self.portfolio.is_net_long(order.instrument_id))
-        self.assertTrue(self.portfolio.is_net_short(order.instrument_id))
-        self.assertFalse(self.portfolio.is_flat(order.instrument_id))
-        self.assertFalse(self.portfolio.is_completely_flat())
+        assert self.portfolio.net_exposures(BINANCE) == {USDT: Money(7987.77875000, USDT)}
+        assert self.portfolio.unrealized_pnls(BINANCE) == {USDT: Money(-262.77875000, USDT)}
+        assert self.portfolio.maint_margins(BINANCE) == {USDT: Money(7.98777875, USDT)}
+        assert self.portfolio.net_exposure(BTCUSDT_BINANCE.id) == Money(7987.77875000, USDT)
+        assert self.portfolio.unrealized_pnl(BTCUSDT_BINANCE.id) == Money(-262.77875000, USDT)
+        assert self.portfolio.net_position(order.instrument_id) == Decimal("-0.515")
+        assert not self.portfolio.is_net_long(order.instrument_id)
+        assert self.portfolio.is_net_short(order.instrument_id)
+        assert not self.portfolio.is_flat(order.instrument_id)
+        assert not self.portfolio.is_completely_flat()
 
     def test_opening_positions_with_multi_asset_account(self):
         # Arrange
@@ -762,22 +739,10 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_opened(position))
 
         # Assert
-        self.assertEqual(
-            {ETH: Money(26.59220848, ETH)},
-            self.portfolio.net_exposures(BITMEX),
-        )
-        self.assertEqual(
-            {ETH: Money(0.20608962, ETH)},
-            self.portfolio.maint_margins(BITMEX),
-        )
-        self.assertEqual(
-            Money(26.59220848, ETH),
-            self.portfolio.net_exposure(ETHUSD_BITMEX.id),
-        )
-        self.assertEqual(
-            Money(0.00000000, ETH),
-            self.portfolio.unrealized_pnl(ETHUSD_BITMEX.id),
-        )
+        assert self.portfolio.net_exposures(BITMEX) == {ETH: Money(26.59220848, ETH)}
+        assert self.portfolio.maint_margins(BITMEX) == {ETH: Money(0.20608962, ETH)}
+        assert self.portfolio.net_exposure(ETHUSD_BITMEX.id) == Money(26.59220848, ETH)
+        assert self.portfolio.unrealized_pnl(ETHUSD_BITMEX.id) == Money(0.00000000, ETH)
 
     def test_unrealized_pnl_when_insufficient_data_for_xrate_returns_none(self):
         # Arrange
@@ -836,7 +801,7 @@ class PortfolioTests(unittest.TestCase):
         result = self.portfolio.unrealized_pnls(BITMEX)
 
         # # Assert
-        self.assertEqual({}, result)
+        assert result == {}
 
     def test_market_value_when_insufficient_data_for_xrate_returns_none(self):
         # Arrange
@@ -908,7 +873,7 @@ class PortfolioTests(unittest.TestCase):
         result = self.portfolio.net_exposures(BITMEX)
 
         # Assert
-        self.assertEqual({BTC: Money(0.00200000, BTC)}, result)
+        assert result == {BTC: Money(0.00200000, BTC)}
 
     def test_opening_several_positions_updates_portfolio(self):
         # Arrange
@@ -1004,37 +969,19 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(position_opened2)
 
         # Assert
-        self.assertEqual(
-            {USD: Money(210816.00, USD)},
-            self.portfolio.net_exposures(SIM),
-        )
-        self.assertEqual(
-            {USD: Money(10816.00, USD)},
-            self.portfolio.unrealized_pnls(SIM),
-        )
-        self.assertEqual({USD: Money(3912.06, USD)}, self.portfolio.maint_margins(SIM)),
-        self.assertEqual(
-            Money(80501.00, USD),
-            self.portfolio.net_exposure(AUDUSD_SIM.id),
-        )
-        self.assertEqual(
-            Money(130315.00, USD),
-            self.portfolio.net_exposure(GBPUSD_SIM.id),
-        )
-        self.assertEqual(
-            Money(-19499.00, USD),
-            self.portfolio.unrealized_pnl(AUDUSD_SIM.id),
-        )
-        self.assertEqual(
-            Money(30315.00, USD),
-            self.portfolio.unrealized_pnl(GBPUSD_SIM.id),
-        )
-        self.assertEqual(Decimal(100000), self.portfolio.net_position(AUDUSD_SIM.id))
-        self.assertEqual(Decimal(100000), self.portfolio.net_position(GBPUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_net_long(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_net_short(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_flat(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_completely_flat())
+        assert self.portfolio.net_exposures(SIM) == {USD: Money(210816.00, USD)}
+        assert self.portfolio.unrealized_pnls(SIM) == {USD: Money(10816.00, USD)}
+        assert self.portfolio.maint_margins(SIM) == {USD: Money(3912.06, USD)}
+        assert self.portfolio.net_exposure(AUDUSD_SIM.id) == Money(80501.00, USD)
+        assert self.portfolio.net_exposure(GBPUSD_SIM.id) == Money(130315.00, USD)
+        assert self.portfolio.unrealized_pnl(AUDUSD_SIM.id) == Money(-19499.00, USD)
+        assert self.portfolio.unrealized_pnl(GBPUSD_SIM.id) == Money(30315.00, USD)
+        assert self.portfolio.net_position(AUDUSD_SIM.id) == Decimal(100000)
+        assert self.portfolio.net_position(GBPUSD_SIM.id) == Decimal(100000)
+        assert self.portfolio.is_net_long(AUDUSD_SIM.id)
+        assert not self.portfolio.is_net_short(AUDUSD_SIM.id)
+        assert not self.portfolio.is_flat(AUDUSD_SIM.id)
+        assert not self.portfolio.is_completely_flat()
 
     def test_modifying_position_updates_portfolio(self):
         # Arrange
@@ -1110,33 +1057,18 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_changed(position))
 
         # Assert
-        self.assertEqual(
-            {USD: Money(40250.50, USD)},
-            self.portfolio.net_exposures(SIM),
-        )
-        self.assertEqual(
-            {USD: Money(-9749.50, USD)},
-            self.portfolio.unrealized_pnls(SIM),
-        )
-        self.assertEqual(
-            {USD: Money(1208.32, USD)},
-            self.portfolio.maint_margins(SIM),
-        )
-        self.assertEqual(
-            Money(40250.50, USD),
-            self.portfolio.net_exposure(AUDUSD_SIM.id),
-        )
-        self.assertEqual(
-            Money(-9749.50, USD),
-            self.portfolio.unrealized_pnl(AUDUSD_SIM.id),
-        )
-        self.assertEqual(Decimal(50000), self.portfolio.net_position(AUDUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_net_long(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_net_short(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_flat(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_completely_flat())
-        self.assertEqual({}, self.portfolio.unrealized_pnls(BINANCE))
-        self.assertIsNone(self.portfolio.net_exposures(BINANCE))
+        assert self.portfolio.net_exposures(SIM) == {USD: Money(40250.50, USD)}
+        assert self.portfolio.unrealized_pnls(SIM) == {USD: Money(-9749.50, USD)}
+        assert self.portfolio.maint_margins(SIM) == {USD: Money(1208.32, USD)}
+        assert self.portfolio.net_exposure(AUDUSD_SIM.id) == Money(40250.50, USD)
+        assert self.portfolio.unrealized_pnl(AUDUSD_SIM.id) == Money(-9749.50, USD)
+        assert self.portfolio.net_position(AUDUSD_SIM.id) == Decimal(50000)
+        assert self.portfolio.is_net_long(AUDUSD_SIM.id)
+        assert not self.portfolio.is_net_short(AUDUSD_SIM.id)
+        assert not self.portfolio.is_flat(AUDUSD_SIM.id)
+        assert not self.portfolio.is_completely_flat()
+        assert self.portfolio.unrealized_pnls(BINANCE) == {}
+        assert self.portfolio.net_exposures(BINANCE) is None
 
     def test_closing_position_updates_portfolio(self):
         # Arrange
@@ -1200,16 +1132,16 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_closed(position))
 
         # Assert
-        self.assertEqual({}, self.portfolio.net_exposures(SIM))
-        self.assertEqual({}, self.portfolio.unrealized_pnls(SIM))
-        self.assertEqual({}, self.portfolio.maint_margins(SIM))
-        self.assertEqual(Money(0, USD), self.portfolio.net_exposure(AUDUSD_SIM.id))
-        self.assertEqual(Money(0, USD), self.portfolio.unrealized_pnl(AUDUSD_SIM.id))
-        self.assertEqual(Decimal(0), self.portfolio.net_position(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_net_long(AUDUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_net_short(AUDUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_flat(AUDUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_completely_flat())
+        assert self.portfolio.net_exposures(SIM) == {}
+        assert self.portfolio.unrealized_pnls(SIM) == {}
+        assert self.portfolio.maint_margins(SIM) == {}
+        assert self.portfolio.net_exposure(AUDUSD_SIM.id) == Money(0, USD)
+        assert self.portfolio.unrealized_pnl(AUDUSD_SIM.id) == Money(0, USD)
+        assert self.portfolio.net_position(AUDUSD_SIM.id) == Decimal(0)
+        assert not self.portfolio.is_net_long(AUDUSD_SIM.id)
+        assert not self.portfolio.is_net_short(AUDUSD_SIM.id)
+        assert self.portfolio.is_flat(AUDUSD_SIM.id)
+        assert self.portfolio.is_completely_flat()
 
     def test_several_positions_with_different_instruments_updates_portfolio(self):
         # Arrange
@@ -1333,26 +1265,14 @@ class PortfolioTests(unittest.TestCase):
         self.portfolio.update_position(TestStubs.event_position_closed(position3))
 
         # Assert
-        self.assertEqual(
-            {USD: Money(-38998.00, USD)},
-            self.portfolio.unrealized_pnls(SIM),
-        )
-        self.assertEqual(
-            {USD: Money(161002.00, USD)},
-            self.portfolio.net_exposures(SIM),
-        )
-        self.assertEqual({USD: Money(3912.06, USD)}, self.portfolio.maint_margins(SIM)),
-        self.assertEqual(
-            Money(161002.00, USD),
-            self.portfolio.net_exposure(AUDUSD_SIM.id),
-        )
-        self.assertEqual(
-            Money(-38998.00, USD),
-            self.portfolio.unrealized_pnl(AUDUSD_SIM.id),
-        )
-        self.assertEqual(Money(0, USD), self.portfolio.unrealized_pnl(GBPUSD_SIM.id))
-        self.assertEqual(Decimal(200000), self.portfolio.net_position(AUDUSD_SIM.id))
-        self.assertEqual(Decimal(0), self.portfolio.net_position(GBPUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_net_long(AUDUSD_SIM.id))
-        self.assertTrue(self.portfolio.is_flat(GBPUSD_SIM.id))
-        self.assertFalse(self.portfolio.is_completely_flat())
+        assert {USD: Money(-38998.00, USD)} == self.portfolio.unrealized_pnls(SIM)
+        assert {USD: Money(161002.00, USD)} == self.portfolio.net_exposures(SIM)
+        assert self.portfolio.maint_margins(SIM) == {USD: Money(3912.06, USD)}
+        assert Money(161002.00, USD) == self.portfolio.net_exposure(AUDUSD_SIM.id)
+        assert Money(-38998.00, USD) == self.portfolio.unrealized_pnl(AUDUSD_SIM.id)
+        assert self.portfolio.unrealized_pnl(GBPUSD_SIM.id) == Money(0, USD)
+        assert self.portfolio.net_position(AUDUSD_SIM.id) == Decimal(200000)
+        assert self.portfolio.net_position(GBPUSD_SIM.id) == Decimal(0)
+        assert self.portfolio.is_net_long(AUDUSD_SIM.id)
+        assert self.portfolio.is_flat(GBPUSD_SIM.id)
+        assert not self.portfolio.is_completely_flat()

--- a/tests/unit_tests/trading/test_trading_strategy.py
+++ b/tests/unit_tests/trading/test_trading_strategy.py
@@ -15,9 +15,8 @@
 
 from datetime import datetime
 from datetime import timedelta
-import unittest
 
-from parameterized import parameterized
+import pytest
 import pytz
 
 from nautilus_trader.backtest.data_client import BacktestMarketDataClient
@@ -70,8 +69,8 @@ GBPUSD_SIM = TestInstrumentProvider.default_fx_ccy("GBP/USD")
 USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 
 
-class TradingStrategyTests(unittest.TestCase):
-    def setUp(self):
+class TestTradingStrategy:
+    def setup(self):
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
@@ -172,9 +171,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertTrue(strategy1 == strategy1)
-        self.assertTrue(strategy1 == strategy2)
-        self.assertTrue(strategy2 != strategy3)
+        assert strategy1 == strategy1
+        assert strategy1 == strategy2
+        assert strategy2 != strategy3
 
     def test_str_and_repr(self):
         # Arrange
@@ -182,8 +181,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual("TradingStrategy-GBP/USD-MM", str(strategy))
-        self.assertEqual("TradingStrategy-GBP/USD-MM", repr(strategy))
+        assert str(strategy) == "TradingStrategy-GBP/USD-MM"
+        assert repr(strategy) == "TradingStrategy-GBP/USD-MM"
 
     def test_id(self):
         # Arrange
@@ -191,7 +190,7 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(StrategyId("TradingStrategy-001"), strategy.id)
+        assert strategy.id == StrategyId("TradingStrategy-001")
 
     def test_initialization(self):
         # Arrange
@@ -199,8 +198,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertTrue(ComponentState.INITIALIZED, strategy.state)
-        self.assertFalse(strategy.indicators_initialized())
+        assert ComponentState.INITIALIZED == strategy.state
+        assert not strategy.indicators_initialized()
 
     def test_handle_event(self):
         # Arrange
@@ -212,7 +211,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_event(event)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_start_when_not_overridden_does_nothing(self):
         # Arrange
@@ -222,7 +221,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_start()
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_stop_when_not_overridden_does_nothing(self):
         # Arrange
@@ -232,7 +231,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_stop()
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_resume_when_not_overridden_does_nothing(self):
         # Arrange
@@ -242,7 +241,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_resume()
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_reset_when_not_overridden_does_nothing(self):
         # Arrange
@@ -252,7 +251,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_reset()
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_save_when_not_overridden_does_nothing(self):
         # Arrange
@@ -262,7 +261,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_save()
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_load_when_not_overridden_does_nothing(self):
         # Arrange
@@ -272,7 +271,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_load({})
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_dispose_when_not_overridden_does_nothing(self):
         # Arrange
@@ -282,7 +281,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_load({})
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_quote_tick_when_not_overridden_does_nothing(self):
         # Arrange
@@ -294,7 +293,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_quote_tick(tick)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_trade_tick_when_not_overridden_does_nothing(self):
         # Arrange
@@ -306,7 +305,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_trade_tick(tick)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_bar_when_not_overridden_does_nothing(self):
         # Arrange
@@ -318,7 +317,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_bar(bar)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_data_when_not_overridden_does_nothing(self):
         # Arrange
@@ -335,7 +334,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_data(news_event)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_on_event_when_not_overridden_does_nothing(self):
         # Arrange
@@ -346,7 +345,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.on_event(event)
 
         # Assert
-        self.assertTrue(True)  # Exception not raised
+        assert True  # Exception not raised
 
     def test_start_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -354,7 +353,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.start)
+        with pytest.raises(RuntimeError):
+            strategy.start()
 
     def test_stop_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -369,7 +369,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.stop)
+        with pytest.raises(RuntimeError):
+            strategy.stop()
 
     def test_resume_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -391,7 +392,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.resume)
+        with pytest.raises(RuntimeError):
+            strategy.resume()
 
     def test_reset_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -399,7 +401,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.reset)
+        with pytest.raises(RuntimeError):
+            strategy.reset()
 
     def test_dispose_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -407,7 +410,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.dispose)
+        with pytest.raises(RuntimeError):
+            strategy.dispose()
 
     def test_save_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -415,7 +419,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.save)
+        with pytest.raises(RuntimeError):
+            strategy.save()
 
     def test_load_when_not_registered_with_trader_raises_runtime_error(self):
         # Arrange
@@ -423,7 +428,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.load, {})
+        with pytest.raises(RuntimeError):
+            strategy.load({})
 
     def test_start_when_not_in_valid_state_raises_invalid_state_trigger(self):
         # Arrange
@@ -438,7 +444,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(InvalidStateTrigger, strategy.start)
+        with pytest.raises(InvalidStateTrigger):
+            strategy.start()
 
     def test_stop_when_not_in_valid_state_raises_invalid_state_trigger(self):
         # Arrange
@@ -453,7 +460,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(InvalidStateTrigger, strategy.stop)
+        with pytest.raises(InvalidStateTrigger):
+            strategy.stop()
 
     def test_resume_when_not_in_valid_state_raises_invalid_state_trigger(self):
         # Arrange
@@ -468,7 +476,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(InvalidStateTrigger, strategy.resume)
+        with pytest.raises(InvalidStateTrigger):
+            strategy.resume()
 
     def test_reset_when_not_in_valid_state_raises_invalid_state_trigger(self):
         # Arrange
@@ -483,7 +492,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(InvalidStateTrigger, strategy.reset)
+        with pytest.raises(InvalidStateTrigger):
+            strategy.reset()
 
     def test_dispose_when_not_in_valid_state_raises_invalid_state_trigger(self):
         # Arrange
@@ -498,7 +508,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(InvalidStateTrigger, strategy.dispose)
+        with pytest.raises(InvalidStateTrigger):
+            strategy.dispose()
 
     def test_start_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -511,8 +522,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.start)
-        self.assertEqual(ComponentState.RUNNING, strategy.state)
+        with pytest.raises(RuntimeError):
+            strategy.start()
+        assert strategy.state == ComponentState.RUNNING
 
     def test_stop_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -528,8 +540,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.stop)
-        self.assertEqual(ComponentState.STOPPED, strategy.state)
+        with pytest.raises(RuntimeError):
+            strategy.stop()
+        assert strategy.state == ComponentState.STOPPED
 
     def test_resume_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -547,8 +560,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.resume)
-        self.assertEqual(ComponentState.RUNNING, strategy.state)
+        with pytest.raises(RuntimeError):
+            strategy.resume()
+        assert strategy.state == ComponentState.RUNNING
 
     def test_reset_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -561,8 +575,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.reset)
-        self.assertEqual(ComponentState.INITIALIZED, strategy.state)
+        with pytest.raises(RuntimeError):
+            strategy.reset()
+        assert strategy.state == ComponentState.INITIALIZED
 
     def test_dispose_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -575,8 +590,9 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.dispose)
-        self.assertEqual(ComponentState.DISPOSED, strategy.state)
+        with pytest.raises(RuntimeError):
+            strategy.dispose()
+        assert strategy.state == ComponentState.DISPOSED
 
     def test_save_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -589,7 +605,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.save)
+        with pytest.raises(RuntimeError):
+            strategy.save()
 
     def test_load_when_user_code_raises_error_logs_and_reraises(self):
         # Arrange
@@ -602,7 +619,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.load, {"something": b"123456"})
+        with pytest.raises(RuntimeError):
+            strategy.load({"something": b"123456"})
 
     def test_load(self):
         # Arrange
@@ -620,7 +638,7 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Assert
         # TODO: Write a users custom save method
-        self.assertTrue(True)
+        assert True
 
     def test_handle_quote_tick_when_user_code_raises_exception_logs_and_reraises(self):
         # Arrange
@@ -638,7 +656,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.handle_quote_tick, tick)
+        with pytest.raises(RuntimeError):
+            strategy.handle_quote_tick(tick)
 
     def test_handle_trade_tick_when_user_code_raises_exception_logs_and_reraises(self):
         # Arrange
@@ -656,7 +675,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.handle_trade_tick, tick)
+        with pytest.raises(RuntimeError):
+            strategy.handle_trade_tick(tick)
 
     def test_handle_bar_when_user_code_raises_exception_logs_and_reraises(self):
         # Arrange
@@ -674,7 +694,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.handle_bar, bar)
+        with pytest.raises(RuntimeError):
+            strategy.handle_bar(bar)
 
     def test_handle_data_when_user_code_raises_exception_logs_and_reraises(self):
         # Arrange
@@ -690,17 +711,16 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(
-            RuntimeError,
-            strategy.handle_data,
-            NewsEvent(
-                impact=NewsImpact.HIGH,
-                name="Unemployment Rate",
-                currency=USD,
-                ts_event_ns=0,
-                ts_recv_ns=0,
-            ),
-        )
+        with pytest.raises(RuntimeError):
+            strategy.handle_data(
+                NewsEvent(
+                    impact=NewsImpact.HIGH,
+                    name="Unemployment Rate",
+                    currency=USD,
+                    ts_event_ns=0,
+                    ts_recv_ns=0,
+                ),
+            )
 
     def test_handle_event_when_user_code_raises_exception_logs_and_reraises(self):
         # Arrange
@@ -718,7 +738,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.on_event, event)
+        with pytest.raises(RuntimeError):
+            strategy.on_event(event)
 
     def test_register_data_engine(self):
         # Arrange
@@ -733,7 +754,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_data_engine(self.data_engine)
 
         # Assert
-        self.assertIsNotNone(strategy.cache)
+        assert strategy.cache is not None
 
     def test_register_risk_engine(self):
         # Arrange
@@ -748,7 +769,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_risk_engine(self.risk_engine)
 
         # Assert
-        self.assertIsNotNone(strategy.cache)
+        assert strategy.cache is not None
 
     def test_register_portfolio(self):
         # Arrange
@@ -763,7 +784,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_portfolio(self.portfolio)
 
         # Assert
-        self.assertIsNotNone(strategy.portfolio)
+        assert strategy.portfolio is not None
 
     def test_start(self):
         # Arrange
@@ -782,8 +803,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.start()
 
         # Assert
-        self.assertTrue("on_start" in strategy.calls)
-        self.assertEqual(ComponentState.RUNNING, strategy.state)
+        assert "on_start" in strategy.calls
+        assert strategy.state == ComponentState.RUNNING
 
     def test_stop(self):
         # Arrange
@@ -803,8 +824,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.stop()
 
         # Assert
-        self.assertTrue("on_stop" in strategy.calls)
-        self.assertEqual(ComponentState.STOPPED, strategy.state)
+        assert "on_stop" in strategy.calls
+        assert strategy.state == ComponentState.STOPPED
 
     def test_resume(self):
         # Arrange
@@ -826,8 +847,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.resume()
 
         # Assert
-        self.assertTrue("on_resume" in strategy.calls)
-        self.assertEqual(ComponentState.RUNNING, strategy.state)
+        assert "on_resume" in strategy.calls
+        assert strategy.state == ComponentState.RUNNING
 
     def test_reset(self):
         # Arrange
@@ -856,10 +877,10 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.reset()
 
         # Assert
-        self.assertTrue("on_reset" in strategy.calls)
-        self.assertEqual(ComponentState.INITIALIZED, strategy.state)
-        self.assertEqual(0, strategy.ema1.count)
-        self.assertEqual(0, strategy.ema2.count)
+        assert "on_reset" in strategy.calls
+        assert strategy.state == ComponentState.INITIALIZED
+        assert strategy.ema1.count == 0
+        assert strategy.ema2.count == 0
 
     def test_dispose(self):
         # Arrange
@@ -877,8 +898,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.dispose()
 
         # Assert
-        self.assertTrue("on_dispose" in strategy.calls)
-        self.assertEqual(ComponentState.DISPOSED, strategy.state)
+        assert "on_dispose" in strategy.calls
+        assert strategy.state == ComponentState.DISPOSED
 
     def test_save_load(self):
         # Arrange
@@ -895,9 +916,9 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.load(state)
 
         # Assert
-        self.assertEqual({"UserState": 1}, state)
-        self.assertTrue("on_save" in strategy.calls)
-        self.assertEqual(ComponentState.INITIALIZED, strategy.state)
+        assert state == {"UserState": 1}
+        assert "on_save" in strategy.calls
+        assert strategy.state == ComponentState.INITIALIZED
 
     def test_register_indicator_for_quote_ticks_when_already_registered(self):
         # Arrange
@@ -916,9 +937,9 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_indicator_for_quote_ticks(AUDUSD_SIM.id, ema2)
         strategy.register_indicator_for_quote_ticks(AUDUSD_SIM.id, ema2)
 
-        self.assertEqual(2, len(strategy.registered_indicators))
-        self.assertIn(ema1, strategy.registered_indicators)
-        self.assertIn(ema2, strategy.registered_indicators)
+        assert len(strategy.registered_indicators) == 2
+        assert ema1 in strategy.registered_indicators
+        assert ema2 in strategy.registered_indicators
 
     def test_register_indicator_for_trade_ticks_when_already_registered(self):
         # Arrange
@@ -937,9 +958,9 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_indicator_for_trade_ticks(AUDUSD_SIM.id, ema2)
         strategy.register_indicator_for_trade_ticks(AUDUSD_SIM.id, ema2)
 
-        self.assertEqual(2, len(strategy.registered_indicators))
-        self.assertIn(ema1, strategy.registered_indicators)
-        self.assertIn(ema2, strategy.registered_indicators)
+        assert len(strategy.registered_indicators) == 2
+        assert ema1 in strategy.registered_indicators
+        assert ema2 in strategy.registered_indicators
 
     def test_register_indicator_for_bars_when_already_registered(self):
         # Arrange
@@ -959,9 +980,9 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_indicator_for_bars(bar_type, ema2)
         strategy.register_indicator_for_bars(bar_type, ema2)
 
-        self.assertEqual(2, len(strategy.registered_indicators))
-        self.assertIn(ema1, strategy.registered_indicators)
-        self.assertIn(ema2, strategy.registered_indicators)
+        assert len(strategy.registered_indicators) == 2
+        assert ema1 in strategy.registered_indicators
+        assert ema2 in strategy.registered_indicators
 
     def test_register_indicator_for_multiple_data_sources(self):
         # Arrange
@@ -981,8 +1002,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.register_indicator_for_trade_ticks(AUDUSD_SIM.id, ema)
         strategy.register_indicator_for_bars(bar_type, ema)
 
-        self.assertEqual(1, len(strategy.registered_indicators))
-        self.assertIn(ema, strategy.registered_indicators)
+        assert len(strategy.registered_indicators) == 1
+        assert ema in strategy.registered_indicators
 
     def test_handle_quote_tick_updates_indicator_registered_for_quote_ticks(self):
         # Arrange
@@ -1003,7 +1024,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_quote_tick(tick, True)
 
         # Assert
-        self.assertEqual(2, ema.count)
+        assert ema.count == 2
 
     def test_handle_instrument_with_blow_up_logs_exception(self):
         # Arrange
@@ -1019,7 +1040,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(RuntimeError, strategy.handle_instrument, AUDUSD_SIM)
+        with pytest.raises(RuntimeError):
+            strategy.handle_instrument(AUDUSD_SIM)
 
     def test_handle_instrument_when_not_running_does_not_send_to_on_instrument(self):
         # Arrange
@@ -1034,8 +1056,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_instrument(AUDUSD_SIM)
 
         # Assert
-        self.assertEqual([], strategy.calls)
-        self.assertEqual([], strategy.object_storer.get_store())
+        assert strategy.calls == []
+        assert strategy.object_storer.get_store() == []
 
     def test_handle_instrument_when_running_sends_to_on_instrument(self):
         # Arrange
@@ -1052,8 +1074,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_instrument(AUDUSD_SIM)
 
         # Assert
-        self.assertEqual(["on_start", "on_instrument"], strategy.calls)
-        self.assertEqual(AUDUSD_SIM, strategy.object_storer.get_store()[0])
+        assert strategy.calls == ["on_start", "on_instrument"]
+        assert strategy.object_storer.get_store()[0] == AUDUSD_SIM
 
     def test_handle_quote_tick_when_not_running_does_not_send_to_on_quote_tick(self):
         # Arrange
@@ -1070,8 +1092,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_quote_tick(tick)
 
         # Assert
-        self.assertEqual([], strategy.calls)
-        self.assertEqual([], strategy.object_storer.get_store())
+        assert strategy.calls == []
+        assert strategy.object_storer.get_store() == []
 
     def test_handle_quote_tick_when_running_sends_to_on_quote_tick(self):
         # Arrange
@@ -1090,8 +1112,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_quote_tick(tick)
 
         # Assert
-        self.assertEqual(["on_start", "on_quote_tick"], strategy.calls)
-        self.assertEqual(tick, strategy.object_storer.get_store()[0])
+        assert strategy.calls == ["on_start", "on_quote_tick"]
+        assert strategy.object_storer.get_store()[0] == tick
 
     def test_handle_quote_ticks_with_no_ticks_logs_and_continues(self):
         # Arrange
@@ -1109,7 +1131,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_quote_ticks([])
 
         # Assert
-        self.assertEqual(0, ema.count)
+        assert ema.count == 0
 
     def test_handle_quote_ticks_updates_indicator_registered_for_quote_ticks(self):
         # Arrange
@@ -1129,7 +1151,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_quote_ticks([tick])
 
         # Assert
-        self.assertEqual(1, ema.count)
+        assert ema.count == 1
 
     def test_handle_trade_tick_when_not_running_does_not_send_to_on_trade_tick(self):
         # Arrange
@@ -1146,8 +1168,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_trade_tick(tick)
 
         # Assert
-        self.assertEqual([], strategy.calls)
-        self.assertEqual([], strategy.object_storer.get_store())
+        assert strategy.calls == []
+        assert strategy.object_storer.get_store() == []
 
     def test_handle_trade_tick_when_running_sends_to_on_trade_tick(self):
         # Arrange
@@ -1166,8 +1188,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_trade_tick(tick)
 
         # Assert
-        self.assertEqual(["on_start", "on_trade_tick"], strategy.calls)
-        self.assertEqual(tick, strategy.object_storer.get_store()[0])
+        assert strategy.calls == ["on_start", "on_trade_tick"]
+        assert strategy.object_storer.get_store()[0] == tick
 
     def test_handle_trade_tick_updates_indicator_registered_for_trade_ticks(self):
         # Arrange
@@ -1188,7 +1210,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_trade_tick(tick, True)
 
         # Assert
-        self.assertEqual(2, ema.count)
+        assert ema.count == 2
 
     def test_handle_trade_ticks_updates_indicator_registered_for_trade_ticks(self):
         # Arrange
@@ -1208,7 +1230,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_trade_ticks([tick])
 
         # Assert
-        self.assertEqual(1, ema.count)
+        assert ema.count == 1
 
     def test_handle_trade_ticks_with_no_ticks_logs_and_continues(self):
         # Arrange
@@ -1226,7 +1248,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_trade_ticks([])
 
         # Assert
-        self.assertEqual(0, ema.count)
+        assert ema.count == 0
 
     def test_handle_bar_updates_indicator_registered_for_bars(self):
         # Arrange
@@ -1247,7 +1269,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_bar(bar, True)
 
         # Assert
-        self.assertEqual(2, ema.count)
+        assert ema.count == 2
 
     def test_handle_bar_when_not_running_does_not_send_to_on_bar(self):
         # Arrange
@@ -1265,8 +1287,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_bar(bar)
 
         # Assert
-        self.assertEqual([], strategy.calls)
-        self.assertEqual([], strategy.object_storer.get_store())
+        assert strategy.calls == []
+        assert strategy.object_storer.get_store() == []
 
     def test_handle_bar_when_running_sends_to_on_bar(self):
         # Arrange
@@ -1286,8 +1308,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_bar(bar)
 
         # Assert
-        self.assertEqual(["on_start", "on_bar"], strategy.calls)
-        self.assertEqual(bar, strategy.object_storer.get_store()[0])
+        assert strategy.calls == ["on_start", "on_bar"]
+        assert strategy.object_storer.get_store()[0] == bar
 
     def test_handle_bars_updates_indicator_registered_for_bars(self):
         # Arrange
@@ -1307,7 +1329,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_bars([bar])
 
         # Assert
-        self.assertEqual(1, ema.count)
+        assert ema.count == 1
 
     def test_handle_bars_with_no_bars_logs_and_continues(self):
         # Arrange
@@ -1326,7 +1348,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_bars([])
 
         # Assert
-        self.assertEqual(0, ema.count)
+        assert ema.count == 0
 
     def test_handle_data_when_not_running_does_not_send_to_on_data(self):
         strategy = MockStrategy(TestStubs.bartype_audusd_1min_bid())
@@ -1348,8 +1370,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_data(data)
 
         # Assert
-        self.assertEqual([], strategy.calls)
-        self.assertEqual([], strategy.object_storer.get_store())
+        assert strategy.calls == []
+        assert strategy.object_storer.get_store() == []
 
     def test_handle_data_when_running_sends_to_on_data(self):
         strategy = MockStrategy(TestStubs.bartype_audusd_1min_bid())
@@ -1373,8 +1395,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.handle_data(data)
 
         # Assert
-        self.assertEqual(["on_start", "on_data"], strategy.calls)
-        self.assertEqual(data, strategy.object_storer.get_store()[0])
+        assert strategy.calls == ["on_start", "on_data"]
+        assert strategy.object_storer.get_store()[0] == data
 
     def test_stop_cancels_a_running_time_alert(self):
         # Arrange
@@ -1397,7 +1419,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.stop()
 
         # Assert
-        self.assertEqual(0, len(strategy.clock.timer_names()))
+        assert len(strategy.clock.timer_names()) == 0
 
     def test_stop_cancels_a_running_timer(self):
         # Arrange
@@ -1422,7 +1444,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.stop()
 
         # Assert
-        self.assertEqual(0, len(strategy.clock.timer_names()))
+        assert len(strategy.clock.timer_names()) == 0
 
     def test_subscribe_custom_data(self):
         # Arrange
@@ -1443,7 +1465,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.subscribe_data(ClientId("QUANDL"), data_type)
 
         # Assert
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_custom_data(self):
         # Arrange
@@ -1465,7 +1487,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_data(ClientId("QUANDL"), data_type)
 
         # Assert
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_order_book(self):
         # Arrange
@@ -1484,7 +1506,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.subscribe_order_book(AUDUSD_SIM.id, level=2)
 
         # Assert
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_order_book(self):
         # Arrange
@@ -1505,7 +1527,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_order_book(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_order_book_data(self):
         # Arrange
@@ -1524,7 +1546,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.subscribe_order_book_deltas(AUDUSD_SIM.id, level=2)
 
         # Assert
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_order_book_data(self):
         # Arrange
@@ -1545,7 +1567,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_order_book(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_instrument(self):
         # Arrange
@@ -1565,8 +1587,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Assert
         expected_instrument = InstrumentId(Symbol("AUD/USD"), Venue("SIM"))
-        self.assertEqual([expected_instrument], self.data_engine.subscribed_instruments)
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.subscribed_instruments == [expected_instrument]
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_instrument(self):
         # Arrange
@@ -1587,8 +1609,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_instrument(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual([], self.data_engine.subscribed_instruments)
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.subscribed_instruments == []
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_quote_ticks(self):
         # Arrange
@@ -1608,8 +1630,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Assert
         expected_instrument = InstrumentId(Symbol("AUD/USD"), Venue("SIM"))
-        self.assertEqual([expected_instrument], self.data_engine.subscribed_quote_ticks)
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.subscribed_quote_ticks == [expected_instrument]
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_quote_ticks(self):
         # Arrange
@@ -1630,8 +1652,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_quote_ticks(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual([], self.data_engine.subscribed_quote_ticks)
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.subscribed_quote_ticks == []
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_trade_ticks(self):
         # Arrange
@@ -1651,8 +1673,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Assert
         expected_instrument = InstrumentId(Symbol("AUD/USD"), Venue("SIM"))
-        self.assertEqual([expected_instrument], self.data_engine.subscribed_trade_ticks)
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.subscribed_trade_ticks == [expected_instrument]
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_trade_ticks(self):
         # Arrange
@@ -1673,8 +1695,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_trade_ticks(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual([], self.data_engine.subscribed_trade_ticks)
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.subscribed_trade_ticks == []
+        assert self.data_engine.command_count == 2
 
     def test_subscribe_bars(self):
         # Arrange
@@ -1693,8 +1715,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.subscribe_bars(bar_type)
 
         # Assert
-        self.assertEqual([bar_type], self.data_engine.subscribed_bars)
-        self.assertEqual(1, self.data_engine.command_count)
+        assert self.data_engine.subscribed_bars == [bar_type]
+        assert self.data_engine.command_count == 1
 
     def test_unsubscribe_bars(self):
         # Arrange
@@ -1715,8 +1737,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.unsubscribe_bars(bar_type)
 
         # Assert
-        self.assertEqual([], self.data_engine.subscribed_bars)
-        self.assertEqual(2, self.data_engine.command_count)
+        assert self.data_engine.subscribed_bars == []
+        assert self.data_engine.command_count == 2
 
     def test_request_data_sends_request_to_data_engine(self):
         # Arrange
@@ -1737,7 +1759,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.request_data(ClientId("BLOOMBERG-01"), data_type)
 
         # Assert
-        self.assertEqual(1, self.data_engine.request_count)
+        assert self.data_engine.request_count == 1
 
     def test_request_quote_ticks_sends_request_to_data_engine(self):
         # Arrange
@@ -1756,7 +1778,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.request_quote_ticks(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(1, self.data_engine.request_count)
+        assert self.data_engine.request_count == 1
 
     def test_request_trade_ticks_sends_request_to_data_engine(self):
         # Arrange
@@ -1775,7 +1797,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.request_trade_ticks(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(1, self.data_engine.request_count)
+        assert self.data_engine.request_count == 1
 
     def test_request_bars_sends_request_to_data_engine(self):
         # Arrange
@@ -1794,13 +1816,14 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.request_bars(bar_type)
 
         # Assert
-        self.assertEqual(1, self.data_engine.request_count)
+        assert self.data_engine.request_count == 1
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "start,stop",
         [
-            [UNIX_EPOCH, UNIX_EPOCH],
-            [UNIX_EPOCH + timedelta(milliseconds=1), UNIX_EPOCH],
-        ]
+            (UNIX_EPOCH, UNIX_EPOCH),
+            (UNIX_EPOCH + timedelta(milliseconds=1), UNIX_EPOCH),
+        ],
     )
     def test_request_bars_with_invalid_params_raises_value_error(self, start, stop):
         # Arrange
@@ -1817,7 +1840,8 @@ class TradingStrategyTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(ValueError, strategy.request_bars, bar_type, start, stop)
+        with pytest.raises(ValueError):
+            strategy.request_bars(bar_type, start, stop)
 
     def test_submit_order_with_valid_order_successfully_submits(self):
         # Arrange
@@ -1840,11 +1864,11 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.submit_order(order)
 
         # Assert
-        self.assertIn(order, strategy.cache.orders())
-        self.assertEqual(OrderState.FILLED, strategy.cache.orders()[0].state)
-        self.assertNotIn(order.client_order_id, strategy.cache.orders_working())
-        self.assertFalse(strategy.cache.is_order_working(order.client_order_id))
-        self.assertTrue(strategy.cache.is_order_completed(order.client_order_id))
+        assert order in strategy.cache.orders()
+        assert strategy.cache.orders()[0].state == OrderState.FILLED
+        assert order.client_order_id not in strategy.cache.orders_working()
+        assert not strategy.cache.is_order_working(order.client_order_id)
+        assert strategy.cache.is_order_completed(order.client_order_id)
 
     def test_submit_bracket_order_with_valid_order_successfully_submits(self):
         # Arrange
@@ -1874,11 +1898,11 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.submit_bracket_order(order)
 
         # Assert
-        self.assertIn(entry, strategy.cache.orders())
-        self.assertEqual(OrderState.ACCEPTED, entry.state)
-        self.assertIn(entry, strategy.cache.orders_working())
-        self.assertTrue(strategy.cache.is_order_working(entry.client_order_id))
-        self.assertFalse(strategy.cache.is_order_completed(entry.client_order_id))
+        assert entry in strategy.cache.orders()
+        assert entry.state == OrderState.ACCEPTED
+        assert entry in strategy.cache.orders_working()
+        assert strategy.cache.is_order_working(entry.client_order_id)
+        assert not strategy.cache.is_order_completed(entry.client_order_id)
 
     def test_cancel_order(self):
         # Arrange
@@ -1904,16 +1928,13 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.cancel_order(order)
 
         # Assert
-        self.assertIn(order, strategy.cache.orders())
-        self.assertEqual(OrderState.CANCELED, strategy.cache.orders()[0].state)
-        self.assertEqual(
-            order.client_order_id,
-            strategy.cache.orders_completed()[0].client_order_id,
-        )
-        self.assertNotIn(order, strategy.cache.orders_working())
-        self.assertTrue(strategy.cache.order_exists(order.client_order_id))
-        self.assertFalse(strategy.cache.is_order_working(order.client_order_id))
-        self.assertTrue(strategy.cache.is_order_completed(order.client_order_id))
+        assert order in strategy.cache.orders()
+        assert strategy.cache.orders()[0].state == OrderState.CANCELED
+        assert order.client_order_id == strategy.cache.orders_completed()[0].client_order_id
+        assert order not in strategy.cache.orders_working()
+        assert strategy.cache.order_exists(order.client_order_id)
+        assert not strategy.cache.is_order_working(order.client_order_id)
+        assert strategy.cache.is_order_completed(order.client_order_id)
 
     def test_cancel_order_when_pending_cancel_does_not_submit_command(self):
         # Arrange
@@ -1940,11 +1961,11 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.cancel_order(order)
 
         # Assert
-        self.assertEqual(OrderState.PENDING_CANCEL, strategy.cache.orders()[0].state)
-        self.assertIn(order, strategy.cache.orders_working())
-        self.assertTrue(strategy.cache.order_exists(order.client_order_id))
-        self.assertTrue(strategy.cache.is_order_working(order.client_order_id))
-        self.assertFalse(strategy.cache.is_order_completed(order.client_order_id))
+        assert strategy.cache.orders()[0].state == OrderState.PENDING_CANCEL
+        assert order in strategy.cache.orders_working()
+        assert strategy.cache.order_exists(order.client_order_id)
+        assert strategy.cache.is_order_working(order.client_order_id)
+        assert not strategy.cache.is_order_completed(order.client_order_id)
 
     def test_cancel_order_when_completed_does_not_submit_command(self):
         # Arrange
@@ -1971,11 +1992,11 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.cancel_order(order)
 
         # Assert
-        self.assertEqual(OrderState.EXPIRED, strategy.cache.orders()[0].state)
-        self.assertNotIn(order, strategy.cache.orders_working())
-        self.assertTrue(strategy.cache.order_exists(order.client_order_id))
-        self.assertFalse(strategy.cache.is_order_working(order.client_order_id))
-        self.assertTrue(strategy.cache.is_order_completed(order.client_order_id))
+        assert strategy.cache.orders()[0].state == OrderState.EXPIRED
+        assert order not in strategy.cache.orders_working()
+        assert strategy.cache.order_exists(order.client_order_id)
+        assert not strategy.cache.is_order_working(order.client_order_id)
+        assert strategy.cache.is_order_completed(order.client_order_id)
 
     def test_update_order_when_pending_update_does_not_submit_command(self):
         # Arrange
@@ -2006,7 +2027,7 @@ class TradingStrategyTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(1, self.exec_engine.command_count)
+        assert self.exec_engine.command_count == 1
 
     def test_update_order_when_pending_cancel_does_not_submit_command(self):
         # Arrange
@@ -2037,7 +2058,7 @@ class TradingStrategyTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(1, self.exec_engine.command_count)
+        assert self.exec_engine.command_count == 1
 
     def test_update_order_when_completed_does_not_submit_command(self):
         # Arrange
@@ -2068,7 +2089,7 @@ class TradingStrategyTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(1, self.exec_engine.command_count)
+        assert self.exec_engine.command_count == 1
 
     def test_update_order_when_no_changes_does_not_submit_command(self):
         # Arrange
@@ -2098,7 +2119,7 @@ class TradingStrategyTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(1, self.exec_engine.command_count)
+        assert self.exec_engine.command_count == 1
 
     def test_update_order(self):
         # Arrange
@@ -2128,14 +2149,14 @@ class TradingStrategyTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(order, strategy.cache.orders()[0])
-        self.assertEqual(OrderState.ACCEPTED, strategy.cache.orders()[0].state)
-        self.assertEqual(Quantity.from_int(110000), strategy.cache.orders()[0].quantity)
-        self.assertEqual(Price.from_str("90.001"), strategy.cache.orders()[0].price)
-        self.assertTrue(strategy.cache.order_exists(order.client_order_id))
-        self.assertTrue(strategy.cache.is_order_working(order.client_order_id))
-        self.assertFalse(strategy.cache.is_order_completed(order.client_order_id))
-        self.assertTrue(strategy.portfolio.is_flat(order.instrument_id))
+        assert strategy.cache.orders()[0] == order
+        assert strategy.cache.orders()[0].state == OrderState.ACCEPTED
+        assert strategy.cache.orders()[0].quantity == Quantity.from_int(110000)
+        assert strategy.cache.orders()[0].price == Price.from_str("90.001")
+        assert strategy.cache.order_exists(order.client_order_id)
+        assert strategy.cache.is_order_working(order.client_order_id)
+        assert not strategy.cache.is_order_completed(order.client_order_id)
+        assert strategy.portfolio.is_flat(order.instrument_id)
 
     def test_cancel_all_orders(self):
         # Arrange
@@ -2169,12 +2190,12 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.cancel_all_orders(USDJPY_SIM.id)
 
         # Assert
-        self.assertIn(order1, self.cache.orders())
-        self.assertIn(order2, self.cache.orders())
-        self.assertEqual(OrderState.CANCELED, self.cache.orders()[0].state)
-        self.assertEqual(OrderState.CANCELED, self.cache.orders()[1].state)
-        self.assertIn(order1, self.cache.orders_completed())
-        self.assertIn(order2, strategy.cache.orders_completed())
+        assert order1 in self.cache.orders()
+        assert order2 in self.cache.orders()
+        assert self.cache.orders()[0].state == OrderState.CANCELED
+        assert self.cache.orders()[1].state == OrderState.CANCELED
+        assert order1 in self.cache.orders_completed()
+        assert order2 in strategy.cache.orders_completed()
 
     def test_flatten_position_when_position_already_flat_does_nothing(self):
         # Arrange
@@ -2210,7 +2231,7 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.flatten_position(position)
 
         # Assert
-        self.assertTrue(strategy.portfolio.is_completely_flat())
+        assert strategy.portfolio.is_completely_flat()
 
     def test_flatten_position(self):
         # Arrange
@@ -2239,8 +2260,8 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.flatten_position(position)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertTrue(strategy.portfolio.is_completely_flat())
+        assert order.state == OrderState.FILLED
+        assert strategy.portfolio.is_completely_flat()
 
     def test_flatten_all_positions(self):
         # Arrange
@@ -2277,6 +2298,6 @@ class TradingStrategyTests(unittest.TestCase):
         strategy.flatten_all_positions(USDJPY_SIM.id)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order1.state)
-        self.assertEqual(OrderState.FILLED, order2.state)
-        self.assertTrue(strategy.portfolio.is_completely_flat())
+        assert order1.state == OrderState.FILLED
+        assert order2.state == OrderState.FILLED
+        assert strategy.portfolio.is_completely_flat()

--- a/tests/unit_tests/trading/test_trading_trader.py
+++ b/tests/unit_tests/trading/test_trading_trader.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.backtest.data_client import BacktestMarketDataClient
 from nautilus_trader.backtest.exchange import SimulatedExchange
@@ -44,8 +44,8 @@ from tests.test_kit.stubs import TestStubs
 USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 
 
-class TraderTests(unittest.TestCase):
-    def setUp(self):
+class TestTrader:
+    def setup(self):
         # Fixture Setup
         clock = TestClock()
         logger = Logger(clock)
@@ -146,9 +146,9 @@ class TraderTests(unittest.TestCase):
         trader_id = self.trader.id
 
         # Assert
-        self.assertEqual(TraderId("TESTER-000"), trader_id)
-        self.assertEqual(ComponentState.INITIALIZED, self.trader.state)
-        self.assertEqual(2, len(self.trader.strategy_states()))
+        assert trader_id == TraderId("TESTER-000")
+        assert self.trader.state == ComponentState.INITIALIZED
+        assert len(self.trader.strategy_states()) == 2
 
     def test_get_strategy_states(self):
         # Arrange
@@ -156,11 +156,11 @@ class TraderTests(unittest.TestCase):
         status = self.trader.strategy_states()
 
         # Assert
-        self.assertTrue(StrategyId("TradingStrategy-001") in status)
-        self.assertTrue(StrategyId("TradingStrategy-002") in status)
-        self.assertEqual("INITIALIZED", status[StrategyId("TradingStrategy-001")])
-        self.assertEqual("INITIALIZED", status[StrategyId("TradingStrategy-002")])
-        self.assertEqual(2, len(status))
+        assert StrategyId("TradingStrategy-001") in status
+        assert StrategyId("TradingStrategy-002") in status
+        assert status[StrategyId("TradingStrategy-001")] == "INITIALIZED"
+        assert status[StrategyId("TradingStrategy-002")] == "INITIALIZED"
+        assert len(status) == 2
 
     def test_change_strategies(self):
         # Arrange
@@ -173,9 +173,9 @@ class TraderTests(unittest.TestCase):
         self.trader.initialize_strategies(strategies, warn_no_strategies=True)
 
         # Assert
-        self.assertTrue(strategies[0].id in self.trader.strategy_states())
-        self.assertTrue(strategies[1].id in self.trader.strategy_states())
-        self.assertEqual(2, len(self.trader.strategy_states()))
+        assert strategies[0].id in self.trader.strategy_states()
+        assert strategies[1].id in self.trader.strategy_states()
+        assert len(self.trader.strategy_states()) == 2
 
     def test_trader_detects_duplicate_identifiers(self):
         # Arrange
@@ -185,12 +185,8 @@ class TraderTests(unittest.TestCase):
         ]
 
         # Act
-        self.assertRaises(
-            ValueError,
-            self.trader.initialize_strategies,
-            strategies,
-            True,
-        )
+        with pytest.raises(ValueError):
+            self.trader.initialize_strategies(strategies, True)
 
     def test_start_a_trader(self):
         # Arrange
@@ -200,9 +196,9 @@ class TraderTests(unittest.TestCase):
         strategy_states = self.trader.strategy_states()
 
         # Assert
-        self.assertEqual(ComponentState.RUNNING, self.trader.state)
-        self.assertEqual("RUNNING", strategy_states[StrategyId("TradingStrategy-001")])
-        self.assertEqual("RUNNING", strategy_states[StrategyId("TradingStrategy-002")])
+        assert self.trader.state == ComponentState.RUNNING
+        assert strategy_states[StrategyId("TradingStrategy-001")] == "RUNNING"
+        assert strategy_states[StrategyId("TradingStrategy-002")] == "RUNNING"
 
     def test_stop_a_running_trader(self):
         # Arrange
@@ -214,6 +210,6 @@ class TraderTests(unittest.TestCase):
         strategy_states = self.trader.strategy_states()
 
         # Assert
-        self.assertEqual(ComponentState.STOPPED, self.trader.state)
-        self.assertEqual("STOPPED", strategy_states[StrategyId("TradingStrategy-001")])
-        self.assertEqual("STOPPED", strategy_states[StrategyId("TradingStrategy-002")])
+        assert self.trader.state == ComponentState.STOPPED
+        assert strategy_states[StrategyId("TradingStrategy-001")] == "STOPPED"
+        assert strategy_states[StrategyId("TradingStrategy-002")] == "STOPPED"


### PR DESCRIPTION
Issue Ticket: #325

For right now, only `tests/unit_tests/trading/test_trading_strategy.py` has been converted to use pytest. If the conversion is acceptable to the maintainers, I'll convert the rest on this PR.

In order to get the unit tests to run/pass, I did have to modify the `noxfile.py` `tests` session to include the `--extras ALL_EXTRAS` flag, otherwise it complained about a missing `betfairlightweight` import and probably would have complained about the other extras as well. I didn't include the `noxfile.py` changes in this PR as I wasn't sure if it was just me or actually a bug.

Pre-commit hooks were run, unit and integration tests passed. Let me know if I missed anything.