### PR TITLE
Implement event OrderRejected in Rust

### DIFF
--- a/nautilus_core/model/src/events/order/rejected.rs
+++ b/nautilus_core/model/src/events/order/rejected.rs
@@ -13,8 +13,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::fmt::{Display, Formatter};
+
+use anyhow::Result;
 use derive_builder::{self, Builder};
 use nautilus_core::{time::UnixNanos, uuid::UUID4};
+use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -27,6 +31,10 @@ use crate::identifiers::{
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Builder)]
 #[builder(default)]
 #[serde(tag = "type")]
+#[cfg_attr(
+    feature = "python",
+    pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")
+)]
 pub struct OrderRejected {
     pub trader_id: TraderId,
     pub strategy_id: StrategyId,
@@ -38,4 +46,69 @@ pub struct OrderRejected {
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
     pub reconciliation: u8,
+}
+
+impl OrderRejected {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        reason: Ustr,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+        reconciliation: bool,
+    ) -> Result<OrderRejected> {
+        Ok(OrderRejected {
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            account_id,
+            reason,
+            event_id,
+            ts_event,
+            ts_init,
+            reconciliation: reconciliation as u8,
+        })
+    }
+}
+
+impl Display for OrderRejected {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderRejected(instrument_id={}, client_order_id={}, reason={}, ts_event={})",
+            self.instrument_id, self.client_order_id, self.reason, self.ts_event
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::events::order::stubs::*;
+
+    #[rstest]
+    fn test_order_rejected_display(order_rejected_insufficient_margin: OrderRejected) {
+        let display = format!("{}", order_rejected_insufficient_margin);
+        assert_eq!(
+            display,
+            format!(
+                "OrderRejected(instrument_id={}, client_order_id={}, reason={}, ts_event={})",
+                order_rejected_insufficient_margin.instrument_id,
+                order_rejected_insufficient_margin.client_order_id,
+                order_rejected_insufficient_margin.reason,
+                order_rejected_insufficient_margin.ts_event
+            )
+        );
+    }
 }

--- a/nautilus_core/model/src/events/order/stubs.rs
+++ b/nautilus_core/model/src/events/order/stubs.rs
@@ -21,7 +21,10 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType},
-    events::order::{denied::OrderDenied, filled::OrderFilled, initialized::OrderInitialized},
+    events::order::{
+        denied::OrderDenied, filled::OrderFilled, initialized::OrderInitialized,
+        rejected::OrderRejected,
+    },
     identifiers::{
         account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
         order_list_id::OrderListId, strategy_id::StrategyId, stubs::*, trade_id::TradeId,
@@ -79,6 +82,30 @@ pub fn order_denied_max_submitted_rate(
         event_id,
         0,
         0,
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn order_rejected_insufficient_margin(
+    trader_id: TraderId,
+    account_id: AccountId,
+    strategy_id_ema_cross: StrategyId,
+    instrument_id_btc_usdt: InstrumentId,
+    client_order_id: ClientOrderId,
+) -> OrderRejected {
+    let event_id = UUID4::new();
+    OrderRejected::new(
+        trader_id,
+        strategy_id_ema_cross,
+        instrument_id_btc_usdt,
+        client_order_id,
+        account_id,
+        Ustr::from("INSUFFICIENT_MARGIN"),
+        event_id,
+        0,
+        0,
+        false,
     )
     .unwrap()
 }

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -16,3 +16,4 @@
 pub mod denied;
 pub mod filled;
 pub mod initialized;
+pub mod rejected;

--- a/nautilus_core/model/src/python/events/order/rejected.rs
+++ b/nautilus_core/model/src/python/events/order/rejected.rs
@@ -1,0 +1,123 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::str::FromStr;
+
+use nautilus_core::{
+    python::{serialization::from_dict_pyo3, to_pyvalue_err},
+    time::UnixNanos,
+    uuid::UUID4,
+};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::prelude::ToPrimitive;
+use ustr::Ustr;
+
+use crate::{
+    events::order::rejected::OrderRejected,
+    identifiers::{
+        account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
+        strategy_id::StrategyId, trader_id::TraderId,
+    },
+};
+#[pymethods]
+impl OrderRejected {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        reason: &str,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+        reconciliation: bool,
+    ) -> PyResult<Self> {
+        let reason = Ustr::from_str(reason).unwrap();
+        Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            account_id,
+            reason,
+            event_id,
+            ts_event,
+            ts_init,
+            reconciliation,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "{}(trader_id={}, strategy_id={}, instrument_id={}, client_order_id={}, account_id={}, reason={}, event_id={}, ts_event={}, ts_init={})",
+            stringify!(OrderRejected),
+            self.trader_id,
+            self.strategy_id,
+            self.instrument_id,
+            self.client_order_id,
+            self.account_id,
+            self.reason,
+            self.event_id,
+            self.ts_event,
+            self.ts_init
+        )
+    }
+
+    fn __str__(&self) -> String {
+        format!(
+            "{}(instrument_id={}, client_order_id={}, account_id={}, reason={}, ts_event={})",
+            stringify!(OrderRejected),
+            self.instrument_id,
+            self.client_order_id,
+            self.account_id,
+            self.reason,
+            self.ts_event,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("trader_id", self.trader_id.to_string())?;
+        dict.set_item("strategy_id", self.strategy_id.to_string())?;
+        dict.set_item("instrument_id", self.instrument_id.to_string())?;
+        dict.set_item("client_order_id", self.client_order_id.to_string())?;
+        dict.set_item("account_id", self.account_id.to_string())?;
+        dict.set_item("reason", self.reason.to_string())?;
+        dict.set_item("event_id", self.event_id.to_string())?;
+        dict.set_item("ts_event", self.ts_event.to_u64())?;
+        dict.set_item("ts_init", self.ts_init.to_u64())?;
+        dict.set_item("reconciliation", self.reconciliation)?;
+        Ok(dict.into())
+    }
+}

--- a/nautilus_core/model/src/python/mod.rs
+++ b/nautilus_core/model/src/python/mod.rs
@@ -296,5 +296,6 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::events::order::denied::OrderDenied>()?;
     m.add_class::<crate::events::order::filled::OrderFilled>()?;
     m.add_class::<crate::events::order::initialized::OrderInitialized>()?;
+    m.add_class::<crate::events::order::rejected::OrderRejected>()?;
     Ok(())
 }

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -645,6 +645,24 @@ class OrderDenied:
     def from_dict(cls, values: dict[str, str]) -> OrderDenied: ...
     def to_dict(self) -> dict[str, str]: ...
 
+class OrderRejected:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        reason: str,
+        event_id: UUID4,
+        ts_event: int,
+        ts_init: int,
+        reconciliation: bool,
+    ) -> None: ...
+    @classmethod
+    def from_dict(cls, values: dict[str, str]) -> OrderRejected: ...
+    def to_dict(self) -> dict[str, str]: ...
+
 class OrderFilled:
     def __init__(
         self,

--- a/nautilus_trader/test_kit/rust/events_pyo3.py
+++ b/nautilus_trader/test_kit/rust/events_pyo3.py
@@ -23,6 +23,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderDenied
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderListId
+from nautilus_trader.core.nautilus_pyo3 import OrderRejected
 from nautilus_trader.core.nautilus_pyo3 import OrderSide
 from nautilus_trader.core.nautilus_pyo3 import OrderType
 from nautilus_trader.core.nautilus_pyo3 import PositionId
@@ -47,6 +48,22 @@ class TestEventsProviderPyo3:
             event_id=UUID4(uuid),
             ts_init=0,
             ts_event=0,
+        )
+
+    @staticmethod
+    def order_rejected_insufficient_margin() -> OrderRejected:
+        uuid = "91762096-b188-49ea-8562-8d8a4cc22ff2"
+        return OrderRejected(
+            trader_id=TestIdProviderPyo3.trader_id(),
+            strategy_id=TestIdProviderPyo3.strategy_id(),
+            instrument_id=TestIdProviderPyo3.audusd_id(),
+            client_order_id=TestIdProviderPyo3.client_order_id(),
+            account_id=TestIdProviderPyo3.account_id(),
+            reason="INSUFFICIENT_MARGIN",
+            event_id=UUID4(uuid),
+            ts_init=0,
+            ts_event=0,
+            reconciliation=False,
         )
 
     @staticmethod

--- a/tests/unit_tests/model/test_events_pyo3.py
+++ b/tests/unit_tests/model/test_events_pyo3.py
@@ -17,6 +17,7 @@
 from nautilus_trader.core.nautilus_pyo3 import OrderDenied
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
+from nautilus_trader.core.nautilus_pyo3 import OrderRejected
 from nautilus_trader.test_kit.rust.events_pyo3 import TestEventsProviderPyo3
 
 
@@ -82,4 +83,22 @@ def test_order_initialized():
         + "contingency_type=OTO, order_list_id=1, linked_order_ids=[O-2020872378424], "
         + "parent_order_id=None, exec_algorithm_id=None, exec_algorithm_params=None, exec_spawn_id=None, "
         + "tags=ENTRY, event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_init=0)"
+    )
+
+
+def test_order_rejected():
+    event = TestEventsProviderPyo3.order_rejected_insufficient_margin()
+    result_dict = OrderRejected.to_dict(event)
+    order_denied = OrderRejected.from_dict(result_dict)
+    assert order_denied == event
+    assert (
+        str(event)
+        == "OrderRejected(instrument_id=AUD/USD.SIM, client_order_id=O-20210410-022422-001-001-1, "
+        + "account_id=SIM-000, reason=INSUFFICIENT_MARGIN, ts_event=0)"
+    )
+    assert (
+        repr(event)
+        == "OrderRejected(trader_id=TESTER-001, strategy_id=S-001, "
+        + "instrument_id=AUD/USD.SIM, client_order_id=O-20210410-022422-001-001-1, account_id=SIM-000, "
+        + "reason=INSUFFICIENT_MARGIN, event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_event=0, ts_init=0)"
     )


### PR DESCRIPTION
# Pull Request

- finished order event `OrderRejected` in rust and exported in with pyo3 and tested on the python side