### PR TITLE
Refactoring stub data model for identifiers

### DIFF
--- a/nautilus_core/model/src/ffi/identifiers/client_id.rs
+++ b/nautilus_core/model/src/ffi/identifiers/client_id.rs
@@ -44,7 +44,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::identifiers::client_id::stubs::{client_id_binance, client_id_dydx};
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_client_id_to_cstr_c() {

--- a/nautilus_core/model/src/ffi/identifiers/instrument_id.rs
+++ b/nautilus_core/model/src/ffi/identifiers/instrument_id.rs
@@ -76,11 +76,7 @@ pub mod stubs {
 
     use rstest::fixture;
 
-    use crate::identifiers::{
-        instrument_id::InstrumentId,
-        symbol::{stubs::*, Symbol},
-        venue::{stubs::*, Venue},
-    };
+    use crate::identifiers::{instrument_id::InstrumentId, stubs::*, symbol::Symbol, venue::Venue};
 
     #[fixture]
     pub fn btc_usdt_perp_binance() -> InstrumentId {
@@ -88,10 +84,10 @@ pub mod stubs {
     }
 
     #[fixture]
-    pub fn audusd_sim(aud_usd: Symbol, sim: Venue) -> InstrumentId {
+    pub fn audusd_sim(symbol_aud_usd: Symbol, venue_sim: Venue) -> InstrumentId {
         InstrumentId {
-            symbol: aud_usd,
-            venue: sim,
+            symbol: symbol_aud_usd,
+            venue: venue_sim,
         }
     }
 }

--- a/nautilus_core/model/src/identifiers/account_id.rs
+++ b/nautilus_core/model/src/identifiers/account_id.rs
@@ -78,33 +78,14 @@ impl From<&str> for AccountId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use super::*;
-
-    #[fixture]
-    pub fn account_id() -> AccountId {
-        AccountId::from("SIM-001")
-    }
-
-    #[fixture]
-    pub fn account_ib() -> AccountId {
-        AccountId::from("IB-1234567890")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, *};
+    use super::*;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_account_id_new_invalid_string() {

--- a/nautilus_core/model/src/identifiers/client_id.rs
+++ b/nautilus_core/model/src/identifiers/client_id.rs
@@ -63,33 +63,14 @@ impl From<&str> for ClientId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::client_id::ClientId;
-
-    #[fixture]
-    pub fn client_id_binance() -> ClientId {
-        ClientId::from("BINANCE")
-    }
-
-    #[fixture]
-    pub fn client_id_dydx() -> ClientId {
-        ClientId::from("COINBASE")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, *};
+    use super::*;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_string_reprs(client_id_binance: ClientId) {

--- a/nautilus_core/model/src/identifiers/client_order_id.rs
+++ b/nautilus_core/model/src/identifiers/client_order_id.rs
@@ -92,21 +92,6 @@ impl From<&str> for ClientOrderId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::client_order_id::ClientOrderId;
-
-    #[fixture]
-    pub fn client_order_id() -> ClientOrderId {
-        ClientOrderId::from("O-20200814-102234-001-001-1")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
@@ -114,9 +99,12 @@ mod tests {
     use rstest::rstest;
     use ustr::Ustr;
 
-    use super::{stubs::*, ClientOrderId};
-    use crate::identifiers::client_order_id::{
-        optional_ustr_to_vec_client_order_ids, optional_vec_client_order_ids_to_ustr,
+    use super::ClientOrderId;
+    use crate::identifiers::{
+        client_order_id::{
+            optional_ustr_to_vec_client_order_ids, optional_vec_client_order_ids_to_ustr,
+        },
+        stubs::*,
     };
 
     #[rstest]

--- a/nautilus_core/model/src/identifiers/component_id.rs
+++ b/nautilus_core/model/src/identifiers/component_id.rs
@@ -63,28 +63,14 @@ impl From<&str> for ComponentId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::component_id::ComponentId;
-
-    #[fixture]
-    pub fn component_risk_engine() -> ComponentId {
-        ComponentId::from("RiskEngine")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, ComponentId};
+    use super::ComponentId;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_string_reprs(component_risk_engine: ComponentId) {

--- a/nautilus_core/model/src/identifiers/exec_algorithm_id.rs
+++ b/nautilus_core/model/src/identifiers/exec_algorithm_id.rs
@@ -63,28 +63,14 @@ impl From<&str> for ExecAlgorithmId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use super::ExecAlgorithmId;
-
-    #[fixture]
-    pub fn exec_algorithm_id() -> ExecAlgorithmId {
-        ExecAlgorithmId::from("001")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, ExecAlgorithmId};
+    use super::*;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_string_reprs(exec_algorithm_id: ExecAlgorithmId) {

--- a/nautilus_core/model/src/identifiers/instrument_id.rs
+++ b/nautilus_core/model/src/identifiers/instrument_id.rs
@@ -123,12 +123,12 @@ mod tests {
     use rstest::rstest;
 
     use super::InstrumentId;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
-    fn test_instrument_id_parse_success() {
-        let instrument_id = InstrumentId::from("ETH/USDT.BINANCE");
-        assert_eq!(instrument_id.symbol.to_string(), "ETH/USDT");
-        assert_eq!(instrument_id.venue.to_string(), "BINANCE");
+    fn test_instrument_id_parse_success(instrument_id_eth_usdt_binance: InstrumentId) {
+        assert_eq!(instrument_id_eth_usdt_binance.symbol.to_string(), "ETHUSDT");
+        assert_eq!(instrument_id_eth_usdt_binance.venue.to_string(), "BINANCE");
     }
 
     #[rstest]

--- a/nautilus_core/model/src/identifiers/mod.rs
+++ b/nautilus_core/model/src/identifiers/mod.rs
@@ -44,6 +44,9 @@ pub mod trader_id;
 pub mod venue;
 pub mod venue_order_id;
 
+#[cfg(test)]
+pub mod stubs;
+
 impl_from_str_for_identifier!(account_id::AccountId);
 impl_from_str_for_identifier!(client_id::ClientId);
 impl_from_str_for_identifier!(client_order_id::ClientOrderId);

--- a/nautilus_core/model/src/identifiers/order_list_id.rs
+++ b/nautilus_core/model/src/identifiers/order_list_id.rs
@@ -63,32 +63,18 @@ impl From<&str> for OrderListId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::order_list_id::OrderListId;
-
-    #[fixture]
-    pub fn test_order_list_id() -> OrderListId {
-        OrderListId::from("001")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, OrderListId};
+    use super::*;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
-    fn test_string_reprs(test_order_list_id: OrderListId) {
-        assert_eq!(test_order_list_id.to_string(), "001");
-        assert_eq!(format!("{test_order_list_id}"), "001");
+    fn test_string_reprs(order_list_id_test: OrderListId) {
+        assert_eq!(order_list_id_test.to_string(), "001");
+        assert_eq!(format!("{order_list_id_test}"), "001");
     }
 }

--- a/nautilus_core/model/src/identifiers/position_id.rs
+++ b/nautilus_core/model/src/identifiers/position_id.rs
@@ -70,21 +70,6 @@ impl From<&str> for PositionId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::position_id::PositionId;
-
-    #[fixture]
-    pub fn test_position_id() -> PositionId {
-        PositionId::from("P-123456789")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
@@ -92,11 +77,11 @@ mod tests {
     use rstest::rstest;
 
     use super::PositionId;
-    use crate::identifiers::position_id::stubs::test_position_id;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
-    fn test_string_reprs(test_position_id: PositionId) {
-        assert_eq!(test_position_id.to_string(), "P-123456789");
-        assert_eq!(format!("{test_position_id}"), "P-123456789");
+    fn test_string_reprs(position_id_test: PositionId) {
+        assert_eq!(position_id_test.to_string(), "P-123456789");
+        assert_eq!(format!("{position_id_test}"), "P-123456789");
     }
 }

--- a/nautilus_core/model/src/identifiers/strategy_id.rs
+++ b/nautilus_core/model/src/identifiers/strategy_id.rs
@@ -80,21 +80,6 @@ impl From<&str> for StrategyId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::strategy_id::StrategyId;
-
-    #[fixture]
-    pub fn strategy_id_ema_cross() -> StrategyId {
-        StrategyId::from("EMACross-001")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
@@ -102,7 +87,7 @@ mod tests {
     use rstest::rstest;
 
     use super::StrategyId;
-    use crate::identifiers::strategy_id::stubs::strategy_id_ema_cross;
+    use crate::identifiers::stubs::*;
 
     #[rstest]
     fn test_string_reprs(strategy_id_ema_cross: StrategyId) {

--- a/nautilus_core/model/src/identifiers/stubs.rs
+++ b/nautilus_core/model/src/identifiers/stubs.rs
@@ -1,0 +1,144 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use rstest::fixture;
+
+use crate::identifiers::{
+    account_id::AccountId, client_id::ClientId, client_order_id::ClientOrderId,
+    component_id::ComponentId, exec_algorithm_id::ExecAlgorithmId, instrument_id::InstrumentId,
+    order_list_id::OrderListId, position_id::PositionId, strategy_id::StrategyId, symbol::Symbol,
+    trade_id::TradeId, trader_id::TraderId, venue::Venue, venue_order_id::VenueOrderId,
+};
+
+// ---- AccountId ----
+
+#[fixture]
+pub fn account_id() -> AccountId {
+    AccountId::from("SIM-001")
+}
+
+#[fixture]
+pub fn account_ib() -> AccountId {
+    AccountId::from("IB-1234567890")
+}
+
+// ---- ClientId ----
+
+#[fixture]
+pub fn client_id_binance() -> ClientId {
+    ClientId::from("BINANCE")
+}
+
+#[fixture]
+pub fn client_id_dydx() -> ClientId {
+    ClientId::from("COINBASE")
+}
+
+// ---- ClientOrderId ----
+
+#[fixture]
+pub fn client_order_id() -> ClientOrderId {
+    ClientOrderId::from("O-20200814-102234-001-001-1")
+}
+
+// ---- ComponentId ----
+
+#[fixture]
+pub fn component_risk_engine() -> ComponentId {
+    ComponentId::from("RiskEngine")
+}
+
+// ---- ExecAlgorithmId ----
+
+#[fixture]
+pub fn exec_algorithm_id() -> ExecAlgorithmId {
+    ExecAlgorithmId::from("001")
+}
+
+// ---- InstrumentId ----
+
+#[fixture]
+pub fn instrument_id_eth_usdt_binance() -> InstrumentId {
+    InstrumentId::from("ETHUSDT.BINANCE")
+}
+
+#[fixture]
+pub fn instrument_id_btc_usdt() -> InstrumentId {
+    InstrumentId::from("BTCUSDT.COINBASE")
+}
+
+// ---- OrderListId ----
+
+#[fixture]
+pub fn order_list_id_test() -> OrderListId {
+    OrderListId::from("001")
+}
+
+// ---- PositionId ----
+
+#[fixture]
+pub fn position_id_test() -> PositionId {
+    PositionId::from("P-123456789")
+}
+
+// ---- StrategyId ----
+
+#[fixture]
+pub fn strategy_id_ema_cross() -> StrategyId {
+    StrategyId::from("EMACross-001")
+}
+
+// ---- Symbol ----
+
+#[fixture]
+pub fn symbol_eth_perp() -> Symbol {
+    Symbol::from("ETH-PERP")
+}
+
+#[fixture]
+pub fn symbol_aud_usd() -> Symbol {
+    Symbol::from("AUDUSD")
+}
+
+// ---- TradeId ----
+
+#[fixture]
+pub fn test_trade_id() -> TradeId {
+    TradeId::from("1234567890")
+}
+
+// ---- TraderId ----
+#[fixture]
+pub fn trader_test() -> TraderId {
+    TraderId::from("TRADER-001")
+}
+
+// ---- Venue ----
+
+#[fixture]
+pub fn venue_binance() -> Venue {
+    Venue::from("BINANCE")
+}
+
+#[fixture]
+pub fn venue_sim() -> Venue {
+    Venue::from("SIM")
+}
+
+// ---- VenueOrderId ----
+#[fixture]
+pub fn venue_order_id() -> VenueOrderId {
+    VenueOrderId::from("001")
+}

--- a/nautilus_core/model/src/identifiers/symbol.rs
+++ b/nautilus_core/model/src/identifiers/symbol.rs
@@ -71,37 +71,17 @@ impl From<&str> for Symbol {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::symbol::Symbol;
-
-    #[fixture]
-    pub fn eth_perp() -> Symbol {
-        Symbol::from("ETH-PERP")
-    }
-
-    #[fixture]
-    pub fn aud_usd() -> Symbol {
-        Symbol::from("AUDUSD")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, Symbol};
+    use crate::identifiers::{stubs::*, symbol::Symbol};
 
     #[rstest]
-    fn test_string_reprs(eth_perp: Symbol) {
-        assert_eq!(eth_perp.to_string(), "ETH-PERP");
-        assert_eq!(format!("{eth_perp}"), "ETH-PERP");
+    fn test_string_reprs(symbol_eth_perp: Symbol) {
+        assert_eq!(symbol_eth_perp.to_string(), "ETH-PERP");
+        assert_eq!(format!("{symbol_eth_perp}"), "ETH-PERP");
     }
 }

--- a/nautilus_core/model/src/identifiers/trade_id.rs
+++ b/nautilus_core/model/src/identifiers/trade_id.rs
@@ -76,28 +76,13 @@ impl From<&str> for TradeId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::trade_id::TradeId;
-
-    #[fixture]
-    pub fn test_trade_id() -> TradeId {
-        TradeId::from("1234567890")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, TradeId};
+    use crate::identifiers::{stubs::*, trade_id::TradeId};
 
     #[rstest]
     fn test_string_reprs(test_trade_id: TradeId) {

--- a/nautilus_core/model/src/identifiers/trader_id.rs
+++ b/nautilus_core/model/src/identifiers/trader_id.rs
@@ -78,32 +78,17 @@ impl From<&str> for TraderId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::trader_id::TraderId;
-
-    #[fixture]
-    pub fn test_trader() -> TraderId {
-        TraderId::from("TRADER-001")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, TraderId};
+    use crate::identifiers::{stubs::*, trader_id::TraderId};
 
     #[rstest]
-    fn test_string_reprs(test_trader: TraderId) {
-        assert_eq!(test_trader.to_string(), "TRADER-001");
-        assert_eq!(format!("{test_trader}"), "TRADER-001");
+    fn test_string_reprs(trader_test: TraderId) {
+        assert_eq!(trader_test.to_string(), "TRADER-001");
+        assert_eq!(format!("{trader_test}"), "TRADER-001");
     }
 }

--- a/nautilus_core/model/src/identifiers/venue.rs
+++ b/nautilus_core/model/src/identifiers/venue.rs
@@ -83,36 +83,17 @@ impl From<&str> for Venue {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::venue::Venue;
-
-    #[fixture]
-    pub fn binance() -> Venue {
-        Venue::from("BINANCE")
-    }
-    #[fixture]
-    pub fn sim() -> Venue {
-        Venue::from("SIM")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{stubs::*, Venue};
+    use crate::identifiers::{stubs::*, venue::Venue};
 
     #[rstest]
-    fn test_string_reprs(binance: Venue) {
-        assert_eq!(binance.to_string(), "BINANCE");
-        assert_eq!(format!("{binance}"), "BINANCE");
+    fn test_string_reprs(venue_binance: Venue) {
+        assert_eq!(venue_binance.to_string(), "BINANCE");
+        assert_eq!(format!("{venue_binance}"), "BINANCE");
     }
 }

--- a/nautilus_core/model/src/identifiers/venue_order_id.rs
+++ b/nautilus_core/model/src/identifiers/venue_order_id.rs
@@ -71,33 +71,17 @@ impl From<&str> for VenueOrderId {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use rstest::fixture;
-
-    use crate::identifiers::venue_order_id::VenueOrderId;
-
-    #[fixture]
-    pub fn venue_order_id() -> VenueOrderId {
-        VenueOrderId::from("001")
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs;
+    use crate::identifiers::{stubs::*, venue_order_id::VenueOrderId};
 
     #[rstest]
-    fn test_string_reprs() {
-        let id = stubs::venue_order_id();
-        assert_eq!(id.to_string(), "001");
-        assert_eq!(format!("{id}"), "001");
+    fn test_string_reprs(venue_order_id: VenueOrderId) {
+        assert_eq!(venue_order_id.to_string(), "001");
+        assert_eq!(format!("{venue_order_id}"), "001");
     }
 }


### PR DESCRIPTION
# Pull Request

- moved all stub data for `identifiers` to its own file `stub.rs`
- its better if they are all in one file, then its will be easier to import them across other modules with `use crate::identifiers::stubs::*;
`
