### PR TITLE
Betfair fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
         - id: codespell
           description: Checks for common misspellings.
           types_or: [python, cython, rst, markdown]
+          exclude: "nautilus_trader/adapters/betfair/parsing.py"
 
 #  - repo: https://github.com/pre-commit/mirrors-mypy
 #    rev: v0.910

--- a/examples/backtest/fx_ema_cross_audusd_bars_from_ticks.py
+++ b/examples/backtest/fx_ema_cross_audusd_bars_from_ticks.py
@@ -117,6 +117,9 @@ if __name__ == "__main__":
         print(engine.trader.generate_positions_report())
 
     # For repeated backtest runs make sure to reset the engine
+    account = engine.trader.generate_account_report(SIM)
+    assert account.index[0] == pd.Timestamp("2019-12-28 11:49:43.406000+00:00")
+    assert account.index[-1] == pd.Timestamp("2019-12-29 03:36:39.861000+00:00")
     engine.reset()
 
     # Good practice to dispose of the object when done

--- a/examples/backtest/fx_ema_cross_audusd_bars_from_ticks.py
+++ b/examples/backtest/fx_ema_cross_audusd_bars_from_ticks.py
@@ -117,9 +117,6 @@ if __name__ == "__main__":
         print(engine.trader.generate_positions_report())
 
     # For repeated backtest runs make sure to reset the engine
-    account = engine.trader.generate_account_report(SIM)
-    assert account.index[0] == pd.Timestamp("2019-12-28 11:49:43.406000+00:00")
-    assert account.index[-1] == pd.Timestamp("2019-12-29 03:36:39.861000+00:00")
     engine.reset()
 
     # Good practice to dispose of the object when done

--- a/nautilus_trader/adapters/betfair/execution.pyx
+++ b/nautilus_trader/adapters/betfair/execution.pyx
@@ -413,8 +413,7 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
     cpdef void handle_order_stream_update(self, bytes raw) except *:
         """ Handle an update from the order stream socket """
         cdef dict update = orjson.loads(raw)  # type: dict
-        self.create_task(self._handle_order_stream_update(update=update))
-        # self._loop.create_task(self._handle_order_stream_update(update=update))
+        self._loop.create_task(self._handle_order_stream_update(update=update))
 
     async def _handle_order_stream_update(self, update):
         for market in update.get("oc", []):

--- a/nautilus_trader/adapters/betfair/execution.pyx
+++ b/nautilus_trader/adapters/betfair/execution.pyx
@@ -418,12 +418,13 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
     async def _handle_order_stream_update(self, update):
         for market in update.get("oc", []):
             market_id = market["id"]
-            self._log.debug(f"Received order stream update len={len(market.get('orc', []))}")
+            # self._log.debug(f"Received order stream update len={len(market.get('orc', []))}")
             for selection in market.get("orc", []):
                 for order_update in selection.get("uo", []):
-                    self._log.debug(f"order_update: {order_update}")
+                    # self._log.debug(f"order_update: {order_update}")
                     client_order_id = await self.wait_for_order(order_update['id'], timeout_seconds=10.0)
                     if client_order_id is None:
+                        self._log.warning(f"Can't find client_order_id for {order_update}")
                         continue
                     venue_order_id = VenueOrderId(order_update["id"])
                     order = self._engine.cache.order(client_order_id)

--- a/nautilus_trader/adapters/betfair/execution.pyx
+++ b/nautilus_trader/adapters/betfair/execution.pyx
@@ -574,6 +574,6 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
 
 cpdef ExecutionId create_execution_id(dict uo):
     cdef bytes data = orjson.dumps(
-        (uo['id'], uo['p'], uo['s'], uo['side'], uo['pt'], uo['ot'], uo['pd'], uo['md'], uo['avp'], uo['sm'])
+        (uo['id'], uo['p'], uo['s'], uo['side'], uo['pt'], uo['ot'], uo['pd'], uo.get('md'), uo.get('avp'), uo.get('sm'))
     )
     return ExecutionId(hashlib.sha1(data).hexdigest())

--- a/nautilus_trader/adapters/betfair/execution.pyx
+++ b/nautilus_trader/adapters/betfair/execution.pyx
@@ -389,6 +389,16 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
 
 # -- DEBUGGING -------------------------------------------------------------------------------------
 
+    def create_task(self, coro):
+        self._loop.create_task(self._check_task(coro))
+
+    async def _check_task(self, coro):
+        try:
+            awaitable = await coro
+            return awaitable
+        except Exception as e:
+            self._log.exception(f"Unhandled exception: {e}")
+
     cpdef object client(self):
         return self._client
 
@@ -403,97 +413,95 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
     cpdef void handle_order_stream_update(self, bytes raw) except *:
         """ Handle an update from the order stream socket """
         cdef dict update = orjson.loads(raw)  # type: dict
-        self._loop.create_task(self._handle_order_stream_update(update=update))
+        self.create_task(self._handle_order_stream_update(update=update))
+        # self._loop.create_task(self._handle_order_stream_update(update=update))
 
     async def _handle_order_stream_update(self, update):
         for market in update.get("oc", []):
             market_id = market["id"]
+            self._log.debug(f"Received order stream update len={len(market.get('orc', []))}")
             for selection in market.get("orc", []):
-                instrument = self._instrument_provider.get_betting_instrument(
-                    market_id=market_id,
-                    selection_id=str(selection["id"]),
-                    handicap=str(selection.get("hc", "")),
-                )
-                for order in selection.get("uo", []):
-                    self._log.debug(f"order_update: {order}")
-                    client_order_id = await self.wait_for_order(order['id'], timeout_seconds=10.0)
+                for order_update in selection.get("uo", []):
+                    self._log.debug(f"order_update: {order_update}")
+                    client_order_id = await self.wait_for_order(order_update['id'], timeout_seconds=10.0)
                     if client_order_id is None:
                         continue
-                    venue_order_id = VenueOrderId(order["id"])
-
+                    venue_order_id = VenueOrderId(order_update["id"])
+                    order = self._engine.cache.order(client_order_id)
+                    instrument = self._engine.cache.instrument(order.instrument_id)
                     # "E" = Executable (live / working)
-                    if order["status"] == "E":
+                    if order_update["status"] == "E":
                         # Check if this is the first time seeing this order (backtest or replay)
                         if venue_order_id.value in self.venue_order_id_to_client_order_id:
                             # We've already sent an accept for this order in self._post_submit_order
                             self._log.debug(f"Skipping order_accept as order exists: {venue_order_id}")
                         else:
                             self.generate_order_accepted(
-                                strategy_id=None,  # Fetched from cache
+                                strategy_id=order.strategy_id,
                                 instrument_id=instrument.id,
                                 client_order_id=client_order_id,
                                 venue_order_id=venue_order_id,
-                                ts_accepted_ns=millis_to_nanos(order["pd"]),
+                                ts_accepted_ns=millis_to_nanos(order_update["pd"]),
                             )
 
                         # Check for any portion executed
-                        if order["sm"] != 0:
-                            execution_id = ExecutionId(str(order["md"]))  # Use matched date as execution id
+                        if order_update["sm"] != 0:
+                            execution_id = ExecutionId(str(order_update["md"]))  # Use matched date as execution id
                             if execution_id not in self.published_executions[client_order_id]:
                                 self.generate_order_filled(
-                                    strategy_id=None,  # Fetched from cache
+                                    strategy_id=order.strategy_id,
                                     instrument_id=instrument.id,
                                     client_order_id=client_order_id,
                                     venue_order_id=venue_order_id,
                                     execution_id=execution_id,
-                                    position_id=None,  # Assigned in engine
-                                    order_side=B2N_ORDER_STREAM_SIDE[order["side"]],
-                                    last_qty=Quantity(order["sm"], instrument.size_precision),
-                                    last_px=price_to_probability(order["p"]),
+                                    position_id=order.position_id,
+                                    order_side=B2N_ORDER_STREAM_SIDE[order_update["side"]],
+                                    last_qty=Quantity(order_update["sm"], instrument.size_precision),
+                                    last_px=price_to_probability(order_update["p"]),
                                     # avg_px=Decimal(order['avp']),
                                     quote_currency=instrument.quote_currency,
                                     commission=Money(0, self.get_account_currency()),
                                     liquidity_side=LiquiditySide.NONE,
-                                    ts_filled_ns=millis_to_nanos(order["md"]),
+                                    ts_filled_ns=millis_to_nanos(order_update["md"]),
                                 )
                                 self.published_executions[client_order_id].append(execution_id)
 
                     # Execution complete, this order is fulled match or canceled
-                    elif order["status"] == "EC":
-                        if order["sm"] != 0:
-                            execution_id = ExecutionId(str(order["md"]))  # Use matched date as execution id
+                    elif order_update["status"] == "EC":
+                        if order_update["sm"] != 0:
+                            execution_id = ExecutionId(str(order_update["md"]))  # Use matched date as execution id
                             if execution_id not in self.published_executions[client_order_id]:
                                 # At least some part of this order has been filled
                                 self.generate_order_filled(
-                                    strategy_id=None,  # Fetched from cache
+                                    strategy_id=order.strategy_id,
                                     instrument_id=instrument.id,
                                     client_order_id=client_order_id,
                                     venue_order_id=venue_order_id,
                                     execution_id=execution_id,
-                                    position_id=None,  # Assigned in engine
-                                    order_side=B2N_ORDER_STREAM_SIDE[order["side"]],
-                                    last_qty=Quantity(order["sm"], instrument.size_precision),
-                                    last_px=price_to_probability(order['p']),
+                                    position_id=order.position_id,
+                                    order_side=B2N_ORDER_STREAM_SIDE[order_update["side"]],
+                                    last_qty=Quantity(order_update["sm"], instrument.size_precision),
+                                    last_px=price_to_probability(order_update['p']),
                                     quote_currency=instrument.quote_currency,
                                     # avg_px=order['avp'],
                                     commission=Money(0, self.get_account_currency()),
                                     liquidity_side=LiquiditySide.TAKER,  # TODO - Fix this?
-                                    ts_filled_ns=millis_to_nanos(order['md']),
+                                    ts_filled_ns=millis_to_nanos(order_update['md']),
                                 )
-                        if any([order[x] != 0 for x in ("sc", "sl", "sv")]):
-                            cancel_qty = sum([order[k] for k in ("sc", "sl", "sv")])
-                            assert order['sm'] + cancel_qty == order["s"], f"Size matched + canceled != total: {order}"
+                        if any([order_update[x] != 0 for x in ("sc", "sl", "sv")]):
+                            cancel_qty = sum([order_update[k] for k in ("sc", "sl", "sv")])
+                            assert order_update['sm'] + cancel_qty == order_update["s"], f"Size matched + canceled != total: {order_update}"
                             # If this is the result of a UpdateOrder, we don't want to emit a cancel
-                            key = (ClientOrderId(order.get("rfo")), VenueOrderId(order["id"]))
+                            key = (ClientOrderId(order_update.get("rfo")), VenueOrderId(order_update["id"]))
                             self._log.debug(f"cancel key: {key}, pending_update_order_client_ids: {self.pending_update_order_client_ids}")
                             if key not in self.pending_update_order_client_ids:
                                 # The remainder of this order has been canceled
                                 self.generate_order_canceled(
-                                    strategy_id=None,  # Fetched from cache
+                                    strategy_id=order.strategy_id,
                                     instrument_id=instrument.id,
                                     client_order_id=client_order_id,
                                     venue_order_id=venue_order_id,
-                                    ts_canceled_ns=millis_to_nanos(order.get("cd") or order.get("ld") or order.get('md')),
+                                    ts_canceled_ns=millis_to_nanos(order_update.get("cd") or order_update.get("ld") or order_update.get('md')),
                                 )
                         # Market order will not be in self.published_executions
                         if client_order_id in self.published_executions:
@@ -529,8 +537,9 @@ cdef class BetfairExecutionClient(LiveExecutionClient):
         now = start
         while (now - start) < secs_to_nanos(timeout_seconds):
             if venue_order_id in self.venue_order_id_to_client_order_id:
-                self._log.debug(f"Found order in {nanos_to_secs(now - start)} sec ")
-                return self.venue_order_id_to_client_order_id[venue_order_id]
+                client_order_id = self.venue_order_id_to_client_order_id[venue_order_id]
+                self._log.debug(f"Found order in {nanos_to_secs(now - start)} sec: {client_order_id}")
+                return client_order_id
             now = self._clock.timestamp_ns()
             await asyncio.sleep(0)
         self._log.warning(f"Failed to find venue_order_id: {venue_order_id} "

--- a/nautilus_trader/adapters/betfair/parsing.py
+++ b/nautilus_trader/adapters/betfair/parsing.py
@@ -12,9 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
-
 from collections import defaultdict
 import datetime
+import hashlib
 import itertools
 from typing import List, Optional, Union
 
@@ -22,6 +22,7 @@ from betfairlightweight.filters import cancel_instruction
 from betfairlightweight.filters import limit_order
 from betfairlightweight.filters import place_instruction
 from betfairlightweight.filters import replace_instruction
+import orjson
 import pandas as pd
 
 from nautilus_trader.adapters.betfair.common import B2N_MARKET_STREAM_SIDE
@@ -200,6 +201,15 @@ def betfair_account_to_account_state(
         ts_updated_ns=ts_updated_ns,
         timestamp_ns=timestamp_ns,
     )
+
+
+EXECUTION_ID_KEYS = ("id", "p", "s", "side", "pt", "ot", "pd", "md", "avp", "sm")  # noqa:
+
+
+def betfair_execution_id(uo) -> ExecutionId:
+    data = orjson.dumps({k: uo[k] for k in EXECUTION_ID_KEYS if uo.get(k)})
+    hsh = hashlib.sha1(data).hexdigest()  # noqa: S303
+    return ExecutionId(hsh)
 
 
 def _handle_market_snapshot(selection, instrument, ts_event_ns, ts_recv_ns):

--- a/nautilus_trader/model/instruments/base.pxd
+++ b/nautilus_trader/model/instruments/base.pxd
@@ -83,7 +83,7 @@ cdef class Instrument(Data):
     cpdef Currency get_cost_currency(self)
     cpdef Price make_price(self, value)
     cpdef Quantity make_qty(self, value)
-    cpdef Money notional_value(self, Quantity quantity, close_price: Decimal, bint inverse_as_quote=*)
+    cpdef Money notional_value(self, Quantity quantity, price: Decimal, bint inverse_as_quote=*)
     cpdef Money calculate_initial_margin(self, Quantity quantity, Price price, leverage=*, bint inverse_as_quote=*)
     cpdef Money calculate_maint_margin(self, PositionSide side, Quantity quantity, Price last, leverage=*, bint inverse_as_quote=*)
     cpdef Money calculate_commission(self, Quantity last_qty, last_px: Decimal, LiquiditySide liquidity_side, bint inverse_as_quote=*)

--- a/nautilus_trader/model/instruments/base.pyx
+++ b/nautilus_trader/model/instruments/base.pyx
@@ -485,7 +485,7 @@ cdef class Instrument(Data):
 
         notional: Decimal = self.notional_value(
             quantity=quantity,
-            close_price=price.as_decimal(),
+            price=price.as_decimal(),
             inverse_as_quote=inverse_as_quote,
         ).as_decimal()
 
@@ -537,7 +537,7 @@ cdef class Instrument(Data):
 
         notional: Decimal = self.notional_value(
             quantity=quantity,
-            close_price=last.as_decimal(),
+            price=last.as_decimal(),
             inverse_as_quote=inverse_as_quote
         ).as_decimal()
 
@@ -592,7 +592,7 @@ cdef class Instrument(Data):
 
         notional: Decimal = self.notional_value(
             quantity=last_qty,
-            close_price=last_px,
+            price=last_px,
             inverse_as_quote=inverse_as_quote,
         ).as_decimal()
 

--- a/nautilus_trader/model/instruments/betting.pxd
+++ b/nautilus_trader/model/instruments/betting.pxd
@@ -12,10 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+from decimal import Decimal
 
 from cpython.datetime cimport datetime
 
 from nautilus_trader.model.instruments.base cimport Instrument
+from nautilus_trader.model.objects cimport Money
+from nautilus_trader.model.objects cimport Quantity
 
 
 cdef class BettingInstrument(Instrument):
@@ -41,3 +44,5 @@ cdef class BettingInstrument(Instrument):
 
     @staticmethod
     cdef dict to_dict_c(BettingInstrument obj)
+
+    cpdef Money notional_value(self, Quantity quantity, price: Decimal, bint inverse_as_quote=*)

--- a/nautilus_trader/model/instruments/betting.pyx
+++ b/nautilus_trader/model/instruments/betting.pyx
@@ -109,8 +109,8 @@ cdef class BettingInstrument(Instrument):
             min_notional=Money(5, Currency.from_str_c(currency)),
             max_price=None,      # Can be None
             min_price=None,      # Can be None
-            margin_init=Decimal(0),
-            margin_maint=Decimal(0),
+            margin_init=Decimal(1),
+            margin_maint=Decimal(1),
             maker_fee=Decimal(0),
             taker_fee=Decimal(0),
             ts_event_ns=ts_event_ns,
@@ -198,3 +198,10 @@ cdef class BettingInstrument(Instrument):
             return str(s).replace(' ', '').replace(':', '')
 
         return Symbol(value=",".join([_clean(getattr(self, k)) for k in keys]))
+
+    cpdef Money notional_value(self, Quantity quantity, price: Decimal, bint inverse_as_quote=False):
+        Condition.not_none(quantity, "quantity")
+        Condition.type(price, (Decimal, Price), "price")
+        bet_price: Decimal = Decimal("1.0") / price
+        notional_value: Decimal = quantity * self.multiplier * bet_price
+        return Money(notional_value, self.quote_currency)

--- a/tests/integration_tests/adapters/betfair/conftest.py
+++ b/tests/integration_tests/adapters/betfair/conftest.py
@@ -246,6 +246,28 @@ async def execution_client(
 
 
 @pytest.fixture()
+async def live_execution_client(
+    betfair_client, account_id, exec_engine, clock, live_logger, betfair_account_state
+) -> BetfairExecutionClient:
+    client = BetfairExecutionClient(
+        client=betfair_client,
+        account_id=account_id,
+        base_currency=AUD,
+        engine=exec_engine,
+        clock=clock,
+        logger=live_logger,
+        market_filter={},
+        load_instruments=False,
+    )
+    client.instrument_provider().load_all()
+    exec_engine.register_client(client)
+    exec_engine.cache.add_account(account=Account(betfair_account_state))
+    for instrument in client.instrument_provider().list_instruments():
+        exec_engine.cache.add_instrument(instrument)
+    return client
+
+
+@pytest.fixture()
 def betfair_data_client(betfair_client, data_engine, clock, live_logger):
     client = BetfairDataClient(
         client=betfair_client,

--- a/tests/integration_tests/adapters/betfair/conftest.py
+++ b/tests/integration_tests/adapters/betfair/conftest.py
@@ -246,28 +246,6 @@ async def execution_client(
 
 
 @pytest.fixture()
-async def live_execution_client(
-    betfair_client, account_id, exec_engine, clock, live_logger, betfair_account_state
-) -> BetfairExecutionClient:
-    client = BetfairExecutionClient(
-        client=betfair_client,
-        account_id=account_id,
-        base_currency=AUD,
-        engine=exec_engine,
-        clock=clock,
-        logger=live_logger,
-        market_filter={},
-        load_instruments=False,
-    )
-    client.instrument_provider().load_all()
-    exec_engine.register_client(client)
-    exec_engine.cache.add_account(account=Account(betfair_account_state))
-    for instrument in client.instrument_provider().list_instruments():
-        exec_engine.cache.add_instrument(instrument)
-    return client
-
-
-@pytest.fixture()
 def betfair_data_client(betfair_client, data_engine, clock, live_logger):
     client = BetfairDataClient(
         client=betfair_client,

--- a/tests/integration_tests/adapters/betfair/conftest.py
+++ b/tests/integration_tests/adapters/betfair/conftest.py
@@ -105,9 +105,7 @@ def clock() -> LiveClock:
 
 @pytest.fixture()
 def live_logger(event_loop, clock):
-    level_stdout = (
-        LogLevel.DEBUG if os.environ.get("NAUTILUS_DEBUG", False) == "True" else LogLevel.ERROR
-    )
+    level_stdout = LogLevel.DEBUG if os.environ.get("NAUTILUS_DEBUG", False) else LogLevel.ERROR
     return LiveLogger(loop=event_loop, clock=clock, level_stdout=level_stdout)
 
 

--- a/tests/integration_tests/adapters/betfair/conftest.py
+++ b/tests/integration_tests/adapters/betfair/conftest.py
@@ -34,6 +34,7 @@ from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.msgbus.message_bus import MessageBus
 from nautilus_trader.trading.account import Account
 from nautilus_trader.trading.portfolio import Portfolio
+from tests.integration_tests.adapters.betfair.test_kit import BetfairDataProvider
 from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 
 
@@ -47,35 +48,35 @@ def betfairlightweight_mocks(mocker):
     # Mock Navigation / market catalogue endpoints
     mocker.patch(
         "betfairlightweight.endpoints.navigation.Navigation.list_navigation",
-        return_value=BetfairTestStubs.navigation(),
+        return_value=BetfairDataProvider.navigation(),
     )
     mocker.patch(
         "betfairlightweight.endpoints.betting.Betting.list_market_catalogue",
-        return_value=BetfairTestStubs.market_catalogue_short(),
+        return_value=BetfairDataProvider.market_catalogue_short(),
     )
 
     # Mock Account endpoints
     mocker.patch(
         "betfairlightweight.endpoints.account.Account.get_account_details",
-        return_value=BetfairTestStubs.account_detail(),
+        return_value=BetfairDataProvider.account_detail(),
     )
     mocker.patch(
         "betfairlightweight.endpoints.account.Account.get_account_funds",
-        return_value=BetfairTestStubs.account_funds_no_exposure(),
+        return_value=BetfairDataProvider.account_funds_no_exposure(),
     )
 
     # Mock Betting endpoints
     mocker.patch(
         "betfairlightweight.endpoints.betting.Betting.place_orders",
-        return_value=BetfairTestStubs.place_orders_success(),
+        return_value=BetfairDataProvider.place_orders_success(),
     )
     mocker.patch(
         "betfairlightweight.endpoints.betting.Betting.replace_orders",
-        return_value=BetfairTestStubs.replace_orders_success(),
+        return_value=BetfairDataProvider.replace_orders_success(),
     )
     mocker.patch(
         "betfairlightweight.endpoints.betting.Betting.cancel_orders",
-        return_value=BetfairTestStubs.cancel_orders_success(),
+        return_value=BetfairDataProvider.cancel_orders_success(),
     )
 
     # Streaming endpoint

--- a/tests/integration_tests/adapters/betfair/test_betfair_backtest.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_backtest.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
-
+import pandas as pd
 import pytest
 
 from nautilus_trader.adapters.betfair.common import BETFAIR_VENUE
@@ -30,6 +30,7 @@ from nautilus_trader.model.enums import VenueType
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.orderbook.book import OrderBookData
+from tests.integration_tests.adapters.betfair.test_kit import BetfairDataProvider
 from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 from tests.test_kit.strategies import OrderBookImbalanceStrategy
 
@@ -88,14 +89,13 @@ def create_engine(instruments, data):
     return engine
 
 
-@pytest.mark.skip(reason="segfault after latest changes 6/7/21")
 def test_betfair_backtest(instrument_provider):
     # Load instruments
-    instruments = BetfairTestStubs.raw_market_updates_instruments()
+    instruments = BetfairDataProvider.raw_market_updates_instruments()
     instrument_provider.set_instruments(instruments)
 
     # Load market data
-    all_data = BetfairTestStubs.parsed_market_updates(instrument_provider)
+    all_data = BetfairDataProvider.parsed_market_updates(instrument_provider)
 
     # Create strategy
     strategy = OrderBookImbalanceStrategy(instrument_id=instruments[0].id, trade_size=20)
@@ -105,3 +105,8 @@ def test_betfair_backtest(instrument_provider):
 
     assert strategy.instrument_status == InstrumentStatus.CLOSED
     assert strategy.close_price == 1.0
+
+    # Check account states
+    account = engine.trader.generate_account_report(BETFAIR_VENUE)
+    assert account.index[0] == pd.Timestamp("2019-12-28 11:49:43.406000+00:00")
+    assert account.index[-1] == pd.Timestamp("2019-12-29 03:36:39.861000+00:00")

--- a/tests/integration_tests/adapters/betfair/test_betfair_backtest.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_backtest.py
@@ -108,5 +108,5 @@ def test_betfair_backtest(instrument_provider):
 
     # Check account states
     account = engine.trader.generate_account_report(BETFAIR_VENUE)
-    assert account.index[0] == pd.Timestamp("2019-12-28 11:49:43.406000+00:00")
+    assert account.index[0] == pd.Timestamp("2019-12-28 02:23:03.086000+0000")
     assert account.index[-1] == pd.Timestamp("2019-12-29 03:36:39.861000+00:00")

--- a/tests/integration_tests/adapters/betfair/test_betfair_execution.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_execution.py
@@ -459,7 +459,7 @@ async def test_duplicate_execution_id(mocker, execution_client, exec_engine, log
             raw=orjson.dumps(raw),
         )
         execution_client.handle_order_stream_update(raw=orjson.dumps(raw))
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.2)
 
     # Assert
     events = exec_engine.events

--- a/tests/integration_tests/adapters/betfair/test_betfair_execution.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_execution.py
@@ -246,10 +246,10 @@ async def test_order_stream_full_image(mocker, execution_client, exec_engine):
     raw = BetfairDataProvider.streaming_ocm_FULL_IMAGE()
 
     # setup
-    exec_engine.cache.add_order(
-        order=BetfairTestStubs.make_order(),
-        position_id=PositionId("P-001"),
-    )
+    # exec_engine.cache.add_order(
+    #     order=BetfairTestStubs.make_order(),
+    #     position_id=PositionId("P-001"),
+    # )
 
     # assert
     mocker.patch.object(
@@ -257,6 +257,7 @@ async def test_order_stream_full_image(mocker, execution_client, exec_engine):
         "venue_order_id_to_client_order_id",
         _prefill_venue_order_id_to_client_order_id(orjson.loads(raw)),
     )
+
     execution_client.handle_order_stream_update(raw=raw)
     await asyncio.sleep(0.1)
     assert len(exec_engine.events) == 6

--- a/tests/integration_tests/adapters/betfair/test_betfair_execution.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_execution.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import os
-from pprint import pprint
 
 import betfairlightweight
 import orjson
@@ -61,7 +60,7 @@ def setup_exec_client_and_cache(mocker, exec_client, exec_engine, logger, raw):
     Returns: `venue_order_id_to_client_order_id`
     """
     update = orjson.loads(raw)
-    logger.debug(f"raw_data:\n{pprint(update)}")
+    logger.debug(f"raw_data:\n{update}")
     venue_order_ids = _prefill_venue_order_id_to_client_order_id(update)
     venue_order_id_to_client_order_id = {}
     for v_id in venue_order_ids:
@@ -409,13 +408,6 @@ async def test_generate_trades_list(mocker, execution_client):
 
 @pytest.mark.asyncio
 async def test_duplicate_execution_id(mocker, execution_client, exec_engine, logger):
-    raw = orjson.loads(BetfairDataProvider.streaming_ocm_order_update())
-    raw["oc"][0]["orc"][0]["uo"][0]["id"] = "230486317487"
-    raw = orjson.dumps(raw)
-    setup_exec_client_and_cache(
-        mocker=mocker, exec_client=execution_client, exec_engine=exec_engine, logger=logger, raw=raw
-    )
-
     mocker.patch.object(
         execution_client,
         "venue_order_id_to_client_order_id",
@@ -459,7 +451,7 @@ async def test_duplicate_execution_id(mocker, execution_client, exec_engine, log
             raw=orjson.dumps(raw),
         )
         execution_client.handle_order_stream_update(raw=orjson.dumps(raw))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.5)
 
     # Assert
     events = exec_engine.events

--- a/tests/integration_tests/adapters/betfair/test_betfair_execution.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_execution.py
@@ -366,11 +366,14 @@ async def test_order_stream_mixed(mocker, execution_client, exec_engine, logger)
         mocker=mocker, exec_client=execution_client, exec_engine=exec_engine, logger=logger, raw=raw
     )
     execution_client.handle_order_stream_update(raw=raw)
-    await asyncio.sleep(1)
-    assert len(exec_engine.events) == 3
-    assert isinstance(exec_engine.events[0], OrderFilled)
-    assert isinstance(exec_engine.events[1], AccountState)
-    assert isinstance(exec_engine.events[2], OrderCanceled)
+    await asyncio.sleep(0.5)
+    events = exec_engine.events
+    assert len(events) == 5
+    assert isinstance(events[0], OrderFilled) and events[0].venue_order_id.value == "229430281341"
+    assert isinstance(events[1], AccountState)
+    assert isinstance(events[2], OrderFilled) and events[2].venue_order_id.value == "229430281339"
+    assert isinstance(events[3], AccountState)
+    assert isinstance(events[4], OrderCanceled) and events[4].venue_order_id.value == "229430281339"
 
 
 @pytest.mark.asyncio

--- a/tests/integration_tests/adapters/betfair/test_betfair_providers.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_providers.py
@@ -18,7 +18,7 @@ import pytest
 from nautilus_trader.adapters.betfair.providers import load_markets
 from nautilus_trader.adapters.betfair.providers import load_markets_metadata
 from nautilus_trader.adapters.betfair.providers import make_instruments
-from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
+from tests.integration_tests.adapters.betfair.test_kit import BetfairDataProvider
 
 
 @pytest.fixture(autouse=True)
@@ -30,7 +30,7 @@ def fix_mocks(mocker):
     # Mock market catalogue endpoints
     mocker.patch(
         "betfairlightweight.endpoints.betting.Betting.list_market_catalogue",
-        return_value=BetfairTestStubs.market_catalogue(),
+        return_value=BetfairDataProvider.market_catalogue(),
     )
 
 

--- a/tests/integration_tests/adapters/betfair/test_kit.py
+++ b/tests/integration_tests/adapters/betfair/test_kit.py
@@ -213,20 +213,30 @@ class BetfairTestStubs(TestStubs):
 
     @staticmethod
     def make_order(
-        factory=None, instrument_id=None, side=None, price=None, quantity=None
+        factory=None, instrument_id=None, side=None, price=None, quantity=None, client_order_id=None
     ) -> LimitOrder:
         order_factory = factory or BetfairTestStubs.order_factory()
-        order = order_factory.limit(
+
+        return LimitOrder(
+            trader_id=order_factory.trader_id,
+            strategy_id=order_factory.strategy_id,
             instrument_id=instrument_id or BetfairTestStubs.instrument_id(),
+            client_order_id=client_order_id or order_factory._id_generator.generate(),
             order_side=side or OrderSide.BUY,
             quantity=quantity or Quantity.from_str("10"),
             price=price or Price.from_str("0.5"),
+            time_in_force=TimeInForce.GTC,
+            expire_time=None,
+            init_id=BetfairTestStubs.uuid(),
+            timestamp_ns=0,
+            post_only=False,
+            reduce_only=False,
+            hidden=False,
         )
-        return order
 
     @staticmethod
-    def make_submitted_order(ts_submitted_ns=0, timestamp_ns=0, factory=None):
-        order = BetfairTestStubs.make_order(factory=factory)
+    def make_submitted_order(ts_submitted_ns=0, timestamp_ns=0, factory=None, client_order_id=None):
+        order = BetfairTestStubs.make_order(factory=factory, client_order_id=client_order_id)
         submitted = OrderSubmitted(
             trader_id=BetfairTestStubs.trader_id(),
             strategy_id=BetfairTestStubs.strategy_id(),
@@ -242,9 +252,11 @@ class BetfairTestStubs(TestStubs):
 
     @staticmethod
     def make_accepted_order(
-        venue_order_id="1", ts_accepted_ns=0, timestamp_ns=0, factory=None
+        venue_order_id="1", ts_accepted_ns=0, timestamp_ns=0, factory=None, client_order_id=None
     ) -> LimitOrder:
-        order = BetfairTestStubs.make_submitted_order(factory=factory)
+        order = BetfairTestStubs.make_submitted_order(
+            factory=factory, client_order_id=client_order_id
+        )
         accepted = OrderAccepted(
             trader_id=BetfairTestStubs.trader_id(),
             strategy_id=BetfairTestStubs.strategy_id(),

--- a/tests/integration_tests/adapters/betfair/test_kit.py
+++ b/tests/integration_tests/adapters/betfair/test_kit.py
@@ -221,7 +221,7 @@ class BetfairTestStubs(TestStubs):
             trader_id=order_factory.trader_id,
             strategy_id=order_factory.strategy_id,
             instrument_id=instrument_id or BetfairTestStubs.instrument_id(),
-            client_order_id=client_order_id or order_factory._id_generator.generate(),
+            client_order_id=client_order_id or ClientOrderId(str(order_factory.count)),
             order_side=side or OrderSide.BUY,
             quantity=quantity or Quantity.from_str("10"),
             price=price or Price.from_str("0.5"),

--- a/tests/integration_tests/adapters/betfair/test_kit.py
+++ b/tests/integration_tests/adapters/betfair/test_kit.py
@@ -212,13 +212,15 @@ class BetfairTestStubs(TestStubs):
         )
 
     @staticmethod
-    def make_order(factory=None) -> LimitOrder:
+    def make_order(
+        factory=None, instrument_id=None, side=None, price=None, quantity=None
+    ) -> LimitOrder:
         order_factory = factory or BetfairTestStubs.order_factory()
         order = order_factory.limit(
-            BetfairTestStubs.instrument_id(),
-            OrderSide.BUY,
-            Quantity.from_int(10),
-            Price.from_str("0.50"),
+            instrument_id=instrument_id or BetfairTestStubs.instrument_id(),
+            order_side=side or OrderSide.BUY,
+            quantity=quantity or Quantity.from_str("10"),
+            price=price or Price.from_str("0.5"),
         )
         return order
 

--- a/tests/integration_tests/adapters/betfair/test_orderbook.py
+++ b/tests/integration_tests/adapters/betfair/test_orderbook.py
@@ -21,6 +21,7 @@ from nautilus_trader.model.orderbook.book import L2OrderBook
 from nautilus_trader.model.orderbook.book import OrderBookDelta
 from nautilus_trader.model.orderbook.book import OrderBookDeltas
 from nautilus_trader.model.orderbook.book import OrderBookSnapshot
+from tests.integration_tests.adapters.betfair.test_kit import BetfairDataProvider
 from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 
 
@@ -31,7 +32,7 @@ def test_betfair_orderbook(betfair_data_client, provider):
         price_precision=2,
         size_precision=2,
     )
-    for update in BetfairTestStubs.raw_market_updates():
+    for update in BetfairDataProvider.raw_market_updates():
         for message in on_market_update(instrument_provider=provider, update=update):
             try:
                 if isinstance(message, OrderBookSnapshot):

--- a/tests/test_kit/providers.py
+++ b/tests/test_kit/providers.py
@@ -22,6 +22,7 @@ from typing import List
 import pandas as pd
 from pandas import DataFrame
 
+from nautilus_trader.adapters.betfair.common import BETFAIR_VENUE
 from nautilus_trader.backtest.loaders import CSVBarDataLoader
 from nautilus_trader.backtest.loaders import CSVTickDataLoader
 from nautilus_trader.backtest.loaders import ParquetTickDataLoader
@@ -40,6 +41,7 @@ from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments.betting import BettingInstrument
 from nautilus_trader.model.instruments.crypto_swap import CryptoSwap
 from nautilus_trader.model.instruments.currency import CurrencySpot
 from nautilus_trader.model.objects import Money
@@ -485,6 +487,31 @@ class TestInstrumentProvider:
             margin_maint=Decimal("0.03"),
             maker_fee=Decimal("0.00002"),
             taker_fee=Decimal("0.00002"),
+            ts_event_ns=0,
+            ts_recv_ns=0,
+        )
+
+    @staticmethod
+    def betting_instrument():
+        return BettingInstrument(
+            venue_name=BETFAIR_VENUE.value,
+            betting_type="ODDS",
+            competition_id="12282733",
+            competition_name="NFL",
+            event_country_code="GB",
+            event_id="29678534",
+            event_name="NFL",
+            event_open_date=pd.Timestamp("2022-02-07 23:30:00+00:00").to_pydatetime(),
+            event_type_id="6423",
+            event_type_name="American Football",
+            market_id="1.179082386",
+            market_name="AFC Conference Winner",
+            market_start_time=pd.Timestamp("2022-02-07 23:30:00+00:00").to_pydatetime(),
+            market_type="SPECIAL",
+            selection_handicap="",
+            selection_id="50214",
+            selection_name="Kansas City Chiefs",
+            currency="GBP",
             ts_event_ns=0,
             ts_recv_ns=0,
         )

--- a/tests/unit_tests/trading/test_trading_portfolio.py
+++ b/tests/unit_tests/trading/test_trading_portfolio.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 
 import pytest
 
+from nautilus_trader.adapters.betfair.common import BETFAIR_VENUE
 from nautilus_trader.common.clock import TestClock
 from nautilus_trader.common.enums import LogLevel
 from nautilus_trader.common.factories import OrderFactory
@@ -26,6 +27,7 @@ from nautilus_trader.execution.engine import ExecutionEngine
 from nautilus_trader.model.c_enums.order_side import OrderSide
 from nautilus_trader.model.currencies import BTC
 from nautilus_trader.model.currencies import ETH
+from nautilus_trader.model.currencies import GBP
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.currencies import USDT
 from nautilus_trader.model.data.tick import QuoteTick
@@ -36,6 +38,7 @@ from nautilus_trader.model.identifiers import PositionId
 from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import TraderId
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.objects import AccountBalance
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.objects import Price
@@ -52,6 +55,7 @@ from tests.test_kit.stubs import TestStubs
 SIM = Venue("SIM")
 BINANCE = Venue("BINANCE")
 BITMEX = Venue("BITMEX")
+BETFAIR = BETFAIR_VENUE
 
 AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
 GBPUSD_SIM = TestInstrumentProvider.default_fx_ccy("GBP/USD")
@@ -59,6 +63,7 @@ USDJPY_SIM = TestInstrumentProvider.default_fx_ccy("USD/JPY")
 BTCUSDT_BINANCE = TestInstrumentProvider.btcusdt_binance()
 BTCUSD_BITMEX = TestInstrumentProvider.xbtusd_bitmex()
 ETHUSD_BITMEX = TestInstrumentProvider.ethusd_bitmex()
+BETTING_INSTRUMENT = TestInstrumentProvider.betting_instrument()
 
 
 class TestPortfolioFacade:
@@ -220,6 +225,7 @@ class TestPortfolio:
         self.cache.add_instrument(BTCUSDT_BINANCE)
         self.cache.add_instrument(BTCUSD_BITMEX)
         self.cache.add_instrument(ETHUSD_BITMEX)
+        self.cache.add_instrument(BETTING_INSTRUMENT)
 
     def test_account_when_no_account_returns_none(self):
         # Arrange
@@ -404,6 +410,50 @@ class TestPortfolio:
 
         # Assert
         assert self.portfolio.initial_margins(BINANCE) == {}
+
+    def test_order_accept_updates_initial_margin(self):
+        # Arrange
+        state = AccountState(
+            account_id=AccountId("BETFAIR", "01234"),
+            account_type=AccountType.CASH,
+            base_currency=None,  # Multi-currency account
+            reported=True,
+            balances=[
+                AccountBalance(
+                    currency=GBP,
+                    total=Money(1000, GBP),
+                    free=Money(1000, GBP),
+                    locked=Money(0, GBP),
+                ),
+            ],
+            info={},
+            event_id=uuid4(),
+            ts_updated_ns=0,
+            timestamp_ns=0,
+        )
+
+        self.exec_engine.process(state)
+
+        # Create a passive order
+        order1 = self.order_factory.limit(
+            BETTING_INSTRUMENT.id,
+            OrderSide.BUY,
+            Quantity.from_str("100"),
+            Price.from_str("0.5"),
+        )
+
+        self.exec_engine.cache.add_order(order1, PositionId.null())
+
+        # Push states to ACCEPTED
+        order1.apply(TestStubs.event_order_submitted(order1))
+        order1.apply(TestStubs.event_order_accepted(order1, venue_order_id=VenueOrderId("1")))
+        self.exec_engine.cache.update_order(order1)
+
+        # Act
+        self.portfolio.initialize_orders()
+
+        # Assert
+        assert self.portfolio.initial_margins(BETFAIR)[GBP] == Money(200, GBP)
 
     def test_update_positions(self):
         # Arrange


### PR DESCRIPTION
Refactor and fix a handful of things in the Betfair adapter
- Fix execution tests that were skipped
- Pull order and instrument from cache rather than computing
- Fix margins and notional value in Betting Instrument & add simple tests
- Add some more test fixtures and split BetfairTestStubs into BetfairTestStubs/BetfairDataProvider
- Add portfolio initial margin test