### PR TITLE
fix overwrite_or_ignore ParquetDataCatalog

### DIFF
--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -31,7 +31,7 @@ from nautilus_trader.core.data import Data
 from nautilus_trader.core.datetime import maybe_dt_to_unix_nanos
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.persistence.funcs import tokenize
-
+from nautilus_trader.core.datetime import unix_nanos_to_dt
 
 class Partialable:
     """
@@ -153,6 +153,15 @@ class BacktestDataConfig(Partialable):
                 )
             self.data_cls = self.data_cls.fully_qualified_name()
 
+            # Round-trip convert to datetime without deleting ns
+            if isinstance(self.start_time, str):
+                self.start_time = int(self.start_time)
+            if isinstance(self.end_time, str):
+                self.end_time = int(self.end_time)
+            if isinstance(self.start_time, int):
+                self.start_time = unix_nanos_to_dt(self.start_time)
+            if isinstance(self.end_time, int):
+                self.end_time = unix_nanos_to_dt(self.end_time)
     @property
     def data_type(self):
         mod_path, cls_name = self.data_cls.rsplit(":", maxsplit=1)

--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -295,7 +295,7 @@ def write_parquet(
         if partition_cols
         else None
     )
-    if pa.__version__ >= "6.0.0":
+    if int(pa.__version__.split(".")[0]) >= 6:
         kwargs.update(existing_data_behavior="overwrite_or_ignore")
     files = set(fs.glob(resolve_path(path / "**", fs=fs)))
     path = str(resolve_path(path=path, fs=fs))  # type: ignore

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -30,6 +30,7 @@ from nautilus_trader.config import BacktestDataConfig
 from nautilus_trader.config import BacktestRunConfig
 from nautilus_trader.config import BacktestVenueConfig
 from nautilus_trader.config import Partialable
+from nautilus_trader.core.datetime import unix_nanos_to_dt
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.data.venue import InstrumentStatusUpdate
 from nautilus_trader.model.identifiers import ClientId
@@ -262,3 +263,55 @@ class TestBacktestConfig:
     )
     def test_models_to_json(self, model: BaseModel):
         print(json.dumps(model, indent=4, default=pydantic_encoder))
+
+    def test_backtest_data_start_end_nanos_round_trip_returns_same_value_int(self):
+        # Arrange
+        start_time_nanos = 1546383605776999936
+        end_time_nanos = 1546390125908000000
+        config = BacktestDataConfig(
+            catalog_path="/.nautilus/catalog",
+            catalog_fs_protocol="memory",
+            data_cls=NewsEventData,
+            start_time=start_time_nanos,
+            end_time=end_time_nanos,
+        )
+
+        assert start_time_nanos == config.start_time_nanos
+        assert end_time_nanos == config.end_time_nanos
+
+    def test_backtest_data_start_end_nanos_round_trip_returns_same_value_datetime(self):
+        start_time_nanos = 1546383605776999936
+        end_time_nanos = 1546390125908000000
+        start_dt = unix_nanos_to_dt(start_time_nanos)
+        end_dt = unix_nanos_to_dt(end_time_nanos)
+
+        config = BacktestDataConfig(
+            catalog_path="/.nautilus/catalog",
+            catalog_fs_protocol="memory",
+            data_cls=NewsEventData,
+            start_time=start_dt,
+            end_time=end_dt,
+        )
+        assert start_time_nanos == config.start_time_nanos
+        assert end_time_nanos == config.end_time_nanos
+
+    def test_backtest_data_start_end_nanos_round_trip_returns_same_value_str(self):
+        start_time_nanos = 1546383605776999936
+        end_time_nanos = 1546390125908000000
+
+        config = BacktestDataConfig(
+            catalog_path="/.nautilus/catalog",
+            catalog_fs_protocol="memory",
+            data_cls=NewsEventData,
+            start_time=str(start_time_nanos),
+            end_time=str(end_time_nanos),
+        )
+        
+        assert start_time_nanos == config.start_time_nanos
+        assert end_time_nanos == config.end_time_nanos
+
+
+TestBacktestConfig().test_backtest_data_start_end_nanos_round_trip_returns_same_value_int()
+TestBacktestConfig().test_backtest_data_start_end_nanos_round_trip_returns_same_value_str()
+TestBacktestConfig().test_backtest_data_start_end_nanos_round_trip_returns_same_value_datetime()
+TestBacktestConfig().test_backtest_data_config_load()


### PR DESCRIPTION
# Pull Request

Fixes conditional if statement to add "overwrite_or_ignore" flag in the ParquetDataCatalog.

# Current behaviour

The "overwrite_or_ignore" flag is disabled when the pyarrow version is >= 6 AND < 10

# Expected behaviour

The "overwrite_or_ignore" flag is disabled when the pyarrow version is >= 6

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
