### PR TITLE
Fixes to IB instruments

### DIFF
--- a/nautilus_trader/config/common.py
+++ b/nautilus_trader/config/common.py
@@ -109,6 +109,9 @@ class InstrumentProviderConfig(NautilusConfig):
         The list of instrument IDs to be loaded on start (if `load_all_instruments` is False).
     filters : frozendict, optional
         The venue specific instrument loading filters to apply.
+    filter_callable: str, optional
+        A fully qualified path to a callable that takes a single argument, `instrument` and returns a bool, indicating
+        whether the instrument should be loaded
     log_warnings : bool, default True
         If parser warnings should be logged.
     """
@@ -135,6 +138,7 @@ class InstrumentProviderConfig(NautilusConfig):
     load_all: bool = False
     load_ids: Optional[frozenset[str]] = None
     filters: Optional[dict[str, Any]] = None
+    filter_callable: Optional[str] = None
     log_warnings: bool = True
 
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -34,6 +34,7 @@ from ib_insync import TradeLogEntry
 
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import parse_instrument
 from nautilus_trader.model.instruments.equity import Equity
+from nautilus_trader.model.instruments.option import Option
 from tests import TESTS_PACKAGE_ROOT
 
 
@@ -405,3 +406,7 @@ class IBTestExecStubs:
             modelCode="",
             lastLiquidity=0,
         )
+
+
+def filter_out_options(instrument) -> bool:
+    return not isinstance(instrument, Option)

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -65,6 +65,20 @@ class TestIBInstrumentProvider:
         future.set_result(value)
         return future
 
+    def mock_ib_contract_calls(self, mocker, symbol: str, **kwargs):
+        contract_details = IBTestDataStubs.contract_details(symbol)
+        contract = IBTestDataStubs.contract(symbol=symbol, **kwargs)
+        mocker.patch.object(
+            self.provider._client,
+            "reqContractDetailsAsync",
+            return_value=self.async_return_value([contract_details]),
+        )
+        mocker.patch.object(
+            self.provider._client,
+            "qualifyContractsAsync",
+            return_value=self.async_return_value([contract]),
+        )
+
     @pytest.mark.parametrize(
         "filters, expected",
         [
@@ -129,18 +143,7 @@ class TestIBInstrumentProvider:
     async def test_load_equity_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
-        contract = IBTestDataStubs.contract(symbol="AAPL")
-        contract_details = IBTestDataStubs.contract_details("AAPL")
-        mocker.patch.object(
-            self.provider._client,
-            "reqContractDetailsAsync",
-            return_value=self.async_return_value([contract_details]),
-        )
-        mocker.patch.object(
-            self.provider._client,
-            "qualifyContractsAsync",
-            return_value=self.async_return_value([contract]),
-        )
+        self.mock_ib_contract_calls(mocker=mocker, symbol="AAPL")
 
         # Act
         await self.provider.load(secType="STK", symbol="AAPL", exchange="NASDAQ")
@@ -158,18 +161,7 @@ class TestIBInstrumentProvider:
     async def test_load_futures_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("CLZ2.NYMEX")
-        contract = IBTestDataStubs.contract(symbol="CLZ2", exchange="NYMEX")
-        contract_details = IBTestDataStubs.contract_details("CLZ2")
-        mocker.patch.object(
-            self.provider._client,
-            "reqContractDetailsAsync",
-            return_value=self.async_return_value([contract_details]),
-        )
-        mocker.patch.object(
-            self.provider._client,
-            "qualifyContractsAsync",
-            return_value=self.async_return_value([contract]),
-        )
+        self.mock_ib_contract_calls(mocker=mocker, symbol="CLZ2", exchange="NYMEX")
 
         # Act
         await self.provider.load(symbol="CLZ2", exchange="NYMEX")
@@ -186,21 +178,11 @@ class TestIBInstrumentProvider:
     async def test_load_options_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("AAPL211217C00160000.SMART")
-        contract = IBTestDataStubs.contract(
+        self.mock_ib_contract_calls(
+            mocker=mocker,
             secType="OPT",
             symbol="AAPL211217C00160000",
             exchange="NASDAQ",
-        )
-        contract_details = IBTestDataStubs.contract_details("AAPL211217C00160000")
-        mocker.patch.object(
-            self.provider._client,
-            "reqContractDetailsAsync",
-            return_value=self.async_return_value([contract_details]),
-        )
-        mocker.patch.object(
-            self.provider._client,
-            "qualifyContractsAsync",
-            return_value=self.async_return_value([contract]),
         )
 
         # Act
@@ -221,18 +203,11 @@ class TestIBInstrumentProvider:
     async def test_load_forex_contract_instrument(self, mocker):
         # Arrange
         instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
-        contract = IBTestDataStubs.contract(secType="CASH", symbol="EURUSD", exchange="IDEALPRO")
-        contract_details = IBTestDataStubs.contract_details("EURUSD")
-        contract_details.minSize = 1
-        mocker.patch.object(
-            self.provider._client,
-            "reqContractDetailsAsync",
-            return_value=self.async_return_value([contract_details]),
-        )
-        mocker.patch.object(
-            self.provider._client,
-            "qualifyContractsAsync",
-            return_value=self.async_return_value([contract]),
+        self.mock_ib_contract_calls(
+            mocker=mocker,
+            secType="CASH",
+            symbol="EURUSD",
+            exchange="IDEALPRO",
         )
 
         # Act
@@ -249,17 +224,10 @@ class TestIBInstrumentProvider:
     @pytest.mark.asyncio
     async def test_contract_id_to_instrument_id(self, mocker):
         # Arrange
-        contract = IBTestDataStubs.contract(symbol="CLZ2", exchange="NYMEX")
-        contract_details = IBTestDataStubs.contract_details("CLZ2")
-        mocker.patch.object(
-            self.provider._client,
-            "qualifyContractsAsync",
-            return_value=self.async_return_value([contract]),
-        )
-        mocker.patch.object(
-            self.provider._client,
-            "reqContractDetailsAsync",
-            return_value=self.async_return_value([contract_details]),
+        self.mock_ib_contract_calls(
+            mocker=mocker,
+            symbol="CLZ2",
+            exchange="NYMEX",
         )
 
         # Act
@@ -269,6 +237,37 @@ class TestIBInstrumentProvider:
         expected = {138979238: InstrumentId.from_str("CLZ2.NYMEX")}
         assert self.provider.contract_id_to_instrument_id == expected
 
-    def test_none_filters(self):
+    @pytest.mark.asyncio
+    async def test_none_filters(self):
         # Act, Arrange, Assert
         self.provider.load_all(None)
+
+    @pytest.mark.asyncio
+    async def test_instrument_filter_callable_none(self, mocker):
+        # Arrange
+        self.mock_ib_contract_calls(mocker=mocker, symbol="AAPL")
+
+        # Act
+        await self.provider.load()
+
+        # Assert
+        assert len(self.provider.get_all()) == 1
+
+    @pytest.mark.asyncio
+    async def test_instrument_filter_callable_option_filter(self, mocker):
+        # Arrange
+        self.mock_ib_contract_calls(
+            mocker=mocker,
+            secType="OPT",
+            symbol="AAPL211217C00160000",
+            exchange="NASDAQ",
+        )
+        # Act
+        self.provider.config.filter_callable = (
+            "tests.integration_tests.adapters.interactive_brokers.test_kit:filter_out_options"
+        )
+        await self.provider.load()
+        option_instruments = self.provider.get_all()
+
+        # Assert
+        assert len(option_instruments) == 0


### PR DESCRIPTION
- Handful of fixes for options load in IB instrument provider
- Adds a `filter_callable` parameter to InstrumentProviderConfig to allow more flexibility when loading instruments (via a callable)