### PR TITLE
Time event tests

### DIFF
--- a/nautilus_core/backtest/src/engine.rs
+++ b/nautilus_core/backtest/src/engine.rs
@@ -13,7 +13,6 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::cmp::Ordering;
 use std::ops::{Deref, DerefMut};
 
 use nautilus_common::clock::{TestClock, TestClockAPI};
@@ -44,12 +43,10 @@ impl TimeEventAccumulator {
 
     /// Drain the accumulated time event handlers in sorted order (by the events `ts_event`).
     pub fn drain(&mut self) -> Vec<TimeEventHandler> {
-        self.event_handlers.sort_by(|a, b| {
-            a.event
-                .ts_event
-                .partial_cmp(&b.event.ts_event)
-                .unwrap_or(Ordering::Equal)
-        });
+        // stable sort is not necessary since there is no relation between
+        // events of the same clock. Only time based ordering is needed.
+        self.event_handlers
+            .sort_unstable_by_key(|v| v.event.ts_event);
         self.event_handlers.drain(..).collect()
     }
 }

--- a/nautilus_core/common/src/timer.rs
+++ b/nautilus_core/common/src/timer.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn time_event_new(
 }
 
 #[no_mangle]
-pub extern "C" fn time_event_copy(event: &TimeEvent) -> TimeEvent {
+pub extern "C" fn time_event_clone(event: &TimeEvent) -> TimeEvent {
     event.clone()
 }
 

--- a/nautilus_trader/common/clock.pyx
+++ b/nautilus_trader/common/clock.pyx
@@ -579,7 +579,7 @@ cdef class TestClock(Clock):
             event_handler = TimeEventHandler(event, callback)
             event_handlers.append(event_handler)
 
-        # vec_time_event_handlers_drop(raw_handler_vec)
+        vec_time_event_handlers_drop(raw_handler_vec)
 
         return event_handlers
 

--- a/nautilus_trader/common/timer.pyx
+++ b/nautilus_trader/common/timer.pyx
@@ -21,6 +21,7 @@ from libc.stdint cimport uint64_t
 from nautilus_trader.common.timer cimport TimeEvent
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.message cimport Event
+from nautilus_trader.core.rust.common cimport time_event_clone
 from nautilus_trader.core.rust.common cimport time_event_free
 from nautilus_trader.core.rust.common cimport time_event_name_to_cstr
 from nautilus_trader.core.rust.common cimport time_event_new
@@ -118,7 +119,7 @@ cdef class TimeEvent(Event):
     @staticmethod
     cdef TimeEvent from_mem_c(TimeEvent_t mem):
         cdef TimeEvent event = TimeEvent.__new__(TimeEvent)
-        event._mem = mem
+        event._mem = time_event_clone(&mem)
         event.id = UUID4.from_mem_c(mem.event_id)
         event.ts_event = mem.ts_event
         event.ts_init = mem.ts_init

--- a/nautilus_trader/core/includes/common.h
+++ b/nautilus_trader/core/includes/common.h
@@ -292,7 +292,7 @@ struct TimeEvent_t time_event_new(const char *name,
                                   uint64_t ts_event,
                                   uint64_t ts_init);
 
-struct TimeEvent_t time_event_copy(const struct TimeEvent_t *event);
+struct TimeEvent_t time_event_clone(const struct TimeEvent_t *event);
 
 void time_event_free(struct TimeEvent_t event);
 

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -244,7 +244,7 @@ cdef extern from "../includes/common.h":
                                uint64_t ts_event,
                                uint64_t ts_init);
 
-    TimeEvent_t time_event_copy(const TimeEvent_t *event);
+    TimeEvent_t time_event_clone(const TimeEvent_t *event);
 
     void time_event_free(TimeEvent_t event);
 


### PR DESCRIPTION
# Pull Request

TimeEvent `from_mem_c` was assigning memory rather than cloning. This was causing a double free.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tests were run.