### PR TITLE
Support Pandas v2

### DIFF
--- a/nautilus_trader/common/clock.pyx
+++ b/nautilus_trader/common/clock.pyx
@@ -14,12 +14,12 @@
 # -------------------------------------------------------------------------------------------------
 
 import asyncio
-import pytz
 from typing import Callable, Optional
 
 import cython
 import numpy as np
 import pandas as pd
+import pytz
 
 from cpython.datetime cimport datetime
 from cpython.datetime cimport timedelta

--- a/nautilus_trader/common/clock.pyx
+++ b/nautilus_trader/common/clock.pyx
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import asyncio
+import pytz
 from typing import Callable, Optional
 
 import cython
@@ -160,7 +161,7 @@ cdef class Clock:
             The current tz-aware UTC time of the clock.
 
         """
-        return pd.Timestamp(self.timestamp_ns(), tz="UTC")
+        return pd.Timestamp(self.timestamp_ns(), tz=pytz.utc)
 
     cpdef datetime local_now(self, tzinfo tz = None):
         """

--- a/nautilus_trader/core/datetime.pyx
+++ b/nautilus_trader/core/datetime.pyx
@@ -22,7 +22,7 @@ Functions include awareness/tz checks and conversions, as well as ISO 8601 conve
 import pandas as pd
 import pytz
 
-from cpython.datetime cimport datetime
+cimport cpython.datetime
 from cpython.datetime cimport datetime_tzinfo
 from cpython.unicode cimport PyUnicode_Contains
 from libc.stdint cimport uint64_t
@@ -39,7 +39,7 @@ from nautilus_trader.core.rust.core cimport secs_to_nanos as rust_secs_to_nanos
 
 # UNIX epoch is the UTC time at 00:00:00 on 1/1/1970
 # https://en.wikipedia.org/wiki/Unix_time
-cdef datetime UNIX_EPOCH = pd.Timestamp("1970-01-01", tz="UTC")
+cdef datetime UNIX_EPOCH = pd.Timestamp("1970-01-01", tz=pytz.utc)
 
 
 cpdef uint64_t secs_to_nanos(double secs):
@@ -175,7 +175,7 @@ cpdef unix_nanos_to_dt(uint64_t nanos):
     pd.Timestamp
 
     """
-    return pd.Timestamp(nanos, unit="ns", tz="UTC")
+    return pd.Timestamp(nanos, unit="ns", tz=pytz.utc)
 
 
 cpdef dt_to_unix_nanos(dt: pd.Timestamp):
@@ -224,7 +224,7 @@ cpdef maybe_unix_nanos_to_dt(nanos):
     if nanos is None:
         return None
     else:
-        return pd.Timestamp(nanos, unit="ns", tz="UTC")
+        return pd.Timestamp(nanos, unit="ns", tz=pytz.utc)
 
 
 cpdef maybe_dt_to_unix_nanos(dt: pd.Timestamp):
@@ -366,7 +366,7 @@ cpdef object as_utc_index(data: pd.DataFrame):
     if data.index.tzinfo is None:  # tz-naive
         return data.tz_localize(pytz.utc)
     elif data.index.tzinfo != pytz.utc:
-        return pytz.utc.localize(data.index)
+        return data.tz_convert(None).tz_localize(pytz.utc)
     else:
         return data  # Already UTC
 

--- a/nautilus_trader/persistence/loaders.py
+++ b/nautilus_trader/persistence/loaders.py
@@ -38,11 +38,13 @@ class CSVTickDataLoader:
         pd.DataFrame
 
         """
-        return pd.read_csv(
+        df = pd.read_csv(
             file_path,
             index_col="timestamp",
             parse_dates=True,
         )
+        df.index = pd.to_datetime(df.index, format='mixed')
+        return df
 
 
 class CSVBarDataLoader:
@@ -65,11 +67,13 @@ class CSVBarDataLoader:
         pd.DataFrame
 
         """
-        return pd.read_csv(
+        df = pd.read_csv(
             file_path,
             index_col="timestamp",
             parse_dates=True,
         )
+        df.index = pd.to_datetime(df.index, format='mixed')
+        return df
 
 
 def _ts_parser(time_in_secs: str) -> datetime:

--- a/nautilus_trader/persistence/loaders.py
+++ b/nautilus_trader/persistence/loaders.py
@@ -43,7 +43,7 @@ class CSVTickDataLoader:
             index_col="timestamp",
             parse_dates=True,
         )
-        df.index = pd.to_datetime(df.index, format='mixed')
+        df.index = pd.to_datetime(df.index, format="mixed")
         return df
 
 
@@ -72,7 +72,7 @@ class CSVBarDataLoader:
             index_col="timestamp",
             parse_dates=True,
         )
-        df.index = pd.to_datetime(df.index, format='mixed')
+        df.index = pd.to_datetime(df.index, format="mixed")
         return df
 
 


### PR DESCRIPTION
# Pull Request
In Pandas v2, timezone aware datetimeindexes return 'datetime.timezone.utc' for tzinfo. This fails comparison when checking for timezone aware indexes. Explicitly setting these datetimeindexes to pytz.utc allows support for both Pandas 1.5.x and Pandas 2.x

## Type of change

Non-breaking change that allows support for Pandas ^1.5.3 as set in pyproject.toml dependencies.
This appears it will also apply cleanly to master
Slightly unsure about the change to cimport in `nautilus_trader/core/datetime.pyx`

- [ x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

unit_tests and acceptance_tests have passed

