### PR TITLE
Adding a encoding to the bytes() function

### DIFF
--- a/nautilus_trader/persistence/external/readers.py
+++ b/nautilus_trader/persistence/external/readers.py
@@ -289,7 +289,7 @@ class CSVReader(Reader):
             if self.chunked:
                 chunks = (process,)
             else:
-                chunks = tuple([dict(zip(self.header, line.split(bytes(self.separator)))) for line in process.split(b"\n")])  # type: ignore
+                chunks = tuple([dict(zip(self.header, line.split(bytes(self.separator,encoding='utf-8')))) for line in process.split(b"\n")])  # type: ignore
 
         for chunk in chunks:
             if self.instrument_provider_update is not None:


### PR DESCRIPTION
In some cases, without the encoding argument, bytes() function complains about it and failed violently.

# Pull Request

[JM] An addition of small piece of code on the byte() function. Without the "encoding=<xxx>" argument, byte() complains about the missing argument in some cases when I trying to load data from the "histdata.com".

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested by loading a downloaded file from the "histdata.com", and invoked the "nautilus_trader.persistence.external.core::process_files(...)" to be confirmed. The "histdata.com" data refers to the 2022/08 GBP/JPY zipped dataset.
