### PR TITLE
data config: validate that the end time is set after the start time

### DIFF
--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -25,6 +25,7 @@ from nautilus_trader.config import BacktestDataConfig
 from nautilus_trader.config import BacktestRunConfig
 from nautilus_trader.config import BacktestVenueConfig
 from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.core.datetime import dt_to_unix_nanos
 from nautilus_trader.core.inspect import is_nautilus_class
 from nautilus_trader.core.nautilus_pyo3 import DataBackendSession
 from nautilus_trader.model.currency import Currency
@@ -152,14 +153,14 @@ class BacktestNode:
                 if data_config.instrument_id is None:
                     continue  # No instrument associated with data
 
-                if (
-                    data_config.start_time is not None
-                    and data_config.end_time is not None
-                    and data_config.end_time < data_config.start_time
-                ):
-                    raise ValueError(
-                        f"Invalid data config: end_time ({data_config.end_time}) is before start_time ({data_config.start_time})."
-                    )
+                if data_config.start_time is not None and data_config.end_time is not None:
+                    start = dt_to_unix_nanos(data_config.start_time)
+                    end = dt_to_unix_nanos(data_config.end_time)
+
+                    if end < start:
+                        raise ValueError(
+                            f"Invalid data config: end_time ({data_config.end_time}) is before start_time ({data_config.start_time}).",
+                        )
 
                 instrument_id: InstrumentId = InstrumentId.from_str(data_config.instrument_id)
                 if instrument_id.venue not in venue_ids:

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -151,6 +151,16 @@ class BacktestNode:
             for data_config in config.data:
                 if data_config.instrument_id is None:
                     continue  # No instrument associated with data
+
+                if (
+                    data_config.start_time is not None
+                    and data_config.end_time is not None
+                    and data_config.end_time < data_config.start_time
+                ):
+                    raise ValueError(
+                        f"Invalid data config: end_time ({data_config.end_time}) is before start_time ({data_config.start_time})."
+                    )
+
                 instrument_id: InstrumentId = InstrumentId.from_str(data_config.instrument_id)
                 if instrument_id.venue not in venue_ids:
                     raise ValueError(


### PR DESCRIPTION
# Pull Request

Validate that the end time is a timestamp larger than the start time when configuring a backtest with the `BacktestDataConfig`.

## Type of change

Delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

This throws an ValueError when running the code snippet of #1304. 
