### PR TITLE
Implement event OrderPendingUpdate in Rust

### DIFF
--- a/nautilus_core/model/src/events/order/pending_update.rs
+++ b/nautilus_core/model/src/events/order/pending_update.rs
@@ -13,8 +13,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::fmt::{Display, Formatter};
+
+use anyhow::Result;
 use derive_builder::{self, Builder};
 use nautilus_core::{time::UnixNanos, uuid::UUID4};
+use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::{
@@ -26,15 +30,83 @@ use crate::identifiers::{
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Builder)]
 #[builder(default)]
 #[serde(tag = "type")]
+#[cfg_attr(
+    feature = "python",
+    pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")
+)]
 pub struct OrderPendingUpdate {
     pub trader_id: TraderId,
     pub strategy_id: StrategyId,
     pub instrument_id: InstrumentId,
     pub client_order_id: ClientOrderId,
-    pub venue_order_id: Option<VenueOrderId>,
     pub account_id: AccountId,
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
-    pub reconciliation: bool,
+    pub reconciliation: u8,
+    pub venue_order_id: Option<VenueOrderId>,
+}
+
+impl OrderPendingUpdate {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+        reconciliation: bool,
+        venue_order_id: Option<VenueOrderId>,
+    ) -> Result<Self> {
+        Ok(Self {
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            account_id,
+            event_id,
+            ts_event,
+            ts_init,
+            reconciliation: reconciliation as u8,
+            venue_order_id,
+        })
+    }
+}
+
+impl Display for OrderPendingUpdate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderPendingUpdate(instrument_id={}, client_order_id={}, venue_order_id={}, account_id={}, ts_event={})",
+            self.instrument_id,
+            self.client_order_id,
+            self.venue_order_id
+                .map(|venue_order_id| format!("{}", venue_order_id))
+                .unwrap_or_else(|| "None".to_string()),
+            self.account_id,
+            self.ts_event
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use crate::events::order::{pending_update::OrderPendingUpdate, stubs::order_pending_update};
+
+    #[rstest]
+    fn test_order_pending_update_display(order_pending_update: OrderPendingUpdate) {
+        let display = format!("{}", order_pending_update);
+        assert_eq!(
+            display,
+            "OrderPendingUpdate(instrument_id=BTCUSDT.COINBASE, client_order_id=O-20200814-102234-001-001-1, venue_order_id=001, account_id=SIM-001, ts_event=0)"
+        );
+    }
 }

--- a/nautilus_core/model/src/events/order/stubs.rs
+++ b/nautilus_core/model/src/events/order/stubs.rs
@@ -23,8 +23,9 @@ use crate::{
     enums::{ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType},
     events::order::{
         denied::OrderDenied, emulated::OrderEmulated, filled::OrderFilled,
-        initialized::OrderInitialized, rejected::OrderRejected, released::OrderReleased,
-        submitted::OrderSubmitted, triggered::OrderTriggered, updated::OrderUpdated,
+        initialized::OrderInitialized, pending_update::OrderPendingUpdate, rejected::OrderRejected,
+        released::OrderReleased, submitted::OrderSubmitted, triggered::OrderTriggered,
+        updated::OrderUpdated,
     },
     identifiers::{
         account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
@@ -271,6 +272,31 @@ pub fn order_updated(
         Some(account_id),
         Some(Price::from("22000")),
         None,
+    )
+    .unwrap()
+}
+
+#[fixture]
+pub fn order_pending_update(
+    trader_id: TraderId,
+    strategy_id_ema_cross: StrategyId,
+    instrument_id_btc_usdt: InstrumentId,
+    client_order_id: ClientOrderId,
+    account_id: AccountId,
+    venue_order_id: VenueOrderId,
+    uuid4: UUID4,
+) -> OrderPendingUpdate {
+    OrderPendingUpdate::new(
+        trader_id,
+        strategy_id_ema_cross,
+        instrument_id_btc_usdt,
+        client_order_id,
+        account_id,
+        uuid4,
+        0,
+        0,
+        false,
+        Some(venue_order_id),
     )
     .unwrap()
 }

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -17,6 +17,7 @@ pub mod denied;
 pub mod emulated;
 pub mod filled;
 pub mod initialized;
+pub mod pending_update;
 pub mod rejected;
 pub mod released;
 pub mod submitted;

--- a/nautilus_core/model/src/python/events/order/pending_update.rs
+++ b/nautilus_core/model/src/python/events/order/pending_update.rs
@@ -1,0 +1,127 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2023 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::{
+    python::{serialization::from_dict_pyo3, to_pyvalue_err},
+    time::UnixNanos,
+    uuid::UUID4,
+};
+use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::{
+    events::order::pending_update::OrderPendingUpdate,
+    identifiers::{
+        account_id::AccountId, client_order_id::ClientOrderId, instrument_id::InstrumentId,
+        strategy_id::StrategyId, trader_id::TraderId, venue_order_id::VenueOrderId,
+    },
+};
+
+#[pymethods]
+impl OrderPendingUpdate {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        event_id: UUID4,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+        reconciliation: bool,
+        venue_order_id: Option<VenueOrderId>,
+    ) -> PyResult<Self> {
+        Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            account_id,
+            event_id,
+            ts_event,
+            ts_init,
+            reconciliation,
+            venue_order_id,
+        )
+        .map_err(to_pyvalue_err)
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "{}(trader_id={}, strategy_id={}, instrument_id={}, client_order_id={}, venue_order_id={}, account_id={}, event_id={}, ts_event={}, ts_init={})",
+            stringify!(OrderPendingUpdate),
+            self.trader_id,
+            self.strategy_id,
+            self.instrument_id,
+            self.client_order_id,
+            self.venue_order_id
+                .map(|venue_order_id| format!("{}", venue_order_id))
+                .unwrap_or_else(|| "None".to_string()),
+            self.account_id,
+            self.event_id,
+            self.ts_event,
+            self.ts_init
+        )
+    }
+
+    fn __str__(&self) -> String {
+        format!(
+            "{}(instrument_id={}, client_order_id={}, venue_order_id={}, account_id={}, ts_event={})",
+            stringify!(OrderPendingUpdate),
+            self.instrument_id,
+            self.client_order_id,
+            self.venue_order_id
+                .map(|venue_order_id| format!("{}", venue_order_id))
+                .unwrap_or_else(|| "None".to_string()),
+            self.account_id,
+            self.ts_event,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_dict")]
+    fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {
+        from_dict_pyo3(py, values)
+    }
+
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("trader_id", self.trader_id.to_string())?;
+        dict.set_item("strategy_id", self.strategy_id.to_string())?;
+        dict.set_item("instrument_id", self.instrument_id.to_string())?;
+        dict.set_item("client_order_id", self.client_order_id.to_string())?;
+        dict.set_item("account_id", self.account_id.to_string())?;
+        dict.set_item("event_id", self.event_id.to_string())?;
+        dict.set_item("ts_event", self.ts_event.to_u64())?;
+        dict.set_item("ts_init", self.ts_init.to_u64())?;
+        dict.set_item("reconciliation", self.reconciliation)?;
+        match self.venue_order_id {
+            Some(venue_order_id) => dict.set_item("venue_order_id", venue_order_id.to_string())?,
+            None => dict.set_item("venue_order_id", py.None())?,
+        }
+        Ok(dict.into())
+    }
+}

--- a/nautilus_core/model/src/python/mod.rs
+++ b/nautilus_core/model/src/python/mod.rs
@@ -302,5 +302,6 @@ pub fn model(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::events::order::emulated::OrderEmulated>()?;
     m.add_class::<crate::events::order::released::OrderReleased>()?;
     m.add_class::<crate::events::order::updated::OrderUpdated>()?;
+    m.add_class::<crate::events::order::pending_update::OrderPendingUpdate>()?;
     Ok(())
 }

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -954,6 +954,26 @@ class OrderUpdated:
     def from_dict(cls, values: dict[str, str]) -> OrderUpdated: ...
     def to_dict(self) -> dict[str, str]: ...
 
+class OrderPendingUpdate:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        event_id: UUID4,
+        ts_event: int,
+        ts_init: int,
+        reconciliation: bool,
+        venue_order_id: VenueOrderId | None = None,
+    ) -> None: ...
+    @classmethod
+    def from_dict(cls, values: dict[str, str]) -> OrderPendingUpdate: ...
+    def to_dict(self) -> dict[str, str]: ...
+
+
+
 
 ###################################################################################################
 # Infrastructure

--- a/nautilus_trader/test_kit/rust/events_pyo3.py
+++ b/nautilus_trader/test_kit/rust/events_pyo3.py
@@ -24,6 +24,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderEmulated
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
 from nautilus_trader.core.nautilus_pyo3 import OrderListId
+from nautilus_trader.core.nautilus_pyo3 import OrderPendingUpdate
 from nautilus_trader.core.nautilus_pyo3 import OrderRejected
 from nautilus_trader.core.nautilus_pyo3 import OrderReleased
 from nautilus_trader.core.nautilus_pyo3 import OrderSide
@@ -202,4 +203,20 @@ class TestEventsProviderPyo3:
             account_id=TestIdProviderPyo3.account_id(),
             price=Price.from_str("1500.0"),
             trigger_price=None,
+        )
+
+    @staticmethod
+    def order_pending_update() -> OrderPendingUpdate:
+        uuid = "91762096-b188-49ea-8562-8d8a4cc22ff2"
+        return OrderPendingUpdate(
+            trader_id=TestIdProviderPyo3.trader_id(),
+            strategy_id=TestIdProviderPyo3.strategy_id(),
+            instrument_id=TestIdProviderPyo3.ethusdt_binance_id(),
+            client_order_id=TestIdProviderPyo3.client_order_id(),
+            account_id=TestIdProviderPyo3.account_id(),
+            event_id=UUID4(uuid),
+            ts_init=0,
+            ts_event=0,
+            reconciliation=False,
+            venue_order_id=TestIdProviderPyo3.venue_order_id(),
         )

--- a/tests/unit_tests/model/test_events_pyo3.py
+++ b/tests/unit_tests/model/test_events_pyo3.py
@@ -18,6 +18,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderDenied
 from nautilus_trader.core.nautilus_pyo3 import OrderEmulated
 from nautilus_trader.core.nautilus_pyo3 import OrderFilled
 from nautilus_trader.core.nautilus_pyo3 import OrderInitialized
+from nautilus_trader.core.nautilus_pyo3 import OrderPendingUpdate
 from nautilus_trader.core.nautilus_pyo3 import OrderRejected
 from nautilus_trader.core.nautilus_pyo3 import OrderReleased
 from nautilus_trader.core.nautilus_pyo3 import OrderSubmitted
@@ -192,4 +193,21 @@ def test_order_updated():
         == "OrderUpdated(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, client_order_id=O-20210410-022422-001-001-1, "
         + "venue_order_id=123456, account_id=SIM-000, quantity=1.5, price=1500.0, trigger_price=None, "
         + "event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_event=0, ts_init=0)"
+    )
+
+
+def test_order_pending_update():
+    event = TestEventsProviderPyo3.order_pending_update()
+    result_dict = OrderPendingUpdate.to_dict(event)
+    order_pending_update = OrderPendingUpdate.from_dict(result_dict)
+    assert order_pending_update == event
+    assert (
+        str(event)
+        == "OrderPendingUpdate(instrument_id=ETHUSDT.BINANCE, client_order_id=O-20210410-022422-001-001-1, "
+        + "venue_order_id=123456, account_id=SIM-000, ts_event=0)"
+    )
+    assert (
+        repr(event)
+        == "OrderPendingUpdate(trader_id=TESTER-001, strategy_id=S-001, instrument_id=ETHUSDT.BINANCE, client_order_id=O-20210410-022422-001-001-1, "
+        + "venue_order_id=123456, account_id=SIM-000, event_id=91762096-b188-49ea-8562-8d8a4cc22ff2, ts_event=0, ts_init=0)"
     )


### PR DESCRIPTION
# Pull Request

 - finished event `OrderPendingUpdate` in rust and exported in with pyo3 and tested on the python side
