### PR TITLE
Fixing bugs in streaming generic data

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -15,14 +15,17 @@
 
 import dataclasses
 import importlib
+import sys
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
+import pandas as pd
 import pydantic
 from dask.base import tokenize
 
 from nautilus_trader.cache.cache import CacheConfig
 from nautilus_trader.common.config import ImportableActorConfig
+from nautilus_trader.core.datetime import maybe_dt_to_unix_nanos
 from nautilus_trader.data.engine import DataEngineConfig
 from nautilus_trader.execution.engine import ExecEngineConfig
 from nautilus_trader.infrastructure.cache import CacheDatabaseConfig
@@ -152,6 +155,18 @@ class BacktestDataConfig(Partialable):
             filter_expr=self.filter_expr,
             as_nautilus=True,
         )
+
+    @property
+    def start_time_nanos(self) -> int:
+        if self.start_time is None:
+            return 0
+        return maybe_dt_to_unix_nanos(pd.Timestamp(self.start_time))
+
+    @property
+    def end_time_nanos(self) -> int:
+        if self.end_time is None:
+            return sys.maxsize
+        return maybe_dt_to_unix_nanos(pd.Timestamp(self.end_time))
 
     def catalog(self):
         from nautilus_trader.persistence.catalog import DataCatalog

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -15,11 +15,10 @@
 
 import itertools
 import pickle
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import cloudpickle
 import dask
-import pandas as pd
 from dask.base import normalize_token
 from dask.delayed import Delayed
 
@@ -32,17 +31,19 @@ from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.common.actor import Actor
 from nautilus_trader.common.config import ActorFactory
 from nautilus_trader.common.config import ImportableActorConfig
-from nautilus_trader.core.datetime import maybe_dt_to_unix_nanos
 from nautilus_trader.core.inspect import is_nautilus_class
 from nautilus_trader.model.c_enums.book_type import BookTypeParser
 from nautilus_trader.model.currency import Currency
 from nautilus_trader.model.data.bar import Bar
+from nautilus_trader.model.data.base import DataType
+from nautilus_trader.model.data.base import GenericData
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.data.tick import TradeTick
 from nautilus_trader.model.data.venue import InstrumentStatusUpdate
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OMSType
 from nautilus_trader.model.enums import VenueType
+from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.model.objects import Money
@@ -317,6 +318,21 @@ def groupby_datatype(data):
     ]
 
 
+def _extract_generic_data_client_id(data_configs: List[BacktestDataConfig]) -> Dict:
+    """
+    Extract a mapping of data_type : client_id from the list of `data_configs`. In the process of merging the streaming
+    data, we lose the client_id for generic data, we need to inject this back in so the backtest engine can be
+    correctly loaded.
+    """
+    data_client_ids = [
+        (config.data_type, config.client_id) for config in data_configs if config.client_id
+    ]
+    assert len(set(data_client_ids)) == len(
+        dict(data_client_ids)
+    ), "data_type found with multiple client_ids"
+    return dict(data_client_ids)
+
+
 def streaming_backtest_runner(
     run_config_id: str,
     engine: BacktestEngine,
@@ -325,19 +341,21 @@ def streaming_backtest_runner(
 ):
     config = data_configs[0]
     catalog: DataCatalog = config.catalog()
-    start_time = maybe_dt_to_unix_nanos(pd.Timestamp(min(dc.start_time for dc in data_configs)))
-    end_time = maybe_dt_to_unix_nanos(pd.Timestamp(max(dc.end_time for dc in data_configs)))
+
+    data_client_ids = _extract_generic_data_client_id(data_configs=data_configs)
 
     for data in batch_files(
         catalog=catalog,
         data_configs=data_configs,
-        start_time=start_time,
-        end_time=end_time,
         target_batch_size_bytes=batch_size_bytes,
     ):
         engine.clear_data()
         for data in groupby_datatype(data):
-            _load_engine_data(engine=engine, data=data)
+            if data["type"] in data_client_ids:
+                # Generic data - manually re-add client_id as it gets lost in the streaming join
+                data.update({"client_id": ClientId(data_client_ids[data["type"]])})
+                data["data"] = [GenericData(data_type=DataType(cls), data=d) for d in data["data"]]
+        _load_engine_data(engine=engine, data=data)
         engine.run_streaming(run_config_id=run_config_id)
     engine.end_streaming()
 

--- a/nautilus_trader/persistence/batching.py
+++ b/nautilus_trader/persistence/batching.py
@@ -36,8 +36,8 @@ def dataset_batches(
     file_meta: FileMeta, fs: fsspec.AbstractFileSystem, n_rows: int
 ) -> Iterator[pd.DataFrame]:
     d: ds.Dataset = ds.dataset(file_meta.filename, filesystem=fs)
-    filter_expr = (ds.field("ts_event") >= (file_meta.start or 0)) & (
-        ds.field("ts_event") <= (file_meta.end or sys.maxsize)
+    filter_expr = (ds.field("ts_event") >= file_meta.start) & (
+        ds.field("ts_event") <= file_meta.end
     )
     scanner: ds.Scanner = d.scanner(filter=filter_expr, batch_size=n_rows)
     for batch in scanner.to_batches():
@@ -63,8 +63,8 @@ def build_filenames(catalog: DataCatalog, data_configs: List[BacktestDataConfig]
                 datatype=config.data_type,
                 instrument_id=config.instrument_id,
                 client_id=config.client_id,
-                start=config.start_time,
-                end=config.end_time,
+                start=config.start_time_nanos,
+                end=config.end_time_nanos,
             )
         )
     return files

--- a/nautilus_trader/persistence/batching.py
+++ b/nautilus_trader/persistence/batching.py
@@ -16,7 +16,7 @@
 import heapq
 import sys
 from collections import namedtuple
-from typing import Any, List, Set
+from typing import Any, Iterator, List, Set
 
 import fsspec
 import pandas as pd
@@ -29,20 +29,24 @@ from nautilus_trader.serialization.arrow.serializer import ParquetSerializer
 from nautilus_trader.serialization.arrow.util import clean_key
 
 
-FileMeta = namedtuple("FileMeta", "filename datatype instrument_id")
+FileMeta = namedtuple("FileMeta", "filename datatype instrument_id client_id start end")
 
 
 def dataset_batches(
-    file_meta: FileMeta, fs: fsspec.AbstractFileSystem, n_rows: int, filter_expr=None
-):
-    d = ds.dataset(file_meta.filename, filesystem=fs)  # type: ds.Dataset
-    scanner = d.scanner(filter=filter_expr, batch_size=n_rows)  # type: ds.Scanner
+    file_meta: FileMeta, fs: fsspec.AbstractFileSystem, n_rows: int
+) -> Iterator[pd.DataFrame]:
+    d: ds.Dataset = ds.dataset(file_meta.filename, filesystem=fs)
+    filter_expr = (ds.field("ts_event") >= (file_meta.start or 0)) & (
+        ds.field("ts_event") <= (file_meta.end or sys.maxsize)
+    )
+    scanner: ds.Scanner = d.scanner(filter=filter_expr, batch_size=n_rows)
     for batch in scanner.to_batches():
         if batch.num_rows == 0:
             break
         data = batch.to_pandas()
-        data.loc[:, "instrument_id"] = file_meta.instrument_id
-        yield batch.nbytes, data
+        if file_meta.instrument_id:
+            data.loc[:, "instrument_id"] = file_meta.instrument_id
+        yield data
 
 
 def build_filenames(catalog: DataCatalog, data_configs: List[BacktestDataConfig]) -> List[FileMeta]:
@@ -55,7 +59,12 @@ def build_filenames(catalog: DataCatalog, data_configs: List[BacktestDataConfig]
             continue
         files.append(
             FileMeta(
-                filename=filename, datatype=config.data_type, instrument_id=config.instrument_id
+                filename=filename,
+                datatype=config.data_type,
+                instrument_id=config.instrument_id,
+                client_id=config.client_id,
+                start=config.start_time,
+                end=config.end_time,
             )
         )
     return files
@@ -68,19 +77,13 @@ def frame_to_nautilus(df: pd.DataFrame, cls: type) -> List[Any]:
 def batch_files(
     catalog: DataCatalog,
     data_configs: List[BacktestDataConfig],
-    start_time: int,
-    end_time: int,
     read_num_rows: int = 10000,
     target_batch_size_bytes: int = parse_bytes("100mb"),  # noqa: B008
 ):
-    filter_expr = (ds.field("ts_init") > start_time) & (ds.field("ts_init") < end_time)
     files = build_filenames(catalog=catalog, data_configs=data_configs)
     buffer = {fn.filename: pd.DataFrame() for fn in files}
     datasets = {
-        f.filename: dataset_batches(
-            file_meta=f, fs=catalog.fs, n_rows=read_num_rows, filter_expr=filter_expr
-        )
-        for f in files
+        f.filename: dataset_batches(file_meta=f, fs=catalog.fs, n_rows=read_num_rows) for f in files
     }
     completed: Set[str] = set()
     bytes_read = 0
@@ -93,11 +96,10 @@ def batch_files(
                 if next_buf is None:
                     completed.add(fn)
                     continue
-                nbytes, next_buf = next_buf
                 buffer[fn] = buffer[fn].append(next_buf)
 
         # Determine minimum timestamp
-        max_ts_per_frame = [df["ts_init"].max() for df in buffer.values() if not df.empty]
+        max_ts_per_frame = [df["ts_event"].max() for df in buffer.values() if not df.empty]
         if not max_ts_per_frame:
             continue
         min_ts = min(max_ts_per_frame)
@@ -108,7 +110,7 @@ def batch_files(
             df = buffer[f.filename]
             if df.empty:
                 continue
-            ts_filter = df["ts_init"] <= min_ts
+            ts_filter = df["ts_event"] <= min_ts
             batch = df[ts_filter]
             buffer[f.filename] = df[~ts_filter]
             # print(f"{f.filename} batch={len(batch)} buffer={len(buffer)}")
@@ -117,7 +119,7 @@ def batch_files(
             bytes_read += sum([sys.getsizeof(x) for x in objs])
 
         # Merge ticks
-        values.extend(list(heapq.merge(*batches, key=lambda x: x.ts_init)))
+        values.extend(list(heapq.merge(*batches, key=lambda x: x.ts_event)))
         # print(f"iter complete, {bytes_read=}, flushing at target={target_batch_size_bytes}")
         if bytes_read > target_batch_size_bytes:
             yield values


### PR DESCRIPTION
Fixing a couple of bugs related to generic data in streaming backtests.
- `client_id` not correctly passed to backtest engine load_data
- Data objects not being wrapped in GenericData before being loaded 