### PR TITLE
Optional Venue Order Id on generate_order_submitted

### DIFF
--- a/nautilus_trader/execution/client.pxd
+++ b/nautilus_trader/execution/client.pxd
@@ -94,6 +94,7 @@ cdef class ExecutionClient(Component):
         InstrumentId instrument_id,
         ClientOrderId client_order_id,
         uint64_t ts_event,
+        VenueOrderId venue_order_id=*,
     )
     cpdef void generate_order_rejected(
         self,

--- a/nautilus_trader/execution/client.pyx
+++ b/nautilus_trader/execution/client.pyx
@@ -310,6 +310,7 @@ cdef class ExecutionClient(Component):
         InstrumentId instrument_id,
         ClientOrderId client_order_id,
         uint64_t ts_event,
+        VenueOrderId venue_order_id = None,
     ):
         """
         Generate an `OrderSubmitted` event and send it to the `ExecutionEngine`.
@@ -324,7 +325,8 @@ cdef class ExecutionClient(Component):
             The client order ID.
         ts_event : uint64_t
             The UNIX timestamp (nanoseconds) when the order submitted event occurred.
-
+        venue_order_id : VenueOrderId, Optional at this stage
+            The venue order ID (assigned by the venue).
         """
         # Generate event
         cdef OrderSubmitted submitted = OrderSubmitted(

--- a/nautilus_trader/model/events/order.pyx
+++ b/nautilus_trader/model/events/order.pyx
@@ -515,6 +515,8 @@ cdef class OrderSubmitted(OrderEvent):
         The UNIX timestamp (nanoseconds) when the order submitted event occurred.
     ts_init : uint64_t
         The UNIX timestamp (nanoseconds) when the object was initialized.
+    venue_order_id : VenueOrderId, Optional at this stage
+        The venue order ID (assigned by the venue).
     """
 
     def __init__(
@@ -527,13 +529,14 @@ cdef class OrderSubmitted(OrderEvent):
         UUID4 event_id not None,
         uint64_t ts_event,
         uint64_t ts_init,
+        VenueOrderId venue_order_id = None,
     ):
         super().__init__(
             trader_id,
             strategy_id,
             instrument_id,
             client_order_id,
-            None,  # Pending accepted
+            venue_order_id,
             account_id,
             event_id,
             ts_event,


### PR DESCRIPTION
# Pull Request

Allows optional Venue Order Id on `generate_order_submitted` which is useful where `VenueOrderId` is available before at the time of Sumit event i.e IB.

## Type of change

Delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
