### PR TITLE
Add custom_summaries backtests

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -205,6 +205,8 @@ class BacktestEngineConfig(pydantic.BaseModel):
         The configuration for the risk engine.
     exec_engine : ExecEngineConfig, optional
         The configuration for the execution engine.
+    custom_summaries: dict, default=None
+        A dictionary of name:callbacks to be called to add custom summaries to the BacktestResult
     bypass_logging : bool, default=False
         If logging should be bypassed.
     run_analysis : bool, default=True

--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -221,12 +221,14 @@ class BacktestEngineConfig(pydantic.BaseModel):
     data_engine: Optional[DataEngineConfig] = None
     risk_engine: Optional[RiskEngineConfig] = None
     exec_engine: Optional[ExecEngineConfig] = None
-    custom_summaries: Optional[Dict[str, Callable]]
+    custom_summaries: Optional[Dict[str, Callable]] = None
     bypass_logging: bool = False
     run_analysis: bool = True
 
-    @validator("custom_summaries")
+    @validator("custom_summaries", always=True)
     def validate_custom_summaries_signature(cls, v, values):
+        if v is None:
+            v = {}
         for name, cb in v.items():
             sig = inspect.signature(cb)
             assert (

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -820,6 +820,11 @@ cdef class BacktestEngine:
         for currency in self.analyzer.currencies:
             stats_pnls[currency.code] = self.analyzer.get_performance_stats_pnls(currency)
 
+        # Handle any custom functions the user has passed
+        custom_summaries = {}
+        for name, cb in self._config.custom_summaries.items():
+            custom_summaries[name] = cb(self)
+
         return BacktestResult(
             trader_id=self.trader_id.value,
             machine_id=self.machine_id,
@@ -837,6 +842,7 @@ cdef class BacktestEngine:
             total_positions=self.cache.positions_total_count(),
             stats_pnls=stats_pnls,
             stats_returns=self.analyzer.get_performance_stats_returns(),
+            custom_summaries=custom_summaries
         )
 
     def _run(

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -822,7 +822,7 @@ cdef class BacktestEngine:
 
         # Handle any custom functions the user has passed
         custom_summaries = {}
-        for name, cb in self._config.custom_summaries.items():
+        for name, cb in (self._config.custom_summaries or {}).items():
             custom_summaries[name] = cb(self)
 
         return BacktestResult(

--- a/nautilus_trader/backtest/results.py
+++ b/nautilus_trader/backtest/results.py
@@ -40,6 +40,7 @@ class BacktestResult:
     total_positions: int
     stats_pnls: Dict[str, Dict[str, float]]
     stats_returns: Dict[str, float]
+    custom_summaries: Dict[str, Dict]
 
     # account_balances: pd.DataFrame
     # fills_report: pd.DataFrame

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -67,7 +67,7 @@ class TestBacktestConfig:
         aud_usd_data_loader()
         self.catalog = DataCatalog.from_env()
         self.backtest_config = BacktestRunConfig(
-            engine=BacktestEngineConfig(),
+            engine=BacktestEngineConfig(bypass_logging=True),
             venues=[
                 BacktestVenueConfig(
                     name="SIM",
@@ -148,7 +148,7 @@ class TestBacktestConfig:
         result = tokenize(venue)
 
         # Assert
-        assert result == "d2f74877f3aeeba2f89b95807a8ced02"
+        assert result == "929e4f4f526a79fbe27d73fb17762d1d"
 
     def test_data_config_tokenization(self):
         # Arrange, Act
@@ -158,7 +158,7 @@ class TestBacktestConfig:
         result = tokenize(data_config)
 
         # Assert
-        assert result == "a3bac111f5e433648a505aa156a85f32"
+        assert result == "fafc01d1d11d502599034ab80d3e213b"
 
     def test_engine_config_tokenization(self):
         # Arrange,
@@ -168,14 +168,14 @@ class TestBacktestConfig:
         result = tokenize(engine_config)
 
         # Assert
-        assert result == "22d84218139004f8b662d2c6d3dccb4a"
+        assert result == "cf1a057fa354b8b043337a39bc0e1640"
 
     def test_tokenization_config(self):
         # Arrange, Act
         result = tokenize(self.backtest_config)
 
         # Assert
-        assert result == "5a2c9290bb73a4b5884ffce50673e538"
+        assert result == "83aecc5500d48e6dbcce5f23a7fc56bf"
 
     def test_backtest_data_config_load(self):
         instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD")

--- a/tests/unit_tests/backtest/test_backtest_node.py
+++ b/tests/unit_tests/backtest/test_backtest_node.py
@@ -45,7 +45,7 @@ class TestBacktestNode:
         )
         self.backtest_configs = [
             BacktestRunConfig(
-                engine=BacktestEngineConfig(),
+                engine=BacktestEngineConfig(bypass_logging=True),
                 venues=[self.venue_config],
                 data=[self.data_config],
             )
@@ -196,7 +196,7 @@ class TestBacktestNode:
             return {"buys": len([o for o in engine.cache.orders() if o.side == OrderSide.BUY])}
 
         backtest_configs_strategies = self.backtest_configs_strategies[0].replace(
-            engine=BacktestEngineConfig(custom_summaries={"buy_count": buy_count})
+            engine=BacktestEngineConfig(custom_summaries=(("buy_count", buy_count),))
         )
         node = BacktestNode()
 


### PR DESCRIPTION
This PR adds a `custom_summaries` optional config to `BacktestEngineConfig`. This allows adding custom callbacks to run after a backtest and be gathered with the `BacktestResult`.

A simple example: 

```python

def buy_count(engine):
    return {"buys": len([o for o in engine.cache.orders() if o.side == OrderSide.BUY])}

# Setup backtest
backtest_run_config = BacktestRunConfig(
    ... # Other inputs
    engine=BacktestEngineConfig(custom_summaries={"buy_count": buy_count})
)
node = BacktestNode()

# Run backtest
results = node.run_sync([backtest_run_config])
assert results[0].custom_summaries["buy_count"] == {"buys": 48}



```