### PR TITLE
Pyo3 network websocket and socket

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -367,6 +367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +866,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "datafusion"
@@ -1039,6 +1073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1279,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1784,6 +1838,7 @@ dependencies = [
  "pyo3-asyncio",
  "serde_json",
  "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2643,6 +2698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3093,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3121,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -3085,6 +3177,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -1831,6 +1831,7 @@ version = "0.6.0"
 dependencies = [
  "criterion",
  "futures",
+ "futures-util",
  "hyper",
  "hyper-tls",
  "nautilus-core",
@@ -1838,7 +1839,7 @@ dependencies = [
  "pyo3-asyncio",
  "serde_json",
  "tokio",
- "tungstenite",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -3024,6 +3025,20 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]

--- a/nautilus_core/network/Cargo.toml
+++ b/nautilus_core/network/Cargo.toml
@@ -19,7 +19,8 @@ pyo3-asyncio.workspace = true
 tokio.workspace = true
 hyper = { version = "0.14.26", features = ["client", "http1", "server"] }
 hyper-tls = "0.5.0"
-tungstenite = { version = "0.19.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
+futures-util = "0.3.28"
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/nautilus_core/network/Cargo.toml
+++ b/nautilus_core/network/Cargo.toml
@@ -19,6 +19,7 @@ pyo3-asyncio.workspace = true
 tokio.workspace = true
 hyper = { version = "0.14.26", features = ["client", "http1", "server"] }
 hyper-tls = "0.5.0"
+tungstenite = { version = "0.19.0", features = ["native-tls"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/nautilus_core/network/src/lib.rs
+++ b/nautilus_core/network/src/lib.rs
@@ -14,10 +14,12 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod http;
+pub mod socket;
 pub mod websocket;
 
 use http::{HttpClient, HttpResponse};
 use pyo3::prelude::*;
+use socket::SocketClient;
 use websocket::WebSocketClient;
 
 /// Loaded as nautilus_pyo3.network
@@ -26,5 +28,6 @@ pub fn network(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<HttpClient>()?;
     m.add_class::<HttpResponse>()?;
     m.add_class::<WebSocketClient>()?;
+    m.add_class::<SocketClient>()?;
     Ok(())
 }

--- a/nautilus_core/network/src/lib.rs
+++ b/nautilus_core/network/src/lib.rs
@@ -18,11 +18,13 @@ pub mod websocket;
 
 use http::{HttpClient, HttpResponse};
 use pyo3::prelude::*;
+use websocket::WebSocketClient;
 
 /// Loaded as nautilus_pyo3.network
 #[pymodule]
 pub fn network(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<HttpClient>()?;
     m.add_class::<HttpResponse>()?;
+    m.add_class::<WebSocketClient>()?;
     Ok(())
 }

--- a/nautilus_core/network/src/socket.rs
+++ b/nautilus_core/network/src/socket.rs
@@ -1,0 +1,96 @@
+use pyo3::prelude::*;
+use pyo3::{PyObject, Python};
+use std::io;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::tcp::OwnedWriteHalf;
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+use tokio::task;
+
+#[pyclass]
+pub struct SocketClient {
+    read_task: Option<task::JoinHandle<io::Result<()>>>,
+    write_mutex: Arc<Mutex<OwnedWriteHalf>>,
+}
+
+impl SocketClient {
+    pub async fn connect(url: &str, handler: PyObject) -> io::Result<Self> {
+        let stream = TcpStream::connect(url).await?;
+        let (read_half, write_half) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+        let write_mutex = Arc::new(Mutex::new(write_half));
+
+        // keep receiving messages from socket
+        // pass them as arguments to handler
+        let read_task = Some(task::spawn(async move {
+            let mut buf = Vec::new();
+            loop {
+                // TODO: use "\r\n" delimiter but `read_until`
+                // only takes one byte delimiter
+                let n = reader.read_until(b'\r', &mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                Python::with_gil(|py| handler.call1(py, (buf.drain(0..n).as_slice(),))).unwrap();
+            }
+            Ok(())
+        }));
+
+        Ok(Self {
+            read_task,
+            write_mutex,
+        })
+    }
+}
+
+#[pymethods]
+impl SocketClient {
+    #[staticmethod]
+    fn connect_url(url: String, handler: PyObject, py: Python<'_>) -> PyResult<&PyAny> {
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            Ok(SocketClient::connect(&url, handler).await.unwrap())
+        })
+    }
+
+    fn send<'py>(slf: PyRef<'_, Self>, data: Vec<u8>, py: Python<'py>) -> PyResult<&'py PyAny> {
+        let write_half = slf.write_mutex.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            let mut write_half = write_half.lock().await;
+            write_half.write_all(&data).await?;
+            write_half.flush().await?;
+            Ok(())
+        })
+    }
+
+    /// Closing the client aborts the reading task and shuts down the writer half
+    ///
+    /// # Safety
+    /// - The client should not send after being closed
+    /// - The client should be dropped after being closed
+    fn close<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<&'py PyAny> {
+        // cancel reading task
+        if let Some(ref handle) = slf.read_task {
+            handle.abort();
+        }
+
+        // shut down writer
+        let write_half = slf.write_mutex.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            let mut write_half = write_half.lock().await;
+            write_half.shutdown().await.unwrap();
+            Ok(())
+        })
+    }
+}
+
+impl Drop for SocketClient {
+    fn drop(&mut self) {
+        // cancel reading task
+        if let Some(ref handle) = self.read_task {
+            handle.abort();
+        }
+
+        // writer is automatically dropped along with the struct
+    }
+}

--- a/nautilus_core/network/src/websocket.rs
+++ b/nautilus_core/network/src/websocket.rs
@@ -12,3 +12,106 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
+
+use std::{net::TcpStream, panic, sync::Mutex};
+
+use pyo3::prelude::*;
+use tungstenite::{connect, stream::MaybeTlsStream, Message, WebSocket};
+
+#[pyclass]
+struct WebSocketClient {
+    stream: Mutex<WebSocket<MaybeTlsStream<TcpStream>>>,
+}
+
+impl WebSocketClient {
+    pub fn connect(url: &str) -> Self {
+        match connect(url) {
+            Ok((stream, _resp)) => WebSocketClient {
+                stream: Mutex::new(stream),
+            },
+            Err(err) => {
+                panic!("Cannot connect to websocket server {}", err);
+            }
+        }
+    }
+
+    pub fn send(&self, msg: Message) {
+        if let Ok(mut stream) = self.stream.lock() {
+            if let Err(err) = stream.write_message(msg) {
+                panic!("Message could not be sent {}", err);
+            };
+        }
+    }
+
+    pub fn recv(&self) -> Option<Vec<u8>> {
+        if let Ok(mut stream) = self.stream.lock() {
+            match stream.read_message() {
+                Ok(Message::Text(txt)) => Some(txt.into_bytes()),
+                Ok(Message::Binary(data)) => Some(data),
+                Ok(_) => None,
+                Err(err) => {
+                    panic!("Error with stream {}", err);
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[pymethods]
+impl WebSocketClient {
+    #[new]
+    pub fn new(url: String) -> Self {
+        WebSocketClient::connect(&url)
+    }
+
+    pub fn send_bytes(slf: PyRef<'_, Self>, data: Vec<u8>) {
+        slf.send(Message::Binary(data));
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Each iteration returns a chunk of values read from the parquet file.
+    fn __next__(slf: PyRef<'_, Self>) -> Option<PyObject> {
+        slf.recv()
+            .map(|data| Python::with_gil(|py| data.into_py(py)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::TcpListener, thread};
+
+    use tungstenite::accept;
+
+    use super::WebSocketClient;
+
+    #[test]
+    fn test_client() {
+        thread::spawn(|| {
+            let server = TcpListener::bind("127.0.0.1:9001").unwrap();
+            let conn = server.incoming().next().unwrap();
+            let mut websocket = accept(conn.unwrap()).unwrap();
+
+            // echo 10 messages before shutting down
+            for _ in 0..10 {
+                let msg = websocket.read_message().unwrap();
+
+                // We do not want to send back ping/pong messages.
+                if msg.is_binary() || msg.is_text() {
+                    websocket.write_message(msg).unwrap();
+                }
+            }
+        });
+
+        let client = WebSocketClient::connect("ws://127.0.0.1:9001");
+
+        for _ in 0..10 {
+            client.send(tungstenite::Message::Text("ping".to_string()));
+            assert_eq!(client.recv(), Some("ping".to_string().into_bytes()));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

Implement async websocket and socket. Both have a very similar design.

They create a TcpStream and split the read and write ends. The read end is moved into an async task that keeps listening for messages/data. The write end is wrapped in an arc mutex so it can be passed around written to from more than one tasks.

The both take PyObject handlers that is passed to the read loop. The handler is called with any new message/data that is received from the stream.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

End to end test was added for websocket