### PR TITLE
Add OptionsContract in rust with pyo3

### DIFF
--- a/nautilus_core/model/src/instruments/options_contract.rs
+++ b/nautilus_core/model/src/instruments/options_contract.rs
@@ -17,11 +17,11 @@
 
 use std::hash::{Hash, Hasher};
 
+use anyhow::Result;
 use nautilus_core::time::UnixNanos;
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use anyhow::Result;
 
 use super::Instrument;
 use crate::{
@@ -209,28 +209,28 @@ impl Instrument for OptionsContract {
     }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Stubs
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
-pub mod stubs{
+pub mod stubs {
     use std::str::FromStr;
+
     use chrono::{TimeZone, Utc};
+    use nautilus_core::time::UnixNanos;
     use rstest::fixture;
     use rust_decimal::Decimal;
-    use nautilus_core::time::UnixNanos;
-    use crate::enums::{AssetClass, OptionKind};
-    use crate::identifiers::instrument_id::InstrumentId;
-    use crate::identifiers::symbol::Symbol;
-    use crate::instruments::options_contract::OptionsContract;
-    use crate::types::currency::Currency;
-    use crate::types::price::Price;
-    use crate::types::quantity::Quantity;
+
+    use crate::{
+        enums::{AssetClass, OptionKind},
+        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
+        instruments::options_contract::OptionsContract,
+        types::{currency::Currency, price::Price, quantity::Quantity},
+    };
 
     #[fixture]
-    pub fn options_contract_appl()-> OptionsContract{
-        let expiration = Utc.with_ymd_and_hms(2021,12,17,0,0,0).unwrap();
+    pub fn options_contract_appl() -> OptionsContract {
+        let expiration = Utc.with_ymd_and_hms(2021, 12, 17, 0, 0, 0).unwrap();
         OptionsContract::new(
             InstrumentId::from("AAPL211217C00150000.OPRA"),
             Symbol::from("AAPL211217C00150000"),
@@ -251,23 +251,23 @@ pub mod stubs{
             None,
             None,
             None,
-
-        ).unwrap()
+        )
+        .unwrap()
     }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
-mod tests{
+mod tests {
     use rstest::rstest;
-    use crate::instruments::options_contract::OptionsContract;
+
     use super::stubs::*;
+    use crate::instruments::options_contract::OptionsContract;
 
     #[rstest]
-    fn test_equality(options_contract_appl: OptionsContract){
+    fn test_equality(options_contract_appl: OptionsContract) {
         let options_contract_appl2 = options_contract_appl.clone();
         assert_eq!(options_contract_appl, options_contract_appl2);
     }

--- a/nautilus_core/model/src/instruments/options_contract.rs
+++ b/nautilus_core/model/src/instruments/options_contract.rs
@@ -21,6 +21,7 @@ use nautilus_core::time::UnixNanos;
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use anyhow::Result;
 
 use super::Instrument;
 use crate::{
@@ -46,19 +47,18 @@ pub struct OptionsContract {
     pub currency: Currency,
     pub price_precision: u8,
     pub price_increment: Price,
+    pub margin_init: Decimal,
+    pub margin_maint: Decimal,
+    pub maker_fee: Decimal,
+    pub taker_fee: Decimal,
     pub lot_size: Option<Quantity>,
     pub max_quantity: Option<Quantity>,
     pub min_quantity: Option<Quantity>,
     pub max_price: Option<Price>,
     pub min_price: Option<Price>,
-    pub margin_init: Decimal,
-    pub margin_maint: Decimal,
-    pub maker_fee: Decimal,
-    pub taker_fee: Decimal,
 }
 
 impl OptionsContract {
-    #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: InstrumentId,
@@ -71,17 +71,17 @@ impl OptionsContract {
         currency: Currency,
         price_precision: u8,
         price_increment: Price,
+        margin_init: Decimal,
+        margin_maint: Decimal,
+        maker_fee: Decimal,
+        taker_fee: Decimal,
         lot_size: Option<Quantity>,
         max_quantity: Option<Quantity>,
         min_quantity: Option<Quantity>,
         max_price: Option<Price>,
         min_price: Option<Price>,
-        margin_init: Decimal,
-        margin_maint: Decimal,
-        maker_fee: Decimal,
-        taker_fee: Decimal,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             id,
             raw_symbol,
             asset_class,
@@ -101,7 +101,7 @@ impl OptionsContract {
             margin_maint,
             maker_fee,
             taker_fee,
-        }
+        })
     }
 }
 
@@ -206,5 +206,69 @@ impl Instrument for OptionsContract {
 
     fn taker_fee(&self) -> Decimal {
         self.taker_fee
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Stubs
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+pub mod stubs{
+    use std::str::FromStr;
+    use chrono::{TimeZone, Utc};
+    use rstest::fixture;
+    use rust_decimal::Decimal;
+    use nautilus_core::time::UnixNanos;
+    use crate::enums::{AssetClass, OptionKind};
+    use crate::identifiers::instrument_id::InstrumentId;
+    use crate::identifiers::symbol::Symbol;
+    use crate::instruments::options_contract::OptionsContract;
+    use crate::types::currency::Currency;
+    use crate::types::price::Price;
+    use crate::types::quantity::Quantity;
+
+    #[fixture]
+    pub fn options_contract_appl()-> OptionsContract{
+        let expiration = Utc.with_ymd_and_hms(2021,12,17,0,0,0).unwrap();
+        OptionsContract::new(
+            InstrumentId::from("AAPL211217C00150000.OPRA"),
+            Symbol::from("AAPL211217C00150000"),
+            AssetClass::Equity,
+            String::from("AAPL"),
+            OptionKind::Call,
+            expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
+            Price::from("149.0"),
+            Currency::USD(),
+            2,
+            Price::from("0.01"),
+            Decimal::from_str("0.0").unwrap(),
+            Decimal::from_str("0.0").unwrap(),
+            Decimal::from_str("0.001").unwrap(),
+            Decimal::from_str("0.001").unwrap(),
+            Some(Quantity::from("1.0")),
+            None,
+            None,
+            None,
+            None,
+
+        ).unwrap()
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests{
+    use rstest::rstest;
+    use crate::instruments::options_contract::OptionsContract;
+    use super::stubs::*;
+
+    #[rstest]
+    fn test_equality(options_contract_appl: OptionsContract){
+        let options_contract_appl2 = options_contract_appl.clone();
+        assert_eq!(options_contract_appl, options_contract_appl2);
     }
 }

--- a/nautilus_core/model/src/python/instruments/options_contract.rs
+++ b/nautilus_core/model/src/python/instruments/options_contract.rs
@@ -13,7 +13,3 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod crypto_future;
-pub mod crypto_perpetual;
-pub mod currency_pair;
-pub mod options_contract;

--- a/nautilus_core/model/src/python/instruments/options_contract.rs
+++ b/nautilus_core/model/src/python/instruments/options_contract.rs
@@ -13,3 +13,131 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+use nautilus_core::{
+    python::{serialization::from_dict_pyo3, to_pyvalue_err},
+    time::UnixNanos,
+};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::{prelude::ToPrimitive, Decimal};
+
+use crate::{
+    enums::{AssetClass, OptionKind},
+    identifiers::{instrument_id::InstrumentId, symbol::Symbol},
+    instruments::options_contract::OptionsContract,
+    types::{currency::Currency, price::Price, quantity::Quantity},
+};
+
+#[pymethods]
+impl OptionsContract {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        asset_class: AssetClass,
+        underlying: String,
+        option_kind: OptionKind,
+        expiration: UnixNanos,
+        strike_price: Price,
+        currency: Currency,
+        price_precision: u8,
+        price_increment: Price,
+        margin_init: Decimal,
+        margin_maint: Decimal,
+        maker_fee: Decimal,
+        taker_fee: Decimal,
+        lot_size: Option<Quantity>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+    ) -> PyResult<Self> {
+        Self::new(
+            id,
+            raw_symbol,
+            asset_class,
+            underlying,
+            option_kind,
+            expiration,
+            strike_price,
+            currency,
+            price_precision,
+            price_increment,
+            margin_init,
+            margin_maint,
+            maker_fee,
+            taker_fee,
+            lot_size,
+            max_quantity,
+            min_quantity,
+            max_price,
+            min_price,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            _ => panic!("Not implemented"),
+        }
+    }
+
+    fn __hash__(&self) -> isize {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish() as isize
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("type", stringify!(OptionsContract))?;
+        dict.set_item("id", self.id.to_string())?;
+        dict.set_item("raw_symbol", self.raw_symbol.to_string())?;
+        dict.set_item("asset_class", self.asset_class.to_string())?;
+        dict.set_item("underlying", self.underlying.to_string())?;
+        dict.set_item("option_kind", self.option_kind.to_string())?;
+        dict.set_item("expiration", self.expiration.to_i64())?;
+        dict.set_item("strike_price", self.strike_price.to_string())?;
+        dict.set_item("currency", self.currency.code.to_string())?;
+        dict.set_item("price_precision", self.price_precision)?;
+        dict.set_item("price_increment", self.price_increment.to_string())?;
+        dict.set_item("margin_init", self.margin_init.to_f64())?;
+        dict.set_item("margin_maint", self.margin_maint.to_f64())?;
+        dict.set_item("maker_fee", self.maker_fee.to_f64())?;
+        dict.set_item("taker_fee", self.taker_fee.to_f64())?;
+        match self.lot_size {
+            Some(value) => dict.set_item("lot_size", value.to_string())?,
+            None => dict.set_item("lot_size", py.None())?,
+        }
+        match self.max_quantity {
+            Some(value) => dict.set_item("max_quantity", value.to_string())?,
+            None => dict.set_item("max_quantity", py.None())?,
+        }
+        match self.min_quantity {
+            Some(value) => dict.set_item("min_quantity", value.to_string())?,
+            None => dict.set_item("min_quantity", py.None())?,
+        }
+        match self.max_price {
+            Some(value) => dict.set_item("max_price", value.to_string())?,
+            None => dict.set_item("max_price", py.None())?,
+        }
+        match self.min_price {
+            Some(value) => dict.set_item("min_price", value.to_string())?,
+            None => dict.set_item("min_price", py.None())?,
+        }
+        Ok(dict.into())
+    }
+}

--- a/nautilus_trader/test_kit/rust/instruments.py
+++ b/nautilus_trader/test_kit/rust/instruments.py
@@ -18,11 +18,14 @@ from datetime import datetime
 import pandas as pd
 import pytz
 
+from nautilus_trader.core.nautilus_pyo3 import AssetClass
 from nautilus_trader.core.nautilus_pyo3 import CryptoFuture
 from nautilus_trader.core.nautilus_pyo3 import CryptoPerpetual
 from nautilus_trader.core.nautilus_pyo3 import CurrencyPair
 from nautilus_trader.core.nautilus_pyo3 import InstrumentId
 from nautilus_trader.core.nautilus_pyo3 import Money
+from nautilus_trader.core.nautilus_pyo3 import OptionKind
+from nautilus_trader.core.nautilus_pyo3 import OptionsContract
 from nautilus_trader.core.nautilus_pyo3 import Price
 from nautilus_trader.core.nautilus_pyo3 import Quantity
 from nautilus_trader.core.nautilus_pyo3 import Symbol
@@ -105,4 +108,27 @@ class TestInstrumentProviderPyo3:
             Quantity.from_str("0.00001"),
             Price.from_str("1000000"),
             Price.from_str("0.01"),
+        )
+
+    @staticmethod
+    def appl_option(expiry: pd.Timestamp | None = None) -> OptionsContract:
+        if expiry is None:
+            expiry = pd.Timestamp(datetime(2021, 12, 17), tz=pytz.UTC)
+            nanos_expiry = int(expiry.timestamp() * 1e9)
+        return OptionsContract(  # type: ignore
+            InstrumentId.from_str("AAPL211217C00150000.OPRA"),
+            Symbol("AAPL211217C00150000"),
+            AssetClass.EQUITY,
+            "AAPL",
+            OptionKind.CALL,
+            nanos_expiry,
+            Price.from_str("149.0"),
+            TestTypesProviderPyo3.currency_usdt(),
+            2,
+            Price.from_str("0.01"),
+            0.0,
+            0.0,
+            0.001,
+            0.001,
+            Quantity.from_str("1.0"),
         )

--- a/nautilus_trader/test_kit/rust/types.py
+++ b/nautilus_trader/test_kit/rust/types.py
@@ -26,6 +26,10 @@ class TestTypesProviderPyo3:
         return Currency.from_str("USDT")
 
     @staticmethod
+    def currency_usd() -> Currency:
+        return Currency.from_str("USD")
+
+    @staticmethod
     def currency_aud() -> Currency:
         return Currency.from_str("AUD")
 

--- a/tests/unit_tests/model/instruments/test_crypto_future_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_crypto_future_pyo3.py
@@ -20,39 +20,40 @@ from nautilus_trader.test_kit.rust.instruments import TestInstrumentProviderPyo3
 crypto_future_btcusdt = TestInstrumentProviderPyo3.btcusdt_future_binance()
 
 
-class TestCryptoFuturePyo3:
-    def test_equality(self):
-        item_1 = TestInstrumentProviderPyo3.btcusdt_future_binance()
-        item_2 = TestInstrumentProviderPyo3.btcusdt_future_binance()
-        assert item_1 == item_2
+def test_equality():
+    item_1 = TestInstrumentProviderPyo3.btcusdt_future_binance()
+    item_2 = TestInstrumentProviderPyo3.btcusdt_future_binance()
+    assert item_1 == item_2
 
-    def test_hash(self):
-        assert hash(crypto_future_btcusdt) == hash(crypto_future_btcusdt)
 
-    def test_to_dict(self):
-        result = crypto_future_btcusdt.to_dict()
-        assert CryptoFuture.from_dict(result) == crypto_future_btcusdt
-        assert result == {
-            "type": "CryptoPerpetual",
-            "id": "BTCUSDT_220325.BINANCE",
-            "raw_symbol": "BTCUSDT",
-            "underlying": "BTC",
-            "quote_currency": "USDT",
-            "settlement_currency": "USDT",
-            "expiration": 1648166400000000000,
-            "price_precision": 2,
-            "size_precision": 6,
-            "price_increment": "0.01",
-            "size_increment": "0.000001",
-            "margin_maint": 0.0,
-            "margin_init": 0.0,
-            "maker_fee": 0.0,
-            "taker_fee": 0.0,
-            "lot_size": None,
-            "max_notional": None,
-            "max_price": "1000000.0",
-            "max_quantity": "9000",
-            "min_notional": "10.00000000 USDT",
-            "min_price": "0.01",
-            "min_quantity": "0.00001",
-        }
+def test_hash():
+    assert hash(crypto_future_btcusdt) == hash(crypto_future_btcusdt)
+
+
+def test_to_dict():
+    result = crypto_future_btcusdt.to_dict()
+    assert CryptoFuture.from_dict(result) == crypto_future_btcusdt
+    assert result == {
+        "type": "CryptoPerpetual",
+        "id": "BTCUSDT_220325.BINANCE",
+        "raw_symbol": "BTCUSDT",
+        "underlying": "BTC",
+        "quote_currency": "USDT",
+        "settlement_currency": "USDT",
+        "expiration": 1648166400000000000,
+        "price_precision": 2,
+        "size_precision": 6,
+        "price_increment": "0.01",
+        "size_increment": "0.000001",
+        "margin_maint": 0.0,
+        "margin_init": 0.0,
+        "maker_fee": 0.0,
+        "taker_fee": 0.0,
+        "lot_size": None,
+        "max_notional": None,
+        "max_price": "1000000.0",
+        "max_quantity": "9000",
+        "min_notional": "10.00000000 USDT",
+        "min_price": "0.01",
+        "min_quantity": "0.00001",
+    }

--- a/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
@@ -20,38 +20,39 @@ from nautilus_trader.test_kit.rust.instruments import TestInstrumentProviderPyo3
 crypto_perpetual_ethusdt_perp = TestInstrumentProviderPyo3.ethusdt_perp_binance()
 
 
-class TestCryptoPerpetualPyo3:
-    def test_equality(self):
-        item_1 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
-        item_2 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
-        assert item_1 == item_2
+def test_equality():
+    item_1 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
+    item_2 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
+    assert item_1 == item_2
 
-    def test_hash(self):
-        assert hash(crypto_perpetual_ethusdt_perp) == hash(crypto_perpetual_ethusdt_perp)
 
-    def test_to_dict(self):
-        dict = crypto_perpetual_ethusdt_perp.to_dict()
-        assert CryptoPerpetual.from_dict(dict) == crypto_perpetual_ethusdt_perp
-        assert dict == {
-            "type": "CryptoPerpetual",
-            "id": "ETHUSDT-PERP.BINANCE",
-            "raw_symbol": "ETHUSDT",
-            "base_currency": "ETH",
-            "quote_currency": "USDT",
-            "settlement_currency": "USDT",
-            "price_precision": 2,
-            "size_precision": 0,
-            "price_increment": "0.01",
-            "size_increment": "0.001",
-            "lot_size": None,
-            "max_quantity": "10000",
-            "min_quantity": "0.001",
-            "max_notional": None,
-            "min_notional": "10.00000000 USDT",
-            "max_price": "15000.0",
-            "min_price": "1.0",
-            "margin_maint": 0.0,
-            "margin_init": 0.0,
-            "maker_fee": 0.0,
-            "taker_fee": 0.0,
-        }
+def test_hash():
+    assert hash(crypto_perpetual_ethusdt_perp) == hash(crypto_perpetual_ethusdt_perp)
+
+
+def test_to_dict():
+    dict = crypto_perpetual_ethusdt_perp.to_dict()
+    assert CryptoPerpetual.from_dict(dict) == crypto_perpetual_ethusdt_perp
+    assert dict == {
+        "type": "CryptoPerpetual",
+        "id": "ETHUSDT-PERP.BINANCE",
+        "raw_symbol": "ETHUSDT",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "settlement_currency": "USDT",
+        "price_precision": 2,
+        "size_precision": 0,
+        "price_increment": "0.01",
+        "size_increment": "0.001",
+        "lot_size": None,
+        "max_quantity": "10000",
+        "min_quantity": "0.001",
+        "max_notional": None,
+        "min_notional": "10.00000000 USDT",
+        "max_price": "15000.0",
+        "min_price": "1.0",
+        "margin_maint": 0.0,
+        "margin_init": 0.0,
+        "maker_fee": 0.0,
+        "taker_fee": 0.0,
+    }

--- a/tests/unit_tests/model/instruments/test_currency_pair_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_currency_pair_pyo3.py
@@ -20,35 +20,36 @@ from nautilus_trader.test_kit.rust.instruments import TestInstrumentProviderPyo3
 btcusdt_binance = TestInstrumentProviderPyo3.btcusdt_binance()
 
 
-class TestCurrencyPairPyo3:
-    def test_equality(self):
-        item_1 = TestInstrumentProviderPyo3.btcusdt_binance()
-        item_2 = TestInstrumentProviderPyo3.btcusdt_binance()
-        assert item_1 == item_2
+def test_equality():
+    item_1 = TestInstrumentProviderPyo3.btcusdt_binance()
+    item_2 = TestInstrumentProviderPyo3.btcusdt_binance()
+    assert item_1 == item_2
 
-    def test_hash(self):
-        assert hash(btcusdt_binance) == hash(btcusdt_binance)
 
-    def test_to_dict(self):
-        dict = btcusdt_binance.to_dict()
-        assert CurrencyPair.from_dict(dict) == btcusdt_binance
-        assert dict == {
-            "type": "CurrencyPair",
-            "id": "BTCUSDT.BINANCE",
-            "raw_symbol": "BTCUSDT",
-            "base_currency": "BTC",
-            "quote_currency": "USDT",
-            "price_precision": 2,
-            "size_precision": 6,
-            "price_increment": "0.01",
-            "size_increment": "0.000001",
-            "margin_maint": 0.0,
-            "margin_init": 0.0,
-            "maker_fee": 0.0,
-            "taker_fee": 0.0,
-            "lot_size": None,
-            "max_quantity": "9000",
-            "min_quantity": "0.00001",
-            "min_price": "0.01",
-            "max_price": "1000000",
-        }
+def test_hash():
+    assert hash(btcusdt_binance) == hash(btcusdt_binance)
+
+
+def test_to_dict():
+    dict = btcusdt_binance.to_dict()
+    assert CurrencyPair.from_dict(dict) == btcusdt_binance
+    assert dict == {
+        "type": "CurrencyPair",
+        "id": "BTCUSDT.BINANCE",
+        "raw_symbol": "BTCUSDT",
+        "base_currency": "BTC",
+        "quote_currency": "USDT",
+        "price_precision": 2,
+        "size_precision": 6,
+        "price_increment": "0.01",
+        "size_increment": "0.000001",
+        "margin_maint": 0.0,
+        "margin_init": 0.0,
+        "maker_fee": 0.0,
+        "taker_fee": 0.0,
+        "lot_size": None,
+        "max_quantity": "9000",
+        "min_quantity": "0.00001",
+        "min_price": "0.01",
+        "max_price": "1000000",
+    }

--- a/tests/unit_tests/model/instruments/test_options_contract_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_options_contract_pyo3.py
@@ -1,0 +1,57 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.core.nautilus_pyo3 import OptionsContract
+from nautilus_trader.test_kit.rust.instruments import TestInstrumentProviderPyo3
+
+
+aapl_option = TestInstrumentProviderPyo3.appl_option()
+
+
+def test_equality():
+    item_1 = TestInstrumentProviderPyo3.appl_option()
+    item_2 = TestInstrumentProviderPyo3.appl_option()
+    assert item_1 == item_2
+
+
+def test_hash():
+    assert hash(aapl_option) == hash(aapl_option)
+
+
+def test_to_dict():
+    dict = aapl_option.to_dict()
+    assert OptionsContract.from_dict(dict) == aapl_option
+    assert dict == {
+        "type": "OptionsContract",
+        "id": "AAPL211217C00150000.OPRA",
+        "raw_symbol": "AAPL211217C00150000",
+        "asset_class": "EQUITY",
+        "underlying": "AAPL",
+        "option_kind": "CALL",
+        "expiration": 1639699200000000000,
+        "strike_price": "149.0",
+        "currency": "USDT",
+        "price_precision": 2,
+        "price_increment": "0.01",
+        "margin_init": 0.0,
+        "margin_maint": 0.0,
+        "maker_fee": 0.001,
+        "taker_fee": 0.001,
+        "lot_size": "1.0",
+        "max_quantity": None,
+        "min_quantity": None,
+        "max_price": None,
+        "min_price": None,
+    }


### PR DESCRIPTION
# Pull Request

- existing Python pyo3 tests for instruments refactoring for function based tests
- struct `OptionsContract` with pymethods and pyo3 python tests