### PR TITLE
Catalog data streaming

### DIFF
--- a/nautilus_trader/persistence/catalog.py
+++ b/nautilus_trader/persistence/catalog.py
@@ -382,7 +382,6 @@ class DataCatalog(metaclass=Singleton):
                 options=options,
             )
             end_nanos = int(result.x[0])
-            print(start_nanos, end_nanos)
             if (start_nanos, end_nanos) == last:
                 break
             yield start_nanos, end_nanos

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -14,11 +14,13 @@
 # -------------------------------------------------------------------------------------------------
 
 import datetime
+import functools
 import sys
 
 import fsspec
 import pyarrow.dataset as ds
 import pytest
+from dask.utils import parse_bytes
 
 from nautilus_trader.adapters.betfair.providers import BetfairInstrumentProvider
 from nautilus_trader.model.data.tick import QuoteTick
@@ -29,6 +31,9 @@ from nautilus_trader.model.instruments.betting import BettingInstrument
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.persistence.catalog import DataCatalog
+from nautilus_trader.persistence.catalog import calculate_data_size
+from nautilus_trader.persistence.catalog import make_unix_ns
+from nautilus_trader.persistence.catalog import search_data_size_timestamp
 from nautilus_trader.persistence.external.core import dicts_to_dataframes
 from nautilus_trader.persistence.external.core import process_files
 from nautilus_trader.persistence.external.core import split_and_serialize
@@ -179,3 +184,50 @@ class TestPersistenceCatalog:
 
         filtered_deltas = self.catalog.order_book_deltas(filter_expr=ds.field("action") == "DELETE")
         assert len(filtered_deltas) == 351
+
+    def test_calculate_data_size(self):
+        # Arrange
+        instrument_ids = self.catalog.instruments()["id"].tolist()
+        func = functools.partial(
+            calculate_data_size,
+            root_path=self.catalog.path,
+            fs=self.catalog.fs,
+            instrument_ids=instrument_ids,
+            data_types=[TradeTick],
+            start_time=1576840503572000000,
+        )
+
+        # Act
+        results = [
+            func(end_time=make_unix_ns("2019-12-20 11:30:00")),
+            func(end_time=make_unix_ns("2019-12-20 15:00:00")),
+            func(end_time=make_unix_ns("2019-12-20 18:00:00")),
+            func(end_time=make_unix_ns("2019-12-20 22:00:00")),
+        ]
+
+        # Assert
+        expected = [1138, 7019, 12459, 34749]
+        assert results == expected
+
+    def test_search_data_size_timestamp(self):
+        instrument_ids = self.catalog.instruments()["id"].tolist()
+        target_func = search_data_size_timestamp(
+            root_path=self.catalog.path,
+            fs=self.catalog.fs,
+            instrument_ids=instrument_ids,
+            data_types=[TradeTick],
+            start_time=1576840503572000000,
+            target_size=parse_bytes("1mib"),
+        )
+        result = target_func([1576878597067000000])
+        assert result == 1013827
+
+    def test_calc_streaming_chunks(self):
+        instrument_ids = self.catalog.instruments()["id"].tolist()
+        chunks = self.catalog.calc_streaming_chunks(
+            instrument_ids=instrument_ids,
+            data_types=[TradeTick],
+            start_time=1576840503572000000,
+            target_size=parse_bytes("100mib"),
+        )
+        assert chunks


### PR DESCRIPTION
This PR adds a method `calc_streaming_chunks` to the `DataCatalog` for calculating start/end timestamps for batches of data given a list of instrument IDs, data types and a desired `target_size` (in bytes). This will allow the creation of "larger than memory" backtests that can stream batches of multiple instruments and data types *correctly*. We're using `scipy.minimize` to optimise a target function (the total bytes to read given instrument/data type inputs) by varying the end_timestamps. 

The problem may appear trivial on the surface (why not just read a portion from each table?) but when considering backtests containing multiple instruments or data types with tick streams that may vary in granularity significantly - this is the only way (that I can see thus far) that guarantees that the backtest engine will received all of the ticks it requires in a given batch. 