### PR TITLE
IB balances filter and placeOrder for intended account_id

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -208,6 +208,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         contract_details = self.instrument_provider.contract_details[command.instrument_id.value]
         order: IBOrder = nautilus_order_to_ib_order(order=command.order)
+        order.account = self.account_id.get_id()
         trade: IBTrade = self._client.placeOrder(contract=contract_details.contract, order=order)
         self._ib_insync_orders[command.order.client_order_id] = trade
         self.generate_order_submitted(
@@ -229,6 +230,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             order.totalQuantity = command.quantity.as_double()
         if getattr(order, "lmtPrice", None) != command.price:
             order.lmtPrice = command.price.as_double()
+        order.account = self.account_id.get_id()
         new_trade: IBTrade = self._client.placeOrder(contract=trade.contract, order=order)
         self._ib_insync_orders[command.client_order_id] = new_trade
         trade.modifyEvent += self._on_order_modify
@@ -377,7 +379,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     def on_account_update(self, account_values: list[AccountValue]):
         self._log.debug(str(account_values))
-        balances, margins = account_values_to_nautilus_account_info(account_values)
+        balances, margins = account_values_to_nautilus_account_info(account_values, self.account_id)
         ts_event: int = self._clock.timestamp_ns()
         self.generate_account_state(
             balances=balances,

--- a/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
@@ -25,6 +25,7 @@ from nautilus_trader.model.c_enums.order_side import OrderSide
 from nautilus_trader.model.c_enums.order_side import OrderSideParser
 from nautilus_trader.model.currency import Currency
 from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.objects import AccountBalance
 from nautilus_trader.model.objects import MarginBalance
 from nautilus_trader.model.objects import Money
@@ -69,6 +70,7 @@ def ib_order_to_nautilus_order_type(order: IBOrder) -> OrderType:
 
 def account_values_to_nautilus_account_info(
     account_values: list[AccountValue],
+    account_id: AccountId,
 ) -> tuple[list[AccountBalance], list[MarginBalance]]:
     """
     When querying for account information, ib_insync returns a list of individual fields for potentially multiple
@@ -80,7 +82,12 @@ def account_values_to_nautilus_account_info(
 
     balances = []
     margin_balances = []
-    for (_, currency), fields in groupby(sorted(account_values, key=group_key), key=group_key):
+    for (account, currency), fields in groupby(
+        sorted(account_values, key=group_key),
+        key=group_key,
+    ):
+        if not (account == account_id.get_id()):
+            continue
         if currency in ("", "BASE"):
             # Only report in base currency
             continue

--- a/nautilus_trader/model/identifiers.pxd
+++ b/nautilus_trader/model/identifiers.pxd
@@ -79,6 +79,7 @@ cdef class AccountId(Identifier):
     cdef AccountId_t _mem
 
     cpdef str get_issuer(self)
+    cpdef str get_id(self)
 
 
 cdef class ClientOrderId(Identifier):

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -538,6 +538,17 @@ cdef class AccountId(Identifier):
         """
         return self.to_str().split("-")[0]
 
+    cpdef str get_id(self):
+        """
+        Return the account ID without issuer name.
+
+        Returns
+        -------
+        str
+
+        """
+        return self.to_str().split("-")[1]
+
 
 cdef class ClientOrderId(Identifier):
     """

--- a/tests/integration_tests/adapters/interactive_brokers/base.py
+++ b/tests/integration_tests/adapters/interactive_brokers/base.py
@@ -89,6 +89,7 @@ class InteractiveBrokersTestBase:
                 config=InteractiveBrokersExecClientConfig(  # noqa: S106
                     username="test",
                     password="test",
+                    account_id="DU123456",
                 ),
                 msgbus=self.msgbus,
                 cache=self.cache,

--- a/tests/unit_tests/portfolio/test_portfolio.py
+++ b/tests/unit_tests/portfolio/test_portfolio.py
@@ -144,6 +144,7 @@ class TestPortfolio:
 
         # Assert
         assert result.id.get_issuer() == "BINANCE"
+        assert result.id.get_id() == "1513111"
 
     def test_balances_locked_when_no_account_for_venue_returns_none(self):
         # Arrange, Act, Assert


### PR DESCRIPTION
# Pull Request

This PR will make sure balances are returned for the intended account in case of multiple accounts on the TWS gateway. Also it will make sure the orders are placed to that intended account only. Furthermore this will add verification check that logged in account of the TWS/Gateway is same as expected, being logged into wrong account (account_id not matching with the Nautilus Config account_id) will Engine will not receive any account balances and orders will not be accepted by the Gateway.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested with TWS connectivity.
