### PR TITLE
Add Python interface tests for DataBackendSession

### DIFF
--- a/nautilus_core/persistence/src/backend/session.rs
+++ b/nautilus_core/persistence/src/backend/session.rs
@@ -208,6 +208,25 @@ impl DataQueryResult {
     }
 }
 
+impl Iterator for DataQueryResult {
+    type Item = Vec<Data>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.drop_chunk();
+
+        for _ in 0..self.size {
+            match self.result.next() {
+                Some(item) => self.acc.push(item),
+                None => break,
+            }
+        }
+
+        let mut acc: Vec<Data> = Vec::new();
+        std::mem::swap(&mut acc, &mut self.acc);
+        Some(acc)
+    }
+}
+
 impl Drop for DataQueryResult {
     fn drop(&mut self) {
         self.drop_chunk();

--- a/nautilus_core/persistence/src/python/backend/session.rs
+++ b/nautilus_core/persistence/src/python/backend/session.rs
@@ -14,9 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_core::{ffi::cvec::CVec, python::to_pyruntime_err};
-use nautilus_model::data::{
-    bar::Bar, delta::OrderBookDelta, quote::QuoteTick, trade::TradeTick, Data,
-};
+use nautilus_model::data::{bar::Bar, delta::OrderBookDelta, quote::QuoteTick, trade::TradeTick};
 use pyo3::{prelude::*, types::PyCapsule};
 
 use crate::backend::session::{DataBackendSession, DataQueryResult};


### PR DESCRIPTION
# Pull Request

Add tests for the Python interface to DataBackendSession. It shows that monotonicity is maintained across the pyo3 bindings to the session.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tests passed
