### PR TITLE
Benchmark catalog v2 for single and multi stream

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -1703,6 +1703,7 @@ version = "0.4.0"
 dependencies = [
  "binary-heap-plus",
  "compare",
+ "criterion",
  "datafusion",
  "futures",
  "nautilus_core",

--- a/nautilus_core/persistence/Cargo.toml
+++ b/nautilus_core/persistence/Cargo.toml
@@ -27,3 +27,10 @@ pin-project-lite = "0.2.9"
 [features]
 extension-module = ["pyo3/extension-module", "nautilus_core/extension-module", "nautilus_model/extension-module"]
 default = []
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "persistence_benchmark"
+harness = false

--- a/nautilus_core/persistence/benches/persistence_benchmark.rs
+++ b/nautilus_core/persistence/benches/persistence_benchmark.rs
@@ -1,0 +1,85 @@
+use std::fs;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use nautilus_model::data::tick::{QuoteTick, TradeTick};
+use nautilus_persistence::session::{PersistenceCatalog, QueryResult};
+use pyo3_asyncio::tokio::get_runtime;
+
+fn single_stream_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_stream");
+    group.sample_size(10);
+    let chunk_size = 5000;
+    // about 10 M records
+    let file_path = "../../bench_data/quotes_0005.parquet";
+
+    group.bench_function("persistence v2", |b| {
+        b.iter_batched(
+            || {
+                let rt = get_runtime();
+                let mut catalog = PersistenceCatalog::new(chunk_size);
+                rt.block_on(catalog.add_file::<QuoteTick>("quote_tick", file_path))
+                    .unwrap();
+                let _guard = rt.enter();
+                catalog.to_query_result()
+            },
+            |query_result: QueryResult| {
+                let rt = get_runtime();
+                let _guard = rt.enter();
+                let count: usize = query_result.map(|vec| vec.len()).sum();
+                assert_eq!(count, 9689614);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn multi_stream_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multi_stream");
+    group.sample_size(10);
+    let chunk_size = 5000;
+    // about 72 M records, with streams split across multiple files
+    let dir_path = "../../bench_data/multi_stream_data";
+
+    group.bench_function("persistence v2", |b| {
+        b.iter_batched(
+            || {
+                let rt = get_runtime();
+                let mut catalog = PersistenceCatalog::new(chunk_size);
+
+                for entry in fs::read_dir(dir_path).expect("No such directory") {
+                    let entry = entry.expect("Failed to read directory");
+                    let path = entry.path();
+
+                    if path.is_file() && path.extension().unwrap() == "parquet" {
+                        let file_name = path.file_stem().unwrap().to_str().unwrap();
+
+                        if file_name.contains("quotes") {
+                            rt.block_on(
+                                catalog.add_file::<QuoteTick>(file_name, path.to_str().unwrap()),
+                            )
+                            .unwrap();
+                        } else if file_name.contains("trades") {
+                            rt.block_on(
+                                catalog.add_file::<TradeTick>(file_name, path.to_str().unwrap()),
+                            )
+                            .unwrap();
+                        }
+                    }
+                }
+
+                let _guard = rt.enter();
+                catalog.to_query_result()
+            },
+            |query_result: QueryResult| {
+                let rt = get_runtime();
+                let _guard = rt.enter();
+                let count: usize = query_result.map(|vec| vec.len()).sum();
+                assert_eq!(count, 72536038);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, single_stream_bench, multi_stream_bench);
+criterion_main!(benches);

--- a/nautilus_core/persistence/tests/test_catalog.rs
+++ b/nautilus_core/persistence/tests/test_catalog.rs
@@ -16,22 +16,14 @@
 use nautilus_model::data::tick::{Data, QuoteTick, TradeTick};
 use nautilus_persistence::session::{PersistenceCatalog, QueryResult};
 
-// Note: "current_thread" hangs up for some reason
+// Note: "current_thread" configuration hangs up for some reason
 #[tokio::test(flavor = "multi_thread")]
-async fn test_quote_ticks() {
-    let mut catalog = PersistenceCatalog::new(5000);
+async fn test_v2_bench_data() {
+    let file_path = "../../tests/test_data/quote_tick_data.parquet";
+    let length = 9500;
+    let mut catalog = PersistenceCatalog::new(10000);
     catalog
-        .add_file::<QuoteTick>(
-            "quote_tick",
-            "../../tests/test_data/quote_tick_data.parquet",
-        )
-        .await
-        .unwrap();
-    catalog
-        .add_file::<QuoteTick>(
-            "quote_tick_2",
-            "../../tests/test_data/quote_tick_data.parquet",
-        )
+        .add_file::<QuoteTick>("quotes_0005", file_path)
         .await
         .unwrap();
     let query_result: QueryResult = catalog.to_query_result();
@@ -51,11 +43,7 @@ async fn test_quote_ticks() {
         true
     };
 
-    match &ticks[0] {
-        Data::Trade(_) => assert!(false),
-        Data::Quote(q) => assert_eq!("EUR/USD.SIM", q.instrument_id.to_string()),
-    }
-    assert_eq!(ticks.len(), 19000);
+    assert_eq!(ticks.len(), length);
     assert!(is_ascending_by_init(&ticks));
 }
 

--- a/tests/performance_tests/test_perf_catalog.py
+++ b/tests/performance_tests/test_perf_catalog.py
@@ -15,16 +15,21 @@
 
 import shutil
 import tempfile
+import os
 
 import pytest
 
 from nautilus_trader.test_kit.mocks.data import data_catalog_setup
 from nautilus_trader.test_kit.performance import PerformanceHarness
 from tests.unit_tests.persistence.test_catalog import TestPersistenceCatalogFile
+from nautilus_trader.core.nautilus_pyo3.persistence import ParquetType
+from nautilus_trader.core.nautilus_pyo3.persistence import PythonCatalog
 
+from nautilus_trader.persistence.wranglers import list_from_capsule
+from nautilus_trader import PACKAGE_ROOT
 
 @pytest.mark.skip(reason="update tests for new API")
-class TestBacktestEnginePerformance(PerformanceHarness):
+class TestCatalogPerformance(PerformanceHarness):
     @staticmethod
     def test_load_quote_ticks_python(benchmark):
         tempdir = tempfile.mkdtemp()
@@ -68,3 +73,52 @@ class TestBacktestEnginePerformance(PerformanceHarness):
 
         benchmark.pedantic(run, setup=setup, rounds=1, iterations=1, warmup_rounds=1)
         shutil.rmtree(tempdir)
+
+    @staticmethod
+    def test_load_single_stream_catalog_v2(benchmark):
+        def setup():
+            file_path = os.path.join(PACKAGE_ROOT, "bench_data/quotes_0005.parquet")
+            session = PythonCatalog()
+            session.add_file("quote_ticks", file_path, ParquetType.QuoteTick)
+            return (session.to_query_result(),), {}
+
+        def run(result):
+            count = 0
+            for chunk in result:
+                count += len(list_from_capsule(chunk))
+
+            assert count == 9689614
+
+        benchmark.pedantic(run, setup=setup, rounds=1, iterations=1, warmup_rounds=1)
+
+
+    @staticmethod
+    def test_load_multi_stream_catalog_v2(benchmark):
+        def setup():
+            dir_path = os.path.join(PACKAGE_ROOT, "bench_data/multi_stream_data/")
+
+            session = PythonCatalog()
+
+            for dirpath, _, filenames in os.walk(dir_path):
+                for filename in filenames:
+                    if filename.endswith("parquet"):
+                        file_stem = os.path.splitext(filename)[0]
+                        if "quotes" in filename:
+                            full_path = os.path.join(dirpath, filename)
+                            session.add_file(file_stem, full_path, ParquetType.QuoteTick)
+                        elif "trades" in filename:
+                            full_path = os.path.join(dirpath, filename)
+                            session.add_file(file_stem, full_path, ParquetType.TradeTick)
+
+            return (session.to_query_result(),), {}
+
+        def run(result):
+            count = 0
+            for chunk in result:
+                ticks = list_from_capsule(chunk)
+                count += len(ticks)
+
+            # check total count is correct
+            assert count == 72536038
+
+        benchmark.pedantic(run, setup=setup, rounds=1, iterations=1, warmup_rounds=1)


### PR DESCRIPTION
# Pull Request

Adds benchmarks for single and multi stream. Benchmarks measure how long it takes for catalog to load 10 M ticks from a single file and 72 M ticks from 61 files. This is a good stress test for the stream merging datafusion based catalog.

The python tests are expected to take more time because of the overhead of initializing python objects and acquiring GIL.

The benchmarks were run on an AMD 5600U machine and gave the following.

| Test | Rust | Python |
| -- | -- | -- |
| single stream (10M) | 2.4s | 3.2s |
| multi stream (72M, 61 files) | 23s | NA |

The multi-stream python bench requires 8+ gb of ram and could not be run.

An appropriate measure for the catalog is it's throughput which can be measured in terms of ticks per second. Here we can compare with previous iterations described in #705 

1. Rust catalog v2 - datafusion and kmerge ~ 3M/s
2. Rust catalog v1 - arrow2 and Python merge logic ~ (TODO)
3. Catalog - Pure Python - 100K/s

## Type of change

- [x] Performance tests

## How has this change been tested?

The benchmarks were run and passed.