### PR TITLE
FeatherWriter cleanup

### DIFF
--- a/nautilus_trader/persistence/streaming.py
+++ b/nautilus_trader/persistence/streaming.py
@@ -118,7 +118,6 @@ class FeatherWriter:
             self.logger.error(f"Failed to serialize {cls=}")
             self.logger.error(f"ERROR = `{ex}`")
             self.logger.debug(f"data = {original}")
-            raise
 
     def check_flush(self):
         now = datetime.datetime.now()

--- a/nautilus_trader/serialization/arrow/schema.py
+++ b/nautilus_trader/serialization/arrow/schema.py
@@ -202,7 +202,7 @@ NAUTILUS_PARQUET_SCHEMA = {
             "post_only": pa.bool_(),
             "reduce_only": pa.bool_(),
             # -- Options fields -- #
-            "price": pa.string(),
+            "price": pa.float64(),
             "trigger_price": pa.string(),
             "trigger_type": pa.dictionary(pa.int8(), pa.string()),
             "limit_offset": pa.string(),

--- a/nautilus_trader/system/kernel.pyx
+++ b/nautilus_trader/system/kernel.pyx
@@ -392,6 +392,7 @@ cdef class NautilusKernel:
             path=path,
             fs_protocol=config.fs_protocol,
             flush_interval=config.flush_interval,
+            logger=self.log
         )
         self.persistence_writers.append(writer)
         self.trader.subscribe("*", writer.write)

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -89,7 +89,7 @@ class TestPersistenceStreaming:
             "OrderBookDeltas": 1077,
             "OrderBookSnapshot": 1,
             "OrderFilled": 344,
-            "OrderInitialized": 1,
+            "OrderInitialized": 323,
             "OrderSubmitted": 323,
             "PositionChanged": 343,
             "PositionOpened": 1,


### PR DESCRIPTION
- Fix a bug persisting OrderInitialized events.
- Replace prints with proper logger
- Log errors on failed persistence write
- Don't log repeatedly for missing writers