### PR TITLE
Refactor orders and events

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -466,6 +466,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +563,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign_vec"
@@ -683,6 +755,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -899,6 +977,7 @@ version = "0.2.0"
 dependencies = [
  "cbindgen",
  "criterion",
+ "derive_builder",
  "iai",
  "nautilus_core",
  "pyo3",

--- a/nautilus_core/model/Cargo.toml
+++ b/nautilus_core/model/Cargo.toml
@@ -11,6 +11,7 @@ name = "nautilus_model"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
+derive_builder = "0.12.0"
 nautilus_core = { path = "../core" }
 pyo3.workspace = true
 rust-fsm.workspace = true
@@ -18,10 +19,7 @@ strum.workspace = true
 thiserror.workspace = true
 
 [features]
-extension-module = [
-    "pyo3/extension-module",
-    "nautilus_core/extension-module",
-]
+extension-module = ["pyo3/extension-module", "nautilus_core/extension-module"]
 default = []
 
 [dev-dependencies]

--- a/nautilus_core/model/src/events/order.rs
+++ b/nautilus_core/model/src/events/order.rs
@@ -29,8 +29,11 @@ use crate::types::currency::Currency;
 use crate::types::money::Money;
 use crate::types::price::Price;
 use crate::types::quantity::Quantity;
+use derive_builder::{self, Builder};
 use nautilus_core::time::UnixNanos;
 use nautilus_core::uuid::UUID4;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub enum OrderEvent {
@@ -52,12 +55,31 @@ pub enum OrderEvent {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub struct OrderInitialized {
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
+#[builder(default)]
+pub struct OrderMetaData {
     pub trader_id: TraderId,
     pub strategy_id: StrategyId,
     pub instrument_id: InstrumentId,
     pub client_order_id: ClientOrderId,
+}
+
+impl Default for OrderMetaData {
+    fn default() -> Self {
+        Self {
+            trader_id: TraderId::new("TRADER-001"),
+            strategy_id: StrategyId::new("S-001"),
+            instrument_id: InstrumentId::from("AUD/USD.SIM"),
+            client_order_id: ClientOrderId::new("O-123456789"),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
+#[builder(default)]
+pub struct OrderInitialized {
+    pub metadata: Rc<OrderMetaData>,
     pub order_side: OrderSide,
     pub order_type: OrderType,
     pub quantity: Quantity,
@@ -84,26 +106,65 @@ pub struct OrderInitialized {
     pub reconciliation: bool,
 }
 
+impl Default for OrderInitialized {
+    fn default() -> Self {
+        Self {
+            metadata: Default::default(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            quantity: Quantity::new(100_000.0, 0),
+            price: Default::default(),
+            trigger_price: Default::default(),
+            trigger_type: Default::default(),
+            time_in_force: TimeInForce::Day,
+            expire_time: Default::default(),
+            post_only: Default::default(),
+            reduce_only: Default::default(),
+            display_qty: Default::default(),
+            limit_offset: Default::default(),
+            trailing_offset: Default::default(),
+            trailing_offset_type: Default::default(),
+            emulation_trigger: Default::default(),
+            contingency_type: Default::default(),
+            order_list_id: Default::default(),
+            linked_order_ids: Default::default(),
+            parent_order_id: Default::default(),
+            tags: Default::default(),
+            event_id: Default::default(),
+            ts_event: Default::default(),
+            ts_init: Default::default(),
+            reconciliation: Default::default(),
+        }
+    }
+}
+
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
+#[builder(default)]
 pub struct OrderDenied {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub reason: String,
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
 }
 
+impl Default for OrderDenied {
+    fn default() -> Self {
+        Self {
+            metadata: Default::default(),
+            reason: Default::default(),
+            event_id: Default::default(),
+            ts_event: Default::default(),
+            ts_init: Default::default(),
+        }
+    }
+}
+
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderSubmitted {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub account_id: AccountId,
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
@@ -111,12 +172,9 @@ pub struct OrderSubmitted {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderAccepted {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -126,12 +184,9 @@ pub struct OrderAccepted {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderRejected {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub reason: String,
@@ -142,12 +197,9 @@ pub struct OrderRejected {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderCanceled {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -157,12 +209,9 @@ pub struct OrderCanceled {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderExpired {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -172,12 +221,9 @@ pub struct OrderExpired {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderTriggered {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -187,12 +233,9 @@ pub struct OrderTriggered {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderPendingUpdate {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -202,12 +245,9 @@ pub struct OrderPendingUpdate {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderPendingCancel {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -217,12 +257,9 @@ pub struct OrderPendingCancel {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderModifyRejected {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub reason: String,
@@ -233,12 +270,9 @@ pub struct OrderModifyRejected {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderCancelRejected {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub reason: String,
@@ -249,12 +283,9 @@ pub struct OrderCancelRejected {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderUpdated {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub quantity: Quantity,
@@ -267,12 +298,9 @@ pub struct OrderUpdated {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderFilled {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub trade_id: TradeId,
@@ -290,394 +318,29 @@ pub struct OrderFilled {
     pub reconciliation: bool,
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Builders
-////////////////////////////////////////////////////////////////////////////////
-pub struct OrderInitializedBuilder {
-    trader_id: TraderId,
-    strategy_id: StrategyId,
-    instrument_id: InstrumentId,
-    client_order_id: ClientOrderId,
-    order_side: OrderSide,
-    order_type: OrderType,
-    quantity: Quantity,
-    price: Option<Price>,
-    trigger_price: Option<Price>,
-    trigger_type: Option<TriggerType>,
-    time_in_force: TimeInForce,
-    expire_time: Option<UnixNanos>,
-    post_only: bool,
-    reduce_only: bool,
-    display_qty: Option<Quantity>,
-    limit_offset: Option<Price>,
-    trailing_offset: Option<Price>,
-    trailing_offset_type: Option<TriggerType>,
-    emulation_trigger: Option<TriggerType>,
-    contingency_type: Option<ContingencyType>,
-    order_list_id: Option<OrderListId>,
-    linked_order_ids: Option<Vec<ClientOrderId>>,
-    parent_order_id: Option<ClientOrderId>,
-    tags: Option<String>,
-    event_id: UUID4,
-    ts_event: UnixNanos,
-    ts_init: UnixNanos,
-    reconciliation: bool,
+macro_rules! impl_derefs_for_order {
+    ($struct: ident) => {
+        impl Deref for $struct {
+            type Target = OrderMetaData;
+
+            fn deref(&self) -> &Self::Target {
+                &self.metadata
+            }
+        }
+    };
 }
 
-impl Default for OrderInitializedBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl OrderInitializedBuilder {
-    pub fn new() -> Self {
-        OrderInitializedBuilder {
-            trader_id: TraderId::new("TRADER-001"),
-            strategy_id: StrategyId::new("S-001"),
-            instrument_id: InstrumentId::from("AUD/USD.SIM"),
-            client_order_id: ClientOrderId::new("O-123456789"),
-            order_side: OrderSide::Buy,
-            order_type: OrderType::Market,
-            quantity: Quantity::new(100_000.0, 0),
-            price: None,
-            trigger_price: None,
-            trigger_type: None,
-            time_in_force: TimeInForce::Day,
-            expire_time: None,
-            post_only: false,
-            reduce_only: false,
-            display_qty: None,
-            limit_offset: None,
-            trailing_offset: None,
-            trailing_offset_type: None,
-            emulation_trigger: None,
-            contingency_type: None,
-            order_list_id: None,
-            linked_order_ids: None,
-            parent_order_id: None,
-            tags: None,
-            event_id: Default::default(),
-            ts_event: 0,
-            ts_init: 0,
-            reconciliation: false,
-        }
-    }
-    pub fn build(self) -> OrderInitialized {
-        OrderInitialized {
-            trader_id: self.trader_id,
-            strategy_id: self.strategy_id,
-            instrument_id: self.instrument_id,
-            client_order_id: self.client_order_id,
-            order_side: self.order_side,
-            order_type: self.order_type,
-            quantity: self.quantity,
-            price: self.price,
-            trigger_price: self.trigger_price,
-            trigger_type: self.trigger_type,
-            time_in_force: self.time_in_force,
-            expire_time: self.expire_time,
-            post_only: self.post_only,
-            reduce_only: self.reduce_only,
-            display_qty: self.display_qty,
-            limit_offset: self.limit_offset,
-            trailing_offset: self.trailing_offset,
-            trailing_offset_type: self.trailing_offset_type,
-            emulation_trigger: self.emulation_trigger,
-            contingency_type: self.contingency_type,
-            order_list_id: self.order_list_id,
-            linked_order_ids: self.linked_order_ids,
-            parent_order_id: self.parent_order_id,
-            tags: self.tags,
-            event_id: self.event_id,
-            ts_event: self.ts_event,
-            ts_init: self.ts_init,
-            reconciliation: self.reconciliation,
-        }
-    }
-    pub fn trader_id(mut self, trader_id: TraderId) -> Self {
-        self.trader_id = trader_id;
-        self
-    }
-    pub fn strategy_id(mut self, strategy_id: StrategyId) -> Self {
-        self.strategy_id = strategy_id;
-        self
-    }
-    pub fn instrument_id(mut self, instrument_id: InstrumentId) -> Self {
-        self.instrument_id = instrument_id;
-        self
-    }
-    pub fn order_side(mut self, order_side: OrderSide) -> Self {
-        self.order_side = order_side;
-        self
-    }
-    pub fn quantity(mut self, quantity: Quantity) -> Self {
-        self.quantity = quantity;
-        self
-    }
-    pub fn time_in_force(mut self, time_if_force: TimeInForce) -> Self {
-        self.time_in_force = time_if_force;
-        self
-    }
-    pub fn ts_event(mut self, ts_event: UnixNanos) -> Self {
-        self.ts_event = ts_event;
-        self
-    }
-    pub fn ts_init(mut self, ts_init: UnixNanos) -> Self {
-        self.ts_init = ts_init;
-        self
-    }
-}
-
-pub struct OrderDeniedBuilder {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
-    pub reason: String,
-    pub event_id: UUID4,
-    pub ts_event: UnixNanos,
-    pub ts_init: UnixNanos,
-}
-
-impl OrderDeniedBuilder {
-    pub fn new(init: &OrderInitialized) -> Self {
-        OrderDeniedBuilder {
-            trader_id: init.trader_id.clone(),
-            strategy_id: init.strategy_id.clone(),
-            instrument_id: init.instrument_id.clone(),
-            client_order_id: init.client_order_id.clone(),
-            reason: String::from(""),
-            event_id: Default::default(),
-            ts_event: 0,
-            ts_init: 0,
-        }
-    }
-    pub fn build(self) -> OrderDenied {
-        OrderDenied {
-            trader_id: self.trader_id,
-            strategy_id: self.strategy_id,
-            instrument_id: self.instrument_id,
-            client_order_id: self.client_order_id,
-            reason: self.reason,
-            event_id: self.event_id,
-            ts_event: self.ts_event,
-            ts_init: self.ts_init,
-        }
-    }
-    pub fn reason(mut self, reason: &str) -> Self {
-        self.reason = reason.to_string();
-        self
-    }
-    pub fn ts_event(mut self, ts_event: UnixNanos) -> Self {
-        self.ts_event = ts_event;
-        self
-    }
-    pub fn ts_init(mut self, ts_init: UnixNanos) -> Self {
-        self.ts_init = ts_init;
-        self
-    }
-}
-
-pub struct OrderSubmittedBuilder {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
-    pub account_id: AccountId,
-    pub event_id: UUID4,
-    pub ts_event: UnixNanos,
-    pub ts_init: UnixNanos,
-}
-
-impl OrderSubmittedBuilder {
-    pub fn new(init: &OrderInitialized) -> Self {
-        OrderSubmittedBuilder {
-            trader_id: init.trader_id.clone(),
-            strategy_id: init.strategy_id.clone(),
-            instrument_id: init.instrument_id.clone(),
-            client_order_id: init.client_order_id.clone(),
-            account_id: AccountId::new("SIM-001"),
-            event_id: Default::default(),
-            ts_event: 0,
-            ts_init: 0,
-        }
-    }
-    pub fn build(self) -> OrderSubmitted {
-        OrderSubmitted {
-            trader_id: self.trader_id,
-            strategy_id: self.strategy_id,
-            instrument_id: self.instrument_id,
-            client_order_id: self.client_order_id,
-            account_id: self.account_id,
-            event_id: self.event_id,
-            ts_event: self.ts_event,
-            ts_init: self.ts_init,
-        }
-    }
-    pub fn ts_event(mut self, ts_event: UnixNanos) -> Self {
-        self.ts_event = ts_event;
-        self
-    }
-    pub fn ts_init(mut self, ts_init: UnixNanos) -> Self {
-        self.ts_init = ts_init;
-        self
-    }
-}
-
-pub struct OrderAcceptedBuilder {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
-    pub venue_order_id: VenueOrderId,
-    pub account_id: AccountId,
-    pub event_id: UUID4,
-    pub ts_event: UnixNanos,
-    pub ts_init: UnixNanos,
-}
-
-impl OrderAcceptedBuilder {
-    pub fn new(event: &OrderSubmitted) -> Self {
-        OrderAcceptedBuilder {
-            trader_id: event.trader_id.clone(),
-            strategy_id: event.strategy_id.clone(),
-            instrument_id: event.instrument_id.clone(),
-            client_order_id: event.client_order_id.clone(),
-            venue_order_id: VenueOrderId::new("001"),
-            account_id: event.account_id.clone(),
-            event_id: Default::default(),
-            ts_event: 0,
-            ts_init: 0,
-        }
-    }
-    pub fn build(self) -> OrderAccepted {
-        OrderAccepted {
-            trader_id: self.trader_id,
-            strategy_id: self.strategy_id,
-            instrument_id: self.instrument_id,
-            client_order_id: self.client_order_id,
-            venue_order_id: self.venue_order_id,
-            account_id: self.account_id,
-            event_id: self.event_id,
-            ts_event: self.ts_event,
-            ts_init: self.ts_init,
-            reconciliation: false,
-        }
-    }
-    pub fn venue_order_id(mut self, venue_order_id: VenueOrderId) -> Self {
-        self.venue_order_id = venue_order_id;
-        self
-    }
-    pub fn account_id(mut self, account_id: AccountId) -> Self {
-        self.account_id = account_id;
-        self
-    }
-    pub fn ts_event(mut self, ts_event: UnixNanos) -> Self {
-        self.ts_event = ts_event;
-        self
-    }
-    pub fn ts_init(mut self, ts_init: UnixNanos) -> Self {
-        self.ts_init = ts_init;
-        self
-    }
-}
-pub struct OrderFilledBuilder {
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
-    pub venue_order_id: VenueOrderId,
-    pub account_id: AccountId,
-    pub trade_id: TradeId,
-    pub position_id: Option<PositionId>,
-    pub order_side: OrderSide,
-    pub order_type: OrderType,
-    pub last_qty: Quantity,
-    pub last_px: Price,
-    pub currency: Currency,
-    pub commission: Money,
-    pub liquidity_side: LiquiditySide,
-    pub event_id: UUID4,
-    pub ts_event: UnixNanos,
-    pub ts_init: UnixNanos,
-    pub reconciliation: bool,
-}
-
-impl OrderFilledBuilder {
-    pub fn new(init: &OrderInitialized, accepted: &OrderAccepted) -> Self {
-        let usd = Currency::new("USD", 2, 840, "United States dollar", CurrencyType::Fiat);
-        OrderFilledBuilder {
-            trader_id: init.trader_id.clone(),
-            strategy_id: init.strategy_id.clone(),
-            instrument_id: init.instrument_id.clone(),
-            client_order_id: init.client_order_id.clone(),
-            venue_order_id: accepted.venue_order_id.clone(),
-            account_id: accepted.account_id.clone(),
-            trade_id: TradeId::new("001"),
-            position_id: None,
-            order_side: OrderSide::Buy,
-            order_type: init.order_type,
-            last_qty: init.quantity.clone(),
-            last_px: Price::new(1.0, 0),
-            currency: usd.clone(),
-            commission: Money::new(0.0, usd),
-            liquidity_side: LiquiditySide::Taker,
-            event_id: Default::default(),
-            ts_event: 0,
-            ts_init: 0,
-            reconciliation: false,
-        }
-    }
-    pub fn build(self) -> OrderFilled {
-        OrderFilled {
-            trader_id: self.trader_id,
-            strategy_id: self.strategy_id,
-            instrument_id: self.instrument_id,
-            client_order_id: self.client_order_id,
-            venue_order_id: self.venue_order_id,
-            account_id: self.account_id,
-            trade_id: self.trade_id,
-            position_id: self.position_id,
-            order_side: self.order_side,
-            order_type: self.order_type,
-            last_qty: self.last_qty,
-            last_px: self.last_px,
-            currency: self.currency,
-            commission: self.commission,
-            liquidity_side: self.liquidity_side,
-            event_id: self.event_id,
-            ts_event: self.ts_event,
-            ts_init: self.ts_init,
-            reconciliation: self.reconciliation,
-        }
-    }
-    pub fn trade_id(mut self, trade_id: TradeId) -> Self {
-        self.trade_id = trade_id;
-        self
-    }
-    pub fn last_qty(mut self, last_qty: Quantity) -> Self {
-        self.last_qty = last_qty;
-        self
-    }
-    pub fn last_px(mut self, last_px: Price) -> Self {
-        self.last_px = last_px;
-        self
-    }
-    pub fn commission(mut self, commission: Money) -> Self {
-        self.commission = commission;
-        self
-    }
-    pub fn liquidity_side(mut self, liquidity_side: LiquiditySide) -> Self {
-        self.liquidity_side = liquidity_side;
-        self
-    }
-    pub fn ts_event(mut self, ts_event: UnixNanos) -> Self {
-        self.ts_event = ts_event;
-        self
-    }
-    pub fn ts_init(mut self, ts_init: UnixNanos) -> Self {
-        self.ts_init = ts_init;
-        self
-    }
-}
+impl_derefs_for_order!(OrderTriggered);
+impl_derefs_for_order!(OrderPendingUpdate);
+impl_derefs_for_order!(OrderExpired);
+impl_derefs_for_order!(OrderCanceled);
+impl_derefs_for_order!(OrderRejected);
+impl_derefs_for_order!(OrderAccepted);
+impl_derefs_for_order!(OrderSubmitted);
+impl_derefs_for_order!(OrderDenied);
+impl_derefs_for_order!(OrderInitialized);
+impl_derefs_for_order!(OrderPendingCancel);
+impl_derefs_for_order!(OrderModifyRejected);
+impl_derefs_for_order!(OrderCancelRejected);
+impl_derefs_for_order!(OrderUpdated);
+impl_derefs_for_order!(OrderFilled);

--- a/nautilus_core/model/src/events/order.rs
+++ b/nautilus_core/model/src/events/order.rs
@@ -14,7 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use crate::enums::{
-    ContingencyType, CurrencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType,
+    ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType,
 };
 use crate::identifiers::account_id::AccountId;
 use crate::identifiers::client_order_id::ClientOrderId;
@@ -32,7 +32,7 @@ use crate::types::quantity::Quantity;
 use derive_builder::{self, Builder};
 use nautilus_core::time::UnixNanos;
 use nautilus_core::uuid::UUID4;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::rc::Rc;
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -57,14 +57,14 @@ pub enum OrderEvent {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 #[builder(default)]
-pub struct OrderMetaData {
+pub struct OrderMetadata {
     pub trader_id: TraderId,
     pub strategy_id: StrategyId,
     pub instrument_id: InstrumentId,
     pub client_order_id: ClientOrderId,
 }
 
-impl Default for OrderMetaData {
+impl Default for OrderMetadata {
     fn default() -> Self {
         Self {
             trader_id: TraderId::new("TRADER-001"),
@@ -79,7 +79,7 @@ impl Default for OrderMetaData {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 #[builder(default)]
 pub struct OrderInitialized {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub order_side: OrderSide,
     pub order_type: OrderType,
     pub quantity: Quantity,
@@ -139,32 +139,20 @@ impl Default for OrderInitialized {
 }
 
 #[repr(C)]
-#[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Default, Builder)]
 #[builder(default)]
 pub struct OrderDenied {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub reason: String,
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
 }
 
-impl Default for OrderDenied {
-    fn default() -> Self {
-        Self {
-            metadata: Default::default(),
-            reason: Default::default(),
-            event_id: Default::default(),
-            ts_event: Default::default(),
-            ts_init: Default::default(),
-        }
-    }
-}
-
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderSubmitted {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub account_id: AccountId,
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
@@ -174,7 +162,7 @@ pub struct OrderSubmitted {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderAccepted {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -186,7 +174,7 @@ pub struct OrderAccepted {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderRejected {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub reason: String,
@@ -199,7 +187,7 @@ pub struct OrderRejected {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderCanceled {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -211,7 +199,7 @@ pub struct OrderCanceled {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderExpired {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -223,7 +211,7 @@ pub struct OrderExpired {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderTriggered {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub event_id: UUID4,
@@ -235,7 +223,7 @@ pub struct OrderTriggered {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderPendingUpdate {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -247,7 +235,7 @@ pub struct OrderPendingUpdate {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderPendingCancel {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: AccountId,
     pub event_id: UUID4,
@@ -259,7 +247,7 @@ pub struct OrderPendingCancel {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderModifyRejected {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub reason: String,
@@ -272,7 +260,7 @@ pub struct OrderModifyRejected {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderCancelRejected {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub reason: String,
@@ -285,7 +273,7 @@ pub struct OrderCancelRejected {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderUpdated {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,
     pub quantity: Quantity,
@@ -300,7 +288,7 @@ pub struct OrderUpdated {
 #[repr(C)]
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Builder)]
 pub struct OrderFilled {
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: VenueOrderId,
     pub account_id: AccountId,
     pub trade_id: TradeId,
@@ -321,7 +309,7 @@ pub struct OrderFilled {
 macro_rules! impl_derefs_for_order {
     ($struct: ident) => {
         impl Deref for $struct {
-            type Target = OrderMetaData;
+            type Target = OrderMetadata;
 
             fn deref(&self) -> &Self::Target {
                 &self.metadata

--- a/nautilus_core/model/src/orders/mod.rs
+++ b/nautilus_core/model/src/orders/mod.rs
@@ -15,12 +15,14 @@
 
 #![allow(dead_code)]
 
+use std::rc::Rc;
+
 use crate::enums::{
     ContingencyType, LiquiditySide, OrderSide, OrderStatus, OrderType, PositionSide, TimeInForce,
     TriggerType,
 };
 use crate::events::order::{
-    OrderAccepted, OrderCancelRejected, OrderDenied, OrderEvent, OrderInitialized,
+    OrderAccepted, OrderCancelRejected, OrderDenied, OrderEvent, OrderInitialized, OrderMetaData,
     OrderModifyRejected, OrderPendingCancel, OrderPendingUpdate, OrderRejected, OrderSubmitted,
     OrderUpdated,
 };
@@ -185,10 +187,7 @@ struct Order {
     previous_status: Option<OrderStatus>,
     triggered_price: Option<Price>,
     pub status: OrderStatus,
-    pub trader_id: TraderId,
-    pub strategy_id: StrategyId,
-    pub instrument_id: InstrumentId,
-    pub client_order_id: ClientOrderId,
+    pub metadata: Rc<OrderMetaData>,
     pub venue_order_id: Option<VenueOrderId>,
     pub position_id: Option<PositionId>,
     pub account_id: Option<AccountId>,
@@ -226,15 +225,15 @@ struct Order {
 
 impl PartialEq<Self> for Order {
     fn eq(&self, other: &Self) -> bool {
-        self.client_order_id == other.client_order_id
+        // TODO: can implement deref and deref mut for order metadata here too
+        self.metadata.client_order_id == other.metadata.client_order_id
     }
 }
 
 impl Eq for Order {}
 
-impl Order {
-    /// Initialize a new `Order` by consuming the given `OrderInitialized` event.
-    pub fn new(init: OrderInitialized) -> Self {
+impl From<OrderInitialized> for Order {
+    fn from(value: OrderInitialized) -> Self {
         Self {
             events: Vec::new(),
             venue_order_ids: Vec::new(),
@@ -243,79 +242,77 @@ impl Order {
             previous_status: None,
             triggered_price: None,
             status: OrderStatus::Initialized,
-            trader_id: init.trader_id,
-            strategy_id: init.strategy_id,
-            instrument_id: init.instrument_id,
-            client_order_id: init.client_order_id,
+            metadata: value.metadata,
             venue_order_id: None,
             position_id: None,
             account_id: None,
             last_trade_id: None,
-            side: init.order_side,
-            order_type: init.order_type,
-            quantity: init.quantity.clone(),
-            price: init.price,
-            trigger_price: init.trigger_price,
-            trigger_type: init.trigger_type,
-            time_in_force: init.time_in_force,
+            side: value.order_side,
+            order_type: value.order_type,
+            quantity: value.quantity.clone(),
+            price: value.price,
+            trigger_price: value.trigger_price,
+            trigger_type: value.trigger_type,
+            time_in_force: value.time_in_force,
             expire_time: None,
             liquidity_side: None,
-            is_post_only: init.post_only,
-            is_reduce_only: init.reduce_only,
+            is_post_only: value.post_only,
+            is_reduce_only: value.reduce_only,
             display_qty: None,
             limit_offset: None,
             trailing_offset: None,
             trailing_offset_type: None,
-            emulation_trigger: init.emulation_trigger,
-            contingency_type: init.contingency_type,
-            order_list_id: init.order_list_id,
-            linked_order_ids: init.linked_order_ids,
-            parent_order_id: init.parent_order_id,
-            tags: init.tags,
+            emulation_trigger: value.emulation_trigger,
+            contingency_type: value.contingency_type,
+            order_list_id: value.order_list_id,
+            linked_order_ids: value.linked_order_ids,
+            parent_order_id: value.parent_order_id,
+            tags: value.tags,
             filled_qty: Quantity::new(0.0, 0),
-            leaves_qty: init.quantity,
+            leaves_qty: value.quantity,
             avg_px: None,
             slippage: None,
-            init_id: init.event_id,
+            init_id: value.event_id,
             ts_triggered: None,
-            ts_init: init.ts_event,
-            ts_last: init.ts_event,
+            ts_init: value.ts_event,
+            ts_last: value.ts_event,
         }
     }
+}
 
-    pub fn init_event(&self) -> OrderInitialized {
-        OrderInitialized {
-            trader_id: self.trader_id.clone(),
-            strategy_id: self.strategy_id.clone(),
-            instrument_id: self.instrument_id.clone(),
-            client_order_id: self.client_order_id.clone(),
-            order_side: self.side,
-            order_type: self.order_type,
-            quantity: self.quantity.clone(),
-            price: self.price.clone(),
-            trigger_price: self.triggered_price.clone(),
-            trigger_type: self.trigger_type,
-            time_in_force: self.time_in_force,
-            expire_time: self.expire_time,
-            post_only: self.is_post_only,
-            reduce_only: self.is_reduce_only,
-            display_qty: self.display_qty.clone(),
-            limit_offset: self.limit_offset.clone(),
-            trailing_offset: self.trailing_offset.clone(),
-            trailing_offset_type: self.trailing_offset_type,
-            emulation_trigger: self.emulation_trigger,
-            contingency_type: self.contingency_type,
-            order_list_id: self.order_list_id.clone(),
-            linked_order_ids: self.linked_order_ids.clone(),
-            parent_order_id: self.parent_order_id.clone(),
-            tags: self.tags.clone(),
-            event_id: self.init_id.clone(),
-            ts_event: self.ts_init,
-            ts_init: self.ts_init,
+impl From<&Order> for OrderInitialized {
+    fn from(value: &Order) -> Self {
+        Self {
+            metadata: value.metadata.clone(),
+            order_side: value.side,
+            order_type: value.order_type,
+            quantity: value.quantity.clone(),
+            price: value.price.clone(),
+            trigger_price: value.triggered_price.clone(),
+            trigger_type: value.trigger_type,
+            time_in_force: value.time_in_force,
+            expire_time: value.expire_time,
+            post_only: value.is_post_only,
+            reduce_only: value.is_reduce_only,
+            display_qty: value.display_qty.clone(),
+            limit_offset: value.limit_offset.clone(),
+            trailing_offset: value.trailing_offset.clone(),
+            trailing_offset_type: value.trailing_offset_type,
+            emulation_trigger: value.emulation_trigger,
+            contingency_type: value.contingency_type,
+            order_list_id: value.order_list_id.clone(),
+            linked_order_ids: value.linked_order_ids.clone(),
+            parent_order_id: value.parent_order_id.clone(),
+            tags: value.tags.clone(),
+            event_id: value.init_id.clone(),
+            ts_event: value.ts_init,
+            ts_init: value.ts_init,
             reconciliation: false,
         }
     }
+}
 
+impl Order {
     pub fn last_event(&self) -> Option<&OrderEvent> {
         self.events.last()
     }
@@ -556,11 +553,9 @@ mod tests {
 
     #[test]
     fn test_order_initialized() {
-        let init = OrderInitializedBuilder::new().build();
-        let order = Order::new(init.clone());
+        let order: Order = OrderInitializedBuilder::default().build().unwrap().into();
 
         assert_eq!(order.status, OrderStatus::Initialized);
-        assert_eq!(order.init_event(), init);
         assert_eq!(order.last_event(), None);
         assert_eq!(order.event_count(), 0);
         assert!(order.venue_order_ids.is_empty());
@@ -623,11 +618,12 @@ mod tests {
         position_qty: Quantity,
         expected: bool,
     ) {
-        let init = OrderInitializedBuilder::new()
+        let order: Order = OrderInitializedBuilder::default()
             .order_side(order_side)
             .quantity(order_qty)
-            .build();
-        let order = Order::new(init);
+            .build()
+            .unwrap()
+            .into();
 
         assert_eq!(
             order.would_reduce_only(position_side, position_qty),
@@ -637,9 +633,9 @@ mod tests {
 
     #[test]
     fn test_order_state_transition_denied() {
-        let init = OrderInitializedBuilder::new().build();
-        let denied = OrderDeniedBuilder::new(&init).build();
-        let mut order = Order::new(init);
+        let init = OrderInitializedBuilder::default().build().unwrap();
+        let denied = OrderDeniedBuilder::default().build().unwrap();
+        let mut order: Order = init.into();
         let event = OrderEvent::OrderDenied(denied);
 
         let _ = order.apply(event.clone());

--- a/nautilus_core/model/src/orders/mod.rs
+++ b/nautilus_core/model/src/orders/mod.rs
@@ -22,18 +22,15 @@ use crate::enums::{
     TriggerType,
 };
 use crate::events::order::{
-    OrderAccepted, OrderCancelRejected, OrderDenied, OrderEvent, OrderInitialized, OrderMetaData,
+    OrderAccepted, OrderCancelRejected, OrderDenied, OrderEvent, OrderInitialized, OrderMetadata,
     OrderModifyRejected, OrderPendingCancel, OrderPendingUpdate, OrderRejected, OrderSubmitted,
     OrderUpdated,
 };
 use crate::identifiers::account_id::AccountId;
 use crate::identifiers::client_order_id::ClientOrderId;
-use crate::identifiers::instrument_id::InstrumentId;
 use crate::identifiers::order_list_id::OrderListId;
 use crate::identifiers::position_id::PositionId;
-use crate::identifiers::strategy_id::StrategyId;
 use crate::identifiers::trade_id::TradeId;
-use crate::identifiers::trader_id::TraderId;
 use crate::identifiers::venue_order_id::VenueOrderId;
 use crate::types::fixed::fixed_i64_to_f64;
 use crate::types::price::Price;
@@ -187,7 +184,7 @@ struct Order {
     previous_status: Option<OrderStatus>,
     triggered_price: Option<Price>,
     pub status: OrderStatus,
-    pub metadata: Rc<OrderMetaData>,
+    pub metadata: Rc<OrderMetadata>,
     pub venue_order_id: Option<VenueOrderId>,
     pub position_id: Option<PositionId>,
     pub account_id: Option<AccountId>,


### PR DESCRIPTION
# Pull Request

Refactor orders and events

Extract common field values into separate struct
impl Deref, From and Into where needed
Use derive_builder crate

Apart from ergonomic improvements having a common OrderMetaData struct with string values that are mostly unchanged between orders is a significant improvement on the memory footprint.

## Type of change

[x]: Refactor

## How has this change been tested?

Order tests were run and passed.
