### PR TITLE
Implement event OrderEmulated in Rust

### DIFF
--- a/nautilus_core/model/src/events/order/emulated.rs
+++ b/nautilus_core/model/src/events/order/emulated.rs
@@ -13,8 +13,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::fmt::{Display, Formatter};
+
+use anyhow::Result;
 use derive_builder::{self, Builder};
 use nautilus_core::{time::UnixNanos, uuid::UUID4};
+use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::{
@@ -26,6 +30,10 @@ use crate::identifiers::{
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Builder)]
 #[builder(default)]
 #[serde(tag = "type")]
+#[cfg_attr(
+    feature = "python",
+    pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")
+)]
 pub struct OrderEmulated {
     pub trader_id: TraderId,
     pub strategy_id: StrategyId,
@@ -34,4 +42,56 @@ pub struct OrderEmulated {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+}
+
+impl OrderEmulated {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> Result<OrderEmulated> {
+        Ok(OrderEmulated {
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            event_id,
+            ts_event,
+            ts_init,
+        })
+    }
+}
+
+impl Display for OrderEmulated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderEmulated(instrument_id={}, client_order_id={})",
+            self.instrument_id, self.client_order_id
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::events::order::{emulated::OrderEmulated, stubs::*};
+
+    #[rstest]
+    fn test_order_emulated(order_emulated: OrderEmulated) {
+        let display = format!("{}", order_emulated);
+        assert_eq!(
+            display,
+            "OrderEmulated(instrument_id=BTCUSDT.COINBASE, client_order_id=O-20200814-102234-001-001-1)"
+        );
+    }
 }

--- a/nautilus_core/model/src/events/order/stubs.rs
+++ b/nautilus_core/model/src/events/order/stubs.rs
@@ -22,8 +22,9 @@ use ustr::Ustr;
 use crate::{
     enums::{ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType},
     events::order::{
-        denied::OrderDenied, filled::OrderFilled, initialized::OrderInitialized,
-        rejected::OrderRejected, submitted::OrderSubmitted, triggered::OrderTriggered,
+        denied::OrderDenied, emulated::OrderEmulated, filled::OrderFilled,
+        initialized::OrderInitialized, rejected::OrderRejected, submitted::OrderSubmitted,
+        triggered::OrderTriggered,
     },
     identifiers::{
         account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
@@ -201,6 +202,26 @@ pub fn order_triggered(
         false,
         Some(venue_order_id),
         Some(account_id),
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn order_emulated(
+    trader_id: TraderId,
+    strategy_id_ema_cross: StrategyId,
+    instrument_id_btc_usdt: InstrumentId,
+    client_order_id: ClientOrderId,
+    uuid4: UUID4,
+) -> OrderEmulated {
+    OrderEmulated::new(
+        trader_id,
+        strategy_id_ema_cross,
+        instrument_id_btc_usdt,
+        client_order_id,
+        uuid4,
+        0,
+        0,
     )
     .unwrap()
 }

--- a/nautilus_core/model/src/python/events/order/emulated.rs
+++ b/nautilus_core/model/src/python/events/order/emulated.rs
@@ -1,0 +1,102 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::{
+    python::{serialization::from_dict_pyo3, to_pyvalue_err},
+    time::UnixNanos,
+    uuid::UUID4,
+};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::{
+    events::order::emulated::OrderEmulated,
+    identifiers::{
+        client_order_id::ClientOrderId, instrument_id::InstrumentId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+};
+
+#[pymethods]
+impl OrderEmulated {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> PyResult<Self> {
+        Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            event_id,
+            ts_event,
+            ts_init,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "OrderEmulated(trader_id={}, strategy_id={}, instrument_id={}, client_order_id={}, event_id={}, ts_init={})",
+            self.trader_id,
+            self.strategy_id,
+            self.instrument_id,
+            self.client_order_id,
+            self.event_id,
+            self.ts_init,
+        )
+    }
+
+    fn __str__(&self) -> String {
+        format!(
+            "OrderEmulated(instrument_id={}, client_order_id={})",
+            self.instrument_id, self.client_order_id,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("trader_id", self.trader_id.to_string())?;
+        dict.set_item("strategy_id", self.strategy_id.to_string())?;
+        dict.set_item("instrument_id", self.instrument_id.to_string())?;
+        dict.set_item("client_order_id", self.client_order_id.to_string())?;
+        dict.set_item("event_id", self.event_id.to_string())?;
+        dict.set_item("ts_event", self.ts_event.to_u64())?;
+        dict.set_item("ts_init", self.ts_init.to_u64())?;
+        Ok(dict.into())
+    }
+}

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod denied;
+pub mod emulated;
 pub mod filled;
 pub mod initialized;
 pub mod rejected;

--- a/nautilus_core/model/src/python/mod.rs
+++ b/nautilus_core/model/src/python/mod.rs
@@ -299,5 +299,6 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::events::order::rejected::OrderRejected>()?;
     m.add_class::<crate::events::order::triggered::OrderTriggered>()?;
     m.add_class::<crate::events::order::submitted::OrderSubmitted>()?;
+    m.add_class::<crate::events::order::emulated::OrderEmulated>()?;
     Ok(())
 }

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -769,6 +769,21 @@ class OrderSubmitted:
     def from_dict(cls, values: dict[str, str]) -> OrderSubmitted: ...
     def to_dict(self) -> dict[str, str]: ...
 
+class OrderEmulated:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        event_id: UUID4,
+        ts_event: int,
+        ts_init: int,
+    ) -> None : ...
+    @classmethod
+    def from_dict(cls, values: dict[str, str]) -> OrderEmulated: ...
+    def to_dict(self) -> dict[str, str]: ...
+
 
 ###################################################################################################
 # Infrastructure

--- a/nautilus_trader/test_kit/rust/events_pyo3.py
+++ b/nautilus_trader/test_kit/rust/events_pyo3.py
@@ -20,6 +20,7 @@ from nautilus_trader.core.nautilus_pyo3 import Currency
 from nautilus_trader.core.nautilus_pyo3 import LiquiditySide
 from nautilus_trader.core.nautilus_pyo3 import Money
 from nautilus_trader.core.nautilus_pyo3 import OrderDenied
+from nautilus_trader.core.nautilus_pyo3 import OrderEmulated
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderListId
@@ -150,6 +151,19 @@ class TestEventsProviderPyo3:
             instrument_id=TestIdProviderPyo3.ethusdt_binance_id(),
             client_order_id=TestIdProviderPyo3.client_order_id(),
             account_id=TestIdProviderPyo3.account_id(),
+            event_id=UUID4(uuid),
+            ts_init=0,
+            ts_event=0,
+        )
+
+    @staticmethod
+    def order_emulated() -> OrderEmulated:
+        uuid = "91762096-b188-49ea-8562-8d8a4cc22ff2"
+        return OrderEmulated(
+            trader_id=TestIdProviderPyo3.trader_id(),
+            strategy_id=TestIdProviderPyo3.strategy_id(),
+            instrument_id=TestIdProviderPyo3.ethusdt_binance_id(),
+            client_order_id=TestIdProviderPyo3.client_order_id(),
             event_id=UUID4(uuid),
             ts_init=0,
             ts_event=0,

--- a/tests/unit_tests/model/test_events_pyo3.py
+++ b/tests/unit_tests/model/test_events_pyo3.py
@@ -15,6 +15,7 @@
 
 
 from nautilus_trader.core.nautilus_pyo3 import OrderDenied
+from nautilus_trader.core.nautilus_pyo3 import OrderEmulated
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderRejected
@@ -138,4 +139,21 @@ def test_order_submitted():
         == "OrderSubmitted(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, "
         + "client_order_id=O-20210410-022422-001-001-1, account_id=SIM-000, "
         + "event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_event=0, ts_init=0)"
+    )
+
+
+def test_order_emulated():
+    event = TestEventsProviderPyo3.order_emulated()
+    result_dict = OrderEmulated.to_dict(event)
+    order_emulated = OrderEmulated.from_dict(result_dict)
+    assert order_emulated == event
+    assert (
+        str(event)
+        == "OrderEmulated(instrument_id=ETHUSDT.BINANCE, client_order_id=O-20210410-022422-001-001-1)"
+    )
+    assert (
+        repr(event)
+        == "OrderEmulated(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, "
+        + "client_order_id=O-20210410-022422-001-001-1, "
+        + "event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_init=0)"
     )


### PR DESCRIPTION
# Pull Request

- finished event `OrderEmulated` in rust and exported in with pyo3 and tested on the python side