### PR TITLE
Convert unittest tests to pytest (misc files)

### DIFF
--- a/tests/acceptance_tests/test_backtest_acceptance.py
+++ b/tests/acceptance_tests/test_backtest_acceptance.py
@@ -15,7 +15,6 @@
 
 from decimal import Decimal
 import os
-import unittest
 
 import pandas as pd
 
@@ -40,8 +39,8 @@ from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.strategies import EMACross
 
 
-class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsUSDJPYWit:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -80,7 +79,7 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_strategy(self):
@@ -97,12 +96,9 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert - Should return expected PnL
-        self.assertEqual(2689, strategy.fast_ema.count)
-        self.assertEqual(115043, self.engine.iteration)
-        self.assertEqual(
-            Money(997731.23, USD),
-            self.engine.portfolio.account(self.venue).balance_total(USD),
-        )
+        assert strategy.fast_ema.count == 2689
+        assert self.engine.iteration == 115043
+        assert self.engine.portfolio.account(self.venue).balance_total(USD) == Money(997731.23, USD)
 
     def test_rerun_ema_cross_strategy_returns_identical_performance(self):
         # Arrange
@@ -123,7 +119,7 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         result2 = self.engine.analyzer.get_performance_stats_pnls()
 
         # Assert
-        self.assertEqual(all(result1), all(result2))
+        assert all(result2) == all(result1)
 
     def test_run_multiple_strategies(self):
         # Arrange
@@ -153,17 +149,14 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy1, strategy2])
 
         # Assert
-        self.assertEqual(2689, strategy1.fast_ema.count)
-        self.assertEqual(2689, strategy2.fast_ema.count)
-        self.assertEqual(115043, self.engine.iteration)
-        self.assertEqual(
-            Money(992818.88, USD),
-            self.engine.portfolio.account(self.venue).balance_total(USD),
-        )
+        assert strategy1.fast_ema.count == 2689
+        assert strategy2.fast_ema.count == 2689
+        assert self.engine.iteration == 115043
+        assert self.engine.portfolio.account(self.venue).balance_total(USD) == Money(992818.88, USD)
 
 
-class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsGBPUSDWit:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -202,7 +195,7 @@ class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_minute_bar_spec(self):
@@ -219,16 +212,13 @@ class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(8353, strategy.fast_ema.count)
-        self.assertEqual(120467, self.engine.iteration)
-        self.assertEqual(
-            Money(947226.84, GBP),
-            self.engine.portfolio.account(self.venue).balance_total(GBP),
-        )
+        assert strategy.fast_ema.count == 8353
+        assert self.engine.iteration == 120467
+        assert self.engine.portfolio.account(self.venue).balance_total(GBP) == Money(947226.84, GBP)
 
 
-class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsAUDUSDWith:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -256,7 +246,7 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_minute_bar_spec(self):
@@ -273,12 +263,9 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(1771, strategy.fast_ema.count)
-        self.assertEqual(99999, self.engine.iteration)
-        self.assertEqual(
-            Money(991360.19, AUD),
-            self.engine.portfolio.account(self.venue).balance_total(AUD),
-        )
+        assert strategy.fast_ema.count == 1771
+        assert self.engine.iteration == 99999
+        assert self.engine.portfolio.account(self.venue).balance_total(AUD) == Money(991360.19, AUD)
 
     def test_run_ema_cross_with_tick_bar_spec(self):
         # Arrange
@@ -294,16 +281,13 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(999, strategy.fast_ema.count)
-        self.assertEqual(99999, self.engine.iteration)
-        self.assertEqual(
-            Money(995431.92, AUD),
-            self.engine.portfolio.account(self.venue).balance_total(AUD),
-        )
+        assert strategy.fast_ema.count == 999
+        assert self.engine.iteration == 99999
+        assert self.engine.portfolio.account(self.venue).balance_total(AUD) == Money(995431.92, AUD)
 
 
-class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsETHUSDTWithT:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -324,7 +308,7 @@ class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
             starting_balances=[Money(1_000_000, USDT)],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_tick_bar_spec(self):
@@ -341,16 +325,15 @@ class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(279, strategy.fast_ema.count)
-        self.assertEqual(69806, self.engine.iteration)
-        self.assertEqual(
-            Money(998462.61716820, USDT),
-            self.engine.portfolio.account(self.venue).balance_total(USDT),
+        assert strategy.fast_ema.count == 279
+        assert self.engine.iteration == 69806
+        assert self.engine.portfolio.account(self.venue).balance_total(USDT) == Money(
+            998462.61716820, USDT
         )
 
 
-class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsBTCUSDTWithTradesAndQ:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -372,7 +355,7 @@ class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
             starting_balances=[Money(1_000_000, USDT), Money(10, BTC)],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_tick_bar_spec(self):
@@ -389,9 +372,8 @@ class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(39, strategy.fast_ema.count)
-        self.assertEqual(19998, self.engine.iteration)
-        self.assertEqual(
-            Money(999843.73560000, USDT),
-            self.engine.portfolio.account(self.venue).balance_total(USDT),
+        assert strategy.fast_ema.count == 39
+        assert self.engine.iteration == 19998
+        assert self.engine.portfolio.account(self.venue).balance_total(USDT) == Money(
+            999843.73560000, USDT
         )

--- a/tests/acceptance_tests/test_backtest_cached.py
+++ b/tests/acceptance_tests/test_backtest_cached.py
@@ -15,7 +15,6 @@
 
 from decimal import Decimal
 import os
-import unittest
 
 import pandas as pd
 
@@ -40,8 +39,8 @@ from tests.test_kit.providers import TestInstrumentProvider
 from tests.test_kit.strategies import EMACross
 
 
-class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsUSDJPYWit:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -80,7 +79,7 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_strategy(self):
@@ -97,12 +96,9 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert - Should return expected PnL
-        self.assertEqual(2689, strategy.fast_ema.count)
-        self.assertEqual(115043, self.engine.iteration)
-        self.assertEqual(
-            Money(997731.23, USD),
-            self.engine.portfolio.account(self.venue).balance_total(USD),
-        )
+        assert strategy.fast_ema.count == 2689
+        assert self.engine.iteration == 115043
+        assert self.engine.portfolio.account(self.venue).balance_total(USD) == Money(997731.23, USD)
 
     def test_rerun_ema_cross_strategy_returns_identical_performance(self):
         # Arrange
@@ -123,7 +119,7 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         result2 = self.engine.analyzer.get_performance_stats_pnls()
 
         # Assert
-        self.assertEqual(all(result1), all(result2))
+        assert all(result2) == all(result1)
 
     def test_run_multiple_strategies(self):
         # Arrange
@@ -153,17 +149,14 @@ class BacktestAcceptanceTestsUSDJPYWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy1, strategy2])
 
         # Assert
-        self.assertEqual(2689, strategy1.fast_ema.count)
-        self.assertEqual(2689, strategy2.fast_ema.count)
-        self.assertEqual(115043, self.engine.iteration)
-        self.assertEqual(
-            Money(992818.88, USD),
-            self.engine.portfolio.account(self.venue).balance_total(USD),
-        )
+        assert strategy1.fast_ema.count == 2689
+        assert strategy2.fast_ema.count == 2689
+        assert self.engine.iteration == 115043
+        assert self.engine.portfolio.account(self.venue).balance_total(USD) == Money(992818.88, USD)
 
 
-class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsGBPUSDWit:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -202,7 +195,7 @@ class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_minute_bar_spec(self):
@@ -219,16 +212,13 @@ class BacktestAcceptanceTestsGBPUSDWithBars(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(8353, strategy.fast_ema.count)
-        self.assertEqual(120467, self.engine.iteration)
-        self.assertEqual(
-            Money(947226.84, GBP),
-            self.engine.portfolio.account(self.venue).balance_total(GBP),
-        )
+        assert strategy.fast_ema.count == 8353
+        assert self.engine.iteration == 120467
+        assert self.engine.portfolio.account(self.venue).balance_total(GBP) == Money(947226.84, GBP)
 
 
-class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsAUDUSDWith:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -256,7 +246,7 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
             modules=[fx_rollover_interest],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_minute_bar_spec(self):
@@ -273,12 +263,9 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(1771, strategy.fast_ema.count)
-        self.assertEqual(99999, self.engine.iteration)
-        self.assertEqual(
-            Money(991360.19, AUD),
-            self.engine.portfolio.account(self.venue).balance_total(AUD),
-        )
+        assert strategy.fast_ema.count == 1771
+        assert self.engine.iteration == 99999
+        assert self.engine.portfolio.account(self.venue).balance_total(AUD) == Money(991360.19, AUD)
 
     def test_run_ema_cross_with_tick_bar_spec(self):
         # Arrange
@@ -294,16 +281,13 @@ class BacktestAcceptanceTestsAUDUSDWithTicks(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(999, strategy.fast_ema.count)
-        self.assertEqual(99999, self.engine.iteration)
-        self.assertEqual(
-            Money(995431.92, AUD),
-            self.engine.portfolio.account(self.venue).balance_total(AUD),
-        )
+        assert strategy.fast_ema.count == 999
+        assert self.engine.iteration == 99999
+        assert self.engine.portfolio.account(self.venue).balance_total(AUD) == Money(995431.92, AUD)
 
 
-class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsETHUSDTWithT:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,
@@ -325,7 +309,7 @@ class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
             starting_balances=[Money(1_000_000, USDT)],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_tick_bar_spec(self):
@@ -342,16 +326,15 @@ class BacktestAcceptanceTestsETHUSDTWithTrades(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(279, strategy.fast_ema.count)
-        self.assertEqual(69806, self.engine.iteration)
-        self.assertEqual(
-            Money(998462.61716820, USDT),
-            self.engine.portfolio.account(self.venue).balance_total(USDT),
+        assert strategy.fast_ema.count == 279
+        assert self.engine.iteration == 69806
+        assert self.engine.portfolio.account(self.venue).balance_total(USDT) == Money(
+            998462.61716820, USDT
         )
 
 
-class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
-    def setUp(self):
+class TestBacktestAcceptanceTestsBTCUSDTWithTradesAndQ:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=False,
@@ -373,7 +356,7 @@ class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
             starting_balances=[Money(1_000_000, USDT), Money(1, BTC)],
         )
 
-    def tearDown(self):
+    def teardown(self):
         self.engine.dispose()
 
     def test_run_ema_cross_with_tick_bar_spec(self):
@@ -390,9 +373,8 @@ class BacktestAcceptanceTestsBTCUSDTWithTradesAndQuotes(unittest.TestCase):
         self.engine.run(strategies=[strategy])
 
         # Assert
-        self.assertEqual(39, strategy.fast_ema.count)
-        self.assertEqual(19998, self.engine.iteration)
-        self.assertEqual(
-            Money(999843.73560000, USDT),
-            self.engine.portfolio.account(self.venue).balance_total(USDT),
+        assert strategy.fast_ema.count == 39
+        assert self.engine.iteration == 19998
+        assert self.engine.portfolio.account(self.venue).balance_total(USDT) == Money(
+            999843.73560000, USDT
         )

--- a/tests/integration_tests/live/test_live_node.py
+++ b/tests/integration_tests/live/test_live_node.py
@@ -16,7 +16,6 @@
 import asyncio
 import threading
 import time
-import unittest
 
 from nautilus_trader.adapters.ccxt.factories import CCXTDataClientFactory
 from nautilus_trader.adapters.ccxt.factories import CCXTExecutionClientFactory
@@ -25,7 +24,7 @@ from nautilus_trader.live.node import TradingNode
 from nautilus_trader.trading.strategy import TradingStrategy
 
 
-class TradingNodeConfigurationTests(unittest.TestCase):
+class TestTradingNodeConfiguration:
     def test_config_with_inmemory_execution_database(self):
         # Arrange
         config = {
@@ -64,7 +63,7 @@ class TradingNodeConfigurationTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertIsNotNone(node)
+        assert node is not None
 
     def test_config_with_redis_execution_database(self):
         # Arrange
@@ -106,11 +105,11 @@ class TradingNodeConfigurationTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertIsNotNone(node)
+        assert node is not None
 
 
-class TradingNodeOperationTests(unittest.TestCase):
-    def setUp(self):
+class TestTradingNodeOperation:
+    def setup(self):
         # Fixture Setup
 
         # Fresh isolated loop testing pattern
@@ -148,7 +147,7 @@ class TradingNodeOperationTests(unittest.TestCase):
         loop = self.node.get_event_loop()
 
         # Assert
-        self.assertTrue(isinstance(loop, asyncio.AbstractEventLoop))
+        assert isinstance(loop, asyncio.AbstractEventLoop)
 
     def test_add_data_client_factory(self):
         self.node.add_data_client_factory("CCXT", CCXTDataClientFactory)
@@ -168,7 +167,7 @@ class TradingNodeOperationTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(ComponentState.RUNNING, self.node.trader.state)
+        assert self.node.trader.state == ComponentState.RUNNING
         self.loop.call_soon_threadsafe(self.node.stop)
 
     def test_stop(self):
@@ -184,7 +183,7 @@ class TradingNodeOperationTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(ComponentState.STOPPED, self.node.trader.state)
+        assert self.node.trader.state == ComponentState.STOPPED
 
     def test_dispose(self):
         # Arrange
@@ -202,4 +201,4 @@ class TradingNodeOperationTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertEqual(ComponentState.DISPOSED, self.node.trader.state)
+        assert self.node.trader.state == ComponentState.DISPOSED

--- a/tests/unit_tests/backtest/test_backtest_exchange.py
+++ b/tests/unit_tests/backtest/test_backtest_exchange.py
@@ -15,7 +15,6 @@
 
 from datetime import timedelta
 from decimal import Decimal
-import unittest
 
 import pytest
 
@@ -71,8 +70,8 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 XBTUSD_BITMEX = TestInstrumentProvider.xbtusd_bitmex()
 
 
-class SimulatedExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestSimulatedExchange:
+    def setup(self):
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
@@ -170,14 +169,14 @@ class SimulatedExchangeTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("SimulatedExchange(SIM)", repr(self.exchange))
+        assert repr(self.exchange) == "SimulatedExchange(SIM)"
 
     def test_check_residuals(self):
         # Arrange
         # Act
         self.exchange.check_residuals()
         # Assert
-        self.assertTrue(True)  # No exceptions raised
+        assert True  # No exceptions raised
 
     def test_process_quote_tick_sets_market(self):
         # Arrange
@@ -246,17 +245,17 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         # TODO: Revisit testing
-        self.assertEqual(3, len(self.exchange.get_working_orders()))
-        self.assertIn(bracket1.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket1.take_profit, self.exchange.get_working_orders().values())
-        self.assertIn(entry2, self.exchange.get_working_orders().values())
+        assert len(self.exchange.get_working_orders()) == 3
+        assert bracket1.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket1.take_profit in self.exchange.get_working_orders().values()
+        assert entry2 in self.exchange.get_working_orders().values()
 
     def test_get_working_orders_when_no_orders_returns_empty_dict(self):
         # Arrange
         # Act
         orders = self.exchange.get_working_orders()
 
-        self.assertEqual({}, orders)
+        assert orders == {}
 
     def test_submit_buy_limit_order_with_no_market_accepts_order(self):
         # Arrange
@@ -271,9 +270,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted))
+        assert order.state == OrderState.ACCEPTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted)
 
     def test_submit_sell_limit_order_with_no_market_accepts_order(self):
         # Arrange
@@ -288,9 +287,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted))
+        assert order.state == OrderState.ACCEPTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted)
 
     def test_submit_buy_market_order_with_no_market_rejects_order(self):
         # Arrange
@@ -304,9 +303,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderRejected))
+        assert order.state == OrderState.REJECTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderRejected)
 
     def test_submit_sell_market_order_with_no_market_rejects_order(self):
         # Arrange
@@ -320,9 +319,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderRejected))
+        assert order.state == OrderState.REJECTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderRejected)
 
     def test_submit_order_with_invalid_price_gets_rejected(self):
         # Arrange: Prepare market
@@ -345,7 +344,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
+        assert order.state == OrderState.REJECTED
 
     def test_submit_order_when_quantity_below_min_then_gets_denied(self):
         # Arrange: Prepare market
@@ -359,7 +358,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.DENIED, order.state)
+        assert order.state == OrderState.DENIED
 
     def test_submit_order_when_quantity_above_max_then_gets_denied(self):
         # Arrange: Prepare market
@@ -373,7 +372,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.DENIED, order.state)
+        assert order.state == OrderState.DENIED
 
     def test_submit_market_order(self):
         # Arrange: Prepare market
@@ -396,8 +395,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Decimal("90.005"), order.avg_px)  # No slippage
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == Decimal("90.005")  # No slippage
 
     def test_submit_post_only_limit_order_when_marketable_then_rejects(self):
         # Arrange: Prepare market
@@ -421,8 +420,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_limit_order(self):
         # Arrange: Prepare market
@@ -445,9 +444,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_limit_order_when_marketable_then_fills(self):
         # Arrange: Prepare market
@@ -471,9 +470,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(LiquiditySide.TAKER, order.liquidity_side)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.FILLED
+        assert order.liquidity_side == LiquiditySide.TAKER
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_limit_order_fills_at_correct_price(self):
         # Arrange: Prepare market
@@ -497,8 +496,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(tick.ask, order.avg_px)
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == tick.ask
 
     def test_submit_limit_order_fills_at_most_book_volume(self):
         # Arrange: Prepare market
@@ -522,8 +521,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(1_000_000, order.filled_qty)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == 1_000_000
 
     def test_submit_stop_market_order_inside_market_rejects(self):
         # Arrange: Prepare market
@@ -546,8 +545,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_stop_market_order(self):
         # Arrange: Prepare market
@@ -570,9 +569,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_stop_limit_order_when_inside_market_rejects(self):
         # Arrange: Prepare market
@@ -596,8 +595,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_stop_limit_order(self):
         # Arrange: Prepare market
@@ -621,9 +620,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_bracket_market_order(self):
         # Arrange: Prepare market
@@ -656,9 +655,9 @@ class SimulatedExchangeTests(unittest.TestCase):
             ClientOrderId("O-19700101-000000-000-001-3")
         )
 
-        self.assertEqual(OrderState.FILLED, entry_order.state)
-        self.assertEqual(OrderState.ACCEPTED, stop_loss_order.state)
-        self.assertEqual(OrderState.ACCEPTED, take_profit_order.state)
+        assert entry_order.state == OrderState.FILLED
+        assert stop_loss_order.state == OrderState.ACCEPTED
+        assert take_profit_order.state == OrderState.ACCEPTED
 
     def test_submit_stop_market_order_with_bracket(self):
         # Arrange: Prepare market
@@ -692,11 +691,11 @@ class SimulatedExchangeTests(unittest.TestCase):
             ClientOrderId("O-19700101-000000-000-001-3")
         )
 
-        self.assertEqual(OrderState.ACCEPTED, entry_order.state)
-        self.assertEqual(OrderState.SUBMITTED, stop_loss_order.state)
-        self.assertEqual(OrderState.SUBMITTED, take_profit_order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(entry_order.client_order_id, self.exchange.get_working_orders())
+        assert entry_order.state == OrderState.ACCEPTED
+        assert stop_loss_order.state == OrderState.SUBMITTED
+        assert take_profit_order.state == OrderState.SUBMITTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert entry_order.client_order_id in self.exchange.get_working_orders()
 
     def test_cancel_stop_order(self):
         # Arrange: Prepare market
@@ -721,8 +720,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.cancel_order(order)
 
         # Assert
-        self.assertEqual(OrderState.CANCELED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.CANCELED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_cancel_stop_order_when_order_does_not_exist_generates_cancel_reject(self):
         # Arrange
@@ -740,7 +739,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.handle_cancel_order(command)
 
         # Assert
-        self.assertEqual(2, self.exec_engine.event_count)
+        assert self.exec_engine.event_count == 2
 
     def test_update_stop_order_when_order_does_not_exist(self):
         # Arrange
@@ -761,7 +760,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.handle_update_order(command)
 
         # Assert
-        self.assertEqual(2, self.exec_engine.event_count)
+        assert self.exec_engine.event_count == 2
 
     def test_update_order_with_zero_quantity_rejects_amendment(self):
         # Arrange: Prepare market
@@ -787,9 +786,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, Quantity.zero(), Price.from_str("90.001"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))  # Order still working
-        self.assertEqual(Price.from_str("90.001"), order.price)  # Did not update
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1  # Order still working
+        assert order.price == Price.from_str("90.001")  # Did not update
 
     def test_update_post_only_limit_order_when_marketable_then_rejects_amendment(self):
         # Arrange: Prepare market
@@ -815,9 +814,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))  # Order still working
-        self.assertEqual(Price.from_str("90.001"), order.price)  # Did not update
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1  # Order still working
+        assert order.price == Price.from_str("90.001")  # Did not update
 
     def test_update_limit_order_when_marketable_then_fills_order(self):
         # Arrange: Prepare market
@@ -843,9 +842,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.005"), order.avg_px)
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.005")
 
     def test_update_stop_market_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -872,9 +871,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.price)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.010")
 
     def test_update_stop_market_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -899,9 +898,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.011"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.011"), order.price)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.011")
 
     def test_update_untriggered_stop_limit_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -929,9 +928,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.trigger)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.trigger == Price.from_str("90.010")
 
     def test_update_untriggered_stop_limit_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -957,9 +956,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.011"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.011"), order.trigger)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.trigger == Price.from_str("90.011")
 
     def test_update_triggered_post_only_stop_limit_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -997,10 +996,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.010"))
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.000"), order.price)
+        assert order.state == OrderState.TRIGGERED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.000")
 
     def test_update_triggered_stop_limit_order_when_price_inside_market_then_fills(
         self,
@@ -1038,10 +1037,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.010"))
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.price)
+        assert order.state == OrderState.FILLED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.price == Price.from_str("90.010")
 
     def test_update_triggered_stop_limit_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -1076,10 +1075,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.005"), order.price)
+        assert order.state == OrderState.TRIGGERED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.005")
 
     def test_update_bracket_orders_working_stop_loss(self):
         # Arrange: Prepare market
@@ -1113,8 +1112,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, bracket_order.stop_loss.state)
-        self.assertEqual(Price.from_str("85.100"), bracket_order.stop_loss.price)
+        assert bracket_order.stop_loss.state == OrderState.ACCEPTED
+        assert bracket_order.stop_loss.price == Price.from_str("85.100")
 
     def test_order_fills_gets_commissioned(self):
         # Arrange: Prepare market
@@ -1156,11 +1155,11 @@ class SimulatedExchangeTests(unittest.TestCase):
         fill_event3 = self.strategy.object_storer.get_store()[7]
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Money(180.01, JPY), fill_event1.commission)
-        self.assertEqual(Money(180.01, JPY), fill_event2.commission)
-        self.assertEqual(Money(90.00, JPY), fill_event3.commission)
-        self.assertTrue(Money(999995.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert fill_event1.commission == Money(180.01, JPY)
+        assert fill_event2.commission == Money(180.01, JPY)
+        assert fill_event3.commission == Money(90.00, JPY)
+        assert Money(999995.00, USD), self.exchange.get_account().balance_total(USD)
 
     def test_expire_order(self):
         # Arrange: Prepare market
@@ -1197,8 +1196,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.EXPIRED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.EXPIRED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_buy_stop_order(self):
         # Arrange: Prepare market
@@ -1244,10 +1243,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Price.from_str("96.711"), order.avg_px)
-        self.assertEqual(Money(999997.86, USD), self.exchange.get_account().balance_total(USD))
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == Price.from_str("96.711")
+        assert self.exchange.get_account().balance_total(USD) == Money(999997.86, USD)
 
     def test_process_quote_tick_triggers_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1283,8 +1282,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.TRIGGERED
+        assert len(self.exchange.get_working_orders()) == 1
 
     def test_process_quote_tick_rejects_triggered_post_only_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1321,8 +1320,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_triggered_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1369,8 +1368,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_buy_limit_order(self):
         # Arrange: Prepare market
@@ -1416,10 +1415,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.001"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.001")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_stop_order(self):
         # Arrange: Prepare market
@@ -1454,10 +1453,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.000"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.000")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_limit_order(self):
         # Arrange: Prepare market
@@ -1492,10 +1491,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.101"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.101")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_buy_limit_entry_with_bracket(self):
         # Arrange: Prepare market
@@ -1536,12 +1535,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_limit_entry_with_bracket(self):
         # Arrange: Prepare market
@@ -1582,12 +1581,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))  # SL and TP
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket.take_profit, self.exchange.get_working_orders().values())
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2  # SL and TP
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket.take_profit in self.exchange.get_working_orders().values()
 
     def test_process_trade_tick_fills_buy_limit_entry_bracket(self):
         # Arrange: Prepare market
@@ -1645,12 +1644,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))  # SL and TP only
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket.take_profit, self.exchange.get_working_orders().values())
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2  # SL and TP only
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket.take_profit in self.exchange.get_working_orders().values()
 
     def test_filling_oco_sell_cancels_other_order(self):
         # Arrange: Prepare market
@@ -1703,12 +1702,12 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         print(self.exchange.cache.position(PositionId("2-001")))
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.FILLED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.CANCELED, bracket.take_profit.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.FILLED
+        assert bracket.take_profit.state == OrderState.CANCELED
+        assert len(self.exchange.get_working_orders()) == 0
         # TODO: WIP - fix handling of OCO orders
-        # self.assertEqual(0, len(self.exchange.cache.positions_open()))
+        # assert len(self.exchange.cache.positions_open()) == 0
 
     def test_realized_pnl_contains_commission(self):
         # Arrange: Prepare market
@@ -1731,8 +1730,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         position = self.exec_engine.cache.positions_open()[0]
 
         # Assert
-        self.assertEqual(Money(-180.01, JPY), position.realized_pnl)
-        self.assertEqual([Money(180.01, JPY)], position.commissions())
+        assert position.realized_pnl == Money(-180.01, JPY)
+        assert position.commissions() == [Money(180.01, JPY)]
 
     def test_unrealized_pnl(self):
         # Arrange: Prepare market
@@ -1779,7 +1778,7 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         position = self.exec_engine.cache.positions_open()[0]
-        self.assertEqual(Money(499900.00, JPY), position.unrealized_pnl(Price.from_str("100.003")))
+        assert position.unrealized_pnl(Price.from_str("100.003")) == Money(499900.00, JPY)
 
     def test_adjust_account_changes_balance(self):
         # Arrange
@@ -1790,7 +1789,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         result = self.exchange.exec_client.get_account().balance_total(USD)
 
         # Assert
-        self.assertEqual(Money(1001000.00, USD), result)
+        assert result == Money(1001000.00, USD)
 
     def test_adjust_account_when_account_frozen_does_not_change_balance(self):
         # Arrange
@@ -1819,7 +1818,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         result = exchange.get_account().balance_total(USD)
 
         # Assert
-        self.assertEqual(Money(1000000.00, USD), result)
+        assert result == Money(1000000.00, USD)
 
     def test_position_flipped_when_reduce_order_exceeds_original_quantity(self):
         # Arrange: Prepare market
@@ -1870,15 +1869,15 @@ class SimulatedExchangeTests(unittest.TestCase):
         # Assert
         position_open = self.exec_engine.cache.positions_open()[0]
         position_closed = self.exec_engine.cache.positions_closed()[0]
-        self.assertEqual(PositionSide.SHORT, position_open.side)
-        self.assertEqual(Quantity.from_int(50000), position_open.quantity)
-        self.assertEqual(Money(999619.98, JPY), position_closed.realized_pnl)
-        self.assertEqual([Money(380.02, JPY)], position_closed.commissions())
-        self.assertEqual(Money(1016660.97, USD), self.exchange.get_account().balance_total(USD))
+        assert position_open.side == PositionSide.SHORT
+        assert position_open.quantity == Quantity.from_int(50000)
+        assert position_closed.realized_pnl == Money(999619.98, JPY)
+        assert position_closed.commissions() == [Money(380.02, JPY)]
+        assert self.exchange.get_account().balance_total(USD) == Money(1016660.97, USD)
 
 
-class BitmexExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestBitmexExchange:
+    def setup(self):
         # Fixture Setup
         self.strategies = [MockStrategy(TestStubs.bartype_btcusdt_binance_100tick_last())]
 
@@ -2014,26 +2013,14 @@ class BitmexExchangeTests(unittest.TestCase):
         self.portfolio.update_tick(quote2)
 
         # Assert
-        self.assertEqual(
-            LiquiditySide.TAKER,
-            self.strategy.object_storer.get_store()[1].liquidity_side,
-        )
-        self.assertEqual(
-            LiquiditySide.MAKER,
-            self.strategy.object_storer.get_store()[5].liquidity_side,
-        )
-        self.assertEqual(
-            Money(0.00652543, BTC),
-            self.strategy.object_storer.get_store()[1].commission,
-        )
-        self.assertEqual(
-            Money(-0.00217552, BTC),
-            self.strategy.object_storer.get_store()[5].commission,
-        )
+        assert self.strategy.object_storer.get_store()[1].liquidity_side == LiquiditySide.TAKER
+        assert self.strategy.object_storer.get_store()[5].liquidity_side == LiquiditySide.MAKER
+        assert self.strategy.object_storer.get_store()[1].commission == Money(0.00652543, BTC)
+        assert self.strategy.object_storer.get_store()[5].commission == Money(-0.00217552, BTC)
 
 
-class OrderBookExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestOrderBookExchange:
+    def setup(self):
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
@@ -2163,10 +2150,10 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Decimal("2000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("15.33333333333333333333333333"), order.avg_px)
-        self.assertEqual(Money(999999.98, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert order.filled_qty == Decimal("2000.0")  # No slippage
+        assert order.avg_px == Decimal("15.33333333333333333333333333")
+        assert self.exchange.get_account().balance_total(USD) == Money(999999.98, USD)
 
     def test_aggressive_partial_fill(self):
         # Arrange: Prepare market
@@ -2201,10 +2188,10 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("6000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("15.93333333333333333333333333"), order.avg_px)
-        self.assertEqual(Money(999999.94, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("6000.0")  # No slippage
+        assert order.avg_px == Decimal("15.93333333333333333333333333")
+        assert self.exchange.get_account().balance_total(USD) == Money(999999.94, USD)
 
     def test_passive_post_only_insert(self):
         # Arrange: Prepare market
@@ -2227,7 +2214,7 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
+        assert order.state == OrderState.ACCEPTED
 
     # TODO - Need to discuss how we are going to support passive quotes trading now
     @pytest.mark.skip
@@ -2262,9 +2249,9 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("1000.0"), order.filled_qty)
-        self.assertEqual(Decimal("15.0"), order.avg_px)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("1000.0")
+        assert order.avg_px == Decimal("15.0")
 
     # TODO - Need to discuss how we are going to support passive quotes trading now
     @pytest.mark.skip
@@ -2299,6 +2286,6 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick1)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("1000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("14.0"), order.avg_px)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("1000.0")  # No slippage
+        assert order.avg_px == Decimal("14.0")

--- a/tests/unit_tests/common/test_common_enums.py
+++ b/tests/unit_tests/common/test_common_enums.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-from parameterized import parameterized
 import pytest
 
 from nautilus_trader.common.c_enums.component_state import ComponentState
@@ -33,7 +32,8 @@ class TestComponentState:
         with pytest.raises(ValueError):
             ComponentStateParser.from_str_py("")
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "enum,expected",
         [
             [ComponentState.INITIALIZED, "INITIALIZED"],
             [ComponentState.STARTING, "STARTING"],
@@ -45,7 +45,7 @@ class TestComponentState:
             [ComponentState.DISPOSING, "DISPOSING"],
             [ComponentState.DISPOSED, "DISPOSED"],
             [ComponentState.FAULTED, "FAULTED"],
-        ]
+        ],
     )
     def test_component_state_to_str(self, enum, expected):
         # Arrange
@@ -55,7 +55,8 @@ class TestComponentState:
         # Assert
         assert result == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "string,expected",
         [
             ["INITIALIZED", ComponentState.INITIALIZED],
             ["STARTING", ComponentState.STARTING],
@@ -67,7 +68,7 @@ class TestComponentState:
             ["DISPOSING", ComponentState.DISPOSING],
             ["DISPOSED", ComponentState.DISPOSED],
             ["FAULTED", ComponentState.FAULTED],
-        ]
+        ],
     )
     def test_component_state_from_str(self, string, expected):
         # Arrange
@@ -89,7 +90,8 @@ class TestComponentTrigger:
         with pytest.raises(ValueError):
             ComponentTriggerParser.from_str_py("")
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "enum,expected",
         [
             [ComponentTrigger.START, "START"],
             [ComponentTrigger.RUNNING, "RUNNING"],
@@ -99,7 +101,7 @@ class TestComponentTrigger:
             [ComponentTrigger.RESET, "RESET"],
             [ComponentTrigger.DISPOSE, "DISPOSE"],
             [ComponentTrigger.DISPOSED, "DISPOSED"],
-        ]
+        ],
     )
     def test_component_trigger_to_str(self, enum, expected):
         # Arrange
@@ -109,7 +111,8 @@ class TestComponentTrigger:
         # Assert
         assert result == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "string,expected",
         [
             ["START", ComponentTrigger.START],
             ["RUNNING", ComponentTrigger.RUNNING],
@@ -119,7 +122,7 @@ class TestComponentTrigger:
             ["RESET", ComponentTrigger.RESET],
             ["DISPOSE", ComponentTrigger.DISPOSE],
             ["DISPOSED", ComponentTrigger.DISPOSED],
-        ]
+        ],
     )
     def test_component_trigger_from_str(self, string, expected):
         # Arrange

--- a/tests/unit_tests/model/test_model_position.py
+++ b/tests/unit_tests/model/test_model_position.py
@@ -15,7 +15,6 @@
 
 from decimal import Decimal
 
-from parameterized import parameterized
 import pytest
 
 from nautilus_trader.common.clock import TestClock
@@ -66,11 +65,12 @@ class TestPosition:
         with pytest.raises(ValueError):
             Position.side_from_order_side(0)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "order_side,expected",
         [
             [OrderSide.BUY, PositionSide.LONG],
             [OrderSide.SELL, PositionSide.SHORT],
-        ]
+        ],
     )
     def test_side_from_order_side_given_valid_sides_returns_expected_side(
         self, order_side, expected

--- a/tests/unit_tests/trading/test_trading_filters.py
+++ b/tests/unit_tests/trading/test_trading_filters.py
@@ -17,7 +17,6 @@ from datetime import datetime
 import os
 
 import pandas as pd
-from parameterized import parameterized
 import pytest
 import pytz
 
@@ -34,13 +33,14 @@ class TestForexSessionFilter:
         # Fixture Setup
         self.session_filter = ForexSessionFilter()
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "session,expected",
         [
             [ForexSession.SYDNEY, "1970-01-01 10:00:00+10:00"],
             [ForexSession.TOKYO, "1970-01-01 09:00:00+09:00"],
             [ForexSession.LONDON, "1970-01-01 01:00:00+01:00"],
             [ForexSession.NEW_YORK, "1969-12-31 19:00:00-05:00"],
-        ]
+        ],
     )
     def test_local_from_utc_given_various_sessions_returns_expected_datetime(
         self, session, expected
@@ -52,13 +52,14 @@ class TestForexSessionFilter:
         # Assert
         assert str(result) == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "session,expected",
         [
             [ForexSession.SYDNEY, datetime(1970, 1, 1, 21, 0, tzinfo=pytz.utc)],
             [ForexSession.TOKYO, datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)],
             [ForexSession.LONDON, datetime(1970, 1, 1, 7, 0, tzinfo=pytz.utc)],
             [ForexSession.NEW_YORK, datetime(1970, 1, 1, 13, 0, tzinfo=pytz.utc)],
-        ]
+        ],
     )
     def test_next_start_given_various_sessions_returns_expected_datetime(self, session, expected):
         # Arrange
@@ -86,13 +87,14 @@ class TestForexSessionFilter:
         # Assert
         assert result == datetime(2020, 7, 14, 0, 0, tzinfo=pytz.utc)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "session,expected",
         [
             [ForexSession.SYDNEY, datetime(1969, 12, 31, 21, 0, tzinfo=pytz.utc)],
             [ForexSession.TOKYO, datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)],
             [ForexSession.LONDON, datetime(1969, 12, 31, 7, 0, tzinfo=pytz.utc)],
             [ForexSession.NEW_YORK, datetime(1969, 12, 31, 13, 0, tzinfo=pytz.utc)],
-        ]
+        ],
     )
     def test_prev_start_given_various_sessions_returns_expected_datetime(self, session, expected):
         # Arrange
@@ -102,13 +104,14 @@ class TestForexSessionFilter:
         # Assert
         assert result == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "session,expected",
         [
             [ForexSession.SYDNEY, datetime(1970, 1, 1, 6, 0, tzinfo=pytz.utc)],
             [ForexSession.TOKYO, datetime(1970, 1, 1, 9, 0, tzinfo=pytz.utc)],
             [ForexSession.LONDON, datetime(1970, 1, 1, 15, 0, tzinfo=pytz.utc)],
             [ForexSession.NEW_YORK, datetime(1970, 1, 1, 22, 0, tzinfo=pytz.utc)],
-        ]
+        ],
     )
     def test_next_end_given_various_sessions_returns_expected_datetime(self, session, expected):
         # Arrange
@@ -118,13 +121,14 @@ class TestForexSessionFilter:
         # Assert
         assert result == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "session,expected",
         [
             [ForexSession.SYDNEY, datetime(1969, 12, 31, 6, 0, tzinfo=pytz.utc)],
             [ForexSession.TOKYO, datetime(1969, 12, 31, 9, 0, tzinfo=pytz.utc)],
             [ForexSession.LONDON, datetime(1969, 12, 31, 15, 0, tzinfo=pytz.utc)],
             [ForexSession.NEW_YORK, datetime(1969, 12, 31, 22, 0, tzinfo=pytz.utc)],
-        ]
+        ],
     )
     def test_prev_end_given_various_sessions_returns_expected_datetime(self, session, expected):
         # Arrange


### PR DESCRIPTION
Issue Ticket: #325

The next batch PR for converting unittest to pytest

The following files have been converted (7 total):

- tests/unit_tests/acceptance_tests/*.py
- tests/unit_tests/backtest/test_backtest_exchange.py
- tests/integration_tests/live/test_live_node.py
- tests/unit_tests/trading/test_trading_filters.py
- tests/unit_tests/model/test_model/position.py