### PR TITLE
risk engine: reset the state when starting a new backtest

### DIFF
--- a/nautilus_trader/common/component.pxd
+++ b/nautilus_trader/common/component.pxd
@@ -183,6 +183,7 @@ cdef class Throttler:
     cdef readonly int sent_count
     """If count of messages sent from the throttler.\n\n:returns: `int`"""
 
+    cpdef void reset(self)
     cpdef double used(self)
     cpdef void send(self, msg)
     cdef int64_t _delta_next(self)

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -1436,6 +1436,16 @@ cdef class Throttler:
         """
         return len(self._buffer)
 
+    cpdef void reset(self):
+        """
+        Reset the state of the throttler.
+        """
+        self._buffer.clear()
+        self._warm = False
+        self.recv_count = 0
+        self.sent_count = 0
+        self.is_limiting = False
+
     cpdef double used(self):
         """
         Return the percentage of maximum rate currently used.

--- a/nautilus_trader/risk/engine.pyx
+++ b/nautilus_trader/risk/engine.pyx
@@ -386,6 +386,8 @@ cdef class RiskEngine(Component):
     cpdef void _reset(self):
         self.command_count = 0
         self.event_count = 0
+        self._order_submit_throttler.reset()
+        self._order_modify_throttler.reset()
 
     cpdef void _dispose(self):
         pass


### PR DESCRIPTION
# Pull Request

Reset the state of the risk engine. Otherwise, all new orders are rejected when starting a new backtest.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Local  running of multiple backtests.
