### PR TITLE
Couple of IB fixes

### DIFF
--- a/examples/live/interactive_brokers_book_imbalance.py
+++ b/examples/live/interactive_brokers_book_imbalance.py
@@ -60,6 +60,7 @@ config_node = TradingNodeConfig(
         "IB": InteractiveBrokersDataClientConfig(
             instrument_provider=provider_config,
             read_only_api=False,
+            start_gateway=False,
         ),
     },
     exec_clients={
@@ -67,6 +68,7 @@ config_node = TradingNodeConfig(
             routing=RoutingConfig(default=True, venues={"IDEALPRO"}),
             instrument_provider=provider_config,
             read_only_api=False,
+            start_gateway=False,
         ),
     },
     timeout_connection=90.0,

--- a/examples/live/interactive_brokers_example.py
+++ b/examples/live/interactive_brokers_example.py
@@ -57,15 +57,17 @@ config_node = TradingNodeConfig(
     log_level="DEBUG",
     data_clients={
         "IB": InteractiveBrokersDataClientConfig(
-            gateway_host="127.0.0.1",
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
                 filters=msgspec.json.encode(instrument_filters),
             ),
+            start_gateway=False,
         ),
     },
     exec_clients={
-        "IB": InteractiveBrokersExecClientConfig(),
+        "IB": InteractiveBrokersExecClientConfig(
+            start_gateway=False,
+        ),
     },
     timeout_connection=90.0,
     timeout_reconciliation=5.0,

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -103,7 +103,7 @@ def get_cached_ib_client(
             port = port or GATEWAY.port
     port = port or InteractiveBrokersGateway.PORTS[trading_mode]
 
-    client_key: tuple = (host, port)
+    client_key: tuple = (host, port, client_id)
 
     if client_key not in IB_INSYNC_CLIENTS:
         client = ib_insync.IB()
@@ -112,7 +112,7 @@ def get_cached_ib_client(
                 try:
                     client.connect(host=host, port=port, timeout=6, clientId=client_id)
                     break
-                except (TimeoutError, AttributeError, asyncio.TimeoutError):
+                except (TimeoutError, AttributeError, asyncio.TimeoutError, ConnectionRefusedError):
                     continue
             else:
                 raise TimeoutError(f"Failed to connect to gateway in {timeout}s")
@@ -190,8 +190,8 @@ class InteractiveBrokersLiveDataClientFactory(LiveDataClientFactory):
 
         """
         client = get_cached_ib_client(
-            username=config.username,
-            password=config.password,
+            username=config.username or os.environ["TWS_USERNAME"],
+            password=config.password or os.environ["TWS_PASSWORD"],
             host=config.gateway_host,
             port=config.gateway_port,
             trading_mode=config.trading_mode,
@@ -262,8 +262,8 @@ class InteractiveBrokersLiveExecClientFactory(LiveExecClientFactory):
 
         """
         client = get_cached_ib_client(
-            username=config.username,
-            password=config.password,
+            username=config.username or os.environ["TWS_USERNAME"],
+            password=config.password or os.environ["TWS_PASSWORD"],
             host=config.gateway_host,
             port=config.gateway_port,
             client_id=config.client_id,

--- a/nautilus_trader/live/node.py
+++ b/nautilus_trader/live/node.py
@@ -335,8 +335,8 @@ class TradingNode:
             self.kernel.log.debug(f"{self.kernel.data_engine.get_data_queue_task()}")
             self.kernel.log.debug(f"{self.kernel.exec_engine.get_cmd_queue_task()}")
             self.kernel.log.debug(f"{self.kernel.exec_engine.get_evt_queue_task()}")
-            # self.kernel.log.debug(f"{self.kernel.risk_engine.get_cmd_queue_task()}")
-            # self.kernel.log.debug(f"{self.kernel.risk_engine.get_evt_queue_task()}")
+            self.kernel.log.debug(f"{self.kernel.risk_engine.get_cmd_queue_task()}")
+            self.kernel.log.debug(f"{self.kernel.risk_engine.get_evt_queue_task()}")
 
             if self.kernel.trader.is_running:
                 self.kernel.trader.stop()
@@ -474,8 +474,8 @@ class TradingNode:
                 self.kernel.data_engine.get_req_queue_task(),
                 self.kernel.data_engine.get_res_queue_task(),
                 self.kernel.data_engine.get_data_queue_task(),
-                # self.kernel.risk_engine.get_cmd_queue_task(),
-                # self.kernel.risk_engine.get_evt_queue_task(),
+                self.kernel.risk_engine.get_cmd_queue_task(),
+                self.kernel.risk_engine.get_evt_queue_task(),
                 self.kernel.exec_engine.get_cmd_queue_task(),
                 self.kernel.exec_engine.get_evt_queue_task(),
             ]

--- a/nautilus_trader/live/node.py
+++ b/nautilus_trader/live/node.py
@@ -335,8 +335,8 @@ class TradingNode:
             self.kernel.log.debug(f"{self.kernel.data_engine.get_data_queue_task()}")
             self.kernel.log.debug(f"{self.kernel.exec_engine.get_cmd_queue_task()}")
             self.kernel.log.debug(f"{self.kernel.exec_engine.get_evt_queue_task()}")
-            self.kernel.log.debug(f"{self.kernel.risk_engine.get_cmd_queue_task()}")
-            self.kernel.log.debug(f"{self.kernel.risk_engine.get_evt_queue_task()}")
+            # self.kernel.log.debug(f"{self.kernel.risk_engine.get_cmd_queue_task()}")
+            # self.kernel.log.debug(f"{self.kernel.risk_engine.get_evt_queue_task()}")
 
             if self.kernel.trader.is_running:
                 self.kernel.trader.stop()
@@ -474,8 +474,8 @@ class TradingNode:
                 self.kernel.data_engine.get_req_queue_task(),
                 self.kernel.data_engine.get_res_queue_task(),
                 self.kernel.data_engine.get_data_queue_task(),
-                self.kernel.risk_engine.get_cmd_queue_task(),
-                self.kernel.risk_engine.get_evt_queue_task(),
+                # self.kernel.risk_engine.get_cmd_queue_task(),
+                # self.kernel.risk_engine.get_evt_queue_task(),
                 self.kernel.exec_engine.get_cmd_queue_task(),
                 self.kernel.exec_engine.get_evt_queue_task(),
             ]


### PR DESCRIPTION
- Default to `start_gateway=False` in examples. Gateway has been quite flaky recently. 
- Fix ENV vars not being automatically picked up.