### PR TITLE
Use CVec for Vec of TimeEventHandlers

### DIFF
--- a/nautilus_core/backtest/cbindgen_cython.toml
+++ b/nautilus_core/backtest/cbindgen_cython.toml
@@ -21,7 +21,6 @@ header = '"../includes/backtest.h"'
 
 "nautilus_trader.core.rust.common" = [
     "TestClockAPI",
-    "Vec_TimeEventHandler",
 ]
 
 "nautilus_trader.core.rust.core" = [

--- a/nautilus_core/backtest/src/engine.rs
+++ b/nautilus_core/backtest/src/engine.rs
@@ -15,10 +15,10 @@
 
 use std::cmp::Ordering;
 use std::ops::{Deref, DerefMut};
-use std::ptr::null;
 
 use nautilus_common::clock::{TestClock, TestClockAPI};
-use nautilus_common::timer::{TimeEventHandler, Vec_TimeEventHandler};
+use nautilus_common::timer::TimeEventHandler;
+use nautilus_core::cvec::CVec;
 use nautilus_core::time::UnixNanos;
 
 /// Provides a means of accumulating and draining time event handlers.
@@ -102,19 +102,8 @@ pub extern "C" fn time_event_accumulator_advance_clock(
 }
 
 #[no_mangle]
-pub extern "C" fn time_event_accumulator_drain(
-    accumulator: &mut TimeEventAccumulatorAPI,
-) -> Vec_TimeEventHandler {
-    let handlers = accumulator.drain();
-    let len = handlers.len();
-    let data = match handlers.is_empty() {
-        true => null() as *const TimeEventHandler,
-        false => &handlers.leak()[0],
-    };
-    Vec_TimeEventHandler {
-        ptr: data as *const TimeEventHandler,
-        len,
-    }
+pub extern "C" fn time_event_accumulator_drain(accumulator: &mut TimeEventAccumulatorAPI) -> CVec {
+    accumulator.drain().into()
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/nautilus_core/common/src/timer.rs
+++ b/nautilus_core/common/src/timer.rs
@@ -99,14 +99,6 @@ impl Ord for TimeEventHandler {
     }
 }
 
-#[repr(C)]
-#[allow(non_camel_case_types)]
-/// Provides a vector of time event handlers.
-pub struct Vec_TimeEventHandler {
-    pub ptr: *const TimeEventHandler,
-    pub len: usize,
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // C API
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,6 +145,11 @@ pub trait Timer {
     fn pop_event(&self, event_id: UUID4, ts_init: UnixNanos) -> TimeEvent;
     fn iterate_next_time(&mut self, ts_now: UnixNanos);
     fn cancel(&mut self);
+}
+
+#[no_mangle]
+pub extern "C" fn dummy(v: TimeEventHandler) -> TimeEventHandler {
+    v
 }
 
 #[derive(Clone)]

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -21,7 +21,7 @@ from nautilus_trader.common.logging cimport Logger
 from nautilus_trader.common.logging cimport LoggerAdapter
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.rust.backtest cimport TimeEventAccumulatorAPI
-from nautilus_trader.core.rust.common cimport Vec_TimeEventHandler
+from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.uuid cimport UUID4
 from nautilus_trader.data.engine cimport DataEngine
 
@@ -50,10 +50,10 @@ cdef class BacktestEngine:
     cdef uint64_t _iteration
 
     cdef Data _next(self)
-    cdef Vec_TimeEventHandler _advance_time(self, uint64_t now_ns, list clocks)
+    cdef CVec _advance_time(self, uint64_t now_ns, list clocks)
     cdef void _process_raw_time_event_handlers(
         self,
-        Vec_TimeEventHandler raw_handlers,
+        CVec raw_handlers,
         list clocks,
         uint64_t now_ns,
         bint only_now,

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -60,8 +60,8 @@ from nautilus_trader.core.rust.backtest cimport time_event_accumulator_drain
 from nautilus_trader.core.rust.backtest cimport time_event_accumulator_free
 from nautilus_trader.core.rust.backtest cimport time_event_accumulator_new
 from nautilus_trader.core.rust.common cimport TimeEventHandler_t
-from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.rust.common cimport vec_time_event_handlers_drop
+from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.uuid cimport UUID4
 from nautilus_trader.execution.algorithm cimport ExecAlgorithm
 from nautilus_trader.model.data.bar cimport Bar

--- a/nautilus_trader/common/clock.pxd
+++ b/nautilus_trader/common/clock.pxd
@@ -25,7 +25,7 @@ from nautilus_trader.common.timer cimport LiveTimer
 from nautilus_trader.common.timer cimport TimeEvent
 from nautilus_trader.core.rust.common cimport LiveClockAPI
 from nautilus_trader.core.rust.common cimport TestClockAPI
-from nautilus_trader.core.rust.common cimport Vec_TimeEventHandler
+from nautilus_trader.core.rust.core cimport CVec
 
 
 cdef class Clock:
@@ -72,7 +72,7 @@ cdef class TestClock(Clock):
     cdef TestClockAPI _mem
 
     cpdef void set_time(self, uint64_t to_time_ns)
-    cdef Vec_TimeEventHandler advance_time_c(self, uint64_t to_time_ns, bint set_time=*)
+    cdef CVec advance_time_c(self, uint64_t to_time_ns, bint set_time=*)
     cpdef list advance_time(self, uint64_t to_time_ns, bint set_time=*)
 
 

--- a/nautilus_trader/common/clock.pyx
+++ b/nautilus_trader/common/clock.pyx
@@ -35,7 +35,6 @@ from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.datetime cimport dt_to_unix_nanos
 from nautilus_trader.core.datetime cimport maybe_dt_to_unix_nanos
 from nautilus_trader.core.rust.common cimport TimeEventHandler_t
-from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.rust.common cimport live_clock_free
 from nautilus_trader.core.rust.common cimport live_clock_new
 from nautilus_trader.core.rust.common cimport live_clock_timestamp
@@ -59,6 +58,7 @@ from nautilus_trader.core.rust.common cimport test_clock_timestamp_ms
 from nautilus_trader.core.rust.common cimport test_clock_timestamp_ns
 from nautilus_trader.core.rust.common cimport test_clock_timestamp_us
 from nautilus_trader.core.rust.common cimport vec_time_event_handlers_drop
+from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.rust.core cimport nanos_to_millis
 from nautilus_trader.core.rust.core cimport nanos_to_secs
 from nautilus_trader.core.rust.core cimport unix_timestamp

--- a/nautilus_trader/core/includes/backtest.h
+++ b/nautilus_trader/core/includes/backtest.h
@@ -23,4 +23,4 @@ void time_event_accumulator_advance_clock(struct TimeEventAccumulatorAPI *accumu
                                           uint64_t to_time_ns,
                                           uint8_t set_time);
 
-Vec_TimeEventHandler time_event_accumulator_drain(struct TimeEventAccumulatorAPI *accumulator);
+CVec time_event_accumulator_drain(struct TimeEventAccumulatorAPI *accumulator);

--- a/nautilus_trader/core/includes/common.h
+++ b/nautilus_trader/core/includes/common.h
@@ -70,6 +70,19 @@ typedef struct TestClockAPI {
     struct TestClock *_0;
 } TestClockAPI;
 
+typedef struct LiveClockAPI {
+    struct LiveClock *_0;
+} LiveClockAPI;
+
+/**
+ * Logger is not C FFI safe, so we box and pass it as an opaque pointer.
+ * This works because Logger fields don't need to be accessed, only functions
+ * are called.
+ */
+typedef struct CLogger {
+    struct Logger_t *_0;
+} CLogger;
+
 /**
  * Represents a time event occurring at the event timestamp.
  */
@@ -105,27 +118,6 @@ typedef struct TimeEventHandler_t {
      */
     PyObject *callback_ptr;
 } TimeEventHandler_t;
-
-/**
- * Provides a vector of time event handlers.
- */
-typedef struct Vec_TimeEventHandler {
-    const struct TimeEventHandler_t *ptr;
-    uintptr_t len;
-} Vec_TimeEventHandler;
-
-typedef struct LiveClockAPI {
-    struct LiveClock *_0;
-} LiveClockAPI;
-
-/**
- * Logger is not C FFI safe, so we box and pass it as an opaque pointer.
- * This works because Logger fields don't need to be accessed, only functions
- * are called.
- */
-typedef struct CLogger {
-    struct Logger_t *_0;
-} CLogger;
 
 struct TestClockAPI test_clock_new(void);
 
@@ -177,11 +169,9 @@ void test_clock_set_timer_ns(struct TestClockAPI *clock,
  * # Safety
  * - Assumes `set_time` is a correct `uint8_t` of either 0 or 1.
  */
-struct Vec_TimeEventHandler test_clock_advance_time(struct TestClockAPI *clock,
-                                                    uint64_t to_time_ns,
-                                                    uint8_t set_time);
+CVec test_clock_advance_time(struct TestClockAPI *clock, uint64_t to_time_ns, uint8_t set_time);
 
-void vec_time_event_handlers_drop(struct Vec_TimeEventHandler v);
+void vec_time_event_handlers_drop(CVec v);
 
 /**
  * # Safety
@@ -312,3 +302,5 @@ const char *time_event_name_to_cstr(const struct TimeEvent_t *event);
  * Returns a [`TimeEvent`] as a C string pointer.
  */
 const char *time_event_to_cstr(const struct TimeEvent_t *event);
+
+struct TimeEventHandler_t dummy(struct TimeEventHandler_t v);

--- a/nautilus_trader/core/rust/backtest.pxd
+++ b/nautilus_trader/core/rust/backtest.pxd
@@ -3,7 +3,7 @@
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
 from nautilus_trader.core.rust.common cimport TestClockAPI
-from nautilus_trader.core.rust.core cimport UUID4_t, CVec
+from nautilus_trader.core.rust.core cimport UUID4_t
 
 cdef extern from "../includes/backtest.h":
 

--- a/nautilus_trader/core/rust/backtest.pxd
+++ b/nautilus_trader/core/rust/backtest.pxd
@@ -2,8 +2,8 @@
 
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
-from nautilus_trader.core.rust.common cimport TestClockAPI, Vec_TimeEventHandler
-from nautilus_trader.core.rust.core cimport UUID4_t
+from nautilus_trader.core.rust.common cimport TestClockAPI
+from nautilus_trader.core.rust.core cimport UUID4_t, CVec
 
 cdef extern from "../includes/backtest.h":
 
@@ -23,4 +23,4 @@ cdef extern from "../includes/backtest.h":
                                               uint64_t to_time_ns,
                                               uint8_t set_time);
 
-    Vec_TimeEventHandler time_event_accumulator_drain(TimeEventAccumulatorAPI *accumulator);
+    CVec time_event_accumulator_drain(TimeEventAccumulatorAPI *accumulator);

--- a/nautilus_trader/core/rust/backtest.pxd
+++ b/nautilus_trader/core/rust/backtest.pxd
@@ -3,7 +3,7 @@
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
 from nautilus_trader.core.rust.common cimport TestClockAPI
-from nautilus_trader.core.rust.core cimport UUID4_t
+from nautilus_trader.core.rust.core cimport UUID4_t, CVec
 
 cdef extern from "../includes/backtest.h":
 

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -2,7 +2,7 @@
 
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
-from nautilus_trader.core.rust.core cimport UUID4_t, CVec
+from nautilus_trader.core.rust.core cimport UUID4_t
 
 cdef extern from "../includes/common.h":
 

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -2,7 +2,7 @@
 
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
-from nautilus_trader.core.rust.core cimport UUID4_t
+from nautilus_trader.core.rust.core cimport UUID4_t, CVec
 
 cdef extern from "../includes/common.h":
 

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -2,7 +2,7 @@
 
 from cpython.object cimport PyObject
 from libc.stdint cimport uint8_t, uint64_t, uintptr_t
-from nautilus_trader.core.rust.core cimport UUID4_t
+from nautilus_trader.core.rust.core cimport UUID4_t, CVec
 
 cdef extern from "../includes/common.h":
 
@@ -70,6 +70,15 @@ cdef extern from "../includes/common.h":
     cdef struct TestClockAPI:
         TestClock *_0;
 
+    cdef struct LiveClockAPI:
+        LiveClock *_0;
+
+    # Logger is not C FFI safe, so we box and pass it as an opaque pointer.
+    # This works because Logger fields don't need to be accessed, only functions
+    # are called.
+    cdef struct CLogger:
+        Logger_t *_0;
+
     # Represents a time event occurring at the event timestamp.
     cdef struct TimeEvent_t:
         # The event name.
@@ -87,20 +96,6 @@ cdef extern from "../includes/common.h":
         TimeEvent_t event;
         # The event ID.
         PyObject *callback_ptr;
-
-    # Provides a vector of time event handlers.
-    cdef struct Vec_TimeEventHandler:
-        const TimeEventHandler_t *ptr;
-        uintptr_t len;
-
-    cdef struct LiveClockAPI:
-        LiveClock *_0;
-
-    # Logger is not C FFI safe, so we box and pass it as an opaque pointer.
-    # This works because Logger fields don't need to be accessed, only functions
-    # are called.
-    cdef struct CLogger:
-        Logger_t *_0;
 
     TestClockAPI test_clock_new();
 
@@ -144,11 +139,9 @@ cdef extern from "../includes/common.h":
 
     # # Safety
     # - Assumes `set_time` is a correct `uint8_t` of either 0 or 1.
-    Vec_TimeEventHandler test_clock_advance_time(TestClockAPI *clock,
-                                                 uint64_t to_time_ns,
-                                                 uint8_t set_time);
+    CVec test_clock_advance_time(TestClockAPI *clock, uint64_t to_time_ns, uint8_t set_time);
 
-    void vec_time_event_handlers_drop(Vec_TimeEventHandler v);
+    void vec_time_event_handlers_drop(CVec v);
 
     # # Safety
     # - Assumes `name_ptr` is a valid C string pointer.
@@ -259,3 +252,5 @@ cdef extern from "../includes/common.h":
 
     # Returns a [`TimeEvent`] as a C string pointer.
     const char *time_event_to_cstr(const TimeEvent_t *event);
+
+    TimeEventHandler_t dummy(TimeEventHandler_t v);


### PR DESCRIPTION
# Pull Request

Use CVec to pass vector of TimeEventHandlers to Cython for consistency

## Type of change

Delete options that are not relevant.

- [x] Refactor

## How has this change been tested?

Tests were run
