### PR TITLE
Test rust pyo3 SimpleMovingAverage from python

### DIFF
--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -194,6 +194,17 @@ class BarType:
     def from_str(cls, value: str) -> BarType: ...
 
 class Bar:
+    def __init__(
+        self,
+        bar_type: BarType,
+        open: Price,
+        high: Price,
+        low: Price,
+        close: Price,
+        volume: Quantity,
+        ts_event: int,
+        ts_init: int,
+    ) -> None: ...
     @staticmethod
     def get_fields() -> dict[str, str]: ...
 
@@ -204,10 +215,30 @@ class OrderBookDelta:
     def get_fields() -> dict[str, str]: ...
 
 class QuoteTick:
+    def __init__(
+        self,
+        instrument_id: InstrumentId,
+        bid_price: Price,
+        ask_price: Price,
+        bid_size: Quantity,
+        ask_size: Quantity,
+        ts_event: int,
+        ts_init: int,
+    ) -> None: ...
     @staticmethod
     def get_fields() -> dict[str, str]: ...
 
 class TradeTick:
+    def __init__(
+        self,
+        instrument_id: InstrumentId,
+        price: Price,
+        size: Quantity,
+        aggressor_side: AggressorSide,
+        trade_id: TradeId,
+        ts_event: int,
+        ts_init: int,
+    ) -> None: ...
     @staticmethod
     def get_fields() -> dict[str, str]: ...
     @classmethod
@@ -793,3 +824,32 @@ class TradeTickDataWrangler:
     @property
     def size_precision(self) -> int: ...
     def process_record_batches_bytes(self, data: bytes) -> list[TradeTick]: ...
+
+
+###################################################################################################
+# Indicators
+###################################################################################################
+class SimpleMovingAverage:
+    def __init__(
+        self,
+        period: int,
+        price_type: PriceType = None,
+    )-> None: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def period(self) -> int: ...
+    @property
+    def count(self) -> int: ...
+    @property
+    def initialized(self) -> bool: ...
+    @property
+    def has_inputs(self) -> bool: ...
+    @property
+    def value(self) -> float: ...
+
+    def update_raw(self, value: float) -> None: ...
+    def reset(self) -> None: ...
+    def handle_quote_tick(self, tick: QuoteTick) -> None: ...
+    def handle_trade_tick(self, tick: TradeTick) -> None: ...
+    def handle_bar(self, bar: Bar) -> None: ...

--- a/nautilus_trader/test_kit/rust/data_pyo3.py
+++ b/nautilus_trader/test_kit/rust/data_pyo3.py
@@ -1,0 +1,105 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.core.nautilus_pyo3 import AggressorSide
+from nautilus_trader.core.nautilus_pyo3 import Bar
+from nautilus_trader.core.nautilus_pyo3 import BarAggregation
+from nautilus_trader.core.nautilus_pyo3 import BarSpecification
+from nautilus_trader.core.nautilus_pyo3 import BarType
+from nautilus_trader.core.nautilus_pyo3 import InstrumentId
+from nautilus_trader.core.nautilus_pyo3 import Price
+from nautilus_trader.core.nautilus_pyo3 import PriceType
+from nautilus_trader.core.nautilus_pyo3 import Quantity
+from nautilus_trader.core.nautilus_pyo3 import QuoteTick
+from nautilus_trader.core.nautilus_pyo3 import TradeTick
+from nautilus_trader.test_kit.rust.identifiers_pyo3 import TestIdProviderPyo3
+
+
+class TestDataProviderPyo3:
+    @staticmethod
+    def trade_tick(
+        instrument_id: InstrumentId | None = None,
+        price: float = 1987.0,
+        size: float = 0.1,
+        ts_event: int = 0,
+        ts_init: int = 0,
+    ) -> TradeTick:
+        inst = instrument_id or TestIdProviderPyo3.ethusdt_binance_id()
+        return TradeTick(
+            instrument_id=inst,
+            price=Price.from_str(str(price)),
+            size=Quantity.from_str(str(size)),
+            aggressor_side=AggressorSide.BUYER,
+            trade_id=TestIdProviderPyo3.trade_id(),
+            ts_init=ts_init,
+            ts_event=ts_event,
+        )
+
+    @staticmethod
+    def quote_tick(
+        instrument_id: InstrumentId | None = None,
+        bid_price: float = 1987.0,
+        ask_price: float = 1988.0,
+        ask_size: float = 100_000.0,
+        bid_size: float = 100_000.0,
+        ts_event: int = 0,
+        ts_init: int = 0,
+    ) -> QuoteTick:
+        inst = instrument_id or TestIdProviderPyo3.ethusdt_binance_id()
+        return QuoteTick(
+            instrument_id=inst,
+            bid_price=Price.from_str(str(bid_price)),
+            ask_price=Price.from_str(str(ask_price)),
+            bid_size=Quantity.from_str(str(bid_size)),
+            ask_size=Quantity.from_str(str(ask_size)),
+            ts_event=ts_event,
+            ts_init=ts_init,
+        )
+
+    @staticmethod
+    def bar_spec_1min_bid() -> BarSpecification:
+        return BarSpecification(1, BarAggregation.MINUTE, PriceType.BID)
+
+    @staticmethod
+    def bar_spec_1min_ask() -> BarSpecification:
+        return BarSpecification(1, BarAggregation.MINUTE, PriceType.ASK)
+
+    @staticmethod
+    def bar_spec_1min_last() -> BarSpecification:
+        return BarSpecification(1, BarAggregation.MINUTE, PriceType.LAST)
+
+    @staticmethod
+    def bar_spec_1min_mid() -> BarSpecification:
+        return BarSpecification(1, BarAggregation.MINUTE, PriceType.MID)
+
+    @staticmethod
+    def bartype_ethusdt_1min_bid() -> BarType:
+        return BarType(
+            TestIdProviderPyo3.ethusdt_binance_id(),
+            TestDataProviderPyo3.bar_spec_1min_bid(),
+        )
+
+    @staticmethod
+    def bar_5decimal() -> Bar:
+        return Bar(
+            bar_type=TestDataProviderPyo3.bartype_ethusdt_1min_bid(),
+            open=Price.from_str("1.00002"),
+            high=Price.from_str("1.00004"),
+            low=Price.from_str("1.00001"),
+            close=Price.from_str("1.00003"),
+            volume=Quantity.from_int(1_000_000),
+            ts_event=0,
+            ts_init=0,
+        )

--- a/tests/unit_tests/indicators/rust/test_sma_pyo3.py
+++ b/tests/unit_tests/indicators/rust/test_sma_pyo3.py
@@ -1,0 +1,186 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+
+from nautilus_trader.core.nautilus_pyo3 import PriceType
+from nautilus_trader.core.nautilus_pyo3 import SimpleMovingAverage
+from nautilus_trader.test_kit.rust.data_pyo3 import TestDataProviderPyo3
+
+
+@pytest.fixture(scope="function")
+def sma():
+    return SimpleMovingAverage(10)
+
+
+def test_sma(sma: SimpleMovingAverage):
+    assert sma.name == "SimpleMovingAverage"
+
+
+def test_str_repr_returns_expected_string(sma: SimpleMovingAverage):
+    # Arrange, Act, Assert
+    assert str(sma) == "SimpleMovingAverage(10)"
+    assert repr(sma) == "SimpleMovingAverage(10)"
+
+
+def test_period_returns_expected_value(sma: SimpleMovingAverage):
+    # Arrange, Act, Assert
+    assert sma.period == 10
+
+
+def test_initialized_without_inputs_returns_false(sma: SimpleMovingAverage):
+    # Arrange, Act, Assert
+    assert sma.initialized is False
+
+
+def test_initialized_with_required_inputs_returns_true(sma: SimpleMovingAverage):
+    # Arrange
+    sma.update_raw(1.0)
+    sma.update_raw(2.0)
+    sma.update_raw(3.0)
+    sma.update_raw(4.0)
+    sma.update_raw(5.0)
+    sma.update_raw(6.0)
+    sma.update_raw(7.0)
+    sma.update_raw(8.0)
+    sma.update_raw(9.0)
+    sma.update_raw(10.0)
+
+    # Act, Assert
+    assert sma.initialized is True
+    assert sma.count == 10
+    assert sma.value == 5.5
+
+
+def test_handle_quote_tick_updates_indicator(sma: SimpleMovingAverage):
+    # Arrange
+    indicator = SimpleMovingAverage(10, PriceType.MID)
+
+    tick = TestDataProviderPyo3.quote_tick()
+
+    # Act
+    indicator.handle_quote_tick(tick)
+
+    # Assert
+    assert indicator.has_inputs
+    assert round(indicator.value, 1) == 1987.5
+
+
+def test_handle_trade_tick_updates_indicator(sma: SimpleMovingAverage):
+    # Arrange
+    indicator = SimpleMovingAverage(10)
+
+    tick = TestDataProviderPyo3.trade_tick()
+
+    # Act
+    indicator.handle_trade_tick(tick)
+
+    # Assert
+    assert indicator.has_inputs
+    assert round(indicator.value, 1) == 1987.0
+
+
+def test_handle_bar_updates_indicator(sma: SimpleMovingAverage):
+    # Arrange
+    indicator = SimpleMovingAverage(10)
+
+    bar = TestDataProviderPyo3.bar_5decimal()
+
+    # Act
+    indicator.handle_bar(bar)
+
+    # Assert
+    assert indicator.has_inputs
+    assert indicator.value == 1.00003
+
+
+def test_value_with_one_input_returns_expected_value(sma: SimpleMovingAverage):
+    # Arrange
+    sma.update_raw(1.0)
+
+    # Act, Assert
+    assert sma.value == 1.0
+
+
+def test_value_with_three_inputs_returns_expected_value(sma: SimpleMovingAverage):
+    # Arrange
+    sma.update_raw(1.0)
+    sma.update_raw(2.0)
+    sma.update_raw(3.0)
+
+    # Act, Assert
+    assert sma.value == 2.0
+
+
+def test_value_at_returns_expected_value(sma: SimpleMovingAverage):
+    # Arrange
+    sma.update_raw(1.0)
+    sma.update_raw(2.0)
+    sma.update_raw(3.0)
+
+    # Act, Assert
+    assert sma.value == 2.0
+
+
+def test_handle_quote_tick_updates_with_expected_value(sma: SimpleMovingAverage):
+    # Arrange
+    sma_for_ticks1 = SimpleMovingAverage(10, PriceType.ASK)
+    sma_for_ticks2 = SimpleMovingAverage(10, PriceType.MID)
+    sma_for_ticks3 = SimpleMovingAverage(10, PriceType.BID)
+
+    tick = TestDataProviderPyo3.quote_tick(
+        bid_price=1.00001,
+        ask_price=1.00003,
+    )
+
+    # Act
+    sma_for_ticks1.handle_quote_tick(tick)
+    sma_for_ticks2.handle_quote_tick(tick)
+    sma_for_ticks3.handle_quote_tick(tick)
+
+    # Assert
+    assert sma_for_ticks1.has_inputs
+    assert sma_for_ticks2.has_inputs
+    assert sma_for_ticks3.has_inputs
+    assert round(sma_for_ticks1.value, 5) == 1.00003
+    assert round(sma_for_ticks2.value, 5) == 1.00002
+    assert round(sma_for_ticks3.value, 5) == 1.00001
+
+
+def test_handle_trade_tick_updates_with_expected_value(sma: SimpleMovingAverage):
+    # Arrange
+    sma_for_ticks = SimpleMovingAverage(10)
+
+    tick = TestDataProviderPyo3.trade_tick()
+
+    # Act
+    sma_for_ticks.handle_trade_tick(tick)
+
+    # Assert
+    assert sma_for_ticks.has_inputs
+    assert round(sma_for_ticks.value, 1) == 1987.0
+
+
+def test_reset_successfully_returns_indicator_to_fresh_state(sma: SimpleMovingAverage):
+    # Arrange
+    for _i in range(1000):
+        sma.update_raw(1.0)
+
+    # Act
+    sma.reset()
+
+    # Assert
+    assert not sma.initialized
+    assert sma.value == 0


### PR DESCRIPTION
# Pull Request

- update `nautilus_pyo3.pyi` with proper typing for `__init__` methods and other types
- `TestDataProviderPyo3` for testing rust pyo3 types from `model` crate `data` module
- Eventhough indicators are properly tested in rust, we still need to be sure that pyo3 methods and fields are correctly defined, so we need to test it from python side also. Added python tests for rust pyo3 `SimpleMovingAverage`
