### PR TITLE
Fixes to IB Adapter

### DIFF
--- a/examples/live/interactive_brokers_example.py
+++ b/examples/live/interactive_brokers_example.py
@@ -31,6 +31,20 @@ from nautilus_trader.live.node import TradingNode
 # *** THIS INTEGRATION IS STILL UNDER CONSTRUCTION. ***
 # *** PLEASE CONSIDER IT TO BE IN AN UNSTABLE BETA PHASE AND EXERCISE CAUTION. ***
 
+instrument_filters = [
+    {
+        "secType": "STK",
+        "symbol": "AAPL",
+        "exchange": "SMART",
+        "primaryExchange": "NASDAQ",
+    },
+    {
+        "secType": "CASH",
+        "primaryExchange": "IDEALPRO",
+        "localSymbol": "EUR.USD",
+    },
+]
+
 # Configure the trading node
 config_node = TradingNodeConfig(
     trader_id="TESTER-001",
@@ -40,14 +54,9 @@ config_node = TradingNodeConfig(
             gateway_host="127.0.0.1",
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
-                filters=tuple(
-                    {
-                        "secType": "STK",
-                        "symbol": "9988",
-                        "exchange": "SEHK",
-                        # "currency": "USD",
-                    }.items()
-                ),
+                filters={
+                    "filters": tuple([tuple(filt.items()) for filt in instrument_filters]),
+                },
             ),
         ),
     },
@@ -66,12 +75,12 @@ node = TradingNode(config=config_node)
 
 # Configure your strategy
 strategy_config = SubscribeStrategyConfig(
-    instrument_id="AAC.NYSE",
+    instrument_id="AAPL.NASDAQ",
     # book_type=None,
     # snapshots=True,
-    # trade_ticks=True,
-    # quote_ticks=True,
-    bars=True,
+    trade_ticks=True,
+    quote_ticks=True,
+    # bars=True,
 )
 # Instantiate your strategy
 strategy = SubscribeStrategy(config=strategy_config)

--- a/examples/live/interactive_brokers_example.py
+++ b/examples/live/interactive_brokers_example.py
@@ -43,8 +43,8 @@ config_node = TradingNodeConfig(
                 filters=tuple(
                     {
                         "secType": "STK",
-                        "symbol": "SEC0",
-                        "exchange": "BVME.ETF",
+                        "symbol": "9988",
+                        "exchange": "SEHK",
                         # "currency": "USD",
                     }.items()
                 ),

--- a/examples/live/interactive_brokers_example.py
+++ b/examples/live/interactive_brokers_example.py
@@ -15,8 +15,12 @@
 # -------------------------------------------------------------------------------------------------
 
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
+from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersExecClientConfig
 from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveDataClientFactory,
+)
+from nautilus_trader.adapters.interactive_brokers.factories import (
+    InteractiveBrokersLiveExecClientFactory,
 )
 from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.config import TradingNodeConfig
@@ -60,9 +64,9 @@ config_node = TradingNodeConfig(
             ),
         ),
     },
-    # exec_clients={
-    #     "IB": InteractiveBrokersExecClientConfig(),
-    # },
+    exec_clients={
+        "IB": InteractiveBrokersExecClientConfig(),
+    },
     timeout_connection=90.0,
     timeout_reconciliation=5.0,
     timeout_portfolio=5.0,
@@ -90,7 +94,7 @@ node.trader.add_strategy(strategy)
 
 # Register your client factories with the node (can take user defined factories)
 node.add_data_client_factory("IB", InteractiveBrokersLiveDataClientFactory)
-# node.add_exec_client_factory("IB", InteractiveBrokersLiveExecutionClientFactory)
+node.add_exec_client_factory("IB", InteractiveBrokersLiveExecClientFactory)
 node.build()
 
 # Stop and dispose of the node with SIGINT/CTRL+C

--- a/nautilus_trader/adapters/interactive_brokers/config.py
+++ b/nautilus_trader/adapters/interactive_brokers/config.py
@@ -58,12 +58,12 @@ class InteractiveBrokersDataClientConfig(LiveDataClientConfig):
     def __init__(self, **kwargs):
         kwargs["username"] = (
             kwargs.get("username", os.environ["TWS_USERNAME"])
-            if kwargs.get("start_gateway")
+            if kwargs.get("start_gateway", True)
             else ""
         )
         kwargs["password"] = (
             kwargs.get("password", os.environ["TWS_PASSWORD"])
-            if kwargs.get("start_gateway")
+            if kwargs.get("start_gateway", True)
             else ""
         )
         super().__init__(**kwargs)

--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -119,13 +119,11 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             await self._client.connect()
 
         # Load instruments based on config
-        # try:
         await self.instrument_provider.initialize()
-        # except Exception as e:
-        #     self._log.exception(e)
-        #     return
         for instrument in self.instrument_provider.get_all().values():
             self._handle_data(instrument)
+
+        # Connected
         self._set_connected(True)
         self._log.info("Connected.")
 

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -26,6 +26,9 @@ from ib_insync import Trade as IBTrade
 
 from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
 from nautilus_trader.adapters.interactive_brokers.parsing.execution import (
+    account_values_to_nautilus_account_info,
+)
+from nautilus_trader.adapters.interactive_brokers.parsing.execution import (
     ib_order_to_nautilus_order_type,
 )
 from nautilus_trader.adapters.interactive_brokers.parsing.execution import (
@@ -59,8 +62,6 @@ from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.instruments.base import Instrument
-from nautilus_trader.model.objects import AccountBalance
-from nautilus_trader.model.objects import MarginBalance
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
@@ -367,16 +368,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         )
 
     def on_account_update(self, account_values: List[AccountValue]):
-        balances: List[AccountBalance] = [
-            AccountBalance(
-                total=Money.from_str(f"{acc.value} {acc.currency}"),
-                free=Money.from_str(f"{acc.value} {acc.currency}"),
-                locked=Money.from_str(f"0 {acc.currency}"),
-            )
-            for acc in account_values
-        ]
-        # TODO (bm) - need to get info for margins
-        margins: list[MarginBalance] = []
+        balances, margins = account_values_to_nautilus_account_info(account_values)
         ts_event: int = self._clock.timestamp_ns()
         self.generate_account_state(
             balances=balances, margins=margins, reported=True, ts_event=ts_event

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -53,6 +53,7 @@ def get_cached_ib_client(
     timeout: int = 300,
     client_id: int = 1,
     start_gateway: bool = True,
+    read_only_api: bool = True,
 ) -> ib_insync.IB:
     """
     Cache and return a InteractiveBrokers HTTP client with the given key and secret.
@@ -80,6 +81,8 @@ def get_cached_ib_client(
         The client_id to connect with
     start_gateway: bool
         Start the IB Gateway docker container
+    read_only_api: bool
+        Set read-only (no execution) when starting the gateway.
 
     Returns
     -------
@@ -91,10 +94,14 @@ def get_cached_ib_client(
         # Start gateway
         if GATEWAY is None:
             GATEWAY = InteractiveBrokersGateway(
-                username=username, password=password, trading_mode=trading_mode
+                username=username,
+                password=password,
+                trading_mode=trading_mode,
+                read_only_api=read_only_api,
             )
             GATEWAY.safe_start(wait=timeout)
             port = port or GATEWAY.port
+    port = port or InteractiveBrokersGateway.PORTS[trading_mode]
 
     client_key: tuple = (host, port)
 

--- a/nautilus_trader/adapters/interactive_brokers/gateway.py
+++ b/nautilus_trader/adapters/interactive_brokers/gateway.py
@@ -59,6 +59,8 @@ class InteractiveBrokersGateway:
         start: bool = False,
         logger: Optional[logging.Logger] = None,
     ):
+        assert username is not None, "`username` not set"
+        assert password is not None, "`password` not set"
         self.username = username
         self.password = password
         self.trading_mode = trading_mode
@@ -147,8 +149,8 @@ class InteractiveBrokersGateway:
             ports={"4001": "4001", "4002": "4002", "5900": "5900"},
             platform="amd64",
             environment={
-                "TWSUSERID": self.username,
-                "TWSPASSWORD": self.password,
+                "TWS_USERID": self.username,
+                "TWS_PASSWORD": self.password,
                 "TRADING_MODE": self.trading_mode,
             },
         )

--- a/nautilus_trader/adapters/interactive_brokers/gateway.py
+++ b/nautilus_trader/adapters/interactive_brokers/gateway.py
@@ -57,6 +57,7 @@ class InteractiveBrokersGateway:
         port: Optional[int] = None,
         trading_mode: Optional[str] = "paper",
         start: bool = False,
+        read_only_api: bool = True,
         logger: Optional[logging.Logger] = None,
     ):
         assert username is not None, "`username` not set"
@@ -64,6 +65,7 @@ class InteractiveBrokersGateway:
         self.username = username
         self.password = password
         self.trading_mode = trading_mode
+        self.read_only_api = read_only_api
         self.host = host
         self.port = port or self.PORTS[trading_mode]
         if docker is None:
@@ -152,6 +154,7 @@ class InteractiveBrokersGateway:
                 "TWS_USERID": self.username,
                 "TWS_PASSWORD": self.password,
                 "TRADING_MODE": self.trading_mode,
+                "READ_ONLY_API": {True: "yes", False: "no"}[self.read_only_api],
             },
         )
         self.log.info("Container starting, waiting for ready")

--- a/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
@@ -12,7 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+from itertools import groupby
 
+from ib_insync import AccountValue
 from ib_insync import LimitOrder as IBLimitOrder
 from ib_insync import MarketOrder as IBMarketOrder
 from ib_insync import Order as IBOrder
@@ -21,7 +23,11 @@ from ib_insync import StopOrder as IBStopOrder
 
 from nautilus_trader.model.c_enums.order_side import OrderSide
 from nautilus_trader.model.c_enums.order_side import OrderSideParser
+from nautilus_trader.model.currency import Currency
 from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.objects import AccountBalance
+from nautilus_trader.model.objects import MarginBalance
+from nautilus_trader.model.objects import Money
 from nautilus_trader.model.orders.base import Order as NautilusOrder
 from nautilus_trader.model.orders.limit import LimitOrder as NautilusLimitOrder
 from nautilus_trader.model.orders.market import MarketOrder as NautilusMarketOrder
@@ -57,3 +63,44 @@ def ib_order_to_nautilus_order_type(order: IBOrder) -> OrderType:
         return OrderType.STOP_MARKET
     elif isinstance(order, IBStopLimitOrder):
         return OrderType.STOP_LIMIT
+
+
+def account_values_to_nautilus_account_info(
+    account_values: list[AccountValue],
+) -> tuple[list[AccountBalance], list[MarginBalance]]:
+    """
+    When querying for account information, ib_insync returns a list of individual fields for potentially multiple
+    accounts. Parse these individual fields and return a list of balances and margin balances.
+    """
+
+    def group_key(x: AccountValue):
+        return (x.account, x.currency)
+
+    balances = []
+    margin_balances = []
+    for (_, currency), fields in groupby(sorted(account_values, key=group_key), key=group_key):
+        if currency == "BASE":
+            # Not a real currency, aggregation of account
+            continue
+        account_fields = {f.tag: f.value for f in fields}
+        if "TotalCashBalance" in account_fields:
+            total_cash = float(account_fields["TotalCashBalance"])
+            free = float(account_fields["CashBalance"])
+            balance = AccountBalance(
+                total=Money(total_cash, Currency.from_str(currency)),
+                free=Money(free, Currency.from_str(currency)),
+                locked=Money(total_cash - free, Currency.from_str(currency)),
+            )
+            balances.append(balance)
+        if "InitMarginReq" in account_fields:
+            margin_balance = MarginBalance(
+                initial=Money(
+                    float(account_fields["InitMarginReq"]), currency=Currency.from_str(currency)
+                ),
+                maintenance=Money(
+                    float(account_fields["MaintMarginReq"]), currency=Currency.from_str(currency)
+                ),
+            )
+            margin_balances.append(margin_balance)
+
+    return balances, margin_balances

--- a/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
@@ -16,8 +16,12 @@
 from ib_insync import LimitOrder as IBLimitOrder
 from ib_insync import MarketOrder as IBMarketOrder
 from ib_insync import Order as IBOrder
+from ib_insync import StopLimitOrder as IBStopLimitOrder
+from ib_insync import StopOrder as IBStopOrder
 
+from nautilus_trader.model.c_enums.order_side import OrderSide
 from nautilus_trader.model.c_enums.order_side import OrderSideParser
+from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.orders.base import Order as NautilusOrder
 from nautilus_trader.model.orders.limit import LimitOrder as NautilusLimitOrder
 from nautilus_trader.model.orders.market import MarketOrder as NautilusMarketOrder
@@ -38,3 +42,18 @@ def nautilus_order_to_ib_order(order: NautilusOrder) -> IBOrder:
         )
     else:
         raise NotImplementedError(f"IB order type not implemented {type(order)} for {order}")
+
+
+def ib_order_side_to_nautilus_side(action: str) -> OrderSide:
+    return OrderSideParser.from_str(action.upper())
+
+
+def ib_order_to_nautilus_order_type(order: IBOrder) -> OrderType:
+    if isinstance(order, IBMarketOrder):
+        return OrderType.MARKET
+    elif isinstance(order, IBLimitOrder):
+        return OrderType.LIMIT
+    elif isinstance(order, IBStopOrder):
+        return OrderType.STOP_MARKET
+    elif isinstance(order, IBStopLimitOrder):
+        return OrderType.STOP_LIMIT

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -175,7 +175,7 @@ def parse_forex_contract(
         price_precision=price_precision,
         size_precision=Quantity.from_int(1),
         price_increment=Price(details.minTick, price_precision),
-        size_increment=Quantity(details.sizeMinTick or 1, 1),
+        size_increment=Quantity(getattr(details, "sizeMinTick", 1), 1),
         lot_size=None,
         max_quantity=None,
         min_quantity=None,

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -175,7 +175,7 @@ def parse_forex_contract(
         price_precision=price_precision,
         size_precision=Quantity.from_int(1),
         price_increment=Price(details.minTick, price_precision),
-        size_increment=Quantity(getattr(details, "sizeMinTick", 1), 1),
+        size_increment=Quantity(getattr(details, "sizeMinTick", None) or 1, 1),
         lot_size=None,
         max_quantity=None,
         min_quantity=None,

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -113,9 +113,6 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         for filt in self._parse_filters(filters):
             await self.load(**dict(filt or {}))
 
-    async def load_async(self, instrument_id: InstrumentId, filters: Optional[dict] = None):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
-
     async def get_contract_details(
         self,
         contract: Contract,

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -12,3 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+import pytest
+from ib_insync import IB
+
+
+@pytest.fixture
+def ib() -> IB:
+    return IB()

--- a/tests/integration_tests/adapters/interactive_brokers/responses/account_values.json
+++ b/tests/integration_tests/adapters/interactive_brokers/responses/account_values.json
@@ -1,0 +1,674 @@
+[
+  {
+    "account": "DU123456",
+    "tag": "AccountType",
+    "value": "COMPANY",
+    "currency": "",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "Cushion",
+    "value": "1",
+    "currency": "",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "LookAheadNextChange",
+    "value": "0",
+    "currency": "",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "AccruedCash",
+    "value": "5000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "AvailableFunds",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "BuyingPower",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "EquityWithLoanValue",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "ExcessLiquidity",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "FullAvailableFunds",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "FullExcessLiquidity",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "FullInitMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "FullMaintMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "GrossPositionValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "InitMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "LookAheadAvailableFunds",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "LookAheadExcessLiquidity",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "LookAheadInitMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "LookAheadMaintMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "MaintMarginReq",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "NetLiquidation",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "TotalCashValue",
+    "value": "100000.0",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Currency",
+    "value": "AUD",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CashBalance",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TotalCashBalance",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccruedCash",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "StockMarketValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "OptionMarketValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FutureOptionValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FuturesPNL",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetLiquidationByCurrency",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "UnrealizedPnL",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealizedPnL",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "ExchangeRate",
+    "value": "1.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FundValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetDividend",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MutualFundValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MoneyMarketFundValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CorporateBondValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBondValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBillValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "WarrantValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FxCashBalance",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccountOrGroup",
+    "value": "All",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealCurrency",
+    "value": "AUD",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "IssuerOptionValue",
+    "value": "0.00",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Cryptocurrency",
+    "value": "",
+    "currency": "AUD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Currency",
+    "value": "USD",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CashBalance",
+    "value": "100000.0",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TotalCashBalance",
+    "value": "100000.0",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccruedCash",
+    "value": "5000.0",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "StockMarketValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "OptionMarketValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FutureOptionValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FuturesPNL",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetLiquidationByCurrency",
+    "value": "1008811.38",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "UnrealizedPnL",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealizedPnL",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "ExchangeRate",
+    "value": "1.480111",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FundValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetDividend",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MutualFundValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MoneyMarketFundValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CorporateBondValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBondValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBillValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "WarrantValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FxCashBalance",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccountOrGroup",
+    "value": "All",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealCurrency",
+    "value": "USD",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "IssuerOptionValue",
+    "value": "0.00",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Cryptocurrency",
+    "value": "",
+    "currency": "USD",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Currency",
+    "value": "BASE",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CashBalance",
+    "value": "10000012",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TotalCashBalance",
+    "value": "10000012",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccruedCash",
+    "value": "5000.0",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "StockMarketValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "OptionMarketValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FutureOptionValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FuturesPNL",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetLiquidationByCurrency",
+    "value": "10000023",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "UnrealizedPnL",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealizedPnL",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "ExchangeRate",
+    "value": "1.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FundValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "NetDividend",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MutualFundValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "MoneyMarketFundValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "CorporateBondValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBondValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "TBillValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "WarrantValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "FxCashBalance",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "AccountOrGroup",
+    "value": "All",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "RealCurrency",
+    "value": "BASE",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "IssuerOptionValue",
+    "value": "0.00",
+    "currency": "BASE",
+    "modelCode": ""
+  },
+  {
+    "account": "All",
+    "tag": "Cryptocurrency",
+    "value": "",
+    "currency": "BASE",
+    "modelCode": ""
+  }
+]

--- a/tests/integration_tests/adapters/interactive_brokers/test_data.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_data.py
@@ -24,7 +24,7 @@ from nautilus_trader.backtest.data.providers import TestInstrumentProvider
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.enums import BookType
 from tests.integration_tests.adapters.interactive_brokers.base import InteractiveBrokersTestBase
-from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 
 
 class TestInteractiveBrokersData(InteractiveBrokersTestBase):
@@ -53,10 +53,10 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     @pytest.mark.asyncio
     async def test_subscribe_trade_ticks(self, event_loop):
         # Arrange
-        instrument_aapl = IBTestStubs.instrument(symbol="AAPL")
+        instrument_aapl = IBTestDataStubs.instrument(symbol="AAPL")
         self.data_client.instrument_provider.contract_details[
             instrument_aapl.id.value
-        ] = IBTestStubs.contract_details("AAPL")
+        ] = IBTestDataStubs.contract_details("AAPL")
 
         # Act
         with patch.object(self.data_client, "_client") as mock:
@@ -82,8 +82,8 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     @pytest.mark.asyncio
     async def test_subscribe_order_book_deltas(self, event_loop):
         # Arrange
-        instrument = IBTestStubs.instrument(symbol="AAPL")
-        self.instrument_setup(instrument, IBTestStubs.contract_details("AAPL"))
+        instrument = IBTestDataStubs.instrument(symbol="AAPL")
+        self.instrument_setup(instrument, IBTestDataStubs.contract_details("AAPL"))
 
         # Act
         with patch.object(self.data_client, "_client") as mock:
@@ -113,31 +113,31 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     async def test_on_book_update(self, event_loop):
         # Arrange
         self.instrument_setup(
-            IBTestStubs.instrument(symbol="EURUSD"), IBTestStubs.contract_details("EURUSD")
+            IBTestDataStubs.instrument(symbol="EURUSD"), IBTestDataStubs.contract_details("EURUSD")
         )
 
         # Act
-        for ticker in IBTestStubs.market_depth(name="eurusd"):
+        for ticker in IBTestDataStubs.market_depth(name="eurusd"):
             self.data_client._on_order_book_snapshot(ticker=ticker, book_type=BookType.L2_MBP)
 
     @pytest.mark.asyncio
     async def test_on_ticker_update(self, event_loop):
         # Arrange
         self.instrument_setup(
-            IBTestStubs.instrument(symbol="EURUSD"), IBTestStubs.contract_details("EURUSD")
+            IBTestDataStubs.instrument(symbol="EURUSD"), IBTestDataStubs.contract_details("EURUSD")
         )
 
         # Act
-        for ticker in IBTestStubs.tickers("eurusd"):
+        for ticker in IBTestDataStubs.tickers("eurusd"):
             self.data_client._on_trade_ticker_update(ticker=ticker)
 
     @pytest.mark.asyncio
     async def test_on_quote_tick_update(self, event_loop):
         # Arrange
         self.instrument_setup(
-            IBTestStubs.instrument(symbol="EURUSD"), IBTestStubs.contract_details("EURUSD")
+            IBTestDataStubs.instrument(symbol="EURUSD"), IBTestDataStubs.contract_details("EURUSD")
         )
-        contract = IBTestStubs.contract_details("EURUSD").contract
+        contract = IBTestDataStubs.contract_details("EURUSD").contract
         ticker = Ticker(
             time=datetime.datetime(2022, 3, 4, 6, 8, 36, 992576, tzinfo=datetime.timezone.utc),
             bid=99.45,
@@ -152,8 +152,8 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     @pytest.mark.asyncio
     async def test_on_quote_tick_update_nans(self, event_loop):
         # Arrange
-        self.instrument_setup(self.instrument, IBTestStubs.contract_details("AAPL"))
-        contract = IBTestStubs.contract_details("AAPL").contract
+        self.instrument_setup(self.instrument, IBTestDataStubs.contract_details("AAPL"))
+        contract = IBTestDataStubs.contract_details("AAPL").contract
         ticker = Ticker(
             time=datetime.datetime(2022, 3, 4, 6, 8, 36, 992576, tzinfo=datetime.timezone.utc),
             bidSize=44600.0,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -16,7 +16,6 @@ import datetime
 from unittest.mock import patch
 
 import pytest
-from ib_insync import AccountValue
 from ib_insync import CommissionReport
 from ib_insync import Contract
 from ib_insync import Fill
@@ -32,12 +31,13 @@ from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.objects import AccountBalance
+from nautilus_trader.model.objects import MarginBalance
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from tests.integration_tests.adapters.interactive_brokers.base import InteractiveBrokersTestBase
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBExecTestStubs
-from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 from tests.test_kit.stubs.commands import TestCommandStubs
 from tests.test_kit.stubs.execution import TestExecStubs
 from tests.test_kit.stubs.identifiers import TestIdStubs
@@ -46,8 +46,8 @@ from tests.test_kit.stubs.identifiers import TestIdStubs
 class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     def setup(self):
         super().setup()
-        self.instrument = IBTestStubs.instrument("AAPL")
-        self.contract_details = IBTestStubs.contract_details("AAPL")
+        self.instrument = IBTestDataStubs.instrument("AAPL")
+        self.contract_details = IBTestDataStubs.contract_details("AAPL")
         self.contract = self.contract_details.contract
 
     def instrument_setup(self, instrument=None, contract_details=None):
@@ -72,8 +72,8 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
 
     def test_place_order(self):
         # Arrange
-        instrument = IBTestStubs.instrument("AAPL")
-        contract_details = IBTestStubs.contract_details("AAPL")
+        instrument = IBTestDataStubs.instrument("AAPL")
+        contract_details = IBTestDataStubs.contract_details("AAPL")
         self.instrument_setup(instrument=instrument, contract_details=contract_details)
         order = TestExecStubs.limit_order(
             instrument_id=instrument.id,
@@ -107,10 +107,10 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
 
     def test_update_order(self):
         # Arrange
-        instrument = IBTestStubs.instrument("AAPL")
-        contract_details = IBTestStubs.contract_details("AAPL")
+        instrument = IBTestDataStubs.instrument("AAPL")
+        contract_details = IBTestDataStubs.contract_details("AAPL")
         contract = contract_details.contract
-        order = IBTestStubs.create_order()
+        order = IBExecTestStubs.create_order()
         self.instrument_setup(instrument=instrument, contract_details=contract_details)
         self.exec_client._ib_insync_orders[TestIdStubs.client_order_id()] = Trade(
             contract=contract, order=order
@@ -148,10 +148,10 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
 
     def test_cancel_order(self):
         # Arrange
-        instrument = IBTestStubs.instrument("AAPL")
-        contract_details = IBTestStubs.contract_details("AAPL")
+        instrument = IBTestDataStubs.instrument("AAPL")
+        contract_details = IBTestDataStubs.contract_details("AAPL")
         contract = contract_details.contract
-        order = IBTestStubs.create_order()
+        order = IBExecTestStubs.create_order()
         self.instrument_setup(instrument=instrument, contract_details=contract_details)
         self.exec_client._ib_insync_orders[TestIdStubs.client_order_id()] = Trade(
             contract=contract, order=order
@@ -237,7 +237,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         # Arrange
         self.instrument_setup()
         nautilus_order = TestExecStubs.limit_order()
-        contract = IBTestStubs.contract_details("AAPL").contract
+        contract = IBTestDataStubs.contract_details("AAPL").contract
         self.exec_client._venue_order_id_to_client_order_id[
             VenueOrderId("0")
         ] = TestIdStubs.client_order_id()
@@ -290,7 +290,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         self.exec_client._client_order_id_to_strategy_id[
             nautilus_order.client_order_id
         ] = TestIdStubs.strategy_id()
-        order = IBExecTestStubs.ib_order(permId=1)
+        order = IBExecTestStubs.create_order(permId=1)
         trade = IBExecTestStubs.trade_submitted(order=order)
         self.cache.add_order(nautilus_order, None)
         self.exec_client._venue_order_id_to_client_order_id[
@@ -306,8 +306,8 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         expected = {
             "client_order_id": nautilus_order.client_order_id,
             "instrument_id": self.instrument.id,
-            "price": Price.from_str("0.01"),
-            "quantity": Quantity.from_str("1"),
+            "price": Price.from_str("105.00"),
+            "quantity": Quantity.from_str("100000"),
             "strategy_id": TestIdStubs.strategy_id(),
             "trigger_price": None,
             "ts_event": 1646449588378175000,
@@ -324,7 +324,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         self.exec_client._client_order_id_to_strategy_id[
             nautilus_order.client_order_id
         ] = TestIdStubs.strategy_id()
-        order = IBExecTestStubs.ib_order(permId=1)
+        order = IBExecTestStubs.create_order(permId=1)
         trade = IBExecTestStubs.trade_pre_cancel(order=order)
         self.cache.add_order(nautilus_order, None)
         self.exec_client._venue_order_id_to_client_order_id[
@@ -354,7 +354,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         self.exec_client._client_order_id_to_strategy_id[
             nautilus_order.client_order_id
         ] = TestIdStubs.strategy_id()
-        order = IBExecTestStubs.ib_order(permId=1)
+        order = IBExecTestStubs.create_order(permId=1)
         trade = IBExecTestStubs.trade_canceled(order=order)
         self.cache.add_order(nautilus_order, None)
         self.exec_client._venue_order_id_to_client_order_id[
@@ -379,25 +379,37 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     @pytest.mark.asyncio
     async def test_on_account_update(self):
         # Arrange
-        acctVal = AccountValue("TEST", "paper", "100000", "USD", "")
+        account_values = IBTestDataStubs.account_values()
 
         # Act
         with patch.object(self.exec_client, "generate_account_state") as mock:
-            self.exec_client.on_account_update([acctVal])
+            self.exec_client.on_account_update(account_values)
 
         # Assert
         name, args, kwargs = mock.mock_calls[0]
         expected = {
             "balances": [
                 AccountBalance(
+                    total=Money.from_str("0.00 AUD"),
+                    locked=Money.from_str("0.00 AUD"),
+                    free=Money.from_str("0.00 AUD"),
+                ),
+                AccountBalance(
                     total=Money.from_str("100_000.00 USD"),
-                    locked=Money.from_str("0 USD"),
+                    locked=Money.from_str("0.00 USD"),
                     free=Money.from_str("100_000.00 USD"),
+                ),
+            ],
+            "margins": [
+                MarginBalance(
+                    initial=Money.from_str("0.00 AUD"),
+                    maintenance=Money.from_str("0.00 AUD"),
+                    instrument_id=None,
                 )
             ],
-            "margins": [],
             "reported": True,
             "ts_event": kwargs["ts_event"],
         }
         assert expected["balances"][0].to_dict() == kwargs["balances"][0].to_dict()
-        assert all([kwargs[k] == expected[k] for k in kwargs if k not in ("balances",)])
+        assert expected["margins"][0].to_dict() == kwargs["margins"][0].to_dict()
+        assert all([kwargs[k] == expected[k] for k in kwargs if k not in ("balances", "margins")])

--- a/tests/integration_tests/adapters/interactive_brokers/test_historic.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_historic.py
@@ -32,7 +32,7 @@ from nautilus_trader.model.data.bar import BarSpecification
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.data.tick import TradeTick
 from nautilus_trader.persistence.catalog.parquet import ParquetDataCatalog
-from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 from tests.test_kit.mocks.data import data_catalog_setup
 
 
@@ -45,8 +45,8 @@ class TestInteractiveBrokersHistoric:
     @pytest.mark.skipif(sys.platform == "win32", reason="test path broken on Windows")
     def test_back_fill_catalog_ticks(self, mocker):
         # Arrange
-        contract_details = IBTestStubs.contract_details("AAPL")
-        contract = IBTestStubs.contract()
+        contract_details = IBTestDataStubs.contract_details("AAPL")
+        contract = IBTestDataStubs.contract()
         mocker.patch.object(self.ib, "reqContractDetails", return_value=[contract_details])
         mock_ticks = mocker.patch.object(self.ib, "reqHistoricalTicks", return_value=[])
 
@@ -54,7 +54,7 @@ class TestInteractiveBrokersHistoric:
         back_fill_catalog(
             ib=self.ib,
             catalog=self.catalog,
-            contracts=[IBTestStubs.contract()],
+            contracts=[IBTestDataStubs.contract()],
             start_date=datetime.date(2020, 1, 1),
             end_date=datetime.date(2020, 1, 2),
             tz_name="America/New_York",
@@ -95,8 +95,8 @@ class TestInteractiveBrokersHistoric:
     @pytest.mark.skipif(sys.platform == "win32", reason="test path broken on Windows")
     def test_back_fill_catalog_bars(self, mocker):
         # Arrange
-        contract_details = IBTestStubs.contract_details("AAPL")
-        contract = IBTestStubs.contract()
+        contract_details = IBTestDataStubs.contract_details("AAPL")
+        contract = IBTestDataStubs.contract()
         mocker.patch.object(self.ib, "reqContractDetails", return_value=[contract_details])
         mock_ticks = mocker.patch.object(self.ib, "reqHistoricalData", return_value=[])
 
@@ -104,7 +104,7 @@ class TestInteractiveBrokersHistoric:
         back_fill_catalog(
             ib=self.ib,
             catalog=self.catalog,
-            contracts=[IBTestStubs.contract()],
+            contracts=[IBTestDataStubs.contract()],
             start_date=datetime.date(2020, 1, 1),
             end_date=datetime.date(2020, 1, 2),
             tz_name="America/New_York",
@@ -128,8 +128,8 @@ class TestInteractiveBrokersHistoric:
 
     def test_parse_historic_trade_ticks(self):
         # Arrange
-        raw = IBTestStubs.historic_trades()
-        instrument = IBTestStubs.instrument(symbol="AAPL")
+        raw = IBTestDataStubs.historic_trades()
+        instrument = IBTestDataStubs.instrument(symbol="AAPL")
 
         # Act
         ticks = parse_historic_trade_ticks(historic_ticks=raw, instrument=instrument)
@@ -153,8 +153,8 @@ class TestInteractiveBrokersHistoric:
 
     def test_parse_historic_quote_ticks(self):
         # Arrange
-        raw = IBTestStubs.historic_bid_ask()
-        instrument = IBTestStubs.instrument(symbol="AAPL")
+        raw = IBTestDataStubs.historic_bid_ask()
+        instrument = IBTestDataStubs.instrument(symbol="AAPL")
 
         # Act
         ticks = parse_historic_quote_ticks(historic_ticks=raw, instrument=instrument)
@@ -177,8 +177,8 @@ class TestInteractiveBrokersHistoric:
 
     def test_parse_historic_bar(self):
         # Arrange
-        raw = IBTestStubs.historic_bars()
-        instrument = IBTestStubs.instrument(symbol="AAPL")
+        raw = IBTestDataStubs.historic_bars()
+        instrument = IBTestDataStubs.instrument(symbol="AAPL")
 
         # Act
         ticks = parse_historic_bars(

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -22,6 +22,7 @@ import msgspec
 import pandas as pd
 from ib_insync import BarData
 from ib_insync import Contract
+from ib_insync import Execution
 from ib_insync import HistoricalTickBidAsk
 from ib_insync import HistoricalTickLast
 from ib_insync import LimitOrder as IBLimitOrder
@@ -324,4 +325,27 @@ class IBExecTestStubs:
                     errorCode=10148,
                 ),
             ],
+        )
+
+    @staticmethod
+    def execution() -> Execution:
+        return Execution(
+            execId="1",
+            time=datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+            acctNumber="111",
+            exchange="NYSE",
+            side="BUY",
+            shares=100,
+            price=50.0,
+            permId=0,
+            clientId=0,
+            orderId=0,
+            liquidation=0,
+            cumQty=100,
+            avgPrice=50.0,
+            orderRef="",
+            evRule="",
+            evMultiplier=0.0,
+            modelCode="",
+            lastLiquidity=0,
         )

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -133,7 +133,7 @@ class IBExecTestStubs:
     @staticmethod
     def trade_pending_submit(contract=None, order: IBOrder = None) -> Trade:
         contract = contract or IBTestDataStubs.contract_details("AAPL").contract
-        order = order or IBExecTestStubs.ib_order()
+        order = order or IBExecTestStubs.create_order()
         return Trade(
             contract=contract,
             order=order,

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -20,14 +20,14 @@ from nautilus_trader.adapters.interactive_brokers.parsing.execution import (
     nautilus_order_to_ib_order,
 )
 from tests.integration_tests.adapters.interactive_brokers.base import InteractiveBrokersTestBase
-from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 from tests.test_kit.stubs.execution import TestExecStubs
 
 
 class TestInteractiveBrokersData(InteractiveBrokersTestBase):
     def setup(self):
         super().setup()
-        self.instrument = IBTestStubs.instrument("AAPL")
+        self.instrument = IBTestDataStubs.instrument("AAPL")
 
     def test_nautilus_order_to_ib_market_order(self):
         # Arrange

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -40,7 +40,7 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.objects import Price
-from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 
 
 class TestIBInstrumentProvider:
@@ -127,8 +127,8 @@ class TestIBInstrumentProvider:
     async def test_load_equity_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
-        contract = IBTestStubs.contract(symbol="AAPL")
-        contract_details = IBTestStubs.contract_details("AAPL")
+        contract = IBTestDataStubs.contract(symbol="AAPL")
+        contract_details = IBTestDataStubs.contract_details("AAPL")
         mocker.patch.object(
             self.provider._client,
             "reqContractDetailsAsync",
@@ -156,8 +156,8 @@ class TestIBInstrumentProvider:
     async def test_load_futures_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("CLZ2.NYMEX")
-        contract = IBTestStubs.contract(symbol="CLZ2", exchange="NYMEX")
-        contract_details = IBTestStubs.contract_details("CLZ2")
+        contract = IBTestDataStubs.contract(symbol="CLZ2", exchange="NYMEX")
+        contract_details = IBTestDataStubs.contract_details("CLZ2")
         mocker.patch.object(
             self.provider._client,
             "reqContractDetailsAsync",
@@ -184,10 +184,10 @@ class TestIBInstrumentProvider:
     async def test_load_options_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("AAPL211217C00160000.SMART")
-        contract = IBTestStubs.contract(
+        contract = IBTestDataStubs.contract(
             secType="OPT", symbol="AAPL211217C00160000", exchange="NASDAQ"
         )
-        contract_details = IBTestStubs.contract_details("AAPL211217C00160000")
+        contract_details = IBTestDataStubs.contract_details("AAPL211217C00160000")
         mocker.patch.object(
             self.provider._client,
             "reqContractDetailsAsync",
@@ -217,8 +217,8 @@ class TestIBInstrumentProvider:
     async def test_load_forex_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
-        contract = IBTestStubs.contract(secType="CASH", symbol="EURUSD", exchange="IDEALPRO")
-        contract_details = IBTestStubs.contract_details("EURUSD")
+        contract = IBTestDataStubs.contract(secType="CASH", symbol="EURUSD", exchange="IDEALPRO")
+        contract_details = IBTestDataStubs.contract_details("EURUSD")
         contract_details.minSize = 1
         mocker.patch.object(
             self.provider._client,
@@ -245,8 +245,8 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_contract_id_to_instrument_id(self, mocker):
         # Arrange
-        contract = IBTestStubs.contract(symbol="CLZ2", exchange="NYMEX")
-        contract_details = IBTestStubs.contract_details("CLZ2")
+        contract = IBTestDataStubs.contract(symbol="CLZ2", exchange="NYMEX")
+        contract_details = IBTestDataStubs.contract_details("CLZ2")
         mocker.patch.object(
             self.provider._client,
             "qualifyContractsAsync",

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -219,6 +219,7 @@ class TestIBInstrumentProvider:
         instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
         contract = IBTestStubs.contract(secType="CASH", symbol="EURUSD", exchange="IDEALPRO")
         contract_details = IBTestStubs.contract_details("EURUSD")
+        contract_details.minSize = 1
         mocker.patch.object(
             self.provider._client,
             "reqContractDetailsAsync",


### PR DESCRIPTION
# Pull Request

Fixing a couple of issues with interactive brokers adapters:
- Fix instrument filters bug #812
- Fix missing sizeMinTick #813  
- Fix bug in gateway not setting username/password and env var names
- Add `read_api` to gateway startup to allow execution
- Add exec details for order fills
- Add account balance handling on startup

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tests.