### PR TITLE
Convert backtest and cache tests to pytest

### DIFF
--- a/tests/unit_tests/backtest/test_backtest_exchange.py
+++ b/tests/unit_tests/backtest/test_backtest_exchange.py
@@ -15,7 +15,6 @@
 
 from datetime import timedelta
 from decimal import Decimal
-import unittest
 
 import pytest
 
@@ -71,8 +70,8 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 XBTUSD_BITMEX = TestInstrumentProvider.xbtusd_bitmex()
 
 
-class SimulatedExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestSimulatedExchange:
+    def setup(self):
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
@@ -170,14 +169,14 @@ class SimulatedExchangeTests(unittest.TestCase):
         # Arrange
         # Act
         # Assert
-        self.assertEqual("SimulatedExchange(SIM)", repr(self.exchange))
+        assert repr(self.exchange) == "SimulatedExchange(SIM)"
 
     def test_check_residuals(self):
         # Arrange
         # Act
         self.exchange.check_residuals()
         # Assert
-        self.assertTrue(True)  # No exceptions raised
+        assert True  # No exceptions raised
 
     def test_process_quote_tick_sets_market(self):
         # Arrange
@@ -246,17 +245,17 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         # TODO: Revisit testing
-        self.assertEqual(3, len(self.exchange.get_working_orders()))
-        self.assertIn(bracket1.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket1.take_profit, self.exchange.get_working_orders().values())
-        self.assertIn(entry2, self.exchange.get_working_orders().values())
+        assert len(self.exchange.get_working_orders()) == 3
+        assert bracket1.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket1.take_profit in self.exchange.get_working_orders().values()
+        assert entry2 in self.exchange.get_working_orders().values()
 
     def test_get_working_orders_when_no_orders_returns_empty_dict(self):
         # Arrange
         # Act
         orders = self.exchange.get_working_orders()
 
-        self.assertEqual({}, orders)
+        assert orders == {}
 
     def test_submit_buy_limit_order_with_no_market_accepts_order(self):
         # Arrange
@@ -271,9 +270,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted))
+        assert order.state == OrderState.ACCEPTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted)
 
     def test_submit_sell_limit_order_with_no_market_accepts_order(self):
         # Arrange
@@ -288,9 +287,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted))
+        assert order.state == OrderState.ACCEPTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderAccepted)
 
     def test_submit_buy_market_order_with_no_market_rejects_order(self):
         # Arrange
@@ -304,9 +303,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderRejected))
+        assert order.state == OrderState.REJECTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderRejected)
 
     def test_submit_sell_market_order_with_no_market_rejects_order(self):
         # Arrange
@@ -320,9 +319,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(2, self.strategy.object_storer.count)
-        self.assertTrue(isinstance(self.strategy.object_storer.get_store()[1], OrderRejected))
+        assert order.state == OrderState.REJECTED
+        assert self.strategy.object_storer.count == 2
+        assert isinstance(self.strategy.object_storer.get_store()[1], OrderRejected)
 
     def test_submit_order_with_invalid_price_gets_rejected(self):
         # Arrange: Prepare market
@@ -345,7 +344,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
+        assert order.state == OrderState.REJECTED
 
     def test_submit_order_when_quantity_below_min_then_gets_denied(self):
         # Arrange: Prepare market
@@ -359,7 +358,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.DENIED, order.state)
+        assert order.state == OrderState.DENIED
 
     def test_submit_order_when_quantity_above_max_then_gets_denied(self):
         # Arrange: Prepare market
@@ -373,7 +372,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.DENIED, order.state)
+        assert order.state == OrderState.DENIED
 
     def test_submit_market_order(self):
         # Arrange: Prepare market
@@ -396,8 +395,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Decimal("90.005"), order.avg_px)  # No slippage
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == Decimal("90.005")  # No slippage
 
     def test_submit_post_only_limit_order_when_marketable_then_rejects(self):
         # Arrange: Prepare market
@@ -421,8 +420,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_limit_order(self):
         # Arrange: Prepare market
@@ -445,9 +444,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_limit_order_when_marketable_then_fills(self):
         # Arrange: Prepare market
@@ -471,9 +470,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(LiquiditySide.TAKER, order.liquidity_side)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.FILLED
+        assert order.liquidity_side == LiquiditySide.TAKER
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_limit_order_fills_at_correct_price(self):
         # Arrange: Prepare market
@@ -497,8 +496,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(tick.ask, order.avg_px)
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == tick.ask
 
     def test_submit_limit_order_fills_at_most_book_volume(self):
         # Arrange: Prepare market
@@ -522,8 +521,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(1_000_000, order.filled_qty)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == 1_000_000
 
     def test_submit_stop_market_order_inside_market_rejects(self):
         # Arrange: Prepare market
@@ -546,8 +545,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_stop_market_order(self):
         # Arrange: Prepare market
@@ -570,9 +569,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_stop_limit_order_when_inside_market_rejects(self):
         # Arrange: Prepare market
@@ -596,8 +595,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_submit_stop_limit_order(self):
         # Arrange: Prepare market
@@ -621,9 +620,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(order.client_order_id, self.exchange.get_working_orders())
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.client_order_id in self.exchange.get_working_orders()
 
     def test_submit_bracket_market_order(self):
         # Arrange: Prepare market
@@ -656,9 +655,9 @@ class SimulatedExchangeTests(unittest.TestCase):
             ClientOrderId("O-19700101-000000-000-001-3")
         )
 
-        self.assertEqual(OrderState.FILLED, entry_order.state)
-        self.assertEqual(OrderState.ACCEPTED, stop_loss_order.state)
-        self.assertEqual(OrderState.ACCEPTED, take_profit_order.state)
+        assert entry_order.state == OrderState.FILLED
+        assert stop_loss_order.state == OrderState.ACCEPTED
+        assert take_profit_order.state == OrderState.ACCEPTED
 
     def test_submit_stop_market_order_with_bracket(self):
         # Arrange: Prepare market
@@ -692,11 +691,11 @@ class SimulatedExchangeTests(unittest.TestCase):
             ClientOrderId("O-19700101-000000-000-001-3")
         )
 
-        self.assertEqual(OrderState.ACCEPTED, entry_order.state)
-        self.assertEqual(OrderState.SUBMITTED, stop_loss_order.state)
-        self.assertEqual(OrderState.SUBMITTED, take_profit_order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertIn(entry_order.client_order_id, self.exchange.get_working_orders())
+        assert entry_order.state == OrderState.ACCEPTED
+        assert stop_loss_order.state == OrderState.SUBMITTED
+        assert take_profit_order.state == OrderState.SUBMITTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert entry_order.client_order_id in self.exchange.get_working_orders()
 
     def test_cancel_stop_order(self):
         # Arrange: Prepare market
@@ -721,8 +720,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.cancel_order(order)
 
         # Assert
-        self.assertEqual(OrderState.CANCELED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.CANCELED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_cancel_stop_order_when_order_does_not_exist_generates_cancel_reject(self):
         # Arrange
@@ -740,7 +739,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.handle_cancel_order(command)
 
         # Assert
-        self.assertEqual(2, self.exec_engine.event_count)
+        assert self.exec_engine.event_count == 2
 
     def test_update_stop_order_when_order_does_not_exist(self):
         # Arrange
@@ -761,7 +760,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.handle_update_order(command)
 
         # Assert
-        self.assertEqual(2, self.exec_engine.event_count)
+        assert self.exec_engine.event_count == 2
 
     def test_update_order_with_zero_quantity_rejects_amendment(self):
         # Arrange: Prepare market
@@ -787,9 +786,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, Quantity.zero(), Price.from_str("90.001"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))  # Order still working
-        self.assertEqual(Price.from_str("90.001"), order.price)  # Did not update
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1  # Order still working
+        assert order.price == Price.from_str("90.001")  # Did not update
 
     def test_update_post_only_limit_order_when_marketable_then_rejects_amendment(self):
         # Arrange: Prepare market
@@ -815,9 +814,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))  # Order still working
-        self.assertEqual(Price.from_str("90.001"), order.price)  # Did not update
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1  # Order still working
+        assert order.price == Price.from_str("90.001")  # Did not update
 
     def test_update_limit_order_when_marketable_then_fills_order(self):
         # Arrange: Prepare market
@@ -843,9 +842,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.005"), order.avg_px)
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.005")
 
     def test_update_stop_market_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -872,9 +871,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.price)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.010")
 
     def test_update_stop_market_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -899,9 +898,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.011"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.011"), order.price)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.011")
 
     def test_update_untriggered_stop_limit_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -929,9 +928,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.trigger)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.trigger == Price.from_str("90.010")
 
     def test_update_untriggered_stop_limit_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -957,9 +956,9 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.011"))
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.011"), order.trigger)
+        assert order.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.trigger == Price.from_str("90.011")
 
     def test_update_triggered_post_only_stop_limit_order_when_price_inside_market_then_rejects_amendment(
         self,
@@ -997,10 +996,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.010"))
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.000"), order.price)
+        assert order.state == OrderState.TRIGGERED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.000")
 
     def test_update_triggered_stop_limit_order_when_price_inside_market_then_fills(
         self,
@@ -1038,10 +1037,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.010"))
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.010"), order.price)
+        assert order.state == OrderState.FILLED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.price == Price.from_str("90.010")
 
     def test_update_triggered_stop_limit_order_when_price_valid_then_amends(self):
         # Arrange: Prepare market
@@ -1076,10 +1075,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.strategy.update_order(order, order.quantity, Price.from_str("90.005"))
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertTrue(order.is_triggered)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.005"), order.price)
+        assert order.state == OrderState.TRIGGERED
+        assert order.is_triggered
+        assert len(self.exchange.get_working_orders()) == 1
+        assert order.price == Price.from_str("90.005")
 
     def test_update_bracket_orders_working_stop_loss(self):
         # Arrange: Prepare market
@@ -1113,8 +1112,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, bracket_order.stop_loss.state)
-        self.assertEqual(Price.from_str("85.100"), bracket_order.stop_loss.price)
+        assert bracket_order.stop_loss.state == OrderState.ACCEPTED
+        assert bracket_order.stop_loss.price == Price.from_str("85.100")
 
     def test_order_fills_gets_commissioned(self):
         # Arrange: Prepare market
@@ -1156,11 +1155,11 @@ class SimulatedExchangeTests(unittest.TestCase):
         fill_event3 = self.strategy.object_storer.get_store()[7]
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Money(180.01, JPY), fill_event1.commission)
-        self.assertEqual(Money(180.01, JPY), fill_event2.commission)
-        self.assertEqual(Money(90.00, JPY), fill_event3.commission)
-        self.assertTrue(Money(999995.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert fill_event1.commission == Money(180.01, JPY)
+        assert fill_event2.commission == Money(180.01, JPY)
+        assert fill_event3.commission == Money(90.00, JPY)
+        assert self.exchange.get_account().balance_total(USD) == Money(999995.00, USD)
 
     def test_expire_order(self):
         # Arrange: Prepare market
@@ -1197,8 +1196,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.EXPIRED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.EXPIRED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_buy_stop_order(self):
         # Arrange: Prepare market
@@ -1244,10 +1243,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Price.from_str("96.711"), order.avg_px)
-        self.assertEqual(Money(999997.86, USD), self.exchange.get_account().balance_total(USD))
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.state == OrderState.FILLED
+        assert order.avg_px == Price.from_str("96.711")
+        assert self.exchange.get_account().balance_total(USD) == Money(999997.86, USD)
 
     def test_process_quote_tick_triggers_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1283,8 +1282,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.TRIGGERED, order.state)
-        self.assertEqual(1, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.TRIGGERED
+        assert len(self.exchange.get_working_orders()) == 1
 
     def test_process_quote_tick_rejects_triggered_post_only_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1321,8 +1320,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.REJECTED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.REJECTED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_triggered_buy_stop_limit_order(self):
         # Arrange: Prepare market
@@ -1369,8 +1368,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
 
     def test_process_quote_tick_fills_buy_limit_order(self):
         # Arrange: Prepare market
@@ -1416,10 +1415,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.001"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.001")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_stop_order(self):
         # Arrange: Prepare market
@@ -1454,10 +1453,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.000"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.000")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_limit_order(self):
         # Arrange: Prepare market
@@ -1492,10 +1491,10 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
-        self.assertEqual(Price.from_str("90.101"), order.avg_px)
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert len(self.exchange.get_working_orders()) == 0
+        assert order.avg_px == Price.from_str("90.101")
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_buy_limit_entry_with_bracket(self):
         # Arrange: Prepare market
@@ -1536,12 +1535,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertEqual(Money(999998.00, USD), self.exchange.get_account().balance_total(USD))
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert self.exchange.get_account().balance_total(USD) == Money(999998.00, USD)
 
     def test_process_quote_tick_fills_sell_limit_entry_with_bracket(self):
         # Arrange: Prepare market
@@ -1582,12 +1581,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick2)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))  # SL and TP
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket.take_profit, self.exchange.get_working_orders().values())
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2  # SL and TP
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket.take_profit in self.exchange.get_working_orders().values()
 
     def test_process_trade_tick_fills_buy_limit_entry_bracket(self):
         # Arrange: Prepare market
@@ -1645,12 +1644,12 @@ class SimulatedExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick3)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.ACCEPTED, bracket.take_profit.state)
-        self.assertEqual(2, len(self.exchange.get_working_orders()))  # SL and TP only
-        self.assertIn(bracket.stop_loss, self.exchange.get_working_orders().values())
-        self.assertIn(bracket.take_profit, self.exchange.get_working_orders().values())
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.ACCEPTED
+        assert bracket.take_profit.state == OrderState.ACCEPTED
+        assert len(self.exchange.get_working_orders()) == 2  # SL and TP only
+        assert bracket.stop_loss in self.exchange.get_working_orders().values()
+        assert bracket.take_profit in self.exchange.get_working_orders().values()
 
     def test_filling_oco_sell_cancels_other_order(self):
         # Arrange: Prepare market
@@ -1703,12 +1702,12 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         print(self.exchange.cache.position(PositionId("2-001")))
-        self.assertEqual(OrderState.FILLED, entry.state)
-        self.assertEqual(OrderState.FILLED, bracket.stop_loss.state)
-        self.assertEqual(OrderState.CANCELED, bracket.take_profit.state)
-        self.assertEqual(0, len(self.exchange.get_working_orders()))
+        assert entry.state == OrderState.FILLED
+        assert bracket.stop_loss.state == OrderState.FILLED
+        assert bracket.take_profit.state == OrderState.CANCELED
+        assert len(self.exchange.get_working_orders()) == 0
         # TODO: WIP - fix handling of OCO orders
-        # self.assertEqual(0, len(self.exchange.cache.positions_open()))
+        # assert len(self.exchange.cache.positions_open()) == 0
 
     def test_realized_pnl_contains_commission(self):
         # Arrange: Prepare market
@@ -1731,8 +1730,8 @@ class SimulatedExchangeTests(unittest.TestCase):
         position = self.exec_engine.cache.positions_open()[0]
 
         # Assert
-        self.assertEqual(Money(-180.01, JPY), position.realized_pnl)
-        self.assertEqual([Money(180.01, JPY)], position.commissions())
+        assert position.realized_pnl == Money(-180.01, JPY)
+        assert position.commissions() == [Money(180.01, JPY)]
 
     def test_unrealized_pnl(self):
         # Arrange: Prepare market
@@ -1779,7 +1778,7 @@ class SimulatedExchangeTests(unittest.TestCase):
 
         # Assert
         position = self.exec_engine.cache.positions_open()[0]
-        self.assertEqual(Money(499900.00, JPY), position.unrealized_pnl(Price.from_str("100.003")))
+        assert position.unrealized_pnl(Price.from_str("100.003")) == Money(499900.00, JPY)
 
     def test_adjust_account_changes_balance(self):
         # Arrange
@@ -1790,7 +1789,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         result = self.exchange.exec_client.get_account().balance_total(USD)
 
         # Assert
-        self.assertEqual(Money(1001000.00, USD), result)
+        assert result == Money(1001000.00, USD)
 
     def test_adjust_account_when_account_frozen_does_not_change_balance(self):
         # Arrange
@@ -1819,7 +1818,7 @@ class SimulatedExchangeTests(unittest.TestCase):
         result = exchange.get_account().balance_total(USD)
 
         # Assert
-        self.assertEqual(Money(1000000.00, USD), result)
+        assert result == Money(1000000.00, USD)
 
     def test_position_flipped_when_reduce_order_exceeds_original_quantity(self):
         # Arrange: Prepare market
@@ -1870,15 +1869,15 @@ class SimulatedExchangeTests(unittest.TestCase):
         # Assert
         position_open = self.exec_engine.cache.positions_open()[0]
         position_closed = self.exec_engine.cache.positions_closed()[0]
-        self.assertEqual(PositionSide.SHORT, position_open.side)
-        self.assertEqual(Quantity.from_int(50000), position_open.quantity)
-        self.assertEqual(Money(999619.98, JPY), position_closed.realized_pnl)
-        self.assertEqual([Money(380.02, JPY)], position_closed.commissions())
-        self.assertEqual(Money(1016660.97, USD), self.exchange.get_account().balance_total(USD))
+        assert position_open.side == PositionSide.SHORT
+        assert position_open.quantity == Quantity.from_int(50000)
+        assert position_closed.realized_pnl == Money(999619.98, JPY)
+        assert position_closed.commissions() == [Money(380.02, JPY)]
+        assert self.exchange.get_account().balance_total(USD) == Money(1016660.97, USD)
 
 
-class BitmexExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestBitmexExchange:
+    def setup(self):
         # Fixture Setup
         self.strategies = [MockStrategy(TestStubs.bartype_btcusdt_binance_100tick_last())]
 
@@ -2014,26 +2013,14 @@ class BitmexExchangeTests(unittest.TestCase):
         self.portfolio.update_tick(quote2)
 
         # Assert
-        self.assertEqual(
-            LiquiditySide.TAKER,
-            self.strategy.object_storer.get_store()[1].liquidity_side,
-        )
-        self.assertEqual(
-            LiquiditySide.MAKER,
-            self.strategy.object_storer.get_store()[5].liquidity_side,
-        )
-        self.assertEqual(
-            Money(0.00652543, BTC),
-            self.strategy.object_storer.get_store()[1].commission,
-        )
-        self.assertEqual(
-            Money(-0.00217552, BTC),
-            self.strategy.object_storer.get_store()[5].commission,
-        )
+        assert self.strategy.object_storer.get_store()[1].liquidity_side == LiquiditySide.TAKER
+        assert self.strategy.object_storer.get_store()[5].liquidity_side == LiquiditySide.MAKER
+        assert self.strategy.object_storer.get_store()[1].commission == Money(0.00652543, BTC)
+        assert self.strategy.object_storer.get_store()[5].commission == Money(-0.00217552, BTC)
 
 
-class OrderBookExchangeTests(unittest.TestCase):
-    def setUp(self):
+class TestOrderBookExchange:
+    def setup(self):
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
@@ -2163,10 +2150,10 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.FILLED, order.state)
-        self.assertEqual(Decimal("2000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("15.33333333333333333333333333"), order.avg_px)
-        self.assertEqual(Money(999999.98, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.FILLED
+        assert order.filled_qty == Decimal("2000.0")  # No slippage
+        assert order.avg_px == Decimal("15.33333333333333333333333333")
+        assert self.exchange.get_account().balance_total(USD) == Money(999999.98, USD)
 
     def test_aggressive_partial_fill(self):
         # Arrange: Prepare market
@@ -2201,10 +2188,10 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("6000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("15.93333333333333333333333333"), order.avg_px)
-        self.assertEqual(Money(999999.94, USD), self.exchange.get_account().balance_total(USD))
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("6000.0")  # No slippage
+        assert order.avg_px == Decimal("15.93333333333333333333333333")
+        assert self.exchange.get_account().balance_total(USD) == Money(999999.94, USD)
 
     def test_passive_post_only_insert(self):
         # Arrange: Prepare market
@@ -2227,7 +2214,7 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.strategy.submit_order(order)
 
         # Assert
-        self.assertEqual(OrderState.ACCEPTED, order.state)
+        assert order.state == OrderState.ACCEPTED
 
     # TODO - Need to discuss how we are going to support passive quotes trading now
     @pytest.mark.skip
@@ -2262,9 +2249,9 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("1000.0"), order.filled_qty)
-        self.assertEqual(Decimal("15.0"), order.avg_px)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("1000.0")
+        assert order.avg_px == Decimal("15.0")
 
     # TODO - Need to discuss how we are going to support passive quotes trading now
     @pytest.mark.skip
@@ -2299,6 +2286,6 @@ class OrderBookExchangeTests(unittest.TestCase):
         self.exchange.process_tick(tick1)
 
         # Assert
-        self.assertEqual(OrderState.PARTIALLY_FILLED, order.state)
-        self.assertEqual(Quantity.from_str("1000.0"), order.filled_qty)  # No slippage
-        self.assertEqual(Decimal("14.0"), order.avg_px)
+        assert order.state == OrderState.PARTIALLY_FILLED
+        assert order.filled_qty == Quantity.from_str("1000.0")  # No slippage
+        assert order.avg_px == Decimal("14.0")

--- a/tests/unit_tests/cache/test_data_base.py
+++ b/tests/unit_tests/cache/test_data_base.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.cache.base import CacheFacade
 from nautilus_trader.core.type import DataType
@@ -32,17 +32,17 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class DataTypeTests(unittest.TestCase):
+class TestDataType:
     def test_data_type_instantiation(self):
         # Arrange
         # Act
         data_type = DataType(str, {"type": "NEWS_WIRE"})
 
         # Assert
-        self.assertEqual(str, data_type.type)
-        self.assertEqual({"type": "NEWS_WIRE"}, data_type.metadata)
-        self.assertEqual("<str> {'type': 'NEWS_WIRE'}", str(data_type))
-        self.assertEqual("DataType(type=str, metadata={'type': 'NEWS_WIRE'})", repr(data_type))
+        assert data_type.type == str
+        assert data_type.metadata == {"type": "NEWS_WIRE"}
+        assert str(data_type) == "<str> {'type': 'NEWS_WIRE'}"
+        assert repr(data_type) == "DataType(type=str, metadata={'type': 'NEWS_WIRE'})"
 
     def test_data_equality_and_hash(self):
         # Arrange
@@ -52,11 +52,11 @@ class DataTypeTests(unittest.TestCase):
         data_type3 = DataType(int, {"type": "FED_DATA", "topic": "NonFarmPayroll"})
 
         # Assert
-        self.assertTrue(data_type1 == data_type1)
-        self.assertTrue(data_type1 != data_type2)
-        self.assertTrue(data_type1 != data_type2)
-        self.assertTrue(data_type1 != data_type3)
-        self.assertEqual(int, type(hash(data_type1)))
+        assert data_type1 == data_type1
+        assert data_type1 != data_type2
+        assert data_type1 != data_type2
+        assert data_type1 != data_type3
+        assert type(hash(data_type1)) == int
 
     def test_data_type_as_key_in_dict(self):
         # Arrange
@@ -66,7 +66,7 @@ class DataTypeTests(unittest.TestCase):
         hash_map = {data_type: []}
 
         # Assert
-        self.assertIn(data_type, hash_map)
+        assert data_type in hash_map
 
     def test_data_instantiation(self):
         # Arrange
@@ -82,84 +82,87 @@ class DataTypeTests(unittest.TestCase):
         generic_data = GenericData(data_type, data)
 
         # Assert
-        self.assertEqual(data_type, generic_data.data_type)
-        self.assertEqual(data, generic_data.data)
+        assert generic_data.data_type == data_type
+        assert generic_data.data == data
 
 
-class CacheFacadeTests(unittest.TestCase):
-    def setUp(self):
+class TestCacheFacade:
+    def setup(self):
         # Fixture Setup
         self.facade = CacheFacade()
 
     def test_instrument_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.instrument_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.instrument_ids()
 
     def test_instruments_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.instruments)
+        with pytest.raises(NotImplementedError):
+            self.facade.instruments()
 
     def test_quote_ticks_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.quote_ticks, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.quote_ticks(AUDUSD_SIM.id)
 
     def test_trade_ticks_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.trade_ticks, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.trade_ticks(AUDUSD_SIM.id)
 
     def test_bars_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError, self.facade.bars, TestStubs.bartype_gbpusd_1sec_mid()
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.bars(TestStubs.bartype_gbpusd_1sec_mid())
 
     def test_instrument_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.instrument, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.instrument(AUDUSD_SIM.id)
 
     def test_price_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.price, AUDUSD_SIM.id, PriceType.MID)
+        with pytest.raises(NotImplementedError):
+            self.facade.price(AUDUSD_SIM.id, PriceType.MID)
 
     def test_order_book_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.order_book, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.order_book(AUDUSD_SIM.id)
 
     def test_quote_tick_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.quote_tick, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.quote_tick(AUDUSD_SIM.id)
 
     def test_trade_tick_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.trade_tick, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.trade_tick(AUDUSD_SIM.id)
 
     def test_bar_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.bar, TestStubs.bartype_gbpusd_1sec_mid())
+        with pytest.raises(NotImplementedError):
+            self.facade.bar(TestStubs.bartype_gbpusd_1sec_mid())
 
     def test_quote_tick_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.quote_tick_count, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.quote_tick_count(AUDUSD_SIM.id)
 
     def test_trade_tick_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.trade_tick_count, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.trade_tick_count(AUDUSD_SIM.id)
 
     def test_bar_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.bar_count,
-            TestStubs.bartype_gbpusd_1sec_mid(),
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.bar_count(TestStubs.bartype_gbpusd_1sec_mid())
 
     def test_has_order_book_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.has_order_book, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.has_order_book(AUDUSD_SIM.id)
 
     def test_has_quote_ticks_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.has_quote_ticks, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.has_quote_ticks(AUDUSD_SIM.id)
 
     def test_has_trade_ticks_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.has_trade_ticks, AUDUSD_SIM.id)
+        with pytest.raises(NotImplementedError):
+            self.facade.has_trade_ticks(AUDUSD_SIM.id)
 
     def test_has_bars_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.has_bars,
-            TestStubs.bartype_gbpusd_1sec_mid(),
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.has_bars(TestStubs.bartype_gbpusd_1sec_mid())
 
     def test_get_xrate_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.get_xrate,
-            SIM,
-            AUDUSD_SIM.base_currency,
-            AUDUSD_SIM.quote_currency,
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.get_xrate(SIM, AUDUSD_SIM.base_currency, AUDUSD_SIM.quote_currency)

--- a/tests/unit_tests/cache/test_data_cache.py
+++ b/tests/unit_tests/cache/test_data_cache.py
@@ -14,9 +14,8 @@
 # -------------------------------------------------------------------------------------------------
 
 from decimal import Decimal
-import unittest
 
-from parameterized import parameterized
+import pytest
 
 from nautilus_trader.model.bar import Bar
 from nautilus_trader.model.currencies import AUD
@@ -42,8 +41,8 @@ AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 ETHUSDT_BINANCE = TestInstrumentProvider.ethusdt_binance()
 
 
-class CacheTests(unittest.TestCase):
-    def setUp(self):
+class TestCache:
+    def setup(self):
         # Fixture Setup
         self.cache = TestStubs.cache()
 
@@ -53,106 +52,106 @@ class CacheTests(unittest.TestCase):
         self.cache.reset()
 
         # Assert
-        self.assertEqual([], self.cache.instruments())
-        self.assertEqual([], self.cache.quote_ticks(AUDUSD_SIM.id))
-        self.assertEqual([], self.cache.trade_ticks(AUDUSD_SIM.id))
-        self.assertEqual([], self.cache.bars(TestStubs.bartype_gbpusd_1sec_mid()))
+        assert self.cache.instruments() == []
+        assert self.cache.quote_ticks(AUDUSD_SIM.id) == []
+        assert self.cache.trade_ticks(AUDUSD_SIM.id) == []
+        assert self.cache.bars(TestStubs.bartype_gbpusd_1sec_mid()) == []
 
     def test_instrument_ids_when_no_instruments_returns_empty_list(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual([], self.cache.instrument_ids())
+        assert self.cache.instrument_ids() == []
 
     def test_instruments_when_no_instruments_returns_empty_list(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual([], self.cache.instruments())
+        assert self.cache.instruments() == []
 
     def test_quote_ticks_for_unknown_instrument_returns_empty_list(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual([], self.cache.quote_ticks(AUDUSD_SIM.id))
+        assert self.cache.quote_ticks(AUDUSD_SIM.id) == []
 
     def test_trade_ticks_for_unknown_instrument_returns_empty_list(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual([], self.cache.trade_ticks(AUDUSD_SIM.id))
+        assert self.cache.trade_ticks(AUDUSD_SIM.id) == []
 
     def test_bars_for_unknown_bar_type_returns_empty_list(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual([], self.cache.bars(TestStubs.bartype_gbpusd_1sec_mid()))
+        assert self.cache.bars(TestStubs.bartype_gbpusd_1sec_mid()) == []
 
     def test_instrument_when_no_instruments_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.instrument(AUDUSD_SIM.id))
+        assert self.cache.instrument(AUDUSD_SIM.id) is None
 
     def test_order_book_for_unknown_instrument_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.order_book(AUDUSD_SIM.id))
+        assert self.cache.order_book(AUDUSD_SIM.id) is None
 
     def test_quote_tick_when_no_ticks_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.quote_tick(AUDUSD_SIM.id))
+        assert self.cache.quote_tick(AUDUSD_SIM.id) is None
 
     def test_trade_tick_when_no_ticks_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.trade_tick(AUDUSD_SIM.id))
+        assert self.cache.trade_tick(AUDUSD_SIM.id) is None
 
     def test_bar_when_no_bars_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.bar(TestStubs.bartype_gbpusd_1sec_mid()))
+        assert self.cache.bar(TestStubs.bartype_gbpusd_1sec_mid()) is None
 
     def test_quote_tick_count_for_unknown_instrument_returns_zero(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0, self.cache.quote_tick_count(AUDUSD_SIM.id))
+        assert self.cache.quote_tick_count(AUDUSD_SIM.id) == 0
 
     def test_trade_tick_count_for_unknown_instrument_returns_zero(self):
         # Arrange
         # Act
         # Assert
-        self.assertEqual(0, self.cache.trade_tick_count(AUDUSD_SIM.id))
+        assert self.cache.trade_tick_count(AUDUSD_SIM.id) == 0
 
     def test_has_order_book_for_unknown_instrument_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.has_order_book(AUDUSD_SIM.id))
+        assert not self.cache.has_order_book(AUDUSD_SIM.id)
 
     def test_has_quote_ticks_for_unknown_instrument_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.has_quote_ticks(AUDUSD_SIM.id))
+        assert not self.cache.has_quote_ticks(AUDUSD_SIM.id)
 
     def test_has_trade_ticks_for_unknown_instrument_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.has_trade_ticks(AUDUSD_SIM.id))
+        assert not self.cache.has_trade_ticks(AUDUSD_SIM.id)
 
     def test_has_bars_for_unknown_bar_type_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.has_bars(TestStubs.bartype_gbpusd_1sec_mid()))
+        assert not self.cache.has_bars(TestStubs.bartype_gbpusd_1sec_mid())
 
     def test_instrument_ids_when_one_instrument_returns_expected_list(self):
         # Arrange
@@ -164,7 +163,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instrument_ids()
 
         # Assert
-        self.assertEqual([instrument.id], result)
+        assert result == [instrument.id]
 
     def test_instrument_ids_given_same_venue_returns_expected_list(self):
         # Arrange
@@ -176,7 +175,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instrument_ids(venue=instrument.venue)
 
         # Assert
-        self.assertEqual([instrument.id], result)
+        assert result == [instrument.id]
 
     def test_instrument_ids_given_different_venue_returns_empty_list(self):
         # Arrange
@@ -188,7 +187,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instrument_ids(venue=SIM)
 
         # Assert
-        self.assertEqual([], result)
+        assert result == []
 
     def test_instruments_when_one_instrument_returns_expected_list(self):
         # Arrange
@@ -200,7 +199,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instruments()
 
         # Assert
-        self.assertEqual([instrument], result)
+        assert result == [instrument]
 
     def test_instruments_given_same_venue_returns_expected_list(self):
         # Arrange
@@ -212,7 +211,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instruments(venue=instrument.venue)
 
         # Assert
-        self.assertEqual([instrument], result)
+        assert result == [instrument]
 
     def test_instruments_given_different_venue_returns_empty_list(self):
         # Arrange
@@ -224,7 +223,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instruments(venue=SIM)
 
         # Assert
-        self.assertEqual([], result)
+        assert result == []
 
     def test_quote_ticks_when_one_tick_returns_expected_list(self):
         # Arrange
@@ -244,7 +243,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.quote_ticks(tick.instrument_id)
 
         # Assert
-        self.assertEqual([tick], result)
+        assert result == [tick]
 
     def test_add_quote_ticks_when_already_ticks_does_not_add(self):
         # Arrange
@@ -265,7 +264,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.quote_ticks(tick.instrument_id)
 
         # Assert
-        self.assertEqual([tick], result)
+        assert result == [tick]
 
     def test_trade_ticks_when_one_tick_returns_expected_list(self):
         # Arrange
@@ -285,7 +284,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.trade_ticks(tick.instrument_id)
 
         # Assert
-        self.assertEqual([tick], result)
+        assert result == [tick]
 
     def test_add_trade_ticks_when_already_ticks_does_not_add(self):
         # Arrange
@@ -306,7 +305,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.trade_ticks(tick.instrument_id)
 
         # Assert
-        self.assertEqual([tick], result)
+        assert result == [tick]
 
     def test_bars_when_one_bar_returns_expected_list(self):
         # Arrange
@@ -328,7 +327,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.bars(bar_type)
 
         # Assert
-        self.assertTrue([bar], result)
+        assert result == [bar]
 
     def test_add_bars_when_already_bars_does_not_add(self):
         # Arrange
@@ -351,7 +350,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.bars(bar_type)
 
         # Assert
-        self.assertTrue([bar], result)
+        assert result == [bar]
 
     def test_instrument_when_no_instrument_returns_none(self):
         # Arrange
@@ -359,7 +358,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instrument(AUDUSD_SIM.id)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_instrument_when_instrument_exists_returns_expected(self):
         # Arrange
@@ -369,7 +368,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.instrument(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(AUDUSD_SIM, result)
+        assert result == AUDUSD_SIM
 
     def test_order_book_when_order_book_exists_returns_expected(self):
         # Arrange
@@ -395,14 +394,14 @@ class CacheTests(unittest.TestCase):
         result = self.cache.order_book(ETHUSDT_BINANCE.id)
 
         # Assert
-        self.assertEqual(order_book, result)
+        assert result == order_book
 
     def test_price_when_no_ticks_returns_none(self):
         # Act
         result = self.cache.price(AUDUSD_SIM.id, PriceType.LAST)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_price_given_last_when_no_trade_ticks_returns_none(self):
         # Act
@@ -421,7 +420,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.price(AUDUSD_SIM.id, PriceType.LAST)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_price_given_quote_price_type_when_no_quote_ticks_returns_none(self):
         # Arrange
@@ -441,7 +440,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.price(AUDUSD_SIM.id, PriceType.MID)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_price_given_last_when_trade_tick_returns_expected_price(self):
         # Arrange
@@ -461,14 +460,15 @@ class CacheTests(unittest.TestCase):
         result = self.cache.price(AUDUSD_SIM.id, PriceType.LAST)
 
         # Assert
-        self.assertEqual(Price.from_str("1.00000"), result)
+        assert result == Price.from_str("1.00000")
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "price_type,expected",
         [
-            [PriceType.BID, Price.from_str("1.00000")],
-            [PriceType.ASK, Price.from_str("1.00001")],
-            [PriceType.MID, Price.from_str("1.000005")],
-        ]
+            (PriceType.BID, Price.from_str("1.00000")),
+            (PriceType.ASK, Price.from_str("1.00001")),
+            (PriceType.MID, Price.from_str("1.000005")),
+        ],
     )
     def test_price_given_various_quote_price_types_when_quote_tick_returns_expected_price(
         self, price_type, expected
@@ -490,7 +490,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.price(AUDUSD_SIM.id, price_type)
 
         # Assert
-        self.assertEqual(expected, result)
+        assert result == expected
 
     def test_quote_tick_when_index_out_of_range_returns_none(self):
         # Arrange
@@ -510,8 +510,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.quote_tick(AUDUSD_SIM.id, index=1)
 
         # Assert
-        self.assertEqual(1, self.cache.quote_tick_count(AUDUSD_SIM.id))
-        self.assertIsNone(result)
+        assert self.cache.quote_tick_count(AUDUSD_SIM.id) == 1
+        assert result is None
 
     def test_quote_tick_with_two_ticks_returns_expected_tick(self):
         # Arrange
@@ -542,8 +542,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.quote_tick(AUDUSD_SIM.id, index=0)
 
         # Assert
-        self.assertEqual(2, self.cache.quote_tick_count(AUDUSD_SIM.id))
-        self.assertEqual(tick2, result)
+        assert self.cache.quote_tick_count(AUDUSD_SIM.id) == 2
+        assert result == tick2
 
     def test_trade_tick_when_index_out_of_range_returns_none(self):
         # Arrange
@@ -563,8 +563,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.trade_tick(AUDUSD_SIM.id, index=1)
 
         # Assert
-        self.assertEqual(1, self.cache.trade_tick_count(AUDUSD_SIM.id))
-        self.assertIsNone(result)
+        assert self.cache.trade_tick_count(AUDUSD_SIM.id) == 1
+        assert result is None
 
     def test_trade_tick_with_one_tick_returns_expected_tick(self):
         # Arrange
@@ -595,8 +595,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.trade_tick(AUDUSD_SIM.id, index=0)
 
         # Assert
-        self.assertEqual(2, self.cache.trade_tick_count(AUDUSD_SIM.id))
-        self.assertEqual(tick2, result)
+        assert self.cache.trade_tick_count(AUDUSD_SIM.id) == 2
+        assert result == tick2
 
     def test_bar_index_out_of_range_returns_expected_bar(self):
         # Arrange
@@ -618,8 +618,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.bar(bar_type, index=1)
 
         # Assert
-        self.assertEqual(1, self.cache.bar_count(bar_type))
-        self.assertIsNone(result)
+        assert self.cache.bar_count(bar_type) == 1
+        assert result is None
 
     def test_bar_with_two_bars_returns_expected_bar(self):
         # Arrange
@@ -653,8 +653,8 @@ class CacheTests(unittest.TestCase):
         result = self.cache.bar(bar_type, index=0)
 
         # Assert
-        self.assertEqual(2, self.cache.bar_count(bar_type))
-        self.assertEqual(bar2, result)
+        assert self.cache.bar_count(bar_type) == 2
+        assert result == bar2
 
     def test_get_xrate_returns_correct_rate(self):
         # Arrange
@@ -676,7 +676,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.get_xrate(SIM, JPY, USD)
 
         # Assert
-        self.assertEqual(Decimal("0.009025266685348968705339031887"), result)
+        assert result == Decimal("0.009025266685348968705339031887")
 
     def test_get_xrate_with_no_conversion_returns_one(self):
         # Arrange
@@ -684,7 +684,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.get_xrate(SIM, AUD, AUD)
 
         # Assert
-        self.assertEqual(Decimal("1"), result)
+        assert result == Decimal("1")
 
     def test_get_xrate_with_conversion(self):
         # Arrange
@@ -706,4 +706,4 @@ class CacheTests(unittest.TestCase):
         result = self.cache.get_xrate(SIM, AUD, USD)
 
         # Assert
-        self.assertEqual(Decimal("0.80005"), result)
+        assert result == Decimal("0.80005")

--- a/tests/unit_tests/cache/test_execution_base.py
+++ b/tests/unit_tests/cache/test_execution_base.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import unittest
+import pytest
 
 from nautilus_trader.cache.base import CacheFacade
 from nautilus_trader.model.identifiers import AccountId
@@ -29,143 +29,159 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 
 
-class ExecutionCacheFacadeTests(unittest.TestCase):
-    def setUp(self):
+class TestExecutionCacheFacade:
+    def setup(self):
         # Fixture Setup
         self.facade = CacheFacade()
 
     def test_instrument_ids_when_no_instruments_returns_empty_list(self):
-        self.assertRaises(NotImplementedError, self.facade.instrument_ids, SIM)
+        with pytest.raises(NotImplementedError):
+            self.facade.instrument_ids(SIM)
 
     def test_instruments_when_no_instruments_returns_empty_list(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.instruments,
-            SIM,
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.instruments(SIM)
 
     def test_account_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.account, AccountId("SIM", "000"))
+        with pytest.raises(NotImplementedError):
+            self.facade.account(AccountId("SIM", "000"))
 
     def test_account_for_venue_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.account_for_venue, SIM)
+        with pytest.raises(NotImplementedError):
+            self.facade.account_for_venue(SIM)
 
     def test_account_id_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.account_id, SIM)
+        with pytest.raises(NotImplementedError):
+            self.facade.account_id(SIM)
 
     def test_accounts_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.accounts)
+        with pytest.raises(NotImplementedError):
+            self.facade.accounts()
 
     def test_client_order_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.client_order_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.client_order_ids()
 
     def test_client_order_ids_working_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.client_order_ids_working)
+        with pytest.raises(NotImplementedError):
+            self.facade.client_order_ids_working()
 
     def test_client_order_ids_completed_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.client_order_ids_completed)
+        with pytest.raises(NotImplementedError):
+            self.facade.client_order_ids_completed()
 
     def test_position_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.position_ids()
 
     def test_position_open_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position_open_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.position_open_ids()
 
     def test_position_closed_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position_closed_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.position_closed_ids()
 
     def test_strategy_ids_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.strategy_ids)
+        with pytest.raises(NotImplementedError):
+            self.facade.strategy_ids()
 
     def test_order_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.order, ClientOrderId("O-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.order(ClientOrderId("O-123456"))
 
     def test_cld_ord_id_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.client_order_id, VenueOrderId("1"))
+        with pytest.raises(NotImplementedError):
+            self.facade.client_order_id(VenueOrderId("1"))
 
     def test_order_id_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError, self.facade.venue_order_id, ClientOrderId("O-123456")
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.venue_order_id(ClientOrderId("O-123456"))
 
     def test_orders_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders()
 
     def test_orders_working_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders_working)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders_working()
 
     def test_orders_completed_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders_completed)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders_completed()
 
     def test_order_exists_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.order_exists, ClientOrderId("O-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.order_exists(ClientOrderId("O-123456"))
 
     def test_is_order_working_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError, self.facade.is_order_working, ClientOrderId("O-123456")
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.is_order_working(ClientOrderId("O-123456"))
 
     def test_is_order_completed_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.is_order_completed,
-            ClientOrderId("O-123456"),
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.is_order_completed(ClientOrderId("O-123456"))
 
     def test_orders_total_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders_total_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders_total_count()
 
     def test_orders_working_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders_working_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders_working_count()
 
     def test_orders_completed_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.orders_completed_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.orders_completed_count()
 
     def test_position_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position, PositionId("P-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.position(PositionId("P-123456"))
 
     def test_position_id_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position_id, ClientOrderId("O-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.position_id(ClientOrderId("O-123456"))
 
     def test_positions_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions()
 
     def test_positions_open_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions_open)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions_open()
 
     def test_positions_closed_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions_closed)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions_closed()
 
     def test_position_exists_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.position_exists, PositionId("P-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.position_exists(PositionId("P-123456"))
 
     def test_is_position_open_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.is_position_open, PositionId("P-123456"))
+        with pytest.raises(NotImplementedError):
+            self.facade.is_position_open(PositionId("P-123456"))
 
     def test_is_position_closed_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError, self.facade.is_position_closed, PositionId("P-123456")
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.is_position_closed(PositionId("P-123456"))
 
     def test_positions_total_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions_total_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions_total_count()
 
     def test_positions_open_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions_open_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions_open_count()
 
     def test_positions_closed_count_when_not_implemented_raises_exception(self):
-        self.assertRaises(NotImplementedError, self.facade.positions_closed_count)
+        with pytest.raises(NotImplementedError):
+            self.facade.positions_closed_count()
 
     def test_strategy_id_for_order_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.strategy_id_for_order,
-            ClientOrderId("O-123456"),
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.strategy_id_for_order(ClientOrderId("O-123456"))
 
     def test_strategy_id_for_position_when_not_implemented_raises_exception(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.facade.strategy_id_for_position,
-            PositionId("P-123456"),
-        )
+        with pytest.raises(NotImplementedError):
+            self.facade.strategy_id_for_position(PositionId("P-123456"))

--- a/tests/unit_tests/cache/test_execution_cache.py
+++ b/tests/unit_tests/cache/test_execution_cache.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 from decimal import Decimal
-import unittest
 
 from nautilus_trader.backtest.engine import BacktestEngine
 from nautilus_trader.common.clock import TestClock
@@ -52,8 +51,8 @@ GBPUSD_SIM = TestInstrumentProvider.default_fx_ccy("GBP/USD")
 BTCUSD_BINANCE = TestInstrumentProvider.btcusdt_binance()
 
 
-class CacheTests(unittest.TestCase):
-    def setUp(self):
+class TestCache:
+    def setup(self):
         # Fixture Setup
         clock = TestClock()
         logger = Logger(clock)
@@ -76,7 +75,7 @@ class CacheTests(unittest.TestCase):
         self.cache.cache_currencies()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_cache_instruments_with_no_instruments(self):
         # Arrange
@@ -84,7 +83,7 @@ class CacheTests(unittest.TestCase):
         self.cache.cache_instruments()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_cache_accounts_with_no_accounts(self):
         # Arrange
@@ -92,7 +91,7 @@ class CacheTests(unittest.TestCase):
         self.cache.cache_accounts()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_cache_orders_with_no_orders(self):
         # Arrange
@@ -100,7 +99,7 @@ class CacheTests(unittest.TestCase):
         self.cache.cache_orders()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_cache_positions_with_no_positions(self):
         # Arrange
@@ -108,7 +107,7 @@ class CacheTests(unittest.TestCase):
         self.cache.cache_positions()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_build_index_with_no_objects(self):
         # Arrange
@@ -116,7 +115,7 @@ class CacheTests(unittest.TestCase):
         self.cache.build_index()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_add_currency(self):
         # Arrange
@@ -132,7 +131,7 @@ class CacheTests(unittest.TestCase):
         self.cache.add_currency(currency)
 
         # Assert
-        self.assertEqual(currency, Currency.from_str("1INCH"))
+        assert Currency.from_str("1INCH") == currency
 
     def test_add_account(self):
         # Arrange
@@ -143,7 +142,7 @@ class CacheTests(unittest.TestCase):
         self.cache.add_account(account)
 
         # Assert
-        self.assertEqual(account, self.cache.load_account(account.id))
+        assert self.cache.load_account(account.id) == account
 
     def test_load_instrument(self):
         # Arrange
@@ -153,7 +152,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.load_instrument(AUDUSD_SIM.id)
 
         # Assert
-        self.assertEqual(AUDUSD_SIM, result)
+        assert result == AUDUSD_SIM
 
     def test_load_account(self):
         # Arrange
@@ -166,7 +165,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.load_account(account.id)
 
         # Assert
-        self.assertEqual(account, result)
+        assert result == account
 
     def test_account_for_venue(self):
         # Arrange
@@ -174,7 +173,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.account_for_venue(Venue("SIM"))
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_accounts_when_no_accounts_returns_empty_list(self):
         # Arrange
@@ -182,7 +181,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.accounts()
 
         # Assert
-        self.assertEqual([], result)
+        assert result == []
 
     def test_get_strategy_ids_with_no_ids_returns_empty_set(self):
         # Arrange
@@ -190,7 +189,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.strategy_ids()
 
         # Assert
-        self.assertEqual(set(), result)
+        assert result == set()
 
     def test_get_order_ids_with_no_ids_returns_empty_set(self):
         # Arrange
@@ -198,7 +197,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.client_order_ids()
 
         # Assert
-        self.assertEqual(set(), result)
+        assert result == set()
 
     def test_get_strategy_ids_with_id_returns_correct_set(self):
         # Arrange
@@ -208,19 +207,19 @@ class CacheTests(unittest.TestCase):
         result = self.cache.strategy_ids()
 
         # Assert
-        self.assertEqual({self.strategy.id}, result)
+        assert result == {self.strategy.id}
 
     def test_position_exists_when_no_position_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.position_exists(PositionId("P-123456")))
+        assert not self.cache.position_exists(PositionId("P-123456"))
 
     def test_order_exists_when_no_order_returns_false(self):
         # Arrange
         # Act
         # Assert
-        self.assertFalse(self.cache.order_exists(ClientOrderId("O-123456")))
+        assert not self.cache.order_exists(ClientOrderId("O-123456"))
 
     def test_position_when_no_position_returns_none(self):
         # Arrange
@@ -230,7 +229,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.position(position_id)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_order_when_no_order_returns_none(self):
         # Arrange
@@ -240,13 +239,13 @@ class CacheTests(unittest.TestCase):
         result = self.cache.order(order_id)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
     def test_strategy_id_for_position_when_no_strategy_registered_returns_none(self):
         # Arrange
         # Act
         # Assert
-        self.assertIsNone(self.cache.strategy_id_for_position(PositionId("P-123456")))
+        assert self.cache.strategy_id_for_position(PositionId("P-123456")) is None
 
     def test_add_order(self):
         # Arrange
@@ -262,28 +261,20 @@ class CacheTests(unittest.TestCase):
         self.cache.add_order(order, position_id)
 
         # Assert
-        self.assertIn(order.client_order_id, self.cache.client_order_ids())
-        self.assertIn(
-            order.client_order_id,
-            self.cache.client_order_ids(instrument_id=order.instrument_id),
+        assert order.client_order_id in self.cache.client_order_ids()
+        assert order.client_order_id in self.cache.client_order_ids(
+            instrument_id=order.instrument_id
         )
-        self.assertIn(
-            order.client_order_id,
-            self.cache.client_order_ids(strategy_id=self.strategy.id),
+        assert order.client_order_id in self.cache.client_order_ids(strategy_id=self.strategy.id)
+        assert order.client_order_id not in self.cache.client_order_ids(
+            strategy_id=StrategyId("S-ZX1")
         )
-        self.assertNotIn(
-            order.client_order_id,
-            self.cache.client_order_ids(strategy_id=StrategyId("S-ZX1")),
+        assert order.client_order_id in self.cache.client_order_ids(
+            instrument_id=order.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertIn(
-            order.client_order_id,
-            self.cache.client_order_ids(
-                instrument_id=order.instrument_id, strategy_id=self.strategy.id
-            ),
-        )
-        self.assertIn(order, self.cache.orders())
-        self.assertEqual(VenueOrderId.null(), self.cache.venue_order_id(order.client_order_id))
-        self.assertIsNone(self.cache.client_order_id(order.venue_order_id))
+        assert order in self.cache.orders()
+        assert self.cache.venue_order_id(order.client_order_id) == VenueOrderId.null()
+        assert self.cache.client_order_id(order.venue_order_id) is None
 
     def test_load_order(self):
         # Arrange
@@ -300,7 +291,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.load_order(order.client_order_id)
 
         # Assert
-        self.assertEqual(order, result)
+        assert result == order
 
     def test_add_position(self):
         # Arrange
@@ -326,29 +317,21 @@ class CacheTests(unittest.TestCase):
         self.cache.add_position(position)
 
         # Assert
-        self.assertTrue(self.cache.position_exists(position.id))
-        self.assertIn(position.id, self.cache.position_ids())
-        self.assertIn(position, self.cache.positions())
-        self.assertIn(position, self.cache.positions_open())
-        self.assertIn(position, self.cache.positions_open(instrument_id=position.instrument_id))
-        self.assertIn(position, self.cache.positions_open(strategy_id=self.strategy.id))
-        self.assertIn(
-            position,
-            self.cache.positions_open(
-                instrument_id=position.instrument_id,
-                strategy_id=self.strategy.id,
-            ),
+        assert self.cache.position_exists(position.id)
+        assert position.id in self.cache.position_ids()
+        assert position in self.cache.positions()
+        assert position in self.cache.positions_open()
+        assert position in self.cache.positions_open(instrument_id=position.instrument_id)
+        assert position in self.cache.positions_open(strategy_id=self.strategy.id)
+        assert position in self.cache.positions_open(
+            instrument_id=position.instrument_id,
+            strategy_id=self.strategy.id,
         )
-        self.assertNotIn(position, self.cache.positions_closed())
-        self.assertNotIn(
-            position, self.cache.positions_closed(instrument_id=position.instrument_id)
-        )
-        self.assertNotIn(position, self.cache.positions_closed(strategy_id=self.strategy.id))
-        self.assertNotIn(
-            position,
-            self.cache.positions_closed(
-                instrument_id=position.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert position not in self.cache.positions_closed()
+        assert position not in self.cache.positions_closed(instrument_id=position.instrument_id)
+        assert position not in self.cache.positions_closed(strategy_id=self.strategy.id)
+        assert position not in self.cache.positions_closed(
+            instrument_id=position.instrument_id, strategy_id=self.strategy.id
         )
 
     def test_load_position(self):
@@ -376,7 +359,7 @@ class CacheTests(unittest.TestCase):
         result = self.cache.load_position(position.id)
 
         # Assert
-        self.assertEqual(position, result)
+        assert result == position
 
     def test_update_order_for_accepted_order(self):
         # Arrange
@@ -399,30 +382,24 @@ class CacheTests(unittest.TestCase):
         self.cache.update_order(order)
 
         # Assert
-        self.assertTrue(self.cache.order_exists(order.client_order_id))
-        self.assertIn(order.client_order_id, self.cache.client_order_ids())
-        self.assertIn(order, self.cache.orders())
-        self.assertIn(order, self.cache.orders_working())
-        self.assertIn(order, self.cache.orders_working(instrument_id=order.instrument_id))
-        self.assertIn(order, self.cache.orders_working(strategy_id=self.strategy.id))
-        self.assertIn(
-            order,
-            self.cache.orders_working(
-                instrument_id=order.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert self.cache.order_exists(order.client_order_id)
+        assert order.client_order_id in self.cache.client_order_ids()
+        assert order in self.cache.orders()
+        assert order in self.cache.orders_working()
+        assert order in self.cache.orders_working(instrument_id=order.instrument_id)
+        assert order in self.cache.orders_working(strategy_id=self.strategy.id)
+        assert order in self.cache.orders_working(
+            instrument_id=order.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertNotIn(order, self.cache.orders_completed())
-        self.assertNotIn(order, self.cache.orders_completed(instrument_id=order.instrument_id))
-        self.assertNotIn(order, self.cache.orders_completed(strategy_id=self.strategy.id))
-        self.assertNotIn(
-            order,
-            self.cache.orders_completed(
-                instrument_id=order.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert order not in self.cache.orders_completed()
+        assert order not in self.cache.orders_completed(instrument_id=order.instrument_id)
+        assert order not in self.cache.orders_completed(strategy_id=self.strategy.id)
+        assert order not in self.cache.orders_completed(
+            instrument_id=order.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertEqual(1, self.cache.orders_working_count())
-        self.assertEqual(0, self.cache.orders_completed_count())
-        self.assertEqual(1, self.cache.orders_total_count())
+        assert self.cache.orders_working_count() == 1
+        assert self.cache.orders_completed_count() == 0
+        assert self.cache.orders_total_count() == 1
 
     def test_update_order_for_completed_order(self):
         # Arrange
@@ -450,31 +427,25 @@ class CacheTests(unittest.TestCase):
         self.cache.update_order(order)
 
         # Assert
-        self.assertTrue(self.cache.order_exists(order.client_order_id))
-        self.assertIn(order.client_order_id, self.cache.client_order_ids())
-        self.assertIn(order, self.cache.orders())
-        self.assertIn(order, self.cache.orders_completed())
-        self.assertIn(order, self.cache.orders_completed(instrument_id=order.instrument_id))
-        self.assertIn(order, self.cache.orders_completed(strategy_id=self.strategy.id))
-        self.assertIn(
-            order,
-            self.cache.orders_completed(
-                instrument_id=order.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert self.cache.order_exists(order.client_order_id)
+        assert order.client_order_id in self.cache.client_order_ids()
+        assert order in self.cache.orders()
+        assert order in self.cache.orders_completed()
+        assert order in self.cache.orders_completed(instrument_id=order.instrument_id)
+        assert order in self.cache.orders_completed(strategy_id=self.strategy.id)
+        assert order in self.cache.orders_completed(
+            instrument_id=order.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertNotIn(order, self.cache.orders_working())
-        self.assertNotIn(order, self.cache.orders_working(instrument_id=order.instrument_id))
-        self.assertNotIn(order, self.cache.orders_working(strategy_id=self.strategy.id))
-        self.assertNotIn(
-            order,
-            self.cache.orders_working(
-                instrument_id=order.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert order not in self.cache.orders_working()
+        assert order not in self.cache.orders_working(instrument_id=order.instrument_id)
+        assert order not in self.cache.orders_working(strategy_id=self.strategy.id)
+        assert order not in self.cache.orders_working(
+            instrument_id=order.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertEqual(order.venue_order_id, self.cache.venue_order_id(order.client_order_id))
-        self.assertEqual(0, self.cache.orders_working_count())
-        self.assertEqual(1, self.cache.orders_completed_count())
-        self.assertEqual(1, self.cache.orders_total_count())
+        assert self.cache.venue_order_id(order.client_order_id) == order.venue_order_id
+        assert self.cache.orders_working_count() == 0
+        assert self.cache.orders_completed_count() == 1
+        assert self.cache.orders_total_count() == 1
 
     def test_update_position_for_open_position(self):
         # Arrange
@@ -504,33 +475,25 @@ class CacheTests(unittest.TestCase):
         self.cache.add_position(position)
 
         # Assert
-        self.assertTrue(self.cache.position_exists(position.id))
-        self.assertIn(position.id, self.cache.position_ids())
-        self.assertIn(position, self.cache.positions())
-        self.assertIn(position, self.cache.positions_open())
-        self.assertIn(position, self.cache.positions_open(instrument_id=position.instrument_id))
-        self.assertIn(position, self.cache.positions_open(strategy_id=self.strategy.id))
-        self.assertIn(
-            position,
-            self.cache.positions_open(
-                instrument_id=position.instrument_id, strategy_id=self.strategy.id
-            ),
+        assert self.cache.position_exists(position.id)
+        assert position.id in self.cache.position_ids()
+        assert position in self.cache.positions()
+        assert position in self.cache.positions_open()
+        assert position in self.cache.positions_open(instrument_id=position.instrument_id)
+        assert position in self.cache.positions_open(strategy_id=self.strategy.id)
+        assert position in self.cache.positions_open(
+            instrument_id=position.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertNotIn(position, self.cache.positions_closed())
-        self.assertNotIn(
-            position, self.cache.positions_closed(instrument_id=position.instrument_id)
+        assert position not in self.cache.positions_closed()
+        assert position not in self.cache.positions_closed(instrument_id=position.instrument_id)
+        assert position not in self.cache.positions_closed(strategy_id=self.strategy.id)
+        assert position not in self.cache.positions_closed(
+            instrument_id=position.instrument_id, strategy_id=self.strategy.id
         )
-        self.assertNotIn(position, self.cache.positions_closed(strategy_id=self.strategy.id))
-        self.assertNotIn(
-            position,
-            self.cache.positions_closed(
-                instrument_id=position.instrument_id, strategy_id=self.strategy.id
-            ),
-        )
-        self.assertEqual(position, self.cache.position(position_id))
-        self.assertEqual(1, self.cache.positions_open_count())
-        self.assertEqual(0, self.cache.positions_closed_count())
-        self.assertEqual(1, self.cache.positions_total_count())
+        assert self.cache.position(position_id) == position
+        assert self.cache.positions_open_count() == 1
+        assert self.cache.positions_closed_count() == 0
+        assert self.cache.positions_total_count() == 1
 
     def test_update_position_for_closed_position(self):
         # Arrange
@@ -581,39 +544,27 @@ class CacheTests(unittest.TestCase):
         self.cache.update_position(position)
 
         # Assert
-        self.assertTrue(self.cache.position_exists(position.id))
-        self.assertIn(position.id, self.cache.position_ids())
-        self.assertIn(position, self.cache.positions())
-        self.assertIn(position, self.cache.positions_closed())
-        self.assertIn(
-            position,
-            self.cache.positions_closed(instrument_id=position.instrument_id),
+        assert self.cache.position_exists(position.id)
+        assert position.id in self.cache.position_ids()
+        assert position in self.cache.positions()
+        assert position in self.cache.positions_closed()
+        assert position in self.cache.positions_closed(instrument_id=position.instrument_id)
+        assert position in self.cache.positions_closed(strategy_id=self.strategy.id)
+        assert position in self.cache.positions_closed(
+            instrument_id=position.instrument_id,
+            strategy_id=self.strategy.id,
         )
-        self.assertIn(
-            position,
-            self.cache.positions_closed(strategy_id=self.strategy.id),
+        assert position not in self.cache.positions_open()
+        assert position not in self.cache.positions_open(instrument_id=position.instrument_id)
+        assert position not in self.cache.positions_open(strategy_id=self.strategy.id)
+        assert position not in self.cache.positions_open(
+            instrument_id=position.instrument_id,
+            strategy_id=self.strategy.id,
         )
-        self.assertIn(
-            position,
-            self.cache.positions_closed(
-                instrument_id=position.instrument_id,
-                strategy_id=self.strategy.id,
-            ),
-        )
-        self.assertNotIn(position, self.cache.positions_open())
-        self.assertNotIn(position, self.cache.positions_open(instrument_id=position.instrument_id))
-        self.assertNotIn(position, self.cache.positions_open(strategy_id=self.strategy.id))
-        self.assertNotIn(
-            position,
-            self.cache.positions_open(
-                instrument_id=position.instrument_id,
-                strategy_id=self.strategy.id,
-            ),
-        )
-        self.assertEqual(position, self.cache.position(position_id))
-        self.assertEqual(0, self.cache.positions_open_count())
-        self.assertEqual(1, self.cache.positions_closed_count())
-        self.assertEqual(1, self.cache.positions_total_count())
+        assert self.cache.position(position_id) == position
+        assert self.cache.positions_open_count() == 0
+        assert self.cache.positions_closed_count() == 1
+        assert self.cache.positions_total_count() == 1
 
     def test_positions_queries_with_multiple_open_returns_expected_positions(self):
         # Arrange
@@ -782,7 +733,7 @@ class CacheTests(unittest.TestCase):
         self.cache.update_account(account)
 
         # Assert
-        self.assertTrue(True)  # No exceptions raised
+        assert True  # No exceptions raised
 
     def test_delete_strategy(self):
         # Arrange
@@ -792,7 +743,7 @@ class CacheTests(unittest.TestCase):
         self.cache.delete_strategy(self.strategy)
 
         # Assert
-        self.assertNotIn(self.strategy.id, self.cache.strategy_ids())
+        assert self.strategy.id not in self.cache.strategy_ids()
 
     def test_check_residuals(self):
         # Arrange
@@ -842,7 +793,7 @@ class CacheTests(unittest.TestCase):
         self.cache.check_residuals()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
     def test_reset(self):
         # Arrange
@@ -893,9 +844,9 @@ class CacheTests(unittest.TestCase):
         self.cache.reset()
 
         # Assert
-        self.assertEqual(0, len(self.cache.strategy_ids()))
-        self.assertEqual(0, self.cache.orders_total_count())
-        self.assertEqual(0, self.cache.positions_total_count())
+        assert len(self.cache.strategy_ids()) == 0
+        assert self.cache.orders_total_count() == 0
+        assert self.cache.positions_total_count() == 0
 
     def test_flush_db(self):
         # Arrange
@@ -945,11 +896,11 @@ class CacheTests(unittest.TestCase):
         self.cache.flush_db()
 
         # Assert
-        self.assertTrue(True)  # No exception raised
+        assert True  # No exception raised
 
 
-class ExecutionCacheIntegrityCheckTests(unittest.TestCase):
-    def setUp(self):
+class TestExecutionCacheIntegrityCheck:
+    def setup(self):
         # Fixture Setup
         self.engine = BacktestEngine(
             bypass_logging=True,  # Uncomment this to see integrity check failure messages
@@ -1001,7 +952,7 @@ class ExecutionCacheIntegrityCheckTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertFalse(self.cache.check_integrity())
+        assert not self.cache.check_integrity()
 
     def test_exec_cache_check_integrity_when_index_cleared_fails(self):
         # Arrange
@@ -1021,4 +972,4 @@ class ExecutionCacheIntegrityCheckTests(unittest.TestCase):
 
         # Act
         # Assert
-        self.assertFalse(self.cache.check_integrity())
+        assert not self.cache.check_integrity()


### PR DESCRIPTION
Issue ref: https://github.com/nautechsystems/nautilus_trader/issues/325.

While doing the conversion, I've noticed a `print` in `test_backtest_exchange` on line 1705/1704. Is it supposed to be there?

In addition, there were two `assertTrue`s in `test_data_cache.py` that I'm quite sure were supposed to be `assertEqual`s instead. I've changed them to equality assertions, but this resulted in **two new failing tests**:

- `TestCache.test_bars_when_one_bar_returns_expected_list`
- `TestCache.test_add_bars_when_already_bars_does_not_add`

Could someone take a look at these?