### PR TITLE
Attach method name when raising not implemented error

### DIFF
--- a/nautilus_trader/accounting/accounts/base.pyx
+++ b/nautilus_trader/accounting/accounts/base.pyx
@@ -458,10 +458,10 @@ cdef class Account:
         bool
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_unleveraged` must be implemented in the subclass")  # pragma: no cover
 
     cdef void _recalculate_balance(self, Currency currency):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_recalculate_balance` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Money calculate_commission(
         self,
@@ -471,7 +471,7 @@ cdef class Account:
         LiquiditySide liquidity_side,
         bint use_quote_for_inverse=False,
     ):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `calculate_commission` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list calculate_pnls(
         self,
@@ -479,7 +479,7 @@ cdef class Account:
         OrderFilled fill,
         Position position: Optional[Position] = None,
     ):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `calculate_pnls` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Money balance_impact(
         self,
@@ -488,4 +488,4 @@ cdef class Account:
         Price price,
         OrderSide order_side,
     ):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `balance_impact` must be implemented in the subclass")  # pragma: no cover

--- a/nautilus_trader/adapters/_template/data.py
+++ b/nautilus_trader/adapters/_template/data.py
@@ -60,29 +60,43 @@ class TemplateLiveDataClient(LiveDataClient):
     """
 
     async def _connect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_connect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _disconnect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_disconnect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def reset(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `reset` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def dispose(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `dispose` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- SUBSCRIPTIONS ----------------------------------------------------------------------------
 
     async def _subscribe(self, data_type: DataType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe(self, data_type: DataType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- REQUESTS ---------------------------------------------------------------------------------
 
     async def _request(self, data_type: DataType, correlation_id: UUID4) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request` must be implemented in the subclass",
+        )  # pragma: no cover
 
 
 class TemplateLiveMarketDataClient(LiveMarketDataClient):
@@ -134,27 +148,41 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
     """
 
     async def _connect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_connect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _disconnect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_disconnect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def reset(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `reset` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def dispose(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `dispose` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- SUBSCRIPTIONS ----------------------------------------------------------------------------
 
     async def _subscribe(self, data_type: DataType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_instruments(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_instruments` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_instrument(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_instrument` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_order_book_deltas(
         self,
@@ -163,7 +191,9 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         depth: int | None = None,
         kwargs: dict | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_order_book_deltas` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_order_book_snapshots(
         self,
@@ -172,69 +202,111 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         depth: int | None = None,
         kwargs: dict | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_order_book_snapshots` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_ticker(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_ticker` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_quote_ticks` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_trade_ticks` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_bars(self, bar_type: BarType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_bars` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_instrument_status` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_subscribe_instrument_close` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe(self, data_type: DataType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_instruments(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_instruments` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_instrument` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_order_book_deltas` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_order_book_snapshots` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_ticker(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_ticker` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_quote_tick` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_trade_ticks` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_bars(self, bar_type: BarType) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_bars` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_instrument_status` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _unsubscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_unsubscribe_instrument_close` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- REQUESTS ---------------------------------------------------------------------------------
 
     async def _request(self, data_type: DataType, correlation_id: UUID4) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _request_instrument(self, instrument_id: InstrumentId, correlation_id: UUID4):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request_instrument` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _request_instruments(self, venue: Venue, correlation_id: UUID4):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request_instruments` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _request_quote_ticks(
         self,
@@ -244,7 +316,9 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request_quote_tick` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _request_trade_ticks(
         self,
@@ -254,7 +328,9 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request_trade_ticks` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _request_bars(
         self,
@@ -264,4 +340,6 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_request_bars` must be implemented in the subclass",
+        )  # pragma: no cover

--- a/nautilus_trader/adapters/_template/execution.py
+++ b/nautilus_trader/adapters/_template/execution.py
@@ -68,16 +68,24 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
     """
 
     async def _connect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_connect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _disconnect(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_disconnect` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def reset(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `reset` must be implemented in the subclass",
+        )  # pragma: no cover
 
     def dispose(self) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `dispose` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- EXECUTION REPORTS ------------------------------------------------------------------------
 
@@ -87,7 +95,9 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
         client_order_id: ClientOrderId | None = None,
         venue_order_id: VenueOrderId | None = None,
     ) -> OrderStatusReport | None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_order_status_report` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_order_status_reports(
         self,
@@ -96,7 +106,9 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
         end: pd.Timestamp | None = None,
         open_only: bool = False,
     ) -> list[OrderStatusReport]:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_order_status_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_trade_reports(
         self,
@@ -105,7 +117,9 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ) -> list[TradeReport]:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_trade_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_position_status_reports(
         self,
@@ -113,24 +127,38 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ) -> list[PositionStatusReport]:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_position_status_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     # -- COMMAND HANDLERS -------------------------------------------------------------------------
 
     async def _submit_order(self, command: SubmitOrder) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_submit_order` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _submit_order_list(self, command: SubmitOrderList) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_submit_order_list` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _modify_order(self, command: ModifyOrder) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_modify_order` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _cancel_order(self, command: CancelOrder) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_cancel_order` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _cancel_all_orders(self, command: CancelAllOrders) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_cancel_all_orders` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def _query_order(self, command: QueryOrder) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `_query_order` must be implemented in the subclass",
+        )  # pragma: no cover

--- a/nautilus_trader/adapters/_template/providers.py
+++ b/nautilus_trader/adapters/_template/providers.py
@@ -36,14 +36,20 @@ class TemplateInstrumentProvider(InstrumentProvider):
     """
 
     async def load_all_async(self, filters: dict | None = None) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_all_async` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def load_ids_async(
         self,
         instrument_ids: list[InstrumentId],
         filters: dict | None = None,
     ) -> None:
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_ids_async` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def load_async(self, instrument_id: InstrumentId, filters: dict | None = None):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_async` must be implemented in the subclass",
+        )  # pragma: no cover

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -122,7 +122,7 @@ class Base:
         req_id: int | None = None,
         name: str | tuple | None = None,
     ):
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `get` must be implemented in the subclass")
 
 
 class Subscriptions(Base):

--- a/nautilus_trader/backtest/modules.pyx
+++ b/nautilus_trader/backtest/modules.pyx
@@ -71,20 +71,20 @@ cdef class SimulationModule(Actor):
         self.exchange = exchange
 
     cpdef void pre_process(self, Data data):
-        """Abstract method (implement in subclass)."""
+        """Abstract method `pre_process` (implement in subclass)."""
         pass
 
     cpdef void process(self, uint64_t ts_now):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `process` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void log_diagnostics(self, LoggerAdapter log):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `log_diagnostics` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void reset(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `reset` must be implemented in the subclass")  # pragma: no cover
 
 
 _TZ_US_EAST = pytz.timezone("US/Eastern")

--- a/nautilus_trader/cache/base.pyx
+++ b/nautilus_trader/cache/base.pyx
@@ -44,93 +44,93 @@ cdef class CacheFacade:
 
     cpdef bytes get(self, str key):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `get` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add(self, str key, bytes value):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add` must be implemented in the subclass")  # pragma: no cover
 
 # -- DATA QUERIES ---------------------------------------------------------------------------------
 
     cpdef list tickers(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `tickers` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list quote_ticks(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `quote_ticks` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list trade_ticks(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `trade_ticks` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list bars(self, BarType bar_type):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `bars` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Price price(self, InstrumentId instrument_id, PriceType price_type):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `price` must be implemented in the subclass")  # pragma: no cover
 
     cpdef OrderBook order_book(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_book` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Ticker ticker(self, InstrumentId instrument_id, int index=0):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `ticker` must be implemented in the subclass")  # pragma: no cover
 
     cpdef QuoteTick quote_tick(self, InstrumentId instrument_id, int index=0):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `quote_tick` must be implemented in the subclass")  # pragma: no cover
 
     cpdef TradeTick trade_tick(self, InstrumentId instrument_id, int index=0):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `trade_tick` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Bar bar(self, BarType bar_type, int index=0):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `bar` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int book_update_count(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `book_update_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int ticker_count(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `ticket_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int quote_tick_count(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `quote_tick_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int trade_tick_count(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `trade_tick_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int bar_count(self, BarType bar_type):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `bar_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint has_order_book(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_order_book` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint has_tickers(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_tickers` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint has_quote_ticks(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_quote_ticks` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint has_trade_ticks(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_trade_ticks` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint has_bars(self, BarType bar_type):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_bars` must be implemented in the subclass")  # pragma: no cover
 
     cpdef double get_xrate(
         self,
@@ -140,286 +140,286 @@ cdef class CacheFacade:
         PriceType price_type=PriceType.MID,
     ):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `get_xrate` must be implemented in the subclass")  # pragma: no cover
 
 # -- INSTRUMENT QUERIES ---------------------------------------------------------------------------
 
     cpdef Instrument instrument(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `instrument` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list instrument_ids(self, Venue venue = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `instrument_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list instruments(self, Venue venue = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `instruments` must be implemented in the subclass")  # pragma: no cover
 
 # -- SYNTHETIC QUERIES ----------------------------------------------------------------------------
 
     cpdef SyntheticInstrument synthetic(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `synthetic` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list synthetic_ids(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `synthetic_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list synthetics(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `synthetics` must be implemented in the subclass")  # pragma: no cover
 
 # -- ACCOUNT QUERIES ------------------------------------------------------------------------------
 
     cpdef Account account(self, AccountId account_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `account` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Account account_for_venue(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `account_for_venue` must be implemented in the subclass")  # pragma: no cover
 
     cpdef AccountId account_id(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `account_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list accounts(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `accounts` must be implemented in the subclass")  # pragma: no cover
 
 # -- IDENTIFIER QUERIES ---------------------------------------------------------------------------
 
     cpdef set client_order_ids(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set client_order_ids_open(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_ids_open` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set client_order_ids_closed(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_ids_closed` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set client_order_ids_emulated(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_ids_emulated` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set client_order_ids_inflight(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_ids_inflight` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set order_list_ids(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_list_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set position_ids(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set position_open_ids(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_open_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set position_closed_ids(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_closed_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set actor_ids(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `actor_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set strategy_ids(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `strategy_ids` must be implemented in the subclass")  # pragma: no cover
 
     cpdef set exec_algorithm_ids(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `exec_algorithm_ids` must be implemented in the subclass")  # pragma: no cover
 
 # -- ORDER QUERIES --------------------------------------------------------------------------------
 
     cpdef Order order(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef ClientOrderId client_order_id(self, VenueOrderId venue_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_order_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef VenueOrderId venue_order_id(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `venue_order_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef ClientId client_id(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `client_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_open(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_open` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_closed(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_closed` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_emulated(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_emulated` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_inflight(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_inflight` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_for_position(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_for_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint order_exists(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_exists` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_order_open(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_order_open` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_order_closed(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_order_closed` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_order_emulated(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_order_emulated` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_order_inflight(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_order_inflight` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_order_pending_cancel_local(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_order_pending_cancel_local` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int orders_open_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_open_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int orders_closed_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_closed_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int orders_emulated_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_emulated_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int orders_inflight_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_inflight_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int orders_total_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_total_count` must be implemented in the subclass")  # pragma: no cover
 
 # -- ORDER_LIST_QUERIES ---------------------------------------------------------------------------
 
     cpdef OrderList order_list(self, OrderListId order_list_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_list` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list order_lists(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_lists` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint order_list_exists(self, OrderListId order_list_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `order_list_exists` must be implemented in the subclass")  # pragma: no cover
 
 # -- EXEC ALGORITHM QUERIES -----------------------------------------------------------------------
 
     cpdef list orders_for_exec_algorithm(self, ExecAlgorithmId exec_algorithm_id, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, OrderSide side = OrderSide.NO_ORDER_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_for_exec_algorithm` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list orders_for_exec_spawn(self, ClientOrderId exec_spawn_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `orders_for_exec_spawn` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Quantity exec_spawn_total_quantity(self, ClientOrderId exec_spawn_id, bint active_only=False):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `exec_spawn_total_quantity` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Quantity exec_spawn_total_filled_qty(self, ClientOrderId exec_spawn_id, bint active_only=False):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `exec_spawn_total_filled_qty` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Quantity exec_spawn_total_leaves_qty(self, ClientOrderId exec_spawn_id, bint active_only=False):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `exec_spawn_total_leaves_qty` must be implemented in the subclass")  # pragma: no cover
 
 # -- POSITION QUERIES -----------------------------------------------------------------------------
 
     cpdef Position position(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Position position_for_order(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_for_order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef PositionId position_id(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list position_snapshots(self, PositionId position_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_snapshots` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list positions(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, PositionSide side = PositionSide.NO_POSITION_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint position_exists(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `position_exists` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list positions_open(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, PositionSide side = PositionSide.NO_POSITION_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions_open` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list positions_closed(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions_closed` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_position_open(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_position_open` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_position_closed(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_position_closed` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int positions_open_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, PositionSide side = PositionSide.NO_POSITION_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions_open_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int positions_closed_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions_closed_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef int positions_total_count(self, Venue venue = None, InstrumentId instrument_id = None, StrategyId strategy_id = None, PositionSide side = PositionSide.NO_POSITION_SIDE):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `positions_total_count` must be implemented in the subclass")  # pragma: no cover
 
 # -- STRATEGY QUERIES -----------------------------------------------------------------------------
 
     cpdef StrategyId strategy_id_for_order(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `strategy_id_for_order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef StrategyId strategy_id_for_position(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `strategy_id_for_position` must be implemented in the subclass")  # pragma: no cover

--- a/nautilus_trader/cache/facade.pyx
+++ b/nautilus_trader/cache/facade.pyx
@@ -79,152 +79,152 @@ cdef class CacheDatabaseFacade:
 
     cpdef void flush(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `flush` must be implemented in the subclass")  # pragma: no cover
 
     cpdef list[str] keys(self, str pattern = "*"):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `keys` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_currencies(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_currencies` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_instruments(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_instruments` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_synthetics(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_synthetics` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_accounts(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_accounts` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_orders(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_orders` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_positions(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_positions` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_index_order_position(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_index_order_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_index_order_client(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_index_order_client` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Currency load_currency(self, str code):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_currency` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Instrument load_instrument(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_instrument` must be implemented in the subclass")  # pragma: no cover
 
     cpdef SyntheticInstrument load_synthetic(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_synthetic` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Account load_account(self, AccountId account_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_account` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Order load_order(self, ClientOrderId client_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Position load_position(self, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_actor(self, ComponentId component_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_actor` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void delete_actor(self, ComponentId component_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `delete_actor` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict load_strategy(self, StrategyId strategy_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `load_strategy` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void delete_strategy(self, StrategyId strategy_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `delete_strategy` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add(self, str key, bytes value):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_currency(self, Currency currency):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_currency` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_instrument(self, Instrument instrument):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_instrument` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_synthetic(self, SyntheticInstrument synthetic):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_synthetic` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_account(self, Account account):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_account` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_order(self, Order order, PositionId position_id = None, ClientId client_id = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void add_position(self, Position position):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `add_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void index_venue_order_id(self, ClientOrderId client_order_id, VenueOrderId venue_order_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `index_venue_order_id` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void index_order_position(self, ClientOrderId client_order_id, PositionId position_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `index_order_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void update_account(self, Account event):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_account` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void update_order(self, Order order):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_order` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void update_position(self, Position position):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void update_actor(self, Actor actor):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_actor` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void update_strategy(self, Strategy strategy):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_strategy` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void snapshot_order_state(self, Order order):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `snapshot_order_state` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void snapshot_position_state(self, Position position, uint64_t ts_snapshot, Money unrealized_pnl = None):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `snapshot_position_state` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void heartbeat(self, datetime timestamp):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `heartbeat` must be implemented in the subclass")  # pragma: no cover

--- a/nautilus_trader/common/clock.pyx
+++ b/nautilus_trader/common/clock.pyx
@@ -94,7 +94,7 @@ cdef class Clock:
         list[str]
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `timer_names` must be implemented in the subclass")  # pragma: no cover
 
     @property
     def timer_count(self) -> int:
@@ -106,7 +106,7 @@ cdef class Clock:
         int
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `timer_count` must be implemented in the subclass")  # pragma: no cover
 
     cpdef double timestamp(self):
         """
@@ -121,7 +121,7 @@ cdef class Clock:
         https://en.wikipedia.org/wiki/Unix_time
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `timestamp` must be implemented in the subclass")  # pragma: no cover
 
     cpdef uint64_t timestamp_ms(self):
         """
@@ -136,7 +136,7 @@ cdef class Clock:
         https://en.wikipedia.org/wiki/Unix_time
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `timestamp_ms` must be implemented in the subclass")  # pragma: no cover
 
     cpdef uint64_t timestamp_ns(self):
         """
@@ -151,7 +151,7 @@ cdef class Clock:
         https://en.wikipedia.org/wiki/Unix_time
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `timestamp_ns` must be implemented in the subclass")  # pragma: no cover
 
     cpdef datetime utc_now(self):
         """
@@ -196,7 +196,7 @@ cdef class Clock:
             If `handler` is not of type `Callable`.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `register_default_handler` must be implemented in the subclass")  # pragma: no cover
 
     cpdef uint64_t next_time_ns(self, str name):
         """
@@ -217,7 +217,7 @@ cdef class Clock:
             If `name` is not a valid string.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `next_time_ns` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void set_time_alert(
         self,
@@ -303,7 +303,7 @@ cdef class Clock:
         time event will be generated (rather than being invalid and failing a condition check).
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `set_time_alert_ns` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void set_timer(
         self,
@@ -407,7 +407,7 @@ cdef class Clock:
             If `callback` is ``None`` and no default handler is registered.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `set_timer_ns` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void cancel_timer(self, str name):
         """
@@ -426,13 +426,13 @@ cdef class Clock:
             If `name` is not an active timer name for this clock.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `cancel_timer` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void cancel_timers(self):
         """
         Cancel all timers.
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `cancel_timers` must be implemented in the subclass")  # pragma: no cover
 
 
 cdef class TestClock(Clock):
@@ -1114,7 +1114,7 @@ cdef class LiveTimer:
 
     cdef object _start_timer(self, uint64_t ts_now):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_start_timer` must be implemented in the subclass")  # pragma: no cover
 
 
 cdef class ThreadTimer(LiveTimer):

--- a/nautilus_trader/common/providers.py
+++ b/nautilus_trader/common/providers.py
@@ -81,7 +81,9 @@ class InstrumentProvider:
         Load the latest instruments into the provider asynchronously, optionally
         applying the given filters.
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_all_async` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def load_ids_async(
         self,
@@ -105,7 +107,9 @@ class InstrumentProvider:
             If any `instrument_id.venue` is not equal to `self.venue`.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_ids_async` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def load_async(
         self,
@@ -129,7 +133,9 @@ class InstrumentProvider:
             If `instrument_id.venue` is not equal to `self.venue`.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `load_async` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def initialize(self) -> None:
         """

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -324,7 +324,7 @@ cdef class BarAggregator:
         self._builder.set_partial(partial_bar)
 
     cdef void _apply_update(self, Price price, Quantity size, uint64_t ts_event):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_apply_update` must be implemented in the subclass")  # pragma: no cover
 
     cdef void _build_now_and_send(self):
         cdef Bar bar = self._builder.build_now()

--- a/nautilus_trader/data/client.pyx
+++ b/nautilus_trader/data/client.pyx
@@ -401,7 +401,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to {data_type}: not implemented. "
             f"You can implement by overriding the `subscribe` method for this client.",
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe` must be implemented in the subclass")
 
     cpdef void subscribe_instruments(self):
         """
@@ -412,7 +412,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to all `Instrument` data: not implemented. "
             f"You can implement by overriding the `subscribe_instruments` method for this client.",
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_instruments` must be implemented in the subclass")
 
     cpdef void subscribe_instrument(self, InstrumentId instrument_id):
         """
@@ -423,7 +423,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `Instrument` data for {instrument_id}: not implemented. "
             f"You can implement by overriding the `subscribe_instrument` method for this client.",
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_instrument` must be implemented in the subclass")
 
     cpdef void subscribe_order_book_deltas(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict kwargs = None):
         """
@@ -445,7 +445,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `OrderBookDeltas` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_order_book_deltas` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_order_book_deltas` must be implemented in the subclass")
 
     cpdef void subscribe_order_book_snapshots(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict kwargs = None):
         """
@@ -467,7 +467,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `OrderBook` snapshots data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_order_book_snapshots` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_order_book_snapshots` must be implemented in the subclass")
 
     cpdef void subscribe_ticker(self, InstrumentId instrument_id):
         """
@@ -483,7 +483,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `Ticker` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_ticker` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_ticker` must be implemented in the subclass")
 
     cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id):
         """
@@ -499,7 +499,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `QuoteTick` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_quote_ticks` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_quote_ticks` must be implemented in the subclass")
 
     cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id):
         """
@@ -515,7 +515,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `TradeTick` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_trade_ticks` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_trade_ticks` must be implemented in the subclass")
 
     cpdef void subscribe_venue_status(self, Venue venue):
         """
@@ -531,7 +531,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `VenueStatus` data for {venue}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_venue_status` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_venue_status` must be implemented in the subclass")
 
     cpdef void subscribe_instrument_status(self, InstrumentId instrument_id):
         """
@@ -547,7 +547,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `InstrumentStatus` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_instrument_status` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_instrument_status` must be implemented in the subclass")
 
     cpdef void subscribe_instrument_close(self, InstrumentId instrument_id):
         """
@@ -563,7 +563,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `InstrumentClose` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_instrument_close` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_instrument_close` must be implemented in the subclass")
 
     cpdef void subscribe_bars(self, BarType bar_type):
         """
@@ -579,7 +579,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot subscribe to `Bar` data for {bar_type}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `subscribe_bars` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `subscribe_bars` must be implemented in the subclass")
 
     cpdef void unsubscribe(self, DataType data_type):
         """
@@ -605,7 +605,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from all `Instrument` data: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_instruments` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_instruments` must be implemented in the subclass")
 
     cpdef void unsubscribe_instrument(self, InstrumentId instrument_id):
         """
@@ -621,7 +621,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `Instrument` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_instrument` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_instrument` must be implemented in the subclass")
 
     cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id):
         """
@@ -637,7 +637,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `OrderBookDeltas` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_order_book_deltas` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_order_book_deltas` must be implemented in the subclass")
 
     cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id):
         """
@@ -653,7 +653,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `OrderBook` snapshot data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_order_book_snapshots` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_order_book_snapshots` must be implemented in the subclass")
 
     cpdef void unsubscribe_ticker(self, InstrumentId instrument_id):
         """
@@ -669,7 +669,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `Ticker` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_ticker` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_ticker` must be implemented in the subclass")
 
     cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id):
         """
@@ -685,7 +685,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `QuoteTick` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_quote_ticks` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_quote_ticks` must be implemented in the subclass")
 
     cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id):
         """
@@ -701,7 +701,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `TradeTick` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_trade_ticks` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_trade_ticks` must be implemented in the subclass")
 
     cpdef void unsubscribe_bars(self, BarType bar_type):
         """
@@ -717,7 +717,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `Bar` data for {bar_type}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_bars` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_bars` must be implemented in the subclass")
 
     cpdef void unsubscribe_venue_status(self, Venue venue):
         """
@@ -733,7 +733,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `VenueStatus` data for {venue}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_venue_status` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_venue_status` must be implemented in the subclass")
 
     cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id):
         """
@@ -749,7 +749,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `InstrumentStatus` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_instrument_status` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_instrument_status` must be implemented in the subclass")
 
     cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id):
         """
@@ -765,7 +765,7 @@ cdef class MarketDataClient(DataClient):
             f"Cannot unsubscribe from `InstrumentClose` data for {instrument_id}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `unsubscribe_instrument_close` method for this client.",  # pragma: no cover
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `unsubscribe_instrument_close` must be implemented in the subclass")
 
     cpdef void _add_subscription(self, DataType data_type):
         Condition.not_none(data_type, "data_type")

--- a/nautilus_trader/execution/client.pyx
+++ b/nautilus_trader/execution/client.pyx
@@ -179,7 +179,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `submit_order` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `submit_order` must be implemented in the subclass")
 
     cpdef void submit_order_list(self, SubmitOrderList command):
         """
@@ -195,7 +195,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `submit_order_list` method for this client.",  # pragma: no cover   # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `submit_order_list` must be implemented in the subclass")
 
     cpdef void modify_order(self, ModifyOrder command):
         """
@@ -211,7 +211,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `modify_order` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `modify_order` must be implemented in the subclass")
 
     cpdef void cancel_order(self, CancelOrder command):
         """
@@ -227,7 +227,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `cancel_order` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `cancel_order` must be implemented in the subclass")
 
     cpdef void cancel_all_orders(self, CancelAllOrders command):
         """
@@ -243,7 +243,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `cancel_all_orders` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `cancel_all_orders` must be implemented in the subclass")
 
     cpdef void batch_cancel_orders(self, BatchCancelOrders command):
         """
@@ -259,7 +259,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `batch_cancel_orders` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `batch_cancel_orders` must be implemented in the subclass")
 
     cpdef void query_order(self, QueryOrder command):
         """
@@ -276,7 +276,7 @@ cdef class ExecutionClient(Component):
             f"Cannot execute command {command}: not implemented. "  # pragma: no cover
             f"You can implement by overriding the `query_order` method for this client.",  # pragma: no cover  # noqa
         )
-        raise NotImplementedError("method must be implemented in the subclass")
+        raise NotImplementedError("method `query_order` must be implemented in the subclass")
 
 # -- EVENT HANDLERS -------------------------------------------------------------------------------
 

--- a/nautilus_trader/indicators/average/moving_average.pyx
+++ b/nautilus_trader/indicators/average/moving_average.pyx
@@ -78,7 +78,7 @@ cdef class MovingAverage(Indicator):
             The update value.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `update_raw` must be implemented in the subclass")  # pragma: no cover
 
     cpdef void _increment_count(self):
         self.count += 1

--- a/nautilus_trader/indicators/base/indicator.pyx
+++ b/nautilus_trader/indicators/base/indicator.pyx
@@ -47,15 +47,15 @@ cdef class Indicator:
 
     cpdef void handle_quote_tick(self, QuoteTick tick):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError(f"Cannot handle {repr(tick)}: method not implemented in subclass")  # pragma: no cover
+        raise NotImplementedError(f"Cannot handle {repr(tick)}: method `handle_quote_tick` not implemented in subclass")  # pragma: no cover
 
     cpdef void handle_trade_tick(self, TradeTick tick):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError(f"Cannot handle {repr(tick)}: method not implemented in subclass")  # pragma: no cover
+        raise NotImplementedError(f"Cannot handle {repr(tick)}: method `handle_trade_tick` not implemented in subclass")  # pragma: no cover
 
     cpdef void handle_bar(self, Bar bar):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError(f"Cannot handle {repr(bar)}: method not implemented in subclass")  # pragma: no cover
+        raise NotImplementedError(f"Cannot handle {repr(bar)}: method `handle_bar` not implemented in subclass")  # pragma: no cover
 
     cpdef void reset(self):
         """
@@ -75,4 +75,4 @@ cdef class Indicator:
 
     cpdef void _reset(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_reset` must be implemented in the subclass")  # pragma: no cover

--- a/nautilus_trader/live/execution_client.py
+++ b/nautilus_trader/live/execution_client.py
@@ -313,7 +313,9 @@ class LiveExecutionClient(ExecutionClient):
             If both the `client_order_id` and `venue_order_id` are ``None``.
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_order_status_report` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_order_status_reports(
         self,
@@ -343,7 +345,9 @@ class LiveExecutionClient(ExecutionClient):
         list[OrderStatusReport]
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_order_status_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_trade_reports(
         self,
@@ -373,7 +377,9 @@ class LiveExecutionClient(ExecutionClient):
         list[TradeReport]
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_trade_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_position_status_reports(
         self,
@@ -400,7 +406,9 @@ class LiveExecutionClient(ExecutionClient):
         list[PositionStatusReport]
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `generate_position_status_reports` must be implemented in the subclass",
+        )  # pragma: no cover
 
     async def generate_mass_status(
         self,

--- a/nautilus_trader/live/factories.py
+++ b/nautilus_trader/live/factories.py
@@ -65,7 +65,9 @@ class LiveDataClientFactory:
         LiveDataClient
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `create` must be implemented in the subclass",
+        )  # pragma: no cover
 
 
 class LiveExecClientFactory:
@@ -108,4 +110,6 @@ class LiveExecClientFactory:
         LiveExecutionClient
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError(
+            "method `create' must be implemented in the subclass",
+        )  # pragma: no cover

--- a/nautilus_trader/model/events/order.pyx
+++ b/nautilus_trader/model/events/order.pyx
@@ -195,7 +195,7 @@ cdef class OrderEvent(Event):
         raise NotImplementedError("abstract property must be implemented")
 
     def set_client_order_id(self, ClientOrderId client_order_id):
-        raise NotImplementedError("abstract method must be implemented")
+        raise NotImplementedError("abstract method `set_client_order_i` must be implemented")
 
 
 cdef class OrderInitialized(OrderEvent):

--- a/nautilus_trader/model/identifiers.pyx
+++ b/nautilus_trader/model/identifiers.pyx
@@ -61,10 +61,10 @@ cdef class Identifier:
     """
 
     def __getstate__(self):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `__getstate__` must be implemented in the subclass")  # pragma: no cover
 
     def __setstate__(self, state):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `__setstate__` must be implemented in the subclass")  # pragma: no cover
 
     def __lt__(self, Identifier other) -> bool:
         return self.to_str() < other.to_str()
@@ -85,7 +85,7 @@ cdef class Identifier:
         return f"{type(self).__name__}('{self.to_str()}')"
 
     cdef str to_str(self):
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `to_str` must be implemented in the subclass")  # pragma: no cover
 
     @property
     def value(self) -> str:

--- a/nautilus_trader/model/orders/base.pyx
+++ b/nautilus_trader/model/orders/base.pyx
@@ -286,7 +286,7 @@ cdef class Order:
         str
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `info` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict to_dict(self):
         """
@@ -297,7 +297,7 @@ cdef class Order:
         dict[str, object]
 
         """
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `to_dict` must be implemented in the subclass")  # pragma: no cover
 
     cdef void set_triggered_price_c(self, Price triggered_price):
         Condition.not_none(triggered_price, "triggered_price")
@@ -340,10 +340,10 @@ cdef class Order:
         return time_in_force_to_str(self.time_in_force)
 
     cdef bint has_price_c(self):
-        raise NotImplementedError("method must be implemented in subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_price_c` must be implemented in subclass")  # pragma: no cover
 
     cdef bint has_trigger_price_c(self):
-        raise NotImplementedError("method must be implemented in subclass")  # pragma: no cover
+        raise NotImplementedError("method `has_trigger_price_c` must be implemented in subclass")  # pragma: no cover
 
     cdef bint is_buy_c(self):
         return self.side == OrderSide.BUY
@@ -1034,11 +1034,11 @@ cdef class Order:
 
     cdef void _updated(self, OrderUpdated event):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_updated` must be implemented in the subclass")  # pragma: no cover
 
     cdef void _triggered(self, OrderTriggered event):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `_triggered` must be implemented in the subclass")  # pragma: no cover
 
     cdef void _canceled(self, OrderCanceled event):
         pass  # Do nothing else

--- a/nautilus_trader/portfolio/base.pyx
+++ b/nautilus_trader/portfolio/base.pyx
@@ -28,52 +28,52 @@ cdef class PortfolioFacade:
 
     cpdef Account account(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `account` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict balances_locked(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `balances_locked` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict margins_init(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `margins_init` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict margins_maint(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `margins_maint` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict unrealized_pnls(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `unrealized_pnls` must be implemented in the subclass")  # pragma: no cover
 
     cpdef dict net_exposures(self, Venue venue):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `net_exposure` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Money unrealized_pnl(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `unrealized_pnl` must be implemented in the subclass")  # pragma: no cover
 
     cpdef Money net_exposure(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `next_exposure` must be implemented in the subclass")  # pragma: no cover
 
     cpdef object net_position(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `net_position` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_net_long(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_net_long` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_net_short(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_net_short` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_flat(self, InstrumentId instrument_id):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_flat` must be implemented in the subclass")  # pragma: no cover
 
     cpdef bint is_completely_flat(self):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `is_completely_flat` must be implemented in the subclass")  # pragma: no cover

--- a/nautilus_trader/risk/sizing.pyx
+++ b/nautilus_trader/risk/sizing.pyx
@@ -73,7 +73,7 @@ cdef class PositionSizer:
         int units=1,
     ):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `calculate` must be implemented in the subclass")  # pragma: no cover
 
     cdef object _calculate_risk_ticks(self, Price entry, Price stop_loss):
         return abs(entry - stop_loss) / self.instrument.price_increment

--- a/nautilus_trader/serialization/base.pyx
+++ b/nautilus_trader/serialization/base.pyx
@@ -262,8 +262,8 @@ cdef class Serializer:
 
     cpdef bytes serialize(self, object obj):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `serialize` must be implemented in the subclass")  # pragma: no cover
 
     cpdef object deserialize(self, bytes obj_bytes):
         """Abstract method (implement in subclass)."""
-        raise NotImplementedError("method must be implemented in the subclass")  # pragma: no cover
+        raise NotImplementedError("method `deserialize` must be implemented in the subclass")  # pragma: no cover


### PR DESCRIPTION
# Pull Request

```
2023-12-03T13:11:47.021937001Z [ERR] FILIP-001.ExecClient-BYBIT: Failed to generate AccountState: method must be implemented in the subclass
```

For these type of errors it's hard to pinpoint the exact method where it happened and why it must be implemented.
 - Attached method name to error string when raising not implemented error
