### PR TITLE
Rename persistence classes

### DIFF
--- a/nautilus_core/persistence/benches/persistence_benchmark.rs
+++ b/nautilus_core/persistence/benches/persistence_benchmark.rs
@@ -17,10 +17,10 @@ fn single_stream_bench(c: &mut Criterion) {
             || {
                 let rt = get_runtime();
                 let mut catalog = DataBackendSession::new(chunk_size);
-                rt.block_on(catalog.add_file::<QuoteTick>("quote_tick", file_path))
+                rt.block_on(catalog.add_file_default_query::<QuoteTick>("quote_tick", file_path))
                     .unwrap();
                 let _guard = rt.enter();
-                catalog.to_query_result()
+                catalog.get_query_result()
             },
             |query_result: QueryResult| {
                 let rt = get_runtime();
@@ -54,21 +54,23 @@ fn multi_stream_bench(c: &mut Criterion) {
                         let file_name = path.file_stem().unwrap().to_str().unwrap();
 
                         if file_name.contains("quotes") {
-                            rt.block_on(
-                                catalog.add_file::<QuoteTick>(file_name, path.to_str().unwrap()),
-                            )
+                            rt.block_on(catalog.add_file_default_query::<QuoteTick>(
+                                file_name,
+                                path.to_str().unwrap(),
+                            ))
                             .unwrap();
                         } else if file_name.contains("trades") {
-                            rt.block_on(
-                                catalog.add_file::<TradeTick>(file_name, path.to_str().unwrap()),
-                            )
+                            rt.block_on(catalog.add_file_default_query::<TradeTick>(
+                                file_name,
+                                path.to_str().unwrap(),
+                            ))
                             .unwrap();
                         }
                     }
                 }
 
                 let _guard = rt.enter();
-                catalog.to_query_result()
+                catalog.get_query_result()
             },
             |query_result: QueryResult| {
                 let rt = get_runtime();

--- a/nautilus_core/persistence/src/lib.rs
+++ b/nautilus_core/persistence/src/lib.rs
@@ -19,13 +19,13 @@ pub mod session;
 
 use parquet::ParquetType;
 use pyo3::prelude::*;
-use session::{DataCatalogBackend, PythonQueryResult};
+use session::{DataBackendSession, DataQueryResult};
 
 /// Loaded as nautilus_pyo3.persistence
 #[pymodule]
 pub fn persistence(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<ParquetType>()?;
-    m.add_class::<DataCatalogBackend>()?;
-    m.add_class::<PythonQueryResult>()?;
+    m.add_class::<DataBackendSession>()?;
+    m.add_class::<DataQueryResult>()?;
     Ok(())
 }

--- a/nautilus_core/persistence/src/session.rs
+++ b/nautilus_core/persistence/src/session.rs
@@ -55,6 +55,7 @@ where
 /// The session is used to register data sources and make queries on them. A
 /// query returns a Chunk of Arrow records. It is decoded and converted into
 /// a Vec of data by types that implement [`DecodeDataFromRecordBatch`].
+#[pyclass]
 pub struct DataBackendSession {
     session_ctx: SessionContext,
     batch_streams: Vec<Box<dyn Stream<Item = IntoIter<Data>> + Unpin>>,
@@ -73,7 +74,11 @@ impl DataBackendSession {
 
     // Query a file for all it's records. the caller must specify `T` to indicate
     // the kind of data expected from this query.
-    pub async fn add_file<T>(&mut self, table_name: &str, file_path: &str) -> Result<()>
+    pub async fn add_file_default_query<T>(
+        &mut self,
+        table_name: &str,
+        file_path: &str,
+    ) -> Result<()>
     where
         T: DecodeDataFromRecordBatch + Into<Data>,
     {
@@ -102,7 +107,7 @@ impl DataBackendSession {
     // #Safety
     // They query should ensure the records are ordered by the `ts_init` field
     // in ascending order.
-    pub async fn add_file_with_query<T>(
+    pub async fn add_file_with_custom_query<T>(
         &mut self,
         table_name: &str,
         file_path: &str,
@@ -146,7 +151,7 @@ impl DataBackendSession {
     // Passes the output of the query though the a KMerge which sorts the
     // queries in ascending order of `ts_init`.
     // QueryResult is an iterator that return Vec<Data>.
-    pub fn to_query_result(&mut self) -> QueryResult<Data> {
+    pub fn get_query_result(&mut self) -> QueryResult<Data> {
         // TODO: No need to kmerge if there is only one batch stream
         let mut kmerge: KMerge<_, _, _> = KMerge::new(TsInitComparator);
 
@@ -176,22 +181,18 @@ impl Iterator for QueryResult {
 /// Python API
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Store the DataFustion session context.
-#[pyclass]
-pub struct DataCatalogBackend(DataBackendSession);
-
 // Note: Intended to be used on a single python thread
 unsafe impl Send for DataBackendSession {}
 
 #[pymethods]
-impl DataCatalogBackend {
+impl DataBackendSession {
     #[new]
     #[pyo3(signature=(chunk_size=5000))]
     #[must_use]
     pub fn new_session(chunk_size: usize) -> Self {
         // Initialize runtime here
         get_runtime();
-        Self(DataBackendSession::new(chunk_size))
+        Self::new(chunk_size)
     }
 
     pub fn add_file(
@@ -205,33 +206,38 @@ impl DataCatalogBackend {
 
         match parquet_type {
             ParquetType::OrderBookSnapshot => {
-                match block_on(slf.0.add_file::<OrderBookSnapshot>(table_name, file_path)) {
+                match block_on(
+                    slf.add_file_default_query::<OrderBookSnapshot>(table_name, file_path),
+                ) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
                 }
             }
             ParquetType::OrderBookDelta => {
-                match block_on(slf.0.add_file::<OrderBookDelta>(table_name, file_path)) {
+                match block_on(slf.add_file_default_query::<OrderBookDelta>(table_name, file_path))
+                {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
                 }
             }
             ParquetType::QuoteTick => {
-                match block_on(slf.0.add_file::<QuoteTick>(table_name, file_path)) {
+                match block_on(slf.add_file_default_query::<QuoteTick>(table_name, file_path)) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
                 }
             }
             ParquetType::TradeTick => {
-                match block_on(slf.0.add_file::<TradeTick>(table_name, file_path)) {
+                match block_on(slf.add_file_default_query::<TradeTick>(table_name, file_path)) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
                 }
             }
-            ParquetType::Bar => match block_on(slf.0.add_file::<Bar>(table_name, file_path)) {
-                Ok(_) => (),
-                Err(err) => panic!("Failed new_query with error {err}"),
-            },
+            ParquetType::Bar => {
+                match block_on(slf.add_file_default_query::<Bar>(table_name, file_path)) {
+                    Ok(_) => (),
+                    Err(err) => panic!("Failed new_query with error {err}"),
+                }
+            }
         }
     }
 
@@ -247,18 +253,18 @@ impl DataCatalogBackend {
 
         match parquet_type {
             ParquetType::OrderBookSnapshot => {
-                match block_on(
-                    slf.0
-                        .add_file_with_query::<OrderBookSnapshot>(table_name, file_path, sql_query),
-                ) {
+                match block_on(slf.add_file_with_custom_query::<OrderBookSnapshot>(
+                    table_name, file_path, sql_query,
+                )) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
                 }
             }
             ParquetType::OrderBookDelta => {
                 match block_on(
-                    slf.0
-                        .add_file_with_query::<OrderBookDelta>(table_name, file_path, sql_query),
+                    slf.add_file_with_custom_query::<OrderBookDelta>(
+                        table_name, file_path, sql_query,
+                    ),
                 ) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
@@ -266,8 +272,7 @@ impl DataCatalogBackend {
             }
             ParquetType::QuoteTick => {
                 match block_on(
-                    slf.0
-                        .add_file_with_query::<QuoteTick>(table_name, file_path, sql_query),
+                    slf.add_file_with_custom_query::<QuoteTick>(table_name, file_path, sql_query),
                 ) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
@@ -275,8 +280,7 @@ impl DataCatalogBackend {
             }
             ParquetType::TradeTick => {
                 match block_on(
-                    slf.0
-                        .add_file_with_query::<TradeTick>(table_name, file_path, sql_query),
+                    slf.add_file_with_custom_query::<TradeTick>(table_name, file_path, sql_query),
                 ) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
@@ -284,8 +288,7 @@ impl DataCatalogBackend {
             }
             ParquetType::Bar => {
                 match block_on(
-                    slf.0
-                        .add_file_with_query::<Bar>(table_name, file_path, sql_query),
+                    slf.add_file_with_custom_query::<Bar>(table_name, file_path, sql_query),
                 ) {
                     Ok(_) => (),
                     Err(err) => panic!("Failed new_query with error {err}"),
@@ -295,23 +298,23 @@ impl DataCatalogBackend {
     }
 
     #[must_use]
-    pub fn to_query_result(mut slf: PyRefMut<'_, Self>) -> PythonQueryResult {
+    pub fn to_query_result(mut slf: PyRefMut<'_, Self>) -> DataQueryResult {
         let rt = get_runtime();
         let _guard = rt.enter();
 
-        let query_result = slf.0.to_query_result();
-        PythonQueryResult::new(query_result)
+        let query_result = slf.get_query_result();
+        DataQueryResult::new(query_result)
     }
 }
 
 #[pyclass]
-pub struct PythonQueryResult {
+pub struct DataQueryResult {
     result: QueryResult<Data>,
     chunk: Option<CVec>,
 }
 
 #[pymethods]
-impl PythonQueryResult {
+impl DataQueryResult {
     /// The reader implements an iterator.
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
@@ -332,9 +335,9 @@ impl PythonQueryResult {
 }
 
 // Note: Intended to be used on a single python thread
-unsafe impl Send for PythonQueryResult {}
+unsafe impl Send for DataQueryResult {}
 
-impl PythonQueryResult {
+impl DataQueryResult {
     fn new(result: QueryResult<Data>) -> Self {
         Self {
             result,
@@ -353,7 +356,7 @@ impl PythonQueryResult {
     }
 }
 
-impl Drop for PythonQueryResult {
+impl Drop for DataQueryResult {
     fn drop(&mut self) {
         self.drop_chunk();
     }

--- a/nautilus_core/persistence/tests/test_catalog.rs
+++ b/nautilus_core/persistence/tests/test_catalog.rs
@@ -24,10 +24,10 @@ async fn test_quote_ticks() {
     let length = 9500;
     let mut catalog = DataBackendSession::new(10000);
     catalog
-        .add_file::<QuoteTick>("quotes_0005", file_path)
+        .add_file_default_query::<QuoteTick>("quotes_0005", file_path)
         .await
         .unwrap();
-    let query_result: QueryResult = catalog.to_query_result();
+    let query_result: QueryResult = catalog.get_query_result();
     let ticks: Vec<Data> = query_result.flatten().collect();
 
     // NOTE: is_sorted_by_key is unstable otherwise use
@@ -59,20 +59,20 @@ async fn test_quote_ticks() {
 async fn test_data_ticks() {
     let mut catalog = DataBackendSession::new(5000);
     catalog
-        .add_file::<QuoteTick>(
+        .add_file_default_query::<QuoteTick>(
             "quote_tick",
             "../../tests/test_data/quote_tick_data.parquet",
         )
         .await
         .unwrap();
     catalog
-        .add_file::<TradeTick>(
+        .add_file_default_query::<TradeTick>(
             "quote_tick_2",
             "../../tests/test_data/trade_tick_data.parquet",
         )
         .await
         .unwrap();
-    let query_result: QueryResult = catalog.to_query_result();
+    let query_result: QueryResult = catalog.get_query_result();
     let ticks: Vec<Data> = query_result.flatten().collect();
 
     // NOTE: is_sorted_by_key is unstable otherwise use


### PR DESCRIPTION
# Pull Request

`DataCatalogBackend` => `DataBackendSession`
`PythonQueryResult` => `DataQueryResult`

This is a breaking change because it renames public API. But it is needed because the current names are leaky and confusing.

## Type of change

Delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this change been tested?

GitHub CI tests