### PR TITLE
Fix unsupported union

### DIFF
--- a/nautilus_trader/config/common.py
+++ b/nautilus_trader/config/common.py
@@ -581,7 +581,7 @@ class StrategyConfig(NautilusConfig, kw_only=True, frozen=True):
     oms_type : OmsType, optional
         The order management system type for the strategy. This will determine
         how the `ExecutionEngine` handles position IDs (see docs).
-    external_order_claims : list[InstrumentId | str], optional
+    external_order_claims : list[InstrumentId], optional
         The external order claim instrument IDs.
         External orders for matching instrument IDs will be associated with (claimed by) the strategy.
     manage_contingent_orders : bool, default False
@@ -596,7 +596,7 @@ class StrategyConfig(NautilusConfig, kw_only=True, frozen=True):
     strategy_id: StrategyId | None = None
     order_id_tag: str | None = None
     oms_type: str | None = None
-    external_order_claims: list[InstrumentId | str] | None = None
+    external_order_claims: list[InstrumentId] | None = None
     manage_contingent_orders: bool = False
     manage_gtd_expiry: bool = False
 


### PR DESCRIPTION
# Pull Request

Fixes below msgspec error.
```
    return msgspec.json.decode(raw, type=cls, dec_hook=msgspec_decoding_hook)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Type unions containing a custom type may not contain any additional types other than `None` - type `nautilus_trader.model.identifiers.InstrumentId | str` is not supported
```

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

StrategyConfig validation/decoding working fine now.
