### PR TITLE
Fix bug in overwriting parquet instruments

### DIFF
--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -31,6 +31,7 @@ from fsspec.core import OpenFile
 from tqdm import tqdm
 
 from nautilus_trader.model.data.base import GenericData
+from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.persistence.catalog import DataCatalog
 from nautilus_trader.persistence.external.metadata import write_partition_column_mappings
 from nautilus_trader.persistence.external.readers import Reader
@@ -195,6 +196,21 @@ def determine_partition_cols(cls: type, instrument_id: str = None) -> Union[List
     return None
 
 
+def merge_existing_data(catalog: DataCatalog, cls: type, df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Handle existing data for instrument subclasses; instruments all live in a single file, so merge with existing data.
+    For all other classes, simply return data unchanged.
+    """
+    if cls not in Instrument.__subclasses__():
+        return df
+    else:
+        try:
+            existing = catalog.instruments(instrument_type=cls)
+            return existing.append(df.drop(["type"], axis=1)).drop_duplicates()
+        except pa.lib.ArrowInvalid:
+            return df
+
+
 def write_tables(catalog: DataCatalog, tables: Dict[type, Dict[str, pd.DataFrame]], **kwargs):
     """
     Write tables to catalog.
@@ -217,11 +233,12 @@ def write_tables(catalog: DataCatalog, tables: Dict[type, Dict[str, pd.DataFrame
         partition_cols = determine_partition_cols(cls=cls, instrument_id=instrument_id)
         name = f"{class_to_filename(cls)}.parquet"
         path = f"{catalog.path}/data/{name}"
+        merged = merge_existing_data(catalog=catalog, cls=cls, df=df)
         with named_lock(name):
             write_parquet(
                 fs=catalog.fs,
                 path=path,
-                df=df,
+                df=merged,
                 partition_cols=partition_cols,
                 schema=schema,
                 **kwargs,

--- a/tests/unit_tests/persistence/external/test_core.py
+++ b/tests/unit_tests/persistence/external/test_core.py
@@ -465,7 +465,7 @@ class TestPersistenceCore:
         expected = [
             f"/root/data/betfair_ticker.parquet/instrument_id={ins1}/20191220.parquet",
             f"/root/data/betfair_ticker.parquet/instrument_id={ins2}/20191220.parquet",
-            "/root/data/betting_instrument.parquet/20210921.parquet",
+            "/root/data/betting_instrument.parquet/20210922.parquet",
             f"/root/data/instrument_status_update.parquet/instrument_id={ins1}/20191220.parquet",
             f"/root/data/instrument_status_update.parquet/instrument_id={ins2}/20191220.parquet",
             f"/root/data/order_book_data.parquet/instrument_id={ins1}/20191220.parquet",

--- a/tests/unit_tests/persistence/external/test_parsers.py
+++ b/tests/unit_tests/persistence/external/test_parsers.py
@@ -16,9 +16,7 @@
 import pathlib
 import sys
 from functools import partial
-from unittest.mock import Mock
 
-import fsspec.implementations.memory
 import orjson
 import pandas as pd
 import pytest
@@ -54,15 +52,7 @@ class TestPersistenceParsers:
         data_catalog_setup()
         self.catalog = DataCatalog.from_env()
         self.reader = MockReader()
-        self.mock_catalog = self._mock_catalog()
         self.line_preprocessor = TestLineProcessor()
-
-    @staticmethod
-    def _mock_catalog():
-        mock_catalog = Mock(spec=DataCatalog)
-        mock_catalog.path = "/root"
-        mock_catalog.fs = fsspec.implementations.memory.MemoryFileSystem()
-        return mock_catalog
 
     def test_line_preprocessor_preprocess(self):
         line = b'2021-06-29T06:04:11.943000 - {"op":"mcm","id":1,"clk":"AOkiAKEMAL4P","pt":1624946651810}\n'
@@ -155,7 +145,7 @@ class TestPersistenceParsers:
 
         reader = TextReader(line_parser=parser)
         raw_file = make_raw_files(glob_path=f"{TEST_DATA_DIR}/binance-btcusdt-instrument.txt")[0]
-        result = process_raw_file(catalog=self.mock_catalog, raw_file=raw_file, reader=reader)
+        result = process_raw_file(catalog=self.catalog, raw_file=raw_file, reader=reader)
         expected = 1
         assert result == expected
 
@@ -171,14 +161,14 @@ class TestPersistenceParsers:
 
         reader = CSVReader(block_parser=parser, as_dataframe=True)
         raw_file = make_raw_files(glob_path=f"{TEST_DATA_DIR}/truefx-audusd-ticks.csv")[0]
-        result = process_raw_file(catalog=self.mock_catalog, raw_file=raw_file, reader=reader)
+        result = process_raw_file(catalog=self.catalog, raw_file=raw_file, reader=reader)
         assert result == 100000
 
     def test_text_reader(self):
         provider = BetfairInstrumentProvider.from_instruments([])
         reader = BetfairTestStubs.betfair_reader(provider)  # type: TextReader
         raw_file = make_raw_files(glob_path=f"{TEST_DATA_DIR}/betfair/1.166811431.bz2")[0]
-        result = process_raw_file(catalog=self.mock_catalog, raw_file=raw_file, reader=reader)
+        result = process_raw_file(catalog=self.catalog, raw_file=raw_file, reader=reader)
         assert result == 22692
 
     def test_byte_json_parser(self):
@@ -189,7 +179,7 @@ class TestPersistenceParsers:
 
         reader = ByteReader(block_parser=parser)
         raw_file = make_raw_files(glob_path=f"{TEST_DATA_DIR}/crypto*.json")[0]
-        result = process_raw_file(catalog=self.mock_catalog, raw_file=raw_file, reader=reader)
+        result = process_raw_file(catalog=self.catalog, raw_file=raw_file, reader=reader)
         assert result == 6
 
     def test_parquet_reader(self):
@@ -205,7 +195,7 @@ class TestPersistenceParsers:
 
         reader = ParquetReader(parser=parser)
         raw_file = make_raw_files(glob_path=f"{TEST_DATA_DIR}/binance-btcusdt-quotes.parquet")[0]
-        result = process_raw_file(catalog=self.mock_catalog, raw_file=raw_file, reader=reader)
+        result = process_raw_file(catalog=self.catalog, raw_file=raw_file, reader=reader)
         assert result == 451
 
 

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -75,6 +75,13 @@ class TestPersistenceCatalog:
         instruments = self.catalog.instruments()
         assert len(instruments) == 2
 
+    def test_writing_instruments_doesnt_overwrite(self):
+        instruments = self.catalog.instruments(as_nautilus=True)
+        write_objects(catalog=self.catalog, chunk=[instruments[0]])
+        write_objects(catalog=self.catalog, chunk=[instruments[1]])
+        instruments = self.catalog.instruments(as_nautilus=True)
+        assert len(instruments) == 2
+
     def test_data_catalog_instruments_filtered_df(self):
         instrument_id = (
             "Basketball,,29628709,20191221-001000,ODDS,MATCH_ODDS,1.166564490,237491,0.0.BETFAIR"


### PR DESCRIPTION
Fixes a bug that was overwriting instruments when written to parquet. This was a side effect of removing code in #440 