### PR TITLE
Add CryptoPerpetual instrument for Rust

### DIFF
--- a/nautilus_core/model/src/data/bar_py.rs
+++ b/nautilus_core/model/src/data/bar_py.rs
@@ -18,7 +18,11 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable, time::UnixNanos};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+    time::UnixNanos,
+};
 use pyo3::{prelude::*, pyclass::CompareOp, types::PyDict};
 
 use super::bar::{Bar, BarSpecification, BarType};
@@ -215,14 +219,7 @@ impl Bar {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/data/delta_py.rs
+++ b/nautilus_core/model/src/data/delta_py.rs
@@ -18,7 +18,11 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable, time::UnixNanos};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+    time::UnixNanos,
+};
 use pyo3::{prelude::*, pyclass::CompareOp, types::PyDict};
 
 use super::{delta::OrderBookDelta, order::BookOrder};
@@ -126,14 +130,7 @@ impl OrderBookDelta {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/data/order_py.rs
+++ b/nautilus_core/model/src/data/order_py.rs
@@ -18,7 +18,10 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+};
 use pyo3::{prelude::*, pyclass::CompareOp, types::PyDict};
 
 use super::order::{BookOrder, OrderId};
@@ -109,14 +112,7 @@ impl BookOrder {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     pub fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/data/quote_py.rs
+++ b/nautilus_core/model/src/data/quote_py.rs
@@ -19,7 +19,11 @@ use std::{
     str::FromStr,
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable, time::UnixNanos};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+    time::UnixNanos,
+};
 use pyo3::{
     prelude::*,
     pyclass::CompareOp,
@@ -249,14 +253,7 @@ impl QuoteTick {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/data/ticker_py.rs
+++ b/nautilus_core/model/src/data/ticker_py.rs
@@ -18,7 +18,11 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable, time::UnixNanos};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+    time::UnixNanos,
+};
 use pyo3::{prelude::*, pyclass::CompareOp, types::PyDict};
 
 use super::ticker::Ticker;
@@ -90,14 +94,7 @@ impl Ticker {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     pub fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/data/trade_py.rs
+++ b/nautilus_core/model/src/data/trade_py.rs
@@ -19,7 +19,11 @@ use std::{
     str::FromStr,
 };
 
-use nautilus_core::{python::to_pyvalue_err, serialization::Serializable, time::UnixNanos};
+use nautilus_core::{
+    python::to_pyvalue_err,
+    serialization::{from_dict_pyo3, Serializable},
+    time::UnixNanos,
+};
 use pyo3::{
     prelude::*,
     pyclass::CompareOp,
@@ -201,14 +205,7 @@ impl TradeTick {
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
-        // Extract to JSON string
-        let json_str: String = PyModule::import(py, "json")?
-            .call_method("dumps", (values,), None)?
-            .extract()?;
-
-        // Deserialize to object
-        let instance = serde_json::from_slice(&json_str.into_bytes()).map_err(to_pyvalue_err)?;
-        Ok(instance)
+        from_dict_pyo3(py, values)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/instruments/crypto_perpetual.rs
+++ b/nautilus_core/model/src/instruments/crypto_perpetual.rs
@@ -15,45 +15,51 @@
 
 #![allow(dead_code)] // Allow for development
 
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
 
-use pyo3::prelude::*;
-use rust_decimal::Decimal;
+use anyhow::Result;
+use nautilus_core::{python::to_pyvalue_err, serialization::from_dict_pyo3};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::{prelude::*, Decimal};
 use serde::{Deserialize, Serialize};
 
-use super::Instrument;
 use crate::{
     enums::{AssetClass, AssetType},
     identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-    types::{currency::Currency, price::Price, quantity::Quantity},
+    instruments::Instrument,
+    types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
 };
 
 #[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[pyclass]
+#[pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")]
 pub struct CryptoPerpetual {
     pub id: InstrumentId,
     pub raw_symbol: Symbol,
-    pub quote_currency: Currency,
     pub base_currency: Currency,
+    pub quote_currency: Currency,
     pub settlement_currency: Currency,
     pub price_precision: u8,
     pub size_precision: u8,
     pub price_increment: Price,
     pub size_increment: Quantity,
-    pub lot_size: Option<Quantity>,
-    pub max_quantity: Option<Quantity>,
-    pub min_quantity: Option<Quantity>,
-    pub max_price: Option<Price>,
-    pub min_price: Option<Price>,
     pub margin_init: Decimal,
     pub margin_maint: Decimal,
     pub maker_fee: Decimal,
     pub taker_fee: Decimal,
+    pub lot_size: Option<Quantity>,
+    pub max_quantity: Option<Quantity>,
+    pub min_quantity: Option<Quantity>,
+    pub max_notional: Option<Money>,
+    pub min_notional: Option<Money>,
+    pub max_price: Option<Price>,
+    pub min_price: Option<Price>,
 }
 
 impl CryptoPerpetual {
-    #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: InstrumentId,
@@ -65,17 +71,19 @@ impl CryptoPerpetual {
         size_precision: u8,
         price_increment: Price,
         size_increment: Quantity,
-        lot_size: Option<Quantity>,
-        max_quantity: Option<Quantity>,
-        min_quantity: Option<Quantity>,
-        max_price: Option<Price>,
-        min_price: Option<Price>,
         margin_init: Decimal,
         margin_maint: Decimal,
         maker_fee: Decimal,
         taker_fee: Decimal,
-    ) -> Self {
-        Self {
+        lot_size: Option<Quantity>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_notional: Option<Money>,
+        min_notional: Option<Money>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+    ) -> Result<Self> {
+        Ok(Self {
             id,
             raw_symbol,
             base_currency,
@@ -85,16 +93,18 @@ impl CryptoPerpetual {
             size_precision,
             price_increment,
             size_increment,
-            lot_size,
-            max_quantity,
-            min_quantity,
-            max_price,
-            min_price,
             margin_init,
             margin_maint,
             maker_fee,
             taker_fee,
-        }
+            lot_size,
+            max_quantity,
+            min_quantity,
+            max_notional,
+            min_notional,
+            max_price,
+            min_price,
+        })
     }
 }
 
@@ -199,5 +209,189 @@ impl Instrument for CryptoPerpetual {
 
     fn taker_fee(&self) -> Decimal {
         self.taker_fee
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl CryptoPerpetual {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        id: InstrumentId,
+        symbol: Symbol,
+        base_currency: Currency,
+        quote_currency: Currency,
+        settlement_currency: Currency,
+        price_precision: u8,
+        size_precision: u8,
+        price_increment: Price,
+        size_increment: Quantity,
+        margin_init: Decimal,
+        margin_maint: Decimal,
+        maker_fee: Decimal,
+        taker_fee: Decimal,
+        lot_size: Option<Quantity>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_notional: Option<Money>,
+        min_notional: Option<Money>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+    ) -> PyResult<Self> {
+        Self::new(
+            id,
+            symbol,
+            base_currency,
+            quote_currency,
+            settlement_currency,
+            price_precision,
+            size_precision,
+            price_increment,
+            size_increment,
+            margin_init,
+            margin_maint,
+            maker_fee,
+            taker_fee,
+            lot_size,
+            max_quantity,
+            min_quantity,
+            max_notional,
+            min_notional,
+            max_price,
+            min_price,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            _ => panic!("Not implemented"),
+        }
+    }
+
+    fn __hash__(&self) -> isize {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish() as isize
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("type", "CryptoPerpetual".to_string())?;
+        dict.set_item("id", self.id.to_string())?;
+        dict.set_item("raw_symbol", self.raw_symbol.to_string())?;
+        dict.set_item("base_currency", self.base_currency.code.to_string())?;
+        dict.set_item("quote_currency", self.quote_currency.code.to_string())?;
+        dict.set_item(
+            "settlement_currency",
+            self.settlement_currency.code.to_string(),
+        )?;
+        dict.set_item("price_precision", self.price_precision)?;
+        dict.set_item("size_precision", self.size_precision)?;
+        dict.set_item("price_increment", self.price_increment.to_string())?;
+        dict.set_item("size_increment", self.size_increment.to_string())?;
+        dict.set_item("margin_init", self.margin_init.to_f64())?;
+        dict.set_item("margin_maint", self.margin_maint.to_f64())?;
+        dict.set_item("maker_fee", self.margin_init.to_f64())?;
+        dict.set_item("taker_fee", self.margin_init.to_f64())?;
+        match self.lot_size {
+            Some(value) => dict.set_item("lot_size", value.to_string())?,
+            None => dict.set_item("lot_size", py.None())?,
+        }
+        match self.max_quantity {
+            Some(value) => dict.set_item("max_quantity", value.to_string())?,
+            None => dict.set_item("max_quantity", py.None())?,
+        }
+        match self.min_quantity {
+            Some(value) => dict.set_item("min_quantity", value.to_string())?,
+            None => dict.set_item("min_quantity", py.None())?,
+        }
+        match self.max_notional {
+            Some(value) => dict.set_item("max_notional", value.to_string())?,
+            None => dict.set_item("max_notional", py.None())?,
+        }
+        match self.min_notional {
+            Some(value) => dict.set_item("min_notional", value.to_string())?,
+            None => dict.set_item("min_notional", py.None())?,
+        }
+        match self.max_price {
+            Some(value) => dict.set_item("max_price", value.to_string())?,
+            None => dict.set_item("max_price", py.None())?,
+        }
+        match self.min_price {
+            Some(value) => dict.set_item("min_price", value.to_string())?,
+            None => dict.set_item("min_price", py.None())?,
+        }
+        Ok(dict.into())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Stubs
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+pub mod stubs {
+    use std::str::FromStr;
+
+    use rstest::fixture;
+    use rust_decimal::Decimal;
+
+    use crate::{
+        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
+        instruments::crypto_perpetual::CryptoPerpetual,
+        types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
+    };
+
+    #[fixture]
+    pub fn crypto_perpetual_ethusdt() -> CryptoPerpetual {
+        CryptoPerpetual::new(
+            InstrumentId::from("ETHUSDT-PERP.BINANCE"),
+            Symbol::from("ETHUSDT"),
+            Currency::from("ETH"),
+            Currency::from("USDT"),
+            Currency::from("USDT"),
+            2,
+            0,
+            Price::from("0.01"),
+            Quantity::from("0.001"),
+            Decimal::from_str("0.0").unwrap(),
+            Decimal::from_str("0.0").unwrap(),
+            Decimal::from_str("0.001").unwrap(),
+            Decimal::from_str("0.001").unwrap(),
+            None,
+            Some(Quantity::from("10000.0")),
+            Some(Quantity::from("0.001")),
+            None,
+            Some(Money::new(10.00, Currency::from("USDT")).unwrap()),
+            Some(Price::from("15000.00")),
+            Some(Price::from("1.0")),
+        )
+        .unwrap()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::stubs::*;
+    use crate::instruments::crypto_perpetual::CryptoPerpetual;
+
+    #[rstest]
+    fn test_equality(crypto_perpetual_ethusdt: CryptoPerpetual) {
+        let cloned = crypto_perpetual_ethusdt.clone();
+        assert_eq!(crypto_perpetual_ethusdt, cloned)
     }
 }

--- a/nautilus_core/model/src/instruments/mod.rs
+++ b/nautilus_core/model/src/instruments/mod.rs
@@ -13,14 +13,14 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-mod crypto_future;
-mod crypto_perpetual;
-mod currency_pair;
-mod equity;
-mod futures_contract;
-mod options_contract;
-mod synthetic;
-mod synthetic_api;
+pub mod crypto_future;
+pub mod crypto_perpetual;
+pub mod currency_pair;
+pub mod equity;
+pub mod futures_contract;
+pub mod options_contract;
+pub mod synthetic;
+pub mod synthetic_api;
 
 use anyhow::Result;
 use rust_decimal::Decimal;

--- a/nautilus_core/model/src/lib.rs
+++ b/nautilus_core/model/src/lib.rs
@@ -31,6 +31,7 @@ pub mod types;
 /// Loaded as nautilus_pyo3.model
 #[pymodule]
 pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
+    // data
     m.add_class::<data::bar::BarSpecification>()?;
     m.add_class::<data::bar::BarType>()?;
     m.add_class::<data::bar::Bar>()?;
@@ -38,6 +39,7 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<data::delta::OrderBookDelta>()?;
     m.add_class::<data::quote::QuoteTick>()?;
     m.add_class::<data::trade::TradeTick>()?;
+    // enums
     m.add_class::<enums::AccountType>()?;
     m.add_class::<enums::AggregationSource>()?;
     m.add_class::<enums::AggressorSide>()?;
@@ -62,6 +64,7 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<enums::TradingState>()?;
     m.add_class::<enums::TrailingOffsetType>()?;
     m.add_class::<enums::TriggerType>()?;
+    // identifiers
     m.add_class::<identifiers::account_id::AccountId>()?;
     m.add_class::<identifiers::client_id::ClientId>()?;
     m.add_class::<identifiers::client_order_id::ClientOrderId>()?;
@@ -76,6 +79,7 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<identifiers::trader_id::TraderId>()?;
     m.add_class::<identifiers::venue::Venue>()?;
     m.add_class::<identifiers::venue_order_id::VenueOrderId>()?;
+    // orders
     m.add_class::<orders::limit::LimitOrder>()?;
     m.add_class::<orders::limit_if_touched::LimitIfTouchedOrder>()?;
     m.add_class::<orders::market::MarketOrder>()?;
@@ -88,5 +92,13 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<types::money::Money>()?;
     m.add_class::<types::price::Price>()?;
     m.add_class::<types::quantity::Quantity>()?;
+    // instruments
+    m.add_class::<instruments::crypto_future::CryptoFuture>()?;
+    m.add_class::<instruments::crypto_perpetual::CryptoPerpetual>()?;
+    m.add_class::<instruments::currency_pair::CurrencyPair>()?;
+    m.add_class::<instruments::equity::Equity>()?;
+    m.add_class::<instruments::futures_contract::FuturesContract>()?;
+    m.add_class::<instruments::options_contract::OptionsContract>()?;
+    m.add_class::<instruments::synthetic::SyntheticInstrument>()?;
     Ok(())
 }

--- a/nautilus_trader/test_kit/rust/instruments.py
+++ b/nautilus_trader/test_kit/rust/instruments.py
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+
+from nautilus_trader.core.nautilus_pyo3.model import CryptoPerpetual
+from nautilus_trader.core.nautilus_pyo3.model import InstrumentId
+from nautilus_trader.core.nautilus_pyo3.model import Money
+from nautilus_trader.core.nautilus_pyo3.model import Price
+from nautilus_trader.core.nautilus_pyo3.model import Quantity
+from nautilus_trader.core.nautilus_pyo3.model import Symbol
+from nautilus_trader.test_kit.rust.types import TestTypesProviderPyo3
+
+
+class TestInstrumentProviderPyo3:
+    @staticmethod
+    def ethusdt_perp_binance() -> CryptoPerpetual:
+        return CryptoPerpetual(
+            InstrumentId.from_str("ETHUSDT-PERP.BINANCE"),
+            Symbol("ETHUSDT"),
+            TestTypesProviderPyo3.currency_eth(),
+            TestTypesProviderPyo3.currency_usdt(),
+            TestTypesProviderPyo3.currency_usdt(),
+            2,
+            0,
+            Price.from_str("0.01"),
+            Quantity.from_str("0.001"),
+            0.0,
+            0.0,
+            0.001,
+            0.001,
+            None,
+            Quantity.from_str("10000"),
+            Quantity.from_str("0.001"),
+            None,
+            Money(10.0, TestTypesProviderPyo3.currency_usdt()),
+            Price.from_str("15000.0"),
+            Price.from_str("1.0"),
+        )

--- a/nautilus_trader/test_kit/rust/types.py
+++ b/nautilus_trader/test_kit/rust/types.py
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.core.nautilus_pyo3.model import Currency
+
+
+class TestTypesProviderPyo3:
+    @staticmethod
+    def currency_btc() -> Currency:
+        return Currency.from_str("BTC")
+
+    @staticmethod
+    def currency_usdt() -> Currency:
+        return Currency.from_str("USDT")
+
+    @staticmethod
+    def currency_aud() -> Currency:
+        return Currency.from_str("AUD")
+
+    @staticmethod
+    def currency_gbp() -> Currency:
+        return Currency.from_str("GBP")
+
+    @staticmethod
+    def currency_eth() -> Currency:
+        return Currency.from_str("ETH")

--- a/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+
+from nautilus_trader.core.nautilus_pyo3.model import CryptoPerpetual
+from nautilus_trader.test_kit.rust.instruments import TestInstrumentProviderPyo3
+
+
+crypto_perpetual_ethusdt_perp = TestInstrumentProviderPyo3.ethusdt_perp_binance()
+
+
+class TestCryptoPerpetual:
+    def test_equality(self):
+        item_1 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
+        item_2 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
+        assert item_1 == item_2
+
+    def test_hash(self):
+        assert hash(crypto_perpetual_ethusdt_perp) == hash(crypto_perpetual_ethusdt_perp)
+
+    def test_to_dict(self):
+        dict = crypto_perpetual_ethusdt_perp.to_dict()
+        assert CryptoPerpetual.from_dict(dict) == crypto_perpetual_ethusdt_perp
+        assert dict == {
+            "type": "CryptoPerpetual",
+            "id": "ETHUSDT-PERP.BINANCE",
+            "raw_symbol": "ETHUSDT",
+            "base_currency": "ETH",
+            "quote_currency": "USDT",
+            "settlement_currency": "USDT",
+            "price_precision": 2,
+            "size_precision": 0,
+            "price_increment": "0.01",
+            "size_increment": "0.001",
+            "lot_size": None,
+            "max_quantity": "10000",
+            "min_quantity": "0.001",
+            "max_notional": None,
+            "min_notional": "10.00000000 USDT",
+            "max_price": "15000.0",
+            "min_price": "1.0",
+            "margin_maint": 0.0,
+            "margin_init": 0.0,
+            "maker_fee": 0.0,
+            "taker_fee": 0.0,
+        }


### PR DESCRIPTION
# Pull Request

- created `from_dict_pyo3` generic rust function, and attached it to `from_dict` function for reuse
- finished `CryptoPerpetual` struct and added proper `pymethods` so that it can be used in python
- created rust testkit for instruments type
- pyo3 tests for `CryptoPerpetual`
