### PR TITLE
Bar prices in get_xrate

### DIFF
--- a/nautilus_trader/cache/cache.pxd
+++ b/nautilus_trader/cache/cache.pxd
@@ -53,6 +53,7 @@ cdef class Cache(CacheFacade):
     cdef dict _trade_ticks
     cdef dict _order_books
     cdef dict _bars
+    cdef dict _bars_for_instrument_id
     cdef dict _currencies
     cdef dict _instruments
     cdef dict _accounts

--- a/tests/unit_tests/cache/test_cache_data.py
+++ b/tests/unit_tests/cache/test_cache_data.py
@@ -21,6 +21,8 @@ from nautilus_trader.backtest.data.providers import TestInstrumentProvider
 from nautilus_trader.model.currencies import AUD
 from nautilus_trader.model.currencies import JPY
 from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.data.bar import Bar
+from nautilus_trader.model.data.bar import BarType
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.enums import PriceType
@@ -517,6 +519,82 @@ class TestCache:
         )
 
         self.cache.add_quote_tick(tick)
+
+        # Act
+        result = self.cache.get_xrate(SIM, AUD, USD)
+
+        # Assert
+        assert result == 0.80005
+
+    def test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate(self):
+        # Arrange
+        self.cache.reset()
+        self.cache.add_instrument(AUDUSD_SIM)
+
+        bid_price = Price.from_str("0.80000")
+        bid_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
+            open=bid_price,
+            high=bid_price,
+            low=bid_price,
+            close=bid_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        ask_price = Price.from_str("0.80010")
+        ask_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
+            open=ask_price,
+            high=ask_price,
+            low=ask_price,
+            close=ask_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        self.cache.add_bar(bid_bar)
+        self.cache.add_bar(ask_bar)
+
+        # Act
+        result = self.cache.get_xrate(SIM, AUD, USD)
+
+        # Assert
+        assert result == 0.80005
+
+    def test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars(self):
+        # Arrange
+        self.cache.reset()
+        self.cache.add_instrument(AUDUSD_SIM)
+        bid_price = Price.from_str("0.80000")
+        ask_price = Price.from_str("0.80010")
+
+        bid_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
+            open=bid_price,
+            high=bid_price,
+            low=bid_price,
+            close=bid_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        ask_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
+            open=ask_price,
+            high=ask_price,
+            low=ask_price,
+            close=ask_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        self.cache.add_bars([TestDataStubs.bar_5decimal(), bid_bar])
+        self.cache.add_bars([TestDataStubs.bar_5decimal(), ask_bar])
 
         # Act
         result = self.cache.get_xrate(SIM, AUD, USD)


### PR DESCRIPTION
# Pull Request

Changes to the get_xrate method. If no quotes are found for an instrument, the bar close prices are used instead.

Only bars with PriceType.BID, PriceType.ASK are supported.
Only uses the Bar prices if both bid and ask bars exist for the instrument.

## Type of change

Please delete options that are not relevant.
- [x ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate
test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars

