### PR TITLE
Fix bug in generic data data_type 

### DIFF
--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -349,7 +349,7 @@ def streaming_backtest_runner(
             if data["type"] in data_client_ids:
                 # Generic data - manually re-add client_id as it gets lost in the streaming join
                 data.update({"client_id": ClientId(data_client_ids[data["type"]])})
-                data["data"] = [GenericData(data_type=DataType(cls), data=d) for d in data["data"]]
+                data["data"] = [GenericData(data_type=DataType(data["type"]), data=d) for d in data["data"]]
             _load_engine_data(engine=engine, data=data)
         engine.run_streaming(run_config_id=run_config_id)
     engine.end_streaming()

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -349,7 +349,9 @@ def streaming_backtest_runner(
             if data["type"] in data_client_ids:
                 # Generic data - manually re-add client_id as it gets lost in the streaming join
                 data.update({"client_id": ClientId(data_client_ids[data["type"]])})
-                data["data"] = [GenericData(data_type=DataType(data["type"]), data=d) for d in data["data"]]
+                data["data"] = [
+                    GenericData(data_type=DataType(data["type"]), data=d) for d in data["data"]
+                ]
             _load_engine_data(engine=engine, data=data)
         engine.run_streaming(run_config_id=run_config_id)
     engine.end_streaming()


### PR DESCRIPTION
Fixes a bug in `streaming_backtest_runner` when loading generic data, currently returning the wrong `Data.data_type`