### PR TITLE
Load quote ticks as dataframe. use_rust=True, as_nautilus=False

### DIFF
--- a/nautilus_trader/model/objects.pyx
+++ b/nautilus_trader/model/objects.pyx
@@ -31,7 +31,7 @@ from libc.stdint cimport uint8_t
 from libc.stdint cimport uint64_t
 
 from nautilus_trader.core.correctness cimport Condition
-from nautilus_trader.core.rust.model cimport FIXED_SCALAR
+from nautilus_trader.core.rust.model cimport FIXED_SCALAR as RUST_FIXED_SCALAR
 from nautilus_trader.core.rust.model cimport MONEY_MAX as RUST_MONEY_MAX
 from nautilus_trader.core.rust.model cimport MONEY_MIN as RUST_MONEY_MIN
 from nautilus_trader.core.rust.model cimport PRICE_MAX as RUST_PRICE_MAX
@@ -61,6 +61,7 @@ PRICE_MIN = RUST_PRICE_MIN
 MONEY_MAX = RUST_MONEY_MAX
 MONEY_MIN = RUST_MONEY_MIN
 
+FIXED_SCALAR = RUST_FIXED_SCALAR
 
 @cython.auto_pickle(True)
 cdef class Quantity:
@@ -220,7 +221,7 @@ cdef class Quantity:
         return hash(self._mem.raw)
 
     def __str__(self) -> str:
-        return f"{self._mem.raw / FIXED_SCALAR:.{self._mem.precision}f}"
+        return f"{self._mem.raw / RUST_FIXED_SCALAR:.{self._mem.precision}f}"
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}('{self}')"
@@ -286,11 +287,11 @@ cdef class Quantity:
         return self._mem.raw
 
     cdef double as_f64_c(self) except *:
-        return self._mem.raw / FIXED_SCALAR
+        return self._mem.raw / RUST_FIXED_SCALAR
 
     @staticmethod
     cdef double raw_to_f64_c(uint64_t raw) except *:
-        return raw / FIXED_SCALAR
+        return raw / RUST_FIXED_SCALAR
 
     @staticmethod
     def raw_to_f64(raw) -> float:
@@ -611,7 +612,7 @@ cdef class Price:
         return hash(self._mem.raw)
 
     def __str__(self) -> str:
-        return f"{self._mem.raw / FIXED_SCALAR:.{self._mem.precision}f}"
+        return f"{self._mem.raw / RUST_FIXED_SCALAR:.{self._mem.precision}f}"
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}('{self}')"
@@ -683,7 +684,7 @@ cdef class Price:
         return self._mem.raw
 
     cdef double as_f64_c(self) except *:
-        return self._mem.raw / FIXED_SCALAR
+        return self._mem.raw / RUST_FIXED_SCALAR
 
     @staticmethod
     cdef object _extract_decimal(object obj):
@@ -709,7 +710,7 @@ cdef class Price:
 
     @staticmethod
     cdef double raw_to_f64_c(uint64_t raw) except *:
-        return raw / FIXED_SCALAR
+        return raw / RUST_FIXED_SCALAR
 
     @staticmethod
     def raw_to_f64(raw) -> float:
@@ -954,7 +955,7 @@ cdef class Money:
         return hash((self._mem.raw, self.currency.code))
 
     def __str__(self) -> str:
-        return f"{self._mem.raw / FIXED_SCALAR:.{self._mem.currency.precision}f}"
+        return f"{self._mem.raw / RUST_FIXED_SCALAR:.{self._mem.currency.precision}f}"
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}('{str(self)}', {self.currency.code})"
@@ -990,11 +991,11 @@ cdef class Money:
         return self._mem.raw
 
     cdef double as_f64_c(self):
-        return self._mem.raw / FIXED_SCALAR
+        return self._mem.raw / RUST_FIXED_SCALAR
 
     @staticmethod
     cdef double raw_to_f64_c(uint64_t raw) except *:
-        return raw / FIXED_SCALAR
+        return raw / RUST_FIXED_SCALAR
 
     @staticmethod
     def from_raw(uint64_t raw, uint8_t precision):

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -51,8 +51,7 @@ def int_to_float_dataframe(df: pd.DataFrame):
                 or dtype == np.uint64
                 and (col != "ts_event" and col != "ts_init")
     ]
-    for col in cols:
-        df[col] = df[col] / FIXED_SCALAR
+    df[cols] = df[cols] / FIXED_SCALAR
     return df
 
 class ParquetDataCatalog(BaseDataCatalog):

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -20,6 +20,7 @@ import platform
 from typing import Callable, Dict, List, Optional, Union
 
 import fsspec
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -32,6 +33,7 @@ from nautilus_trader.model.data.base import DataType
 from nautilus_trader.model.data.base import GenericData
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.data.tick import TradeTick
+from nautilus_trader.model.objects import FIXED_SCALAR
 from nautilus_trader.persistence.catalog.base import BaseDataCatalog
 from nautilus_trader.persistence.catalog.rust.reader import ParquetFileReader
 from nautilus_trader.persistence.external.metadata import load_mappings
@@ -142,12 +144,31 @@ class ParquetDataCatalog(BaseDataCatalog):
                 return pd.DataFrame() if as_dataframe else None
 
         dataset = ds.dataset(full_path, partitioning="hive", filesystem=self.fs)
+
         table_kwargs = table_kwargs or {}
         if projections:
             projected = {**{c: ds.field(c) for c in dataset.schema.names}, **projections}
             table_kwargs.update(columns=projected)
         table = dataset.to_table(filter=combine_filters(*filters), **(table_kwargs or {}))
         mappings = self.load_inverse_mappings(path=full_path)
+
+        if (
+            cls in (QuoteTick, TradeTick)
+            and kwargs.get("use_rust")
+            and not kwargs.get("as_nautilus")
+        ):
+            schema = dataset.schema
+            cols = [
+                name
+                for name, t in zip(schema.names, schema.types)
+                if t.to_pandas_dtype() == np.int64
+                or t.to_pandas_dtype() == np.uint64
+                and (name != "ts_event" and name != "ts_init")
+            ]
+            df = table.to_pandas()
+            for col in cols:
+                df[col] = df[col] / FIXED_SCALAR
+            return df
 
         if cls in (QuoteTick, TradeTick) and kwargs.get("use_rust"):
             ticks = []


### PR DESCRIPTION
Load quotes ticks as pd.DataFrame using the use_rust=True, as_nautilus=False arguments in the ParquetDataCatalog.

- [ x] New feature (non-breaking change which adds functionality)

## How has this change been tested?
Test added: test_data_catalog_quote_ticks_use_rust
The length, type and values of the dataframe contents are asserted.
