### PR TITLE
Orderbook C API CVec fixes

### DIFF
--- a/nautilus_core/model/src/orderbook/level_api.rs
+++ b/nautilus_core/model/src/orderbook/level_api.rs
@@ -98,7 +98,7 @@ pub extern "C" fn level_exposure(level: &Level_API) -> f64 {
 #[no_mangle]
 pub extern "C" fn vec_levels_drop(v: CVec) {
     let CVec { ptr, len, cap } = v;
-    let data: Vec<Level> = unsafe { Vec::from_raw_parts(ptr as *mut Level, len, cap) };
+    let data: Vec<Level_API> = unsafe { Vec::from_raw_parts(ptr as *mut Level_API, len, cap) };
     drop(data); // Memory freed here
 }
 

--- a/nautilus_trader/model/orderbook/book.pyx
+++ b/nautilus_trader/model/orderbook/book.pyx
@@ -373,8 +373,7 @@ cdef class OrderBook(Data):
         for i in range(raw_levels_vec.len):
             levels.append(Level.from_mem_c(raw_levels[i]))
 
-        # TODO(chris): Reimplement to avoid segfaults
-        # vec_levels_drop(raw_levels_vec)
+        vec_levels_drop(raw_levels_vec)
 
         return levels
 

--- a/nautilus_trader/model/orderbook/book.pyx
+++ b/nautilus_trader/model/orderbook/book.pyx
@@ -397,8 +397,7 @@ cdef class OrderBook(Data):
         for i in range(raw_levels_vec.len):
             levels.append(Level.from_mem_c(raw_levels[i]))
 
-        # TODO(chris): Reimplement to avoid segfaults
-        # vec_levels_drop(raw_levels_vec)
+        vec_levels_drop(raw_levels_vec)
 
         return levels
 


### PR DESCRIPTION
# Pull Request

This fixes how CVec is being dropped for orderbook exposed C APIs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

`test_orderbook.py` tests were run and passed
