### PR TITLE
Convert analysis tests to pytest

### DIFF
--- a/tests/unit_tests/analysis/test_analysis_performance.py
+++ b/tests/unit_tests/analysis/test_analysis_performance.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 from datetime import datetime
-import unittest
 
 from nautilus_trader.analysis.performance import PerformanceAnalyzer
 from nautilus_trader.common.clock import TestClock
@@ -36,8 +35,8 @@ AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 GBPUSD_SIM = TestInstrumentProvider.default_fx_ccy("GBP/USD")
 
 
-class AnalyzerTests(unittest.TestCase):
-    def setUp(self):
+class TestAnalyzer:
+    def setup(self):
         # Fixture Setup
         self.analyzer = PerformanceAnalyzer()
         self.order_factory = OrderFactory(
@@ -52,7 +51,7 @@ class AnalyzerTests(unittest.TestCase):
         result = self.analyzer.daily_returns()
 
         # Assert
-        self.assertTrue(result.empty)
+        assert result.empty
 
     def test_get_realized_pnls_when_no_data_returns_none(self):
         # Arrange
@@ -60,7 +59,7 @@ class AnalyzerTests(unittest.TestCase):
         result = self.analyzer.realized_pnls()
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_get_realized_pnls_with_currency_when_no_data_returns_none(self):
         # Arrange
@@ -68,7 +67,7 @@ class AnalyzerTests(unittest.TestCase):
         result = self.analyzer.realized_pnls(AUD)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_analyzer_tracks_daily_returns(self):
         # Arrange
@@ -98,9 +97,9 @@ class AnalyzerTests(unittest.TestCase):
         result = self.analyzer.daily_returns()
 
         # Assert
-        self.assertEqual(10, len(result))
-        self.assertEqual(-0.12, sum(result))
-        self.assertEqual(-0.20, result.iloc[9])
+        assert len(result) == 10
+        assert sum(result) == -0.12
+        assert result.iloc[9] == -0.20
 
     def test_get_realized_pnls_when_all_flat_positions_returns_expected_series(self):
         # Arrange
@@ -172,6 +171,6 @@ class AnalyzerTests(unittest.TestCase):
         result = self.analyzer.realized_pnls(USD)
 
         # Assert
-        self.assertEqual(2, len(result))
-        self.assertEqual(6.0, result["P-1"])
-        self.assertEqual(16.0, result["P-2"])
+        assert len(result) == 2
+        assert result["P-1"] == 6.0
+        assert result["P-2"] == 16.0

--- a/tests/unit_tests/analysis/test_analysis_reports.py
+++ b/tests/unit_tests/analysis/test_analysis_reports.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
-
 from nautilus_trader.analysis.reports import ReportProvider
 from nautilus_trader.common.clock import TestClock
 from nautilus_trader.common.factories import OrderFactory
@@ -44,8 +42,8 @@ AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 GBPUSD_SIM = TestInstrumentProvider.default_fx_ccy("GBP/USD")
 
 
-class ReportProviderTests(unittest.TestCase):
-    def setUp(self):
+class TestReportProvider:
+    def setup(self):
         # Fixture Setup
         self.account_id = TestStubs.account_id()
         self.order_factory = OrderFactory(
@@ -83,7 +81,7 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_account_report(account)
 
         # Assert
-        self.assertEqual(1, len(report))
+        assert len(report) == 1
 
     def test_generate_orders_report_with_no_order_returns_emtpy_dataframe(self):
         # Arrange
@@ -93,7 +91,7 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_orders_report([])
 
         # Assert
-        self.assertTrue(report.empty)
+        assert report.empty
 
     def test_generate_orders_fills_report_with_no_order_returns_emtpy_dataframe(self):
         # Arrange
@@ -103,7 +101,7 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_order_fills_report([])
 
         # Assert
-        self.assertTrue(report.empty)
+        assert report.empty
 
     def test_generate_positions_report_with_no_positions_returns_emtpy_dataframe(self):
         # Arrange
@@ -113,7 +111,7 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_positions_report([])
 
         # Assert
-        self.assertTrue(report.empty)
+        assert report.empty
 
     def test_generate_orders_report(self):
         # Arrange
@@ -154,16 +152,16 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_orders_report(orders)
 
         # Assert
-        self.assertEqual(2, len(report))
-        self.assertEqual("client_order_id", report.index.name)
-        self.assertEqual(order1.client_order_id.value, report.index[0])
-        self.assertEqual("AUD/USD.SIM", report.iloc[0]["instrument_id"])
-        self.assertEqual("BUY", report.iloc[0]["side"])
-        self.assertEqual("LIMIT", report.iloc[0]["type"])
-        self.assertEqual("1500000", report.iloc[0]["quantity"])
-        self.assertEqual("0.80011", report.iloc[0]["avg_px"])
-        self.assertEqual("0.00001", report.iloc[0]["slippage"])
-        self.assertEqual(None, report.iloc[1]["avg_px"])
+        assert len(report) == 2
+        assert report.index.name == "client_order_id"
+        assert report.index[0] == order1.client_order_id.value
+        assert report.iloc[0]["instrument_id"] == "AUD/USD.SIM"
+        assert report.iloc[0]["side"] == "BUY"
+        assert report.iloc[0]["type"] == "LIMIT"
+        assert report.iloc[0]["quantity"] == "1500000"
+        assert report.iloc[0]["avg_px"] == "0.80011"
+        assert report.iloc[0]["slippage"] == "0.00001"
+        assert report.iloc[1]["avg_px"] is None
 
     def test_generate_order_fills_report(self):
         # Arrange
@@ -205,15 +203,15 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_order_fills_report(orders)
 
         # Assert
-        self.assertEqual(1, len(report))
-        self.assertEqual("client_order_id", report.index.name)
-        self.assertEqual(order1.client_order_id.value, report.index[0])
-        self.assertEqual("AUD/USD.SIM", report.iloc[0]["instrument_id"])
-        self.assertEqual("BUY", report.iloc[0]["side"])
-        self.assertEqual("LIMIT", report.iloc[0]["type"])
-        self.assertEqual("1500000", report.iloc[0]["quantity"])
-        self.assertEqual("0.80011", report.iloc[0]["avg_px"])
-        self.assertEqual("0.00001", report.iloc[0]["slippage"])
+        assert len(report) == 1
+        assert report.index.name == "client_order_id"
+        assert report.index[0] == order1.client_order_id.value
+        assert report.iloc[0]["instrument_id"] == "AUD/USD.SIM"
+        assert report.iloc[0]["side"] == "BUY"
+        assert report.iloc[0]["type"] == "LIMIT"
+        assert report.iloc[0]["quantity"] == "1500000"
+        assert report.iloc[0]["avg_px"] == "0.80011"
+        assert report.iloc[0]["slippage"] == "0.00001"
 
     def test_generate_positions_report(self):
         # Arrange
@@ -259,16 +257,16 @@ class ReportProviderTests(unittest.TestCase):
         report = report_provider.generate_positions_report(positions)
 
         # Assert
-        self.assertEqual(2, len(report))
-        self.assertEqual("position_id", report.index.name)
-        self.assertEqual(position1.id.value, report.index[0])
-        self.assertEqual("AUD/USD.SIM", report.iloc[0]["instrument_id"])
-        self.assertEqual("BUY", report.iloc[0]["entry"])
-        self.assertEqual("FLAT", report.iloc[0]["side"])
-        self.assertEqual("100000", report.iloc[0]["peak_qty"])
-        self.assertEqual("1.00010", report.iloc[0]["avg_px_open"])
-        self.assertEqual("1.00010", report.iloc[0]["avg_px_close"])
-        self.assertEqual(UNIX_EPOCH, report.iloc[0]["ts_opened"])
-        self.assertEqual(UNIX_EPOCH, report.iloc[0]["ts_closed"])
-        self.assertEqual("0.00000", report.iloc[0]["realized_points"])
-        self.assertEqual("0.00000", report.iloc[0]["realized_return"])
+        assert len(report) == 2
+        assert report.index.name == "position_id"
+        assert report.index[0] == position1.id.value
+        assert report.iloc[0]["instrument_id"] == "AUD/USD.SIM"
+        assert report.iloc[0]["entry"] == "BUY"
+        assert report.iloc[0]["side"] == "FLAT"
+        assert report.iloc[0]["peak_qty"] == "100000"
+        assert report.iloc[0]["avg_px_open"] == "1.00010"
+        assert report.iloc[0]["avg_px_close"] == "1.00010"
+        assert report.iloc[0]["ts_opened"] == UNIX_EPOCH
+        assert report.iloc[0]["ts_closed"] == UNIX_EPOCH
+        assert report.iloc[0]["realized_points"] == "0.00000"
+        assert report.iloc[0]["realized_return"] == "0.00000"


### PR DESCRIPTION
This pull request converts tests in the `tests/unit_tests/analysis` directory from unittest to pytest.

Let me know if you'd like me to also modify the tests to use pytest fixture functions instead of classes with a `setup` method.

Also, I've noticed that in `test_analysis_reports.py`, `self.account_id` appears unused. Should I remove it?