### PR TITLE
Trader ID missing in Position dict

### DIFF
--- a/nautilus_trader/model/position.pyx
+++ b/nautilus_trader/model/position.pyx
@@ -133,6 +133,7 @@ cdef class Position:
         """
         return {
             "position_id": self.id.to_str(),
+            "trader_id": self.trader_id.to_str(),
             "strategy_id": self.strategy_id.to_str(),
             "instrument_id": self.instrument_id.to_str(),
             "account_id": self.account_id.to_str(),

--- a/tests/unit_tests/model/test_position.py
+++ b/tests/unit_tests/model/test_position.py
@@ -136,6 +136,7 @@ class TestPosition:
         # Assert
         assert result == {
             "position_id": "P-123456",
+            "trader_id": "TESTER-000",
             "strategy_id": "S-001",
             "instrument_id": "AUD/USD.SIM",
             "account_id": "SIM-000",
@@ -184,6 +185,7 @@ class TestPosition:
         # Assert
         assert result == {
             "position_id": "P-123456",
+            "trader_id": "TESTER-000",
             "strategy_id": "S-001",
             "instrument_id": "AAPL.NASDAQ",
             "account_id": "SIM-000",
@@ -232,6 +234,7 @@ class TestPosition:
         # Assert
         assert result == {
             "position_id": "P-123456",
+            "trader_id": "TESTER-000",
             "strategy_id": "S-001",
             "instrument_id": "AAPL.NASDAQ",
             "account_id": "SIM-000",


### PR DESCRIPTION
# Pull Request

- add missing `trader_id` to function `to_dict` for `Position` class