### PR TITLE
AccountId function to return id without issuer string

### DIFF
--- a/nautilus_trader/model/identifiers.pxd
+++ b/nautilus_trader/model/identifiers.pxd
@@ -79,6 +79,7 @@ cdef class AccountId(Identifier):
     cdef AccountId_t _mem
 
     cpdef str get_issuer(self)
+    cpdef str get_id(self)
 
 
 cdef class ClientOrderId(Identifier):

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -538,6 +538,17 @@ cdef class AccountId(Identifier):
         """
         return self.to_str().split("-")[0]
 
+    cpdef str get_id(self):
+        """
+        Return the account ID without issuer name.
+
+        Returns
+        -------
+        str
+
+        """
+        return self.to_str().split("-")[1]
+
 
 cdef class ClientOrderId(Identifier):
     """

--- a/tests/unit_tests/portfolio/test_portfolio.py
+++ b/tests/unit_tests/portfolio/test_portfolio.py
@@ -144,6 +144,7 @@ class TestPortfolio:
 
         # Assert
         assert result.id.get_issuer() == "BINANCE"
+        assert result.id.get_id() == "1513111"
 
     def test_balances_locked_when_no_account_for_venue_returns_none(self):
         # Arrange, Act, Assert


### PR DESCRIPTION
# Pull Request

Added new function in AccountId to get the original account_id without issuer string. Useful in the adapter to refer original account_id.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Returns original string without issuer. Added in TestPortfolio as well.
