### PR TITLE
Implement OrderListIdGenerator in rust

### DIFF
--- a/nautilus_core/common/src/generators/mod.rs
+++ b/nautilus_core/common/src/generators/mod.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod client_order_id;
+pub mod order_list_id;
 
 pub trait IdentifierGenerator<T> {
     fn set_count(&mut self, count: usize);

--- a/nautilus_core/common/src/generators/order_list_id.rs
+++ b/nautilus_core/common/src/generators/order_list_id.rs
@@ -15,20 +15,20 @@
 
 use chrono::{Datelike, NaiveDateTime, Timelike};
 use nautilus_model::identifiers::{
-    client_order_id::ClientOrderId, strategy_id::StrategyId, trader_id::TraderId,
+    order_list_id::OrderListId, strategy_id::StrategyId, trader_id::TraderId,
 };
 
 use crate::{clock::Clock, generators::IdentifierGenerator};
 
 #[repr(C)]
-pub struct ClientOrderIdGenerator {
+pub struct OrderListIdGenerator {
     trader_id: TraderId,
     strategy_id: StrategyId,
     clock: Box<dyn Clock>,
     count: usize,
 }
 
-impl ClientOrderIdGenerator {
+impl OrderListIdGenerator {
     pub fn new(
         trader_id: TraderId,
         strategy_id: StrategyId,
@@ -44,7 +44,7 @@ impl ClientOrderIdGenerator {
     }
 }
 
-impl IdentifierGenerator<ClientOrderId> for ClientOrderIdGenerator {
+impl IdentifierGenerator<OrderListId> for OrderListIdGenerator {
     fn set_count(&mut self, count: usize) {
         self.count = count;
     }
@@ -57,16 +57,16 @@ impl IdentifierGenerator<ClientOrderId> for ClientOrderIdGenerator {
         self.count
     }
 
-    fn generate(&mut self) -> ClientOrderId {
+    fn generate(&mut self) -> OrderListId {
         let datetime_tag = self.get_datetime_tag();
         let trader_tag = self.trader_id.get_tag();
         let strategy_tag = self.strategy_id.get_tag();
         self.count += 1;
         let id = format!(
-            "O-{}-{}-{}-{}",
+            "OL-{}-{}-{}-{}",
             datetime_tag, trader_tag, strategy_tag, self.count
         );
-        ClientOrderId::new(&id).unwrap()
+        OrderListId::new(&id).unwrap()
     }
 
     fn get_datetime_tag(&mut self) -> String {
@@ -89,92 +89,92 @@ impl IdentifierGenerator<ClientOrderId> for ClientOrderIdGenerator {
 #[cfg(test)]
 mod tests {
     use nautilus_model::identifiers::{
-        client_order_id::ClientOrderId, strategy_id::StrategyId, trader_id::TraderId,
+        order_list_id::OrderListId, strategy_id::StrategyId, trader_id::TraderId,
     };
     use rstest::rstest;
 
     use crate::{
         clock::TestClock,
-        generators::{client_order_id::ClientOrderIdGenerator, IdentifierGenerator},
+        generators::{order_list_id::OrderListIdGenerator, IdentifierGenerator},
     };
 
-    fn get_client_order_id_generator(initial_count: Option<usize>) -> ClientOrderIdGenerator {
+    fn get_order_list_id_generator(initial_count: Option<usize>) -> OrderListIdGenerator {
         let trader_id = TraderId::from("TRADER-001");
         let strategy_id = StrategyId::from("EMACross-001");
         let clock = TestClock::new();
-        ClientOrderIdGenerator::new(trader_id, strategy_id, Box::new(clock), initial_count)
+        OrderListIdGenerator::new(trader_id, strategy_id, Box::new(clock), initial_count)
     }
 
     #[rstest]
     fn test_init() {
-        let generator = get_client_order_id_generator(None);
+        let generator = get_order_list_id_generator(None);
         assert_eq!(generator.count(), 0);
     }
 
     #[rstest]
     fn test_init_with_initial_count() {
-        let generator = get_client_order_id_generator(Some(7));
+        let generator = get_order_list_id_generator(Some(7));
         assert_eq!(generator.count(), 7);
     }
 
     #[rstest]
     fn test_datetime_tag() {
-        let mut generator = get_client_order_id_generator(None);
+        let mut generator = get_order_list_id_generator(None);
         let tag = generator.get_datetime_tag();
         let result = "19700101-0000";
         assert_eq!(tag, result);
     }
 
     #[rstest]
-    fn test_generate_client_order_id_from_start() {
-        let mut generator = get_client_order_id_generator(None);
+    fn test_generate_order_list_id_from_start() {
+        let mut generator = get_order_list_id_generator(None);
         let result1 = generator.generate();
         let result2 = generator.generate();
         let result3 = generator.generate();
         assert_eq!(
             result1,
-            ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-1").unwrap()
         );
         assert_eq!(
             result2,
-            ClientOrderId::new("O-19700101-0000-001-001-2").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-2").unwrap()
         );
         assert_eq!(
             result3,
-            ClientOrderId::new("O-19700101-0000-001-001-3").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-3").unwrap()
         );
     }
 
     #[rstest]
-    fn test_generate_client_order_id_from_initial() {
-        let mut generator = get_client_order_id_generator(Some(5));
+    fn test_generate_order_list_id_from_initial() {
+        let mut generator = get_order_list_id_generator(Some(5));
         let result1 = generator.generate();
         let result2 = generator.generate();
         let result3 = generator.generate();
         assert_eq!(
             result1,
-            ClientOrderId::new("O-19700101-0000-001-001-6").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-6").unwrap()
         );
         assert_eq!(
             result2,
-            ClientOrderId::new("O-19700101-0000-001-001-7").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-7").unwrap()
         );
         assert_eq!(
             result3,
-            ClientOrderId::new("O-19700101-0000-001-001-8").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-8").unwrap()
         );
     }
 
     #[rstest]
     fn test_reset() {
-        let mut generator = get_client_order_id_generator(None);
+        let mut generator = get_order_list_id_generator(None);
         generator.generate();
         generator.generate();
         generator.reset();
         let result = generator.generate();
         assert_eq!(
             result,
-            ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
+            OrderListId::new("OL-19700101-0000-001-001-1").unwrap()
         );
     }
 }


### PR DESCRIPTION
# Pull Request

- removed arc mutex from count variable in `ClientOrderIdGenerator` as trader and backtesting is single-threaded and we dont want to pay performance penalty introducing thread safe generators
- added `OrderListIdGenerator` with rust tests