### PR TITLE
Rust option example

### DIFF
--- a/nautilus_core/model/src/option_test/mod.rs
+++ b/nautilus_core/model/src/option_test/mod.rs
@@ -13,9 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod data;
-pub mod enums;
-pub mod identifiers;
-pub mod orderbook;
-pub mod types;
-pub mod option_test;
+pub mod option;

--- a/nautilus_core/model/src/option_test/option.rs
+++ b/nautilus_core/model/src/option_test/option.rs
@@ -1,0 +1,88 @@
+use crate::identifiers::instrument_id::InstrumentId;
+use pyo3::{ffi, FromPyPointer, Python, PyObject};
+use crate::types::price::Price;
+use pyo3::prelude::*;
+
+fn type_of<T>(_: &T) -> &'static str {
+    std::any::type_name::<T>()
+}
+
+/////////////////////////////////////////////
+/// Parse InstrumentId or Option<InstrumentId> from a PyObject
+use pyo3::prelude::PyResult;
+use pyo3::{
+    // Python, 
+    FromPyObject,
+    AsPyPointer
+};
+use crate::identifiers::instrument_id::instrument_id_from_pystrs;
+use pyo3::types::{PyTuple, PyAny};
+
+impl FromPyObject<'_> for InstrumentId {
+    fn extract(obj: &PyAny) -> PyResult<Self> {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let state = obj.call_method0("__getstate__").unwrap();
+        let tupl: &PyTuple = state
+                    .extract()
+                    .unwrap();
+        let instrument_id;
+        unsafe {
+            instrument_id = instrument_id_from_pystrs(
+                tupl.get_item(0).unwrap().as_ptr(),
+                tupl.get_item(1).unwrap().as_ptr()
+            );
+        }
+        Ok(instrument_id)
+    }
+}
+
+/////////////////////////////////////////////
+#[repr(C)]
+pub enum OptionTag {
+    None = 0,
+    Some = 1
+}
+
+#[repr(C)]
+pub struct Option_InstrumentId {
+    tag: OptionTag,
+    some: InstrumentId
+}
+
+#[repr(C)]
+pub struct Option_Price {
+    tag: OptionTag,
+    some: Price
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn pyobject_to_option_parse_test(
+    instrument_id_ptr: *mut ffi::PyObject,
+)
+{
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    
+    // .extract method: FromPyObject trait is implemented on InstrumentId
+    let instrument_id_option = 
+        PyObject::from_borrowed_ptr(py, instrument_id_ptr)
+        .extract::<Option<InstrumentId>>(py).unwrap();
+    
+    println!("{} | {:?} | {:?}", "instrument_id_option", instrument_id_option, type_of(&instrument_id_option));
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn create_instrument_id_option(
+) -> Option<InstrumentId>
+{
+    Some(InstrumentId::from("EUR/USD.DUKA"))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn create_price_option(
+) -> Option<Price>
+{
+    Some(Price::from("1.2345"))
+}

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -44,6 +44,11 @@ typedef enum CurrencyType {
     Fiat,
 } CurrencyType;
 
+typedef enum OptionTag {
+    None = 0,
+    Some = 1,
+} OptionTag;
+
 typedef enum OrderSide {
     Buy = 1,
     Sell = 2,
@@ -201,6 +206,16 @@ typedef struct Money_t {
     int64_t raw;
     struct Currency_t currency;
 } Money_t;
+
+typedef struct Option_InstrumentId {
+    enum OptionTag tag;
+    struct InstrumentId_t some;
+} Option_InstrumentId;
+
+typedef struct Option_Price {
+    enum OptionTag tag;
+    struct Price_t some;
+} Option_Price;
 
 /**
  * Returns a [BarSpecification] as a Python str.
@@ -737,3 +752,9 @@ void quantity_add_assign_u64(struct Quantity_t a, uint64_t b);
 void quantity_sub_assign(struct Quantity_t a, struct Quantity_t b);
 
 void quantity_sub_assign_u64(struct Quantity_t a, uint64_t b);
+
+void pyobject_to_option_parse_test(PyObject *instrument_id_ptr);
+
+struct Option_InstrumentId create_instrument_id_option(void);
+
+struct Option_Price create_price_option(void);

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -40,6 +40,10 @@ cdef extern from "../includes/model.h":
         Crypto,
         Fiat,
 
+    cdef enum OptionTag:
+        None # = 0,
+        Some # = 1,
+
     cdef enum OrderSide:
         Buy # = 1,
         Sell # = 2,
@@ -170,6 +174,14 @@ cdef extern from "../includes/model.h":
     cdef struct Money_t:
         int64_t raw;
         Currency_t currency;
+
+    cdef struct Option_InstrumentId:
+        OptionTag tag;
+        InstrumentId_t some;
+
+    cdef struct Option_Price:
+        OptionTag tag;
+        Price_t some;
 
     # Returns a [BarSpecification] as a Python str.
     #
@@ -633,3 +645,9 @@ cdef extern from "../includes/model.h":
     void quantity_sub_assign(Quantity_t a, Quantity_t b);
 
     void quantity_sub_assign_u64(Quantity_t a, uint64_t b);
+
+    void pyobject_to_option_parse_test(PyObject *instrument_id_ptr);
+
+    Option_InstrumentId create_instrument_id_option();
+
+    Option_Price create_price_option();

--- a/nautilus_trader/examples/run.py
+++ b/nautilus_trader/examples/run.py
@@ -1,0 +1,2 @@
+from test import main
+main()

--- a/nautilus_trader/examples/test.pyx
+++ b/nautilus_trader/examples/test.pyx
@@ -1,0 +1,49 @@
+from cpython.object cimport PyObject
+#from nautilus_trader.core.rust.model cimport StructWithOption
+#from nautilus_trader.core.rust.model cimport Option_InstrumentId
+from nautilus_trader.model.identifiers cimport InstrumentId
+from nautilus_trader.core.rust.model cimport pyobject_to_option_parse_test
+from nautilus_trader.core.rust.model cimport instrument_id_to_pystr
+from nautilus_trader.core.rust.model cimport create_price_option
+from nautilus_trader.core.rust.model cimport Option_InstrumentId
+from nautilus_trader.core.rust.model cimport Option_Price
+from nautilus_trader.core.rust.model cimport create_instrument_id_option
+
+cdef test_pyobject_to_option_parse():
+    # Test PyObject > Option<T> with value
+    cdef InstrumentId instrument_id
+    instrument_id = InstrumentId.from_str("EUR/USD.DUKA")
+    pyobject_to_option_parse_test(<PyObject *>instrument_id)
+
+    # Test PyObject > Option<T> with None
+    instrument_id = None
+    pyobject_to_option_parse_test(<PyObject *>instrument_id)
+
+cdef test_option_access_from_cython():
+    # Test access to Option<Price> from Cython
+    cdef Option_Price price_option = create_price_option()
+    print(price_option)
+    print(price_option.some)
+    print(price_option.some.raw, price_option.some.precision)
+
+
+    # Test access to Option<InstrumentId> from Cython
+    
+    # Can't print InstrumentId_t because it contains a string.
+    # ERROR: Cannot convert 'InstrumentId_t' to Python object   
+    cdef Option_InstrumentId instrument_id_option = create_instrument_id_option()
+    print(instrument_id_option.tag)
+    #print(instrument_id_option) # error
+    #print(instrument_id_option.some) # error
+    instrument_id_option.some
+    instrument_id_option.some.symbol
+    instrument_id_option.some.venue
+
+cpdef main():
+    test_pyobject_to_option_parse()
+    test_option_access_from_cython()
+
+    
+  
+      
+

--- a/nautilus_trader/examples/test.pyx
+++ b/nautilus_trader/examples/test.pyx
@@ -1,6 +1,4 @@
 from cpython.object cimport PyObject
-#from nautilus_trader.core.rust.model cimport StructWithOption
-#from nautilus_trader.core.rust.model cimport Option_InstrumentId
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.core.rust.model cimport pyobject_to_option_parse_test
 from nautilus_trader.core.rust.model cimport instrument_id_to_pystr
@@ -30,7 +28,7 @@ cdef test_option_access_from_cython():
     # Test access to Option<InstrumentId> from Cython
     
     # Can't print InstrumentId_t because it contains a string.
-    # ERROR: Cannot convert 'InstrumentId_t' to Python object   
+    # ERROR: Cannot convert 'InstrumentId_t' to Python object
     cdef Option_InstrumentId instrument_id_option = create_instrument_id_option()
     print(instrument_id_option.tag)
     #print(instrument_id_option) # error


### PR DESCRIPTION
# Pull Request

A working of example to parse Option<T> directly from the *mut PyObject without propagating the Option concept up into Cython. Also shows accessing Option<T> from Cython.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?


