### PR TITLE
Rust ffi methods for monotonic time

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -396,6 +396,7 @@ name = "nautilus_core"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
+ "lazy_static",
  "pyo3",
  "uuid",
 ]

--- a/nautilus_core/core/Cargo.toml
+++ b/nautilus_core/core/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["rlib", "staticlib"]
 cbindgen = "^0.20.0"
 pyo3 = "^0.16.5"
 uuid = { version = "^0.8.2", features = ["v4"] }
+lazy_static = "1.4.0"
 
 [build-dependencies]
 cbindgen = "^0.20.0"

--- a/nautilus_core/core/src/time.rs
+++ b/nautilus_core/core/src/time.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use lazy_static::lazy_static;
+use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -22,9 +24,41 @@ pub type Timestamp = u64;
 /// Represents a timedelta in nanoseconds.
 pub type Timedelta = i64;
 
+/// A static reference to an instant of system time.
+/// This is used to calculated monotonic durations
+/// of elapsed time.
+lazy_static! {
+    pub static ref INSTANT: Instant = Instant::now();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // C API
 ////////////////////////////////////////////////////////////////////////////////
+
+/// Returns monotonic time elapsed from given instant
+#[no_mangle]
+pub extern "C" fn mono_unix_timestamp() -> f64 {
+    INSTANT.elapsed().as_secs_f64()
+}
+
+/// Returns monotonic time elapsed from given instant in milliseconds
+#[no_mangle]
+pub extern "C" fn mono_unix_timestamp_ms() -> u64 {
+    INSTANT.elapsed().as_millis() as u64
+}
+
+/// Returns monotonic time elapsed from given instant in microseconds
+#[no_mangle]
+pub extern "C" fn mono_unix_timestamp_us() -> u64 {
+    INSTANT.elapsed().as_micros() as u64
+}
+
+/// Returns monotonic time elapsed from given instant in nanoseconds
+#[no_mangle]
+pub extern "C" fn mono_unix_timestamp_ns() -> u64 {
+    INSTANT.elapsed().as_nanos() as u64
+}
+
 /// Returns the current seconds since the UNIX epoch.
 #[no_mangle]
 pub extern "C" fn unix_timestamp() -> f64 {
@@ -132,5 +166,68 @@ mod tests {
         assert!(result4 >= result3);
         assert!(result5 >= result4);
         assert!(result1 > 1650000000000000000)
+    }
+
+    #[test]
+    fn test_mono_unix_timestamp_is_monotonic_increasing() {
+        let result1 = time::mono_unix_timestamp();
+        let result2 = time::mono_unix_timestamp();
+        let result3 = time::mono_unix_timestamp();
+        let result4 = time::mono_unix_timestamp();
+        let result5 = time::mono_unix_timestamp();
+
+        assert!(result2 >= result1);
+        assert!(result3 >= result2);
+        assert!(result4 >= result3);
+        assert!(result5 >= result4);
+        assert!(result1 > 0.0)
+    }
+
+    #[test]
+    #[allow(unused_comparisons)]
+    fn test_mono_unix_timestamp_ms_is_monotonic_increasing() {
+        let result1 = time::mono_unix_timestamp_ms();
+        let result2 = time::mono_unix_timestamp_ms();
+        let result3 = time::mono_unix_timestamp_ms();
+        let result4 = time::mono_unix_timestamp_ms();
+        let result5 = time::mono_unix_timestamp_ms();
+
+        assert!(result2 >= result1);
+        assert!(result3 >= result2);
+        assert!(result4 >= result3);
+        assert!(result5 >= result4);
+        // monotonic time elapsed may yield 0 because
+        // not enough time has passed since instant
+        assert!(result1 >= 0)
+    }
+
+    #[test]
+    fn test_mono_unix_timestamp_us_is_monotonic_increasing() {
+        let result1 = time::mono_unix_timestamp_us();
+        let result2 = time::mono_unix_timestamp_us();
+        let result3 = time::mono_unix_timestamp_us();
+        let result4 = time::mono_unix_timestamp_us();
+        let result5 = time::mono_unix_timestamp_us();
+
+        assert!(result2 >= result1);
+        assert!(result3 >= result2);
+        assert!(result4 >= result3);
+        assert!(result5 >= result4);
+        assert!(result1 > 0)
+    }
+
+    #[test]
+    fn test_mono_unix_timestamp_ns_is_monotonic_increasing() {
+        let result1 = time::mono_unix_timestamp_ns();
+        let result2 = time::mono_unix_timestamp_ns();
+        let result3 = time::mono_unix_timestamp_ns();
+        let result4 = time::mono_unix_timestamp_ns();
+        let result5 = time::mono_unix_timestamp_ns();
+
+        assert!(result2 >= result1);
+        assert!(result3 >= result2);
+        assert!(result4 >= result3);
+        assert!(result5 >= result4);
+        assert!(result1 > 0)
     }
 }

--- a/nautilus_trader/core/includes/core.h
+++ b/nautilus_trader/core/includes/core.h
@@ -12,6 +12,26 @@ typedef struct UUID4_t {
 } UUID4_t;
 
 /**
+ * Returns monotonic time elapsed from given instant
+ */
+double mono_unix_timestamp(void);
+
+/**
+ * Returns monotonic time elapsed from given instant in milliseconds
+ */
+uint64_t mono_unix_timestamp_ms(void);
+
+/**
+ * Returns monotonic time elapsed from given instant in microseconds
+ */
+uint64_t mono_unix_timestamp_us(void);
+
+/**
+ * Returns monotonic time elapsed from given instant in nanoseconds
+ */
+uint64_t mono_unix_timestamp_ns(void);
+
+/**
  * Returns the current seconds since the UNIX epoch.
  */
 double unix_timestamp(void);

--- a/nautilus_trader/core/rust/core.pxd
+++ b/nautilus_trader/core/rust/core.pxd
@@ -11,6 +11,18 @@ cdef extern from "../includes/core.h":
     cdef struct UUID4_t:
         String *value;
 
+    # Returns monotonic time elapsed from given instant
+    double mono_unix_timestamp();
+
+    # Returns monotonic time elapsed from given instant in milliseconds
+    uint64_t mono_unix_timestamp_ms();
+
+    # Returns monotonic time elapsed from given instant in microseconds
+    uint64_t mono_unix_timestamp_us();
+
+    # Returns monotonic time elapsed from given instant in nanoseconds
+    uint64_t mono_unix_timestamp_ns();
+
     # Returns the current seconds since the UNIX epoch.
     double unix_timestamp();
 


### PR DESCRIPTION
# Pull Request

Add Rust ffi methods for monotonic time for timestamp, ms, us, ns

## Type of change

- [ x ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Test cases for all 