### PR TITLE
IB connect timeout

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -110,7 +110,7 @@ def get_cached_ib_client(
         if connect:
             for _ in range(10):
                 try:
-                    client.connect(host=host, port=port, timeout=1, clientId=client_id)
+                    client.connect(host=host, port=port, timeout=6, clientId=client_id)
                     break
                 except (TimeoutError, AttributeError, asyncio.TimeoutError):
                     continue


### PR DESCRIPTION
# Pull Request

IB Connect timeout of 1 sec is too low and client connection fails.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested?

Timeout has been changed to 6 sec. Connections to TWS works fine.
