### PR TITLE
Unify the InstrumentId as per 'localSymbol@exchange.IB'

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -16,7 +16,7 @@
 from nautilus_trader.model.identifiers import Venue
 
 
-IB_VENUE = Venue("InteractiveBrokers")
+IB_VENUE = Venue("IB")
 
 
 class ContractId(int):

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -110,7 +110,7 @@ def get_cached_ib_client(
         if connect:
             for _ in range(10):
                 try:
-                    client.connect(host=host, port=port, timeout=1, clientId=client_id)
+                    client.connect(host=host, port=port, timeout=6, clientId=client_id)
                     break
                 except (TimeoutError, AttributeError, asyncio.TimeoutError):
                     continue

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -22,6 +22,7 @@ from ib_insync import Fill
 from ib_insync import LimitOrder
 from ib_insync import Trade
 
+from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.enums import OrderType
@@ -267,7 +268,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         expected = {
             "client_order_id": ClientOrderId("O-20210410-022422-001-001-1"),
             "commission": Money("1.00", USD),
-            "instrument_id": InstrumentId.from_str("AAPL.NASDAQ"),
+            "instrument_id": InstrumentId.from_str(f"AAPL@NASDAQ.{IB_VENUE}"),
             "last_px": Price.from_str("50.00"),
             "last_qty": Quantity.from_str("100"),
             "liquidity_side": LiquiditySide.NONE,
@@ -339,7 +340,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         call = mock.call_args_list[0]
         expected = {
             "client_order_id": ClientOrderId("O-20210410-022422-001-001-1"),
-            "instrument_id": InstrumentId.from_str("AAPL.NASDAQ"),
+            "instrument_id": InstrumentId.from_str(f"AAPL@NASDAQ.{IB_VENUE}"),
             "strategy_id": StrategyId("S-001"),
             "ts_event": 1646533038455087000,
             "venue_order_id": VenueOrderId("1"),
@@ -369,7 +370,7 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         name, args, kwargs = mock.mock_calls[0]
         expected = {
             "client_order_id": ClientOrderId("O-20210410-022422-001-001-1"),
-            "instrument_id": InstrumentId.from_str("AAPL.NASDAQ"),
+            "instrument_id": InstrumentId.from_str(f"AAPL@NASDAQ.{IB_VENUE}"),
             "strategy_id": StrategyId("S-001"),
             "ts_event": 1646533382000847000,
             "venue_order_id": VenueOrderId("1"),

--- a/tests/integration_tests/adapters/interactive_brokers/test_historic.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_historic.py
@@ -21,6 +21,7 @@ import pandas as pd
 import pytest
 import pytz
 
+from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
 from nautilus_trader.adapters.interactive_brokers.historic import _bar_spec_to_hist_data_request
 from nautilus_trader.adapters.interactive_brokers.historic import back_fill_catalog
 from nautilus_trader.adapters.interactive_brokers.historic import parse_historic_bars
@@ -140,7 +141,7 @@ class TestInteractiveBrokersHistoric:
         expected = TradeTick.from_dict(
             {
                 "type": "TradeTick",
-                "instrument_id": "AAPL.NASDAQ",
+                "instrument_id": f"AAPL@NASDAQ.{IB_VENUE}",
                 "price": "6.20",
                 "size": "30",
                 "aggressor_side": "NONE",
@@ -164,7 +165,7 @@ class TestInteractiveBrokersHistoric:
         expected = QuoteTick.from_dict(
             {
                 "type": "QuoteTick",
-                "instrument_id": "AAPL.NASDAQ",
+                "instrument_id": f"AAPL@NASDAQ.{IB_VENUE}",
                 "bid": "0.99",
                 "ask": "15.30",
                 "bid_size": "1",
@@ -190,7 +191,7 @@ class TestInteractiveBrokersHistoric:
         expected = Bar.from_dict(
             {
                 "type": "Bar",
-                "bar_type": "AAPL.NASDAQ-1-MINUTE-LAST-EXTERNAL",
+                "bar_type": f"AAPL@NASDAQ.{IB_VENUE}-1-MINUTE-LAST-EXTERNAL",
                 "open": "219.00",
                 "high": "219.00",
                 "low": "219.00",

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -13,11 +13,18 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from ib_insync import Contract as IBContract
 from ib_insync import LimitOrder as IBLimitOrder
 from ib_insync import MarketOrder as IBMarketOrder
 
 from nautilus_trader.adapters.interactive_brokers.parsing.execution import (
     nautilus_order_to_ib_order,
+)
+from nautilus_trader.adapters.interactive_brokers.parsing.instruments import (
+    ib_contract_to_instrument_id,
+)
+from nautilus_trader.adapters.interactive_brokers.parsing.instruments import (
+    nautilus_instrument_to_ib_contract,
 )
 from tests.integration_tests.adapters.interactive_brokers.base import InteractiveBrokersTestBase
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
@@ -53,3 +60,28 @@ class TestInteractiveBrokersData(InteractiveBrokersTestBase):
         assert result.action == expected.action
         assert result.totalQuantity == expected.totalQuantity
         assert result.lmtPrice == expected.lmtPrice
+
+    def test_nautilus_instrument_to_ib_contract(self):
+        # Act
+        result = nautilus_instrument_to_ib_contract(self.instrument)
+
+        # Assert
+        expected = IBContract(
+            secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"
+        )
+        assert result.secType == expected.secType
+        assert result.exchange == expected.exchange
+        assert result.primaryExchange == expected.primaryExchange
+        assert result.localSymbol == expected.localSymbol
+
+    def test_ib_contract_to_instrument_id(self):
+        # Arrange
+        ib_contract = IBTestDataStubs.contract_details(self.instrument.native_symbol.value).contract
+
+        # Act
+        result = ib_contract_to_instrument_id(ib_contract)
+
+        # Assert
+        expected = self.instrument.id
+        assert result.symbol == expected.symbol
+        assert result.venue == expected.venue

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -26,6 +26,7 @@ from ib_insync import Future
 from ib_insync import Option
 from ib_insync import Stock
 
+from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
 from nautilus_trader.adapters.interactive_brokers.providers import (
     InteractiveBrokersInstrumentProvider,
 )
@@ -38,7 +39,6 @@ from nautilus_trader.model.enums import AssetType
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.objects import Price
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 
@@ -126,7 +126,7 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_load_equity_contract_instrument(self, mocker):
         # Arrange
-        instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+        instrument_id = InstrumentId.from_str(f"AAPL@NASDAQ.{IB_VENUE}")
         contract = IBTestDataStubs.contract(symbol="AAPL")
         contract_details = IBTestDataStubs.contract_details("AAPL")
         mocker.patch.object(
@@ -145,7 +145,7 @@ class TestIBInstrumentProvider:
         equity = self.provider.find(instrument_id)
 
         # Assert
-        assert InstrumentId(symbol=Symbol("AAPL"), venue=Venue("NASDAQ")) == equity.id
+        assert InstrumentId(symbol=Symbol("AAPL@NASDAQ"), venue=IB_VENUE) == equity.id
         assert equity.asset_class == AssetClass.EQUITY
         assert equity.asset_type == AssetType.SPOT
         assert 100 == equity.multiplier
@@ -155,7 +155,7 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_load_futures_contract_instrument(self, mocker):
         # Arrange
-        instrument_id = InstrumentId.from_str("CLZ2.NYMEX")
+        instrument_id = InstrumentId.from_str(f"CLZ2@NYMEX.{IB_VENUE}")
         contract = IBTestDataStubs.contract(symbol="CLZ2", exchange="NYMEX")
         contract_details = IBTestDataStubs.contract_details("CLZ2")
         mocker.patch.object(
@@ -183,7 +183,7 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_load_options_contract_instrument(self, mocker):
         # Arrange
-        instrument_id = InstrumentId.from_str("AAPL211217C00160000.SMART")
+        instrument_id = InstrumentId.from_str(f"AAPL211217C00160000@SMART.{IB_VENUE}")
         contract = IBTestDataStubs.contract(
             secType="OPT", symbol="AAPL211217C00160000", exchange="NASDAQ"
         )
@@ -216,7 +216,7 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_load_forex_contract_instrument(self, mocker):
         # Arrange
-        instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
+        instrument_id = InstrumentId.from_str(f"EUR.USD@IDEALPRO.{IB_VENUE}")
         contract = IBTestDataStubs.contract(secType="CASH", symbol="EURUSD", exchange="IDEALPRO")
         contract_details = IBTestDataStubs.contract_details("EURUSD")
         contract_details.minSize = 1
@@ -262,7 +262,7 @@ class TestIBInstrumentProvider:
         await self.provider.load(symbol="CLZ2", exchange="NYMEX")
 
         # Assert
-        expected = {138979238: InstrumentId.from_str("CLZ2.NYMEX")}
+        expected = {138979238: InstrumentId.from_str(f"CLZ2@NYMEX.{IB_VENUE}")}
         assert self.provider.contract_id_to_instrument_id == expected
 
     def test_none_filters(self):


### PR DESCRIPTION
# Pull Request

In followup of discussion started in #861. Feel free to turn down the PR / feedback in case not-compliant or doesn't make sense.

This changes are as following and breaking applicable for existing persistance Catalog/Cache data, will need translating InstrumentId.

- Unify the InstrumentId as per 'localSymbol@exchange.IB' (this will make it more compitible with core and easy backtesting setup]
- IB_VENUE value has been shortened to 'IB' as now it will be part of InstrumentId
- nautilus_instrument_to_ib_contract and ib_contract_to_instrument_id helper functions added to convert between InstrumentId and IBContract.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How has this change been tested?

The built-in tests for adapter are passed. InstrumentId is updated in tests accordingly.
