### PR TITLE
Add metadata to BacktestDataConfig

### DIFF
--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -143,6 +143,7 @@ class BacktestDataConfig(Partialable):
     end_time: Optional[Union[datetime, str, int]] = None
     filter_expr: Optional[str] = None
     client_id: Optional[str] = None
+    metadata: Optional[Dict] = None
 
     def __post_init__(self):
         if not isinstance(self.data_cls, str):
@@ -201,6 +202,7 @@ class BacktestDataConfig(Partialable):
                 "start": start_time or query["start"],
                 "end": end_time or query["end"],
                 "filter_expr": parse_filters_expr(query.pop("filter_expr", "None")),
+                "metadata": self.metadata,
             }
         )
 

--- a/nautilus_trader/persistence/catalog/base.py
+++ b/nautilus_trader/persistence/catalog/base.py
@@ -286,6 +286,7 @@ class BaseDataCatalog(ABC, metaclass=_CombinedMeta):
         cls: type,
         filter_expr: Optional[Callable] = None,
         as_nautilus: bool = False,
+        metadata: Optional[Dict] = None,
         **kwargs,
     ):
         data = self._query(
@@ -297,7 +298,7 @@ class BaseDataCatalog(ABC, metaclass=_CombinedMeta):
         if as_nautilus:
             if data is None:
                 return []
-            return [GenericData(data_type=DataType(cls), data=d) for d in data]
+            return [GenericData(data_type=DataType(cls, metadata=metadata), data=d) for d in data]
         return data
 
     @abstractmethod

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -190,11 +190,13 @@ class TestBacktestConfig:
             catalog_fs_protocol="memory",
             data_cls=NewsEventData,
             client_id="NewsClient",
+            metadata={"kind": "news"},
         )
         result = c.load()
         assert len(result["data"]) == 86985
         assert result["instrument"] is None
         assert result["client_id"] == ClientId("NewsClient")
+        assert result["data"][0].data_type.metadata == {"kind": "news"}
 
     def test_backtest_data_config_filters(self):
         # Arrange


### PR DESCRIPTION
Allow passing metdata through to GenericData class for BacktestDataConfig