### PR TITLE
Fix the Volume Quantity error

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -336,7 +336,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
                 high=Price(bar.high, instrument.price_precision),
                 low=Price(bar.low, instrument.price_precision),
                 close=Price(bar.close, instrument.price_precision),
-                volume=Quantity(bar.volume, instrument.size_precision),
+                volume=Quantity(max(0, bar.volume), instrument.size_precision),
                 ts_event=ts_event,
                 ts_init=ts_init,
             )


### PR DESCRIPTION
# Pull Request

IB returns -1 as Volume value where not available i.e. Forex bars. The change will use zero as minimum quantity for compliance with Nautilus Quantity.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Minor fix. Bars return as expected.
