### PR TITLE
Optional `request_id` in Actor REQUESTS

### DIFF
--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -23,6 +23,7 @@ from nautilus_trader.common.logging cimport Logger
 from nautilus_trader.common.logging cimport LoggerAdapter
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.message cimport Event
+from nautilus_trader.core.uuid cimport UUID4
 from nautilus_trader.data.messages cimport DataCommand
 from nautilus_trader.data.messages cimport DataRequest
 from nautilus_trader.data.messages cimport DataResponse
@@ -147,15 +148,16 @@ cdef class Actor(Component):
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 
-    cpdef void request_data(self, ClientId client_id, DataType data_type)
-    cpdef void request_instrument(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void request_instruments(self, Venue venue, ClientId client_id=*)
+    cpdef void request_data(self, ClientId client_id, DataType data_type, UUID4 request_id=*)
+    cpdef void request_instrument(self, InstrumentId instrument_id, ClientId client_id=*, UUID4 request_id=*)
+    cpdef void request_instruments(self, Venue venue, ClientId client_id=*, UUID4 request_id=*)
     cpdef void request_quote_ticks(
         self,
         InstrumentId instrument_id,
         datetime start=*,
         datetime end=*,
         ClientId client_id=*,
+        UUID4 request_id=*,
     )
     cpdef void request_trade_ticks(
         self,
@@ -163,6 +165,7 @@ cdef class Actor(Component):
         datetime start=*,
         datetime end=*,
         ClientId client_id=*,
+        UUID4 request_id= *,
     )
     cpdef void request_bars(
         self,
@@ -170,6 +173,7 @@ cdef class Actor(Component):
         datetime start=*,
         datetime end=*,
         ClientId client_id=*,
+        UUID4 request_id= *,
     )
 
 # -- HANDLERS -------------------------------------------------------------------------------------

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1553,7 +1553,7 @@ cdef class Actor(Component):
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 
-    cpdef void request_data(self, ClientId client_id, DataType data_type):
+    cpdef void request_data(self, ClientId client_id, DataType data_type, UUID4 request_id = None):
         """
         Request custom data for the given data type from the given data client.
 
@@ -1563,6 +1563,9 @@ cdef class Actor(Component):
             The data client ID.
         data_type : DataType
             The data type for the request.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         """
         Condition.not_none(client_id, "client_id")
@@ -1574,13 +1577,13 @@ cdef class Actor(Component):
             venue=None,
             data_type=data_type,
             callback=self._handle_data_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 
         self._send_data_req(request)
 
-    cpdef void request_instrument(self, InstrumentId instrument_id, ClientId client_id = None):
+    cpdef void request_instrument(self, InstrumentId instrument_id, ClientId client_id = None, UUID4 request_id = None):
         """
         Request `Instrument` data for the given instrument ID.
 
@@ -1591,6 +1594,9 @@ cdef class Actor(Component):
         client_id : ClientId, optional
             The specific client ID for the command.
             If ``None`` then will be inferred from the venue in the instrument ID.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         """
         Condition.not_none(instrument_id, "instrument_id")
@@ -1602,13 +1608,13 @@ cdef class Actor(Component):
                 "instrument_id": instrument_id,
             }),
             callback=self._handle_instrument_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 
         self._send_data_req(request)
 
-    cpdef void request_instruments(self, Venue venue, ClientId client_id = None):
+    cpdef void request_instruments(self, Venue venue, ClientId client_id = None, UUID4 request_id = None):
         """
         Request all `Instrument` data for the given venue.
 
@@ -1619,6 +1625,9 @@ cdef class Actor(Component):
         client_id : ClientId, optional
             The specific client ID for the command.
             If ``None`` then will be inferred from the venue in the instrument ID.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         """
         Condition.not_none(venue, "venue")
@@ -1630,7 +1639,7 @@ cdef class Actor(Component):
                 "venue": venue,
             }),
             callback=self._handle_instruments_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 
@@ -1642,6 +1651,7 @@ cdef class Actor(Component):
         datetime start = None,
         datetime end = None,
         ClientId client_id = None,
+        UUID4 request_id = None,
     ):
         """
         Request historical `QuoteTick` data.
@@ -1660,6 +1670,9 @@ cdef class Actor(Component):
         client_id : ClientId, optional
             The specific client ID for the command.
             If ``None`` then will be inferred from the venue in the instrument ID.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         Raises
         ------
@@ -1681,7 +1694,7 @@ cdef class Actor(Component):
                 "end": end,
             }),
             callback=self._handle_quote_ticks_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 
@@ -1693,6 +1706,7 @@ cdef class Actor(Component):
         datetime start = None,
         datetime end = None,
         ClientId client_id = None,
+        UUID4 request_id = None,
     ):
         """
         Request historical `TradeTick` data.
@@ -1711,6 +1725,9 @@ cdef class Actor(Component):
         client_id : ClientId, optional
             The specific client ID for the command.
             If ``None`` then will be inferred from the venue in the instrument ID.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         Raises
         ------
@@ -1732,7 +1749,7 @@ cdef class Actor(Component):
                 "end": end,
             }),
             callback=self._handle_trade_ticks_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 
@@ -1744,6 +1761,7 @@ cdef class Actor(Component):
         datetime start = None,
         datetime end = None,
         ClientId client_id = None,
+        UUID4 request_id = None,
     ):
         """
         Request historical `Bar` data.
@@ -1762,6 +1780,9 @@ cdef class Actor(Component):
         client_id : ClientId, optional
             The specific client ID for the command.
             If ``None`` then will be inferred from the venue in the instrument ID.
+        request_id : UUID4, optional
+            The specific request ID for the command.
+            If ``None`` then will be generated.
 
         Raises
         ------
@@ -1783,7 +1804,7 @@ cdef class Actor(Component):
                 "end": end,
             }),
             callback=self._handle_bars_response,
-            request_id=UUID4(),
+            request_id=request_id or UUID4(),
             ts_init=self._clock.timestamp_ns(),
         )
 


### PR DESCRIPTION
# Pull Request

Adds the Optional `request_id` for the in Actor requests. This allow the requests to be tracked by Actor/Strategy and ease working with asyncio. Hope this will be common useful feature.

## Type of change

Delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

