### PR TITLE
Implement ClientOrderIdGenerator in rust

### DIFF
--- a/nautilus_core/common/src/clock.rs
+++ b/nautilus_core/common/src/clock.rs
@@ -88,7 +88,6 @@ impl Default for MonotonicClock {
 /// # Notes
 /// An active timer is one which has not expired (`timer.is_expired == False`).
 pub trait Clock {
-
     /// Return the current UNIX time in seconds.
     fn timestamp(&mut self) -> f64;
 
@@ -222,8 +221,6 @@ impl Default for TestClock {
 }
 
 impl Clock for TestClock {
-
-
     fn timestamp(&mut self) -> f64 {
         nanos_to_secs(self.time_ns)
     }
@@ -345,8 +342,7 @@ pub struct LiveClock {
     callbacks_py: HashMap<String, PyObject>,
 }
 
-impl LiveClock{
-
+impl LiveClock {
     pub fn new() -> Self {
         Self {
             internal: MonotonicClock::default(),
@@ -366,8 +362,6 @@ impl Default for LiveClock {
 }
 
 impl Clock for LiveClock {
-
-
     fn timestamp(&mut self) -> f64 {
         self.internal.unix_timestamp_secs()
     }

--- a/nautilus_core/common/src/clock.rs
+++ b/nautilus_core/common/src/clock.rs
@@ -88,8 +88,6 @@ impl Default for MonotonicClock {
 /// # Notes
 /// An active timer is one which has not expired (`timer.is_expired == False`).
 pub trait Clock {
-    /// Return a new [Clock].
-    fn new() -> Self;
 
     /// Return the current UNIX time in seconds.
     fn timestamp(&mut self) -> f64;
@@ -151,6 +149,17 @@ pub struct TestClock {
 }
 
 impl TestClock {
+    pub fn new() -> Self {
+        Self {
+            time_ns: 0,
+            timers: HashMap::new(),
+            default_callback: None,
+            default_callback_py: None,
+            _callbacks: HashMap::new(), // TBC
+            callbacks_py: HashMap::new(),
+        }
+    }
+
     #[must_use]
     pub fn get_timers(&self) -> &HashMap<String, TestTimer> {
         &self.timers
@@ -206,17 +215,14 @@ impl TestClock {
     }
 }
 
-impl Clock for TestClock {
-    fn new() -> Self {
-        Self {
-            time_ns: 0,
-            timers: HashMap::new(),
-            default_callback: None,
-            default_callback_py: None,
-            _callbacks: HashMap::new(), // TBC
-            callbacks_py: HashMap::new(),
-        }
+impl Default for TestClock {
+    fn default() -> Self {
+        Self::new()
     }
+}
+
+impl Clock for TestClock {
+
 
     fn timestamp(&mut self) -> f64 {
         nanos_to_secs(self.time_ns)
@@ -339,8 +345,9 @@ pub struct LiveClock {
     callbacks_py: HashMap<String, PyObject>,
 }
 
-impl Clock for LiveClock {
-    fn new() -> Self {
+impl LiveClock{
+
+    pub fn new() -> Self {
         Self {
             internal: MonotonicClock::default(),
             timers: HashMap::new(),
@@ -350,6 +357,16 @@ impl Clock for LiveClock {
             callbacks_py: HashMap::new(),
         }
     }
+}
+
+impl Default for LiveClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for LiveClock {
+
 
     fn timestamp(&mut self) -> f64 {
         self.internal.unix_timestamp_secs()

--- a/nautilus_core/common/src/generators/client_order_id.rs
+++ b/nautilus_core/common/src/generators/client_order_id.rs
@@ -28,32 +28,37 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-
-use crate::generators::IdentifierGenerator;
 use std::sync::{Arc, Mutex};
+
 use chrono::{Datelike, NaiveDateTime, Timelike};
-use nautilus_model::identifiers::client_order_id::ClientOrderId;
-use nautilus_model::identifiers::strategy_id::StrategyId;
-use nautilus_model::identifiers::trader_id::TraderId;
-use crate::clock::{Clock};
+use nautilus_model::identifiers::{
+    client_order_id::ClientOrderId, strategy_id::StrategyId, trader_id::TraderId,
+};
+
+use crate::{clock::Clock, generators::IdentifierGenerator};
 
 #[derive()]
 #[repr(C)]
-pub struct ClientOrderIdGenerator{
+pub struct ClientOrderIdGenerator {
     trader_id: TraderId,
     strategy_id: StrategyId,
     clock: Box<dyn Clock>,
-    count: Arc<Mutex<usize>>
+    count: Arc<Mutex<usize>>,
 }
 
 impl ClientOrderIdGenerator {
-    pub fn new(trader_id: TraderId, strategy_id: StrategyId, clock: Box<dyn Clock>, initial_count: Option<usize>) -> Self {
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        clock: Box<dyn Clock>,
+        initial_count: Option<usize>,
+    ) -> Self {
         let count = Arc::new(Mutex::new(initial_count.unwrap_or(0)));
         Self {
             trader_id,
             strategy_id,
             clock,
-            count
+            count,
         }
     }
 }
@@ -72,22 +77,31 @@ impl IdentifierGenerator<ClientOrderId> for ClientOrderIdGenerator {
         let c = self.count.lock().unwrap();
         *c
     }
-    fn generate(&mut self) -> ClientOrderId{
+    fn generate(&mut self) -> ClientOrderId {
         let datetime_tag = self.get_datetime_tag();
         let trader_tag = self.trader_id.get_tag();
         let strategy_tag = self.strategy_id.get_tag();
         let mut c = self.count.lock().unwrap();
         *c += 1;
         let current_count = *c;
-        let id = format!("O-{}-{}-{}-{}", datetime_tag,trader_tag, strategy_tag, current_count);
-        let client_order_id = ClientOrderId::new(&id).unwrap();
-        client_order_id
+        let id = format!(
+            "O-{}-{}-{}-{}",
+            datetime_tag, trader_tag, strategy_tag, current_count
+        );
+        ClientOrderId::new(&id).unwrap()
     }
 
     fn get_datetime_tag(&mut self) -> String {
         let millis = self.clock.timestamp_ms() as i64;
         let now_utc = NaiveDateTime::from_timestamp_millis(millis).unwrap();
-        format!("{}{:02}{:02}-{:02}{:02}", now_utc.year(), now_utc.month(), now_utc.day(), now_utc.hour(), now_utc.minute())
+        format!(
+            "{}{:02}{:02}-{:02}{:02}",
+            now_utc.year(),
+            now_utc.month(),
+            now_utc.day(),
+            now_utc.hour(),
+            now_utc.minute()
+        )
     }
 }
 
@@ -95,44 +109,43 @@ impl IdentifierGenerator<ClientOrderId> for ClientOrderIdGenerator {
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
-mod tests{
+mod tests {
+    use nautilus_model::identifiers::{
+        client_order_id::ClientOrderId, strategy_id::StrategyId, trader_id::TraderId,
+    };
     use rstest::rstest;
-    use nautilus_model::identifiers::client_order_id::ClientOrderId;
-    use nautilus_model::identifiers::strategy_id::StrategyId;
-    use crate::generators::client_order_id::ClientOrderIdGenerator;
-    use nautilus_model::identifiers::trader_id::TraderId;
-    use crate::clock::{TestClock};
-    use crate::generators::IdentifierGenerator;
 
-    fn get_client_order_id_generator(
-        initial_count: Option<usize>,
-    ) -> ClientOrderIdGenerator {
+    use crate::{
+        clock::TestClock,
+        generators::{client_order_id::ClientOrderIdGenerator, IdentifierGenerator},
+    };
+
+    fn get_client_order_id_generator(initial_count: Option<usize>) -> ClientOrderIdGenerator {
         let trader_id = TraderId::from("TRADER-001");
         let strategy_id = StrategyId::from("EMACross-001");
         let clock = TestClock::new();
-        ClientOrderIdGenerator::new(trader_id, strategy_id, Box::new(clock),initial_count)
+        ClientOrderIdGenerator::new(trader_id, strategy_id, Box::new(clock), initial_count)
     }
 
     #[rstest]
-    fn test_init(){
+    fn test_init() {
         let generator = get_client_order_id_generator(None);
         assert_eq!(generator.count(), 0);
     }
 
     #[rstest]
-    fn test_init_with_initial_count(){
+    fn test_init_with_initial_count() {
         let generator = get_client_order_id_generator(Some(7));
         assert_eq!(generator.count(), 7);
     }
 
     #[rstest]
-    fn test_datetime_tag(){
+    fn test_datetime_tag() {
         let mut generator = get_client_order_id_generator(None);
         let tag = generator.get_datetime_tag();
         let result = "19700101-0000";
         assert_eq!(tag, result);
     }
-
 
     #[rstest]
     fn test_generate_order_id() {
@@ -141,26 +154,29 @@ mod tests{
         let result2 = generator.generate();
         let result3 = generator.generate();
         assert_eq!(
-            result1, ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
+            result1,
+            ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
         );
         assert_eq!(
-            result2, ClientOrderId::new("O-19700101-0000-001-001-2").unwrap()
+            result2,
+            ClientOrderId::new("O-19700101-0000-001-001-2").unwrap()
         );
         assert_eq!(
-            result3, ClientOrderId::new("O-19700101-0000-001-001-3") .unwrap()
+            result3,
+            ClientOrderId::new("O-19700101-0000-001-001-3").unwrap()
         );
     }
 
     #[rstest]
-    fn test_reset(){
+    fn test_reset() {
         let mut generator = get_client_order_id_generator(None);
         generator.generate();
         generator.generate();
         generator.reset();
         let result = generator.generate();
         assert_eq!(
-            result, ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
+            result,
+            ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
         );
-
     }
 }

--- a/nautilus_core/common/src/generators/mod.rs
+++ b/nautilus_core/common/src/generators/mod.rs
@@ -13,19 +13,18 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod clock;
-pub mod enums;
-pub mod logging;
-pub mod msgbus;
-pub mod testing;
-pub mod timer;
-pub mod generators;
-#[cfg(feature = "ffi")]
-pub mod ffi;
-#[cfg(feature = "python")]
-pub mod python;
+pub mod client_order_id;
 
-#[cfg(feature = "test")]
-pub mod stubs {
-    use crate::{clock::stubs::*, logging::stubs::*};
+
+pub trait IdentifierGenerator<T>{
+
+    fn set_count(&mut self, count: usize);
+
+    fn reset(&mut self);
+
+    fn count(&self) -> usize;
+
+    fn generate(&mut self) -> T;
+
+    fn get_datetime_tag(&mut self) -> String;
 }

--- a/nautilus_core/common/src/generators/mod.rs
+++ b/nautilus_core/common/src/generators/mod.rs
@@ -15,9 +15,7 @@
 
 pub mod client_order_id;
 
-
-pub trait IdentifierGenerator<T>{
-
+pub trait IdentifierGenerator<T> {
     fn set_count(&mut self, count: usize);
 
     fn reset(&mut self);

--- a/nautilus_core/common/src/lib.rs
+++ b/nautilus_core/common/src/lib.rs
@@ -15,15 +15,15 @@
 
 pub mod clock;
 pub mod enums;
-pub mod logging;
-pub mod msgbus;
-pub mod testing;
-pub mod timer;
-pub mod generators;
 #[cfg(feature = "ffi")]
 pub mod ffi;
+pub mod generators;
+pub mod logging;
+pub mod msgbus;
 #[cfg(feature = "python")]
 pub mod python;
+pub mod testing;
+pub mod timer;
 
 #[cfg(feature = "test")]
 pub mod stubs {

--- a/nautilus_core/model/src/identifiers/strategy_id.rs
+++ b/nautilus_core/model/src/identifiers/strategy_id.rs
@@ -53,7 +53,7 @@ impl StrategyId {
     }
 
     pub fn get_tag(&self) -> &str {
-        self.value.split("-").last().unwrap()
+        self.value.split('-').last().unwrap()
     }
 }
 

--- a/nautilus_core/model/src/identifiers/strategy_id.rs
+++ b/nautilus_core/model/src/identifiers/strategy_id.rs
@@ -51,6 +51,10 @@ impl StrategyId {
             value: Ustr::from(s),
         })
     }
+
+    pub fn get_tag(&self) -> &str {
+        self.value.split("-").last().unwrap()
+    }
 }
 
 impl Default for StrategyId {
@@ -93,5 +97,10 @@ mod tests {
     fn test_string_reprs(strategy_id_ema_cross: StrategyId) {
         assert_eq!(strategy_id_ema_cross.to_string(), "EMACross-001");
         assert_eq!(format!("{strategy_id_ema_cross}"), "EMACross-001");
+    }
+
+    #[rstest]
+    fn test_get_tag(strategy_id_ema_cross: StrategyId) {
+        assert_eq!(strategy_id_ema_cross.get_tag(), "001");
     }
 }

--- a/nautilus_core/model/src/identifiers/stubs.rs
+++ b/nautilus_core/model/src/identifiers/stubs.rs
@@ -115,13 +115,13 @@ pub fn symbol_aud_usd() -> Symbol {
 // ---- TradeId ----
 
 #[fixture]
-pub fn test_trade_id() -> TradeId {
+pub fn trade_id() -> TradeId {
     TradeId::from("1234567890")
 }
 
 // ---- TraderId ----
 #[fixture]
-pub fn trader_test() -> TraderId {
+pub fn trader_id() -> TraderId {
     TraderId::from("TRADER-001")
 }
 

--- a/nautilus_core/model/src/identifiers/trade_id.rs
+++ b/nautilus_core/model/src/identifiers/trade_id.rs
@@ -85,8 +85,8 @@ mod tests {
     use crate::identifiers::{stubs::*, trade_id::TradeId};
 
     #[rstest]
-    fn test_string_reprs(test_trade_id: TradeId) {
-        assert_eq!(test_trade_id.to_string(), "1234567890");
-        assert_eq!(format!("{test_trade_id}"), "1234567890");
+    fn test_string_reprs(trade_id: TradeId) {
+        assert_eq!(trade_id.to_string(), "1234567890");
+        assert_eq!(format!("{trade_id}"), "1234567890");
     }
 }

--- a/nautilus_core/model/src/identifiers/trader_id.rs
+++ b/nautilus_core/model/src/identifiers/trader_id.rs
@@ -51,7 +51,7 @@ impl TraderId {
     }
 
     pub fn get_tag(&self) -> &str {
-        self.value.split("-").last().unwrap()
+        self.value.split('-').last().unwrap()
     }
 }
 
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_get_tag(trader_id: TraderId){
+    fn test_get_tag(trader_id: TraderId) {
         assert_eq!(trader_id.get_tag(), "001");
     }
 }

--- a/nautilus_core/model/src/identifiers/trader_id.rs
+++ b/nautilus_core/model/src/identifiers/trader_id.rs
@@ -49,6 +49,10 @@ impl TraderId {
             value: Ustr::from(s),
         })
     }
+
+    pub fn get_tag(&self) -> &str {
+        self.value.split("-").last().unwrap()
+    }
 }
 
 impl Default for TraderId {
@@ -87,8 +91,13 @@ mod tests {
     use crate::identifiers::{stubs::*, trader_id::TraderId};
 
     #[rstest]
-    fn test_string_reprs(trader_test: TraderId) {
-        assert_eq!(trader_test.to_string(), "TRADER-001");
-        assert_eq!(format!("{trader_test}"), "TRADER-001");
+    fn test_string_reprs(trader_id: TraderId) {
+        assert_eq!(trader_id.to_string(), "TRADER-001");
+        assert_eq!(format!("{trader_id}"), "TRADER-001");
+    }
+
+    #[rstest]
+    fn test_get_tag(trader_id: TraderId){
+        assert_eq!(trader_id.get_tag(), "001");
     }
 }

--- a/nautilus_core/model/src/orders/stubs.rs
+++ b/nautilus_core/model/src/orders/stubs.rs
@@ -24,7 +24,7 @@ use crate::{
 
 // ---- MarketOrder ----
 pub fn market_order(quantity: Quantity, time_in_force: Option<TimeInForce>) -> MarketOrder {
-    let trader = trader_test();
+    let trader = trader_id();
     let strategy = strategy_id_ema_cross();
     let instrument = instrument_id_eth_usdt_binance();
     let client_order_id = client_order_id();


### PR DESCRIPTION
# Pull Request

- remove `new` method from `Clock` trait
- created `IdentifierGenerator<T>` trait
- implemented `ClientOrderIdGenerator` with boxed trait object for `Clock` fully tested in Rust
- added `get_tag` function for `StrategyId` and `TraderId`