### PR TITLE
Add auto-reconnect feature to Tcp socket connection

### DIFF
--- a/nautilus_core/network/src/lib.rs
+++ b/nautilus_core/network/src/lib.rs
@@ -22,7 +22,7 @@ pub mod websocket;
 use http::{HttpClient, HttpMethod, HttpResponse};
 use pyo3::prelude::*;
 use ratelimiter::quota::Quota;
-use socket::SocketClient;
+use socket::{SocketClient, SocketConfig};
 use websocket::WebSocketClient;
 
 /// Loaded as nautilus_pyo3.network
@@ -34,5 +34,6 @@ pub fn network(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<HttpResponse>()?;
     m.add_class::<WebSocketClient>()?;
     m.add_class::<SocketClient>()?;
+    m.add_class::<SocketConfig>()?;
     Ok(())
 }

--- a/nautilus_trader/adapters/betfair/sockets.py
+++ b/nautilus_trader/adapters/betfair/sockets.py
@@ -23,6 +23,7 @@ from nautilus_trader.adapters.betfair.client import BetfairHttpClient
 from nautilus_trader.common.logging import Logger
 from nautilus_trader.common.logging import LoggerAdapter
 from nautilus_trader.core.nautilus_pyo3.network import SocketClient
+from nautilus_trader.core.nautilus_pyo3.network import SocketConfig
 
 
 HOST = "stream-api.betfair.com"
@@ -72,10 +73,12 @@ class BetfairStreamClient:
 
         self._log.info("Connecting betfair socket client..")
         self._client = await SocketClient.connect(
-            url=f"{self.host}:{self.port}",
-            handler=self.handler,
-            ssl=True,
-            suffix=self.crlf,
+            SocketConfig(
+                url=f"{self.host}:{self.port}",
+                handler=self.handler,
+                ssl=True,
+                suffix=self.crlf,
+            ),
         )
 
         self._log.debug("Running post connect")


### PR DESCRIPTION
# Pull Request

Add Tcp auto reconnect following a similar model as the websocket. Also add optional pre, post-reconnect and disconnect hooks for Tcp connection. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

An updated tcp socket disconnect and reconnect test. 