### PR TITLE
Add pre_process hook to SimulationModule

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -1036,6 +1036,12 @@ cdef class BacktestEngine:
                     raw_handlers = self._advance_time(data.ts_init, clocks)
                     raw_handlers_count = raw_handlers.len
 
+                # Run pre-process for any simulation_modules
+                if isinstance(data, (OrderBookDelta, OrderBookDeltas, QuoteTick, TradeTick, Bar, InstrumentStatusUpdate)):
+                    venue = self._venues[data.instrument_id.venue]
+                    for module in venue.modules:
+                        module.pre_data(data)
+
                 # Process data through venue
                 if isinstance(data, OrderBookDelta):
                     self._venues[data.instrument_id.venue].process_order_book_delta(data)

--- a/nautilus_trader/backtest/modules.pxd
+++ b/nautilus_trader/backtest/modules.pxd
@@ -20,12 +20,14 @@ from nautilus_trader.accounting.calculators cimport RolloverInterestCalculator
 from nautilus_trader.backtest.exchange cimport SimulatedExchange
 from nautilus_trader.common.actor cimport Actor
 from nautilus_trader.common.logging cimport LoggerAdapter
+from nautilus_trader.core.data cimport Data
 
 
 cdef class SimulationModule(Actor):
     cdef readonly SimulatedExchange exchange
 
     cpdef void register_venue(self, SimulatedExchange exchange)
+    cpdef void pre_data(self, Data data)
     cpdef void process(self, uint64_t ts_now)
     cpdef void log_diagnostics(self, LoggerAdapter log)
     cpdef void reset(self)

--- a/nautilus_trader/backtest/modules.pxd
+++ b/nautilus_trader/backtest/modules.pxd
@@ -27,7 +27,7 @@ cdef class SimulationModule(Actor):
     cdef readonly SimulatedExchange exchange
 
     cpdef void register_venue(self, SimulatedExchange exchange)
-    cpdef void pre_data(self, Data data)
+    cpdef void pre_process(self, Data data)
     cpdef void process(self, uint64_t ts_now)
     cpdef void log_diagnostics(self, LoggerAdapter log)
     cpdef void reset(self)

--- a/nautilus_trader/backtest/modules.pyx
+++ b/nautilus_trader/backtest/modules.pyx
@@ -70,7 +70,7 @@ cdef class SimulationModule(Actor):
 
         self.exchange = exchange
 
-    cpdef void pre_data(self, Data data):
+    cpdef void pre_process(self, Data data):
         """Abstract method (implement in subclass)."""
         pass
 

--- a/nautilus_trader/backtest/modules.pyx
+++ b/nautilus_trader/backtest/modules.pyx
@@ -17,6 +17,7 @@ import pandas as pd
 import pytz
 
 from nautilus_trader.config import ActorConfig
+from nautilus_trader.core.data import Data
 
 from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
@@ -68,6 +69,10 @@ cdef class SimulationModule(Actor):
         Condition.not_none(exchange, "exchange")
 
         self.exchange = exchange
+
+    cpdef void pre_data(self, Data data):
+        """Abstract method (implement in subclass)."""
+        pass
 
     cpdef void process(self, uint64_t ts_now):
         """Abstract method (implement in subclass)."""

--- a/tests/unit_tests/backtest/test_exchange.py
+++ b/tests/unit_tests/backtest/test_exchange.py
@@ -2905,7 +2905,7 @@ class TestSimulatedExchangeL2:
         )
 
         class TradeTickFillModule(SimulationModule):
-            def pre_data(self, data):
+            def pre_process(self, data):
                 if isinstance(data, TradeTick):
                     matching_engine = self.exchange.get_matching_engine(data.instrument_id)
                     book = matching_engine.get_book()
@@ -3002,7 +3002,7 @@ class TestSimulatedExchangeL2:
             instrument=USDJPY_SIM,
             price=91.000,
         )
-        self.module.pre_data(trade)
+        self.module.pre_process(trade)
         self.exchange.process_trade_tick(trade)
 
         # Assert

--- a/tests/unit_tests/backtest/test_modules.py
+++ b/tests/unit_tests/backtest/test_modules.py
@@ -23,6 +23,7 @@ from nautilus_trader.backtest.modules import SimulationModuleConfig
 from nautilus_trader.common.logging import LoggerAdapter
 from nautilus_trader.config import BacktestEngineConfig
 from nautilus_trader.config import LoggingConfig
+from nautilus_trader.core.data import Data
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OmsType
@@ -70,6 +71,27 @@ class TestSimulationModules:
     def test_python_module(self):
         # Arrange
         class PythonModule(SimulationModule):
+            def process(self, ts_now: int):
+                assert self.exchange
+
+            def log_diagnostics(self, log: LoggerAdapter):
+                pass
+
+        config = SimulationModuleConfig()
+        engine = self.create_engine(modules=[PythonModule(config)])
+
+        # Act
+        engine.run()
+
+    def test_pre_data_custom_order_fill(self):
+        # Arrange
+        class PythonModule(SimulationModule):
+            def pre_data(self, data: Data):
+                if data.ts_init == 1359676979900000000:
+                    assert data
+                    matching_engine = self.exchange.get_matching_engine(data.instrument_id)
+                    assert matching_engine
+
             def process(self, ts_now: int):
                 assert self.exchange
 


### PR DESCRIPTION
# Pull Request

Adds a `pre_process` hook to the SimulationModule and calls inside the BacktestEngine prior to passing through to the matching engines.

Should allow more complicated matching logic to be applied.

### Example: Passive fills

An example use case is custom fills for limit (passive) orders, which could look something like: 

```python
class PassiveFillModule(SimulationModule):
    def pre_process(self, data):
        # On trade tick
        if isinstance(data, TradeTick):
            # Check for any open passive orders
            open_orders = [o for o in self.cache.orders_open(instrument_id=data.instrument_id) if isinstance(o, LimitOrder)]

            for order in open_orders:
                # Check if trade in cross with our order
                should_fill = (
                    (order.side == OrderSide.BUY and order.price >= data.price) or
                    (order.side == OrderSide.BUY and order.price <= data.price)
                )
                if should_fill:
                    # Fill order
                    matching_engine = self.exchange.get_matching_engine(data.instrument_id)
                    book = matching_engine.get_book()
                    book.update_trade_tick(data)
                    fills = matching_engine.determine_limit_price_and_volume(order)
                    matching_engine.apply_fills(
                        order=order,
                        fills=fills,
                        liquidity_side=LiquiditySide.MAKER,
                    )
```



## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added test.