### PR TITLE
Implement event OrderReleased in Rust

### DIFF
--- a/nautilus_core/model/src/events/order/stubs.rs
+++ b/nautilus_core/model/src/events/order/stubs.rs
@@ -23,8 +23,8 @@ use crate::{
     enums::{ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType},
     events::order::{
         denied::OrderDenied, emulated::OrderEmulated, filled::OrderFilled,
-        initialized::OrderInitialized, rejected::OrderRejected, submitted::OrderSubmitted,
-        triggered::OrderTriggered,
+        initialized::OrderInitialized, rejected::OrderRejected, released::OrderReleased,
+        submitted::OrderSubmitted, triggered::OrderTriggered,
     },
     identifiers::{
         account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
@@ -219,6 +219,27 @@ pub fn order_emulated(
         strategy_id_ema_cross,
         instrument_id_btc_usdt,
         client_order_id,
+        uuid4,
+        0,
+        0,
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn order_released(
+    trader_id: TraderId,
+    strategy_id_ema_cross: StrategyId,
+    instrument_id_btc_usdt: InstrumentId,
+    client_order_id: ClientOrderId,
+    uuid4: UUID4,
+) -> OrderReleased {
+    OrderReleased::new(
+        trader_id,
+        strategy_id_ema_cross,
+        instrument_id_btc_usdt,
+        client_order_id,
+        Price::from_str("22000").unwrap(),
         uuid4,
         0,
         0,

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -18,5 +18,6 @@ pub mod emulated;
 pub mod filled;
 pub mod initialized;
 pub mod rejected;
+pub mod released;
 pub mod submitted;
 pub mod triggered;

--- a/nautilus_core/model/src/python/events/order/released.rs
+++ b/nautilus_core/model/src/python/events/order/released.rs
@@ -1,0 +1,111 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::{
+    python::{serialization::from_dict_pyo3, to_pyvalue_err},
+    time::UnixNanos,
+    uuid::UUID4,
+};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::{
+    events::order::released::OrderReleased,
+    identifiers::{
+        client_order_id::ClientOrderId, instrument_id::InstrumentId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    types::price::Price,
+};
+
+#[pymethods]
+impl OrderReleased {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        released_price: Price,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> PyResult<Self> {
+        Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            released_price,
+            event_id,
+            ts_event,
+            ts_init,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "{}(trader_id={}, strategy_id={}, instrument_id={}, client_order_id={}, released_price={}, event_id={}, ts_init={})",
+            stringify!(OrderReleased),
+            self.trader_id,
+            self.strategy_id,
+            self.instrument_id,
+            self.client_order_id,
+            self.released_price,
+            self.event_id,
+            self.ts_init
+        )
+    }
+
+    fn __str__(&self) -> String {
+        format!(
+            "{}(instrument_id={}, client_order_id={}, released_price={})",
+            stringify!(OrderReleased),
+            self.instrument_id,
+            self.client_order_id,
+            self.released_price
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("trader_id", self.trader_id.to_string())?;
+        dict.set_item("strategy_id", self.strategy_id.to_string())?;
+        dict.set_item("instrument_id", self.instrument_id.to_string())?;
+        dict.set_item("client_order_id", self.client_order_id.to_string())?;
+        dict.set_item("released_price", self.released_price.to_string())?;
+        dict.set_item("event_id", self.event_id.to_string())?;
+        dict.set_item("ts_event", self.ts_event.to_u64())?;
+        dict.set_item("ts_init", self.ts_init.to_u64())?;
+        Ok(dict.into())
+    }
+}

--- a/nautilus_core/model/src/python/mod.rs
+++ b/nautilus_core/model/src/python/mod.rs
@@ -300,5 +300,6 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::events::order::triggered::OrderTriggered>()?;
     m.add_class::<crate::events::order::submitted::OrderSubmitted>()?;
     m.add_class::<crate::events::order::emulated::OrderEmulated>()?;
+    m.add_class::<crate::events::order::released::OrderReleased>()?;
     Ok(())
 }

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -784,6 +784,22 @@ class OrderEmulated:
     def from_dict(cls, values: dict[str, str]) -> OrderEmulated: ...
     def to_dict(self) -> dict[str, str]: ...
 
+class OrderReleased:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        released_price: Price,
+        event_id: UUID4,
+        ts_event: int,
+        ts_init: int,
+    ) -> None: ...
+    @classmethod
+    def from_dict(cls, values: dict[str, str]) -> OrderReleased: ...
+    def to_dict(self) -> dict[str, str]: ...
+
 
 ###################################################################################################
 # Infrastructure

--- a/nautilus_trader/test_kit/rust/events_pyo3.py
+++ b/nautilus_trader/test_kit/rust/events_pyo3.py
@@ -25,6 +25,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderListId
 from nautilus_trader.core.nautilus_pyo3 import OrderRejected
+from nautilus_trader.core.nautilus_pyo3 import OrderReleased
 from nautilus_trader.core.nautilus_pyo3 import OrderSide
 from nautilus_trader.core.nautilus_pyo3 import OrderSubmitted
 from nautilus_trader.core.nautilus_pyo3 import OrderTriggered
@@ -164,6 +165,20 @@ class TestEventsProviderPyo3:
             strategy_id=TestIdProviderPyo3.strategy_id(),
             instrument_id=TestIdProviderPyo3.ethusdt_binance_id(),
             client_order_id=TestIdProviderPyo3.client_order_id(),
+            event_id=UUID4(uuid),
+            ts_init=0,
+            ts_event=0,
+        )
+
+    @staticmethod
+    def order_released() -> OrderReleased:
+        uuid = "91762096-b188-49ea-8562-8d8a4cc22ff2"
+        return OrderReleased(
+            trader_id=TestIdProviderPyo3.trader_id(),
+            strategy_id=TestIdProviderPyo3.strategy_id(),
+            instrument_id=TestIdProviderPyo3.ethusdt_binance_id(),
+            client_order_id=TestIdProviderPyo3.client_order_id(),
+            released_price=Price.from_str("22000.0"),
             event_id=UUID4(uuid),
             ts_init=0,
             ts_event=0,

--- a/tests/unit_tests/model/test_events_pyo3.py
+++ b/tests/unit_tests/model/test_events_pyo3.py
@@ -19,6 +19,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderEmulated
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderRejected
+from nautilus_trader.core.nautilus_pyo3 import OrderReleased
 from nautilus_trader.core.nautilus_pyo3 import OrderSubmitted
 from nautilus_trader.core.nautilus_pyo3 import OrderTriggered
 from nautilus_trader.test_kit.rust.events_pyo3 import TestEventsProviderPyo3
@@ -156,4 +157,20 @@ def test_order_emulated():
         == "OrderEmulated(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, "
         + "client_order_id=O-20210410-022422-001-001-1, "
         + "event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_init=0)"
+    )
+
+
+def test_order_released():
+    event = TestEventsProviderPyo3.order_released()
+    result_dict = OrderReleased.to_dict(event)
+    order_released = OrderReleased.from_dict(result_dict)
+    assert order_released == event
+    assert (
+        str(event)
+        == "OrderReleased(instrument_id=ETHUSDT.BINANCE, client_order_id=O-20210410-022422-001-001-1, released_price=22000.0)"
+    )
+    assert (
+        repr(event)
+        == "OrderReleased(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, "
+        + "client_order_id=O-20210410-022422-001-001-1, released_price=22000.0, event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_init=0)"
     )


### PR DESCRIPTION
# Pull Request

- finished event `OrderReleased` in rust and exported in with pyo3 and tested on the python side