### PR TITLE
Fix reader free

### DIFF
--- a/nautilus_core/model/src/data/tick.rs
+++ b/nautilus_core/model/src/data/tick.rs
@@ -142,6 +142,11 @@ pub extern "C" fn quote_tick_free(tick: QuoteTick) {
 }
 
 #[no_mangle]
+pub extern "C" fn quote_tick_copy(tick: &QuoteTick)  -> QuoteTick {
+    tick.clone()
+}
+
+#[no_mangle]
 pub extern "C" fn quote_tick_new(
     instrument_id: InstrumentId,
     bid: Price,
@@ -201,6 +206,11 @@ pub unsafe extern "C" fn quote_tick_to_pystr(tick: &QuoteTick) -> *mut ffi::PyOb
 #[no_mangle]
 pub extern "C" fn trade_tick_free(tick: TradeTick) {
     drop(tick); // Memory freed here
+}
+
+#[no_mangle]
+pub extern "C" fn trade_tick_copy(tick: &TradeTick)  -> TradeTick {
+    tick.clone()
 }
 
 #[no_mangle]

--- a/nautilus_trader/persistence/catalog/rust/reader.pxd
+++ b/nautilus_trader/persistence/catalog/rust/reader.pxd
@@ -24,10 +24,7 @@ cdef class ParquetReader:
     cdef void* _reader
     cdef CVec _chunk
 
-    cdef list _next_chunk(self)
-    cdef list _parse_chunk(self, CVec chunk)
     cdef void _drop_chunk(self) except *
-
 
 cdef class ParquetFileReader(ParquetReader):
     cdef str _file_path


### PR DESCRIPTION
Fixes the ParquetReader class to free the rust memory.

- [x] Bug fix (non-breaking change which fixes an issue)

tests/unit_tests/persistence/test_catalog_rust.py::test_parquet_reader_frees_rust_memory

The problem was identified by measuring the peak memory usage of the ParquetFileReader class during iteration.

