### PR TITLE
Fix Internal Bar ts_event

### DIFF
--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -44,6 +44,7 @@ cdef class BarBuilder:
     """The builders current update count.\n\n:returns: `int`"""
 
     cdef bint _partial_set
+    cdef uint64_t _last_ts_event
     cdef Price _last_close
     cdef Price _open
     cdef Price _high

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -204,7 +204,7 @@ cdef class BarBuilder:
             self._high = self._last_close
             self._low = self._last_close
             self._close = self._last_close
-            self._last_close = ts_event
+            self._last_ts_event = ts_event
 
         cdef Bar bar = Bar(
             bar_type=self._bar_type,

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -76,6 +76,7 @@ cdef class BarBuilder:
         self._high = None
         self._low = None
         self._close = None
+        self._last_ts_event = 0
         self.volume = Quantity.zero_c(precision=self.size_precision)
 
     def __repr__(self) -> str:
@@ -203,6 +204,7 @@ cdef class BarBuilder:
             self._high = self._last_close
             self._low = self._last_close
             self._close = self._last_close
+            self._last_close = ts_event
 
         cdef Bar bar = Bar(
             bar_type=self._bar_type,
@@ -211,10 +213,11 @@ cdef class BarBuilder:
             low=self._low,
             close=self._close,
             volume=Quantity(self.volume, self.size_precision),
-            ts_event=ts_event,
+            ts_event=self._last_ts_event,
             ts_init=ts_event,
         )
 
+        self._last_ts_event = ts_event
         self._last_close = self._close
         self.reset()
         return bar


### PR DESCRIPTION
# Pull Request

Hi,
I believe this is due to error (if I am not missing the use case otherwise).  Expected behavior is the bar `ts_event` is the bar opening time and the `ts_init` is the closing time. This fixes this problem and internal bars are not consistent with external bar.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
