### PR TITLE
Fix dropping CVec to prevent memory leak

### DIFF
--- a/nautilus_core/core/src/cvec.rs
+++ b/nautilus_core/core/src/cvec.rs
@@ -72,7 +72,9 @@ impl<T> From<Vec<T>> for CVec {
 
 #[no_mangle]
 pub extern "C" fn cvec_drop(cvec: CVec) {
-    drop(cvec) // Memory freed here
+    let CVec { ptr, len, cap } = cvec;
+    let data: Vec<u8> = unsafe { Vec::from_raw_parts(ptr as *mut u8, len, cap) };
+    drop(data) // Memory freed here
 }
 
 #[no_mangle]

--- a/nautilus_core/persistence/src/parquet/mod.rs
+++ b/nautilus_core/persistence/src/parquet/mod.rs
@@ -480,11 +480,11 @@ pub unsafe extern "C" fn parquet_reader_drop_chunk(chunk: CVec, reader_type: Par
     let CVec { ptr, len, cap } = chunk;
     match reader_type {
         ParquetType::QuoteTick => {
-            let data: Vec<u64> = Vec::from_raw_parts(ptr as *mut u64, len, cap);
+            let data: Vec<QuoteTick> = Vec::from_raw_parts(ptr as *mut QuoteTick, len, cap);
             drop(data);
         }
         ParquetType::TradeTick => {
-            let data: Vec<u64> = Vec::from_raw_parts(ptr as *mut u64, len, cap);
+            let data: Vec<TradeTick> = Vec::from_raw_parts(ptr as *mut TradeTick, len, cap);
             drop(data);
         }
     }

--- a/nautilus_core/persistence/tests/test_parquet_reader.rs
+++ b/nautilus_core/persistence/tests/test_parquet_reader.rs
@@ -13,46 +13,47 @@
 // //  limitations under the License.
 // // -------------------------------------------------------------------------------------------------
 //
-// use pyo3::{AsPyPointer, prelude::*, types::*};
-//
-// use nautilus_core::cvec::CVec;
-// use nautilus_persistence::c_api::quote_tick::{
-//     parquet_reader_drop, parquet_reader_drop_chunk, parquet_reader_new, parquet_reader_next_chunk,
-//     ParquetReaderType,
-// };
-//
-// mod test_util;
-//
-// #[test]
-// #[allow(unused_assignments)]
-// fn test_parquet_reader() {
-//     pyo3::prepare_freethreaded_python();
-//
-//     let file_path = "../../tests/test_kit/data/quote_tick_data.parquet";
-//
-//     // return an opaque reader pointer
-//     let file_path = Python::with_gil(|py| PyString::new(py, file_path)).as_ptr();
-//
-//     let reader = unsafe { parquet_reader_new(file_path, ParquetReaderType::QuoteTick) };
-//
-//     let mut total = 0;
-//     let mut chunk = CVec::default();
-//     unsafe {
-//         loop {
-//             chunk = parquet_reader_next_chunk(reader, ParquetReaderType::QuoteTick);
-//             if chunk.len == 0 {
-//                 parquet_reader_drop_chunk(chunk, ParquetReaderType::QuoteTick);
-//                 break;
-//             } else {
-//                 total += chunk.len;
-//                 parquet_reader_drop_chunk(chunk, ParquetReaderType::QuoteTick);
-//             }
-//         }
-//     }
-//
-//     unsafe {
-//         parquet_reader_drop(reader, ParquetReaderType::QuoteTick);
-//     }
-//
-//     assert_eq!(total, 9500);
-// }
+use pyo3::{prelude::*, types::*, AsPyPointer};
+
+use nautilus_core::cvec::CVec;
+use nautilus_persistence::parquet::{
+    parquet_reader_drop, parquet_reader_drop_chunk, parquet_reader_new, parquet_reader_next_chunk,
+    ParquetType,
+};
+
+mod test_util;
+
+#[test]
+#[allow(unused_assignments)]
+fn test_parquet_reader() {
+    pyo3::prepare_freethreaded_python();
+
+    let file_path = "../../tests/test_kit/data/quote_tick_data.parquet";
+
+    // return an opaque reader pointer
+    let reader = Python::with_gil(|py| {
+        let file_path = PyString::new(py, file_path);
+        unsafe { parquet_reader_new(file_path.as_ptr(), ParquetType::QuoteTick, 100) }
+    });
+
+    let mut total = 0;
+    let mut chunk = CVec::default();
+    unsafe {
+        loop {
+            chunk = parquet_reader_next_chunk(reader, ParquetType::QuoteTick);
+            if chunk.len == 0 {
+                parquet_reader_drop_chunk(chunk, ParquetType::QuoteTick);
+                break;
+            } else {
+                total += chunk.len;
+                parquet_reader_drop_chunk(chunk, ParquetType::QuoteTick);
+            }
+        }
+    }
+
+    unsafe {
+        parquet_reader_drop(reader, ParquetType::QuoteTick);
+    }
+
+    assert_eq!(total, 9500);
+}


### PR DESCRIPTION
# Pull Request

CVec should be converted to a Vec with the proper type and then dropped

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Using valgrind on the test example