### PR TITLE
Fix IB FX Instrument base_currency and quote_currency

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -163,8 +163,8 @@ def parse_forex_contract(
     return CurrencyPair(
         instrument_id=instrument_id,
         native_symbol=Symbol(details.contract.localSymbol),
-        base_currency=Currency.from_str(details.contract.currency),
-        quote_currency=Currency.from_str(details.contract.symbol),
+        base_currency=Currency.from_str(details.contract.symbol),
+        quote_currency=Currency.from_str(details.contract.currency),
         price_precision=price_precision,
         size_precision=Quantity.from_int(1),
         price_increment=Price(details.minTick, price_precision),


### PR DESCRIPTION
# Pull Request

Minor fix for base_currency and quote_currency of the IB's FX instrument i.e. EUR/USD have the EUR as base and USD as quote.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
