### PR TITLE
Fix overwrite_or_ignore kwarg

### DIFF
--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -295,7 +295,7 @@ def write_parquet(
         if partition_cols
         else None
     )
-    if pa.__version__ >= "6.0.0":
+    if int(pa.__version__.split(".")[0]) >= 6:
         kwargs.update(existing_data_behavior="overwrite_or_ignore")
     files = set(fs.glob(resolve_path(path / "**", fs=fs)))
     path = str(resolve_path(path=path, fs=fs))  # type: ignore


### PR DESCRIPTION
# Changes

Fixes conditional if statement related to the "overwrite_or_ignore" kwarg in the ParquetDataCatalog.

## Current behaviour
The "overwrite_or_ignore" kwarg is enabled when the pyarrow version is >= 6 AND < 10

## Expected behaviour
The "overwrite_or_ignore" kwarg is enabled when the pyarrow version is >= 6

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
