### PR TITLE
Reorganize instrument stubs in Rust

### DIFF
--- a/nautilus_core/model/src/instruments/crypto_future.rs
+++ b/nautilus_core/model/src/instruments/crypto_future.rs
@@ -220,64 +220,13 @@ impl Instrument for CryptoFuture {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use chrono::{TimeZone, Utc};
-    use nautilus_core::time::UnixNanos;
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-        instruments::crypto_future::CryptoFuture,
-        types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn crypto_future_btcusdt() -> CryptoFuture {
-        let activation = Utc.with_ymd_and_hms(2014, 4, 8, 0, 0, 0).unwrap();
-        let expiration = Utc.with_ymd_and_hms(2014, 7, 8, 0, 0, 0).unwrap();
-        CryptoFuture::new(
-            InstrumentId::from("ETHUSDT-123.BINANCE"),
-            Symbol::from("BTCUSDT"),
-            Currency::from("BTC"),
-            Currency::from("USDT"),
-            Currency::from("USDT"),
-            activation.timestamp_nanos_opt().unwrap() as UnixNanos,
-            expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
-            2,
-            6,
-            Price::from("0.01"),
-            Quantity::from("0.000001"),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            None,
-            Some(Quantity::from("9000.0")),
-            Some(Quantity::from("0.000001")),
-            None,
-            Some(Money::new(10.00, Currency::from("USDT")).unwrap()),
-            Some(Price::from("1000000.00")),
-            Some(Price::from("0.01")),
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::instruments::crypto_future::CryptoFuture;
+    use crate::instruments::{crypto_future::CryptoFuture, stubs::*};
 
     #[rstest]
     fn test_equality(crypto_future_btcusdt: CryptoFuture) {

--- a/nautilus_core/model/src/instruments/crypto_perpetual.rs
+++ b/nautilus_core/model/src/instruments/crypto_perpetual.rs
@@ -212,58 +212,13 @@ impl Instrument for CryptoPerpetual {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-        instruments::crypto_perpetual::CryptoPerpetual,
-        types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn crypto_perpetual_ethusdt() -> CryptoPerpetual {
-        CryptoPerpetual::new(
-            InstrumentId::from("ETHUSDT-PERP.BINANCE"),
-            Symbol::from("ETHUSDT"),
-            Currency::from("ETH"),
-            Currency::from("USDT"),
-            Currency::from("USDT"),
-            2,
-            0,
-            Price::from("0.01"),
-            Quantity::from("0.001"),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            None,
-            Some(Quantity::from("10000.0")),
-            Some(Quantity::from("0.001")),
-            None,
-            Some(Money::new(10.00, Currency::from("USDT")).unwrap()),
-            Some(Price::from("15000.00")),
-            Some(Price::from("1.0")),
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::instruments::crypto_perpetual::CryptoPerpetual;
+    use crate::instruments::{crypto_perpetual::CryptoPerpetual, stubs::*};
 
     #[rstest]
     fn test_equality(crypto_perpetual_ethusdt: CryptoPerpetual) {

--- a/nautilus_core/model/src/instruments/currency_pair.rs
+++ b/nautilus_core/model/src/instruments/currency_pair.rs
@@ -204,54 +204,13 @@ impl Instrument for CurrencyPair {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-        instruments::currency_pair::CurrencyPair,
-        types::{currency::Currency, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn currency_pair_btcusdt() -> CurrencyPair {
-        CurrencyPair::new(
-            InstrumentId::from("BTCUSDT.BINANCE"),
-            Symbol::from("BTCUSDT"),
-            Currency::from("BTC"),
-            Currency::from("USDT"),
-            2,
-            6,
-            Price::from("0.01"),
-            Quantity::from("0.000001"),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            None,
-            Some(Quantity::from("9000")),
-            Some(Quantity::from("0.000001")),
-            Some(Price::from("1000000")),
-            Some(Price::from("0.01")),
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ///////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use crate::instruments::currency_pair::{stubs::currency_pair_btcusdt, CurrencyPair};
+    use crate::instruments::{currency_pair::CurrencyPair, stubs::*};
 
     #[rstest]
     fn test_equality(currency_pair_btcusdt: CurrencyPair) {

--- a/nautilus_core/model/src/instruments/equity.rs
+++ b/nautilus_core/model/src/instruments/equity.rs
@@ -201,54 +201,13 @@ impl Instrument for Equity {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-        instruments::equity::Equity,
-        types::{currency::Currency, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn equity_aapl() -> Equity {
-        Equity::new(
-            InstrumentId::from("AAPL.NASDAQ"),
-            Symbol::from("AAPL"),
-            String::from("US0378331005"),
-            Currency::from("USD"),
-            2,
-            Price::from("0.01"),
-            Quantity::from(1),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Some(Quantity::from(1)),
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::instruments::equity::Equity;
+    use crate::instruments::{equity::Equity, stubs::*};
 
     #[rstest]
     fn test_equality(equity_aapl: Equity) {

--- a/nautilus_core/model/src/instruments/futures_contract.rs
+++ b/nautilus_core/model/src/instruments/futures_contract.rs
@@ -210,62 +210,13 @@ impl Instrument for FuturesContract {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use chrono::{TimeZone, Utc};
-    use nautilus_core::time::UnixNanos;
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        enums::AssetClass,
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol, venue::Venue},
-        instruments::futures_contract::FuturesContract,
-        types::{currency::Currency, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn futures_contract_es() -> FuturesContract {
-        let activation = Utc.with_ymd_and_hms(2021, 4, 8, 0, 0, 0).unwrap();
-        let expiration = Utc.with_ymd_and_hms(2021, 7, 8, 0, 0, 0).unwrap();
-        FuturesContract::new(
-            InstrumentId::new(Symbol::from("ESZ21"), Venue::from("CME")),
-            Symbol::from("ESZ21"),
-            AssetClass::Index,
-            String::from("ES"),
-            activation.timestamp_nanos_opt().unwrap() as UnixNanos,
-            expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
-            Currency::USD(),
-            2,
-            Price::from("0.01"),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Quantity::from("1.0"),
-            Some(Quantity::from("1.0")),
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::instruments::futures_contract::FuturesContract;
+    use crate::instruments::{futures_contract::FuturesContract, stubs::*};
 
     #[rstest]
     fn test_equality(futures_contract_es: FuturesContract) {

--- a/nautilus_core/model/src/instruments/mod.rs
+++ b/nautilus_core/model/src/instruments/mod.rs
@@ -22,6 +22,9 @@ pub mod options_contract;
 pub mod synthetic;
 pub mod synthetic_api;
 
+#[cfg(feature = "stubs")]
+pub mod stubs;
+
 use anyhow::Result;
 use rust_decimal::Decimal;
 

--- a/nautilus_core/model/src/instruments/options_contract.rs
+++ b/nautilus_core/model/src/instruments/options_contract.rs
@@ -213,63 +213,13 @@ impl Instrument for OptionsContract {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Stubs
-////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-pub mod stubs {
-    use std::str::FromStr;
-
-    use chrono::{TimeZone, Utc};
-    use nautilus_core::time::UnixNanos;
-    use rstest::fixture;
-    use rust_decimal::Decimal;
-
-    use crate::{
-        enums::{AssetClass, OptionKind},
-        identifiers::{instrument_id::InstrumentId, symbol::Symbol},
-        instruments::options_contract::OptionsContract,
-        types::{currency::Currency, price::Price, quantity::Quantity},
-    };
-
-    #[fixture]
-    pub fn options_contract_appl() -> OptionsContract {
-        let activation = Utc.with_ymd_and_hms(2021, 9, 17, 0, 0, 0).unwrap();
-        let expiration = Utc.with_ymd_and_hms(2021, 12, 17, 0, 0, 0).unwrap();
-        OptionsContract::new(
-            InstrumentId::from("AAPL211217C00150000.OPRA"),
-            Symbol::from("AAPL211217C00150000"),
-            AssetClass::Equity,
-            String::from("AAPL"),
-            OptionKind::Call,
-            activation.timestamp_nanos_opt().unwrap() as UnixNanos,
-            expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
-            Price::from("149.0"),
-            Currency::USD(),
-            2,
-            Price::from("0.01"),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.0").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Decimal::from_str("0.001").unwrap(),
-            Some(Quantity::from("1.0")),
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap()
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::stubs::*;
-    use crate::instruments::options_contract::OptionsContract;
+    use crate::instruments::{options_contract::OptionsContract, stubs::*};
 
     #[rstest]
     fn test_equality(options_contract_appl: OptionsContract) {

--- a/nautilus_core/model/src/instruments/stubs.rs
+++ b/nautilus_core/model/src/instruments/stubs.rs
@@ -1,0 +1,194 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::str::FromStr;
+
+use chrono::{TimeZone, Utc};
+use nautilus_core::time::UnixNanos;
+use rstest::fixture;
+use rust_decimal::Decimal;
+
+use crate::{
+    enums::{AssetClass, OptionKind},
+    identifiers::{instrument_id::InstrumentId, symbol::Symbol, venue::Venue},
+    instruments::{
+        crypto_future::CryptoFuture, crypto_perpetual::CryptoPerpetual,
+        currency_pair::CurrencyPair, equity::Equity, futures_contract::FuturesContract,
+        options_contract::OptionsContract,
+    },
+    types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
+};
+
+#[fixture]
+pub fn crypto_future_btcusdt() -> CryptoFuture {
+    let activation = Utc.with_ymd_and_hms(2014, 4, 8, 0, 0, 0).unwrap();
+    let expiration = Utc.with_ymd_and_hms(2014, 7, 8, 0, 0, 0).unwrap();
+    CryptoFuture::new(
+        InstrumentId::from("ETHUSDT-123.BINANCE"),
+        Symbol::from("BTCUSDT"),
+        Currency::from("BTC"),
+        Currency::from("USDT"),
+        Currency::from("USDT"),
+        activation.timestamp_nanos_opt().unwrap() as UnixNanos,
+        expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
+        2,
+        6,
+        Price::from("0.01"),
+        Quantity::from("0.000001"),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        None,
+        Some(Quantity::from("9000.0")),
+        Some(Quantity::from("0.000001")),
+        None,
+        Some(Money::new(10.00, Currency::from("USDT")).unwrap()),
+        Some(Price::from("1000000.00")),
+        Some(Price::from("0.01")),
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn crypto_perpetual_ethusdt() -> CryptoPerpetual {
+    CryptoPerpetual::new(
+        InstrumentId::from("ETHUSDT-PERP.BINANCE"),
+        Symbol::from("ETHUSDT"),
+        Currency::from("ETH"),
+        Currency::from("USDT"),
+        Currency::from("USDT"),
+        2,
+        0,
+        Price::from("0.01"),
+        Quantity::from("0.001"),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        None,
+        Some(Quantity::from("10000.0")),
+        Some(Quantity::from("0.001")),
+        None,
+        Some(Money::new(10.00, Currency::from("USDT")).unwrap()),
+        Some(Price::from("15000.00")),
+        Some(Price::from("1.0")),
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn currency_pair_btcusdt() -> CurrencyPair {
+    CurrencyPair::new(
+        InstrumentId::from("BTCUSDT.BINANCE"),
+        Symbol::from("BTCUSDT"),
+        Currency::from("BTC"),
+        Currency::from("USDT"),
+        2,
+        6,
+        Price::from("0.01"),
+        Quantity::from("0.000001"),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        None,
+        Some(Quantity::from("9000")),
+        Some(Quantity::from("0.000001")),
+        Some(Price::from("1000000")),
+        Some(Price::from("0.01")),
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn equity_aapl() -> Equity {
+    Equity::new(
+        InstrumentId::from("AAPL.NASDAQ"),
+        Symbol::from("AAPL"),
+        String::from("US0378331005"),
+        Currency::from("USD"),
+        2,
+        Price::from("0.01"),
+        Quantity::from(1),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Some(Quantity::from(1)),
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn futures_contract_es() -> FuturesContract {
+    let activation = Utc.with_ymd_and_hms(2021, 4, 8, 0, 0, 0).unwrap();
+    let expiration = Utc.with_ymd_and_hms(2021, 7, 8, 0, 0, 0).unwrap();
+    FuturesContract::new(
+        InstrumentId::new(Symbol::from("ESZ21"), Venue::from("CME")),
+        Symbol::from("ESZ21"),
+        AssetClass::Index,
+        String::from("ES"),
+        activation.timestamp_nanos_opt().unwrap() as UnixNanos,
+        expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
+        Currency::USD(),
+        2,
+        Price::from("0.01"),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Quantity::from("1.0"),
+        Some(Quantity::from("1.0")),
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn options_contract_appl() -> OptionsContract {
+    let activation = Utc.with_ymd_and_hms(2021, 9, 17, 0, 0, 0).unwrap();
+    let expiration = Utc.with_ymd_and_hms(2021, 12, 17, 0, 0, 0).unwrap();
+    OptionsContract::new(
+        InstrumentId::from("AAPL211217C00150000.OPRA"),
+        Symbol::from("AAPL211217C00150000"),
+        AssetClass::Equity,
+        String::from("AAPL"),
+        OptionKind::Call,
+        activation.timestamp_nanos_opt().unwrap() as UnixNanos,
+        expiration.timestamp_nanos_opt().unwrap() as UnixNanos,
+        Price::from("149.0"),
+        Currency::USD(),
+        2,
+        Price::from("0.01"),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.0").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Decimal::from_str("0.001").unwrap(),
+        Some(Quantity::from("1.0")),
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap()
+}


### PR DESCRIPTION
# Pull Request

- moved all instrument stubs to separate file with `stubs` feature so then can be reused in other modules
