### PR TITLE
Bar prices in get_xrate

### DIFF
--- a/nautilus_trader/cache/cache.pxd
+++ b/nautilus_trader/cache/cache.pxd
@@ -53,6 +53,7 @@ cdef class Cache(CacheFacade):
     cdef dict _trade_ticks
     cdef dict _order_books
     cdef dict _bars
+    cdef dict _bars_for_instrument_id
     cdef dict _currencies
     cdef dict _instruments
     cdef dict _accounts

--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -644,6 +644,8 @@ cdef class Cache(CacheFacade):
         self._quote_ticks.clear()
         self._trade_ticks.clear()
         self._bars.clear()
+        for v in self._bars_for_instrument_id.values():
+            v.clear()
         self.clear_cache()
         self.clear_index()
 
@@ -1127,7 +1129,7 @@ cdef class Cache(CacheFacade):
         cdef PriceType price_type = bar.bar_type.spec.price_type
         if price_type in (PriceType.BID, PriceType.ASK):
             self._bars_for_instrument_id[price_type][bar.bar_type.instrument_id] = bar
-
+        
     cpdef void add_currency(self, Currency currency) except *:
         """
         Add the given currency to the cache.

--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -1129,7 +1129,7 @@ cdef class Cache(CacheFacade):
         cdef PriceType price_type = bar.bar_type.spec.price_type
         if price_type in (PriceType.BID, PriceType.ASK):
             self._bars_for_instrument_id[price_type][bar.bar_type.instrument_id] = bar
-        
+
     cpdef void add_currency(self, Currency currency) except *:
         """
         Add the given currency to the cache.

--- a/tests/unit_tests/cache/test_cache_data.py
+++ b/tests/unit_tests/cache/test_cache_data.py
@@ -21,6 +21,8 @@ from nautilus_trader.backtest.data.providers import TestInstrumentProvider
 from nautilus_trader.model.currencies import AUD
 from nautilus_trader.model.currencies import JPY
 from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.data.bar import Bar
+from nautilus_trader.model.data.bar import BarType
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.enums import PriceType
@@ -517,6 +519,82 @@ class TestCache:
         )
 
         self.cache.add_quote_tick(tick)
+
+        # Act
+        result = self.cache.get_xrate(SIM, AUD, USD)
+
+        # Assert
+        assert result == 0.80005
+
+    def test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate(self):
+        # Arrange
+        self.cache.reset()
+        self.cache.add_instrument(AUDUSD_SIM)
+
+        bid_price = Price.from_str("0.80000")
+        bid_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
+            open=bid_price,
+            high=bid_price,
+            low=bid_price,
+            close=bid_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        ask_price = Price.from_str("0.80010")
+        ask_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
+            open=ask_price,
+            high=ask_price,
+            low=ask_price,
+            close=ask_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        self.cache.add_bar(bid_bar)
+        self.cache.add_bar(ask_bar)
+
+        # Act
+        result = self.cache.get_xrate(SIM, AUD, USD)
+
+        # Assert
+        assert result == 0.80005
+
+    def test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars(self):
+        # Arrange
+        self.cache.reset()
+        self.cache.add_instrument(AUDUSD_SIM)
+        bid_price = Price.from_str("0.80000")
+        ask_price = Price.from_str("0.80010")
+
+        bid_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
+            open=bid_price,
+            high=bid_price,
+            low=bid_price,
+            close=bid_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        ask_bar = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
+            open=ask_price,
+            high=ask_price,
+            low=ask_price,
+            close=ask_price,
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
+
+        self.cache.add_bars([TestDataStubs.bar_5decimal(), bid_bar])
+        self.cache.add_bars([TestDataStubs.bar_5decimal(), ask_bar])
 
         # Act
         result = self.cache.get_xrate(SIM, AUD, USD)

--- a/tests/unit_tests/cache/test_cache_data.py
+++ b/tests/unit_tests/cache/test_cache_data.py
@@ -615,14 +615,9 @@ class TestCache:
 
         self.cache.add_bars([bid_bar2, bid_bar1])
         self.cache.add_bars([ask_bar2, ask_bar1])
-        
+
         # Act
         result = self.cache.get_xrate(SIM, AUD, USD)
 
         # Assert
         assert result == 0.80005
-
-
-mod = TestCache()
-mod.setup()
-mod.test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars()

--- a/tests/unit_tests/cache/test_cache_data.py
+++ b/tests/unit_tests/cache/test_cache_data.py
@@ -571,7 +571,7 @@ class TestCache:
         bid_price = Price.from_str("0.80000")
         ask_price = Price.from_str("0.80010")
 
-        bid_bar = Bar(
+        bid_bar1 = Bar(
             bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
             open=bid_price,
             high=bid_price,
@@ -581,8 +581,18 @@ class TestCache:
             ts_event=0,
             ts_init=0,
         )
+        bid_bar2 = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-BID-EXTERNAL"),
+            open=Price.from_str("0"),
+            high=Price.from_str("0"),
+            low=Price.from_str("0"),
+            close=Price.from_str("0"),
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
 
-        ask_bar = Bar(
+        ask_bar1 = Bar(
             bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
             open=ask_price,
             high=ask_price,
@@ -592,12 +602,27 @@ class TestCache:
             ts_event=0,
             ts_init=0,
         )
+        ask_bar2 = Bar(
+            bar_type=BarType.from_str(f"{AUDUSD_SIM.id}-1-DAY-ASK-EXTERNAL"),
+            open=Price.from_str("0"),
+            high=Price.from_str("0"),
+            low=Price.from_str("0"),
+            close=Price.from_str("0"),
+            volume=Quantity.from_int(1),
+            ts_event=0,
+            ts_init=0,
+        )
 
-        self.cache.add_bars([TestDataStubs.bar_5decimal(), bid_bar])
-        self.cache.add_bars([TestDataStubs.bar_5decimal(), ask_bar])
-
+        self.cache.add_bars([bid_bar2, bid_bar1])
+        self.cache.add_bars([ask_bar2, ask_bar1])
+        
         # Act
         result = self.cache.get_xrate(SIM, AUD, USD)
 
         # Assert
         assert result == 0.80005
+
+
+mod = TestCache()
+mod.setup()
+mod.test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars()


### PR DESCRIPTION

# Changes

Changes to the get_xrate method. If no quotes are found for an instrument, the bar close prices are used instead.

Only bars with PriceType.BID, PriceType.ASK are supported.
Only uses the Bar prices if both bid and ask bars exist for the instrument.

## Type of change

[x ] New feature (non-breaking change which adds functionality)

How has this change been tested?

test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate
test_get_xrate_fallbacks_to_bars_if_no_quotes_returns_correct_rate_with_add_bars
