### PR TITLE
Fix PositionStatusReport net_qty sign

### DIFF
--- a/nautilus_trader/execution/reports.pyx
+++ b/nautilus_trader/execution/reports.pyx
@@ -413,7 +413,7 @@ cdef class PositionStatusReport(ExecutionReport):
         self.venue_position_id = venue_position_id
         self.position_side = position_side
         self.quantity = quantity
-        self.net_qty = -self.quantity.as_f64_c() if quantity._mem.raw < 0 else self.quantity.as_f64_c()
+        self.net_qty = -self.quantity.as_f64_c() if position_side == PositionSide.SHORT else self.quantity.as_f64_c()
         self.ts_last = ts_last
 
     def __repr__(self) -> str:

--- a/tests/unit_tests/execution/test_execution_reports.py
+++ b/tests/unit_tests/execution/test_execution_reports.py
@@ -125,26 +125,47 @@ class TestExecutionReports:
 
     def test_instantiate_position_status_report(self):
         # Arrange, Act
-        report_id = UUID4()
-        report = PositionStatusReport(
+        report_id1 = UUID4()
+        report1 = PositionStatusReport(
             account_id=AccountId("SIM", "001"),
             instrument_id=AUDUSD_IDEALPRO,
             venue_position_id=PositionId("1"),
             position_side=PositionSide.LONG,
             quantity=Quantity.from_int(1_000_000),
-            report_id=report_id,
+            report_id=report_id1,
+            ts_last=0,
+            ts_init=0,
+        )
+
+        report_id2 = UUID4()
+        report2 = PositionStatusReport(
+            account_id=AccountId("SIM", "001"),
+            instrument_id=AUDUSD_IDEALPRO,
+            venue_position_id=PositionId("2"),
+            position_side=PositionSide.SHORT,
+            quantity=Quantity.from_int(1_000_000),
+            report_id=report_id2,
             ts_last=0,
             ts_init=0,
         )
 
         # Assert
         assert (
-            str(report)
-            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=1, position_side=LONG, quantity=1_000_000, net_qty=1000000.0, report_id={report_id}, ts_last=0, ts_init=0)"  # noqa
+            str(report1)
+            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=1, position_side=LONG, quantity=1_000_000, net_qty=1000000.0, report_id={report_id1}, ts_last=0, ts_init=0)"  # noqa
         )
         assert (
-            repr(report)
-            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=1, position_side=LONG, quantity=1_000_000, net_qty=1000000.0, report_id={report_id}, ts_last=0, ts_init=0)"  # noqa
+            repr(report1)
+            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=1, position_side=LONG, quantity=1_000_000, net_qty=1000000.0, report_id={report_id1}, ts_last=0, ts_init=0)"  # noqa
+        )
+
+        assert (
+            str(report2)
+            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=2, position_side=SHORT, quantity=1_000_000, net_qty=-1000000.0, report_id={report_id2}, ts_last=0, ts_init=0)"  # noqa
+        )
+        assert (
+            repr(report2)
+            == f"PositionStatusReport(account_id=SIM-001, instrument_id=AUD/USD.IDEALPRO, venue_position_id=2, position_side=SHORT, quantity=1_000_000, net_qty=-1000000.0, report_id={report_id2}, ts_last=0, ts_init=0)"  # noqa
         )
 
     def test_instantiate_execution_mass_status_report(self):


### PR DESCRIPTION
# Pull Request

Quantity object can't be negative, `PositionStatusReport.net_qty` will always be positive here.
https://github.com/nautechsystems/nautilus_trader/blob/5446cb7fe12a8bc9477997f2c71bc20eaf3bfc33/nautilus_trader/execution/reports.pyx#L416
Please include a summary of the changes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## How has this change been tested?

Tests added. (pytests can't run on my local env, it reports segmentation fault, will check later
