### PR TITLE
Add missing exchange info when specify specific intruments to load (documentation)

### DIFF
--- a/docs/user_guide/adapters.md
+++ b/docs/user_guide/adapters.md
@@ -66,7 +66,7 @@ InstrumentProviderConfig(load_all=True)
 - Only those instruments explicitly specified in the configuration are loaded on start:
 
 ```python
-InstrumentProviderConfig(load_ids=["BTCUSDT-PERP", "ETHUSDT-PERP"])
+InstrumentProviderConfig(load_ids=["BTCUSDT-PERP.FTX", "ETHUSDT-PERP.FTX"])
 ```
 
 ## Data Clients


### PR DESCRIPTION
# Pull Request

Fix missing exchange lead to :

```
Task exception was never retrieved
future: <Task finished name='Task-7' coro=<FTXDataClient._connect() done, defined at /usr/local/pip-global/nautilus_trader/adapters/ftx/data.py:134> exception=ValueError('The InstrumentId string value was malformed, was ETH-PERP')>
Traceback (most recent call last):
  File "/usr/local/pip-global/nautilus_trader/adapters/ftx/data.py", line 139, in _connect
    await self._instrument_provider.initialize()
  File "/usr/local/pip-global/nautilus_trader/common/providers.py", line 163, in initialize
    instrument_ids = [InstrumentId.from_str(i) for i in self._load_ids_on_start]
  File "/usr/local/pip-global/nautilus_trader/common/providers.py", line 163, in <listcomp>
    instrument_ids = [InstrumentId.from_str(i) for i in self._load_ids_on_start]
  File "nautilus_trader/model/identifiers.pyx", line 296, in nautilus_trader.model.identifiers.InstrumentId.from_str
  File "nautilus_trader/model/identifiers.pyx", line 265, in nautilus_trader.model.identifiers.InstrumentId.from_str_c
ValueError: The InstrumentId string value was malformed, was ETH-PERP
```

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Manually.
