### PR TITLE
Allow Catalog basename_template for Instruments

### DIFF
--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -253,9 +253,6 @@ def write_tables(
         path = f"{catalog.path}/data/{class_to_filename(cls)}.parquet"
         merged = merge_existing_data(catalog=catalog, cls=cls, df=df)
 
-        if not kwargs.get("basename_template") and cls in Instrument.__subclasses__():
-            kwargs["basename_template"] = "{i}.parquet"
-
         write_parquet(
             fs=catalog.fs,
             path=path,
@@ -263,6 +260,11 @@ def write_tables(
             partition_cols=partition_cols,
             schema=schema,
             **kwargs,
+            **(
+                {"basename_template": "{i}.parquet"}
+                if not kwargs.get("basename_template") and cls in Instrument.__subclasses__()
+                else {}
+            ),
         )
         rows_written += len(df)
 

--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -253,6 +253,9 @@ def write_tables(
         path = f"{catalog.path}/data/{class_to_filename(cls)}.parquet"
         merged = merge_existing_data(catalog=catalog, cls=cls, df=df)
 
+        if not kwargs.get("basename_template") and cls in Instrument.__subclasses__():
+            kwargs["basename_template"] = "{i}.parquet"
+
         write_parquet(
             fs=catalog.fs,
             path=path,
@@ -260,7 +263,6 @@ def write_tables(
             partition_cols=partition_cols,
             schema=schema,
             **kwargs,
-            **({"basename_template": "{i}.parquet"} if cls in Instrument.__subclasses__() else {}),
         )
         rows_written += len(df)
 

--- a/nautilus_trader/persistence/external/core.py
+++ b/nautilus_trader/persistence/external/core.py
@@ -251,7 +251,11 @@ def write_tables(
             continue
         partition_cols = determine_partition_cols(cls=cls, instrument_id=instrument_id)
         path = f"{catalog.path}/data/{class_to_filename(cls)}.parquet"
-        merged = merge_existing_data(catalog=catalog, cls=cls, df=df)
+        if kwargs.get("merge_existing_data") is False:
+            merged = df
+        else:
+            merged = merge_existing_data(catalog=catalog, cls=cls, df=df)
+        kwargs.pop("merge_existing_data", None)
 
         write_parquet(
             fs=catalog.fs,

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -489,6 +489,13 @@ class _TestPersistenceCatalog:
         instruments = self.catalog.instruments(as_nautilus=True)
         assert len(instruments) == 2
 
+    def test_writing_instruments_overwrite(self):
+        instruments = self.catalog.instruments(as_nautilus=True)
+        write_objects(catalog=self.catalog, chunk=[instruments[0]], merge_existing_data=False)
+        write_objects(catalog=self.catalog, chunk=[instruments[1]], merge_existing_data=False)
+        instruments = self.catalog.instruments(as_nautilus=True)
+        assert len(instruments) == 1
+
     def test_data_catalog_instruments_filtered_df(self):
         instrument_id = self.catalog.instruments(as_nautilus=True)[0].id.value
         instruments = self.catalog.instruments(instrument_ids=[instrument_id])


### PR DESCRIPTION
# Pull Request

Allow user to choose custom `basename_template` for Catalog. This allows grouping based on need for ease of management.
Also found the fix for #833 by adding additional flag to keep existing functionality as-is.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Functional testing.
