### PR TITLE
Update nautilus_trader.dockerfile

### DIFF
--- a/.docker/nautilus_trader.dockerfile
+++ b/.docker/nautilus_trader.dockerfile
@@ -36,7 +36,7 @@ COPY nautilus_trader ./nautilus_trader
 COPY README.md ./
 RUN poetry install --only main --all-extras
 RUN poetry build -f wheel
-RUN python -m pip install ./dist/*whl --force
+RUN python -m pip install ./dist/*whl --force --no-deps
 RUN find /usr/local/lib/python3.11/site-packages -name "*.pyc" -exec rm -f {} \;
 
 # Final application image


### PR DESCRIPTION
We don't need to (nor want to) reinstall dependencies when running the wheel install. The pupose of this line is to make sure nautilus_trader is copied into site-packages, our dependencies are installed in `poetry install --only main --all-extras`

Installing dependencies here will use pip and risks not installing the exact versions in our lock file. 