### PR TITLE
data catalog: set the min_rows_per_goup when writing a parquet datase…

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -208,12 +208,14 @@ class ParquetDataCatalog(BaseDataCatalog):
             self._fast_write(table=table, path=path, fs=self.fs)
         else:
             # Write parquet file
+            min_max_rows_per_group = 5000
             pds.write_dataset(
                 data=table,
                 base_dir=path,
                 format="parquet",
                 filesystem=self.fs,
-                max_rows_per_group=5000,
+                min_rows_per_group=min_max_rows_per_group,
+                max_rows_per_group=min_max_rows_per_group,
                 **self.dataset_kwargs,
                 **kwargs,
             )

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -313,7 +313,7 @@ class TestPersistenceCatalog:
 
         # Assert
         assert result == ["abc"]
-    
+
     def test_partioning_min_rows_per_group(
         self,
         betfair_catalog: ParquetDataCatalog,
@@ -337,8 +337,8 @@ class TestPersistenceCatalog:
         )
         quote_ticks = []
 
-        # Num quotes needs to be not divisible by 5000 (default value for min_rows_per_group)
-        expected_num_quotes = 5500
+        # Num quotes needs to be less than 5000 (default value for min_rows_per_group)
+        expected_num_quotes = 100
 
         for _ in range(expected_num_quotes):
             quote_tick = QuoteTick(
@@ -351,11 +351,11 @@ class TestPersistenceCatalog:
                 ts_init=0,
             )
             quote_ticks.append(quote_tick)
-        
+
         # Act
         self.catalog.write_data(data=quote_ticks, partitioning=["ts_event"])
 
         result = len(self.catalog.quote_ticks())
-        
+
         # Assert
         assert result == expected_num_quotes

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -313,3 +313,49 @@ class TestPersistenceCatalog:
 
         # Assert
         assert result == ["abc"]
+    
+    def test_partioning_min_rows_per_group(
+        self,
+        betfair_catalog: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        instrument = Equity(
+            instrument_id=InstrumentId(symbol=Symbol("AAPL"), venue=Venue("NASDAQ")),
+            raw_symbol=Symbol("AAPL"),
+            currency=USD,
+            price_precision=2,
+            price_increment=Price.from_str("0.01"),
+            multiplier=Quantity.from_int(1),
+            lot_size=Quantity.from_int(1),
+            isin="US0378331005",
+            ts_event=0,
+            ts_init=0,
+            margin_init=Decimal("0.01"),
+            margin_maint=Decimal("0.005"),
+            maker_fee=Decimal("0.005"),
+            taker_fee=Decimal("0.01"),
+        )
+        quote_ticks = []
+
+        # Num quotes needs to be not divisible by 5000 (default value for min_rows_per_group)
+        expected_num_quotes = 5500
+
+        for _ in range(expected_num_quotes):
+            quote_tick = QuoteTick(
+                instrument_id=instrument.id,
+                bid_price=Price.from_str("2.1"),
+                ask_price=Price.from_str("2.0"),
+                bid_size=Quantity.from_int(10),
+                ask_size=Quantity.from_int(10),
+                ts_event=0,
+                ts_init=0,
+            )
+            quote_ticks.append(quote_tick)
+        
+        # Act
+        self.catalog.write_data(data=quote_ticks, partitioning=["ts_event"])
+
+        result = len(self.catalog.quote_ticks())
+        
+        # Assert
+        assert result == expected_num_quotes


### PR DESCRIPTION
…t to disk for improved IO performance. 

# Pull Request

Set the `min_rows_per_group` attribute when writing a parquet dataset, otherwise it could end up with very small row groups hurting IO performance. This is mentioned in the documentation at the `max_rows_per_group` attribute, and also confirmed by my local tests:
https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html

There is still room for improvement to process an iterator instead of a list to write datasets which do not fit in memory. Will leave that for later.

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Describe how this code was/is tested.
