### PR TITLE
Fix SimulatedExchange generate_account_state timestamp

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,9 +13,11 @@
 - Improved efficiency of `Throttler`.
 - Standardized identifiers on events and objects.
 - Removed redundant `BypassCacheDatabase`.
+- Improved `Account` `str` and `repr`.
 
 ## Fixes
-None
+- Fixed backtest log timestamping.
+- Fixed backtest duplicate initial account event.
 
 ---
 

--- a/nautilus_trader/backtest/data_producer.pyx
+++ b/nautilus_trader/backtest/data_producer.pyx
@@ -349,8 +349,6 @@ cdef class BacktestDataProducer(DataProducerFacade):
             The UNIX timestamp (nanoseconds) for the run stop.
 
         """
-        self._log.info(f"Pre-processing data stream...")
-
         if self._stream:
             # Set data stream start index
             if start_ns < self._stream[0].ts_recv_ns:

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -889,6 +889,10 @@ cdef class BacktestEngine:
         # Setup clocks
         self._test_clock.set_time(start_ns)
 
+        # Setup Exchanges
+        for exchange in self._exchanges.values():
+            exchange.setup()
+
         # Setup data
         self._data_producer.setup(start_ns=start_ns, stop_ns=stop_ns)
 

--- a/nautilus_trader/backtest/exchange.pxd
+++ b/nautilus_trader/backtest/exchange.pxd
@@ -115,6 +115,7 @@ cdef class SimulatedExchange:
     cpdef void process_tick(self, Tick tick) except *
     cpdef void process_modules(self, int64_t now_ns) except *
     cpdef void check_residuals(self) except *
+    cpdef void setup(self) except *
     cpdef void reset(self) except *
 
 # -- COMMAND HANDLERS ------------------------------------------------------------------------------

--- a/nautilus_trader/backtest/exchange.pxd
+++ b/nautilus_trader/backtest/exchange.pxd
@@ -115,7 +115,6 @@ cdef class SimulatedExchange:
     cpdef void process_tick(self, Tick tick) except *
     cpdef void process_modules(self, int64_t now_ns) except *
     cpdef void check_residuals(self) except *
-    cpdef void setup(self) except *
     cpdef void reset(self) except *
 
 # -- COMMAND HANDLERS ------------------------------------------------------------------------------

--- a/nautilus_trader/backtest/exchange.pyx
+++ b/nautilus_trader/backtest/exchange.pyx
@@ -326,7 +326,6 @@ cdef class SimulatedExchange:
         Condition.not_none(client, "client")
 
         self.exec_client = client
-        self._generate_fresh_account_state()
 
         self._log.info(f"Registered {client}.")
 
@@ -457,6 +456,12 @@ cdef class SimulatedExchange:
 
         for order_id in self._oco_orders.values():
             self._log.warning(f"Residual OCO {order_id}")
+
+    cpdef void setup(self) except *:
+        """
+        Setup the exchange ready for a backtest
+        """
+        self._generate_fresh_account_state()
 
     cpdef void reset(self) except *:
         """

--- a/nautilus_trader/backtest/exchange.pyx
+++ b/nautilus_trader/backtest/exchange.pyx
@@ -457,12 +457,6 @@ cdef class SimulatedExchange:
         for order_id in self._oco_orders.values():
             self._log.warning(f"Residual OCO {order_id}")
 
-    cpdef void setup(self) except *:
-        """
-        Setup the exchange ready for a backtest
-        """
-        self._generate_fresh_account_state()
-
     cpdef void reset(self) except *:
         """
         Reset the simulated exchange.

--- a/nautilus_trader/common/logging.pxd
+++ b/nautilus_trader/common/logging.pxd
@@ -68,6 +68,7 @@ cdef class Logger:
     cdef readonly bint is_bypassed
     """If the logger is in bypass mode.\n\n:returns: `bool`"""
 
+    cdef void change_clock_c(self, Clock clock) except *
     cdef void log_c(self, dict record) except *
     cdef dict create_record(self, LogLevel level, LogColor color, str component, str msg, dict annotations=*)
 

--- a/nautilus_trader/common/logging.pyx
+++ b/nautilus_trader/common/logging.pyx
@@ -142,6 +142,19 @@ cdef class Logger:
         self.system_id = system_id
         self.is_bypassed = bypass
 
+    cdef void change_clock_c(self, Clock clock) except *:
+        """
+        Change the loggers internal clock to the given clock.
+
+        Parameters
+        ----------
+        clock : Clock
+
+        """
+        Condition.not_none(clock, "clock")
+
+        self._clock = clock
+
     cdef void log_c(self, dict record) except *:
         """
         Handle the given record by sending it to configured sinks.

--- a/nautilus_trader/execution/client.pyx
+++ b/nautilus_trader/execution/client.pyx
@@ -876,12 +876,10 @@ cdef class ExecutionClient:
 
         cdef list pnls = self._account.calculate_pnls(instrument, position, fill)
 
+        # Calculate final PnL
         if self.base_currency is not None:
             # Check single-currency PnLs
             assert len(pnls) == 1
-
-        # Calculate final PnL
-        if self.base_currency:
             return self._calculate_balance_single_currency(fill=fill, pnl=pnls[0])
         else:
             return self._calculate_balance_multi_currency(fill=fill, pnls=pnls)

--- a/nautilus_trader/trading/account.pyx
+++ b/nautilus_trader/trading/account.pyx
@@ -16,6 +16,7 @@
 from decimal import Decimal
 
 from nautilus_trader.core.correctness cimport Condition
+from nautilus_trader.model.c_enums.account_type cimport AccountTypeParser
 from nautilus_trader.model.c_enums.order_side cimport OrderSide
 from nautilus_trader.model.events.account cimport AccountState
 from nautilus_trader.model.identifiers cimport Venue
@@ -66,7 +67,11 @@ cdef class Account:
         return hash(self.id.value)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(id={self.id.value})"
+        cdef str base_str = self.base_currency.code if self.base_currency is not None else None
+        return (f"{type(self).__name__}("
+                f"id={self.id.value}, "
+                f"type={AccountTypeParser.to_str(self.type)}, "
+                f"base={base_str})")
 
     cdef AccountState last_event_c(self):
         return self._events[-1]  # Always at least one event

--- a/tests/unit_tests/backtest/test_backtest_engine.py
+++ b/tests/unit_tests/backtest/test_backtest_engine.py
@@ -18,6 +18,7 @@ import pytest
 
 from nautilus_trader.backtest.engine import BacktestEngine
 from nautilus_trader.backtest.models import FillModel
+from nautilus_trader.common.enums import LogLevel
 from nautilus_trader.core.type import DataType
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.data.base import GenericData
@@ -353,7 +354,10 @@ class TestBacktestEngineData:
 class TestBacktestEngine:
     def setup(self):
         # Fixture Setup
-        self.engine = BacktestEngine(use_data_cache=True)
+        self.engine = BacktestEngine(
+            use_data_cache=True,
+            level_stdout=LogLevel.DEBUG,
+        )
 
         usdjpy = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 
@@ -423,5 +427,9 @@ class TestBacktestEngine:
         start = pd.Timestamp("2013-01-31 23:59:59.700000+00:00")
         self.engine.run(start=start)
 
-        account = self.engine.trader.generate_account_report(Venue("SIM"))
-        assert account.index[0] == start
+        # Act
+        report = self.engine.trader.generate_account_report(Venue("SIM"))
+
+        # Assert
+        assert len(report) == 1
+        assert report.index[0] == start

--- a/tests/unit_tests/backtest/test_backtest_engine.py
+++ b/tests/unit_tests/backtest/test_backtest_engine.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import pandas as pd
 import pytest
 
 from nautilus_trader.backtest.engine import BacktestEngine
@@ -416,3 +417,11 @@ class TestBacktestEngine:
 
         # Assert
         assert True  # No exceptions raised
+
+    def test_account_state_timestamp(self):
+        # Arrange
+        start = pd.Timestamp("2013-01-31 23:59:59.700000+00:00")
+        self.engine.run(start=start)
+
+        account = self.engine.trader.generate_account_report(Venue("SIM"))
+        assert account.index[0] == start

--- a/tests/unit_tests/backtest/test_backtest_exchange.py
+++ b/tests/unit_tests/backtest/test_backtest_exchange.py
@@ -171,6 +171,7 @@ class TestSimulatedExchange:
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
+        self.exchange.setup()
 
     def test_repr(self):
         # Arrange
@@ -1981,6 +1982,7 @@ class TestBitmexExchange:
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
+        self.exchange.setup()
 
     def test_commission_maker_taker_order(self):
         # Arrange
@@ -2139,6 +2141,7 @@ class TestOrderBookExchange:
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
+        self.exchange.setup()
 
     def test_submit_limit_order_aggressive_multiple_levels(self):
         # Arrange: Prepare market

--- a/tests/unit_tests/backtest/test_backtest_exchange.py
+++ b/tests/unit_tests/backtest/test_backtest_exchange.py
@@ -168,10 +168,10 @@ class TestSimulatedExchange:
         )
 
         # Start components
+        self.exchange.reset()
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
-        self.exchange.setup()
 
     def test_repr(self):
         # Arrange
@@ -1979,10 +1979,10 @@ class TestBitmexExchange:
             self.logger,
         )
 
+        self.exchange.reset()
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
-        self.exchange.setup()
 
     def test_commission_maker_taker_order(self):
         # Arrange
@@ -2138,10 +2138,10 @@ class TestOrderBookExchange:
             self.logger,
         )
 
+        self.exchange.reset()
         self.data_engine.start()
         self.exec_engine.start()
         self.strategy.start()
-        self.exchange.setup()
 
     def test_submit_limit_order_aggressive_multiple_levels(self):
         # Arrange: Prepare market

--- a/tests/unit_tests/trading/test_trading_account.py
+++ b/tests/unit_tests/trading/test_trading_account.py
@@ -113,8 +113,8 @@ class TestAccount:
 
         # Assert
         assert account.id == AccountId("SIM", "001")
-        assert str(account) == "Account(id=SIM-001)"
-        assert repr(account) == "Account(id=SIM-001)"
+        assert str(account) == "Account(id=SIM-001, type=CASH, base=USD)"
+        assert repr(account) == "Account(id=SIM-001, type=CASH, base=USD)"
         assert isinstance(hash(account), int)
         assert account == account
         assert not account != account

--- a/tests/unit_tests/trading/test_trading_strategy.py
+++ b/tests/unit_tests/trading/test_trading_strategy.py
@@ -168,6 +168,7 @@ class TestTradingStrategy:
 
         self.data_engine.start()
         self.exec_engine.start()
+        self.exchange.setup()
 
     def test_strategy_equality(self):
         # Arrange

--- a/tests/unit_tests/trading/test_trading_strategy.py
+++ b/tests/unit_tests/trading/test_trading_strategy.py
@@ -25,6 +25,7 @@ from nautilus_trader.backtest.execution import BacktestExecClient
 from nautilus_trader.backtest.models import FillModel
 from nautilus_trader.common.clock import TestClock
 from nautilus_trader.common.enums import ComponentState
+from nautilus_trader.common.enums import LogLevel
 from nautilus_trader.common.logging import Logger
 from nautilus_trader.common.uuid import UUIDFactory
 from nautilus_trader.core.fsm import InvalidStateTrigger
@@ -74,7 +75,10 @@ class TestTradingStrategy:
         # Fixture Setup
         self.clock = TestClock()
         self.uuid_factory = UUIDFactory()
-        self.logger = Logger(self.clock)
+        self.logger = Logger(
+            clock=self.clock,
+            level_stdout=LogLevel.DEBUG,
+        )
 
         self.trader_id = TestStubs.trader_id()
         self.account_id = TestStubs.account_id()
@@ -154,7 +158,7 @@ class TestTradingStrategy:
         self.exchange.register_client(self.exec_client)
         self.data_engine.register_client(self.data_client)
         self.exec_engine.register_client(self.exec_client)
-        self.exec_engine.process(TestStubs.event_account_state())
+        self.exchange.reset()
 
         # Add instruments
         self.data_engine.process(AUDUSD_SIM)
@@ -168,7 +172,6 @@ class TestTradingStrategy:
 
         self.data_engine.start()
         self.exec_engine.start()
-        self.exchange.setup()
 
     def test_strategy_equality(self):
         # Arrange


### PR DESCRIPTION
Fixes #388 

- Adds a new `setup` method to SimluatedExchange that is called after setup clocks in BacktestEngine
- Adds simple test