### PR TITLE
Convert unittest tests to pytest (tests/unit_tests/indicators)

### DIFF
--- a/tests/unit_tests/indicators/test_ama.py
+++ b/tests/unit_tests/indicators/test_ama.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.ama import AdaptiveMovingAverage
 from nautilus_trader.model.enums import PriceType
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class AdaptiveMovingAverageTests(unittest.TestCase):
-    def setUp(self):
+class TestAdaptiveMovingAverage:
+    def setup(self):
         # Fixture Setup
         self.ama = AdaptiveMovingAverage(10, 2, 30)
 
@@ -33,26 +31,26 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("AdaptiveMovingAverage", self.ama.name)
+        assert self.ama.name == "AdaptiveMovingAverage"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("AdaptiveMovingAverage(10, 2, 30)", str(self.ama))
-        self.assertEqual("AdaptiveMovingAverage(10, 2, 30)", repr(self.ama))
+        assert str(self.ama) == "AdaptiveMovingAverage(10, 2, 30)"
+        assert repr(self.ama) == "AdaptiveMovingAverage(10, 2, 30)"
 
     def test_period(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.ama.period)
+        assert self.ama.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.ama.initialized)
+        assert self.ama.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -62,7 +60,7 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
             self.ama.update_raw(1.00000)
 
         # Assert
-        self.assertEqual(True, self.ama.initialized)
+        assert self.ama.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -74,8 +72,8 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00002, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00002
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -87,8 +85,8 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -100,8 +98,8 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input(self):
         # Arrange
@@ -109,7 +107,7 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.ama.value)
+        assert self.ama.value == 1.0
 
     def test_value_with_three_inputs(self):
         # Arrange
@@ -119,7 +117,7 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(2.135802469135802, self.ama.value, 10)
+        assert self.ama.value == 2.135802469135802
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -130,5 +128,5 @@ class AdaptiveMovingAverageTests(unittest.TestCase):
         self.ama.reset()
 
         # Assert
-        self.assertFalse(self.ama.initialized)
-        self.assertEqual(0, self.ama.value)
+        assert not self.ama.initialized
+        assert self.ama.value == 0

--- a/tests/unit_tests/indicators/test_atr.py
+++ b/tests/unit_tests/indicators/test_atr.py
@@ -14,7 +14,8 @@
 # -------------------------------------------------------------------------------------------------
 
 import sys
-import unittest
+
+import pytest
 
 from nautilus_trader.indicators.atr import AverageTrueRange
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +25,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class AverageTrueRangeTests(unittest.TestCase):
-    def setUp(self):
+class TestAverageTrueRange:
+    def setup(self):
         # Fixture Setup
         self.atr = AverageTrueRange(10)
 
@@ -33,26 +34,26 @@ class AverageTrueRangeTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("AverageTrueRange", self.atr.name)
+        assert self.atr.name == "AverageTrueRange"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("AverageTrueRange(10, SIMPLE, True, 0.0)", str(self.atr))
-        self.assertEqual("AverageTrueRange(10, SIMPLE, True, 0.0)", repr(self.atr))
+        assert str(self.atr) == "AverageTrueRange(10, SIMPLE, True, 0.0)"
+        assert repr(self.atr) == "AverageTrueRange(10, SIMPLE, True, 0.0)"
 
     def test_period(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.atr.period)
+        assert self.atr.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.atr.initialized)
+        assert self.atr.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -61,7 +62,7 @@ class AverageTrueRangeTests(unittest.TestCase):
             self.atr.update_raw(1.00000, 1.00000, 1.00000)
 
         # Assert
-        self.assertEqual(True, self.atr.initialized)
+        assert self.atr.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -73,14 +74,14 @@ class AverageTrueRangeTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(2.999999999997449e-05, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 2.999999999997449e-05
 
     def test_value_with_no_inputs_returns_zero(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0.0, self.atr.value)
+        assert self.atr.value == 0.0
 
     def test_value_with_epsilon_input(self):
         # Arrange
@@ -89,7 +90,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.atr.value)
+        assert self.atr.value == 0.0
 
     def test_value_with_one_ones_input(self):
         # Arrange
@@ -97,7 +98,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.atr.value)
+        assert self.atr.value == 0.0
 
     def test_value_with_one_input(self):
         # Arrange
@@ -105,7 +106,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertAlmostEqual(0.00020, self.atr.value)
+        assert self.atr.value == pytest.approx(0.00020)
 
     def test_value_with_three_inputs(self):
         # Arrange
@@ -115,7 +116,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertAlmostEqual(0.00020, self.atr.value)
+        assert self.atr.value == pytest.approx(0.00020)
 
     def test_value_with_close_on_high(self):
         # Arrange
@@ -130,7 +131,7 @@ class AverageTrueRangeTests(unittest.TestCase):
             self.atr.update_raw(high, low, close)
 
         # Assert
-        self.assertAlmostEqual(0.00010, self.atr.value, 2)
+        assert self.atr.value == pytest.approx(0.00010, 2)
 
     def test_value_with_close_on_low(self):
         # Arrange
@@ -145,7 +146,7 @@ class AverageTrueRangeTests(unittest.TestCase):
             self.atr.update_raw(high, low, close)
 
         # Assert
-        self.assertAlmostEqual(0.00010, self.atr.value)
+        assert self.atr.value == pytest.approx(0.00010)
 
     def test_floor_with_ten_ones_inputs(self):
         # Arrange
@@ -157,7 +158,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(5e-05, floored_atr.value)
+        assert floored_atr.value == 5e-05
 
     def test_floor_with_exponentially_decreasing_high_inputs(self):
         # Arrange
@@ -174,7 +175,7 @@ class AverageTrueRangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(5e-05, floored_atr.value)
+        assert floored_atr.value == 5e-05
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -185,5 +186,5 @@ class AverageTrueRangeTests(unittest.TestCase):
         self.atr.reset()
 
         # Assert
-        self.assertFalse(self.atr.initialized)
-        self.assertEqual(0, self.atr.value)
+        assert not self.atr.initialized
+        assert self.atr.value == 0

--- a/tests/unit_tests/indicators/test_base_indicator.py
+++ b/tests/unit_tests/indicators/test_base_indicator.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.indicators.base.indicator import Indicator
 from tests.test_kit.providers import TestInstrumentProvider
@@ -23,7 +23,7 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class IndicatorTests(unittest.TestCase):
+class TestIndicator:
     def test_handle_quote_tick_raises_not_implemented_error(self):
         # Arrange
         indicator = Indicator([])
@@ -32,7 +32,8 @@ class IndicatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, indicator.handle_quote_tick, tick)
+        with pytest.raises(NotImplementedError):
+            indicator.handle_quote_tick(tick)
 
     def test_handle_trade_tick_raises_not_implemented_error(self):
         # Arrange
@@ -42,7 +43,8 @@ class IndicatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, indicator.handle_trade_tick, tick)
+        with pytest.raises(NotImplementedError):
+            indicator.handle_trade_tick(tick)
 
     def test_handle_bar_raises_not_implemented_error(self):
         # Arrange
@@ -52,7 +54,8 @@ class IndicatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, indicator.handle_bar, bar)
+        with pytest.raises(NotImplementedError):
+            indicator.handle_bar(bar)
 
     def test_reset_raises_not_implemented_error(self):
         # Arrange
@@ -60,4 +63,5 @@ class IndicatorTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertRaises(NotImplementedError, indicator.reset)
+        with pytest.raises(NotImplementedError):
+            indicator.reset()

--- a/tests/unit_tests/indicators/test_bid_ask_min_max.py
+++ b/tests/unit_tests/indicators/test_bid_ask_min_max.py
@@ -12,7 +12,6 @@
 
 from datetime import datetime
 from datetime import timedelta
-import unittest
 
 import pytz
 
@@ -26,7 +25,7 @@ from nautilus_trader.model.objects import Quantity
 from nautilus_trader.model.tick import QuoteTick
 
 
-class BidAskMinMaxTests(unittest.TestCase):
+class TestBidAskMinMax:
     instrument_id = InstrumentId(Symbol("SPY"), Venue("NYSE"))
 
     def test_instantiate(self):
@@ -35,11 +34,11 @@ class BidAskMinMaxTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(None, indicator.bids.min_price)
-        self.assertEqual(None, indicator.bids.max_price)
-        self.assertEqual(None, indicator.asks.min_price)
-        self.assertEqual(None, indicator.asks.max_price)
-        self.assertEqual(False, indicator.initialized)
+        assert indicator.bids.min_price is None
+        assert indicator.bids.max_price is None
+        assert indicator.asks.min_price is None
+        assert indicator.asks.max_price is None
+        assert indicator.initialized is False
 
     def test_handle_quote_tick(self):
         # Arrange
@@ -71,10 +70,10 @@ class BidAskMinMaxTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Price.from_str("0.9"), indicator.bids.min_price)
-        self.assertEqual(Price.from_str("1.0"), indicator.bids.max_price)
-        self.assertEqual(Price.from_str("2.1"), indicator.asks.min_price)
-        self.assertEqual(Price.from_str("2.1"), indicator.asks.max_price)
+        assert indicator.bids.min_price == Price.from_str("0.9")
+        assert indicator.bids.max_price == Price.from_str("1.0")
+        assert indicator.asks.min_price == Price.from_str("2.1")
+        assert indicator.asks.max_price == Price.from_str("2.1")
 
     def test_reset(self):
         # Arrange
@@ -96,19 +95,19 @@ class BidAskMinMaxTests(unittest.TestCase):
         indicator.reset()
 
         # Assert
-        self.assertIsNone(indicator.bids.min_price)
-        self.assertIsNone(indicator.asks.min_price)
+        assert indicator.bids.min_price is None
+        assert indicator.asks.min_price is None
 
 
-class WindowedMinMaxPricesTests(unittest.TestCase):
+class TestWindowedMinMaxPrices:
     def test_instantiate(self):
         # Arrange
         instance = WindowedMinMaxPrices(timedelta(minutes=5))
 
         # Act
         # Assert
-        self.assertEqual(None, instance.min_price)
-        self.assertEqual(None, instance.max_price)
+        assert instance.min_price is None
+        assert instance.max_price is None
 
     def test_add_price(self):
         # Arrange
@@ -120,8 +119,8 @@ class WindowedMinMaxPricesTests(unittest.TestCase):
             Price.from_str("1.0"),
         )
         # Assert
-        self.assertEqual(Price.from_str("1.0"), instance.min_price)
-        self.assertEqual(Price.from_str("1.0"), instance.max_price)
+        assert instance.min_price == Price.from_str("1.0")
+        assert instance.max_price == Price.from_str("1.0")
 
     def test_add_multiple_prices(self):
         # Arrange
@@ -139,8 +138,8 @@ class WindowedMinMaxPricesTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Price.from_str("0.9"), instance.min_price)
-        self.assertEqual(Price.from_str("1.0"), instance.max_price)
+        assert instance.min_price == Price.from_str("0.9")
+        assert instance.max_price == Price.from_str("1.0")
 
     def test_expire_items(self):
         # Arrange
@@ -164,8 +163,8 @@ class WindowedMinMaxPricesTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(Price.from_str("0.95"), instance.min_price)
-        self.assertEqual(Price.from_str("0.95"), instance.max_price)
+        assert instance.min_price == Price.from_str("0.95")
+        assert instance.max_price == Price.from_str("0.95")
 
     def test_reset(self):
         # Arrange
@@ -179,5 +178,5 @@ class WindowedMinMaxPricesTests(unittest.TestCase):
         instance.reset()
 
         # Assert
-        self.assertEqual(None, instance.min_price)
-        self.assertEqual(None, instance.max_price)
+        assert instance.min_price is None
+        assert instance.max_price is None

--- a/tests/unit_tests/indicators/test_bollinger_bands.py
+++ b/tests/unit_tests/indicators/test_bollinger_bands.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.bollinger_bands import BollingerBands
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,14 +21,14 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class BollingerBandsTests(unittest.TestCase):
+class TestBollingerBands:
     def test_name_returns_expected_name(self):
         # Arrange
         indicator = BollingerBands(20, 2.0)
 
         # Act
         # Assert
-        self.assertEqual("BollingerBands", indicator.name)
+        assert indicator.name == "BollingerBands"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
@@ -38,8 +36,8 @@ class BollingerBandsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual("BollingerBands(20, 2.0, SIMPLE)", str(indicator))
-        self.assertEqual("BollingerBands(20, 2.0, SIMPLE)", repr(indicator))
+        assert str(indicator) == "BollingerBands(20, 2.0, SIMPLE)"
+        assert repr(indicator) == "BollingerBands(20, 2.0, SIMPLE)"
 
     def test_properties_after_instantiation(self):
         # Arrange
@@ -47,11 +45,11 @@ class BollingerBandsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(20, indicator.period)
-        self.assertEqual(2.0, indicator.k)
-        self.assertEqual(0, indicator.upper)
-        self.assertEqual(0, indicator.lower)
-        self.assertEqual(0, indicator.middle)
+        assert indicator.period == 20
+        assert indicator.k == 2.0
+        assert indicator.upper == 0
+        assert indicator.lower == 0
+        assert indicator.middle == 0
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -65,7 +63,7 @@ class BollingerBandsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, indicator.initialized)
+        assert indicator.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -77,8 +75,8 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.1666916666666667, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.1666916666666667
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -90,8 +88,8 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -103,8 +101,8 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.0000266666666666, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.0000266666666666
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -114,9 +112,9 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.update_raw(1.00020, 1.00000, 1.00010)
 
         # Assert
-        self.assertEqual(1.00010, indicator.upper)
-        self.assertEqual(1.00010, indicator.middle)
-        self.assertEqual(1.00010, indicator.lower)
+        assert indicator.upper == 1.00010
+        assert indicator.middle == 1.00010
+        assert indicator.lower == 1.00010
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -128,9 +126,9 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.update_raw(1.00040, 1.00020, 1.00021)
 
         # Assert
-        self.assertEqual(1.0003155506390384, indicator.upper)
-        self.assertEqual(1.0001900000000001, indicator.middle)
-        self.assertEqual(1.0000644493609618, indicator.lower)
+        assert indicator.upper == 1.0003155506390384
+        assert indicator.middle == 1.0001900000000001
+        assert indicator.lower == 1.0000644493609618
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -146,7 +144,7 @@ class BollingerBandsTests(unittest.TestCase):
         indicator.reset()
 
         # Assert
-        self.assertFalse(indicator.initialized)
-        self.assertEqual(0, indicator.upper)
-        self.assertEqual(0, indicator.middle)
-        self.assertEqual(0, indicator.lower)
+        assert not indicator.initialized
+        assert indicator.upper == 0
+        assert indicator.middle == 0
+        assert indicator.lower == 0

--- a/tests/unit_tests/indicators/test_donchian_channel.py
+++ b/tests/unit_tests/indicators/test_donchian_channel.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.donchian_channel import DonchianChannel
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,8 +21,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class DonchianChannelTests(unittest.TestCase):
-    def setUp(self):
+class TestDonchianChannel:
+    def setup(self):
         # Fixture Setup
         self.dc = DonchianChannel(10)
 
@@ -32,26 +30,26 @@ class DonchianChannelTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("DonchianChannel", self.dc.name)
+        assert self.dc.name == "DonchianChannel"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("DonchianChannel(10)", str(self.dc))
-        self.assertEqual("DonchianChannel(10)", repr(self.dc))
+        assert str(self.dc) == "DonchianChannel(10)"
+        assert repr(self.dc) == "DonchianChannel(10)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.dc.period)
+        assert self.dc.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.dc.initialized)
+        assert self.dc.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -68,7 +66,7 @@ class DonchianChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.dc.initialized)
+        assert self.dc.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -80,8 +78,8 @@ class DonchianChannelTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.0000200000000001, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.0000200000000001
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -93,8 +91,8 @@ class DonchianChannelTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -106,8 +104,8 @@ class DonchianChannelTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.000025, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.000025
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -115,9 +113,9 @@ class DonchianChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.00020, self.dc.upper)
-        self.assertEqual(1.00010, self.dc.middle)
-        self.assertEqual(1.00000, self.dc.lower)
+        assert self.dc.upper == 1.00020
+        assert self.dc.middle == 1.00010
+        assert self.dc.lower == 1.00000
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -127,9 +125,9 @@ class DonchianChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.00040, self.dc.upper)
-        self.assertEqual(1.00020, self.dc.middle)
-        self.assertEqual(1.00000, self.dc.lower)
+        assert self.dc.upper == 1.00040
+        assert self.dc.middle == 1.00020
+        assert self.dc.lower == 1.00000
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -141,7 +139,7 @@ class DonchianChannelTests(unittest.TestCase):
         self.dc.reset()
 
         # Assert
-        self.assertFalse(self.dc.initialized)
-        self.assertEqual(0, self.dc.upper)
-        self.assertEqual(0, self.dc.middle)
-        self.assertEqual(0, self.dc.lower)
+        assert not self.dc.initialized
+        assert self.dc.upper == 0
+        assert self.dc.middle == 0
+        assert self.dc.lower == 0

--- a/tests/unit_tests/indicators/test_efficiency_ratio.py
+++ b/tests/unit_tests/indicators/test_efficiency_ratio.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.efficiency_ratio import EfficiencyRatio
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,31 +21,31 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class EfficiencyRatioTests(unittest.TestCase):
-    def setUp(self):
+class TestEfficiencyRatio:
+    def setup(self):
         # Fixture Setup
         self.er = EfficiencyRatio(10)
 
     def test_name_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("EfficiencyRatio", self.er.name)
+        assert self.er.name == "EfficiencyRatio"
 
     def test_str_repr_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("EfficiencyRatio(10)", str(self.er))
-        self.assertEqual("EfficiencyRatio(10)", repr(self.er))
+        assert str(self.er) == "EfficiencyRatio(10)"
+        assert repr(self.er) == "EfficiencyRatio(10)"
 
     def test_period(self):
         # Act
         # Assert
-        self.assertEqual(10, self.er.period)
+        assert self.er.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Act
         # Assert
-        self.assertEqual(False, self.er.initialized)
+        assert self.er.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -56,7 +54,7 @@ class EfficiencyRatioTests(unittest.TestCase):
             self.er.update_raw(1.00000)
 
         # Assert
-        self.assertEqual(True, self.er.initialized)
+        assert self.er.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -68,8 +66,8 @@ class EfficiencyRatioTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_value_with_one_input(self):
         # Arrange
@@ -77,7 +75,7 @@ class EfficiencyRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.er.value)
+        assert self.er.value == 0.0
 
     def test_value_with_efficient_higher_inputs(self):
         # Arrange
@@ -89,7 +87,7 @@ class EfficiencyRatioTests(unittest.TestCase):
             self.er.update_raw(initial_price)
 
         # Assert
-        self.assertEqual(1.0, self.er.value)
+        assert self.er.value == 1.0
 
     def test_value_with_efficient_lower_inputs(self):
         # Arrange
@@ -101,7 +99,7 @@ class EfficiencyRatioTests(unittest.TestCase):
             self.er.update_raw(initial_price)
 
         # Assert
-        self.assertEqual(1.0, self.er.value)
+        assert self.er.value == 1.0
 
     def test_value_with_oscillating_inputs_returns_zero(self):
         # Arrange
@@ -113,7 +111,7 @@ class EfficiencyRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.er.value)
+        assert self.er.value == 0.0
 
     def test_value_with_half_oscillating_inputs_returns_zero(self):
         # Arrange
@@ -125,7 +123,7 @@ class EfficiencyRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.3333333333333333, self.er.value)
+        assert self.er.value == 0.3333333333333333
 
     def test_value_with_noisy_inputs(self):
         # Arrange
@@ -139,7 +137,7 @@ class EfficiencyRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.42857142857215363, self.er.value)
+        assert self.er.value == 0.42857142857215363
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -150,5 +148,5 @@ class EfficiencyRatioTests(unittest.TestCase):
         self.er.reset()
 
         # Assert
-        self.assertFalse(self.er.initialized)
-        self.assertEqual(0, self.er.value)
+        assert not self.er.initialized
+        assert self.er.value == 0

--- a/tests/unit_tests/indicators/test_ema.py
+++ b/tests/unit_tests/indicators/test_ema.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.ema import ExponentialMovingAverage
 from nautilus_trader.model.enums import PriceType
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class ExponentialMovingAverageTests(unittest.TestCase):
-    def setUp(self):
+class TestExponentialMovingAverage:
+    def setup(self):
         # Fixture Setup
         self.ema = ExponentialMovingAverage(10)
 
@@ -33,32 +31,32 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("ExponentialMovingAverage", self.ema.name)
+        assert self.ema.name == "ExponentialMovingAverage"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("ExponentialMovingAverage(10)", str(self.ema))
-        self.assertEqual("ExponentialMovingAverage(10)", repr(self.ema))
+        assert str(self.ema) == "ExponentialMovingAverage(10)"
+        assert repr(self.ema) == "ExponentialMovingAverage(10)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.ema.period)
+        assert self.ema.period == 10
 
     def test_multiplier_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0.18181818181818182, self.ema.alpha)
+        assert self.ema.alpha == 0.18181818181818182
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.ema.initialized)
+        assert self.ema.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -76,7 +74,7 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         # Act
 
         # Assert
-        self.assertEqual(True, self.ema.initialized)
+        assert self.ema.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -88,8 +86,8 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00002, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00002
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -101,8 +99,8 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -114,8 +112,8 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -123,7 +121,7 @@ class ExponentialMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.ema.value)
+        assert self.ema.value == 1.0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -133,7 +131,7 @@ class ExponentialMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.5123966942148757, self.ema.value)
+        assert self.ema.value == 1.5123966942148757
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -144,5 +142,5 @@ class ExponentialMovingAverageTests(unittest.TestCase):
         self.ema.reset()
 
         # Assert
-        self.assertFalse(self.ema.initialized)
-        self.assertEqual(0.0, self.ema.value)
+        assert not self.ema.initialized
+        assert self.ema.value == 0.0

--- a/tests/unit_tests/indicators/test_fuzzy_candlesticks.py
+++ b/tests/unit_tests/indicators/test_fuzzy_candlesticks.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 import numpy as np
 
 from nautilus_trader.indicators.fuzzy_candlesticks import FuzzyCandle
@@ -30,8 +28,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class FuzzyCandlesticksTests(unittest.TestCase):
-    def setUp(self):
+class TestFuzzyCandlesticks:
+    def setup(self):
         # Fixture Setup
         self.fc = FuzzyCandlesticks(10, 0.5, 1.0, 2.0, 3.0)
 
@@ -63,9 +61,9 @@ class FuzzyCandlesticksTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertTrue(fuzzy_candle1 == fuzzy_candle1)
-        self.assertTrue(fuzzy_candle1 == fuzzy_candle2)
-        self.assertTrue(fuzzy_candle1 != fuzzy_candle3)
+        assert fuzzy_candle1 == fuzzy_candle1
+        assert fuzzy_candle1 == fuzzy_candle2
+        assert fuzzy_candle1 != fuzzy_candle3
 
     def test_fuzzy_str_and_repr(self):
         # Arrange
@@ -79,27 +77,27 @@ class FuzzyCandlesticksTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual("(1, 3, 2, 1, 1)", str(fuzzy_candle))
-        self.assertEqual("FuzzyCandle(1, 3, 2, 1, 1)", repr(fuzzy_candle))
+        assert str(fuzzy_candle) == "(1, 3, 2, 1, 1)"
+        assert repr(fuzzy_candle) == "FuzzyCandle(1, 3, 2, 1, 1)"
 
     def test_name_returns_expected_name(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("FuzzyCandlesticks", self.fc.name)
+        assert self.fc.name == "FuzzyCandlesticks"
 
     def test_str_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("FuzzyCandlesticks(10, 0.5, 1.0, 2.0, 3.0)", str(self.fc))
-        self.assertEqual("FuzzyCandlesticks(10, 0.5, 1.0, 2.0, 3.0)", repr(self.fc))
+        assert str(self.fc) == "FuzzyCandlesticks(10, 0.5, 1.0, 2.0, 3.0)"
+        assert repr(self.fc) == "FuzzyCandlesticks(10, 0.5, 1.0, 2.0, 3.0)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.fc.period)
+        assert self.fc.period == 10
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -111,7 +109,7 @@ class FuzzyCandlesticksTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
+        assert indicator.has_inputs
 
     def test_values_with_doji_bars_returns_expected_results(self):
         # Arrange
@@ -132,12 +130,12 @@ class FuzzyCandlesticksTests(unittest.TestCase):
         result_vector = self.fc.vector
 
         # Assert
-        self.assertTrue(np.array_equal([0, 0, 0, 0, 0], result_vector))
-        self.assertEqual(CandleDirection.NONE, result_candle.direction)
-        self.assertEqual(CandleSize.NONE, result_candle.size)
-        self.assertEqual(CandleBodySize.NONE, result_candle.body_size)
-        self.assertEqual(CandleWickSize.NONE, result_candle.upper_wick_size)
-        self.assertEqual(CandleWickSize.NONE, result_candle.lower_wick_size)
+        assert np.array_equal([0, 0, 0, 0, 0], result_vector)
+        assert result_candle.direction == CandleDirection.NONE
+        assert result_candle.size == CandleSize.NONE
+        assert result_candle.body_size == CandleBodySize.NONE
+        assert result_candle.upper_wick_size == CandleWickSize.NONE
+        assert result_candle.lower_wick_size == CandleWickSize.NONE
 
     def test_values_with_stub_bars_returns_expected_results(self):
         # Arrange
@@ -157,12 +155,12 @@ class FuzzyCandlesticksTests(unittest.TestCase):
         result_vector = self.fc.vector
 
         # Assert
-        self.assertTrue(np.array_equal([1, 1, 1, 1, 1], result_vector))
-        self.assertEqual(CandleDirection.BULL, result_candle.direction)
-        self.assertEqual(CandleSize.VERY_SMALL, result_candle.size)
-        self.assertEqual(CandleBodySize.SMALL, result_candle.body_size)
-        self.assertEqual(CandleWickSize.SMALL, result_candle.upper_wick_size)
-        self.assertEqual(CandleWickSize.SMALL, result_candle.lower_wick_size)
+        assert np.array_equal([1, 1, 1, 1, 1], result_vector)
+        assert result_candle.direction == CandleDirection.BULL
+        assert result_candle.size == CandleSize.VERY_SMALL
+        assert result_candle.body_size == CandleBodySize.SMALL
+        assert result_candle.upper_wick_size == CandleWickSize.SMALL
+        assert result_candle.lower_wick_size == CandleWickSize.SMALL
 
     def test_values_with_down_market_returns_expected_results(self):
         # Arrange
@@ -182,12 +180,12 @@ class FuzzyCandlesticksTests(unittest.TestCase):
         result_vector = self.fc.vector
 
         # Assert
-        self.assertTrue([-1, 2, 4, 2, 2], result_vector)
-        self.assertEqual(CandleDirection.BEAR, result_candle.direction)
-        self.assertEqual(CandleSize.SMALL, result_candle.size)
-        self.assertEqual(CandleBodySize.TREND, result_candle.body_size)
-        self.assertEqual(CandleWickSize.MEDIUM, result_candle.upper_wick_size)
-        self.assertEqual(CandleWickSize.MEDIUM, result_candle.lower_wick_size)
+        assert [-1, 2, 4, 2, 2], result_vector
+        assert result_candle.direction == CandleDirection.BEAR
+        assert result_candle.size == CandleSize.SMALL
+        assert result_candle.body_size == CandleBodySize.TREND
+        assert result_candle.upper_wick_size == CandleWickSize.MEDIUM
+        assert result_candle.lower_wick_size == CandleWickSize.MEDIUM
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -198,4 +196,4 @@ class FuzzyCandlesticksTests(unittest.TestCase):
         self.fc.reset()
 
         # Assert
-        self.assertEqual(False, self.fc.initialized)  # No assertion errors.
+        assert self.fc.initialized is False  # No assertion errors.

--- a/tests/unit_tests/indicators/test_hilbert_period.py
+++ b/tests/unit_tests/indicators/test_hilbert_period.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import sys
-import unittest
 
 from nautilus_trader.indicators.hilbert_period import HilbertPeriod
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +23,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class HilbertPeriodTests(unittest.TestCase):
-    def setUp(self):
+class TestHilbertPeriod:
+    def setup(self):
         # Fixture Setup
         self.h_period = HilbertPeriod()
 
@@ -33,26 +32,26 @@ class HilbertPeriodTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertPeriod", self.h_period.name)
+        assert self.h_period.name == "HilbertPeriod"
 
     def test_str_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertPeriod(7)", str(self.h_period))
-        self.assertEqual("HilbertPeriod(7)", repr(self.h_period))
+        assert str(self.h_period) == "HilbertPeriod(7)"
+        assert repr(self.h_period) == "HilbertPeriod(7)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(7, self.h_period.period)
+        assert self.h_period.period == 7
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.h_period.initialized)
+        assert self.h_period.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -61,7 +60,7 @@ class HilbertPeriodTests(unittest.TestCase):
             self.h_period.update_raw(1.00010, 1.00000)
 
         # Assert
-        self.assertEqual(True, self.h_period.initialized)
+        assert self.h_period.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -73,14 +72,14 @@ class HilbertPeriodTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_value_with_no_inputs_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0, self.h_period.value)
+        assert self.h_period.value == 0
 
     def test_value_with_epsilon_inputs_returns_expected_value(self):
         # Arrange
@@ -89,7 +88,7 @@ class HilbertPeriodTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(7, self.h_period.value)
+        assert self.h_period.value == 7
 
     def test_value_with_ones_inputs_returns_expected_value(self):
         # Arrange
@@ -98,7 +97,7 @@ class HilbertPeriodTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(7, self.h_period.value)
+        assert self.h_period.value == 7
 
     def test_value_with_seven_inputs_returns_expected_value(self):
         # Arrange
@@ -112,7 +111,7 @@ class HilbertPeriodTests(unittest.TestCase):
             self.h_period.update_raw(high, low)
 
         # Assert
-        self.assertEqual(0, self.h_period.value)
+        assert self.h_period.value == 0
 
     def test_value_with_close_on_high_returns_expected_value(self):
         # Arrange
@@ -126,7 +125,7 @@ class HilbertPeriodTests(unittest.TestCase):
             self.h_period.update_raw(high, low)
 
         # Assert
-        self.assertEqual(7, self.h_period.value)
+        assert self.h_period.value == 7
 
     def test_value_with_close_on_low_returns_expected_value(self):
         # Arrange
@@ -140,7 +139,7 @@ class HilbertPeriodTests(unittest.TestCase):
             self.h_period.update_raw(high, low)
 
         # Assert
-        self.assertEqual(7, self.h_period.value)
+        assert self.h_period.value == 7
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -151,4 +150,4 @@ class HilbertPeriodTests(unittest.TestCase):
         self.h_period.reset()
 
         # Assert
-        self.assertEqual(0, self.h_period.value)  # No exceptions raised
+        assert self.h_period.value == 0  # No exceptions raised

--- a/tests/unit_tests/indicators/test_hilbert_snr.py
+++ b/tests/unit_tests/indicators/test_hilbert_snr.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import sys
-import unittest
 
 from nautilus_trader.indicators.hilbert_snr import HilbertSignalNoiseRatio
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +23,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class HilbertSignalNoiseRatioTests(unittest.TestCase):
-    def setUp(self):
+class TestHilbertSignalNoiseRatio:
+    def setup(self):
         # Fixture Setup
         self.snr = HilbertSignalNoiseRatio()
 
@@ -33,26 +32,26 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertSignalNoiseRatio", self.snr.name)
+        assert self.snr.name == "HilbertSignalNoiseRatio"
 
     def test_str_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertSignalNoiseRatio(7)", str(self.snr))
-        self.assertEqual("HilbertSignalNoiseRatio(7)", repr(self.snr))
+        assert str(self.snr) == "HilbertSignalNoiseRatio(7)"
+        assert repr(self.snr) == "HilbertSignalNoiseRatio(7)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(7, self.snr.period)
+        assert self.snr.period == 7
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.snr.initialized)
+        assert self.snr.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -61,7 +60,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
             self.snr.update_raw(1.00010, 1.00000)
 
         # Assert
-        self.assertEqual(True, self.snr.initialized)
+        assert self.snr.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -73,13 +72,13 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertEqual(0, indicator.value)
+        assert indicator.value == 0
 
     def test_value_with_no_inputs_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0.0, self.snr.value)
+        assert self.snr.value == 0.0
 
     def test_value_with_epsilon_inputs_returns_expected_value(self):
         # Arrange
@@ -88,7 +87,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.snr.value)
+        assert self.snr.value == 0
 
     def test_value_with_ones_inputs_returns_expected_value(self):
         # Arrange
@@ -97,7 +96,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.snr.value)
+        assert self.snr.value == 0
 
     def test_value_with_seven_inputs_returns_expected_value(self):
         # Arrange
@@ -111,7 +110,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
             self.snr.update_raw(high, low)
 
         # Assert
-        self.assertEqual(0, self.snr.value)
+        assert self.snr.value == 0
 
     def test_value_with_close_on_high_returns_expected_value(self):
         # Arrange
@@ -125,7 +124,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
             self.snr.update_raw(high, low)
 
         # Assert
-        self.assertEqual(51.90000000000095, self.snr.value)
+        assert self.snr.value == 51.90000000000095
 
     def test_value_with_close_on_low_returns_expected_value(self):
         # Arrange
@@ -139,7 +138,7 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
             self.snr.update_raw(high, low)
 
         # Assert
-        self.assertEqual(51.90000000000095, self.snr.value)
+        assert self.snr.value == 51.90000000000095
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -150,4 +149,4 @@ class HilbertSignalNoiseRatioTests(unittest.TestCase):
         self.snr.reset()
 
         # Assert
-        self.assertEqual(0.0, self.snr.value)  # No assertion errors.
+        assert self.snr.value == 0.0  # No assertion errors.

--- a/tests/unit_tests/indicators/test_hilbert_transform.py
+++ b/tests/unit_tests/indicators/test_hilbert_transform.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import sys
-import unittest
 
 from nautilus_trader.indicators.hilbert_transform import HilbertTransform
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +23,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class HilbertTransformTests(unittest.TestCase):
-    def setUp(self):
+class TestHilbertTransform:
+    def setup(self):
         # Fixture Setup
         self.ht = HilbertTransform()
 
@@ -33,26 +32,26 @@ class HilbertTransformTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertTransform", self.ht.name)
+        assert self.ht.name == "HilbertTransform"
 
     def test_str_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("HilbertTransform(7)", str(self.ht))
-        self.assertEqual("HilbertTransform(7)", repr(self.ht))
+        assert str(self.ht) == "HilbertTransform(7)"
+        assert repr(self.ht) == "HilbertTransform(7)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(7, self.ht.period)
+        assert self.ht.period == 7
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.ht.initialized)
+        assert self.ht.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -61,7 +60,7 @@ class HilbertTransformTests(unittest.TestCase):
             self.ht.update_raw(1.00000)
 
         # Assert
-        self.assertEqual(True, self.ht.initialized)
+        assert self.ht.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -73,15 +72,15 @@ class HilbertTransformTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value_quad)
+        assert indicator.has_inputs
+        assert indicator.value_quad == 0
 
     def test_value_with_no_inputs_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0.0, self.ht.value_in_phase)
-        self.assertEqual(0.0, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.0
+        assert self.ht.value_quad == 0.0
 
     def test_value_with_epsilon_inputs_returns_expected_value(self):
         # Arrange
@@ -90,8 +89,8 @@ class HilbertTransformTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.ht.value_in_phase)
-        self.assertEqual(0.0, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.0
+        assert self.ht.value_quad == 0.0
 
     def test_value_with_ones_inputs_returns_expected_value(self):
         # Arrange
@@ -100,8 +99,8 @@ class HilbertTransformTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.ht.value_in_phase)
-        self.assertEqual(0.0, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.0
+        assert self.ht.value_quad == 0.0
 
     def test_value_with_seven_inputs_returns_expected_value(self):
         # Arrange
@@ -115,8 +114,8 @@ class HilbertTransformTests(unittest.TestCase):
             self.ht.update_raw((high + low) / 2)
 
         # Assert
-        self.assertEqual(0.0, self.ht.value_in_phase)
-        self.assertEqual(0.0, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.0
+        assert self.ht.value_quad == 0.0
 
     def test_value_with_close_on_high_returns_expected_value(self):
         # Arrange
@@ -130,8 +129,8 @@ class HilbertTransformTests(unittest.TestCase):
             self.ht.update_raw((high + low) / 2)
 
         # Assert
-        self.assertEqual(0.001327272727272581, self.ht.value_in_phase)
-        self.assertEqual(0.0005999999999999338, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.001327272727272581
+        assert self.ht.value_quad == 0.0005999999999999338
 
     def test_value_with_close_on_low_returns_expected_value(self):
         # Arrange
@@ -145,8 +144,8 @@ class HilbertTransformTests(unittest.TestCase):
             self.ht.update_raw((high + low) / 2)
 
         # Assert
-        self.assertEqual(-0.001327272727272581, self.ht.value_in_phase)
-        self.assertEqual(-0.0005999999999999338, self.ht.value_quad)
+        assert self.ht.value_in_phase == -0.001327272727272581
+        assert self.ht.value_quad == -0.0005999999999999338
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -157,5 +156,5 @@ class HilbertTransformTests(unittest.TestCase):
         self.ht.reset()
 
         # Assert
-        self.assertEqual(0.0, self.ht.value_in_phase)  # No assertion errors.
-        self.assertEqual(0.0, self.ht.value_quad)
+        assert self.ht.value_in_phase == 0.0  # No assertion errors.
+        assert self.ht.value_quad == 0.0

--- a/tests/unit_tests/indicators/test_hma.py
+++ b/tests/unit_tests/indicators/test_hma.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.hma import HullMovingAverage
 from nautilus_trader.model.enums import PriceType
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,21 +22,21 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class HullMovingAverageTests(unittest.TestCase):
-    def setUp(self):
+class TestHullMovingAverage:
+    def setup(self):
         # Fixture Setup
         self.hma = HullMovingAverage(10)
 
     def test_name_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("HullMovingAverage", self.hma.name)
+        assert self.hma.name == "HullMovingAverage"
 
     def test_str_repr_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("HullMovingAverage(10)", str(self.hma))
-        self.assertEqual("HullMovingAverage(10)", repr(self.hma))
+        assert str(self.hma) == "HullMovingAverage(10)"
+        assert repr(self.hma) == "HullMovingAverage(10)"
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -55,7 +53,7 @@ class HullMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.hma.initialized)
+        assert self.hma.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -67,8 +65,8 @@ class HullMovingAverageTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00002, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00002
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -80,8 +78,8 @@ class HullMovingAverageTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -93,8 +91,8 @@ class HullMovingAverageTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -102,7 +100,7 @@ class HullMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.hma.value)
+        assert self.hma.value == 1.0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -112,7 +110,7 @@ class HullMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.8245614035087718, self.hma.value)
+        assert self.hma.value == 1.8245614035087718
 
     def test_value_with_ten_inputs_returns_expected_value(self):
         # Arrange
@@ -130,7 +128,7 @@ class HullMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0001403928170594, self.hma.value)
+        assert self.hma.value == 1.0001403928170594
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -142,4 +140,4 @@ class HullMovingAverageTests(unittest.TestCase):
         self.hma.reset()
 
         # Assert
-        self.assertFalse(self.hma.initialized)
+        assert not self.hma.initialized

--- a/tests/unit_tests/indicators/test_keltner_channel.py
+++ b/tests/unit_tests/indicators/test_keltner_channel.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.moving_average import MovingAverageType
 from nautilus_trader.indicators.keltner_channel import KeltnerChannel
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class KeltnerChannelTests(unittest.TestCase):
-    def setUp(self):
+class TestKeltnerChannel:
+    def setup(self):
         # Fixture Setup
         self.kc = KeltnerChannel(10, 2.5, MovingAverageType.EXPONENTIAL, MovingAverageType.SIMPLE)
 
@@ -33,32 +31,32 @@ class KeltnerChannelTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("KeltnerChannel", self.kc.name)
+        assert self.kc.name == "KeltnerChannel"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("KeltnerChannel(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)", str(self.kc))
-        self.assertEqual("KeltnerChannel(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)", repr(self.kc))
+        assert str(self.kc) == "KeltnerChannel(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)"
+        assert repr(self.kc) == "KeltnerChannel(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.kc.period)
+        assert self.kc.period == 10
 
     def test_k_multiple_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(2.5, self.kc.k_multiplier)
+        assert self.kc.k_multiplier == 2.5
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.kc.initialized)
+        assert self.kc.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -75,7 +73,7 @@ class KeltnerChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.kc.initialized)
+        assert self.kc.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -87,8 +85,8 @@ class KeltnerChannelTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.0000266666666666, indicator.middle)
+        assert indicator.has_inputs
+        assert indicator.middle == 1.0000266666666666
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -96,9 +94,9 @@ class KeltnerChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0006, self.kc.upper)
-        self.assertEqual(1.0001, self.kc.middle)
-        self.assertEqual(0.9996, self.kc.lower)
+        assert self.kc.upper == 1.0006
+        assert self.kc.middle == 1.0001
+        assert self.kc.lower == 0.9996
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -108,9 +106,9 @@ class KeltnerChannelTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0006512396694212, self.kc.upper)
-        self.assertEqual(1.0001512396694212, self.kc.middle)
-        self.assertEqual(0.9996512396694213, self.kc.lower)
+        assert self.kc.upper == 1.0006512396694212
+        assert self.kc.middle == 1.0001512396694212
+        assert self.kc.lower == 0.9996512396694213
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -122,4 +120,4 @@ class KeltnerChannelTests(unittest.TestCase):
         self.kc.reset()
 
         # Assert
-        self.assertFalse(self.kc.initialized)
+        assert not self.kc.initialized

--- a/tests/unit_tests/indicators/test_keltner_position.py
+++ b/tests/unit_tests/indicators/test_keltner_position.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.indicators.keltner_position import KeltnerPosition
 from tests.test_kit.providers import TestInstrumentProvider
@@ -23,8 +23,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class KeltnerPositionTests(unittest.TestCase):
-    def setUp(self):
+class TestKeltnerPosition:
+    def setup(self):
         # Fixture Setup
         self.kp = KeltnerPosition(10, 2.5)
 
@@ -32,20 +32,20 @@ class KeltnerPositionTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("KeltnerPosition", self.kp.name)
+        assert self.kp.name == "KeltnerPosition"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("KeltnerPosition(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)", str(self.kp))
-        self.assertEqual("KeltnerPosition(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)", repr(self.kp))
+        assert str(self.kp) == "KeltnerPosition(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)"
+        assert repr(self.kp) == "KeltnerPosition(10, 2.5, EXPONENTIAL, SIMPLE, True, 0.0)"
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.kp.initialized)
+        assert self.kp.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -54,19 +54,19 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.kp.initialized)
+        assert self.kp.initialized is True
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.kp.period)
+        assert self.kp.period == 10
 
     def test_k_multiple_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(2.5, self.kp.k_multiplier)
+        assert self.kp.k_multiplier == 2.5
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -78,8 +78,8 @@ class KeltnerPositionTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0.0444444444447405, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0.0444444444447405
 
     def test_value_with_one_input_returns_zero(self):
         # Arrange
@@ -87,7 +87,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.kp.value)
+        assert self.kp.value == 0
 
     def test_value_with_zero_width_input_returns_zero(self):
         # Arrange
@@ -96,7 +96,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.kp.value)
+        assert self.kp.value == 0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -106,7 +106,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.29752066115754594, self.kp.value)
+        assert self.kp.value == 0.29752066115754594
 
     def test_value_with_close_on_high_returns_positive_value(self):
         # Arrange
@@ -121,7 +121,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.637585941284833, self.kp.value)
+        assert self.kp.value == 1.637585941284833
 
     def test_value_with_close_on_low_returns_lower_value(self):
         # Arrange
@@ -136,7 +136,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertAlmostEqual(-1.637585941284833, self.kp.value)
+        assert self.kp.value == pytest.approx(-1.637585941284833)
 
     def test_value_with_ten_inputs_returns_expected_value(self):
         # Arrange
@@ -153,7 +153,7 @@ class KeltnerPositionTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(-0.14281747514671334, self.kp.value)
+        assert self.kp.value == -0.14281747514671334
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -165,4 +165,4 @@ class KeltnerPositionTests(unittest.TestCase):
         self.kp.reset()
 
         # Assert
-        self.assertFalse(self.kp.initialized)
+        assert not self.kp.initialized

--- a/tests/unit_tests/indicators/test_ma_factory.py
+++ b/tests/unit_tests/indicators/test_ma_factory.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.ema import ExponentialMovingAverage
 from nautilus_trader.indicators.average.hma import HullMovingAverage
 from nautilus_trader.indicators.average.ma_factory import MovingAverageFactory
@@ -27,14 +25,14 @@ from tests.test_kit.providers import TestInstrumentProvider
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
+class TestMovingAverageConvergenceDivergence:
     def test_simple_returns_expected_indicator(self):
         # Arrange
         # Act
         indicator = MovingAverageFactory.create(10, MovingAverageType.SIMPLE)
 
         # Assert
-        self.assertTrue(isinstance(indicator, SimpleMovingAverage))
+        assert isinstance(indicator, SimpleMovingAverage)
 
     def test_exponential_returns_expected_indicator(self):
         # Arrange
@@ -42,7 +40,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator = MovingAverageFactory.create(10, MovingAverageType.EXPONENTIAL)
 
         # Assert
-        self.assertTrue(isinstance(indicator, ExponentialMovingAverage))
+        assert isinstance(indicator, ExponentialMovingAverage)
 
     def test_hull_returns_expected_indicator(self):
         # Arrange
@@ -50,7 +48,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator = MovingAverageFactory.create(10, MovingAverageType.HULL)
 
         # Assert
-        self.assertTrue(isinstance(indicator, HullMovingAverage))
+        assert isinstance(indicator, HullMovingAverage)
 
     def test_weighted_returns_expected_indicator(self):
         # Arrange
@@ -58,4 +56,4 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator = MovingAverageFactory.create(10, MovingAverageType.WEIGHTED)
 
         # Assert
-        self.assertTrue(isinstance(indicator, WeightedMovingAverage))
+        assert isinstance(indicator, WeightedMovingAverage)

--- a/tests/unit_tests/indicators/test_macd.py
+++ b/tests/unit_tests/indicators/test_macd.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.macd import MovingAverageConvergenceDivergence
 from nautilus_trader.model.enums import PriceType
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
-    def setUp(self):
+class TestMovingAverageConvergenceDivergence:
+    def setup(self):
         # Fixture Setup
         self.macd = MovingAverageConvergenceDivergence(3, 10)
 
@@ -33,20 +31,20 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("MovingAverageConvergenceDivergence", self.macd.name)
+        assert self.macd.name == "MovingAverageConvergenceDivergence"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("MovingAverageConvergenceDivergence(3, 10, EXPONENTIAL)", str(self.macd))
-        self.assertEqual("MovingAverageConvergenceDivergence(3, 10, EXPONENTIAL)", repr(self.macd))
+        assert str(self.macd) == "MovingAverageConvergenceDivergence(3, 10, EXPONENTIAL)"
+        assert repr(self.macd) == "MovingAverageConvergenceDivergence(3, 10, EXPONENTIAL)"
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.macd.initialized)
+        assert self.macd.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -69,7 +67,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.macd.initialized)
+        assert self.macd.initialized is True
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -81,8 +79,8 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -94,8 +92,8 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -107,8 +105,8 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -116,7 +114,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.macd.value)
+        assert self.macd.value == 0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -126,7 +124,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.7376033057851243, self.macd.value)
+        assert self.macd.value == 0.7376033057851243
 
     def test_value_with_more_inputs_expected_value(self):
         # Arrange
@@ -149,7 +147,7 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(3.2782313673122907, self.macd.value)
+        assert self.macd.value == 3.2782313673122907
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -161,4 +159,4 @@ class MovingAverageConvergenceDivergenceTests(unittest.TestCase):
         self.macd.reset()
 
         # Assert
-        self.assertFalse(self.macd.initialized)
+        assert not self.macd.initialized

--- a/tests/unit_tests/indicators/test_obv.py
+++ b/tests/unit_tests/indicators/test_obv.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.obv import OnBalanceVolume
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,8 +21,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class OnBalanceVolumeTests(unittest.TestCase):
-    def setUp(self):
+class TestOnBalanceVolume:
+    def setup(self):
         # Fixture Setup
         self.obv = OnBalanceVolume(100)
 
@@ -32,26 +30,26 @@ class OnBalanceVolumeTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("OnBalanceVolume", self.obv.name)
+        assert self.obv.name == "OnBalanceVolume"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("OnBalanceVolume(100)", str(self.obv))
-        self.assertEqual("OnBalanceVolume(100)", repr(self.obv))
+        assert str(self.obv) == "OnBalanceVolume(100)"
+        assert repr(self.obv) == "OnBalanceVolume(100)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(100, self.obv.period)
+        assert self.obv.period == 100
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.obv.initialized)
+        assert self.obv.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -60,7 +58,7 @@ class OnBalanceVolumeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.obv.initialized)
+        assert self.obv.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -72,8 +70,8 @@ class OnBalanceVolumeTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1000000, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1000000
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -81,7 +79,7 @@ class OnBalanceVolumeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(10000, self.obv.value)
+        assert self.obv.value == 10000
 
     def test_values_with_higher_inputs_returns_expected_value(self):
         # Arrange
@@ -98,7 +96,7 @@ class OnBalanceVolumeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(90000.0, self.obv.value)
+        assert self.obv.value == 90000.0
 
     def test_values_with_lower_inputs_returns_expected_value(self):
         # Arrange
@@ -115,7 +113,7 @@ class OnBalanceVolumeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(-90000.0, self.obv.value)
+        assert self.obv.value == -90000.0
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -126,4 +124,4 @@ class OnBalanceVolumeTests(unittest.TestCase):
         self.obv.reset()
 
         # Assert
-        self.assertFalse(self.obv.initialized)
+        assert not self.obv.initialized

--- a/tests/unit_tests/indicators/test_pressure.py
+++ b/tests/unit_tests/indicators/test_pressure.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.moving_average import MovingAverageType
 from nautilus_trader.indicators.pressure import Pressure
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class PressureTests(unittest.TestCase):
-    def setUp(self):
+class TestPressure:
+    def setup(self):
         # Fixture Setup
         self.pressure = Pressure(10, MovingAverageType.EXPONENTIAL)
 
@@ -33,26 +31,26 @@ class PressureTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("Pressure", self.pressure.name)
+        assert self.pressure.name == "Pressure"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("Pressure(10, EXPONENTIAL, 0.0)", str(self.pressure))
-        self.assertEqual("Pressure(10, EXPONENTIAL, 0.0)", repr(self.pressure))
+        assert str(self.pressure) == "Pressure(10, EXPONENTIAL, 0.0)"
+        assert repr(self.pressure) == "Pressure(10, EXPONENTIAL, 0.0)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.pressure.period)
+        assert self.pressure.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.pressure.initialized)
+        assert self.pressure.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -61,7 +59,7 @@ class PressureTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.pressure.initialized)
+        assert self.pressure.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -73,8 +71,8 @@ class PressureTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0.333333333328399, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0.333333333328399
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -82,7 +80,7 @@ class PressureTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.pressure.value)
+        assert self.pressure.value == 0
 
     def test_values_with_higher_inputs_returns_expected_value(self):
         # Arrange
@@ -99,8 +97,8 @@ class PressureTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.6027263066543116, self.pressure.value)
-        self.assertEqual(17.427420446202998, self.pressure.value_cumulative)
+        assert self.pressure.value == 1.6027263066543116
+        assert self.pressure.value_cumulative == 17.427420446202998
 
     def test_values_with_all_lower_inputs_returns_expected_value(self):
         # Arrange
@@ -117,8 +115,8 @@ class PressureTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(-1.602726306654309, self.pressure.value)
-        self.assertEqual(-17.427420446203406, self.pressure.value_cumulative)
+        assert self.pressure.value == -1.602726306654309
+        assert self.pressure.value_cumulative == -17.427420446203406
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -129,4 +127,4 @@ class PressureTests(unittest.TestCase):
         self.pressure.reset()
 
         # Assert
-        self.assertFalse(self.pressure.initialized)
+        assert not self.pressure.initialized

--- a/tests/unit_tests/indicators/test_roc.py
+++ b/tests/unit_tests/indicators/test_roc.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.roc import RateOfChange
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,31 +21,31 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class RateOfChangeTests(unittest.TestCase):
-    def setUp(self):
+class TestRateOfChange:
+    def setup(self):
         # Fixture Setup
         self.roc = RateOfChange(3)
 
     def test_name_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("RateOfChange", self.roc.name)
+        assert self.roc.name == "RateOfChange"
 
     def test_str_repr_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("RateOfChange(3)", str(self.roc))
-        self.assertEqual("RateOfChange(3)", repr(self.roc))
+        assert str(self.roc) == "RateOfChange(3)"
+        assert repr(self.roc) == "RateOfChange(3)"
 
     def test_period(self):
         # Act
         # Assert
-        self.assertEqual(3, self.roc.period)
+        assert self.roc.period == 3
 
     def test_initialized_without_inputs_returns_false(self):
         # Act
         # Assert
-        self.assertEqual(False, self.roc.initialized)
+        assert self.roc.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -56,7 +54,7 @@ class RateOfChangeTests(unittest.TestCase):
             self.roc.update_raw(1.00000)
 
         # Assert
-        self.assertEqual(True, self.roc.initialized)
+        assert self.roc.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -68,8 +66,8 @@ class RateOfChangeTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 0
 
     def test_value_with_one_input(self):
         # Arrange
@@ -77,7 +75,7 @@ class RateOfChangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.roc.value)
+        assert self.roc.value == 0
 
     def test_value_with_efficient_higher_inputs(self):
         # Arrange
@@ -89,7 +87,7 @@ class RateOfChangeTests(unittest.TestCase):
             self.roc.update_raw(price)
 
         # Assert
-        self.assertEqual(0.11111111111111116, self.roc.value)
+        assert self.roc.value == 0.11111111111111116
 
     def test_value_with_oscillating_inputs_returns_zero(self):
         # Arrange
@@ -101,7 +99,7 @@ class RateOfChangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.0, self.roc.value)
+        assert self.roc.value == 0.0
 
     def test_value_with_half_oscillating_inputs_returns_zero(self):
         # Arrange
@@ -113,7 +111,7 @@ class RateOfChangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(9.9990000999889e-05, self.roc.value)
+        assert self.roc.value == 9.9990000999889e-05
 
     def test_value_with_noisy_inputs(self):
         # Arrange
@@ -127,7 +125,7 @@ class RateOfChangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(2.9996400432144683e-05, self.roc.value)
+        assert self.roc.value == 2.9996400432144683e-05
 
     def test_log_returns_value_with_noisy_inputs(self):
         # Arrange
@@ -143,7 +141,7 @@ class RateOfChangeTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(2.999595054919663e-05, roc.value)
+        assert roc.value == 2.999595054919663e-05
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -154,5 +152,5 @@ class RateOfChangeTests(unittest.TestCase):
         self.roc.reset()
 
         # Assert
-        self.assertFalse(self.roc.initialized)
-        self.assertEqual(0, self.roc.value)
+        assert not self.roc.initialized
+        assert self.roc.value == 0

--- a/tests/unit_tests/indicators/test_rsi.py
+++ b/tests/unit_tests/indicators/test_rsi.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.rsi import RelativeStrengthIndex
 from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.stubs import TestStubs
@@ -23,8 +21,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class RelativeStrengthIndexTests(unittest.TestCase):
-    def setUp(self):
+class TestRelativeStrengthIndex:
+    def setup(self):
         # Fixture Setup
         self.rsi = RelativeStrengthIndex(10)
 
@@ -32,26 +30,26 @@ class RelativeStrengthIndexTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("RelativeStrengthIndex", self.rsi.name)
+        assert self.rsi.name == "RelativeStrengthIndex"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("RelativeStrengthIndex(10, EXPONENTIAL)", str(self.rsi))
-        self.assertEqual("RelativeStrengthIndex(10, EXPONENTIAL)", repr(self.rsi))
+        assert str(self.rsi) == "RelativeStrengthIndex(10, EXPONENTIAL)"
+        assert repr(self.rsi) == "RelativeStrengthIndex(10, EXPONENTIAL)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.rsi.period)
+        assert self.rsi.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.rsi.initialized)
+        assert self.rsi.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -68,7 +66,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.rsi.initialized)
+        assert self.rsi.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -80,8 +78,8 @@ class RelativeStrengthIndexTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.0
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -89,7 +87,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1, self.rsi.value)
+        assert self.rsi.value == 1
 
     def test_value_with_all_higher_inputs_returns_expected_value(self):
         # Arrange
@@ -100,7 +98,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1, self.rsi.value)
+        assert self.rsi.value == 1
 
     def test_value_with_all_lower_inputs_returns_expected_value(self):
         # Arrange
@@ -111,7 +109,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.rsi.value)
+        assert self.rsi.value == 0
 
     def test_value_with_various_inputs_returns_expected_value(self):
         # Arrange
@@ -124,7 +122,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.6837363325825265, self.rsi.value)
+        assert self.rsi.value == 0.6837363325825265
 
     def test_value_at_returns_expected_value(self):
         # Arrange
@@ -139,7 +137,7 @@ class RelativeStrengthIndexTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0.7615344667662725, self.rsi.value)
+        assert self.rsi.value == 0.7615344667662725
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -151,5 +149,5 @@ class RelativeStrengthIndexTests(unittest.TestCase):
         self.rsi.reset()
 
         # Assert
-        self.assertFalse(self.rsi.initialized)
-        self.assertEqual(0, self.rsi.value)
+        assert not self.rsi.initialized
+        assert self.rsi.value == 0

--- a/tests/unit_tests/indicators/test_sma.py
+++ b/tests/unit_tests/indicators/test_sma.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.average.sma import SimpleMovingAverage
 from nautilus_trader.model.enums import PriceType
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +22,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class SimpleMovingAverageTests(unittest.TestCase):
-    def setUp(self):
+class TestSimpleMovingAverage:
+    def setup(self):
         # Fixture Setup
         self.sma = SimpleMovingAverage(10)
 
@@ -33,26 +31,26 @@ class SimpleMovingAverageTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("SimpleMovingAverage", self.sma.name)
+        assert self.sma.name == "SimpleMovingAverage"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("SimpleMovingAverage(10)", str(self.sma))
-        self.assertEqual("SimpleMovingAverage(10)", repr(self.sma))
+        assert str(self.sma) == "SimpleMovingAverage(10)"
+        assert repr(self.sma) == "SimpleMovingAverage(10)"
 
     def test_period_returns_expected_value(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(10, self.sma.period)
+        assert self.sma.period == 10
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.sma.initialized)
+        assert self.sma.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -69,9 +67,9 @@ class SimpleMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.sma.initialized)
-        self.assertEqual(10, self.sma.count)
-        self.assertEqual(5.5, self.sma.value)
+        assert self.sma.initialized is True
+        assert self.sma.count == 10
+        assert self.sma.value == 5.5
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -83,8 +81,8 @@ class SimpleMovingAverageTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00002, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00002
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -96,8 +94,8 @@ class SimpleMovingAverageTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -109,8 +107,8 @@ class SimpleMovingAverageTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -118,7 +116,7 @@ class SimpleMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.sma.value)
+        assert self.sma.value == 1.0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -128,7 +126,7 @@ class SimpleMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(2.0, self.sma.value)
+        assert self.sma.value == 2.0
 
     def test_value_at_returns_expected_value(self):
         # Arrange
@@ -138,7 +136,7 @@ class SimpleMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(2.0, self.sma.value)
+        assert self.sma.value == 2.0
 
     def test_handle_quote_tick_updates_with_expected_value(self):
         # Arrange
@@ -154,12 +152,12 @@ class SimpleMovingAverageTests(unittest.TestCase):
         sma_for_ticks3.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(sma_for_ticks1.has_inputs)
-        self.assertTrue(sma_for_ticks2.has_inputs)
-        self.assertTrue(sma_for_ticks3.has_inputs)
-        self.assertEqual(1.00003, sma_for_ticks1.value)
-        self.assertEqual(1.00002, sma_for_ticks2.value)
-        self.assertEqual(1.00001, sma_for_ticks3.value)
+        assert sma_for_ticks1.has_inputs
+        assert sma_for_ticks2.has_inputs
+        assert sma_for_ticks3.has_inputs
+        assert sma_for_ticks1.value == 1.00003
+        assert sma_for_ticks2.value == 1.00002
+        assert sma_for_ticks3.value == 1.00001
 
     def test_handle_trade_tick_updates_with_expected_value(self):
         # Arrange
@@ -171,8 +169,8 @@ class SimpleMovingAverageTests(unittest.TestCase):
         sma_for_ticks.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(sma_for_ticks.has_inputs)
-        self.assertEqual(1.00001, sma_for_ticks.value)
+        assert sma_for_ticks.has_inputs
+        assert sma_for_ticks.value == 1.00001
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -183,5 +181,5 @@ class SimpleMovingAverageTests(unittest.TestCase):
         self.sma.reset()
 
         # Assert
-        self.assertFalse(self.sma.initialized)
-        self.assertEqual(0, self.sma.value)
+        assert not self.sma.initialized
+        assert self.sma.value == 0

--- a/tests/unit_tests/indicators/test_spread_analyzer.py
+++ b/tests/unit_tests/indicators/test_spread_analyzer.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.indicators.spread_analyzer import SpreadAnalyzer
 from nautilus_trader.model.objects import Price
@@ -27,17 +27,17 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class SpreadAnalyzerTests(unittest.TestCase):
+class TestSpreadAnalyzer:
     def test_instantiate(self):
         # Arrange
         analyzer = SpreadAnalyzer(AUDUSD_SIM.id, 1000)
 
         # Act
         # Assert
-        self.assertEqual(0, analyzer.current)
-        self.assertEqual(0, analyzer.current)
-        self.assertEqual(0, analyzer.average)
-        self.assertEqual(False, analyzer.initialized)
+        assert analyzer.current == 0
+        assert analyzer.current == 0
+        assert analyzer.average == 0
+        assert analyzer.initialized is False
 
     def test_handle_ticks_initializes_indicator(self):
         # Arrange
@@ -49,7 +49,7 @@ class SpreadAnalyzerTests(unittest.TestCase):
         analyzer.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(analyzer.initialized)
+        assert analyzer.initialized
 
     def test_update_with_incorrect_tick_raises_exception(self):
         # Arrange
@@ -65,7 +65,8 @@ class SpreadAnalyzerTests(unittest.TestCase):
         )
         # Act
         # Assert
-        self.assertRaises(ValueError, analyzer.handle_quote_tick, tick)
+        with pytest.raises(ValueError):
+            analyzer.handle_quote_tick(tick)
 
     def test_update_correctly_updates_analyzer(self):
         # Arrange
@@ -95,8 +96,8 @@ class SpreadAnalyzerTests(unittest.TestCase):
         analyzer.handle_quote_tick(tick2)
 
         # Assert
-        self.assertAlmostEqual(6e-05, analyzer.current)
-        self.assertAlmostEqual(8e-05, analyzer.average)
+        assert analyzer.current == pytest.approx(6e-05)
+        assert analyzer.average == pytest.approx(8e-05)
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -106,5 +107,5 @@ class SpreadAnalyzerTests(unittest.TestCase):
         instance.reset()
 
         # Assert
-        self.assertFalse(instance.initialized)
-        self.assertEqual(0, instance.current)
+        assert not instance.initialized
+        assert instance.current == 0

--- a/tests/unit_tests/indicators/test_stochastics.py
+++ b/tests/unit_tests/indicators/test_stochastics.py
@@ -13,42 +13,40 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.stochastics import Stochastics
 from tests.test_kit.stubs import TestStubs
 
 
-class StochasticsTests(unittest.TestCase):
-    def setUp(self):
+class TestStochastics:
+    def setup(self):
         # Fixture Setup
         self.stochastics = Stochastics(14, 3)
 
     def test_name_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("Stochastics", self.stochastics.name)
+        assert self.stochastics.name == "Stochastics"
 
     def test_str_repr_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("Stochastics(14, 3)", str(self.stochastics))
-        self.assertEqual("Stochastics(14, 3)", repr(self.stochastics))
+        assert str(self.stochastics) == "Stochastics(14, 3)"
+        assert repr(self.stochastics) == "Stochastics(14, 3)"
 
     def test_period_k_returns_expected_value(self):
         # Act
         # Assert
-        self.assertEqual(14, self.stochastics.period_k)
+        assert self.stochastics.period_k == 14
 
     def test_period_d_returns_expected_value(self):
         # Act
         # Assert
-        self.assertEqual(3, self.stochastics.period_d)
+        assert self.stochastics.period_d == 3
 
     def test_initialized_without_inputs_returns_false(self):
         # Act
         # Assert
-        self.assertEqual(False, self.stochastics.initialized)
+        assert self.stochastics.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -69,7 +67,7 @@ class StochasticsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(True, self.stochastics.initialized)
+        assert self.stochastics.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -81,9 +79,9 @@ class StochasticsTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(66.66666666641994, indicator.value_k)
-        self.assertEqual(66.66666666641994, indicator.value_d)
+        assert indicator.has_inputs
+        assert indicator.value_k == 66.66666666641994
+        assert indicator.value_d == 66.66666666641994
 
     def test_values_with_one_input_returns_expected_value(self):
         # Arrange
@@ -91,8 +89,8 @@ class StochasticsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(50.0, self.stochastics.value_k)
-        self.assertEqual(50.0, self.stochastics.value_d)
+        assert self.stochastics.value_k == 50.0
+        assert self.stochastics.value_d == 50.0
 
     def test_value_with_all_higher_inputs_returns_expected_value(self):
         # Arrange
@@ -103,8 +101,8 @@ class StochasticsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(80.0, self.stochastics.value_k)
-        self.assertEqual(75.0, self.stochastics.value_d)
+        assert self.stochastics.value_k == 80.0
+        assert self.stochastics.value_d == 75.0
 
     def test_value_with_all_lower_inputs_returns_expected_value(self):
         # Arrange
@@ -115,8 +113,8 @@ class StochasticsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(20.0, self.stochastics.value_k)
-        self.assertEqual(25.0, self.stochastics.value_d)
+        assert self.stochastics.value_k == 20.0
+        assert self.stochastics.value_d == 25.0
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -126,6 +124,6 @@ class StochasticsTests(unittest.TestCase):
         self.stochastics.reset()  # No assertion errors
 
         # Assert
-        self.assertFalse(self.stochastics.initialized)
-        self.assertEqual(0, self.stochastics.value_k)
-        self.assertEqual(0, self.stochastics.value_d)
+        assert not self.stochastics.initialized
+        assert self.stochastics.value_k == 0
+        assert self.stochastics.value_d == 0

--- a/tests/unit_tests/indicators/test_swings.py
+++ b/tests/unit_tests/indicators/test_swings.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.indicators.swings import Swings
 from nautilus_trader.model.bar import Bar
 from nautilus_trader.model.bar import BarSpecification
@@ -32,8 +30,8 @@ ONE_MIN_BID = BarSpecification(1, BarAggregation.MINUTE, PriceType.BID)
 AUDUSD_1_MIN_BID = BarType(AUDUSD_SIM, ONE_MIN_BID)
 
 
-class SwingsTests(unittest.TestCase):
-    def setUp(self):
+class TestSwings:
+    def setup(self):
         # Fixture Setup
         self.swings = Swings(3)
 
@@ -41,25 +39,25 @@ class SwingsTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("Swings", self.swings.name)
+        assert self.swings.name == "Swings"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("Swings(3)", str(self.swings))
-        self.assertEqual("Swings(3)", repr(self.swings))
+        assert str(self.swings) == "Swings(3)"
+        assert repr(self.swings) == "Swings(3)"
 
     def test_instantiate_returns_expected_property_values(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(3, self.swings.period)
-        self.assertEqual(False, self.swings.initialized)
-        self.assertEqual(0, self.swings.direction)
-        self.assertEqual(False, self.swings.changed)
-        self.assertEqual(0, self.swings.since_high)
-        self.assertEqual(0, self.swings.since_low)
+        assert self.swings.period == 3
+        assert self.swings.initialized is False
+        assert self.swings.direction == 0
+        assert self.swings.changed is False
+        assert self.swings.since_high == 0
+        assert self.swings.since_low == 0
 
     def test_handle_bar(self):
         # Arrange
@@ -78,7 +76,7 @@ class SwingsTests(unittest.TestCase):
         self.swings.handle_bar(bar)
 
         # Assert
-        self.assertTrue(self.swings.has_inputs)
+        assert self.swings.has_inputs
 
     def test_determine_swing_high(self):
         # Arrange
@@ -91,8 +89,8 @@ class SwingsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1, self.swings.direction)
-        self.assertEqual(1.0006, self.swings.high_price)
+        assert self.swings.direction == 1
+        assert self.swings.high_price == 1.0006
 
     def test_determine_swing_low(self):
         # Arrange
@@ -105,8 +103,8 @@ class SwingsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(-1, self.swings.direction)
-        self.assertEqual(1.0001, self.swings.low_price)
+        assert self.swings.direction == -1
+        assert self.swings.low_price == 1.0001
 
     def test_swing_change_high_to_low(self):
         # Arrange
@@ -120,11 +118,11 @@ class SwingsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(-1, self.swings.direction)
-        self.assertTrue(self.swings.changed)
-        self.assertEqual(0, self.swings.since_low)
-        self.assertEqual(1, self.swings.since_high)
-        self.assertEqual(0, self.swings.length)  # Just changed
+        assert self.swings.direction == -1
+        assert self.swings.changed
+        assert self.swings.since_low == 0
+        assert self.swings.since_high == 1
+        assert self.swings.length == 0  # Just changed
 
     def test_swing_change_low_to_high(self):
         # Arrange
@@ -137,11 +135,11 @@ class SwingsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1, self.swings.direction)
-        self.assertTrue(self.swings.changed)
-        self.assertEqual(0, self.swings.since_high)
-        self.assertEqual(1, self.swings.since_low)
-        self.assertEqual(0, self.swings.length)  # Just changed
+        assert self.swings.direction == 1
+        assert self.swings.changed
+        assert self.swings.since_high == 0
+        assert self.swings.since_low == 1
+        assert self.swings.length == 0  # Just changed
 
     def test_swing_changes(self):
         # Arrange
@@ -162,11 +160,11 @@ class SwingsTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1, self.swings.direction)
-        self.assertEqual(3, self.swings.since_low)
-        self.assertEqual(0, self.swings.since_high)
-        self.assertEqual(0.00039999999999995595, self.swings.length)
-        self.assertTrue(self.swings.initialized)
+        assert self.swings.direction == 1
+        assert self.swings.since_low == 3
+        assert self.swings.since_high == 0
+        assert self.swings.length == 0.00039999999999995595
+        assert self.swings.initialized
 
     def test_reset(self):
         # Arrange
@@ -178,5 +176,5 @@ class SwingsTests(unittest.TestCase):
         self.swings.reset()
 
         # Assert
-        self.assertEqual(0, self.swings.has_inputs)
-        self.assertEqual(0, self.swings.direction)
+        assert self.swings.has_inputs == 0
+        assert self.swings.direction == 0

--- a/tests/unit_tests/indicators/test_volatility_ratio.py
+++ b/tests/unit_tests/indicators/test_volatility_ratio.py
@@ -14,7 +14,8 @@
 # -------------------------------------------------------------------------------------------------
 
 import sys
-import unittest
+
+import pytest
 
 from nautilus_trader.indicators.volatility_ratio import VolatilityRatio
 from tests.test_kit.providers import TestInstrumentProvider
@@ -24,8 +25,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class VolatilityCompressionRatioTests(unittest.TestCase):
-    def setUp(self):
+class TestVolatilityCompressionRatio:
+    def setup(self):
         # Fixture Setup
         self.vcr = VolatilityRatio(10, 100)
 
@@ -33,20 +34,20 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("VolatilityRatio", self.vcr.name)
+        assert self.vcr.name == "VolatilityRatio"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("VolatilityRatio(10, 100, SIMPLE, True, 0.0)", str(self.vcr))
-        self.assertEqual("VolatilityRatio(10, 100, SIMPLE, True, 0.0)", repr(self.vcr))
+        assert str(self.vcr) == "VolatilityRatio(10, 100, SIMPLE, True, 0.0)"
+        assert repr(self.vcr) == "VolatilityRatio(10, 100, SIMPLE, True, 0.0)"
 
     def test_initialized_without_inputs_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(False, self.vcr.initialized)
+        assert self.vcr.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -55,7 +56,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
             self.vcr.update_raw(1.00000, 1.00000, 1.00000)
 
         # Assert
-        self.assertEqual(True, self.vcr.initialized)
+        assert self.vcr.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -67,14 +68,14 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.0, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.0
 
     def test_value_with_no_inputs_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0, self.vcr.value)
+        assert self.vcr.value == 0
 
     def test_value_with_epsilon_inputs_returns_expected_value(self):
         # Arrange
@@ -83,7 +84,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.vcr.value)
+        assert self.vcr.value == 0
 
     def test_value_with_one_ones_input_returns_expected_value(self):
         # Arrange
@@ -91,7 +92,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(0, self.vcr.value)
+        assert self.vcr.value == 0
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -99,7 +100,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.vcr.value)
+        assert self.vcr.value == 1.0
 
     def test_value_with_three_inputs_returns_expected_value(self):
         # Arrange
@@ -109,7 +110,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.vcr.value)
+        assert self.vcr.value == 1.0
 
     def test_value_with_close_on_high_returns_expected_value(self):
         # Arrange
@@ -126,7 +127,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
             self.vcr.update_raw(high, low, close)
 
         # Assert
-        self.assertEqual(0.9552015928322548, self.vcr.value, 2)
+        assert self.vcr.value == pytest.approx(0.9552015928322548, 2)
 
     def test_value_with_close_on_low_returns_expected_value(self):
         # Arrange
@@ -143,7 +144,7 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
             self.vcr.update_raw(high, low, close)
 
         # Assert
-        self.assertEqual(0.9547511312217188, self.vcr.value)
+        assert self.vcr.value == 0.9547511312217188
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -154,5 +155,5 @@ class VolatilityCompressionRatioTests(unittest.TestCase):
         self.vcr.reset()
 
         # Assert
-        self.assertFalse(self.vcr.initialized)
-        self.assertEqual(0, self.vcr.value)
+        assert not self.vcr.initialized
+        assert self.vcr.value == 0

--- a/tests/unit_tests/indicators/test_vwap.py
+++ b/tests/unit_tests/indicators/test_vwap.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 from datetime import timedelta
-import unittest
 
 from nautilus_trader.indicators.vwap import VolumeWeightedAveragePrice
 from tests.test_kit.providers import TestInstrumentProvider
@@ -25,26 +24,26 @@ from tests.test_kit.stubs import UNIX_EPOCH
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class VolumeWeightedAveragePriceTests(unittest.TestCase):
-    def setUp(self):
+class TestVolumeWeightedAveragePrice:
+    def setup(self):
         # Fixture Setup
         self.vwap = VolumeWeightedAveragePrice()
 
     def test_name_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("VolumeWeightedAveragePrice", self.vwap.name)
+        assert self.vwap.name == "VolumeWeightedAveragePrice"
 
     def test_str_repr_returns_expected_string(self):
         # Act
         # Assert
-        self.assertEqual("VolumeWeightedAveragePrice()", str(self.vwap))
-        self.assertEqual("VolumeWeightedAveragePrice()", repr(self.vwap))
+        assert str(self.vwap) == "VolumeWeightedAveragePrice()"
+        assert repr(self.vwap) == "VolumeWeightedAveragePrice()"
 
     def test_initialized_without_inputs_returns_false(self):
         # Act
         # Assert
-        self.assertEqual(False, self.vwap.initialized)
+        assert self.vwap.initialized is False
 
     def test_initialized_with_required_inputs_returns_true(self):
         # Arrange
@@ -52,7 +51,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.update_raw(1.00000, 10000, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(True, self.vwap.initialized)
+        assert self.vwap.initialized is True
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -64,8 +63,8 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -73,7 +72,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.00000, self.vwap.value)
+        assert self.vwap.value == 1.00000
 
     def test_values_with_higher_inputs_returns_expected_value(self):
         # Arrange
@@ -90,7 +89,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.update_raw(1.00090, 19000, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(1.0005076923076923, self.vwap.value)
+        assert self.vwap.value == 1.0005076923076923
 
     def test_values_with_all_lower_inputs_returns_expected_value(self):
         # Arrange
@@ -107,7 +106,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.update_raw(1.00010, 11000, UNIX_EPOCH)
 
         # Assert
-        self.assertEqual(1.0006032258064514, self.vwap.value)
+        assert self.vwap.value == 1.0006032258064514
 
     def test_new_day_resets_values(self):
         # Arrange
@@ -125,7 +124,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.update_raw(1.00000, 10000, UNIX_EPOCH + timedelta(1))
 
         # Assert
-        self.assertEqual(1.00000, self.vwap.value)
+        assert self.vwap.value == 1.00000
 
     def test_new_day_with_first_volume_zero_returns_price_as_value(self):
         # Arrange
@@ -134,7 +133,7 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.update_raw(1.00000, 0, UNIX_EPOCH + timedelta(1))
 
         # Assert
-        self.assertEqual(1.00000, self.vwap.value)
+        assert self.vwap.value == 1.00000
 
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
@@ -145,5 +144,5 @@ class VolumeWeightedAveragePriceTests(unittest.TestCase):
         self.vwap.reset()
 
         # Assert
-        self.assertFalse(self.vwap.initialized)
-        self.assertEqual(0, self.vwap.value)
+        assert not self.vwap.initialized
+        assert self.vwap.value == 0

--- a/tests/unit_tests/indicators/test_wma.py
+++ b/tests/unit_tests/indicators/test_wma.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.indicators.average.ma_factory import MovingAverageFactory
 from nautilus_trader.indicators.average.moving_average import MovingAverageType
@@ -26,8 +26,8 @@ from tests.test_kit.stubs import TestStubs
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class WeightedMovingAverageTests(unittest.TestCase):
-    def setUp(self):
+class TestWeightedMovingAverage:
+    def setup(self):
         # Fixture Setup
         self.w = [round(i * 0.1, 2) for i in range(1, 11)]
         self.wma = WeightedMovingAverage(10, self.w)
@@ -40,27 +40,21 @@ class WeightedMovingAverageTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("WeightedMovingAverage", self.wma.name)
+        assert self.wma.name == "WeightedMovingAverage"
 
     def test_str_repr_returns_expected_string(self):
         # Arrange
         # Act
         # Assert
         weights_repr = repr(self.wma.weights)
-        self.assertEqual(
-            f"WeightedMovingAverage(10, {weights_repr})",
-            str(self.wma),
-        )
-        self.assertEqual(
-            f"WeightedMovingAverage(10, {weights_repr})",
-            repr(self.wma),
-        )
+        assert str(self.wma) == f"WeightedMovingAverage(10, {weights_repr})"
+        assert repr(self.wma) == f"WeightedMovingAverage(10, {weights_repr})"
 
     def test_weights_returns_expected_weights(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(self.w, list(self.wma.weights))
+        assert list(self.wma.weights) == self.w
 
     def test_wma_factory_update_raw(self):
         # Arrange
@@ -69,8 +63,8 @@ class WeightedMovingAverageTests(unittest.TestCase):
             self.wma_factory.update_raw(float(i))
 
         # Assert
-        self.assertEqual(8.0, self.wma_factory.value)
-        self.assertEqual(list(self.w), list(self.wma_factory.weights))
+        assert self.wma_factory.value == 8.0
+        assert list(self.wma_factory.weights) == list(self.w)
 
     def test_handle_quote_tick_updates_indicator(self):
         # Arrange
@@ -82,8 +76,8 @@ class WeightedMovingAverageTests(unittest.TestCase):
         indicator.handle_quote_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00002, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00002
 
     def test_handle_trade_tick_updates_indicator(self):
         # Arrange
@@ -95,8 +89,8 @@ class WeightedMovingAverageTests(unittest.TestCase):
         indicator.handle_trade_tick(tick)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00001, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00001
 
     def test_handle_bar_updates_indicator(self):
         # Arrange
@@ -108,8 +102,8 @@ class WeightedMovingAverageTests(unittest.TestCase):
         indicator.handle_bar(bar)
 
         # Assert
-        self.assertTrue(indicator.has_inputs)
-        self.assertEqual(1.00003, indicator.value)
+        assert indicator.has_inputs
+        assert indicator.value == 1.00003
 
     def test_value_with_one_input_returns_expected_value(self):
         # Arrange
@@ -117,7 +111,7 @@ class WeightedMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.0, self.wma.value)
+        assert self.wma.value == 1.0
 
     def test_value_with_two_input_returns_expected_value(self):
         # Arrange
@@ -128,7 +122,7 @@ class WeightedMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual((10 * 1.0 + 1 * 0.9) / 1.9, self.wma.value)
+        assert self.wma.value == (10 * 1.0 + 1 * 0.9) / 1.9
 
     def test_value_with_no_weights(self):
         # Arrange
@@ -137,7 +131,7 @@ class WeightedMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(1.5, self.wma_noweights.value)
+        assert self.wma_noweights.value == 1.5
 
     def test_value_with_ten_inputs_returns_expected_value(self):
         # Arrange
@@ -154,7 +148,7 @@ class WeightedMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertAlmostEqual(7.00, self.wma.value, 2)
+        assert self.wma.value == pytest.approx(7.00, 2)
 
     def test_value_at_returns_expected_value(self):
         # Arrange
@@ -172,7 +166,7 @@ class WeightedMovingAverageTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(8.0, self.wma.value)
+        assert self.wma.value == 8.0
 
     def test_reset(self):
         # Arrange
@@ -184,5 +178,5 @@ class WeightedMovingAverageTests(unittest.TestCase):
         self.wma.reset()
 
         # Assert
-        self.assertFalse(self.wma.initialized)
-        self.assertEqual(0, self.wma.value)
+        assert not self.wma.initialized
+        assert self.wma.value == 0

--- a/tests/unit_tests/live/test_live_data_engine.py
+++ b/tests/unit_tests/live/test_live_data_engine.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import asyncio
-import unittest
 
 from nautilus_trader.common.clock import LiveClock
 from nautilus_trader.common.enums import ComponentState
@@ -44,8 +43,8 @@ BTCUSDT_BINANCE = TestInstrumentProvider.btcusdt_binance()
 ETHUSDT_BINANCE = TestInstrumentProvider.ethusdt_binance()
 
 
-class LiveDataEngineTests(unittest.TestCase):
-    def setUp(self):
+class TestLiveDataEngine:
+    def setup(self):
         # Fixture Setup
         self.clock = LiveClock()
         self.uuid_factory = UUIDFactory()
@@ -72,7 +71,7 @@ class LiveDataEngineTests(unittest.TestCase):
             logger=self.logger,
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
         self.loop.stop()
         self.loop.close()
@@ -83,7 +82,7 @@ class LiveDataEngineTests(unittest.TestCase):
         self.engine.start()
 
         # Assert
-        self.assertTrue(True)  # No exceptions raised
+        assert True  # No exceptions raised
         self.engine.stop()
 
     def test_message_qsize_at_max_blocks_on_put_data_command(self):
@@ -110,8 +109,8 @@ class LiveDataEngineTests(unittest.TestCase):
         self.engine.execute(subscribe)
 
         # Assert
-        self.assertEqual(1, self.engine.message_qsize())
-        self.assertEqual(0, self.engine.command_count)
+        assert self.engine.message_qsize() == 1
+        assert self.engine.command_count == 0
 
     def test_message_qsize_at_max_blocks_on_send_request(self):
         # Arrange
@@ -146,8 +145,8 @@ class LiveDataEngineTests(unittest.TestCase):
         self.engine.send(request)
 
         # Assert
-        self.assertEqual(1, self.engine.message_qsize())
-        self.assertEqual(0, self.engine.command_count)
+        assert self.engine.message_qsize() == 1
+        assert self.engine.command_count == 0
 
     def test_message_qsize_at_max_blocks_on_receive_response(self):
         # Arrange
@@ -174,8 +173,8 @@ class LiveDataEngineTests(unittest.TestCase):
         self.engine.receive(response)  # Add over max size
 
         # Assert
-        self.assertEqual(1, self.engine.message_qsize())
-        self.assertEqual(0, self.engine.command_count)
+        assert self.engine.message_qsize() == 1
+        assert self.engine.command_count == 0
 
     def test_data_qsize_at_max_blocks_on_put_data(self):
         # Arrange
@@ -195,8 +194,8 @@ class LiveDataEngineTests(unittest.TestCase):
         self.engine.process(data)  # Add over max size
 
         # Assert
-        self.assertEqual(1, self.engine.data_qsize())
-        self.assertEqual(0, self.engine.data_count)
+        assert self.engine.data_qsize() == 1
+        assert self.engine.data_count == 0
 
     def test_get_event_loop_returns_expected_loop(self):
         # Arrange
@@ -204,7 +203,7 @@ class LiveDataEngineTests(unittest.TestCase):
         loop = self.engine.get_event_loop()
 
         # Assert
-        self.assertEqual(self.loop, loop)
+        assert loop == self.loop
 
     def test_start(self):
         async def run_test():
@@ -214,7 +213,7 @@ class LiveDataEngineTests(unittest.TestCase):
             await asyncio.sleep(0.1)
 
             # Assert
-            self.assertEqual(ComponentState.RUNNING, self.engine.state)
+            assert self.engine.state == ComponentState.RUNNING
 
             # Tear Down
             self.engine.stop()
@@ -230,7 +229,7 @@ class LiveDataEngineTests(unittest.TestCase):
             self.engine.kill()
 
             # Assert
-            self.assertEqual(ComponentState.STOPPED, self.engine.state)
+            assert self.engine.state == ComponentState.STOPPED
 
         self.loop.run_until_complete(run_test())
 
@@ -241,7 +240,7 @@ class LiveDataEngineTests(unittest.TestCase):
             self.engine.kill()
 
             # Assert
-            self.assertEqual(0, self.engine.data_qsize())
+            assert self.engine.data_qsize() == 0
 
         self.loop.run_until_complete(run_test())
 
@@ -263,8 +262,8 @@ class LiveDataEngineTests(unittest.TestCase):
             await asyncio.sleep(0.1)
 
             # Assert
-            self.assertEqual(0, self.engine.message_qsize())
-            self.assertEqual(1, self.engine.command_count)
+            assert self.engine.message_qsize() == 0
+            assert self.engine.command_count == 1
 
             # Tear Down
             self.engine.stop()
@@ -298,8 +297,8 @@ class LiveDataEngineTests(unittest.TestCase):
             await asyncio.sleep(0.1)
 
             # Assert
-            self.assertEqual(0, self.engine.message_qsize())
-            self.assertEqual(1, self.engine.request_count)
+            assert self.engine.message_qsize() == 0
+            assert self.engine.request_count == 1
 
             # Tear Down
             self.engine.stop()
@@ -325,8 +324,8 @@ class LiveDataEngineTests(unittest.TestCase):
             await asyncio.sleep(0.1)
 
             # Assert
-            self.assertEqual(0, self.engine.message_qsize())
-            self.assertEqual(1, self.engine.response_count)
+            assert self.engine.message_qsize() == 0
+            assert self.engine.response_count == 1
 
             # Tear Down
             self.engine.stop()
@@ -346,8 +345,8 @@ class LiveDataEngineTests(unittest.TestCase):
             await asyncio.sleep(0.1)
 
             # Assert
-            self.assertEqual(0, self.engine.data_qsize())
-            self.assertEqual(1, self.engine.data_count)
+            assert self.engine.data_qsize() == 0
+            assert self.engine.data_count == 1
 
             # Tear Down
             self.engine.stop()


### PR DESCRIPTION
Issue Ticket: #325

The next batch PR for converting unittest to pytest

The following files have been converted (29 total):

- tests/unit_tests/indicators/*.py
- tests/unit_tests/live/test_live_data_engine.py