### PR TITLE
Publish signal

### DIFF
--- a/examples/notebooks/Untitled.ipynb
+++ b/examples/notebooks/Untitled.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "865d1598-73f2-4678-99be-5db41eddd8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nautilus_trader "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "331caaac-da34-4136-9195-b60a164f86bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = \"Test\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "539cd9bb-4f53-4240-b3f5-8b813785e76d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5190bd86-5f4b-487f-8a47-a8be2ffd0b38",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b231a0af-d417-4b05-a63f-5705bc195e50",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b8f5a5f-aecd-4de8-be5d-0f3b0226f39f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86871cb2-3844-4a1a-b788-67dc7a414e3c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96dfcf84-403f-4c36-afc2-08d8a5c82265",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7621074-30c6-4e7f-aaea-9ac25dbe7f3f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (nautilus_trader)",
+   "language": "python",
+   "name": "nautilus_trader"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -47,6 +47,7 @@ from nautilus_trader.msgbus.bus cimport MessageBus
 
 cdef class Actor(Component):
     cdef set _warning_events
+    cdef dict _signal_classes
 
     cdef readonly Clock clock
     """The actors clock.\n\n:returns: `Clock`"""
@@ -133,6 +134,7 @@ cdef class Actor(Component):
     cpdef void unsubscribe_bars(self, BarType bar_type, ClientId client_id=*) except *
     cpdef void unsubscribe_venue_status_updates(self, Venue venue, ClientId client_id=*) except *
     cpdef void publish_data(self, DataType data_type, Data data) except *
+    cpdef void publish_signal(self, str name, int ts_init, object value, bint stream=*) except *
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -68,6 +68,8 @@ from nautilus_trader.model.orderbook.data cimport OrderBookData
 from nautilus_trader.model.orderbook.data cimport OrderBookSnapshot
 from nautilus_trader.msgbus.bus cimport MessageBus
 
+from nautilus_trader.persistence.streaming import generate_signal_class
+
 
 cdef class Actor(Component):
     """
@@ -1336,22 +1338,10 @@ cdef class Actor(Component):
         Condition.true(self.trader_id is not None, "The actor has not been registered")
 
         if name not in self._signal_classes:
-            self._signal_classes[name] = self._generate_signal_class(name=name)
+            self._signal_classes[name] = generate_signal_class(name=name)
         cls = self._signal_classes[name]
         data = cls(ts_init=ts_init, value=value)
         self.publish_data(data_type=DataType(cls), data=data)
-
-    def _generate_signal_class(self, name: str):
-        """
-        Dynamically create a Data subclass for this signal
-        """
-        class SignalData(Data):
-            def __init__(self, value, ts_init: int):
-                super().__init__(ts_init=ts_init, ts_event=ts_init)
-                self.value = value
-
-        SignalData.__name__ = f"Signal{name}"
-        return SignalData
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1336,7 +1336,7 @@ cdef class Actor(Component):
         Condition.true(self.trader_id is not None, "The actor has not been registered")
 
         if name not in self._signal_classes:
-            self._signal_classes[name] = self._generate_signal_class(name=name, value=value)
+            self._signal_classes[name] = self._generate_signal_class(name=name)
         cls = self._signal_classes[name]
         data = cls(ts_init=ts_init, value=value)
         self.publish_data(data_type=DataType(cls), data=data)

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1347,6 +1347,7 @@ cdef class Actor(Component):
         from nautilus_trader.serialization.arrow.serializer import register_parquet
 
         def init(self, value, ts_init: int):
+            super().__init__(ts_init=ts_init, ts_event=ts_init)
             self.value = value
             self.ts_init=  ts_init
 

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1345,17 +1345,13 @@ cdef class Actor(Component):
         """
         Dynamically create a Data subclass for this signal
         """
-        def inner():
+        class SignalData(Data):
+            def __init__(self, value, ts_init: int):
+                super().__init__(ts_init=ts_init, ts_event=ts_init)
+                self.value = value
 
-            class SignalData(Data):
-                def __init__(self, value, ts_init: int):
-                    super().__init__(ts_init=ts_init, ts_event=ts_init)
-                    self.value = value
-
-            SignalData.__name__ = f"Signal{name}"
-            return SignalData
-
-        return inner()
+        SignalData.__name__ = f"Signal{name}"
+        return SignalData
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1336,12 +1336,12 @@ cdef class Actor(Component):
         Condition.true(self.trader_id is not None, "The actor has not been registered")
 
         if name not in self._signal_classes:
-            self._signal_classes[name] = self.setup_signal_persistence(name=name, value=value)
+            self._signal_classes[name] = self._generate_signal_class(name=name, value=value)
         cls = self._signal_classes[name]
         data = cls(ts_init=ts_init, value=value)
         self.publish_data(data_type=DataType(cls), data=data)
 
-    def setup_signal_persistence(self, name: str, value: object):
+    def _generate_signal_class(self, name: str):
         """
         Dynamically create a Data subclass for this signal
         """
@@ -1352,7 +1352,7 @@ cdef class Actor(Component):
                     super().__init__(ts_init=ts_init, ts_event=ts_init)
                     self.value = value
 
-            SignalData.__name__ = f"Signal-{name}"
+            SignalData.__name__ = f"Signal{name}"
             return SignalData
 
         return inner()

--- a/nautilus_trader/persistence/streaming.py
+++ b/nautilus_trader/persistence/streaming.py
@@ -208,3 +208,17 @@ class StreamingFeatherWriter:
             del self._writers[cls]
         for cls in self._files:
             self._files[cls].close()
+
+
+def generate_signal_class(name: str):
+    """
+    Dynamically create a Data subclass for this signal
+    """
+
+    class SignalData(Data):
+        def __init__(self, value, ts_init: int):
+            super().__init__(ts_init=ts_init, ts_event=ts_init)
+            self.value = value
+
+    SignalData.__name__ = f"Signal{name.title()}"
+    return SignalData

--- a/nautilus_trader/persistence/streaming.py
+++ b/nautilus_trader/persistence/streaming.py
@@ -23,6 +23,7 @@ from pyarrow import RecordBatchStreamWriter
 
 from nautilus_trader.common.logging import LoggerAdapter
 from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.core.data import Data
 from nautilus_trader.core.inspect import is_nautilus_class
 from nautilus_trader.model.data.base import GenericData
 from nautilus_trader.model.orderbook.data import OrderBookData
@@ -32,6 +33,7 @@ from nautilus_trader.model.orderbook.data import OrderBookSnapshot
 from nautilus_trader.serialization.arrow.serializer import ParquetSerializer
 from nautilus_trader.serialization.arrow.serializer import get_cls_table
 from nautilus_trader.serialization.arrow.serializer import list_schemas
+from nautilus_trader.serialization.arrow.serializer import register_parquet
 from nautilus_trader.serialization.arrow.util import GENERIC_DATA_PREFIX
 from nautilus_trader.serialization.arrow.util import list_dicts_to_dict_lists
 
@@ -105,6 +107,29 @@ class StreamingFeatherWriter:
             self._files[cls] = f
             self._writers[table_name] = pa.ipc.new_stream(f, schema)
 
+    def handle_signal(self, signal: Data):
+        def serialize(self):
+            return {
+                "ts_init": self.ts_init,
+                "value": self.value,
+            }
+
+        register_parquet(
+            cls=type(signal),
+            serializer=serialize,
+            schema=pa.schema(
+                {
+                    "ts_init": pa.int64(),
+                    "value": {int: pa.int64(), float: pa.float64(), str: pa.string()}[
+                        type(signal.value)
+                    ],
+                }
+            ),
+        )
+        # Refresh schemas, create writer for new table
+        self._schemas = list_schemas()
+        self._create_writers()
+
     def write(self, obj: object) -> None:
         """
         Write the object to the stream.
@@ -127,10 +152,14 @@ class StreamingFeatherWriter:
             cls = obj.data_type.type
         table = get_cls_table(cls).__name__
         if table not in self._writers:
-            if cls not in self.missing_writers:
+            if table.startswith("Signal-"):
+                self.handle_signal(obj)
+            elif cls not in self.missing_writers:
                 self.logger.warning(f"Can't find writer for cls: {cls}")
                 self.missing_writers.add(cls)
-            return
+                return
+            else:
+                return
         writer: RecordBatchStreamWriter = self._writers[table]
         serialized = ParquetSerializer.serialize(obj)
         if isinstance(serialized, dict):

--- a/nautilus_trader/persistence/streaming.py
+++ b/nautilus_trader/persistence/streaming.py
@@ -156,7 +156,7 @@ class StreamingFeatherWriter:
             cls = obj.data_type.type
         table = get_cls_table(cls).__name__
         if table not in self._writers:
-            if table.startswith("Signal-"):
+            if table.startswith("Signal"):
                 self.handle_signal(obj)
             elif cls not in self.missing_writers:
                 self.logger.warning(f"Can't find writer for cls: {cls}")

--- a/tests/unit_tests/common/test_common_actor.py
+++ b/tests/unit_tests/common/test_common_actor.py
@@ -1559,10 +1559,10 @@ class TestActor:
         self.msgbus.subscribe("data*", writer.write)
 
         # Act
-        actor.publish_signal(name="test", ts_init=0, value=5.0)
+        actor.publish_signal(name="Test", ts_init=0, value=5.0)
 
         # Assert
-        assert (catalog.path / "data" / "test.feather").exists()
+        assert catalog.fs.exists(str(catalog.path / "SignalTest.feather"))
 
     def test_subscribe_bars(self):
         # Arrange

--- a/tests/unit_tests/common/test_common_actor.py
+++ b/tests/unit_tests/common/test_common_actor.py
@@ -1559,7 +1559,7 @@ class TestActor:
         self.msgbus.subscribe("data*", writer.write)
 
         # Act
-        actor.publish_signal(name="Test", ts_init=0, value=5.0)
+        actor.publish_signal(name="Test", ts_init=0, value=5.0, stream=True)
 
         # Assert
         assert catalog.fs.exists(str(catalog.path / "SignalTest.feather"))

--- a/tests/unit_tests/common/test_common_actor.py
+++ b/tests/unit_tests/common/test_common_actor.py
@@ -1506,7 +1506,7 @@ class TestActor:
 
         # Act, Assert
         with pytest.raises(KeyError):
-            actor.publish_signal(name="test", value=dict(a=1))
+            actor.publish_signal(name="test", value=dict(a=1), ts_init=0)
 
     def test_publish_signal_sends_to_subscriber(self):
         # Arrange
@@ -1527,10 +1527,13 @@ class TestActor:
 
         # Act
         value = 5.0
-        actor.publish_signal(name="test", value=value)
+        actor.publish_signal(name="test", value=value, ts_init=0)
 
         # Assert
-        assert value in handler
+        msg = handler[0]
+        assert isinstance(msg, Data)
+        assert msg.ts_init == 0
+        assert msg.value == value
 
     def test_publish_data_persist(self):
         # Arrange

--- a/tests/unit_tests/common/test_common_actor.py
+++ b/tests/unit_tests/common/test_common_actor.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
-
+import sys
 from datetime import timedelta
 
 import pytest
@@ -1535,6 +1535,7 @@ class TestActor:
         assert msg.ts_init == 0
         assert msg.value == value
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="test path broken on Windows")
     def test_publish_data_persist(self):
         # Arrange
         actor = MockActor()

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -23,10 +23,12 @@ from nautilus_trader.backtest.node import BacktestNode
 from nautilus_trader.config import BacktestDataConfig
 from nautilus_trader.config import BacktestEngineConfig
 from nautilus_trader.config import BacktestRunConfig
+from nautilus_trader.core.data import Data
 from nautilus_trader.model.data.venue import InstrumentStatusUpdate
 from nautilus_trader.persistence.catalog import DataCatalog
 from nautilus_trader.persistence.external.core import process_files
 from nautilus_trader.persistence.external.readers import CSVReader
+from nautilus_trader.persistence.streaming import generate_signal_class
 from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 from tests.test_kit import PACKAGE_ROOT
 from tests.test_kit.mocks.data import NewsEventData
@@ -135,3 +137,11 @@ class TestPersistenceStreaming:
         )
         result = Counter([r.__class__.__name__ for r in result])
         assert result["NewsEventData"] == 86985
+
+    def test_generate_signal_class(self):
+        cls = generate_signal_class(name="test")
+        instance = cls(value=5.0, ts_init=0)
+        assert isinstance(instance, Data)
+        assert instance.value == 5.0
+        assert instance.ts_init == 0
+        assert instance.ts_event == 0


### PR DESCRIPTION
# Pull Request

This PR adds a `publish_signal` method to the `Actor` class. This allows easier publishing / persisting of simple values when prototyping ideas in a trading strategy.

An `Actor` or `Strategy` can publish (and optionally persist by setting `stream=True`) by calling: 

```python
strategy = Strategy()
strategy.publish_signal(name="Test", ts_init=0, value=5.0, stream=False)
```
The signal will be published with the prefix `Signal`, and as such can be subscribed to via the `msgbus` using:

```python
self.msgbus.subscribe("data.SignalTest")
```

And if `stream=True`, the signal will be persisted into the `DataCatalog` as `SignalTest.feather`, alongside other streaming data.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?
3x tests added