### PR TITLE
handle wrangler nanosecond timestamps

### DIFF
--- a/nautilus_trader/persistence/wranglers.pyx
+++ b/nautilus_trader/persistence/wranglers.pyx
@@ -27,6 +27,7 @@ from libc.stdint cimport uint64_t
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.datetime cimport as_utc_index
+from nautilus_trader.core.datetime cimport dt_to_unix_nanos
 from nautilus_trader.core.rust.core cimport CVec
 from nautilus_trader.core.rust.core cimport secs_to_nanos
 from nautilus_trader.core.rust.model cimport Data_t
@@ -125,7 +126,7 @@ cdef class QuoteTickDataWrangler:
         if "ask_size" not in data.columns:
             data["ask_size"] = float(default_volume)
 
-        cdef uint64_t[:] ts_events = np.ascontiguousarray([secs_to_nanos(dt.timestamp()) for dt in data.index], dtype=np.uint64)  # noqa
+        cdef uint64_t[:] ts_events = np.ascontiguousarray([dt_to_unix_nanos(dt) for dt in data.index], dtype=np.uint64)  # noqa
         cdef uint64_t[:] ts_inits = np.ascontiguousarray([ts_event + ts_init_delta for ts_event in ts_events], dtype=np.uint64)  # noqa
 
         return list(map(
@@ -357,8 +358,7 @@ cdef class TradeTickDataWrangler:
         Condition.false(data.empty, "data.empty")
 
         data = as_utc_index(data)
-
-        cdef uint64_t[:] ts_events = np.ascontiguousarray([secs_to_nanos(dt.timestamp()) for dt in data.index], dtype=np.uint64)  # noqa
+        cdef uint64_t[:] ts_events = np.ascontiguousarray([dt_to_unix_nanos(dt) for dt in data.index], dtype=np.uint64)  # noqa
         cdef uint64_t[:] ts_inits = np.ascontiguousarray([ts_event + ts_init_delta for ts_event in ts_events], dtype=np.uint64)  # noqa
 
         if is_raw:

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -1273,7 +1273,7 @@ class TestTimeBarAggregator:
                 event.handle()
 
         # Assert
-        assert clock.timestamp_ns() == 1610064046674000128
+        assert clock.timestamp_ns() == 1610064046674000000
         assert aggregator.interval_ns == 1_000_000_000
         assert aggregator.next_close_ns == 1610064047000000000
         assert handler[0].open == Price.from_str("39432.99")


### PR DESCRIPTION
Handle timestamps with nanosecond precision in the QuoteTickDataWrangler class.

Tests added:

test_data_wranglers.py::TestQuoteTickDataWrangler::test_process_handles_nanosecond_timestamps

- [x] New feature (non-breaking change which adds functionality)
