### PR TITLE
Fix memory leak

### DIFF
--- a/nautilus_core/common/src/logging.rs
+++ b/nautilus_core/common/src/logging.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::{
     fmt::Display,
     io::{self, BufWriter, Stderr, Stdout, Write},
@@ -22,7 +22,7 @@ use std::{
 use pyo3::ffi;
 
 use nautilus_core::datetime::unix_nanos_to_iso8601;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 use nautilus_core::uuid::UUID4;
 use nautilus_model::identifiers::trader_id::TraderId;
 
@@ -288,6 +288,11 @@ pub unsafe extern "C" fn logger_get_trader_id(logger: &CLogger) -> *mut ffi::PyO
     string_to_pystr(logger.trader_id.to_string().as_str())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn logger_get_trader_id_cstr(logger: &CLogger) -> *const c_char {
+    string_to_cstr(logger.trader_id.to_string().as_str())
+}
+
 /// Return the loggers machine ID.
 ///
 /// # Safety
@@ -297,6 +302,11 @@ pub unsafe extern "C" fn logger_get_trader_id(logger: &CLogger) -> *mut ffi::PyO
 #[no_mangle]
 pub unsafe extern "C" fn logger_get_machine_id(logger: &CLogger) -> *mut ffi::PyObject {
     string_to_pystr(logger.machine_id.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn logger_get_machine_id_cstr(logger: &CLogger) -> *const c_char {
+    string_to_cstr(logger.machine_id.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/common/src/timer.rs
+++ b/nautilus_core/common/src/timer.rs
@@ -12,12 +12,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use pyo3::ffi;
 use std::rc::Rc;
 
 use crate::enums::MessageCategory;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 use nautilus_core::time::{Timedelta, Timestamp};
 use nautilus_core::uuid::UUID4;
 
@@ -91,6 +91,11 @@ pub extern "C" fn time_event_free(event: TimeEvent) {
 #[no_mangle]
 pub unsafe extern "C" fn time_event_name(event: &TimeEvent) -> *mut ffi::PyObject {
     string_to_pystr(event.name.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn time_event_name_cstr(event: &TimeEvent) -> *const c_char {
+    string_to_cstr(event.name.as_str())
 }
 
 /// Represents a bundled event and it's handler.

--- a/nautilus_core/core/src/string.rs
+++ b/nautilus_core/core/src/string.rs
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::ffi::CString;
+use std::os::raw::c_char;
 use pyo3::types::PyString;
 use pyo3::{ffi, FromPyPointer, IntoPyPointer, Py, Python};
 
@@ -50,6 +51,17 @@ pub fn precision_from_str(s: &str) -> u8 {
         return 0;
     }
     return lower_s.split('.').last().unwrap().len() as u8;
+}
+
+#[inline(always)]
+pub fn string_to_cstr(s: &str) -> *const c_char {
+    CString::new(s).expect("CString::new failed").into_raw()
+}
+
+#[no_mangle]
+pub unsafe extern fn cstring_free(s: *const c_char) {
+    let str = CString::from_raw(s as *mut i8);
+    drop(str);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/nautilus_core/core/src/uuid.rs
+++ b/nautilus_core/core/src/uuid.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -20,7 +20,7 @@ use std::rc::Rc;
 
 use pyo3::ffi;
 
-use crate::string::{pystr_to_string, string_to_pystr};
+use crate::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 use uuid::Uuid;
 
 #[repr(C)]
@@ -97,6 +97,11 @@ pub unsafe extern "C" fn uuid4_from_pystr(ptr: *mut ffi::PyObject) -> UUID4 {
 #[no_mangle]
 pub unsafe extern "C" fn uuid4_to_pystr(uuid: &UUID4) -> *mut ffi::PyObject {
     string_to_pystr(uuid.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn uuid4_to_cstr(uuid: &UUID4) -> *const c_char {
+    string_to_cstr(uuid.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/data/bar.rs
+++ b/nautilus_core/model/src/data/bar.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
@@ -24,7 +24,7 @@ use crate::enums::{AggregationSource, BarAggregation, PriceType};
 use crate::identifiers::instrument_id::InstrumentId;
 use crate::types::price::Price;
 use crate::types::quantity::Quantity;
-use nautilus_core::string::string_to_pystr;
+use nautilus_core::string::{string_to_pystr, string_to_cstr};
 use nautilus_core::time::Timestamp;
 
 #[repr(C)]
@@ -76,6 +76,14 @@ pub unsafe extern "C" fn bar_specification_to_pystr(
 ) -> *mut ffi::PyObject {
     string_to_pystr(bar_spec.to_string().as_str())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn bar_specification_to_cstr(
+    bar_spec: &BarSpecification,
+) -> *const c_char {
+    string_to_cstr(bar_spec.to_string().as_str())
+}
+
 #[no_mangle]
 pub extern "C" fn bar_specification_free(bar_spec: BarSpecification) {
     drop(bar_spec); // Memory freed here
@@ -246,6 +254,12 @@ pub unsafe extern "C" fn bar_type_to_pystr(bar_type: &BarType) -> *mut ffi::PyOb
     string_to_pystr(bar_type.to_string().as_str())
 }
 
+
+#[no_mangle]
+pub unsafe extern "C" fn bar_type_to_cstr(bar_type: &BarType) -> *const c_char {
+    string_to_cstr(bar_type.to_string().as_str())
+}
+
 #[no_mangle]
 pub extern "C" fn bar_type_free(bar_type: BarType) {
     drop(bar_type); // Memory freed here
@@ -332,6 +346,11 @@ pub extern "C" fn bar_new_from_raw(
 #[no_mangle]
 pub unsafe extern "C" fn bar_to_pystr(bar: &Bar) -> *mut ffi::PyObject {
     string_to_pystr(bar.to_string().as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bar_to_cstr(bar: &Bar) -> *const c_char {
+    string_to_cstr(bar.to_string().as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/data/tick.rs
+++ b/nautilus_core/model/src/data/tick.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::fmt::{Display, Formatter, Result};
 
 use pyo3::ffi;
@@ -23,7 +23,7 @@ use crate::identifiers::trade_id::TradeId;
 use crate::types::price::Price;
 use crate::types::quantity::Quantity;
 use nautilus_core::correctness;
-use nautilus_core::string::string_to_pystr;
+use nautilus_core::string::{string_to_pystr, string_to_cstr};
 use nautilus_core::time::Timestamp;
 
 /// Represents a single quote tick in a financial market.
@@ -199,6 +199,11 @@ pub unsafe extern "C" fn quote_tick_to_pystr(tick: &QuoteTick) -> *mut ffi::PyOb
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn quote_tick_to_cstr(tick: &QuoteTick) -> *const c_char {
+    string_to_cstr(tick.to_string().as_str())
+}
+
+#[no_mangle]
 pub extern "C" fn trade_tick_free(tick: TradeTick) {
     drop(tick); // Memory freed here
 }
@@ -235,6 +240,11 @@ pub extern "C" fn trade_tick_from_raw(
 #[no_mangle]
 pub unsafe extern "C" fn trade_tick_to_pystr(tick: &TradeTick) -> *mut ffi::PyObject {
     string_to_pystr(tick.to_string().as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn trade_tick_to_cstr(tick: &TradeTick) -> *const c_char {
+    string_to_cstr(tick.to_string().as_str())
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/nautilus_core/model/src/identifiers/account_id.rs
+++ b/nautilus_core/model/src/identifiers/account_id.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
+use std::os::raw::c_char;
 
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
@@ -21,7 +22,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -82,6 +83,12 @@ pub extern "C" fn account_id_free(account_id: AccountId) {
 pub unsafe extern "C" fn account_id_to_pystr(account_id: &AccountId) -> *mut ffi::PyObject {
     string_to_pystr(account_id.value.as_str())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn account_id_to_cstr(account_id: &AccountId) -> *const c_char {
+    string_to_cstr(account_id.value.as_str())
+}
+
 
 #[no_mangle]
 pub extern "C" fn account_id_eq(lhs: &AccountId, rhs: &AccountId) -> u8 {

--- a/nautilus_core/model/src/identifiers/client_id.rs
+++ b/nautilus_core/model/src/identifiers/client_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn client_id_free(client_id: ClientId) {
 #[no_mangle]
 pub unsafe extern "C" fn client_id_to_pystr(client_id: &ClientId) -> *mut ffi::PyObject {
     string_to_pystr(client_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn client_id_to_cstr(client_id: &ClientId) -> *const c_char {
+    string_to_cstr(client_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/client_order_id.rs
+++ b/nautilus_core/model/src/identifiers/client_order_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -83,6 +83,14 @@ pub unsafe extern "C" fn client_order_id_to_pystr(
 ) -> *mut ffi::PyObject {
     string_to_pystr(client_order_id.value.as_str())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn client_order_id_to_cstr(
+    client_order_id: &ClientOrderId,
+) -> *const c_char {
+    string_to_cstr(client_order_id.value.as_str())
+}
+
 
 #[no_mangle]
 pub extern "C" fn client_order_id_eq(lhs: &ClientOrderId, rhs: &ClientOrderId) -> u8 {

--- a/nautilus_core/model/src/identifiers/component_id.rs
+++ b/nautilus_core/model/src/identifiers/component_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -82,6 +82,11 @@ pub unsafe extern "C" fn component_to_pystr(component_id: &ComponentId) -> *mut 
     string_to_pystr(component_id.value.as_str())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn component_to_cstr(component_id: &ComponentId) -> *const c_char {
+    string_to_cstr(component_id.value.as_str())
+}
+
 /// Returns a pointer to a valid Python UTF-8 string.
 ///
 /// # Safety
@@ -91,6 +96,11 @@ pub unsafe extern "C" fn component_to_pystr(component_id: &ComponentId) -> *mut 
 #[no_mangle]
 pub unsafe extern "C" fn component_id_to_pystr(component_id: &ComponentId) -> *mut ffi::PyObject {
     string_to_pystr(component_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn component_id_to_cstr(component_id: &ComponentId) -> *const c_char {
+    string_to_cstr(component_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/exec_algorithm_id.rs
+++ b/nautilus_core/model/src/identifiers/exec_algorithm_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -83,6 +83,14 @@ pub unsafe extern "C" fn exec_algorithm_id_to_pystr(
 ) -> *mut ffi::PyObject {
     string_to_pystr(exec_algorithm_id.value.as_str())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn exec_algorithm_id_to_cstr(
+    exec_algorithm_id: &ExecAlgorithmId,
+) -> *const c_char {
+    string_to_cstr(exec_algorithm_id.value.as_str())
+}
+
 
 #[no_mangle]
 pub extern "C" fn exec_algorithm_id_eq(lhs: &ExecAlgorithmId, rhs: &ExecAlgorithmId) -> u8 {

--- a/nautilus_core/model/src/identifiers/instrument_id.rs
+++ b/nautilus_core/model/src/identifiers/instrument_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use pyo3::ffi;
 
 use crate::identifiers::symbol::{symbol_new, Symbol};
 use crate::identifiers::venue::{venue_new, Venue};
-use nautilus_core::string::string_to_pystr;
+use nautilus_core::string::{string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -118,6 +118,13 @@ pub unsafe extern "C" fn instrument_id_to_pystr(
     instrument_id: &InstrumentId,
 ) -> *mut ffi::PyObject {
     string_to_pystr(instrument_id.to_string().as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn instrument_id_to_cstr(
+    instrument_id: &InstrumentId,
+) -> *const c_char {
+    string_to_cstr(instrument_id.to_string().as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/order_list_id.rs
+++ b/nautilus_core/model/src/identifiers/order_list_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn order_list_id_free(order_list_id: OrderListId) {
 #[no_mangle]
 pub unsafe extern "C" fn order_list_id_to_pystr(order_list_id: &OrderListId) -> *mut ffi::PyObject {
     string_to_pystr(order_list_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn order_list_id_to_cstr(order_list_id: &OrderListId) -> *const c_char {
+    string_to_cstr(order_list_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/position_id.rs
+++ b/nautilus_core/model/src/identifiers/position_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn position_id_free(position_id: PositionId) {
 #[no_mangle]
 pub unsafe extern "C" fn position_id_to_pystr(position_id: &PositionId) -> *mut ffi::PyObject {
     string_to_pystr(position_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn position_id_to_cstr(position_id: &PositionId) -> *const c_char {
+    string_to_cstr(position_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/strategy_id.rs
+++ b/nautilus_core/model/src/identifiers/strategy_id.rs
@@ -12,7 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::rc::Rc;
 

--- a/nautilus_core/model/src/identifiers/symbol.rs
+++ b/nautilus_core/model/src/identifiers/symbol.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn symbol_free(symbol: Symbol) {
 #[no_mangle]
 pub unsafe extern "C" fn symbol_to_pystr(symbol: &Symbol) -> *mut ffi::PyObject {
     string_to_pystr(symbol.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn symbol_to_cstr(symbol: &Symbol) -> *const c_char {
+    string_to_cstr(symbol.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/trade_id.rs
+++ b/nautilus_core/model/src/identifiers/trade_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn trade_id_free(trade_id: TradeId) {
 #[no_mangle]
 pub unsafe extern "C" fn trade_id_to_pystr(trade_id: &TradeId) -> *mut ffi::PyObject {
     string_to_pystr(trade_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn trade_id_to_cstr(trade_id: &TradeId) -> *const c_char {
+    string_to_cstr(trade_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/trader_id.rs
+++ b/nautilus_core/model/src/identifiers/trader_id.rs
@@ -12,7 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::rc::Rc;
 

--- a/nautilus_core/model/src/identifiers/venue.rs
+++ b/nautilus_core/model/src/identifiers/venue.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -80,6 +80,11 @@ pub extern "C" fn venue_free(venue: Venue) {
 #[no_mangle]
 pub unsafe extern "C" fn venue_to_pystr(venue: &Venue) -> *mut ffi::PyObject {
     string_to_pystr(venue.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn venue_to_cstr(venue: &Venue) -> *const c_char {
+    string_to_cstr(venue.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/identifiers/venue_order_id.rs
+++ b/nautilus_core/model/src/identifiers/venue_order_id.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::hash::{Hash, Hasher};
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use pyo3::ffi;
 
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -82,6 +82,13 @@ pub unsafe extern "C" fn venue_order_id_to_pystr(
     venue_order_id: &VenueOrderId,
 ) -> *mut ffi::PyObject {
     string_to_pystr(venue_order_id.value.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn venue_order_id_to_cstr(
+    venue_order_id: &VenueOrderId,
+) -> *const c_char {
+    string_to_cstr(venue_order_id.value.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/types/currency.rs
+++ b/nautilus_core/model/src/types/currency.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-
+use std::os::raw::c_char;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
@@ -21,7 +21,7 @@ use pyo3::ffi;
 
 use crate::enums::CurrencyType;
 use nautilus_core::correctness;
-use nautilus_core::string::{pystr_to_string, string_to_pystr};
+use nautilus_core::string::{pystr_to_string, string_to_pystr, string_to_cstr};
 
 #[repr(C)]
 #[derive(Eq, PartialEq, Clone, Hash, Debug)]
@@ -102,6 +102,11 @@ pub unsafe extern "C" fn currency_to_pystr(currency: &Currency) -> *mut ffi::PyO
     string_to_pystr(format!("{:?}", currency).as_str())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn currency_to_cstr(currency: &Currency) -> *const c_char {
+    string_to_cstr(format!("{:?}", currency).as_str())
+}
+
 /// Returns a pointer to a valid Python UTF-8 string.
 ///
 /// # Safety
@@ -113,6 +118,11 @@ pub unsafe extern "C" fn currency_code_to_pystr(currency: &Currency) -> *mut ffi
     string_to_pystr(currency.code.as_str())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn currency_code_to_cstr(currency: &Currency) -> *const c_char {
+    string_to_cstr(currency.code.as_str())
+}
+
 /// Returns a pointer to a valid Python UTF-8 string.
 ///
 /// # Safety
@@ -122,6 +132,11 @@ pub unsafe extern "C" fn currency_code_to_pystr(currency: &Currency) -> *mut ffi
 #[no_mangle]
 pub unsafe extern "C" fn currency_name_to_pystr(currency: &Currency) -> *mut ffi::PyObject {
     string_to_pystr(currency.name.as_str())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn currency_name_to_cstr(currency: &Currency) -> *const c_char {
+    string_to_cstr(currency.name.as_str())
 }
 
 #[no_mangle]

--- a/nautilus_trader/common/logging.pyx
+++ b/nautilus_trader/common/logging.pyx
@@ -47,11 +47,12 @@ from nautilus_trader.core.rust.common cimport LogColor as RustLogColor
 from nautilus_trader.core.rust.common cimport LogLevel as RustLogLevel
 from nautilus_trader.core.rust.common cimport logger_free
 from nautilus_trader.core.rust.common cimport logger_get_instance_id
-from nautilus_trader.core.rust.common cimport logger_get_machine_id
-from nautilus_trader.core.rust.common cimport logger_get_trader_id
+from nautilus_trader.core.rust.common cimport logger_get_machine_id_cstr
+from nautilus_trader.core.rust.common cimport logger_get_trader_id_cstr
 from nautilus_trader.core.rust.common cimport logger_is_bypassed
 from nautilus_trader.core.rust.common cimport logger_log
 from nautilus_trader.core.rust.common cimport logger_new
+from nautilus_trader.core.string cimport cstr_to_pystr
 from nautilus_trader.core.uuid cimport UUID4
 from nautilus_trader.model.identifiers cimport TraderId
 
@@ -178,7 +179,7 @@ cdef class Logger:
         TraderId
 
         """
-        return TraderId(<str>logger_get_trader_id(&self._mem))
+        return TraderId(cstr_to_pystr(logger_get_trader_id_cstr(&self._mem)))
 
     @property
     def machine_id(self) -> str:
@@ -190,7 +191,7 @@ cdef class Logger:
         str
 
         """
-        return <str>logger_get_machine_id(&self._mem)
+        return cstr_to_pystr(logger_get_machine_id_cstr(&self._mem))
 
     @property
     def instance_id(self) -> UUID4:

--- a/nautilus_trader/common/timer.pyx
+++ b/nautilus_trader/common/timer.pyx
@@ -24,10 +24,11 @@ from nautilus_trader.common.timer cimport TimeEvent
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.message cimport Event
 from nautilus_trader.core.rust.common cimport time_event_free
-from nautilus_trader.core.rust.common cimport time_event_name
+from nautilus_trader.core.rust.common cimport time_event_name_cstr
 from nautilus_trader.core.rust.common cimport time_event_new
 from nautilus_trader.core.rust.core cimport nanos_to_secs
 from nautilus_trader.core.rust.core cimport uuid4_clone
+from nautilus_trader.core.string cimport cstr_to_pystr
 from nautilus_trader.core.uuid cimport UUID4
 
 
@@ -69,7 +70,7 @@ cdef class TimeEvent(Event):
             time_event_free(self._mem)  # `self._mem` moved to Rust (then dropped)
 
     cdef str to_str(self):
-        return <str>time_event_name(&self._mem)
+        return cstr_to_pystr(time_event_name_cstr(&self._mem))
 
     def __eq__(self, TimeEvent other) -> bool:
         return self.to_str() == other.to_str()
@@ -98,7 +99,7 @@ cdef class TimeEvent(Event):
         str
 
         """
-        return <str>time_event_name(&self._mem)
+        return cstr_to_pystr(time_event_name_cstr(&self._mem))
 
     @staticmethod
     cdef TimeEvent from_mem_c(TimeEvent_t mem):

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -128,6 +128,8 @@ cdef extern from "../includes/common.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *logger_get_trader_id(const CLogger *logger);
 
+    const char *logger_get_trader_id_cstr(const CLogger *logger);
+
     # Return the loggers machine ID.
     #
     # # Safety
@@ -135,6 +137,8 @@ cdef extern from "../includes/common.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *logger_get_machine_id(const CLogger *logger);
+
+    const char *logger_get_machine_id_cstr(const CLogger *logger);
 
     UUID4_t logger_get_instance_id(const CLogger *logger);
 
@@ -170,3 +174,5 @@ cdef extern from "../includes/common.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *time_event_name(const TimeEvent_t *event);
+
+    const char *time_event_name_cstr(const TimeEvent_t *event);

--- a/nautilus_trader/core/rust/core.pxd
+++ b/nautilus_trader/core/rust/core.pxd
@@ -51,6 +51,8 @@ cdef extern from "../includes/core.h":
     # Converts nanoseconds (ns) to microseconds (μs).
     uint64_t nanos_to_micros(uint64_t nanos);
 
+    void cstring_free(const char *s);
+
     # Returns the current seconds since the UNIX epoch.
     # This timestamp is guaranteed to be monotonic within a runtime.
     double unix_timestamp();
@@ -86,6 +88,8 @@ cdef extern from "../includes/core.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *uuid4_to_pystr(const UUID4_t *uuid);
+
+    const char *uuid4_to_cstr(const UUID4_t *uuid);
 
     uint8_t uuid4_eq(const UUID4_t *lhs, const UUID4_t *rhs);
 

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -196,6 +196,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *bar_specification_to_pystr(const BarSpecification_t *bar_spec);
 
+    const char *bar_specification_to_cstr(const BarSpecification_t *bar_spec);
+
     void bar_specification_free(BarSpecification_t bar_spec);
 
     uint64_t bar_specification_hash(const BarSpecification_t *bar_spec);
@@ -241,6 +243,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *bar_type_to_pystr(const BarType_t *bar_type);
 
+    const char *bar_type_to_cstr(const BarType_t *bar_type);
+
     void bar_type_free(BarType_t bar_type);
 
     Bar_t bar_new(BarType_t bar_type,
@@ -271,6 +275,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *bar_to_pystr(const Bar_t *bar);
+
+    const char *bar_to_cstr(const Bar_t *bar);
 
     Bar_t bar_copy(const Bar_t *bar);
 
@@ -310,6 +316,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *quote_tick_to_pystr(const QuoteTick_t *tick);
 
+    const char *quote_tick_to_cstr(const QuoteTick_t *tick);
+
     void trade_tick_free(TradeTick_t tick);
 
     TradeTick_t trade_tick_from_raw(InstrumentId_t instrument_id,
@@ -330,6 +338,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *trade_tick_to_pystr(const TradeTick_t *tick);
 
+    const char *trade_tick_to_cstr(const TradeTick_t *tick);
+
     # Returns a Nautilus identifier from a valid Python object pointer.
     #
     # # Safety
@@ -348,6 +358,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *account_id_to_pystr(const AccountId_t *account_id);
+
+    const char *account_id_to_cstr(const AccountId_t *account_id);
 
     uint8_t account_id_eq(const AccountId_t *lhs, const AccountId_t *rhs);
 
@@ -372,6 +384,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *client_id_to_pystr(const ClientId_t *client_id);
 
+    const char *client_id_to_cstr(const ClientId_t *client_id);
+
     uint8_t client_id_eq(const ClientId_t *lhs, const ClientId_t *rhs);
 
     uint64_t client_id_hash(const ClientId_t *client_id);
@@ -394,6 +408,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *client_order_id_to_pystr(const ClientOrderId_t *client_order_id);
+
+    const char *client_order_id_to_cstr(const ClientOrderId_t *client_order_id);
 
     uint8_t client_order_id_eq(const ClientOrderId_t *lhs, const ClientOrderId_t *rhs);
 
@@ -418,6 +434,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *component_to_pystr(const ComponentId_t *component_id);
 
+    const char *component_to_cstr(const ComponentId_t *component_id);
+
     # Returns a pointer to a valid Python UTF-8 string.
     #
     # # Safety
@@ -425,6 +443,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *component_id_to_pystr(const ComponentId_t *component_id);
+
+    const char *component_id_to_cstr(const ComponentId_t *component_id);
 
     uint8_t component_id_eq(const ComponentId_t *lhs, const ComponentId_t *rhs);
 
@@ -448,6 +468,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *exec_algorithm_id_to_pystr(const ExecAlgorithmId_t *exec_algorithm_id);
+
+    const char *exec_algorithm_id_to_cstr(const ExecAlgorithmId_t *exec_algorithm_id);
 
     uint8_t exec_algorithm_id_eq(const ExecAlgorithmId_t *lhs, const ExecAlgorithmId_t *rhs);
 
@@ -480,6 +502,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *instrument_id_to_pystr(const InstrumentId_t *instrument_id);
 
+    const char *instrument_id_to_cstr(const InstrumentId_t *instrument_id);
+
     uint8_t instrument_id_eq(const InstrumentId_t *lhs, const InstrumentId_t *rhs);
 
     uint64_t instrument_id_hash(const InstrumentId_t *instrument_id);
@@ -503,6 +527,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *order_list_id_to_pystr(const OrderListId_t *order_list_id);
 
+    const char *order_list_id_to_cstr(const OrderListId_t *order_list_id);
+
     uint8_t order_list_id_eq(const OrderListId_t *lhs, const OrderListId_t *rhs);
 
     uint64_t order_list_id_hash(const OrderListId_t *order_list_id);
@@ -525,6 +551,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *position_id_to_pystr(const PositionId_t *position_id);
+
+    const char *position_id_to_cstr(const PositionId_t *position_id);
 
     uint8_t position_id_eq(const PositionId_t *lhs, const PositionId_t *rhs);
 
@@ -560,6 +588,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *symbol_to_pystr(const Symbol_t *symbol);
 
+    const char *symbol_to_cstr(const Symbol_t *symbol);
+
     uint8_t symbol_eq(const Symbol_t *lhs, const Symbol_t *rhs);
 
     uint64_t symbol_hash(const Symbol_t *symbol);
@@ -582,6 +612,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *trade_id_to_pystr(const TradeId_t *trade_id);
+
+    const char *trade_id_to_cstr(const TradeId_t *trade_id);
 
     uint8_t trade_id_eq(const TradeId_t *lhs, const TradeId_t *rhs);
 
@@ -617,6 +649,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *venue_to_pystr(const Venue_t *venue);
 
+    const char *venue_to_cstr(const Venue_t *venue);
+
     uint8_t venue_eq(const Venue_t *lhs, const Venue_t *rhs);
 
     uint64_t venue_hash(const Venue_t *venue);
@@ -639,6 +673,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *venue_order_id_to_pystr(const VenueOrderId_t *venue_order_id);
+
+    const char *venue_order_id_to_cstr(const VenueOrderId_t *venue_order_id);
 
     uint8_t venue_order_id_eq(const VenueOrderId_t *lhs, const VenueOrderId_t *rhs);
 
@@ -669,6 +705,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *currency_to_pystr(const Currency_t *currency);
 
+    const char *currency_to_cstr(const Currency_t *currency);
+
     # Returns a pointer to a valid Python UTF-8 string.
     #
     # # Safety
@@ -677,6 +715,8 @@ cdef extern from "../includes/model.h":
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *currency_code_to_pystr(const Currency_t *currency);
 
+    const char *currency_code_to_cstr(const Currency_t *currency);
+
     # Returns a pointer to a valid Python UTF-8 string.
     #
     # # Safety
@@ -684,6 +724,8 @@ cdef extern from "../includes/model.h":
     # to be acquired.
     # - Assumes you are immediately returning this pointer to Python.
     PyObject *currency_name_to_pystr(const Currency_t *currency);
+
+    const char *currency_name_to_cstr(const Currency_t *currency);
 
     uint8_t currency_eq(const Currency_t *lhs, const Currency_t *rhs);
 

--- a/nautilus_trader/core/string.pxd
+++ b/nautilus_trader/core/string.pxd
@@ -17,3 +17,4 @@ from libc.stdint cimport uint8_t
 
 
 cpdef uint8_t precision_from_str(str value) except *
+cdef str cstr_to_pystr(const char* data)

--- a/nautilus_trader/core/string.pyx
+++ b/nautilus_trader/core/string.pyx
@@ -15,9 +15,11 @@
 
 import cython
 
+from cpython.unicode cimport PyUnicode_FromString
 from libc.stdint cimport uint8_t
 
 from nautilus_trader.core.correctness cimport Condition
+from nautilus_trader.core.rust.core cimport cstring_free
 
 
 @cython.boundscheck(False)
@@ -56,3 +58,9 @@ cpdef inline uint8_t precision_from_str(str value) except *:
     else:
         # If does not contain "." then partition[2] will be ""
         return len(value.partition('.')[2])
+
+
+cdef inline str cstr_to_pystr(const char* data):
+    cdef str obj = PyUnicode_FromString(data)
+    cstring_free(data)
+    return obj

--- a/nautilus_trader/core/uuid.pyx
+++ b/nautilus_trader/core/uuid.pyx
@@ -22,7 +22,8 @@ from nautilus_trader.core.rust.core cimport uuid4_free
 from nautilus_trader.core.rust.core cimport uuid4_from_pystr
 from nautilus_trader.core.rust.core cimport uuid4_hash
 from nautilus_trader.core.rust.core cimport uuid4_new
-from nautilus_trader.core.rust.core cimport uuid4_to_pystr
+from nautilus_trader.core.rust.core cimport uuid4_to_cstr
+from nautilus_trader.core.string cimport cstr_to_pystr
 
 
 cdef class UUID4:
@@ -53,7 +54,7 @@ cdef class UUID4:
             self._mem = uuid4_from_pystr(<PyObject *>value)
 
     cdef str to_str(self):
-        return <str>uuid4_to_pystr(&self._mem)
+        return cstr_to_pystr(uuid4_to_cstr(&self._mem))
 
     def __del__(self) -> None:
         if self._mem.value != NULL:

--- a/nautilus_trader/model/currency.pyx
+++ b/nautilus_trader/model/currency.pyx
@@ -18,13 +18,14 @@ from libc.stdint cimport uint8_t
 from libc.stdint cimport uint16_t
 
 from nautilus_trader.core.correctness cimport Condition
-from nautilus_trader.core.rust.model cimport currency_code_to_pystr
+from nautilus_trader.core.rust.model cimport currency_code_to_cstr
 from nautilus_trader.core.rust.model cimport currency_eq
 from nautilus_trader.core.rust.model cimport currency_free
 from nautilus_trader.core.rust.model cimport currency_from_py
 from nautilus_trader.core.rust.model cimport currency_hash
-from nautilus_trader.core.rust.model cimport currency_name_to_pystr
-from nautilus_trader.core.rust.model cimport currency_to_pystr
+from nautilus_trader.core.rust.model cimport currency_name_to_cstr
+from nautilus_trader.core.rust.model cimport currency_to_cstr
+from nautilus_trader.core.string cimport cstr_to_pystr
 from nautilus_trader.model.c_enums.currency_type cimport CurrencyType
 from nautilus_trader.model.currencies cimport _CURRENCY_MAP
 
@@ -110,10 +111,10 @@ cdef class Currency:
         return currency_hash(&self._mem)
 
     def __str__(self) -> str:
-        return <str>currency_code_to_pystr(&self._mem)
+        return cstr_to_pystr(currency_code_to_cstr(&self._mem))
 
     def __repr__(self) -> str:
-        return <str>currency_to_pystr(&self._mem)
+        return cstr_to_pystr(currency_to_cstr(&self._mem))
 
     @property
     def code(self) -> int:
@@ -125,7 +126,7 @@ cdef class Currency:
         str
 
         """
-        return <str>currency_code_to_pystr(&self._mem)
+        return cstr_to_pystr(currency_code_to_cstr(&self._mem))
 
     @property
     def name(self) -> int:
@@ -137,7 +138,7 @@ cdef class Currency:
         str
 
         """
-        return <str>currency_name_to_pystr(&self._mem)
+        return cstr_to_pystr(currency_name_to_cstr(&self._mem))
 
     @property
     def precision(self) -> int:

--- a/nautilus_trader/model/data/bar.pyx
+++ b/nautilus_trader/model/data/bar.pyx
@@ -36,8 +36,8 @@ from nautilus_trader.core.rust.model cimport bar_specification_hash
 from nautilus_trader.core.rust.model cimport bar_specification_le
 from nautilus_trader.core.rust.model cimport bar_specification_lt
 from nautilus_trader.core.rust.model cimport bar_specification_new
-from nautilus_trader.core.rust.model cimport bar_specification_to_pystr
-from nautilus_trader.core.rust.model cimport bar_to_pystr
+from nautilus_trader.core.rust.model cimport bar_specification_to_cstr
+from nautilus_trader.core.rust.model cimport bar_to_cstr
 from nautilus_trader.core.rust.model cimport bar_type_copy
 from nautilus_trader.core.rust.model cimport bar_type_eq
 from nautilus_trader.core.rust.model cimport bar_type_free
@@ -47,10 +47,11 @@ from nautilus_trader.core.rust.model cimport bar_type_hash
 from nautilus_trader.core.rust.model cimport bar_type_le
 from nautilus_trader.core.rust.model cimport bar_type_lt
 from nautilus_trader.core.rust.model cimport bar_type_new
-from nautilus_trader.core.rust.model cimport bar_type_to_pystr
+from nautilus_trader.core.rust.model cimport bar_type_to_cstr
 from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_new
 from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
+from nautilus_trader.core.string cimport cstr_to_pystr
 from nautilus_trader.model.c_enums.aggregation_source cimport AggregationSource
 from nautilus_trader.model.c_enums.aggregation_source cimport AggregationSourceParser
 from nautilus_trader.model.c_enums.bar_aggregation cimport BarAggregation
@@ -115,7 +116,7 @@ cdef class BarSpecification:
         bar_specification_free(self._mem)  # `self._mem` moved to Rust (then dropped)
 
     cdef str to_str(self):
-        return <str>bar_specification_to_pystr(&self._mem)
+        return cstr_to_pystr(bar_specification_to_cstr(&self._mem))
 
     def __eq__(self, BarSpecification other) -> bool:
         return <bint>bar_specification_eq(&self._mem, &other._mem)
@@ -441,7 +442,7 @@ cdef class BarType:
             bar_type_free(self._mem)  # `self._mem` moved to Rust (then dropped)
 
     cdef str to_str(self):
-        return <str>bar_type_to_pystr(&self._mem)
+        return cstr_to_pystr(bar_type_to_cstr(&self._mem))
 
     def __eq__(self, BarType other) -> bool:
         return <bint>bar_type_eq(&self._mem, &other._mem)
@@ -695,7 +696,7 @@ cdef class Bar(Data):
         return bar_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>bar_to_pystr(&self._mem)
+        return cstr_to_pystr(bar_to_cstr(&self._mem))
 
     def __str__(self) -> str:
         return self.to_str()

--- a/nautilus_trader/model/data/tick.pyx
+++ b/nautilus_trader/model/data/tick.pyx
@@ -24,12 +24,14 @@ from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
 from nautilus_trader.core.rust.model cimport quote_tick_free
 from nautilus_trader.core.rust.model cimport quote_tick_from_raw
+from nautilus_trader.core.rust.model cimport quote_tick_to_cstr
 from nautilus_trader.core.rust.model cimport quote_tick_to_pystr
 from nautilus_trader.core.rust.model cimport trade_id_clone
 from nautilus_trader.core.rust.model cimport trade_id_new
 from nautilus_trader.core.rust.model cimport trade_tick_free
 from nautilus_trader.core.rust.model cimport trade_tick_from_raw
-from nautilus_trader.core.rust.model cimport trade_tick_to_pystr
+from nautilus_trader.core.rust.model cimport trade_tick_to_cstr
+from nautilus_trader.core.string cimport cstr_to_pystr
 from nautilus_trader.model.c_enums.aggressor_side cimport AggressorSide
 from nautilus_trader.model.c_enums.aggressor_side cimport AggressorSideParser
 from nautilus_trader.model.c_enums.order_side cimport OrderSide
@@ -152,7 +154,7 @@ cdef class QuoteTick(Data):
         return f"{type(self).__name__}({self})"
 
     cdef str to_str(self):
-        return <str>quote_tick_to_pystr(&self._mem)
+        return cstr_to_pystr(quote_tick_to_cstr(&self._mem))
 
     @staticmethod
     cdef QuoteTick from_raw_c(
@@ -524,7 +526,7 @@ cdef class TradeTick(Data):
         return f"{type(self).__name__}({self.to_str()})"
 
     cdef str to_str(self):
-        return <str>trade_tick_to_pystr(&self._mem)
+        return cstr_to_pystr(trade_tick_to_cstr(&self._mem))
 
     @property
     def instrument_id(self) -> InstrumentId:

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -20,46 +20,46 @@ from nautilus_trader.core.rust.model cimport account_id_eq
 from nautilus_trader.core.rust.model cimport account_id_free
 from nautilus_trader.core.rust.model cimport account_id_hash
 from nautilus_trader.core.rust.model cimport account_id_new
-from nautilus_trader.core.rust.model cimport account_id_to_pystr
+from nautilus_trader.core.rust.model cimport account_id_to_cstr
 from nautilus_trader.core.rust.model cimport client_order_id_eq
 from nautilus_trader.core.rust.model cimport client_order_id_free
 from nautilus_trader.core.rust.model cimport client_order_id_hash
 from nautilus_trader.core.rust.model cimport client_order_id_new
-from nautilus_trader.core.rust.model cimport client_order_id_to_pystr
+from nautilus_trader.core.rust.model cimport client_order_id_to_cstr
 from nautilus_trader.core.rust.model cimport component_id_eq
 from nautilus_trader.core.rust.model cimport component_id_free
 from nautilus_trader.core.rust.model cimport component_id_hash
 from nautilus_trader.core.rust.model cimport component_id_new
-from nautilus_trader.core.rust.model cimport component_id_to_pystr
+from nautilus_trader.core.rust.model cimport component_id_to_cstr
 from nautilus_trader.core.rust.model cimport instrument_id_clone
 from nautilus_trader.core.rust.model cimport instrument_id_eq
 from nautilus_trader.core.rust.model cimport instrument_id_free
 from nautilus_trader.core.rust.model cimport instrument_id_hash
 from nautilus_trader.core.rust.model cimport instrument_id_new
 from nautilus_trader.core.rust.model cimport instrument_id_new_from_pystr
-from nautilus_trader.core.rust.model cimport instrument_id_to_pystr
+from nautilus_trader.core.rust.model cimport instrument_id_to_cstr
 from nautilus_trader.core.rust.model cimport order_list_id_eq
 from nautilus_trader.core.rust.model cimport order_list_id_free
 from nautilus_trader.core.rust.model cimport order_list_id_hash
 from nautilus_trader.core.rust.model cimport order_list_id_new
-from nautilus_trader.core.rust.model cimport order_list_id_to_pystr
+from nautilus_trader.core.rust.model cimport order_list_id_to_cstr
 from nautilus_trader.core.rust.model cimport position_id_eq
 from nautilus_trader.core.rust.model cimport position_id_free
 from nautilus_trader.core.rust.model cimport position_id_hash
 from nautilus_trader.core.rust.model cimport position_id_new
-from nautilus_trader.core.rust.model cimport position_id_to_pystr
+from nautilus_trader.core.rust.model cimport position_id_to_cstr
 from nautilus_trader.core.rust.model cimport symbol_clone
 from nautilus_trader.core.rust.model cimport symbol_eq
 from nautilus_trader.core.rust.model cimport symbol_free
 from nautilus_trader.core.rust.model cimport symbol_hash
 from nautilus_trader.core.rust.model cimport symbol_new
-from nautilus_trader.core.rust.model cimport symbol_to_pystr
+from nautilus_trader.core.rust.model cimport symbol_to_cstr
 from nautilus_trader.core.rust.model cimport trade_id_clone
 from nautilus_trader.core.rust.model cimport trade_id_eq
 from nautilus_trader.core.rust.model cimport trade_id_free
 from nautilus_trader.core.rust.model cimport trade_id_hash
 from nautilus_trader.core.rust.model cimport trade_id_new
-from nautilus_trader.core.rust.model cimport trade_id_to_pystr
+from nautilus_trader.core.rust.model cimport trade_id_to_cstr
 from nautilus_trader.core.rust.model cimport venue_clone
 from nautilus_trader.core.rust.model cimport venue_eq
 from nautilus_trader.core.rust.model cimport venue_free
@@ -69,8 +69,9 @@ from nautilus_trader.core.rust.model cimport venue_order_id_eq
 from nautilus_trader.core.rust.model cimport venue_order_id_free
 from nautilus_trader.core.rust.model cimport venue_order_id_hash
 from nautilus_trader.core.rust.model cimport venue_order_id_new
-from nautilus_trader.core.rust.model cimport venue_order_id_to_pystr
-from nautilus_trader.core.rust.model cimport venue_to_pystr
+from nautilus_trader.core.rust.model cimport venue_order_id_to_cstr
+from nautilus_trader.core.rust.model cimport venue_to_cstr
+from nautilus_trader.core.string cimport cstr_to_pystr
 
 
 cdef class Identifier:
@@ -160,7 +161,7 @@ cdef class Symbol(Identifier):
         return symbol_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>symbol_to_pystr(&self._mem)
+        return cstr_to_pystr(symbol_to_cstr(&self._mem))
 
 
 cdef class Venue(Identifier):
@@ -199,7 +200,7 @@ cdef class Venue(Identifier):
         return venue_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>venue_to_pystr(&self._mem)
+        return cstr_to_pystr(venue_to_cstr(&self._mem))
 
 
 cdef class InstrumentId(Identifier):
@@ -251,7 +252,7 @@ cdef class InstrumentId(Identifier):
         return instrument_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>instrument_id_to_pystr(&self._mem)
+        return cstr_to_pystr(instrument_id_to_cstr(&self._mem))
 
     @staticmethod
     cdef InstrumentId from_mem_c(InstrumentId_t mem):
@@ -349,7 +350,7 @@ cdef class ComponentId(Identifier):
         return component_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>component_id_to_pystr(&self._mem)
+        return cstr_to_pystr(component_id_to_cstr(&self._mem))
 
 
 cdef class ClientId(ComponentId):
@@ -535,7 +536,7 @@ cdef class AccountId(Identifier):
         return account_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>account_id_to_pystr(&self._mem)
+        return cstr_to_pystr(account_id_to_cstr(&self._mem))
 
     cpdef str get_issuer(self):
         """
@@ -599,7 +600,7 @@ cdef class ClientOrderId(Identifier):
         return client_order_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>client_order_id_to_pystr(&self._mem)
+        return cstr_to_pystr(client_order_id_to_cstr(&self._mem))
 
 
 cdef class VenueOrderId(Identifier):
@@ -638,7 +639,7 @@ cdef class VenueOrderId(Identifier):
         return venue_order_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>venue_order_id_to_pystr(&self._mem)
+        return cstr_to_pystr(venue_order_id_to_cstr(&self._mem))
 
 
 cdef class OrderListId(Identifier):
@@ -677,7 +678,7 @@ cdef class OrderListId(Identifier):
         return order_list_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>order_list_id_to_pystr(&self._mem)
+        return cstr_to_pystr(order_list_id_to_cstr(&self._mem))
 
 
 cdef class PositionId(Identifier):
@@ -716,7 +717,7 @@ cdef class PositionId(Identifier):
         return position_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>position_id_to_pystr(&self._mem)
+        return cstr_to_pystr(position_id_to_cstr(&self._mem))
 
     cdef bint is_virtual_c(self) except *:
         return self.to_str().startswith("P-")
@@ -773,7 +774,7 @@ cdef class TradeId(Identifier):
         return trade_id_hash(&self._mem)
 
     cdef str to_str(self):
-        return <str>trade_id_to_pystr(&self._mem)
+        return cstr_to_pystr(trade_id_to_cstr(&self._mem))
 
     @staticmethod
     cdef TradeId from_mem_c(TradeId_t mem):


### PR DESCRIPTION
- [x] Bug fix (non-breaking change which fixes an issue)

**Changes summary.**

[x] Add to_cstr rust C-API methods for classes/methods:
    [x] QuoteTick
    [x] TradeTick
    [x] BarSpecification
    [x] BarType
    [x] Bar
    [x] Currency
    [x] CurrencyCode
    [x] CurrencyName
    [x] UUID
    [x] AccountId
    [x] ClientId
    [x] ClientOrderId
    [x] ComponentIdComponentId
    [x] ExecAlgorithmId
    [x] InstrumentId
    [x] OrderListId
    [x] PositionId
    [x] Symbol
    [x] TradeId
    [x] VenueOrderId
    [x] Venue
    [x] logger_get_trader_id()
    [x] logger_get_machine_id()
    [x] time_event_name()

[x] Add cython cstring conversion method: cstr_to_pystr
    
[x] Update cython classes to use c_str methods
        [x] QuoteTick
        [x] TradeTick
        [x] BarSpecification
        [x] BarType
        [x] Bar
        [x] Currency
        [x] CurrencyCode
        [x] CurrencyName
        [x] UUID
        [x] AccountId
        [x] ComponentId
        [x] ClientId
        [x] InstrumentId
        [x] ClientOrderId
        [x] OrderListId
        [x] PositionId
        [x] Symbol
        [x] TradeId
        [x] Venue
        [x] VenueOrderId
        [x] ExecAlgorithmId
        [x] logger_get_trader_id()
        [x] logger_get_machine_id()
        [x] time_event_name()
