### PR TITLE
Convert unittest tests to pytest (tests/unit_tests/adapters)

### DIFF
--- a/tests/integration_tests/adapters/ccxt/test_ccxt_binance_execution.py
+++ b/tests/integration_tests/adapters/ccxt/test_ccxt_binance_execution.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from nautilus_trader.adapters.ccxt.execution import BinanceCCXTExecutionClient
@@ -51,8 +50,8 @@ async def async_magic():
     return
 
 
-class BinanceExecutionClientTests(unittest.TestCase):
-    def setUp(self):
+class TestBinanceExecutionClient:
+    def setup(self):
         # Fixture Setup
         self.clock = LiveClock()
         self.uuid_factory = UUIDFactory()
@@ -123,7 +122,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
         # Wire up components
         self.exec_engine.register_client(self.client)
 
-    def tearDown(self):
+    def teardown(self):
         self.loop.stop()
         self.loop.close()
 
@@ -135,7 +134,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)  # Allow engine message queue to start
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -154,7 +153,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -175,7 +174,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
         self.loop.run_until_complete(run_test())
 
@@ -189,7 +188,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()
@@ -207,7 +206,7 @@ class BinanceExecutionClientTests(unittest.TestCase):
             self.client.dispose()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()

--- a/tests/integration_tests/adapters/ccxt/test_ccxt_bitmex_execution.py
+++ b/tests/integration_tests/adapters/ccxt/test_ccxt_bitmex_execution.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from nautilus_trader.adapters.ccxt.execution import BitmexCCXTExecutionClient
@@ -50,8 +49,8 @@ async def async_magic():
     return
 
 
-class BitmexExecutionClientTests(unittest.TestCase):
-    def setUp(self):
+class TestBitmexExecutionClient:
+    def setup(self):
         # Fixture Setup
         self.clock = LiveClock()
         self.uuid_factory = UUIDFactory()
@@ -118,7 +117,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
         # Wire up components
         self.exec_engine.register_client(self.client)
 
-    def tearDown(self):
+    def teardown(self):
         self.loop.stop()
         self.loop.close()
 
@@ -130,7 +129,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)  # Allow engine message queue to start
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -149,7 +148,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -170,7 +169,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
         self.loop.run_until_complete(run_test())
 
@@ -184,7 +183,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()
@@ -202,7 +201,7 @@ class BitmexExecutionClientTests(unittest.TestCase):
             self.client.dispose()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()

--- a/tests/integration_tests/adapters/ccxt/test_ccxt_data.py
+++ b/tests/integration_tests/adapters/ccxt/test_ccxt_data.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from nautilus_trader.adapters.ccxt.data import CCXTDataClient
@@ -60,8 +59,8 @@ async def async_magic():
     return
 
 
-class CCXTDataClientTests(unittest.TestCase):
-    def setUp(self):
+class TestCCXTDataClient:
+    def setup(self):
         # Fixture Setup
         self.clock = LiveClock()
         self.uuid_factory = UUIDFactory()
@@ -128,7 +127,7 @@ class CCXTDataClientTests(unittest.TestCase):
 
         self.data_engine.register_client(self.client)
 
-    def tearDown(self):
+    def teardown(self):
         self.loop.stop()
         self.loop.close()
 
@@ -140,7 +139,7 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)  # Allow engine message queue to start
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear down
             self.data_engine.stop()
@@ -159,7 +158,7 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
             # Tear down
             self.data_engine.stop()
@@ -180,7 +179,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
         self.loop.run_until_complete(run_test())
 
@@ -194,7 +193,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.data_engine.stop()
@@ -212,7 +211,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.dispose()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.data_engine.stop()
@@ -230,7 +229,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.subscribe_instrument(BTCUSDT)
 
             # Assert
-            self.assertIn(BTCUSDT, self.client.subscribed_instruments)
+            assert BTCUSDT in self.client.subscribed_instruments
 
             # Tear Down
             self.data_engine.stop()
@@ -249,8 +248,8 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertIn(ETHUSDT, self.client.subscribed_quote_ticks)
-            self.assertTrue(self.data_engine.cache.has_quote_ticks(ETHUSDT))
+            assert ETHUSDT in self.client.subscribed_quote_ticks
+            assert self.data_engine.cache.has_quote_ticks(ETHUSDT)
 
             # Tear Down
             self.data_engine.stop()
@@ -269,8 +268,8 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertIn(ETHUSDT, self.client.subscribed_trade_ticks)
-            self.assertTrue(self.data_engine.cache.has_trade_ticks(ETHUSDT))
+            assert ETHUSDT in self.client.subscribed_trade_ticks
+            assert self.data_engine.cache.has_trade_ticks(ETHUSDT)
 
             # Tear Down
             self.data_engine.stop()
@@ -290,7 +289,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.subscribe_bars(bar_type)
 
             # Assert
-            self.assertIn(bar_type, self.client.subscribed_bars)
+            assert bar_type in self.client.subscribed_bars
 
             # Tear Down
             self.data_engine.stop()
@@ -310,7 +309,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.unsubscribe_instrument(BTCUSDT)
 
             # Assert
-            self.assertNotIn(BTCUSDT, self.client.subscribed_instruments)
+            assert BTCUSDT not in self.client.subscribed_instruments
 
             # Tear Down
             self.data_engine.stop()
@@ -331,7 +330,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.unsubscribe_quote_ticks(ETHUSDT)
 
             # Assert
-            self.assertNotIn(ETHUSDT, self.client.subscribed_quote_ticks)
+            assert ETHUSDT not in self.client.subscribed_quote_ticks
 
             # Tear Down
             self.data_engine.stop()
@@ -351,7 +350,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.unsubscribe_trade_ticks(ETHUSDT)
 
             # Assert
-            self.assertNotIn(ETHUSDT, self.client.subscribed_trade_ticks)
+            assert ETHUSDT not in self.client.subscribed_trade_ticks
 
             # Tear Down
             self.data_engine.stop()
@@ -372,7 +371,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.unsubscribe_bars(bar_type)
 
             # Assert
-            self.assertNotIn(bar_type, self.client.subscribed_bars)
+            assert bar_type not in self.client.subscribed_bars
 
             # Tear Down
             self.data_engine.stop()
@@ -392,7 +391,7 @@ class CCXTDataClientTests(unittest.TestCase):
 
             # Assert
             # Instruments additionally requested on start
-            self.assertEqual(1, self.data_engine.response_count)
+            assert self.data_engine.response_count == 1
 
             # Tear Down
             self.data_engine.stop()
@@ -412,7 +411,7 @@ class CCXTDataClientTests(unittest.TestCase):
 
             # Assert
             # Instruments additionally requested on start
-            self.assertEqual(1, self.data_engine.response_count)
+            assert self.data_engine.response_count == 1
 
             # Tear Down
             self.data_engine.stop()
@@ -430,7 +429,7 @@ class CCXTDataClientTests(unittest.TestCase):
             self.client.request_quote_ticks(BTCUSDT, None, None, 0, uuid4())
 
             # Assert
-            self.assertTrue(True)  # Logs warning
+            assert True  # Logs warning
 
             # Tear Down
             self.data_engine.stop()
@@ -468,8 +467,8 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(1)
 
             # Assert
-            self.assertEqual(1, self.data_engine.response_count)
-            self.assertEqual(1, handler.count)
+            assert self.data_engine.response_count == 1
+            assert handler.count == 1
 
             # Tear Down
             self.data_engine.stop()
@@ -515,9 +514,9 @@ class CCXTDataClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertEqual(1, self.data_engine.response_count)
-            self.assertEqual(1, handler.count)
-            self.assertEqual(100, len(handler.get_store()[0]))
+            assert self.data_engine.response_count == 1
+            assert handler.count == 1
+            assert len(handler.get_store()[0]) == 100
 
             # Tear Down
             self.data_engine.stop()

--- a/tests/integration_tests/adapters/ccxt/test_ccxt_execution.py
+++ b/tests/integration_tests/adapters/ccxt/test_ccxt_execution.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from nautilus_trader.adapters.ccxt.execution import CCXTExecutionClient
@@ -51,8 +50,8 @@ async def async_magic():
     return
 
 
-class CCXTExecutionClientTests(unittest.TestCase):
-    def setUp(self):
+class TestCCXTExecutionClient:
+    def setup(self):
         # Fixture Setup
         self.clock = LiveClock()
         self.uuid_factory = UUIDFactory()
@@ -123,7 +122,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
 
         self.exec_engine.register_client(self.client)
 
-    def tearDown(self):
+    def teardown(self):
         self.loop.stop()
         self.loop.close()
 
@@ -135,7 +134,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)  # Allow engine message queue to start
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -154,7 +153,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
             await asyncio.sleep(0.3)
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
             # Tear down
             self.exec_engine.stop()
@@ -175,7 +174,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertFalse(self.client.is_connected)
+            assert not self.client.is_connected
 
         self.loop.run_until_complete(run_test())
 
@@ -189,7 +188,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
             self.client.reset()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()
@@ -207,7 +206,7 @@ class CCXTExecutionClientTests(unittest.TestCase):
             self.client.dispose()
 
             # Assert
-            self.assertTrue(self.client.is_connected)
+            assert self.client.is_connected
 
             # Tear Down
             self.exec_engine.stop()

--- a/tests/integration_tests/adapters/ccxt/test_ccxt_providers.py
+++ b/tests/integration_tests/adapters/ccxt/test_ccxt_providers.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import unittest
 from unittest.mock import MagicMock
 
 import pytest
@@ -49,7 +48,7 @@ async def async_magic():
     return
 
 
-class CCXTInstrumentProviderTests(unittest.TestCase):
+class TestCCXTInstrumentProvider:
     @pytest.mark.skip  # Tests real API
     def test_real_api(self):
         import ccxt
@@ -61,7 +60,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         provider.load_all()
 
         # Assert
-        self.assertTrue(provider.count > 0)  # No exceptions raised
+        assert provider.count > 0  # No exceptions raised
 
     def test_load_all_when_decimal_precision_mode_exchange(self):
         # Arrange
@@ -83,7 +82,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         provider.load_all()
 
         # Assert
-        self.assertEqual(1236, provider.count)  # No exceptions raised
+        assert provider.count == 1236  # No exceptions raised
 
     def test_load_all_when_tick_size_precision_mode_exchange(self):
         # Arrange
@@ -105,7 +104,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         provider.load_all()
 
         # Assert
-        self.assertEqual(120, provider.count)  # No exceptions raised
+        assert provider.count == 120  # No exceptions raised
 
     def test_load_all_async(self):
         # Fresh isolated loop testing pattern
@@ -133,7 +132,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
             await asyncio.sleep(0.5)
 
             # Assert
-            self.assertTrue(provider.count > 0)  # No exceptions raised
+            assert provider.count > 0  # No exceptions raised
 
         loop.run_until_complete(run_test())
         loop.stop()
@@ -150,7 +149,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         instruments = provider.get_all()
 
         # Assert
-        self.assertEqual({}, instruments)
+        assert instruments == {}
 
     def test_get_all_when_loaded_returns_instruments(self):
         # Arrange
@@ -173,9 +172,9 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         instruments = provider.get_all()
 
         # Assert
-        self.assertTrue(len(instruments) > 0)
-        self.assertEqual(dict, type(instruments))
-        self.assertEqual(InstrumentId, type(next(iter(instruments))))
+        assert len(instruments) > 0
+        assert type(instruments) == dict
+        assert type(next(iter(instruments))) == InstrumentId
 
     def test_get_all_when_load_all_is_true_returns_expected_instruments(self):
         # Arrange
@@ -197,9 +196,9 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         instruments = provider.get_all()
 
         # Assert
-        self.assertTrue(len(instruments) > 0)
-        self.assertEqual(dict, type(instruments))
-        self.assertEqual(InstrumentId, type(next(iter(instruments))))
+        assert len(instruments) > 0
+        assert type(instruments) == dict
+        assert type(next(iter(instruments))) == InstrumentId
 
     def test_get_btcusdt_when_not_loaded_returns_none(self):
         # Arrange
@@ -214,7 +213,7 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         instrument = provider.find(instrument_id)
 
         # Assert
-        self.assertIsNone(instrument)
+        assert instrument is None
 
     def test_get_btcusdt_when_loaded_returns_expected_instrument(self):
         # Arrange
@@ -239,11 +238,11 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         instrument = provider.find(instrument_id)
 
         # Assert
-        self.assertEqual(CurrencySpot, type(instrument))
-        self.assertEqual(AssetClass.CRYPTO, instrument.asset_class)
-        self.assertEqual(AssetType.SPOT, instrument.asset_type)
-        self.assertEqual(BTC, instrument.base_currency)
-        self.assertEqual(USDT, instrument.quote_currency)
+        assert type(instrument) == CurrencySpot
+        assert instrument.asset_class == AssetClass.CRYPTO
+        assert instrument.asset_type == AssetType.SPOT
+        assert instrument.base_currency == BTC
+        assert instrument.quote_currency == USDT
 
     def test_get_btc_currency_when_loaded_returns_expected_currency(self):
         # Arrange
@@ -266,9 +265,9 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         currency = provider.currency("BTC")
 
         # Assert
-        self.assertEqual(Currency, type(currency))
-        self.assertEqual("BTC", currency.code)
-        self.assertEqual(8, currency.precision)
+        assert type(currency) == Currency
+        assert currency.code == "BTC"
+        assert currency.precision == 8
 
     def test_get_random_currency_when_not_loaded_returns_none(self):
         # Arrange
@@ -283,4 +282,4 @@ class CCXTInstrumentProviderTests(unittest.TestCase):
         currency = provider.currency("ZZZ")
 
         # Assert
-        self.assertIsNone(currency)
+        assert currency is None

--- a/tests/integration_tests/adapters/oanda/test_oanda_providers.py
+++ b/tests/integration_tests/adapters/oanda/test_oanda_providers.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import json
-import unittest
 from unittest.mock import MagicMock
 
 from nautilus_trader.adapters.oanda.providers import OandaInstrumentProvider
@@ -31,7 +30,7 @@ from tests import TESTS_PACKAGE_ROOT
 TEST_PATH = TESTS_PACKAGE_ROOT + "/integration_tests/adapters/oanda/responses/"
 
 
-class OandaInstrumentProviderTests(unittest.TestCase):
+class TestOandaInstrumentProvider:
     def test_load_all(self):
         # Arrange
         mock_client = MagicMock()
@@ -47,7 +46,7 @@ class OandaInstrumentProviderTests(unittest.TestCase):
         provider.load_all()
 
         # Assert
-        self.assertTrue(provider.count > 0)  # No exceptions raised
+        assert provider.count > 0  # No exceptions raised
 
     def test_get_all_when_not_loaded_returns_empty_dict(self):
         # Arrange
@@ -59,7 +58,7 @@ class OandaInstrumentProviderTests(unittest.TestCase):
         instruments = provider.get_all()
 
         # Assert
-        self.assertEqual({}, instruments)
+        assert instruments == {}
 
     def test_get_all_when_loaded_returns_instruments(self):
         # Arrange
@@ -77,9 +76,9 @@ class OandaInstrumentProviderTests(unittest.TestCase):
         instruments = provider.get_all()
 
         # Assert
-        self.assertTrue(len(instruments) > 0)
-        self.assertEqual(dict, type(instruments))
-        self.assertEqual(InstrumentId, type(next(iter(instruments))))
+        assert len(instruments) > 0
+        assert type(instruments) == dict
+        assert type(next(iter(instruments))) == InstrumentId
 
     def test_get_audusd_when_not_loaded_returns_none(self):
         # Arrange
@@ -98,7 +97,7 @@ class OandaInstrumentProviderTests(unittest.TestCase):
         instrument = provider.find(instrument_id)
 
         # Assert
-        self.assertIsNone(instrument)
+        assert instrument is None
 
     def test_get_audusd_when_loaded_returns_expected_instrument(self):
         # Arrange
@@ -117,7 +116,7 @@ class OandaInstrumentProviderTests(unittest.TestCase):
         instrument = provider.find(instrument_id)
 
         # Assert
-        self.assertEqual(CFDInstrument, type(instrument))
-        self.assertEqual(AssetClass.FX, instrument.asset_class)
-        self.assertEqual(AssetType.CFD, instrument.asset_type)
-        self.assertEqual(USD, instrument.quote_currency)
+        assert type(instrument) == CFDInstrument
+        assert instrument.asset_class == AssetClass.FX
+        assert instrument.asset_type == AssetType.CFD
+        assert instrument.quote_currency == USD


### PR DESCRIPTION
Issue Ticket: #325

The next batch PR for converting unittest to pytest

The following files have been converted (6 total):

- tests/unit_tests/adapters/ccxt/*.py
- tests/unit_tests/adapters/oanda/*.py