### PR TITLE
Catalog Migrations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 plugins = Cython.Coverage
 source = nautilus_trader
-omit = nautilus_trader/adapters/binance*,nautilus_trader/adapters/ftx*,nautilus_trader/adapters/ib*,nautilus_trader/examples*
+omit = nautilus_trader/adapters/binance*,nautilus_trader/adapters/ftx*,nautilus_trader/adapters/ib*,nautilus_trader/examples*,nautilus_trader/persistence/migrations/*
 
 [report]
 fail_under = 0

--- a/nautilus_trader/persistence/migrate.py
+++ b/nautilus_trader/persistence/migrate.py
@@ -3,8 +3,14 @@ from nautilus_trader.persistence.external.core import write_objects
 
 
 def create_temp_table(func):
+    """Make a temporary copy of any parquet dataset class called by `write_tables`"""
+
     def inner(*args, **kwargs):
-        return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            # Restore old table
+            print()
 
     return inner
 
@@ -12,17 +18,6 @@ def create_temp_table(func):
 write_objects = create_temp_table(write_objects)
 
 
-def maintain_temp_tables(func):
-    def inner(*args, **kwargs):
-        # Create temp tables
-        try:
-            return func(*args, **kwargs)
-        except Exception:
-            # Error - restore temp tables
-            print()
-
-    return inner
-
-
 def migrate(catalog: DataCatalog, version_from: str, version_to: str):
+    """Migrate the `catalog` between versions `version_from` and `version_to`"""
     pass

--- a/nautilus_trader/persistence/migrate.py
+++ b/nautilus_trader/persistence/migrate.py
@@ -2,6 +2,9 @@ from nautilus_trader.persistence.catalog import DataCatalog
 from nautilus_trader.persistence.external.core import write_objects
 
 
+# TODO (bm)
+
+
 def create_temp_table(func):
     """Make a temporary copy of any parquet dataset class called by `write_tables`"""
 

--- a/nautilus_trader/persistence/migrate.py
+++ b/nautilus_trader/persistence/migrate.py
@@ -1,0 +1,28 @@
+from nautilus_trader.persistence.catalog import DataCatalog
+from nautilus_trader.persistence.external.core import write_objects
+
+
+def create_temp_table(func):
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return inner
+
+
+write_objects = create_temp_table(write_objects)
+
+
+def maintain_temp_tables(func):
+    def inner(*args, **kwargs):
+        # Create temp tables
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            # Error - restore temp tables
+            print()
+
+    return inner
+
+
+def migrate(catalog: DataCatalog, version_from: str, version_to: str):
+    pass

--- a/nautilus_trader/persistence/migrations/1.135.0.py
+++ b/nautilus_trader/persistence/migrations/1.135.0.py
@@ -1,0 +1,64 @@
+import warnings
+
+import fsspec
+import pyarrow.dataset as ds
+from tqdm import tqdm
+
+from nautilus_trader.model.data.tick import TradeTick
+from nautilus_trader.persistence.catalog import DataCatalog
+from nautilus_trader.persistence.external.core import write_objects
+
+
+FROM = "1.134.0"
+TO = "1.135.0"
+
+# EXAMPLE ONLY - not working
+
+
+def main(catalog: DataCatalog):
+    """Rename match_id to trade_id in TradeTick"""
+    fs: fsspec.AbstractFileSystem = catalog.fs
+
+    print("Loading instrument ids")
+    instrument_ids = catalog.query(TradeTick, table_kwargs={"columns": ["instrument_id"]})[
+        "instrument_id"
+    ].unique()
+
+    tmp_catalog = DataCatalog(str(catalog.path) + "_tmp")
+    tmp_catalog.fs = catalog.fs
+
+    for ins_id in tqdm(instrument_ids):
+
+        # Load trades for instrument
+        trades = catalog.trade_ticks(
+            instrument_ids=[ins_id],
+            projections={"trade_id": ds.field("match_id")},
+            as_nautilus=True,
+        )
+
+        # Create temp parquet in case of error
+        fs.move(
+            f"{catalog.path}/data/trade_tick.parquet/instrument_id={ins_id}",
+            f"{catalog.path}/data/trade_tick.parquet_tmp/instrument_id={ins_id}",
+            recursive=True,
+        )
+
+        try:
+            # Rewrite to new catalog
+            write_objects(tmp_catalog, trades)
+
+            # Ensure we can query again
+            _ = tmp_catalog.trade_ticks(instrument_ids=[ins_id], as_nautilus=True)
+
+            # Clear temp parquet
+            fs.rm(
+                f"{catalog.path}/data/trade_tick.parquet_tmp/instrument_id={ins_id}", recursive=True
+            )
+
+        except Exception:
+            warnings.warn(f"Failed to write or read instrument_id {ins_id}")
+            fs.move(
+                f"{catalog.path}/data/trade_tick.parquet_tmp/instrument_id={ins_id}",
+                f"{catalog.path}/data/trade_tick.parquet/instrument_id={ins_id}",
+                recursive=True,
+            )

--- a/nautilus_trader/persistence/migrations/1.137.0.py
+++ b/nautilus_trader/persistence/migrations/1.137.0.py
@@ -1,0 +1,28 @@
+import pyarrow.dataset as ds
+
+from nautilus_trader.model.instruments.base import Instrument
+from nautilus_trader.persistence.catalog import DataCatalog
+from nautilus_trader.persistence.external.core import write_objects
+from nautilus_trader.persistence.migrate import maintain_temp_tables
+
+
+FROM = "1.136.0"
+TO = "1.137.0"
+
+
+@maintain_temp_tables
+def main(catalog: DataCatalog):
+    """Rename local_symbol to native_symbol in Instruments"""
+    # fs: fsspec.AbstractFileSystem = catalog.fs
+    for cls in Instrument.__subclasses__():
+        # Load instruments into memory
+        instruments = catalog.instruments(
+            as_nautilus=True,
+            instrument_type=cls,
+            projections={"native_symbol": ds.field("local_symbol")},
+        )
+
+        # Rewrite new instruments
+        write_objects(catalog, instruments)
+
+        # Remove

--- a/nautilus_trader/persistence/migrations/1.137.0.py
+++ b/nautilus_trader/persistence/migrations/1.137.0.py
@@ -6,6 +6,7 @@ import pyarrow.dataset as ds
 from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.persistence.catalog import DataCatalog
 from nautilus_trader.persistence.external.core import write_objects
+from nautilus_trader.serialization.arrow.util import class_to_filename
 
 
 FROM = "1.136.0"
@@ -25,8 +26,8 @@ def main(catalog: DataCatalog):
 
         # Create temp parquet in case of error
         fs.move(
-            f"{catalog.path}/data/equity.parquet",
-            f"{catalog.path}/data/equity.parquet_tmp",
+            f"{catalog.path}/data/{class_to_filename(cls)}.parquet",
+            f"{catalog.path}/data/{class_to_filename(cls)}.parquet_tmp",
             recursive=True,
         )
 
@@ -38,11 +39,11 @@ def main(catalog: DataCatalog):
             _ = catalog.instruments(instrument_type=cls, as_nautilus=True)
 
             # Clear temp parquet
-            fs.rm(f"{catalog.path}/data/equity.parquet_tmp", recursive=True)
+            fs.rm(f"{catalog.path}/data/{class_to_filename(cls)}.parquet_tmp", recursive=True)
         except Exception:
             warnings.warn(f"Failed to write or read instrument type {cls}")
             fs.move(
-                f"{catalog.path}/data/equity.parquet_tmp",
-                f"{catalog.path}/data/equity.parquet",
+                f"{catalog.path}/data/{class_to_filename(cls)}.parquet_tmp",
+                f"{catalog.path}/data/{class_to_filename(cls)}.parquet",
                 recursive=True,
             )

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -243,3 +243,9 @@ class TestPersistenceCatalog:
         # Assert
         bars = self.catalog.bars()
         assert len(bars) == 21
+
+    def test_catalog_projections(self):
+        projections = {"tid": ds.field("trade_id")}
+        trades = self.catalog.trade_ticks(projections=projections)
+        assert "tid" in trades.columns
+        assert trades["trade_id"].equals(trades["tid"])


### PR DESCRIPTION
This PR adds the start of a migration script for the DataCatalog. 

- Allow passing a pyarrow `projection` to the DataCatalog.
- Adds a sample `1.136.0 -> 1.137.0` migration for reference
- Adds a placeholder `migrate.py` file with some signatures to be filled in later