### PR TITLE
Remove Partialable from Backtest config

### DIFF
--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -123,7 +123,6 @@ class BacktestNode:
         """
         results: list[BacktestResult] = []
         for config in self._configs:
-            config.check()  # Check all values set
             result = self._run(
                 run_config_id=config.id,
                 engine_config=config.engine,

--- a/nautilus_trader/config/__init__.py
+++ b/nautilus_trader/config/__init__.py
@@ -23,7 +23,6 @@ from nautilus_trader.config.backtest import BacktestDataConfig
 from nautilus_trader.config.backtest import BacktestEngineConfig
 from nautilus_trader.config.backtest import BacktestRunConfig
 from nautilus_trader.config.backtest import BacktestVenueConfig
-from nautilus_trader.config.backtest import Partialable
 from nautilus_trader.config.common import ActorConfig
 from nautilus_trader.config.common import ActorFactory
 from nautilus_trader.config.common import CacheConfig

--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -112,23 +112,6 @@ class BacktestVenueConfig(Partialable):
     # fill_model: Optional[FillModel] = None  # TODO(cs): Implement
     # modules: Optional[list[SimulationModule]] = None  # TODO(cs): Implement
 
-    def __tokenize__(self):
-        values = [
-            self.name,
-            self.oms_type,
-            self.account_type,
-            self.base_currency,
-            ",".join(sorted([b for b in self.starting_balances])),
-            self.default_leverage,
-            self.leverages,
-            self.book_type,
-            self.routing,
-            self.frozen_account,
-            self.reject_stop_orders,
-            # self.modules,  # TODO(cs): Implement
-        ]
-        return tuple(values)
-
 
 class BacktestDataConfig(Partialable):
     """
@@ -268,9 +251,6 @@ class BacktestEngineConfig(NautilusKernelConfig):
     exec_engine: ExecEngineConfig = ExecEngineConfig()
     run_analysis: bool = True
 
-    def __tokenize__(self):
-        return tuple(self.dict().items())
-
 
 class BacktestRunConfig(Partialable):
     """
@@ -298,7 +278,7 @@ class BacktestRunConfig(Partialable):
 
     @property
     def id(self):
-        return tokenize(self)
+        return tokenize(self.json())
 
 
 def parse_filters_expr(s: str):

--- a/nautilus_trader/config/backtest.py
+++ b/nautilus_trader/config/backtest.py
@@ -17,6 +17,7 @@ import hashlib
 import importlib
 import sys
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional, Union
 
 import msgspec
@@ -255,7 +256,7 @@ def parse_filters_expr(s: str):
 
 
 def encoder(x):
-    if isinstance(x, ConstrainedStr):
+    if isinstance(x, (ConstrainedStr, Decimal)):
         return str(x)
     raise TypeError(f"Objects of type {type(x)} are not supported")
 

--- a/nautilus_trader/core/inspect.pyx
+++ b/nautilus_trader/core/inspect.pyx
@@ -19,9 +19,12 @@ import sys
 
 def is_nautilus_class(cls: type) -> bool:
     """
-    Determine whether a class belongs to `nautilus_trader`.
+    Determine whether a class is a builtin nautilus type.
     """
-    return cls.__module__.startswith("nautilus_trader.")
+    return (
+        cls.__module__.startswith("nautilus_trader.") and
+        not cls.__module__.startswith("nautilus_trader.test_kit")
+    )
 
 
 def get_size_of(obj):

--- a/nautilus_trader/persistence/funcs.py
+++ b/nautilus_trader/persistence/funcs.py
@@ -16,11 +16,11 @@
 import hashlib
 from typing import Union
 
-import cloudpickle
+import msgspec
 
 
-def tokenize(obj: object) -> str:
-    value: bytes = cloudpickle.dumps(obj)
+def tokenize(obj: dict) -> str:
+    value: bytes = msgspec.json.encode(obj)
     return hashlib.sha256(value).hexdigest()
 
 

--- a/nautilus_trader/persistence/funcs.py
+++ b/nautilus_trader/persistence/funcs.py
@@ -13,15 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import hashlib
 from typing import Union
-
-import msgspec
-
-
-def tokenize(obj: dict) -> str:
-    value: bytes = msgspec.json.encode(obj)
-    return hashlib.sha256(value).hexdigest()
 
 
 # Taken from https://github.com/dask/dask/blob/261bf174931580230717abca93fe172e166cc1e8/dask/utils.py

--- a/nautilus_trader/test_kit/stubs/config.py
+++ b/nautilus_trader/test_kit/stubs/config.py
@@ -93,13 +93,15 @@ class TestConfigStubs:
         config: Optional[BacktestEngineConfig] = None,
         instrument_ids: Optional[list[str]] = None,
         data_types: tuple[Data] = (QuoteTick,),
+        data_configs: Optional[list] = None,
         venues: Optional[list[BacktestVenueConfig]] = None,
     ):
         instrument_ids = instrument_ids or []
         run_config = BacktestRunConfig(
             engine=config,
             venues=venues or [TestConfigStubs.backtest_venue_config()],
-            data=[
+            data=data_configs
+            or [
                 BacktestDataConfig(
                     data_cls=cls.fully_qualified_name(),
                     catalog_path=str(catalog.path),

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -31,6 +31,7 @@ from nautilus_trader.config import BacktestDataConfig
 from nautilus_trader.config import BacktestRunConfig
 from nautilus_trader.config import BacktestVenueConfig
 from nautilus_trader.config import Partialable
+from nautilus_trader.config.backtest import tokenize_config
 from nautilus_trader.model.data.tick import QuoteTick
 from nautilus_trader.model.data.venue import InstrumentStatusUpdate
 from nautilus_trader.model.identifiers import ClientId
@@ -369,3 +370,49 @@ class TestBacktestConfig:
     def test_backtest_run_config_id(self):
         token = self.backtest_config.id
         assert token == "a256660cfcf105fbb3ff2aba64001b0a0aedd81fb7a7914e938221e91409c43a"
+
+    @pytest.mark.parametrize(
+        "config_func, keys, kw, expected",
+        [
+            (
+                TestConfigStubs.venue_config,
+                (),
+                {},
+                "7919596b3762fd98d79afa64976a292d408313816d38ec26ebd29e31049b92f9",
+            ),
+            (
+                TestConfigStubs.backtest_data_config,
+                ("catalog",),
+                {},
+                "44e5227fb899f348534c0d1f65f5b34176f0faf492b6795879b9ea1a32645e88",
+            ),
+            (
+                TestConfigStubs.backtest_engine_config,
+                ("catalog",),
+                {"persist": True},
+                "0850cc6c7bb99dbb75c4cd762f870c0f359639fdc416143124ac2b80f3ceca7f",
+            ),
+            (
+                TestConfigStubs.risk_engine_config,
+                (),
+                {},
+                "962367da58082b349922801d5fea53526f1c35149a042c84fde2fc69c8fb46cf",
+            ),
+            (
+                TestConfigStubs.exec_engine_config,
+                (),
+                {},
+                "a6ca5c188b92707f81a9ba5d45700dcbc8aebe0443c1e7b13b10a86c045c6391",
+            ),
+            (
+                TestConfigStubs.streaming_config,
+                ("catalog",),
+                {},
+                "f488bdd4746d00210328b4cee46d9bdf05fab6cdcf6bc00033987f79f245888f",
+            ),
+        ],
+    )
+    def test_tokenize_config(self, config_func, keys, kw, expected):
+        config = config_func(**{k: getattr(self, k) for k in keys}, **kw)
+        token = tokenize_config(config.dict())
+        assert token == expected

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -230,11 +230,14 @@ class TestBacktestConfig:
         )
         json = run_config.json()
         result = len(msgspec.json.encode(json))
-        assert result == 1352
+        assert result in (1352, 1370)  # unix, windows
 
     def test_backtest_run_config_id(self):
         token = self.backtest_config.id
-        assert token == "8653615ebf0412a3cc64e5e4fa38842e59b87d86d75c127bbf8b615048752629"
+        assert token in (
+            "8653615ebf0412a3cc64e5e4fa38842e59b87d86d75c127bbf8b615048752629",  # unix
+            "b2379c3eb60a0be2f10a05fc6b953c943bbb482cbaf7787a63606348e2b879c4",  # windows
+        )
 
     @pytest.mark.parametrize(
         "config_func, keys, kw, expected",
@@ -243,37 +246,46 @@ class TestBacktestConfig:
                 TestConfigStubs.venue_config,
                 (),
                 {},
-                "7919596b3762fd98d79afa64976a292d408313816d38ec26ebd29e31049b92f9",
+                ("7919596b3762fd98d79afa64976a292d408313816d38ec26ebd29e31049b92f9",),
             ),
             (
                 TestConfigStubs.backtest_data_config,
                 ("catalog",),
                 {},
-                "44e5227fb899f348534c0d1f65f5b34176f0faf492b6795879b9ea1a32645e88",
+                (
+                    "44e5227fb899f348534c0d1f65f5b34176f0faf492b6795879b9ea1a32645e88",  # unix
+                    "976eb2b871e6659c646498255dcf6f8bf0af7152f523eb3d55c01e9ad133d99c",  # windows
+                ),
             ),
             (
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                "0850cc6c7bb99dbb75c4cd762f870c0f359639fdc416143124ac2b80f3ceca7f",
+                (
+                    "0850cc6c7bb99dbb75c4cd762f870c0f359639fdc416143124ac2b80f3ceca7f",
+                    "0ac4b233023aec12464ec119d89c67d31025160858096f193d4c72190074d057",
+                ),
             ),
             (
                 TestConfigStubs.risk_engine_config,
                 (),
                 {},
-                "962367da58082b349922801d5fea53526f1c35149a042c84fde2fc69c8fb46cf",
+                ("962367da58082b349922801d5fea53526f1c35149a042c84fde2fc69c8fb46cf",),
             ),
             (
                 TestConfigStubs.exec_engine_config,
                 (),
                 {},
-                "a6ca5c188b92707f81a9ba5d45700dcbc8aebe0443c1e7b13b10a86c045c6391",
+                ("a6ca5c188b92707f81a9ba5d45700dcbc8aebe0443c1e7b13b10a86c045c6391",),
             ),
             (
                 TestConfigStubs.streaming_config,
                 ("catalog",),
                 {},
-                "f488bdd4746d00210328b4cee46d9bdf05fab6cdcf6bc00033987f79f245888f",
+                (
+                    "f488bdd4746d00210328b4cee46d9bdf05fab6cdcf6bc00033987f79f245888f",
+                    "e9af640c98ccba607aca44aa40113cbf67e70c31afd305ea125e00ff3e326cc5",
+                ),
             ),
         ],
     )

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -292,4 +292,4 @@ class TestBacktestConfig:
     def test_tokenize_config(self, config_func, keys, kw, expected):
         config = config_func(**{k: getattr(self, k) for k in keys}, **kw)
         token = tokenize_config(config.dict())
-        assert token == expected
+        assert token in expected

--- a/tests/unit_tests/backtest/test_backtest_config.py
+++ b/tests/unit_tests/backtest/test_backtest_config.py
@@ -294,7 +294,7 @@ class TestBacktestConfig:
         )
         json = run_config.json()
         result = len(msgspec.json.encode(json))
-        assert result == 696
+        assert result in (696, 702)  # unix, windows sizes
 
     def test_run_config_parse_obj(self):
         run_config = TestConfigStubs.backtest_run_config(
@@ -315,7 +315,7 @@ class TestBacktestConfig:
         assert isinstance(config, BacktestRunConfig)
         node = BacktestNode(configs=[config])
         assert isinstance(node, BacktestNode)
-        assert len(raw) == 626
+        assert len(raw) in (626, 628)  # unix, windows sizes
 
     def test_backtest_config_to_json(self):
         assert self.backtest_config.json()

--- a/tests/unit_tests/persistence/test_batching.py
+++ b/tests/unit_tests/persistence/test_batching.py
@@ -54,17 +54,16 @@ class TestPersistenceBatching:
     def test_batch_files_single(self):
         # Arrange
         instrument_ids = self.catalog.instruments()["id"].unique().tolist()
-        base = BacktestDataConfig(
+        shared_kw = dict(
             catalog_path=str(self.catalog.path),
             catalog_fs_protocol=self.catalog.fs.protocol,
             data_cls=OrderBookData,
         )
-
         iter_batches = batch_files(
             catalog=self.catalog,
             data_configs=[
-                base.replace(instrument_id=instrument_ids[0]),
-                base.replace(instrument_id=instrument_ids[1]),
+                BacktestDataConfig(**shared_kw, instrument_id=instrument_ids[0]),
+                BacktestDataConfig(**shared_kw, instrument_id=instrument_ids[1]),
             ],
             target_batch_size_bytes=parse_bytes("10kib"),
             read_num_rows=300,

--- a/tests/unit_tests/persistence/test_batching.py
+++ b/tests/unit_tests/persistence/test_batching.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import fsspec
-import pytest
 
 from nautilus_trader.adapters.betfair.providers import BetfairInstrumentProvider
 from nautilus_trader.backtest.node import BacktestNode
@@ -83,9 +82,6 @@ class TestPersistenceBatching:
             latest_timestamp = max(timestamps)
             assert timestamps == sorted(timestamps)
 
-    @pytest.mark.skip(
-        reason="TypeError: The 'client_id' argument was None",
-    )  # TODO: bm to investigate
     def test_batch_generic_data(self):
         # Arrange
         TestPersistenceStubs.setup_news_event_persistence()

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -109,9 +109,6 @@ class TestPersistenceStreaming:
 
         assert result == expected
 
-    @pytest.mark.skip(
-        reason="TypeError: The 'client_id' argument was None",
-    )  # TODO: bm to investigate
     def test_feather_writer_generic_data(self):
         # Arrange
         TestPersistenceStubs.setup_news_event_persistence()


### PR DESCRIPTION
- Remove Partialable class (not playing nicely with pydantic)
- Remove some unused `__tokenize__` functions
- Fix some skipped tests
- Add some more backtest run config tokenize tests