### PR TITLE
Halt Engine if Exception raised for generate_mass_status

### DIFF
--- a/nautilus_trader/live/execution_client.py
+++ b/nautilus_trader/live/execution_client.py
@@ -433,12 +433,12 @@ class LiveExecutionClient(ExecutionClient):
             mass_status.add_order_reports(reports=reports[0])
             mass_status.add_trade_reports(reports=reports[1])
             mass_status.add_position_reports(reports=reports[2])
+
+            self.reconciliation_active = False
+
+            return mass_status
         except Exception as e:
             self._log.exception("Cannot reconcile execution state", e)
-
-        self.reconciliation_active = False
-
-        return mass_status
 
     async def _query_order(self, command: QueryOrder) -> None:
         self._log.debug(f"Synchronizing order status {command}.")


### PR DESCRIPTION
# Pull Request

When account reconciliation is enabled and TradingNode position doesn't match the actual positions with the Broker, TradingNode would halt and doesn't continue. This is the correct and expecte behavior.
However, if for some reason there is exception raised within any of the three reports, which is quit possible, TradingNode simply raises the exception but continues on treating `reconciliation=True`.


## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)