### PR TITLE
Update or Ignore new Bar with same ts_event

### DIFF
--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -1046,6 +1046,8 @@ cdef class Cache(CacheFacade):
             bars = deque(maxlen=self.bar_capacity)
             self._bars[bar.bar_type] = bars
 
+        if bar._is_revised:
+            bars.popleft()
         bars.appendleft(bar)
 
         cdef PriceType price_type = <PriceType>bar._mem.bar_type.spec.price_type

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -47,6 +47,7 @@ cdef class DataEngine(Component):
     cdef dict _routing_map
     cdef dict _order_book_intervals
     cdef dict _bar_aggregators
+    cdef dict _topic_last_ts
     cdef bint _build_time_bars_with_no_updates
 
     cdef readonly bint debug

--- a/nautilus_trader/model/data/bar.pxd
+++ b/nautilus_trader/model/data/bar.pxd
@@ -67,6 +67,8 @@ cdef class BarType:
 cdef class Bar(Data):
     cdef Bar_t _mem
 
+    cdef bint _is_revised
+
     cdef str to_str(self)
 
     @staticmethod

--- a/nautilus_trader/model/data/bar.pyx
+++ b/nautilus_trader/model/data/bar.pyx
@@ -675,6 +675,8 @@ cdef class Bar(Data):
         The UNIX timestamp (nanoseconds) when the data event occurred.
     ts_init : uint64_t
         The UNIX timestamp (nanoseconds) when the data object was initialized.
+    is_revised : bint
+        Identifier flag if the bar is an update of previous bar. Default is False.
 
     Raises
     ------
@@ -696,6 +698,7 @@ cdef class Bar(Data):
         Quantity volume not None,
         uint64_t ts_event,
         uint64_t ts_init,
+        bint is_revised = False,
     ):
         Condition.true(high._mem.raw >= open._mem.raw, "high was < open")
         Condition.true(high._mem.raw >= low._mem.raw, "high was < low")
@@ -714,6 +717,8 @@ cdef class Bar(Data):
             ts_event,
             ts_init,
         )
+        self._is_revised = is_revised
+
     def __getstate__(self):
         return (
             self.bar_type.instrument_id.value,
@@ -877,6 +882,18 @@ cdef class Bar(Data):
 
         """
         return Quantity.from_raw_c(self._mem.volume.raw, self._mem.volume.precision)
+
+    @property
+    def is_revised(self) -> bool:
+        """
+        Return the is_revised flag of the bar.
+
+        Returns
+        -------
+        bool
+
+        """
+        return bool(self._is_revised)
 
     @staticmethod
     def from_dict(dict values) -> Bar:

--- a/tests/unit_tests/data/test_data_engine.py
+++ b/tests/unit_tests/data/test_data_engine.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+import time
 
 from nautilus_trader.backtest.data.providers import TestInstrumentProvider
 from nautilus_trader.backtest.data_client import BacktestMarketDataClient
@@ -1577,8 +1578,8 @@ class TestDataEngine:
             Price.from_str("1050.00000"),
             Price.from_str("1052.00000"),
             Quantity.from_int(100),
-            0,
-            0,
+            time.time_ns(),
+            time.time_ns(),
         )
 
         # Act
@@ -1626,8 +1627,8 @@ class TestDataEngine:
             Price.from_str("1050.00000"),
             Price.from_str("1052.00000"),
             Quantity.from_int(100),
-            0,
-            0,
+            time.time_ns(),
+            time.time_ns(),
         )
 
         # Act


### PR DESCRIPTION
# Pull Request

This fullfills the requirements described in #897.

- Fixes DataEngine to publish Bars with the latest ts_init [adds saftey specially in Backtesting where duplicate data may be there as error]
- Adds optional `is_revised` flag for Bar. Default is false and doesn't impact the existing implementation. Will open the way for requeting UpToDate bar from brokers and set this to True, which will allow actor/indicator to perform actions accordingly, specially indicators in this case i.e. append if is_revised=False else replace. ***We will need to make Indicators aware of `Bar.is_revised` though to get new functionality.***


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

- Intentionally adding duplicate External Bars, DataEngine will no longer publish duplicates.
- Requesting UpToDate bar works as expected.
