### PR TITLE
Fix InstrumentId functions

### DIFF
--- a/nautilus_core/model/src/identifiers/instrument_id.rs
+++ b/nautilus_core/model/src/identifiers/instrument_id.rs
@@ -76,6 +76,21 @@ impl InstrumentId {
 /// - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
 #[no_mangle]
 pub unsafe extern "C" fn instrument_id_new(
+    symbol: &Symbol,
+    venue: &Venue,
+) -> InstrumentId {
+    let symbol = symbol.clone();
+    let venue = venue.clone();
+    InstrumentId::new(symbol, venue)
+}
+
+/// Returns a Nautilus identifier from valid Python object pointers.
+///
+/// # Safety
+/// - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
+/// - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
+#[no_mangle]
+pub unsafe extern "C" fn instrument_id_new_from_pystr(
     symbol_ptr: *mut ffi::PyObject,
     venue_ptr: *mut ffi::PyObject,
 ) -> InstrumentId {

--- a/nautilus_core/model/src/identifiers/instrument_id.rs
+++ b/nautilus_core/model/src/identifiers/instrument_id.rs
@@ -75,10 +75,7 @@ impl InstrumentId {
 /// - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
 /// - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
 #[no_mangle]
-pub unsafe extern "C" fn instrument_id_new(
-    symbol: &Symbol,
-    venue: &Venue,
-) -> InstrumentId {
+pub unsafe extern "C" fn instrument_id_new(symbol: &Symbol, venue: &Venue) -> InstrumentId {
     let symbol = symbol.clone();
     let venue = venue.clone();
     InstrumentId::new(symbol, venue)
@@ -100,11 +97,8 @@ pub unsafe extern "C" fn instrument_id_new_from_pystr(
 }
 
 #[no_mangle]
-pub extern "C" fn instrument_id_copy(instrument_id: &InstrumentId) -> InstrumentId {
-    InstrumentId {
-        symbol: instrument_id.symbol.clone(),
-        venue: instrument_id.venue.clone(),
-    }
+pub extern "C" fn instrument_id_clone(instrument_id: &InstrumentId) -> InstrumentId {
+    instrument_id.clone()
 }
 
 /// Frees the memory for the given `instrument_id` by dropping.

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -540,7 +540,16 @@ uint64_t exec_algorithm_id_hash(const struct ExecAlgorithmId_t *exec_algorithm_i
  * - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
  * - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
  */
-struct InstrumentId_t instrument_id_new(PyObject *symbol_ptr, PyObject *venue_ptr);
+struct InstrumentId_t instrument_id_new(const struct Symbol_t *symbol, const struct Venue_t *venue);
+
+/**
+ * Returns a Nautilus identifier from valid Python object pointers.
+ *
+ * # Safety
+ * - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
+ * - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
+ */
+struct InstrumentId_t instrument_id_new_from_pystr(PyObject *symbol_ptr, PyObject *venue_ptr);
 
 struct InstrumentId_t instrument_id_copy(const struct InstrumentId_t *instrument_id);
 

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -551,7 +551,7 @@ struct InstrumentId_t instrument_id_new(const struct Symbol_t *symbol, const str
  */
 struct InstrumentId_t instrument_id_new_from_pystr(PyObject *symbol_ptr, PyObject *venue_ptr);
 
-struct InstrumentId_t instrument_id_copy(const struct InstrumentId_t *instrument_id);
+struct InstrumentId_t instrument_id_clone(const struct InstrumentId_t *instrument_id);
 
 /**
  * Frees the memory for the given `instrument_id` by dropping.

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -458,7 +458,14 @@ cdef extern from "../includes/model.h":
     # # Safety
     # - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
     # - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
-    InstrumentId_t instrument_id_new(PyObject *symbol_ptr, PyObject *venue_ptr);
+    InstrumentId_t instrument_id_new(const Symbol_t *symbol, const Venue_t *venue);
+
+    # Returns a Nautilus identifier from valid Python object pointers.
+    #
+    # # Safety
+    # - Assumes `symbol_ptr` is borrowed from a valid Python UTF-8 `str`.
+    # - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
+    InstrumentId_t instrument_id_new_from_pystr(PyObject *symbol_ptr, PyObject *venue_ptr);
 
     InstrumentId_t instrument_id_copy(const InstrumentId_t *instrument_id);
 

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -467,7 +467,7 @@ cdef extern from "../includes/model.h":
     # - Assumes `venue_ptr` is borrowed from a valid Python UTF-8 `str`.
     InstrumentId_t instrument_id_new_from_pystr(PyObject *symbol_ptr, PyObject *venue_ptr);
 
-    InstrumentId_t instrument_id_copy(const InstrumentId_t *instrument_id);
+    InstrumentId_t instrument_id_clone(const InstrumentId_t *instrument_id);
 
     # Frees the memory for the given `instrument_id` by dropping.
     void instrument_id_free(InstrumentId_t instrument_id);

--- a/nautilus_trader/model/data/bar.pyx
+++ b/nautilus_trader/model/data/bar.pyx
@@ -48,7 +48,7 @@ from nautilus_trader.core.rust.model cimport bar_type_le
 from nautilus_trader.core.rust.model cimport bar_type_lt
 from nautilus_trader.core.rust.model cimport bar_type_new
 from nautilus_trader.core.rust.model cimport bar_type_to_pystr
-from nautilus_trader.core.rust.model cimport instrument_id_copy
+from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_new
 from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.model.c_enums.aggregation_source cimport AggregationSource
@@ -407,7 +407,7 @@ cdef class BarType:
         AggregationSource aggregation_source=AggregationSource.EXTERNAL,
     ):
         self._mem = bar_type_new(
-            instrument_id_copy(&instrument_id._mem),
+            instrument_id_clone(&instrument_id._mem),
             bar_spec._mem,
             aggregation_source
         )

--- a/nautilus_trader/model/data/bar.pyx
+++ b/nautilus_trader/model/data/bar.pyx
@@ -50,6 +50,7 @@ from nautilus_trader.core.rust.model cimport bar_type_new
 from nautilus_trader.core.rust.model cimport bar_type_to_pystr
 from nautilus_trader.core.rust.model cimport instrument_id_copy
 from nautilus_trader.core.rust.model cimport instrument_id_new
+from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.model.c_enums.aggregation_source cimport AggregationSource
 from nautilus_trader.model.c_enums.aggregation_source cimport AggregationSourceParser
 from nautilus_trader.model.c_enums.bar_aggregation cimport BarAggregation
@@ -423,7 +424,7 @@ cdef class BarType:
 
     def __setstate__(self, state):
         self._mem = bar_type_new(
-            instrument_id_new(
+            instrument_id_new_from_pystr(
                 <PyObject *>state[0],
                 <PyObject *>state[1]
             ),
@@ -659,7 +660,7 @@ cdef class Bar(Data):
     def __setstate__(self, state):
         self._mem = bar_new_from_raw(
             bar_type_new(
-                instrument_id_new(
+                instrument_id_new_from_pystr(
                     <PyObject *> state[0],
                     <PyObject *> state[1]
                 ),

--- a/nautilus_trader/model/data/tick.pyx
+++ b/nautilus_trader/model/data/tick.pyx
@@ -22,6 +22,7 @@ from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.rust.model cimport instrument_id_copy
 from nautilus_trader.core.rust.model cimport instrument_id_new
+from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.core.rust.model cimport quote_tick_free
 from nautilus_trader.core.rust.model cimport quote_tick_from_raw
 from nautilus_trader.core.rust.model cimport quote_tick_to_pystr
@@ -123,7 +124,7 @@ cdef class QuoteTick(Data):
         self.ts_event = state[10]
         self.ts_init = state[11]
         self._mem = quote_tick_from_raw(
-            instrument_id_new(
+            instrument_id_new_from_pystr(
                 <PyObject *>state[0],
                 <PyObject *>state[1],
             ),
@@ -497,7 +498,7 @@ cdef class TradeTick(Data):
         self.ts_event = state[8]
         self.ts_init = state[9]
         self._mem = trade_tick_from_raw(
-            instrument_id_new(
+            instrument_id_new_from_pystr(
                 <PyObject *>state[0],
                 <PyObject *>state[1],
             ),

--- a/nautilus_trader/model/data/tick.pyx
+++ b/nautilus_trader/model/data/tick.pyx
@@ -20,7 +20,7 @@ from libc.stdint cimport uint64_t
 
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.data cimport Data
-from nautilus_trader.core.rust.model cimport instrument_id_copy
+from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_new
 from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.core.rust.model cimport quote_tick_free
@@ -87,7 +87,7 @@ cdef class QuoteTick(Data):
         super().__init__(ts_event, ts_init)
 
         self._mem = quote_tick_from_raw(
-            instrument_id_copy(&instrument_id._mem),
+            instrument_id_clone(&instrument_id._mem),
             bid._mem.raw,
             ask._mem.raw,
             bid._mem.precision,
@@ -173,7 +173,7 @@ cdef class QuoteTick(Data):
         tick.ts_event = ts_event
         tick.ts_init = ts_init
         tick._mem = quote_tick_from_raw(
-            instrument_id_copy(&instrument_id._mem),
+            instrument_id_clone(&instrument_id._mem),
             raw_bid,
             raw_ask,
             bid_price_prec,
@@ -465,7 +465,7 @@ cdef class TradeTick(Data):
         super().__init__(ts_event, ts_init)
 
         self._mem = trade_tick_from_raw(
-            instrument_id_copy(&instrument_id._mem),
+            instrument_id_clone(&instrument_id._mem),
             price._mem.raw,
             price._mem.precision,
             size._mem.raw,
@@ -603,7 +603,7 @@ cdef class TradeTick(Data):
         tick.ts_event = ts_event
         tick.ts_init = ts_init
         tick._mem = trade_tick_from_raw(
-            instrument_id_copy(&instrument_id._mem),
+            instrument_id_clone(&instrument_id._mem),
             raw_price,
             price_prec,
             raw_size,

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -36,6 +36,7 @@ from nautilus_trader.core.rust.model cimport instrument_id_eq
 from nautilus_trader.core.rust.model cimport instrument_id_free
 from nautilus_trader.core.rust.model cimport instrument_id_hash
 from nautilus_trader.core.rust.model cimport instrument_id_new
+from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.core.rust.model cimport instrument_id_to_pystr
 from nautilus_trader.core.rust.model cimport order_list_id_eq
 from nautilus_trader.core.rust.model cimport order_list_id_free
@@ -213,8 +214,8 @@ cdef class InstrumentId(Identifier):
 
     def __init__(self, Symbol symbol not None, Venue venue not None):
         self._mem = instrument_id_new(
-            <PyObject *>symbol,
-            <PyObject *>venue,
+            &symbol._mem,
+            &venue._mem,
         )
         self.symbol = symbol
         self.venue = venue
@@ -230,7 +231,7 @@ cdef class InstrumentId(Identifier):
         )
 
     def __setstate__(self, state):
-        self._mem = instrument_id_new(
+        self._mem = instrument_id_new_from_pystr(
             <PyObject *>state[0],
             <PyObject *>state[1],
         )
@@ -269,7 +270,7 @@ cdef class InstrumentId(Identifier):
             raise ValueError(f"The InstrumentId string value was malformed, was {value}")
 
         cdef InstrumentId instrument_id = InstrumentId.__new__(InstrumentId)
-        instrument_id._mem = instrument_id_new(
+        instrument_id._mem = instrument_id_new_from_pystr(
             <PyObject *>pieces[0],
             <PyObject *>pieces[1],
         )

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -31,7 +31,7 @@ from nautilus_trader.core.rust.model cimport component_id_free
 from nautilus_trader.core.rust.model cimport component_id_hash
 from nautilus_trader.core.rust.model cimport component_id_new
 from nautilus_trader.core.rust.model cimport component_id_to_pystr
-from nautilus_trader.core.rust.model cimport instrument_id_copy
+from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_eq
 from nautilus_trader.core.rust.model cimport instrument_id_free
 from nautilus_trader.core.rust.model cimport instrument_id_hash
@@ -256,7 +256,7 @@ cdef class InstrumentId(Identifier):
         venue._mem = venue_copy(&raw.venue)
 
         cdef InstrumentId instrument_id = InstrumentId.__new__(InstrumentId)
-        instrument_id._mem = instrument_id_copy(&raw)
+        instrument_id._mem = instrument_id_clone(&raw)
         instrument_id.symbol = symbol
         instrument_id.venue = venue
 


### PR DESCRIPTION
# Pull Request

`instrument_id_new` was used in two different ways in the code base. Most commonly to pass python strings as arguments but sometimes also to pass Symbol and Venue objects. However the implementation was assuming the inputs are only strings. This PR adds two functions for these two types of calls.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Test with large allocations. End to end test is remaining