### PR TITLE
Add core Adaptive MA and Efficiency ratio indicators

### DIFF
--- a/nautilus_core/indicators/src/average/ama.rs
+++ b/nautilus_core/indicators/src/average/ama.rs
@@ -1,0 +1,243 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::Display;
+
+use anyhow::Result;
+use nautilus_model::{
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
+    enums::PriceType,
+};
+use pyo3::prelude::*;
+
+use crate::indicator::Indicator;
+use crate::ratio::efficiency_ratio::EfficiencyRatio;
+
+/// An indicator which calculates an adaptive moving average (AMA) across a
+/// rolling window. Developed by Perry Kaufman, the AMA is a moving average
+/// designed to account for market noise and volatility. The AMA will closely
+/// follow prices when the price swings are relatively small and the noise is
+/// low. The AMA will increase lag when the price swings increase.
+#[repr(C)]
+#[derive(Debug)]
+#[pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")]
+pub struct AdaptiveMovingAverage {
+    /// the period for the internal `EfficiencyRatio` indicator.
+    pub period_efficiency_ratio: usize,
+    /// the period for the fast smoothing constant (> 0)
+    pub period_fast: usize,
+    /// the period for the slow smoothing constant (> 0 < `period_fast`)
+    pub period_slow: usize,
+    /// price type used for calculations
+    pub price_type: PriceType,
+    pub value: f64,
+    pub count: usize,
+    _efficiency_ratio: EfficiencyRatio,
+    _prior_value: Option<f64>,
+    _alpha_fast: f64,
+    _alpha_slow: f64,
+    has_inputs: bool,
+    is_initialized: bool,
+}
+
+impl Display for AdaptiveMovingAverage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}({},{},{})",
+            self.name(),
+            self.period_efficiency_ratio,
+            self.period_fast,
+            self.period_slow
+        )
+    }
+}
+
+impl Indicator for AdaptiveMovingAverage {
+    fn name(&self) -> String {
+        stringify!(AdaptiveMovingAverage).to_string()
+    }
+
+    fn has_inputs(&self) -> bool {
+        self.has_inputs
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    fn handle_quote_tick(&mut self, tick: &QuoteTick) {
+        self.update_raw(tick.extract_price(self.price_type).into());
+    }
+
+    fn handle_trade_tick(&mut self, tick: &TradeTick) {
+        self.update_raw((&tick.price).into());
+    }
+
+    fn handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.close).into());
+    }
+
+    fn reset(&mut self) {
+        self.value = 0.0;
+        self.count = 0;
+        self.has_inputs = false;
+        self.is_initialized = false;
+    }
+}
+
+impl AdaptiveMovingAverage {
+    pub fn new(
+        period_efficiency_ratio: usize,
+        period_fast: usize,
+        period_slow: usize,
+        price_type: Option<PriceType>,
+    ) -> Result<Self> {
+        // Inputs don't require validation, however we return a `Result`
+        // to standardize with other indicators which do need validation.
+        Ok(Self {
+            period_efficiency_ratio,
+            period_fast,
+            period_slow,
+            price_type: price_type.unwrap_or(PriceType::Last),
+            value: 0.0,
+            count: 0,
+            _alpha_fast: 2.0 / (period_fast + 1) as f64,
+            _alpha_slow: 2.0 / (period_slow + 1) as f64,
+            _prior_value: None,
+            has_inputs: false,
+            is_initialized: false,
+            _efficiency_ratio: EfficiencyRatio::new(period_efficiency_ratio, price_type)?,
+        })
+    }
+
+    pub fn alpha_diff(&self)->f64{
+        self._alpha_fast-self._alpha_slow
+    }
+
+    pub fn update_raw(&mut self, value: f64) {
+        if !self.has_inputs{
+            self._prior_value = Some(value);
+            self._efficiency_ratio.update_raw(value);
+            self.value = value;
+            self.has_inputs = true;
+            return;
+        }
+        self._efficiency_ratio.update_raw(value);
+        self._prior_value = Some(self.value);
+        // calculate the smoothing constant
+        let smoothing_constant = (self._efficiency_ratio.value *self.alpha_diff() +self._alpha_slow).powi(2);
+        // calculate the AMA
+        self.value = self._prior_value.unwrap() + smoothing_constant * (value - self._prior_value.unwrap());
+        if self._efficiency_ratio.is_initialized() {
+            self.is_initialized = true;
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self._prior_value = None;
+        self.count = 0;
+        self.has_inputs = false;
+        self.is_initialized = false;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use nautilus_model::data::quote::QuoteTick;
+    use nautilus_model::data::trade::TradeTick;
+
+    use crate::{average::ama::AdaptiveMovingAverage, indicator::Indicator, stubs::*};
+
+    #[rstest]
+    fn test_ama_initialized(indicator_ama_10: AdaptiveMovingAverage) {
+        let display_str = format!("{indicator_ama_10}");
+        assert_eq!(display_str, "AdaptiveMovingAverage(10,2,30)");
+        assert_eq!(indicator_ama_10.name(), "AdaptiveMovingAverage");
+        assert_eq!(indicator_ama_10.has_inputs(), false);
+        assert_eq!(indicator_ama_10.is_initialized(), false);
+    }
+
+    #[rstest]
+    fn test_value_with_one_input(mut indicator_ama_10: AdaptiveMovingAverage){
+        indicator_ama_10.update_raw(1.0);
+        assert_eq!(indicator_ama_10.value,1.0);
+    }
+
+    #[rstest]
+    fn test_value_with_two_inputs(mut indicator_ama_10: AdaptiveMovingAverage){
+        indicator_ama_10.update_raw(1.0);
+        indicator_ama_10.update_raw(2.0);
+        assert_eq!(indicator_ama_10.value, 1.4444444444444442);
+    }
+
+    #[rstest]
+    fn test_value_with_three_inputs(mut indicator_ama_10: AdaptiveMovingAverage){
+        indicator_ama_10.update_raw(1.0);
+        indicator_ama_10.update_raw(2.0);
+        indicator_ama_10.update_raw(3.0);
+        assert_eq!(indicator_ama_10.value, 2.135802469135802);
+    }
+
+    #[rstest]
+    fn test_reset(mut indicator_ama_10: AdaptiveMovingAverage){
+        for _ in 0..10{
+            indicator_ama_10.update_raw(1.0);
+        }
+        assert_eq!(indicator_ama_10.is_initialized, true);
+        indicator_ama_10.reset();
+        assert_eq!(indicator_ama_10.is_initialized,false);
+        assert_eq!(indicator_ama_10.has_inputs,false);
+        assert_eq!(indicator_ama_10.value,0.0);
+    }
+
+    #[rstest]
+    fn test_initialized_after_correct_number_of_input(indicator_ama_10: AdaptiveMovingAverage) {
+        let mut ama = indicator_ama_10;
+        for _ in 0..9 {
+            ama.update_raw(1.0);
+        }
+        assert_eq!(ama.is_initialized, false);
+        ama.update_raw(1.0);
+        assert_eq!(ama.is_initialized, true);
+    }
+
+    #[rstest]
+    fn test_handle_quote_tick(
+        mut indicator_ama_10: AdaptiveMovingAverage,
+        quote_tick: QuoteTick
+    ){
+        indicator_ama_10.handle_quote_tick(&quote_tick);
+        assert_eq!(indicator_ama_10.has_inputs, true);
+        assert_eq!(indicator_ama_10.is_initialized, false);
+        assert_eq!(indicator_ama_10.value, 1501.0);
+    }
+
+    #[rstest]
+    fn test_handle_trade_tick_update(
+        mut indicator_ama_10: AdaptiveMovingAverage,
+        trade_tick: TradeTick
+    ){
+        indicator_ama_10.handle_trade_tick(&trade_tick);
+        assert_eq!(indicator_ama_10.has_inputs, true);
+        assert_eq!(indicator_ama_10.is_initialized, false);
+        assert_eq!(indicator_ama_10.value, 1500.0);
+    }
+}

--- a/nautilus_core/indicators/src/average/ema.rs
+++ b/nautilus_core/indicators/src/average/ema.rs
@@ -194,7 +194,7 @@ impl ExponentialMovingAverage {
 #[cfg(test)]
 mod tests {
     use nautilus_model::{
-        data::{quote::QuoteTick, trade::TradeTick},
+        data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
         enums::PriceType,
     };
     use rstest::rstest;
@@ -252,11 +252,25 @@ mod tests {
     }
 
     #[rstest]
-    fn test_handle_quote_tick(indicator_ema_10: ExponentialMovingAverage, quote_tick: QuoteTick) {
+    fn test_handle_quote_tick_single(
+        indicator_ema_10: ExponentialMovingAverage,
+        quote_tick: QuoteTick,
+    ) {
         let mut ema = indicator_ema_10;
         ema.handle_quote_tick(&quote_tick);
         assert_eq!(ema.has_inputs(), true);
         assert_eq!(ema.value, 1501.0);
+    }
+
+    #[rstest]
+    fn test_handle_quote_tick_multi(mut indicator_ema_10: ExponentialMovingAverage) {
+        let tick1 = quote_tick("1500.0", "1502.0");
+        let tick2 = quote_tick("1502.0", "1504.0");
+
+        indicator_ema_10.handle_quote_tick(&tick1);
+        indicator_ema_10.handle_quote_tick(&tick2);
+        assert_eq!(indicator_ema_10.count, 2);
+        assert_eq!(indicator_ema_10.value, 1501.3636363636363);
     }
 
     #[rstest]
@@ -265,5 +279,16 @@ mod tests {
         ema.handle_trade_tick(&trade_tick);
         assert_eq!(ema.has_inputs(), true);
         assert_eq!(ema.value, 1500.0);
+    }
+
+    #[rstest]
+    fn handle_handle_bar(
+        mut indicator_ema_10: ExponentialMovingAverage,
+        bar_ethusdt_binance_minute_bid: Bar,
+    ) {
+        indicator_ema_10.handle_bar(&bar_ethusdt_binance_minute_bid);
+        assert_eq!(indicator_ema_10.has_inputs, true);
+        assert_eq!(indicator_ema_10.is_initialized, false);
+        assert_eq!(indicator_ema_10.value, 1522.0);
     }
 }

--- a/nautilus_core/indicators/src/average/ema.rs
+++ b/nautilus_core/indicators/src/average/ema.rs
@@ -23,7 +23,7 @@ use nautilus_model::{
 };
 use pyo3::prelude::*;
 
-use crate::Indicator;
+use crate::indicator::Indicator;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -189,27 +189,10 @@ impl ExponentialMovingAverage {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use nautilus_model::enums::PriceType;
-    use rstest::fixture;
-
-    use crate::ema::ExponentialMovingAverage;
-
-    #[fixture]
-    pub fn indicator_ema_10() -> ExponentialMovingAverage {
-        ExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
-    use indicator_ema_10;
     use nautilus_model::{
         data::{quote::QuoteTick, trade::TradeTick},
         enums::{AggressorSide, PriceType},
@@ -218,8 +201,7 @@ mod tests {
     };
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::{ema::ExponentialMovingAverage, Indicator};
+    use crate::{average::ema::ExponentialMovingAverage, indicator::Indicator, stubs::*};
 
     #[rstest]
     fn test_ema_initialized(indicator_ema_10: ExponentialMovingAverage) {

--- a/nautilus_core/indicators/src/average/ema.rs
+++ b/nautilus_core/indicators/src/average/ema.rs
@@ -195,9 +195,7 @@ impl ExponentialMovingAverage {
 mod tests {
     use nautilus_model::{
         data::{quote::QuoteTick, trade::TradeTick},
-        enums::{AggressorSide, PriceType},
-        identifiers::{instrument_id::InstrumentId, trade_id::TradeId},
-        types::{price::Price, quantity::Quantity},
+        enums::PriceType,
     };
     use rstest::rstest;
 
@@ -254,35 +252,17 @@ mod tests {
     }
 
     #[rstest]
-    fn test_handle_quote_tick(indicator_ema_10: ExponentialMovingAverage) {
+    fn test_handle_quote_tick(indicator_ema_10: ExponentialMovingAverage, quote_tick: QuoteTick) {
         let mut ema = indicator_ema_10;
-        let tick = QuoteTick {
-            instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-            bid_price: Price::from("1500.0000"),
-            ask_price: Price::from("1502.0000"),
-            bid_size: Quantity::from("1.00000000"),
-            ask_size: Quantity::from("1.00000000"),
-            ts_event: 1,
-            ts_init: 0,
-        };
-        ema.handle_quote_tick(&tick);
+        ema.handle_quote_tick(&quote_tick);
         assert_eq!(ema.has_inputs(), true);
         assert_eq!(ema.value, 1501.0);
     }
 
     #[rstest]
-    fn test_handle_trade_tick(indicator_ema_10: ExponentialMovingAverage) {
+    fn test_handle_trade_tick(indicator_ema_10: ExponentialMovingAverage, trade_tick: TradeTick) {
         let mut ema = indicator_ema_10;
-        let tick = TradeTick {
-            instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-            price: Price::from("1500.0000"),
-            size: Quantity::from("1.00000000"),
-            aggressor_side: AggressorSide::Buyer,
-            trade_id: TradeId::from("123456789"),
-            ts_event: 1,
-            ts_init: 0,
-        };
-        ema.handle_trade_tick(&tick);
+        ema.handle_trade_tick(&trade_tick);
         assert_eq!(ema.has_inputs(), true);
         assert_eq!(ema.value, 1500.0);
     }

--- a/nautilus_core/indicators/src/average/mod.rs
+++ b/nautilus_core/indicators/src/average/mod.rs
@@ -13,5 +13,6 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+pub mod ama;
 pub mod ema;
 pub mod sma;

--- a/nautilus_core/indicators/src/average/mod.rs
+++ b/nautilus_core/indicators/src/average/mod.rs
@@ -13,18 +13,5 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use pyo3::{prelude::*, types::PyModule, Python};
-
-pub mod average;
-pub mod indicator;
-
-#[cfg(test)]
-mod stubs;
-
-/// Loaded as nautilus_pyo3.indicators
-#[pymodule]
-pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_class::<average::ema::ExponentialMovingAverage>()?;
-    m.add_class::<average::sma::SimpleMovingAverage>()?;
-    Ok(())
-}
+pub mod ema;
+pub mod sma;

--- a/nautilus_core/indicators/src/average/sma.rs
+++ b/nautilus_core/indicators/src/average/sma.rs
@@ -214,11 +214,23 @@ mod tests {
     }
 
     #[rstest]
-    fn test_handle_quote_tick(indicator_sma_10: SimpleMovingAverage, quote_tick: QuoteTick) {
+    fn test_handle_quote_tick_single(indicator_sma_10: SimpleMovingAverage, quote_tick: QuoteTick) {
         let mut sma = indicator_sma_10;
         sma.handle_quote_tick(&quote_tick);
         assert_eq!(sma.count, 1);
         assert_eq!(sma.value, 1501.0);
+    }
+
+    #[rstest]
+    fn test_handle_quote_tick_multi(indicator_sma_10: SimpleMovingAverage) {
+        let mut sma = indicator_sma_10;
+        let tick1 = quote_tick("1500.0", "1502.0");
+        let tick2 = quote_tick("1502.0", "1504.0");
+
+        sma.handle_quote_tick(&tick1);
+        sma.handle_quote_tick(&tick2);
+        assert_eq!(sma.count, 2);
+        assert_eq!(sma.value, 1502.0);
     }
 
     #[rstest]

--- a/nautilus_core/indicators/src/average/sma.rs
+++ b/nautilus_core/indicators/src/average/sma.rs
@@ -23,7 +23,7 @@ use nautilus_model::{
 };
 use pyo3::prelude::*;
 
-use crate::Indicator;
+use crate::indicator::Indicator;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -160,22 +160,6 @@ impl SimpleMovingAverage {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use nautilus_model::enums::PriceType;
-    use rstest::fixture;
-
-    use crate::sma::SimpleMovingAverage;
-
-    #[fixture]
-    pub fn indicator_sma_10() -> SimpleMovingAverage {
-        SimpleMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Test
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
@@ -188,8 +172,7 @@ mod tests {
     };
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::{sma::SimpleMovingAverage, Indicator};
+    use crate::{average::sma::SimpleMovingAverage, indicator::Indicator, stubs::*};
 
     #[rstest]
     fn test_sma_initialized(indicator_sma_10: SimpleMovingAverage) {

--- a/nautilus_core/indicators/src/average/sma.rs
+++ b/nautilus_core/indicators/src/average/sma.rs
@@ -166,9 +166,7 @@ impl SimpleMovingAverage {
 mod tests {
     use nautilus_model::{
         data::{quote::QuoteTick, trade::TradeTick},
-        enums::{AggressorSide, PriceType},
-        identifiers::{instrument_id::InstrumentId, trade_id::TradeId},
-        types::{price::Price, quantity::Quantity},
+        enums::PriceType,
     };
     use rstest::rstest;
 
@@ -216,35 +214,17 @@ mod tests {
     }
 
     #[rstest]
-    fn test_handle_quote_tick(indicator_sma_10: SimpleMovingAverage) {
+    fn test_handle_quote_tick(indicator_sma_10: SimpleMovingAverage, quote_tick: QuoteTick) {
         let mut sma = indicator_sma_10;
-        let tick = QuoteTick {
-            instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-            bid_price: Price::from("1500.0000"),
-            ask_price: Price::from("1502.0000"),
-            bid_size: Quantity::from("1.00000000"),
-            ask_size: Quantity::from("1.00000000"),
-            ts_event: 1,
-            ts_init: 0,
-        };
-        sma.handle_quote_tick(&tick);
+        sma.handle_quote_tick(&quote_tick);
         assert_eq!(sma.count, 1);
         assert_eq!(sma.value, 1501.0);
     }
 
     #[rstest]
-    fn test_handle_trade_tick(indicator_sma_10: SimpleMovingAverage) {
+    fn test_handle_trade_tick(indicator_sma_10: SimpleMovingAverage, trade_tick: TradeTick) {
         let mut sma = indicator_sma_10;
-        let tick = TradeTick {
-            instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-            price: Price::from("1500.0000"),
-            size: Quantity::from("1.00000000"),
-            aggressor_side: AggressorSide::Buyer,
-            trade_id: TradeId::new("123456789").unwrap(),
-            ts_event: 1,
-            ts_init: 0,
-        };
-        sma.handle_trade_tick(&tick);
+        sma.handle_trade_tick(&trade_tick);
         assert_eq!(sma.count, 1);
         assert_eq!(sma.value, 1500.0);
     }

--- a/nautilus_core/indicators/src/indicator.rs
+++ b/nautilus_core/indicators/src/indicator.rs
@@ -13,18 +13,14 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use pyo3::{prelude::*, types::PyModule, Python};
+use nautilus_model::data::{bar::Bar, quote::QuoteTick, trade::TradeTick};
 
-pub mod average;
-pub mod indicator;
-
-#[cfg(test)]
-mod stubs;
-
-/// Loaded as nautilus_pyo3.indicators
-#[pymodule]
-pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_class::<average::ema::ExponentialMovingAverage>()?;
-    m.add_class::<average::sma::SimpleMovingAverage>()?;
-    Ok(())
+pub trait Indicator {
+    fn name(&self) -> String;
+    fn has_inputs(&self) -> bool;
+    fn is_initialized(&self) -> bool;
+    fn handle_quote_tick(&mut self, tick: &QuoteTick);
+    fn handle_trade_tick(&mut self, tick: &TradeTick);
+    fn handle_bar(&mut self, bar: &Bar);
+    fn reset(&mut self);
 }

--- a/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
+++ b/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
@@ -256,4 +256,24 @@ mod tests {
         assert_eq!(efficiency_ratio_10.is_initialized, false);
         assert_eq!(efficiency_ratio_10.value, 0.0);
     }
+
+    #[rstest]
+    fn test_handle_quote_tick(mut efficiency_ratio_10: EfficiencyRatio) {
+        let quote_tick1 = quote_tick("1500.0", "1502.0");
+        let quote_tick2 = quote_tick("1502.0", "1504.0");
+
+        efficiency_ratio_10.handle_quote_tick(&quote_tick1);
+        efficiency_ratio_10.handle_quote_tick(&quote_tick2);
+        assert_eq!(efficiency_ratio_10.value, 1.0);
+    }
+
+    #[rstest]
+    fn test_handle_bar(mut efficiency_ratio_10: EfficiencyRatio) {
+        let bar1 = bar_ethusdt_binance_minute_bid("1500.0");
+        let bar2 = bar_ethusdt_binance_minute_bid("1510.0");
+
+        efficiency_ratio_10.handle_bar(&bar1);
+        efficiency_ratio_10.handle_bar(&bar2);
+        assert_eq!(efficiency_ratio_10.value, 1.0);
+    }
 }

--- a/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
+++ b/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
@@ -1,0 +1,259 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::Display;
+
+use anyhow::Result;
+use nautilus_core::python::to_pyvalue_err;
+use nautilus_model::{
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
+    enums::PriceType,
+};
+use pyo3::prelude::*;
+
+use crate::indicator::Indicator;
+
+/// An indicator which calculates the efficiency ratio across a rolling window.
+/// The Kaufman Efficiency measures the ratio of the relative market speed in
+/// relation to the volatility, this could be thought of as a proxy for noise.
+#[repr(C)]
+#[derive(Debug)]
+#[pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")]
+pub struct EfficiencyRatio {
+    /// The rolling window period for the indicator (>= 2).
+    pub period: usize,
+    pub price_type: PriceType,
+    pub value: f64,
+    pub inputs: Vec<f64>,
+    _deltas: Vec<f64>,
+    is_initialized: bool,
+}
+
+impl Display for EfficiencyRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({})", self.name(), self.period,)
+    }
+}
+
+impl Indicator for EfficiencyRatio {
+    fn name(&self) -> String {
+        stringify!(EfficiencyRatio).to_string()
+    }
+
+    fn has_inputs(&self) -> bool {
+        !self.inputs.is_empty()
+    }
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    fn handle_quote_tick(&mut self, tick: &QuoteTick) {
+        self.update_raw(tick.extract_price(self.price_type).into())
+    }
+
+    fn handle_trade_tick(&mut self, tick: &TradeTick) {
+        self.update_raw((&tick.price).into())
+    }
+
+    fn handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.close).into())
+    }
+
+    fn reset(&mut self) {
+        self.value = 0.0;
+        self.inputs.clear();
+        self.is_initialized = false;
+    }
+}
+
+impl EfficiencyRatio {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Result<Self> {
+        Ok(Self {
+            period,
+            price_type: price_type.unwrap_or(PriceType::Last),
+            value: 0.0,
+            inputs: Vec::with_capacity(period),
+            _deltas: Vec::with_capacity(period),
+            is_initialized: false,
+        })
+    }
+
+    pub fn update_raw(&mut self, value: f64) {
+        self.inputs.push(value);
+        if self.inputs.len() < 2 {
+            self.value = 0.0;
+            return;
+        } else if !self.is_initialized && self.inputs.len() >= self.period {
+            self.is_initialized = true;
+        }
+        let last_diff =
+            (self.inputs[self.inputs.len() - 1] - self.inputs[self.inputs.len() - 2]).abs();
+        self._deltas.push(last_diff);
+        let sum_deltas = self._deltas.iter().sum::<f64>().abs();
+        let net_diff = (self.inputs[self.inputs.len() - 1] - self.inputs[0]).abs();
+        self.value = if sum_deltas == 0.0 {
+            0.0
+        } else {
+            net_diff / sum_deltas
+        };
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl EfficiencyRatio {
+    #[new]
+    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
+        Self::new(period, price_type).map_err(to_pyvalue_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[getter]
+    #[pyo3(name = "period")]
+    fn py_period(&self) -> usize {
+        self.period
+    }
+
+    #[getter]
+    #[pyo3(name = "value")]
+    fn py_value(&self) -> f64 {
+        self.value
+    }
+
+    #[getter]
+    #[pyo3(name = "initialized")]
+    fn py_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    #[pyo3(name = "has_inputs")]
+    fn py_has_inputs(&self) -> bool {
+        self.has_inputs()
+    }
+
+    #[pyo3(name = "update_raw")]
+    fn py_update_raw(&mut self, value: f64) {
+        self.update_raw(value);
+    }
+
+    fn __repr__(&self) -> String {
+        format!("EfficiencyRatio({})", self.period)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+
+    use rstest::rstest;
+
+    use crate::{indicator::Indicator, ratio::efficiency_ratio::EfficiencyRatio, stubs::*};
+
+    #[rstest]
+    fn test_efficiency_ratio_initialized(efficiency_ratio_10: EfficiencyRatio) {
+        let display_str = format!("{}", efficiency_ratio_10);
+        assert_eq!(display_str, "EfficiencyRatio(10)");
+        assert_eq!(efficiency_ratio_10.period, 10);
+        assert_eq!(efficiency_ratio_10.is_initialized, false);
+    }
+
+    #[rstest]
+    fn test_with_correct_number_of_required_inputs(mut efficiency_ratio_10: EfficiencyRatio) {
+        for i in 1..10 {
+            efficiency_ratio_10.update_raw(i as f64);
+        }
+        assert_eq!(efficiency_ratio_10.inputs.len(), 9);
+        assert_eq!(efficiency_ratio_10.is_initialized, false);
+        efficiency_ratio_10.update_raw(1.0);
+        assert_eq!(efficiency_ratio_10.inputs.len(), 10);
+        assert_eq!(efficiency_ratio_10.is_initialized, true);
+    }
+
+    #[rstest]
+    fn test_value_with_one_input(mut efficiency_ratio_10: EfficiencyRatio) {
+        efficiency_ratio_10.update_raw(1.0);
+        assert_eq!(efficiency_ratio_10.value, 0.0);
+    }
+
+    #[rstest]
+    fn test_value_with_efficient_higher_inputs(mut efficiency_ratio_10: EfficiencyRatio) {
+        let mut initial_price = 1.0;
+        for _ in 1..=10 {
+            initial_price += 0.0001;
+            efficiency_ratio_10.update_raw(initial_price);
+        }
+        assert_eq!(efficiency_ratio_10.value, 1.0);
+    }
+
+    #[rstest]
+    fn test_value_with_efficient_lower_inputs(mut efficiency_ratio_10: EfficiencyRatio) {
+        let mut initial_price = 1.0;
+        for _ in 1..=10 {
+            initial_price -= 0.0001;
+            efficiency_ratio_10.update_raw(initial_price);
+        }
+        assert_eq!(efficiency_ratio_10.value, 1.0);
+    }
+
+    #[rstest]
+    fn test_value_with_oscillating_inputs_returns_zero(mut efficiency_ratio_10: EfficiencyRatio) {
+        efficiency_ratio_10.update_raw(1.00000);
+        efficiency_ratio_10.update_raw(1.00010);
+        efficiency_ratio_10.update_raw(1.00000);
+        efficiency_ratio_10.update_raw(0.99990);
+        efficiency_ratio_10.update_raw(1.00000);
+        assert_eq!(efficiency_ratio_10.value, 0.0);
+    }
+
+    #[rstest]
+    fn test_value_with_half_oscillating(mut efficiency_ratio_10: EfficiencyRatio) {
+        efficiency_ratio_10.update_raw(1.00000);
+        efficiency_ratio_10.update_raw(1.00020);
+        efficiency_ratio_10.update_raw(1.00010);
+        efficiency_ratio_10.update_raw(1.00030);
+        efficiency_ratio_10.update_raw(1.00020);
+        assert_eq!(efficiency_ratio_10.value, 0.3333333333333333);
+    }
+
+    #[rstest]
+    fn test_value_with_noisy_inputs(mut efficiency_ratio_10: EfficiencyRatio) {
+        efficiency_ratio_10.update_raw(1.00000);
+        efficiency_ratio_10.update_raw(1.00010);
+        efficiency_ratio_10.update_raw(1.00008);
+        efficiency_ratio_10.update_raw(1.00007);
+        efficiency_ratio_10.update_raw(1.00012);
+        efficiency_ratio_10.update_raw(1.00005);
+        efficiency_ratio_10.update_raw(1.00015);
+        assert_eq!(efficiency_ratio_10.value, 0.42857142857215363);
+    }
+
+    #[rstest]
+    fn test_reset(mut efficiency_ratio_10: EfficiencyRatio) {
+        for i in 1..=10 {
+            efficiency_ratio_10.update_raw(i as f64);
+        }
+        assert_eq!(efficiency_ratio_10.is_initialized, true);
+        efficiency_ratio_10.reset();
+        assert_eq!(efficiency_ratio_10.is_initialized, false);
+        assert_eq!(efficiency_ratio_10.value, 0.0);
+    }
+}

--- a/nautilus_core/indicators/src/ratio/mod.rs
+++ b/nautilus_core/indicators/src/ratio/mod.rs
@@ -13,19 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use pyo3::{prelude::*, types::PyModule, Python};
-
-pub mod average;
-pub mod indicator;
-pub mod ratio;
-
-#[cfg(test)]
-mod stubs;
-
-/// Loaded as nautilus_pyo3.indicators
-#[pymodule]
-pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_class::<average::ema::ExponentialMovingAverage>()?;
-    m.add_class::<average::sma::SimpleMovingAverage>()?;
-    Ok(())
-}
+pub mod efficiency_ratio;

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -21,9 +21,8 @@ use nautilus_model::{
 use rstest::fixture;
 
 use crate::{
-    average::{
-        ema::ExponentialMovingAverage, sma::SimpleMovingAverage,
-    },
+    average::{ema::ExponentialMovingAverage, sma::SimpleMovingAverage},
+    ratio::efficiency_ratio::EfficiencyRatio,
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,4 +67,9 @@ pub fn indicator_sma_10() -> SimpleMovingAverage {
 #[fixture]
 pub fn indicator_ema_10() -> ExponentialMovingAverage {
     ExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+}
+
+#[fixture]
+pub fn efficiency_ratio_10() -> EfficiencyRatio {
+    EfficiencyRatio::new(10, Some(PriceType::Mid)).unwrap()
 }

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -24,6 +24,7 @@ use crate::{
     average::{ema::ExponentialMovingAverage, sma::SimpleMovingAverage},
     ratio::efficiency_ratio::EfficiencyRatio,
 };
+use crate::average::ama::AdaptiveMovingAverage;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Common
@@ -58,6 +59,10 @@ pub fn trade_tick() -> TradeTick {
 // Average
 ////////////////////////////////////////////////////////////////////////////////
 
+#[fixture]
+pub fn indicator_ama_10() -> AdaptiveMovingAverage {
+    AdaptiveMovingAverage::new(10, 2, 30, Some(PriceType::Mid)).unwrap()
+}
 
 #[fixture]
 pub fn indicator_sma_10() -> SimpleMovingAverage {

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -13,28 +13,36 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 use nautilus_model::{
-    data::{quote::QuoteTick, trade::TradeTick},
-    enums::{AggressorSide, PriceType},
-    identifiers::{instrument_id::InstrumentId, trade_id::TradeId},
+    data::{
+        bar::{Bar, BarSpecification, BarType},
+        quote::QuoteTick,
+        trade::TradeTick,
+    },
+    enums::{AggregationSource, AggressorSide, BarAggregation, PriceType},
+    identifiers::{instrument_id::InstrumentId, symbol::Symbol, trade_id::TradeId, venue::Venue},
     types::{price::Price, quantity::Quantity},
 };
-use rstest::fixture;
+use rstest::*;
 
 use crate::{
-    average::{ema::ExponentialMovingAverage, sma::SimpleMovingAverage},
+    average::{
+        ama::AdaptiveMovingAverage, ema::ExponentialMovingAverage, sma::SimpleMovingAverage,
+    },
     ratio::efficiency_ratio::EfficiencyRatio,
 };
-use crate::average::ama::AdaptiveMovingAverage;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Common
 ////////////////////////////////////////////////////////////////////////////////
 #[fixture]
-pub fn quote_tick() -> QuoteTick {
+pub fn quote_tick(
+    #[default("1500")] bid_price: &str,
+    #[default("1502")] ask_price: &str,
+) -> QuoteTick {
     QuoteTick {
         instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-        bid_price: Price::from("1500.0000"),
-        ask_price: Price::from("1502.0000"),
+        bid_price: Price::from(bid_price),
+        ask_price: Price::from(ask_price),
         bid_size: Quantity::from("1.00000000"),
         ask_size: Quantity::from("1.00000000"),
         ts_event: 1,
@@ -52,6 +60,34 @@ pub fn trade_tick() -> TradeTick {
         trade_id: TradeId::from("123456789"),
         ts_event: 1,
         ts_init: 0,
+    }
+}
+
+#[fixture]
+pub fn bar_ethusdt_binance_minute_bid(#[default("1522")] close_price: &str) -> Bar {
+    let instrument_id = InstrumentId {
+        symbol: Symbol::new("ETHUSDT-PERP.BINANCE").unwrap(),
+        venue: Venue::new("BINANCE").unwrap(),
+    };
+    let bar_spec = BarSpecification {
+        step: 1,
+        aggregation: BarAggregation::Minute,
+        price_type: PriceType::Bid,
+    };
+    let bar_type = BarType {
+        instrument_id,
+        spec: bar_spec,
+        aggregation_source: AggregationSource::External,
+    };
+    Bar {
+        bar_type: bar_type,
+        open: Price::from("1500.0"),
+        high: Price::from("1550.0"),
+        low: Price::from("1495.0"),
+        close: Price::from(close_price),
+        volume: Quantity::from("100000"),
+        ts_event: 0,
+        ts_init: 1,
     }
 }
 

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -12,19 +12,17 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
+use nautilus_model::enums::PriceType;
+use rstest::fixture;
 
-use pyo3::{prelude::*, types::PyModule, Python};
+use crate::average::{ema::ExponentialMovingAverage, sma::SimpleMovingAverage};
 
-pub mod average;
-pub mod indicator;
+#[fixture]
+pub fn indicator_sma_10() -> SimpleMovingAverage {
+    SimpleMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+}
 
-#[cfg(test)]
-mod stubs;
-
-/// Loaded as nautilus_pyo3.indicators
-#[pymodule]
-pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_class::<average::ema::ExponentialMovingAverage>()?;
-    m.add_class::<average::sma::SimpleMovingAverage>()?;
-    Ok(())
+#[fixture]
+pub fn indicator_ema_10() -> ExponentialMovingAverage {
+    ExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
 }

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -12,10 +12,53 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
-use nautilus_model::enums::PriceType;
+use nautilus_model::{
+    data::{quote::QuoteTick, trade::TradeTick},
+    enums::{AggressorSide, PriceType},
+    identifiers::{instrument_id::InstrumentId, trade_id::TradeId},
+    types::{price::Price, quantity::Quantity},
+};
 use rstest::fixture;
 
-use crate::average::{ema::ExponentialMovingAverage, sma::SimpleMovingAverage};
+use crate::{
+    average::{
+        ema::ExponentialMovingAverage, sma::SimpleMovingAverage,
+    },
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Common
+////////////////////////////////////////////////////////////////////////////////
+#[fixture]
+pub fn quote_tick() -> QuoteTick {
+    QuoteTick {
+        instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
+        bid_price: Price::from("1500.0000"),
+        ask_price: Price::from("1502.0000"),
+        bid_size: Quantity::from("1.00000000"),
+        ask_size: Quantity::from("1.00000000"),
+        ts_event: 1,
+        ts_init: 0,
+    }
+}
+
+#[fixture]
+pub fn trade_tick() -> TradeTick {
+    TradeTick {
+        instrument_id: InstrumentId::from("ETHUSDT-PERP.BINANCE"),
+        price: Price::from("1500.0000"),
+        size: Quantity::from("1.00000000"),
+        aggressor_side: AggressorSide::Buyer,
+        trade_id: TradeId::from("123456789"),
+        ts_event: 1,
+        ts_init: 0,
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Average
+////////////////////////////////////////////////////////////////////////////////
+
 
 #[fixture]
 pub fn indicator_sma_10() -> SimpleMovingAverage {


### PR DESCRIPTION
# Pull Request

- `AdaptiveMovingAverage` indicator with tests
- `EfficientRatio` indicator with tests
- `indicators` crate reorganization and stubs data file with parametrized fixtures