### PR TITLE
Set backtest leverage options

### DIFF
--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -181,6 +181,8 @@ class BacktestNode:
                 starting_balances=[Money.from_str(m) for m in config.starting_balances],
                 book_type=BookTypeParser.from_str_py(config.book_type),
                 routing=config.routing,
+                default_leverage=Decimal(config.default_leverage),
+                leverages={InstrumentId.from_str(i): Decimal(v) for i, v in config.leverages} if config.leverages else {}
             )
 
         return engine

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from decimal import Decimal
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -182,7 +183,9 @@ class BacktestNode:
                 book_type=BookTypeParser.from_str_py(config.book_type),
                 routing=config.routing,
                 default_leverage=Decimal(config.default_leverage),
-                leverages={InstrumentId.from_str(i): Decimal(v) for i, v in config.leverages} if config.leverages else {}
+                leverages={InstrumentId.from_str(i): Decimal(v) for i, v in config.leverages}
+                if config.leverages
+                else {},
             )
 
         return engine

--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -102,6 +102,8 @@ class BacktestVenueConfig(Partialable):
     starting_balances: List[str]
     book_type: str = "L1_TBBO"
     routing: bool = False
+    default_leverage: float = 1.0
+    leverages: Optional[Dict[str, float]] = None 
     # fill_model: Optional[FillModel] = None  # TODO(cs): Implement next iteration
     # modules: Optional[List[SimulationModule]] = None  # TODO(cs): Implement next iteration
 

--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -117,6 +117,8 @@ class BacktestVenueConfig(Partialable):
             ",".join(sorted([b for b in self.starting_balances])),
             self.book_type,
             self.routing,
+            self.default_leverage,
+            self.leverages,
             # self.modules,  # TODO(cs): Implement next iteration
         ]
         return tuple(values)

--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -103,7 +103,7 @@ class BacktestVenueConfig(Partialable):
     book_type: str = "L1_TBBO"
     routing: bool = False
     default_leverage: float = 1.0
-    leverages: Optional[Dict[str, float]] = None 
+    leverages: Optional[Dict[str, float]] = None
     # fill_model: Optional[FillModel] = None  # TODO(cs): Implement next iteration
     # modules: Optional[List[SimulationModule]] = None  # TODO(cs): Implement next iteration
 


### PR DESCRIPTION
# Pull Request

Changes to accommodate setting venue leverage options.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested?

Re-ran backtest examples after setting `default_leverage` and `leverages`. No errors were encountered. 
