### PR TITLE
Add RelativeStrengthIndex(RSI) indicator for Rust

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "nautilus-model",
  "pyo3",
  "rstest",
+ "strum 0.25.0",
 ]
 
 [[package]]

--- a/nautilus_core/indicators/Cargo.toml
+++ b/nautilus_core/indicators/Cargo.toml
@@ -15,7 +15,7 @@ nautilus-core = { path = "../core" }
 nautilus-model = { path = "../model" }
 anyhow = { workspace = true }
 pyo3 = { workspace = true, optional = true }
-
+strum = { workspace = true }
 [dev-dependencies]
 rstest.workspace = true
 

--- a/nautilus_core/indicators/src/average/dema.rs
+++ b/nautilus_core/indicators/src/average/dema.rs
@@ -23,7 +23,10 @@ use nautilus_model::{
 };
 use pyo3::prelude::*;
 
-use crate::{average::ema::ExponentialMovingAverage, indicator::Indicator};
+use crate::{
+    average::ema::ExponentialMovingAverage,
+    indicator::{Indicator, MovingAverage},
+};
 
 /// The Double Exponential Moving Average attempts to a smoother average with less
 /// lag than the normal Exponential Moving Average (EMA)
@@ -96,8 +99,17 @@ impl DoubleExponentialMovingAverage {
             _ema2: ExponentialMovingAverage::new(period, price_type)?,
         })
     }
+}
 
-    pub fn update_raw(&mut self, value: f64) {
+impl MovingAverage for DoubleExponentialMovingAverage {
+    fn value(&self) -> f64 {
+        self.value
+    }
+
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn update_raw(&mut self, value: f64) {
         if !self.has_inputs {
             self.has_inputs = true;
             self.value = value;
@@ -196,7 +208,11 @@ mod tests {
     use nautilus_model::data::{bar::Bar, quote::QuoteTick, trade::TradeTick};
     use rstest::rstest;
 
-    use crate::{average::dema::DoubleExponentialMovingAverage, indicator::Indicator, stubs::*};
+    use crate::{
+        average::dema::DoubleExponentialMovingAverage,
+        indicator::{Indicator, MovingAverage},
+        stubs::*,
+    };
 
     #[rstest]
     fn test_dema_initialized(indicator_dema_10: DoubleExponentialMovingAverage) {

--- a/nautilus_core/indicators/src/average/ema.rs
+++ b/nautilus_core/indicators/src/average/ema.rs
@@ -23,7 +23,7 @@ use nautilus_model::{
 };
 use pyo3::prelude::*;
 
-use crate::indicator::Indicator;
+use crate::indicator::{Indicator, MovingAverage};
 
 #[repr(C)]
 #[derive(Debug)]
@@ -91,8 +91,17 @@ impl ExponentialMovingAverage {
             is_initialized: false,
         })
     }
+}
 
-    pub fn update_raw(&mut self, value: f64) {
+impl MovingAverage for ExponentialMovingAverage {
+    fn value(&self) -> f64 {
+        self.value
+    }
+
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn update_raw(&mut self, value: f64) {
         if !self.has_inputs {
             self.has_inputs = true;
             self.value = value;
@@ -199,7 +208,11 @@ mod tests {
     };
     use rstest::rstest;
 
-    use crate::{average::ema::ExponentialMovingAverage, indicator::Indicator, stubs::*};
+    use crate::{
+        average::ema::ExponentialMovingAverage,
+        indicator::{Indicator, MovingAverage},
+        stubs::*,
+    };
 
     #[rstest]
     fn test_ema_initialized(indicator_ema_10: ExponentialMovingAverage) {

--- a/nautilus_core/indicators/src/average/mod.rs
+++ b/nautilus_core/indicators/src/average/mod.rs
@@ -12,6 +12,68 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
+use nautilus_model::enums::PriceType;
+use pyo3::prelude::*;
+use strum::{AsRefStr, Display, EnumIter, EnumString, FromRepr};
+
+use crate::{
+    average::{
+        dema::DoubleExponentialMovingAverage, ema::ExponentialMovingAverage,
+        sma::SimpleMovingAverage,
+    },
+    indicator::MovingAverage,
+};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Display,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    AsRefStr,
+    FromRepr,
+    EnumIter,
+    EnumString,
+)]
+#[strum(ascii_case_insensitive)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(
+    feature = "python",
+    pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")
+)]
+pub enum MovingAverageType {
+    Simple,
+    Exponential,
+    DoubleExponential,
+}
+
+pub struct MovingAverageFactory;
+
+impl MovingAverageFactory {
+    pub fn create(
+        moving_average_type: MovingAverageType,
+        period: usize,
+    ) -> Box<dyn MovingAverage + Send> {
+        let price_type = Some(PriceType::Last);
+
+        match moving_average_type {
+            MovingAverageType::Simple => {
+                Box::new(SimpleMovingAverage::new(period, price_type).unwrap())
+            }
+            MovingAverageType::Exponential => {
+                Box::new(ExponentialMovingAverage::new(period, price_type).unwrap())
+            }
+            MovingAverageType::DoubleExponential => {
+                Box::new(DoubleExponentialMovingAverage::new(period, price_type).unwrap())
+            }
+        }
+    }
+}
 
 pub mod ama;
 pub mod dema;

--- a/nautilus_core/indicators/src/average/sma.rs
+++ b/nautilus_core/indicators/src/average/sma.rs
@@ -23,7 +23,7 @@ use nautilus_model::{
 };
 use pyo3::prelude::*;
 
-use crate::indicator::Indicator;
+use crate::indicator::{Indicator, MovingAverage};
 
 #[repr(C)]
 #[derive(Debug)]
@@ -89,8 +89,17 @@ impl SimpleMovingAverage {
             is_initialized: false,
         })
     }
+}
 
-    pub fn update_raw(&mut self, value: f64) {
+impl MovingAverage for SimpleMovingAverage {
+    fn value(&self) -> f64 {
+        self.value
+    }
+
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn update_raw(&mut self, value: f64) {
         if self.inputs.len() == self.period {
             self.inputs.remove(0);
             self.count -= 1;
@@ -170,7 +179,11 @@ mod tests {
     };
     use rstest::rstest;
 
-    use crate::{average::sma::SimpleMovingAverage, indicator::Indicator, stubs::*};
+    use crate::{
+        average::sma::SimpleMovingAverage,
+        indicator::{Indicator, MovingAverage},
+        stubs::*,
+    };
 
     #[rstest]
     fn test_sma_initialized(indicator_sma_10: SimpleMovingAverage) {

--- a/nautilus_core/indicators/src/indicator.rs
+++ b/nautilus_core/indicators/src/indicator.rs
@@ -13,8 +13,11 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::{fmt, fmt::Debug};
+
 use nautilus_model::data::{bar::Bar, quote::QuoteTick, trade::TradeTick};
 
+/// Indicator trait
 pub trait Indicator {
     fn name(&self) -> String;
     fn has_inputs(&self) -> bool;
@@ -23,4 +26,24 @@ pub trait Indicator {
     fn handle_trade_tick(&mut self, tick: &TradeTick);
     fn handle_bar(&mut self, bar: &Bar);
     fn reset(&mut self);
+}
+
+/// Moving average trait
+pub trait MovingAverage: Indicator {
+    fn value(&self) -> f64;
+    fn count(&self) -> usize;
+    fn update_raw(&mut self, value: f64);
+}
+
+impl Debug for dyn Indicator + Send {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Implement custom formatting for the Indicator trait object.
+        write!(f, "Indicator {{ ... }}")
+    }
+}
+impl Debug for dyn MovingAverage + Send {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Implement custom formatting for the Indicator trait object.
+        write!(f, "MovingAverage()")
+    }
 }

--- a/nautilus_core/indicators/src/momentum/mod.rs
+++ b/nautilus_core/indicators/src/momentum/mod.rs
@@ -13,27 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use pyo3::{prelude::*, types::PyModule, Python};
-
-pub mod average;
-pub mod indicator;
-pub mod momentum;
-pub mod ratio;
-
-#[cfg(test)]
-mod stubs;
-
-/// Loaded as nautilus_pyo3.indicators
-#[pymodule]
-pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
-    // average
-    m.add_class::<average::ema::ExponentialMovingAverage>()?;
-    m.add_class::<average::sma::SimpleMovingAverage>()?;
-    m.add_class::<average::ama::AdaptiveMovingAverage>()?;
-    m.add_class::<average::dema::DoubleExponentialMovingAverage>()?;
-    // ratio
-    m.add_class::<ratio::efficiency_ratio::EfficiencyRatio>()?;
-    // momentum
-    m.add_class::<momentum::rsi::RelativeStrengthIndex>()?;
-    Ok(())
-}
+pub mod rsi;

--- a/nautilus_core/indicators/src/momentum/rsi.rs
+++ b/nautilus_core/indicators/src/momentum/rsi.rs
@@ -1,0 +1,312 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::{Debug, Display};
+
+use anyhow::Result;
+use nautilus_core::python::to_pyvalue_err;
+use nautilus_model::{
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
+    enums::PriceType,
+};
+use pyo3::prelude::*;
+
+use crate::{
+    average::{MovingAverageFactory, MovingAverageType},
+    indicator::{Indicator, MovingAverage},
+};
+
+/// An indicator which calculates a relative strength index (RSI) across a rolling window.
+#[repr(C)]
+#[derive(Debug)]
+#[pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")]
+pub struct RelativeStrengthIndex {
+    pub period: usize,
+    pub ma_type: MovingAverageType,
+    pub value: f64,
+    pub count: usize,
+    // pub inputs: Vec<f64>,
+    _has_inputs: bool,
+    _last_value: f64,
+    _average_gain: Box<dyn MovingAverage + Send + 'static>,
+    _average_loss: Box<dyn MovingAverage + Send + 'static>,
+    _rsi_max: f64,
+    is_initialized: bool,
+}
+
+impl Display for RelativeStrengthIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({},{})", self.name(), self.period, self.ma_type)
+    }
+}
+
+impl Indicator for RelativeStrengthIndex {
+    fn name(&self) -> String {
+        stringify!(RelativeStrengthIndex).to_string()
+    }
+
+    fn has_inputs(&self) -> bool {
+        self._has_inputs
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    fn handle_quote_tick(&mut self, tick: &QuoteTick) {
+        self.update_raw(tick.extract_price(PriceType::Mid).into());
+    }
+
+    fn handle_trade_tick(&mut self, tick: &TradeTick) {
+        self.update_raw((tick.price).into());
+    }
+
+    fn handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.close).into());
+    }
+
+    fn reset(&mut self) {
+        self.value = 0.0;
+        self._last_value = 0.0;
+        self.count = 0;
+        self._has_inputs = false;
+        self.is_initialized = false;
+    }
+}
+
+impl RelativeStrengthIndex {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Result<Self> {
+        Ok(Self {
+            period,
+            ma_type: ma_type.unwrap_or(MovingAverageType::Exponential),
+            value: 0.0,
+            _last_value: 0.0,
+            count: 0,
+            // inputs: Vec::new(),
+            _has_inputs: false,
+            _average_gain: MovingAverageFactory::create(MovingAverageType::Exponential, period),
+            _average_loss: MovingAverageFactory::create(MovingAverageType::Exponential, period),
+            _rsi_max: 1.0,
+            is_initialized: false,
+        })
+    }
+
+    pub fn update_raw(&mut self, value: f64) {
+        if !self._has_inputs {
+            self._last_value = value;
+            self._has_inputs = true
+        }
+        let gain = value - self._last_value;
+        if gain > 0.0 {
+            self._average_gain.update_raw(gain);
+            self._average_loss.update_raw(0.0);
+        } else if gain < 0.0 {
+            self._average_loss.update_raw(-gain);
+            self._average_gain.update_raw(0.0);
+        } else {
+            self._average_loss.update_raw(0.0);
+            self._average_gain.update_raw(0.0);
+        }
+        // init count from average gain MA
+        self.count = self._average_gain.count();
+        if !self.is_initialized
+            && self._average_loss.is_initialized()
+            && self._average_gain.is_initialized()
+        {
+            self.is_initialized = true;
+        }
+
+        if self._average_loss.value() == 0.0 {
+            self.value = self._rsi_max;
+            return;
+        }
+
+        let rs = self._average_gain.value() / self._average_loss.value();
+        self.value = self._rsi_max - (self._rsi_max / (1.0 + rs));
+        self._last_value = value;
+
+        if !self.is_initialized && self.count >= self.period {
+            self.is_initialized = true;
+        }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl RelativeStrengthIndex {
+    #[new]
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
+        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[getter]
+    #[pyo3(name = "period")]
+    fn py_period(&self) -> usize {
+        self.period
+    }
+
+    #[getter]
+    #[pyo3(name = "count")]
+    fn py_count(&self) -> usize {
+        self.count
+    }
+
+    #[getter]
+    #[pyo3(name = "value")]
+    fn py_value(&self) -> f64 {
+        self.value
+    }
+
+    #[getter]
+    #[pyo3(name = "initialized")]
+    fn py_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    #[pyo3(name = "update_raw")]
+    fn py_update_raw(&mut self, value: f64) {
+        self.update_raw(value);
+    }
+
+    #[pyo3(name = "handle_quote_tick")]
+    fn py_handle_quote_tick(&mut self, tick: &QuoteTick) {
+        self.py_update_raw(tick.extract_price(PriceType::Mid).into());
+    }
+
+    #[pyo3(name = "handle_bar")]
+    fn py_handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.close).into());
+    }
+
+    #[pyo3(name = "handle_trade_tick")]
+    fn py_handle_trade_tick(&mut self, tick: &TradeTick) {
+        self.update_raw((&tick.price).into());
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ExponentialMovingAverage({})", self.period)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use nautilus_model::data::{bar::Bar, quote::QuoteTick, trade::TradeTick};
+    use rstest::rstest;
+
+    use crate::{indicator::Indicator, momentum::rsi::RelativeStrengthIndex, stubs::*};
+
+    #[rstest]
+    fn test_rsi_initialized(rsi_10: RelativeStrengthIndex) {
+        let display_str = format!("{}", rsi_10);
+        assert_eq!(display_str, "RelativeStrengthIndex(10,EXPONENTIAL)");
+        assert_eq!(rsi_10.period, 10);
+        assert_eq!(rsi_10.is_initialized, false)
+    }
+
+    #[rstest]
+    fn test_initialized_with_required_inputs_returns_true(mut rsi_10: RelativeStrengthIndex) {
+        for i in 0..12 {
+            rsi_10.update_raw(i as f64);
+        }
+        assert_eq!(rsi_10.is_initialized, true)
+    }
+
+    #[rstest]
+    fn test_value_with_one_input_returns_expected_value(mut rsi_10: RelativeStrengthIndex) {
+        rsi_10.update_raw(1.0);
+        assert_eq!(rsi_10.value, 1.0)
+    }
+
+    #[rstest]
+    fn test_value_all_higher_inputs_returns_expected_value(mut rsi_10: RelativeStrengthIndex) {
+        for i in 1..4 {
+            rsi_10.update_raw(i as f64);
+        }
+        assert_eq!(rsi_10.value, 1.0)
+    }
+
+    #[rstest]
+    fn test_value_with_all_lower_inputs_returns_expected_value(mut rsi_10: RelativeStrengthIndex) {
+        for i in (1..4).rev() {
+            rsi_10.update_raw(i as f64);
+        }
+        assert_eq!(rsi_10.value, 0.0)
+    }
+
+    #[rstest]
+    fn test_value_with_various_input_returns_expected_value(mut rsi_10: RelativeStrengthIndex) {
+        rsi_10.update_raw(3.0);
+        rsi_10.update_raw(2.0);
+        rsi_10.update_raw(5.0);
+        rsi_10.update_raw(6.0);
+        rsi_10.update_raw(7.0);
+        rsi_10.update_raw(6.0);
+
+        assert_eq!(rsi_10.value, 0.6837363325825265)
+    }
+
+    #[rstest]
+    fn test_value_at_returns_expected_value(mut rsi_10: RelativeStrengthIndex) {
+        rsi_10.update_raw(3.0);
+        rsi_10.update_raw(2.0);
+        rsi_10.update_raw(5.0);
+        rsi_10.update_raw(6.0);
+        rsi_10.update_raw(7.0);
+        rsi_10.update_raw(6.0);
+        rsi_10.update_raw(6.0);
+        rsi_10.update_raw(7.0);
+
+        assert_eq!(rsi_10.value, 0.7615344667662725);
+    }
+
+    #[rstest]
+    fn test_reset(mut rsi_10: RelativeStrengthIndex) {
+        rsi_10.update_raw(1.0);
+        rsi_10.update_raw(2.0);
+        rsi_10.reset();
+        assert_eq!(rsi_10.is_initialized(), false);
+        assert_eq!(rsi_10.count, 0)
+    }
+
+    #[rstest]
+    fn test_handle_quote_tick(mut rsi_10: RelativeStrengthIndex, quote_tick: QuoteTick) {
+        rsi_10.handle_quote_tick(&quote_tick);
+        assert_eq!(rsi_10.count, 1);
+        assert_eq!(rsi_10.value, 1.0)
+    }
+
+    #[rstest]
+    fn test_handle_trade_tick(mut rsi_10: RelativeStrengthIndex, trade_tick: TradeTick) {
+        rsi_10.handle_trade_tick(&trade_tick);
+        assert_eq!(rsi_10.count, 1);
+        assert_eq!(rsi_10.value, 1.0)
+    }
+
+    #[rstest]
+    fn test_handle_bar(mut rsi_10: RelativeStrengthIndex, bar_ethusdt_binance_minute_bid: Bar) {
+        rsi_10.handle_bar(&bar_ethusdt_binance_minute_bid);
+        assert_eq!(rsi_10.count, 1);
+        assert_eq!(rsi_10.value, 1.0)
+    }
+}

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -27,8 +27,9 @@ use rstest::*;
 use crate::{
     average::{
         ama::AdaptiveMovingAverage, dema::DoubleExponentialMovingAverage,
-        ema::ExponentialMovingAverage, sma::SimpleMovingAverage,
+        ema::ExponentialMovingAverage, sma::SimpleMovingAverage, MovingAverageType,
     },
+    momentum::rsi::RelativeStrengthIndex,
     ratio::efficiency_ratio::EfficiencyRatio,
 };
 
@@ -116,7 +117,19 @@ pub fn indicator_dema_10() -> DoubleExponentialMovingAverage {
     DoubleExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Ratios
+////////////////////////////////////////////////////////////////////////////////
+
 #[fixture]
 pub fn efficiency_ratio_10() -> EfficiencyRatio {
     EfficiencyRatio::new(10, Some(PriceType::Mid)).unwrap()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Momentum
+////////////////////////////////////////////////////////////////////////////////
+#[fixture]
+pub fn rsi_10() -> RelativeStrengthIndex {
+    RelativeStrengthIndex::new(10, Some(MovingAverageType::Exponential)).unwrap()
 }


### PR DESCRIPTION
# Pull Request

- trait `MovingAverage` was implemented that exposed `update_raw` method
- implemented `RelativeStrengthIndex` struct in rust with tests
- new indicator module `momentum` was created where RSI indicator is placed
