### PR TITLE
Fix SandboxLiveExecClientFactory from NodeBuilder

### DIFF
--- a/nautilus_trader/adapters/binance/common/data.py
+++ b/nautilus_trader/adapters/binance/common/data.py
@@ -437,7 +437,7 @@ class BinanceCommonDataClient(LiveMarketDataClient):
         resolution = self._enum_parser.parse_nautilus_bar_aggregation(bar_type.spec.aggregation)
         if self._binance_account_type.is_futures and resolution == "s":
             self._log.error(
-                f"Cannot subscribe to {bar_type}. ",
+                f"Cannot subscribe to {bar_type}. "
                 "Second interval bars are not aggregated by Binance Futures.",
             )
         try:
@@ -481,7 +481,7 @@ class BinanceCommonDataClient(LiveMarketDataClient):
         resolution = self._enum_parser.parse_nautilus_bar_aggregation(bar_type.spec.aggregation)
         if self._binance_account_type.is_futures and resolution == "s":
             self._log.error(
-                f"Cannot unsubscribe from {bar_type}. ",
+                f"Cannot unsubscribe from {bar_type}. "
                 "Second interval bars are not aggregated by Binance Futures.",
             )
         try:
@@ -618,7 +618,7 @@ class BinanceCommonDataClient(LiveMarketDataClient):
             resolution = self._enum_parser.parse_nautilus_bar_aggregation(bar_type.spec.aggregation)
             if not self._binance_account_type.is_spot_or_margin and resolution == "s":
                 self._log.error(
-                    f"Cannot request {bar_type}: ",
+                    f"Cannot request {bar_type}: "
                     "second interval bars are not aggregated by Binance Futures.",
                 )
             try:

--- a/nautilus_trader/live/node_builder.py
+++ b/nautilus_trader/live/node_builder.py
@@ -222,14 +222,15 @@ class TradingNodeBuilder:
                 client_config: LiveExecClientConfig = cfg  # type: ignore
             factory = self._exec_factories[name]
 
-            factory_kws = dict(
-                loop=self._loop,
-                name=name,
-                config=client_config,
-                msgbus=self._msgbus,
-                cache=self._cache,
-                clock=self._clock,
-            )
+            factory_kws = {
+                "loop": self._loop,
+                "name": name,
+                "config": client_config,
+                "msgbus": self._msgbus,
+                "cache": self._cache,
+                "clock": self._clock,
+                "logger": self._log,
+            }
 
             if factory.__name__ == "SandboxLiveExecClientFactory":
                 factory_kws["portfolio"] = self._portfolio

--- a/nautilus_trader/live/node_builder.py
+++ b/nautilus_trader/live/node_builder.py
@@ -226,7 +226,6 @@ class TradingNodeBuilder:
                 loop=self._loop,
                 name=name,
                 config=client_config,
-                portfolio=self._portfolio,
                 msgbus=self._msgbus,
                 cache=self._cache,
                 clock=self._clock,

--- a/nautilus_trader/live/node_builder.py
+++ b/nautilus_trader/live/node_builder.py
@@ -222,14 +222,20 @@ class TradingNodeBuilder:
                 client_config: LiveExecClientConfig = cfg  # type: ignore
             factory = self._exec_factories[name]
 
-            client = factory.create(
+            factory_kws = dict(
                 loop=self._loop,
                 name=name,
                 config=client_config,
+                portfolio=self._portfolio,
                 msgbus=self._msgbus,
                 cache=self._cache,
                 clock=self._clock,
             )
+
+            if factory.__name__ == "SandboxLiveExecClientFactory":
+                factory_kws["portfolio"] = self._portfolio
+
+            client = factory.create(**factory_kws)
 
             self._exec_engine.register_client(client)
 

--- a/nautilus_trader/live/node_builder.py
+++ b/nautilus_trader/live/node_builder.py
@@ -229,7 +229,6 @@ class TradingNodeBuilder:
                 "msgbus": self._msgbus,
                 "cache": self._cache,
                 "clock": self._clock,
-                "logger": self._log,
             }
 
             if factory.__name__ == "SandboxLiveExecClientFactory":


### PR DESCRIPTION
# Pull Request

Fix SandboxLiveExecClientFactory creation

- creation of SandboxLiveExecClientFactory from NodeBuilder expects Portfolio object

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?
Has not beet tested.

Describe how this code was/is tested.
Not tested.

## Thought Process
### Description

SandboxLiveExecClient does not work with

<file:///home/dpetrov/develop/python/nautilus_trader/nautilus_trader/adapters/sandbox/factory.py>

`SandboxLiveExecClientFactory` takes portfolio upon creation.
```
  portfolio : PortfolioFacade
      The read-only portfolio for the client.
```
but `TradingNode.build_exec_clients` does not pass the portfolio
<file:///home/dpetrov/develop/python/nautilus_trader/nautilus_trader/live/node_builder.py>

The change was introduced the following commit:    f0370a767709e520313ba2eac231811ebfbca531

<a id="org7ae446b"></a>

### What happens if I pass the portfolio object down to the factory

<a id="org00b2e70"></a>

### Logs after passing portfolio

-   there seems to be issue with locating an account for venue BINANCE
```    
2024-01-15T08:26:37.704181901Z [DEBUG] Binance-Testnet-Momentum.RiskEngine: Cannot find account for venue BINANCE.
2024-01-15T08:26:37.704672853Z [ERROR] Binance-Testnet-Momentum.Portfolio: Cannot update order: no account registered for BINANCE-001
 ```
This helped with continuing through that issue
```        
248                 factory_kws["portfolio"] = self._portfolio
249
250             import ipdb; ipdb.set_trace()
251             client = factory.create(**factory_kws)
252
--> 253             self._exec_engine.register_client(client)
254
255             # Default client config
256             if client_config.routing.default:
257                 self._exec_engine.register_default_client(client)

ipdb> client.exchange.initialize_account()

2024-01-15T09:22:46.393043760Z [DEBUG] Binance-Testnet-Momentum.Cache: Added Account(id=BINANCE-001).
2024-01-15T09:22:46.393058031Z [DEBUG] Binance-Testnet-Momentum.Cache: Indexed AccountId('BINANCE-001').
2024-01-15T09:22:46.393079933Z [INFO] Binance-Testnet-Momentum.Portfolio: Updated AccountState(account_id=BINANCE-001, account_type=MARGIN, base_currency=USDT, is_reported=True, balances=[AccountBalance(total=1_000_000.00000000 USDT, locked=0.00000000 USDT, free=1_000_000.00000000 USDT)], margins=[], event_id=7abdc683-1712-4323-98c0-b3bb4d23a4a7)

```

<a id="org3b0a103"></a>

### Investigate the following warning

    2024-01-15T09:23:57.292338031Z [WARN] Binance-Testnet-Momentum.ExecClient-BINANCE: Did not received `OrderStatusReport` from request.
   
This warning comes from here
<file:///home/dpetrov/develop/python/nautilus_trader/nautilus_trader/live/execution_client.py>

### Code to run the Sandbox trading on Binance:
```py
import asyncio
import traceback
from decimal import Decimal

import hvac
import uvloop
from nautilus_trader.adapters.binance.common.enums import BinanceAccountType
from nautilus_trader.adapters.binance.config import (
    BinanceDataClientConfig,
    BinanceExecClientConfig,
)
from nautilus_trader.adapters.binance.factories import (
    BinanceLiveDataClientFactory,
    BinanceLiveExecClientFactory,
    get_cached_binance_http_client,
)
from nautilus_trader.adapters.binance.futures.providers import (
    BinanceFuturesInstrumentProvider,
)
from nautilus_trader.adapters.sandbox.config import (
    SandboxExecutionClientConfig,
)
from nautilus_trader.adapters.sandbox.execution import SandboxExecutionClient
from nautilus_trader.adapters.sandbox.factory import (
    SandboxLiveExecClientFactory,
)
from nautilus_trader.common.clock import LiveClock
from nautilus_trader.common.logging import Logger
from nautilus_trader.config import (
    CacheConfig,
    InstrumentProviderConfig,
    LiveExecEngineConfig,
    LoggingConfig,
    TradingNodeConfig,
)
from nautilus_trader.examples.algorithms.twap import (
    TWAPExecAlgorithm,
    TWAPExecAlgorithmConfig,
)
from nautilus_trader.live.node import TradingNode
from nautilus_trader.model.data import BarSpecification, BarType
from nautilus_trader.model.enums import (
    AggregationSource,
    BarAggregation,
    PriceType,
)
from nautilus_trader.model.identifiers import InstrumentId, TraderId, ClientId
from nautilus_trader.config import RoutingConfig

from trader.strategies import EMACrossTWAP, EMACrossTWAPConfig


async def amain(instrument_config):
    clock = LiveClock()
    log = Logger(clock=clock)

    instrument_str = "BTCUSDT-PERP.BINANCE"
    auth_data = hvac.Client().secrets.kv.v2.read_secret(
        path="test/binance", mount_point="sitea"
    )["data"]["data"]

    futures_client = get_cached_binance_http_client(
        clock=clock,
        logger=log,
        account_type=BinanceAccountType.USDT_FUTURE,
        is_testnet=True,
        key=auth_data["fut_api"],
        secret=auth_data["fut_secret"],
    )

    provider = BinanceFuturesInstrumentProvider(
        clock=clock,
        client=futures_client,
        logger=log,
        config=instrument_config,
    )

    await provider.load_all_async()
    instruments = provider.list_all()

    print(f"Found instruments:\n{[ins.id for ins in instruments]}")
    # account_currency = await provider.get_account_currency()

    binance_client_config_kws = dict(
        api_key=auth_data["fut_api"],
        api_secret=auth_data["fut_secret"],
        account_type=BinanceAccountType.USDT_FUTURE,
        base_url_http=None,
        base_url_ws=None,
        us=False,
        testnet=True,
        instrument_provider=instrument_config,
        # account_currency=account_currency,
    )

    config_node = TradingNodeConfig(
        trader_id=TraderId("Binance-Testnet-Momentum"),
        logging=LoggingConfig(log_level="DEBUG", log_colors=True),
        exec_engine=LiveExecEngineConfig(
            reconciliation=True,
            reconciliation_lookback_mins=1440,
            filter_position_reports=True,
        ),
        cache=CacheConfig(
            # database=DatabaseConfig(),
            timestamps_as_iso8601=True,
            flush_on_start=False,
        ),
        data_clients={
            "BINANCE": BinanceDataClientConfig(**binance_client_config_kws)
        },
        exec_clients={
            # "BINANCE": BinanceExecClientConfig(**binance_client_config_kws)
            "SANDBOX": SandboxExecutionClientConfig(
                venue="BINANCE",
                currency="USDT",
                balance=1_000_000,
                routing=RoutingConfig(default=True),
            )
        },
        timeout_connection=20.0,
        timeout_reconciliation=10.0,
        timeout_portfolio=10.0,
        timeout_disconnection=10.0,
        timeout_post_stop=5.0,
    )
    node = TradingNode(config=config_node)

    strategy_config = EMACrossTWAPConfig(
        instrument_id=InstrumentId.from_str(instrument_str),
        bar_type=BarType(
            InstrumentId.from_str(instrument_str),
            BarSpecification(15, BarAggregation.TICK, PriceType.LAST),
            AggregationSource.INTERNAL,
        ),
        trade_size=Decimal("0.10"),
        fast_ema_period=10,
        slow_ema_period=20,
        twap_horizon_secs=10.0,
        twap_interval_secs=2.5,
    )

    strategy = EMACrossTWAP(config=strategy_config)

    node.trader.add_strategy(strategy)
    node.trader.add_exec_algorithm(
        TWAPExecAlgorithm(TWAPExecAlgorithmConfig())
    )

    SandboxExecutionClient.INSTRUMENTS = instruments
    node.add_data_client_factory("BINANCE", BinanceLiveDataClientFactory)
    # node.add_exec_client_factory("BINANCE", BinanceLiveExecClientFactory)
    node.add_exec_client_factory("SANDBOX", SandboxLiveExecClientFactory)

    node.build()
    # exec_clients = node._builder._exec_engine.registered_clients
    binance_exec_client = node._builder._exec_engine._clients.get(
        ClientId("BINANCE")
    )
    binance_exec_client.exchange.initialize_account()

    try:
        await node.run_async()
    except Exception as e:
        print(e)
        print(traceback.format_exc())
    finally:
        await node.stop_async()
        await asyncio.sleep(1)
        return node


def main():
    config = InstrumentProviderConfig(
        load_ids=frozenset(["BTCUSDT-PERP.BINANCE", "ETHUSDT-PERP.BINANCE"])
    )
    node = uvloop.run(amain(config))
    node.dispose()


if __name__ == "__main__":
    main()
```