### PR TITLE
Nautilus SQL schema init folder structure, scripts and POC sql cache database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.key
 *.key_secret
 *.sqlite
+*.env
 
 .benchmarks*
 .coverage*

--- a/Makefile
+++ b/Makefile
@@ -132,3 +132,12 @@ pytest-coverage:
 .PHONY: test-examples
 test-examples:
 	bash scripts/test-examples.sh
+
+.PHONY: init-db
+init-db:
+	(cd nautilus_core && cargo run --bin init-db)
+
+.PHONY: drop-db
+drop-db:
+	(cd nautilus_core && cargo run --bin drop-db)
+

--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -1314,6 +1314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,11 +2273,13 @@ dependencies = [
 name = "nautilus-persistence"
 version = "0.12.0"
 dependencies = [
+ "anyhow",
  "binary-heap-plus",
  "chrono",
  "compare",
  "criterion",
  "datafusion",
+ "dotenv",
  "futures",
  "nautilus-core",
  "nautilus-model",

--- a/nautilus_core/model/Cargo.toml
+++ b/nautilus_core/model/Cargo.toml
@@ -29,6 +29,7 @@ derive_builder = "0.12.0"
 evalexpr = "11.1.0"
 tabled = "0.12.2"
 thousands = "0.2.0"
+rstest = { workspace = true }
 
 [features]
 extension-module = [
@@ -37,13 +38,13 @@ extension-module = [
 ]
 ffi = ["cbindgen"]
 python = ["pyo3"]
+stubs = []
 default = ["ffi", "python"]
 
 [dev-dependencies]
 criterion = { workspace = true }
 float-cmp = { workspace = true }
 iai = { workspace = true }
-rstest = { workspace = true }
 
 [build-dependencies]
 cbindgen = { workspace = true, optional = true }

--- a/nautilus_core/model/src/identifiers/mod.rs
+++ b/nautilus_core/model/src/identifiers/mod.rs
@@ -44,7 +44,7 @@ pub mod trader_id;
 pub mod venue;
 pub mod venue_order_id;
 
-#[cfg(test)]
+#[cfg(feature = "stubs")]
 pub mod stubs;
 
 impl_from_str_for_identifier!(account_id::AccountId);

--- a/nautilus_core/persistence/Cargo.toml
+++ b/nautilus_core/persistence/Cargo.toml
@@ -10,9 +10,17 @@ documentation.workspace = true
 name = "nautilus_persistence"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
+[[bin]]
+name = "init-db"
+path = "src/bin/init_db.rs"
+
+[[bin]]
+name = "drop-db"
+path = "src/bin/drop_db.rs"
+
 [dependencies]
 nautilus-core = { path = "../core" }
-nautilus-model = { path = "../model" }
+nautilus-model = { path = "../model" , features = ["stubs"]}
 chrono = { workspace = true }
 futures = { workspace = true }
 pyo3 = { workspace = true, optional = true }
@@ -23,6 +31,8 @@ binary-heap-plus = "0.5.0"
 compare = "0.1.0"
 datafusion = { version = "33.0.0", default-features = false, features = ["compression", "regex_expressions", "unicode_expressions", "pyarrow"] }
 sqlx = { version = "0.7.2", features = ["sqlite","postgres","any","runtime-tokio"] }
+anyhow = { workspace = true }
+dotenv = "0.15.0"
 
 [features]
 extension-module = [

--- a/nautilus_core/persistence/src/bin/drop_db.rs
+++ b/nautilus_core/persistence/src/bin/drop_db.rs
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use dotenv::dotenv;
+use nautilus_persistence::db::database::{Database, DatabaseEngine};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // load envs if exists
+    dotenv().ok();
+
+    let db = Database::new(Some(DatabaseEngine::POSTGRES), None).await;
+
+    db.execute("DROP SCHEMA IF EXISTS nautilus CASCADE;")
+        .await
+        .map_err(|e| e.to_string())?;
+    db.execute("DROP ROLE IF EXISTS nautilus;")
+        .await
+        .map_err(|e| e.to_string())?;
+    println!("Dropped nautilus schema and role.");
+    Ok(())
+}

--- a/nautilus_core/persistence/src/bin/init_db.rs
+++ b/nautilus_core/persistence/src/bin/init_db.rs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use anyhow::Result;
+use dotenv::dotenv;
+use nautilus_persistence::db::database::{init_db_schema, Database};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // load envs if exists
+    dotenv().ok();
+    let db = Database::new(None, None).await;
+    let sql_schema_dir = "../schema/sql";
+    init_db_schema(&db,sql_schema_dir).await?;
+    Ok(())
+}

--- a/nautilus_core/persistence/src/bin/init_db.rs
+++ b/nautilus_core/persistence/src/bin/init_db.rs
@@ -23,6 +23,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
     let db = Database::new(None, None).await;
     let sql_schema_dir = "../schema/sql";
-    init_db_schema(&db,sql_schema_dir).await?;
+    init_db_schema(&db, sql_schema_dir).await?;
     Ok(())
 }

--- a/nautilus_core/persistence/src/db/database.rs
+++ b/nautilus_core/persistence/src/db/database.rs
@@ -108,7 +108,7 @@ impl Database {
     }
 }
 
-pub async fn init_db_schema(db: &Database,schema_dir: &str) -> Result<()> {
+pub async fn init_db_schema(db: &Database, schema_dir: &str) -> Result<()> {
     // scan all the files in the current directory
     let mut sql_files =
         std::fs::read_dir(schema_dir)?.collect::<Result<Vec<_>, std::io::Error>>()?;

--- a/nautilus_core/persistence/src/db/schema.rs
+++ b/nautilus_core/persistence/src/db/schema.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod database;
-pub mod schema;
-pub mod sql;
+#[derive(sqlx::FromRow)]
+pub struct GeneralItem {
+    pub key: String,
+    pub value: String,
+}

--- a/nautilus_core/persistence/src/db/sql.rs
+++ b/nautilus_core/persistence/src/db/sql.rs
@@ -70,7 +70,9 @@ mod tests {
     async fn setup_sql_cache_database() -> SqlCacheDatabase {
         let db = setup_test_database().await;
         let schema_dir = "../../schema/sql";
-        init_db_schema(&db,schema_dir).await.expect("Failed to init db schema");
+        init_db_schema(&db, schema_dir)
+            .await
+            .expect("Failed to init db schema");
         let trader = trader_id();
         SqlCacheDatabase::new(trader, db)
     }

--- a/nautilus_core/persistence/src/db/sql.rs
+++ b/nautilus_core/persistence/src/db/sql.rs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ------------------------------------------------------------------------------------------------
+
+use nautilus_model::identifiers::trader_id::TraderId;
+use sqlx::Error;
+
+use crate::db::{database::Database, schema::GeneralItem};
+
+pub struct SqlCacheDatabase {
+    trader_id: TraderId,
+    db: Database,
+}
+
+impl SqlCacheDatabase {
+    pub fn new(trader_id: TraderId, database: Database) -> Self {
+        Self {
+            trader_id,
+            db: database,
+        }
+    }
+    pub fn key_trader(&self) -> String {
+        format!("trader-{}", self.trader_id)
+    }
+
+    pub fn key_general(&self) -> String {
+        format!("{}:general:", self.key_trader())
+    }
+
+    pub async fn add(&self, key: String, value: String) -> Result<u64, Error> {
+        let query = format!(
+            "INSERT INTO general (key, value) VALUES ('{}', '{}') ON CONFLICT (key) DO NOTHING;",
+            key, value
+        );
+        self.db.execute(query.as_str()).await
+    }
+
+    pub async fn get(&self, key: String) -> Vec<GeneralItem> {
+        let query = format!("SELECT * FROM general WHERE key = '{}'", key);
+        self.db
+            .fetch_all::<GeneralItem>(query.as_str())
+            .await
+            .unwrap()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use nautilus_model::identifiers::stubs::trader_id;
+
+    use crate::db::{
+        database::{init_db_schema, setup_test_database},
+        sql::SqlCacheDatabase,
+    };
+
+    async fn setup_sql_cache_database() -> SqlCacheDatabase {
+        let db = setup_test_database().await;
+        let schema_dir = "../../schema/sql";
+        init_db_schema(&db,schema_dir).await.expect("Failed to init db schema");
+        let trader = trader_id();
+        SqlCacheDatabase::new(trader, db)
+    }
+
+    #[tokio::test]
+    async fn test_keys() {
+        let cache = setup_sql_cache_database().await;
+        assert_eq!(cache.key_trader(), "trader-TRADER-001");
+        assert_eq!(cache.key_general(), "trader-TRADER-001:general:");
+    }
+
+    #[tokio::test]
+    async fn test_add_get_general() {
+        let cache = setup_sql_cache_database().await;
+        cache
+            .add(String::from("key1"), String::from("value1"))
+            .await
+            .expect("Failed to add key");
+        let value = cache.get(String::from("key1")).await;
+        assert_eq!(value.len(), 1);
+        let item = value.get(0).unwrap();
+        assert_eq!(item.key, "key1");
+        assert_eq!(item.value, "value1");
+    }
+}

--- a/schema/sql/tables.sql
+++ b/schema/sql/tables.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS general (
+    key SERIAL PRIMARY KEY,
+    value TEXT NOT NULL
+);


### PR DESCRIPTION
# Pull Request

- added `*.env` files to gitignore, so they are not picked up by git if they are created locally in source code folders
- created schema folder structure for Nautilus SQL data model
- added two new actions to `Makefile` and that are `init-db` and `drop-db` that will initialize Nautilus SQL schema to connected database ( mostly Postgres here). We will need those actions to resync the latest schema with the database. Migrations of schema will not be currently supported
- added corresponding cargo target for this scripts
- added two utils functions `init_db_schema` and `setup_test_database` that will be used both by cargo targets and tests when initializing testing sqlite database
- initial design for `SqlCacheDatabase` with `general` table for storing custom keys and values
