### PR TITLE
IB instrument ID parsing changes

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -137,7 +137,7 @@ class InteractiveBrokersClient(
         # ConnectionMixin
         self._connection_attempt_counter: int = 0
         self._contract_for_probe: IBContract = instrument_id_to_ib_contract(
-            InstrumentId.from_str("EUR/CHF.IDEALPRO"),
+            InstrumentId.from_str("EUR.CHF=CASH.IDEALPRO"),
         )
 
         # MarketDataMixin

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -81,18 +81,11 @@ RE_OPT = re.compile(
 )
 RE_IND = re.compile(r"^(?P<symbol>\w{1,3})$")
 RE_FUT = re.compile(r"^(?P<symbol>\w{1,3})(?P<month>[FGHJKMNQUVXZ])(?P<year>\d{2})$")
-RE_FUT_ORIGINAL = re.compile(r"^(?P<symbol>\w{1,3})(?P<month>[FGHJKMNQUVXZ])(?P<year>\d)$")
 RE_FUT2 = re.compile(
     r"^(?P<symbol>\w{1,4})(?P<month>(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))(?P<year>\d{2})$",
 )
-RE_FUT2_ORIGINAL = re.compile(
-    r"^(?P<symbol>\w{1,4}) *(?P<month>(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)) (?P<year>\d{2})$",
-)
 RE_FOP = re.compile(
     r"^(?P<symbol>\w{1,3})(?P<month>[FGHJKMNQUVXZ])(?P<year>\d{2})(?P<right>[CP])(?P<strike>.{4,5})$",
-)
-RE_FOP_ORIGINAL = re.compile(
-    r"^(?P<symbol>\w{1,3})(?P<month>[FGHJKMNQUVXZ])(?P<year>\d) (?P<right>[CP])(?P<strike>.{4,5})$",
 )
 RE_CRYPTO = re.compile(r"^(?P<symbol>[A-Z]*)\/(?P<currency>[A-Z]{3})$")
 
@@ -330,16 +323,9 @@ def ib_contract_to_instrument_id(contract: IBContract) -> InstrumentId:
     elif security_type == "CONTFUT":
         symbol = contract.localSymbol.replace(" ", "") or contract.symbol.replace(" ", "")
         venue = contract.exchange
-    elif security_type == "FUT" and (m := RE_FUT_ORIGINAL.match(contract.localSymbol)):
-        symbol = f"{m['symbol']}{m['month']}{decade_digit(m['year'], contract)}{m['year']}"
+    elif security_type in ["FUT", "FOP"]:
+        symbol = contract.localSymbol
         venue = contract.exchange
-    elif security_type == "FUT" and (m := RE_FUT2_ORIGINAL.match(contract.localSymbol)):
-        symbol = f"{m['symbol']}{FUTURES_MONTH_TO_CODE[m['month']]}{m['year']}"
-        venue = contract.exchange
-    elif security_type == "FOP" and (m := RE_FOP_ORIGINAL.match(contract.localSymbol)):
-        symbol = f"{m['symbol']}{m['month']}{decade_digit(m['year'], contract)}{m['year']}{m['right']}{m['strike']}"
-        venue = contract.exchange
-
     elif security_type in ["CASH", "CRYPTO"]:
         symbol = (
             f"{contract.localSymbol}".replace(".", "/") or f"{contract.symbol}/{contract.currency}"

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -301,15 +301,6 @@ def parse_crypto_contract(
     )
 
 
-def decade_digit(last_digit: str, contract: IBContract) -> int:
-    if year := contract.lastTradeDateOrContractMonth[:4]:
-        return int(year[2:3])
-    elif int(last_digit) > int(repr(datetime.datetime.now().year)[-1]):
-        return int(repr(datetime.datetime.now().year)[-2]) - 1
-    else:
-        return int(repr(datetime.datetime.now().year)[-2])
-
-
 def ib_contract_to_instrument_id(contract: IBContract) -> InstrumentId:
     PyCondition.type(contract, IBContract, "IBContract")
 

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -263,12 +263,16 @@ def ib_contract_to_instrument_id(contract: IBContract) -> InstrumentId:
     exchange = contract.exchange.replace(".", "/")
 
     if sec_type == "STK":
-        symbol = f"{contract.symbol}={sec_type}"
+        symbol = f"{contract.localSymbol}={sec_type}"
         venue = contract.primaryExchange if exchange == "SMART" else exchange
-    elif sec_type in ["CONTFUT", "CRYPTO"]:
+    elif sec_type in ["CONTFUT"]:
         symbol = f"{contract.symbol}={sec_type}"
         venue = contract.exchange
-    elif sec_type in ["FUT", "FOP", "OPT", "CASH"]:
+    elif sec_type in ["CASH", "CRYPTO"]:
+        symbol = f"{contract.localSymbol}={sec_type}" or f"{contract.symbol}.{contract.currency}"
+
+        venue = contract.exchange
+    elif sec_type in ["FUT", "FOP", "OPT"]:
         symbol = f"{contract.localSymbol}={sec_type}"
         venue = exchange
     else:
@@ -295,15 +299,15 @@ def instrument_id_to_ib_contract(instrument_id: InstrumentId) -> IBContract:
             secType="STK",
             exchange="SMART",
             primaryExchange=venue,
-            symbol=parts[0],
+            localSymbol=parts[0],
         )
-    if sec_type in ["CONTFUT", "CRYPTO"]:
+    if sec_type in ["CONTFUT"]:
         return IBContract(
             secType=sec_type,
             exchange=venue,
             symbol=parts[0],
         )
-    elif sec_type in ["FUT", "FOP", "OPT", "CASH"]:
+    elif sec_type in ["FUT", "FOP", "OPT", "CASH", "CRYPTO"]:
         return IBContract(
             secType=sec_type,
             exchange=venue,

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import datetime
 import re
 import time
 from decimal import Decimal

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py
@@ -111,7 +111,7 @@ async def test_unsubscribe_ticks(ib_client):
 async def test_subscribe_realtime_bars(ib_client):
     # Arrange
     ib_client._request_id_seq = 999
-    bar_type = BarType.from_str("AAPL.SMART-5-SECOND-BID-EXTERNAL")
+    bar_type = BarType.from_str("AAPL=STK.SMART-5-SECOND-BID-EXTERNAL")
     contract = IBTestContractStubs.aapl_equity_ib_contract()
     use_rth = True
     ib_client._eclient.reqRealTimeBars = Mock()
@@ -134,7 +134,7 @@ async def test_subscribe_realtime_bars(ib_client):
 async def test_unsubscribe_realtime_bars(ib_client):
     # Arrange
     ib_client._request_id_seq = 999
-    bar_type = BarType.from_str("AAPL.SMART-5-SECOND-BID-EXTERNAL")
+    bar_type = BarType.from_str("AAPL=STK.SMART-5-SECOND-BID-EXTERNAL")
     contract = IBTestContractStubs.aapl_equity_ib_contract()
     use_rth = True
     ib_client._eclient.reqRealTimeBars = Mock()
@@ -154,7 +154,7 @@ async def test_unsubscribe_realtime_bars(ib_client):
 async def test_subscribe_historical_bars(ib_client):
     # Arrange
     ib_client._request_id_seq = 999
-    bar_type = BarType.from_str("AAPL.SMART-5-SECOND-BID-EXTERNAL")
+    bar_type = BarType.from_str("AAPL=STK.SMART-5-SECOND-BID-EXTERNAL")
     contract = IBTestContractStubs.aapl_equity_ib_contract()
     use_rth = True
     handle_revised_bars = True
@@ -187,7 +187,7 @@ async def test_subscribe_historical_bars(ib_client):
 async def test_unsubscribe_historical_bars(ib_client):
     # Arrange
     ib_client._request_id_seq = 999
-    bar_type = BarType.from_str("AAPL.SMART-5-SECOND-BID-EXTERNAL")
+    bar_type = BarType.from_str("AAPL=STK.SMART-5-SECOND-BID-EXTERNAL")
     contract = IBTestContractStubs.aapl_equity_ib_contract()
     use_rth = True
     handle_revised_bars = True
@@ -213,7 +213,7 @@ async def test_unsubscribe_historical_bars(ib_client):
 async def test_get_historical_bars(ib_client):
     # Arrange
     ib_client._request_id_seq = 999
-    bar_type = BarType.from_str("AAPL.SMART-5-SECOND-BID-EXTERNAL")
+    bar_type = BarType.from_str("AAPL=STK.SMART-5-SECOND-BID-EXTERNAL")
     contract = IBTestContractStubs.aapl_equity_ib_contract()
     use_rth = True
     end_date_time = "20240101-010000"
@@ -282,7 +282,7 @@ async def test_get_historical_ticks(ib_client):
 
 def test_ib_bar_to_nautilus_bar(ib_client):
     # Arrange
-    bar_type_str = "AAPL.NASDAQ-5-SECOND-BID-INTERNAL"
+    bar_type_str = "AAPL=STK.NASDAQ-5-SECOND-BID-INTERNAL"
     bar_type = BarType.from_str(bar_type_str)
     bar = BarData()
     bar.date = "1704067200"
@@ -313,7 +313,7 @@ def test_ib_bar_to_nautilus_bar(ib_client):
 
 def test_process_bar_data(ib_client):
     # Arrange
-    bar_type_str = "AAPL.NASDAQ-5-SECOND-BID-INTERNAL"
+    bar_type_str = "AAPL=STK.NASDAQ-5-SECOND-BID-INTERNAL"
     previous_bar = BarData()
     previous_bar.date = "1704067200"
     previous_bar.open = 100.01
@@ -354,7 +354,7 @@ def test_process_bar_data(ib_client):
 def test_process_trade_ticks(ib_client):
     # Arrange
     mock_request = Mock(spec=Request)
-    mock_request.name = ["AAPL.NASDAQ"]
+    mock_request.name = ["AAPL=STK.NASDAQ"]
     mock_request.result = []
     ib_client._requests = Mock()
     ib_client._requests.get.return_value = mock_request
@@ -377,7 +377,7 @@ def test_process_trade_ticks(ib_client):
     assert len(mock_request.result) == 2
 
     result_1 = mock_request.result[0]
-    assert result_1.instrument_id == InstrumentId.from_str("AAPL.NASDAQ")
+    assert result_1.instrument_id == InstrumentId.from_str("AAPL=STK.NASDAQ")
     assert result_1.price == Price(100.01, precision=2)
     assert result_1.size == Quantity(100, precision=0)
     assert result_1.aggressor_side == AggressorSide.NO_AGGRESSOR
@@ -386,7 +386,7 @@ def test_process_trade_ticks(ib_client):
     assert result_1.ts_init == 1704067200000000000
 
     result_2 = mock_request.result[1]
-    assert result_2.instrument_id == InstrumentId.from_str("AAPL.NASDAQ")
+    assert result_2.instrument_id == InstrumentId.from_str("AAPL=STK.NASDAQ")
     assert result_2.price == Price(105.01, precision=2)
     assert result_2.size == Quantity(200, precision=0)
     assert result_2.aggressor_side == AggressorSide.NO_AGGRESSOR
@@ -399,7 +399,7 @@ def test_tickByTickBidAsk(ib_client):
     # Arrange
     ib_client._clock.set_time(1704067205000000000)
     mock_subscription = Mock(spec=Subscription)
-    mock_subscription.name = ["AAPL.NASDAQ"]
+    mock_subscription.name = ["AAPL=STK.NASDAQ"]
     ib_client._subscriptions = Mock()
     ib_client._subscriptions.get.return_value = mock_subscription
     ib_client._handle_data = Mock()
@@ -417,7 +417,7 @@ def test_tickByTickBidAsk(ib_client):
 
     # Assert
     quote_tick = QuoteTick(
-        instrument_id=InstrumentId.from_str("AAPL.NASDAQ"),
+        instrument_id=InstrumentId.from_str("AAPL=STK.NASDAQ"),
         bid_price=Price(100.01, precision=2),
         ask_price=Price(100.02, precision=2),
         bid_size=Quantity(100, precision=0),
@@ -432,7 +432,7 @@ def test_tickByTickAllLast(ib_client):
     # Arrange
     ib_client._clock.set_time(1704067205000000000)
     mock_subscription = Mock(spec=Subscription)
-    mock_subscription.name = ["AAPL.NASDAQ"]
+    mock_subscription.name = ["AAPL=STK.NASDAQ"]
     ib_client._subscriptions = Mock()
     ib_client._subscriptions.get.return_value = mock_subscription
     ib_client._handle_data = Mock()
@@ -451,7 +451,7 @@ def test_tickByTickAllLast(ib_client):
 
     # Assert
     trade_tick = TradeTick(
-        instrument_id=InstrumentId.from_str("AAPL.NASDAQ"),
+        instrument_id=InstrumentId.from_str("AAPL=STK.NASDAQ"),
         price=Price(100.01, precision=2),
         size=Quantity(100, precision=0),
         aggressor_side=AggressorSide.NO_AGGRESSOR,
@@ -466,7 +466,7 @@ def test_realtimeBar(ib_client):
     # Arrange
     ib_client._clock.set_time(1704067205000000000)
     mock_subscription = Mock(spec=Subscription)
-    bar_type_str = "AAPL.NASDAQ-5-SECOND-BID-INTERNAL"
+    bar_type_str = "AAPL=STK.NASDAQ-5-SECOND-BID-INTERNAL"
     mock_subscription.name = bar_type_str
     ib_client._subscriptions = Mock()
     ib_client._subscriptions.get.return_value = mock_subscription

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -13,6 +13,9 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+# fmt: on
+import asyncio
+
 import pytest
 
 # fmt: off
@@ -32,7 +35,9 @@ from nautilus_trader.test_kit.stubs.events import TestEventStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
 
 
-# fmt: on
+@pytest.fixture()
+def event_loop():
+    return asyncio.get_event_loop()
 
 
 @pytest.fixture()

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -89,7 +89,7 @@ from nautilus_trader.model.identifiers import InstrumentId
         (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), "FMEU 20240126 D.EUREX"),
         (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D.EUREX"),
         (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0.ENDEX"),
-        (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1.OSE.JPN"),
+        # (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1.OSE.JPN"), # TODO: handle venue with .
         # fmt: on
     ],
 )

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -22,16 +22,6 @@ import pytest
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
 from nautilus_trader.adapters.interactive_brokers.parsing.data import bar_spec_to_bar_size
 from nautilus_trader.adapters.interactive_brokers.parsing.data import timedelta_to_duration_str
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_CASH
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_CRYPTO
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FOP
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FUT
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_IND
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_OPT
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import VENUES_CASH
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import VENUES_CRYPTO
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import VENUES_FUT
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import VENUES_OPT
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import _tick_size_to_precision
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import ib_contract_to_instrument_id
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import instrument_id_to_ib_contract
@@ -42,57 +32,57 @@ from nautilus_trader.model.identifiers import InstrumentId
 # fmt: on
 
 
-@pytest.mark.parametrize(
-    ("contract", "instrument_id"),
-    [
-        # fmt: off
-        (IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD"), "EUR/USD.IDEALPRO"),
-        (IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000"), "AAPL230217P00155000.SMART"),
-        (IBContract(secType="CONTFUT", exchange="CME", symbol="ES"), "ES.CME"),
-        (IBContract(secType="CONTFUT", exchange="CME", symbol="M6E"), "M6E.CME"),
-        (IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL"), "MCL.NYMEX"),
-        (IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI"), "SPI.SNFE"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH3.CME"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH3.CME"),
-        (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYM  JUN 23.CBOT"),
-        (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV3.NYMEX"),
-        (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH3.SNFE"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080.NYBOT"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5.NYBOT"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY.ARCA"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL.NASDAQ"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF-B.NYSE"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M.ASX"),
+INSTRUMENTS = [
+    # fmt: off
+        (IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD"), "EUR.USD=CASH.IDEALPRO"),
+        (IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000"), "AAPL  230217P00155000=OPT.SMART"),
+        (IBContract(secType="CONTFUT", exchange="CME", symbol="ES"), "ES=CONTFUT.CME"),
+        (IBContract(secType="CONTFUT", exchange="CME", symbol="M6E"), "M6E=CONTFUT.CME"),
+        (IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL"), "MCL=CONTFUT.NYMEX"),
+        (IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI"), "SPI=CONTFUT.SNFE"),
+        (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH3=FUT.CME"),
+        (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH3=FUT.CME"),
+        (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYM  JUN 23=FUT.CBOT"),
+        (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV3=FUT.NYMEX"),
+        (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH3=FUT.SNFE"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080=FOP.NYBOT"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5=FOP.NYBOT"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", symbol="SPY"), "SPY=STK.ARCA"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", symbol="AAPL"), "AAPL=STK.NASDAQ"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", symbol="BF B"), "BF B=STK.NYSE"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", symbol="29M"), "29M=STK.ASX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), "SCOI 20251219 M=FUT.EUREX"),
+        (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), "AH_20240221=FUT.LMEOTC"),
+        (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), "INFY24FEBFUT=FUT.NSE"),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), "4TLSN4L=FUT.OMS"),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), "3TLSN4N=FUT.OMS"),
+        (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), "M3FIDRM4P=FUT.MEFFRV"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), "DVCE91MR24=FUT.MEXDER"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), "DVCXC MR24=FUT.MEXDER"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), "DVM3  JN24=FUT.MEXDER"),
+        (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), "SXAH24=FUT.CDE"),
+        (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), "HOILN7=FUT.IPE"),
+        (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), "IBHYH4=FUT.CFE"),
+        (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), "ISP   24L20=FUT.IDEM"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080=FOP.NYBOT"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5=FOP.NYBOT"),
+        (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), "6NZ4 P0655=FOP.CME"),
+        (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), "C OEXD 20261218 50 M=FOP.EUREX"),
+        (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), "WTIF5 C80=FOP.IPE"),
+        (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), "DVIP40000L=FOP.MEXDER"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), "OJF6 C1.3=FOP.NYBOT"),
+        (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), "FCHZ24_C7000=FOP.SGX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), "FMEU 20240125 D=FUT.EUREX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), "FMEU 20240126 D=FUT.EUREX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D=FUT.EUREX"),
+        (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0=FOP.ENDEX"),
+        (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1=FUT.OSE/JPN"),
+        (IBContract(secType="CRYPTO", exchange="PAXOS", symbol="BTC.USD"), "BTC.USD=CRYPTO.PAXOS"),
+    # fmt: on
+]
 
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), "SCOI 20251219 M.EUREX"),
-        (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), "AH_20240221.LMEOTC"),
-        (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), "INFY24FEBFUT.NSE"),
-        (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), "4TLSN4L.OMS"),
-        (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), "3TLSN4N.OMS"),
-        (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), "M3FIDRM4P.MEFFRV"),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), "DVCE91MR24.MEXDER"),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), "DVCXC MR24.MEXDER"),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), "DVM3  JN24.MEXDER"),
-        (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), "SXAH24.CDE"),
-        (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), "HOILN7.IPE"),
-        (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), "IBHYH4.CFE"),
-        (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), "ISP   24L20.IDEM"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080.NYBOT"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5.NYBOT"),
-        (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), "6NZ4 P0655.CME"),
-        (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), "C OEXD 20261218 50 M.EUREX"),
-        (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), "WTIF5 C80.IPE"),
-        (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), "DVIP40000L.MEXDER"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), "OJF6 C1.3.NYBOT"),
-        (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), "FCHZ24_C7000.SGX"),
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), "FMEU 20240125 D.EUREX"),
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), "FMEU 20240126 D.EUREX"),
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D.EUREX"),
-        (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0.ENDEX"),
-        # (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1.OSE.JPN"), # TODO: handle venue with .
-        # fmt: on
-    ],
-)
+
+@pytest.mark.parametrize(("contract", "instrument_id"), INSTRUMENTS)
 def test_ib_contract_to_instrument_id(contract, instrument_id):
     # Arrange, Act
     result = ib_contract_to_instrument_id(contract)
@@ -102,139 +92,13 @@ def test_ib_contract_to_instrument_id(contract, instrument_id):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    ("instrument_id", "contract"),
-    [
-        # fmt: off
-        ("EUR/USD.IDEALPRO", IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD")),
-        ("AAPL230217P00155000.SMART", IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000")),
-        ("ES.CME", IBContract(secType="CONTFUT", exchange="CME", symbol="ES")),
-        ("M6E.CME", IBContract(secType="CONTFUT", exchange="CME", symbol="M6E")),
-        ("MCL.NYMEX", IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL")),
-        ("SPI.SNFE", IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI")),
-        ("ESH23.CME", IBContract(secType="FUT", exchange="CME", localSymbol="ESH3")),
-        ("M6EH23.CME", IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3")),
-        ("MYMM23.CBOT", IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23")),
-        ("MCLV23.NYMEX", IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3")),
-        ("APH23.SNFE", IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3")),
-        ("EX2G23P4080.NYBOT", IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080")),
-        ("DXH23P103.5.NYBOT", IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5")),
-        ("SPY.ARCA", IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY")),
-        ("AAPL.NASDAQ", IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL")),
-        ("BF-B.NYSE", IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B")),
-        ("29M.ASX", IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M")),
-        # fmt: on
-    ],
-)
-def test_instrument_id_to_ib_contract(instrument_id, contract):
+@pytest.mark.parametrize(("contract", "instrument_id"), INSTRUMENTS)
+def test_instrument_id_to_ib_contract(contract, instrument_id):
     # Arrange, Act
     result = instrument_id_to_ib_contract(InstrumentId.from_str(instrument_id))
 
     # Assert
     expected = contract
-    assert result == expected
-
-
-def test_verified_venues_registered():
-    # Arrange, Act
-    expected_venues_cash = {"IDEALPRO"}
-    expected_venues_crypto = {"PAXOS"}
-    expected_venues_opt = {"SMART"}
-    expected_venues_fut = {"CBOT", "CME", "COMEX", "KCBT", "MGE", "NYMEX", "NYBOT", "SNFE"}
-
-    # Assert
-    assert len(set(expected_venues_cash) - set(VENUES_CASH)) == 0
-    assert len(set(expected_venues_crypto) - set(VENUES_CRYPTO)) == 0
-    assert len(set(expected_venues_opt) - set(VENUES_OPT)) == 0
-    assert len(set(expected_venues_fut) - set(VENUES_FUT)) == 0
-
-
-def test_regular_expression_forex():
-    # Arrange
-    symbol = "EUR/USD"
-    expected = {"symbol": "EUR", "currency": "USD"}
-
-    # Act
-    result = RE_CASH.match(symbol).groupdict()
-
-    # Assert
-    assert result == expected
-
-
-def test_regular_expression_crypto():
-    # Arrange
-    symbol = "BTC/USD"
-    expected = {"symbol": "BTC", "currency": "USD"}
-
-    # Act
-    result = RE_CRYPTO.match(symbol).groupdict()
-
-    # Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
-        # fmt: off
-        ("AAPL230217P00155000", {"symbol": "AAPL", "expiry": "230217", "right": "P", "strike": "00155", "decimal": "000"}),
-        ("A230217P00150000", {"symbol": "A", "expiry": "230217", "right": "P", "strike": "00150", "decimal": "000"}),
-        ("CMCSA230217P00039500", {"symbol": "CMCSA", "expiry": "230217", "right": "P", "strike": "00039", "decimal": "500"}),
-        # fmt: on
-    ],
-)
-def test_regular_expression_option(symbol, expected):
-    # Arrange, Act
-    result = RE_OPT.match(symbol).groupdict()
-
-    # Act, Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
-        ("ES", {"symbol": "ES"}),
-        ("MES", {"symbol": "MES"}),
-    ],
-)
-def test_regular_expression_index(symbol, expected):
-    # Arrange, Act
-    result = RE_IND.match(symbol).groupdict()
-
-    # Act, Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
-        ("ESH23", {"symbol": "ES", "month": "H", "year": "23"}),
-        ("M6EH23", {"symbol": "M6E", "month": "H", "year": "23"}),
-    ],
-)
-def test_regular_expression_future(symbol, expected):
-    # Arrange, Act
-    result = RE_FUT.match(symbol).groupdict()
-
-    # Act, Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
-        # fmt: off
-        ("EX2G23P4080", {"symbol": "EX2", "month": "G", "year": "23", "right": "P", "strike": "4080"}),
-        ("DXH23P103.5", {"symbol": "DX", "month": "H", "year": "23", "right": "P", "strike": "103.5"}),
-        # fmt: on
-    ],
-)
-def test_regular_expression_future_options(symbol, expected):
-    # Arrange, Act
-    result = RE_FOP.match(symbol).groupdict()
-
-    # Assert
     assert result == expected
 
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -65,6 +65,36 @@ from nautilus_trader.model.identifiers import InstrumentId
         (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL.NASDAQ"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF-B.NYSE"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M.ASX"),
+
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), ""),
+        (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), ""),
+        (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), ""),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), ""),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), ""),
+        (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), ""),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), ""),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), ""),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), ""),
+        (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), ""),
+        (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), ""),
+        (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), ""),
+        (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), ""),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), ""),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), ""),
+        (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), ""),
+        (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), ""),
+        (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), ""),
+        (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), ""),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), ""),
+        (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), ""),
+        # tests for daily contracts
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), ""),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), ""),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), ""),
+        # contracts with expiration in 2030, with localSymbol formats containing year as a single digit, get parsed as year 2020
+        (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), ""),
+        # contracts with . in Venue
+        (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), ""),
         # fmt: on
     ],
 )

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -25,9 +25,7 @@ from nautilus_trader.adapters.interactive_brokers.parsing.data import timedelta_
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_CASH
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_CRYPTO
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FOP
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FOP_ORIGINAL
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FUT
-from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_FUT_ORIGINAL
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_IND
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_OPT
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import VENUES_CASH
@@ -54,47 +52,44 @@ from nautilus_trader.model.identifiers import InstrumentId
         (IBContract(secType="CONTFUT", exchange="CME", symbol="M6E"), "M6E.CME"),
         (IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL"), "MCL.NYMEX"),
         (IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI"), "SPI.SNFE"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH23.CME"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH23.CME"),
-        (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYMM23.CBOT"),
-        (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV23.NYMEX"),
-        (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH23.SNFE"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G23P4080.NYBOT"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH23P103.5.NYBOT"),
+        (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH3.CME"),
+        (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH3.CME"),
+        (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYM  JUN 23.CBOT"),
+        (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV3.NYMEX"),
+        (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH3.SNFE"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080.NYBOT"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5.NYBOT"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY.ARCA"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL.NASDAQ"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF-B.NYSE"),
         (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M.ASX"),
 
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), ""),
-        (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), ""),
-        (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), ""),
-        (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), ""),
-        (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), ""),
-        (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), ""),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), ""),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), ""),
-        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), ""),
-        (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), ""),
-        (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), ""),
-        (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), ""),
-        (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), ""),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), ""),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), ""),
-        (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), ""),
-        (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), ""),
-        (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), ""),
-        (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), ""),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), ""),
-        (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), ""),
-        # tests for daily contracts
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), ""),
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), ""),
-        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), ""),
-        # contracts with expiration in 2030, with localSymbol formats containing year as a single digit, get parsed as year 2020
-        (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), ""),
-        # contracts with . in Venue
-        (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), ""),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), "SCOI 20251219 M.EUREX"),
+        (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), "AH_20240221.LMEOTC"),
+        (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), "INFY24FEBFUT.NSE"),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), "4TLSN4L.OMS"),
+        (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), "3TLSN4N.OMS"),
+        (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), "M3FIDRM4P.MEFFRV"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), "DVCE91MR24.MEXDER"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), "DVCXC MR24.MEXDER"),
+        (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), "DVM3  JN24.MEXDER"),
+        (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), "SXAH24.CDE"),
+        (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), "HOILN7.IPE"),
+        (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), "IBHYH4.CFE"),
+        (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), "ISP   24L20.IDEM"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080.NYBOT"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5.NYBOT"),
+        (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), "6NZ4 P0655.CME"),
+        (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), "C OEXD 20261218 50 M.EUREX"),
+        (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), "WTIF5 C80.IPE"),
+        (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), "DVIP40000L.MEXDER"),
+        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), "OJF6 C1.3.NYBOT"),
+        (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), "FCHZ24_C7000.SGX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), "FMEU 20240125 D.EUREX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), "FMEU 20240126 D.EUREX"),
+        (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D.EUREX"),
+        (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0.ENDEX"),
+        (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1.OSE.JPN"),
         # fmt: on
     ],
 )
@@ -229,21 +224,6 @@ def test_regular_expression_future(symbol, expected):
 @pytest.mark.parametrize(
     ("symbol", "expected"),
     [
-        ("ESH3", {"symbol": "ES", "month": "H", "year": "3"}),
-        ("M6EH3", {"symbol": "M6E", "month": "H", "year": "3"}),
-    ],
-)
-def test_regular_expression_future_original(symbol, expected):
-    # Arrange, Act
-    result = RE_FUT_ORIGINAL.match(symbol).groupdict()
-
-    # Act, Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
         # fmt: off
         ("EX2G23P4080", {"symbol": "EX2", "month": "G", "year": "23", "right": "P", "strike": "4080"}),
         ("DXH23P103.5", {"symbol": "DX", "month": "H", "year": "23", "right": "P", "strike": "103.5"}),
@@ -253,23 +233,6 @@ def test_regular_expression_future_original(symbol, expected):
 def test_regular_expression_future_options(symbol, expected):
     # Arrange, Act
     result = RE_FOP.match(symbol).groupdict()
-
-    # Assert
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("symbol", "expected"),
-    [
-        # fmt: off
-        ("EX2G3 P4080", {"symbol": "EX2", "month": "G", "year": "3", "right": "P", "strike": "4080"}),
-        ("DXH3 P103.5", {"symbol": "DX", "month": "H", "year": "3", "right": "P", "strike": "103.5"}),
-        # fmt: on
-    ],
-)
-def test_regular_expression_future_options_original(symbol, expected):
-    # Arrange, Act
-    result = RE_FOP_ORIGINAL.match(symbol).groupdict()
 
     # Assert
     assert result == expected

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -47,10 +47,10 @@ INSTRUMENTS = [
         (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH3=FUT.SNFE"),
         (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080=FOP.NYBOT"),
         (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5=FOP.NYBOT"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", symbol="SPY"), "SPY=STK.ARCA"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", symbol="AAPL"), "AAPL=STK.NASDAQ"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", symbol="BF B"), "BF B=STK.NYSE"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", symbol="29M"), "29M=STK.ASX"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY=STK.ARCA"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL=STK.NASDAQ"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF B=STK.NYSE"),
+        (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M=STK.ASX"),
         (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), "SCOI 20251219 M=FUT.EUREX"),
         (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), "AH_20240221=FUT.LMEOTC"),
         (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), "INFY24FEBFUT=FUT.NSE"),
@@ -77,7 +77,7 @@ INSTRUMENTS = [
         (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D=FUT.EUREX"),
         (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0=FOP.ENDEX"),
         (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1=FUT.OSE/JPN"),
-        (IBContract(secType="CRYPTO", exchange="PAXOS", symbol="BTC.USD"), "BTC.USD=CRYPTO.PAXOS"),
+        (IBContract(secType="CRYPTO", exchange="PAXOS", localSymbol="BTC.USD"), "BTC.USD=CRYPTO.PAXOS"),
     # fmt: on
 ]
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -41,7 +41,7 @@ def mock_ib_contract_calls(mocker, instrument_provider, contract_details: Contra
 @pytest.mark.asyncio()
 async def test_load_equity_contract_instrument(mocker, instrument_provider):
     # Arrange
-    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    instrument_id = InstrumentId.from_str("AAPL=STK.NASDAQ")
     mock_ib_contract_calls(
         mocker=mocker,
         instrument_provider=instrument_provider,
@@ -56,7 +56,7 @@ async def test_load_equity_contract_instrument(mocker, instrument_provider):
     instrument_provider._client.stop()
 
     # Assert
-    assert InstrumentId(symbol=Symbol("AAPL"), venue=Venue("NASDAQ")) == equity.id
+    assert InstrumentId(symbol=Symbol("AAPL=STK"), venue=Venue("NASDAQ")) == equity.id
     assert equity.asset_class == AssetClass.EQUITY
     assert equity.instrument_class == InstrumentClass.SPOT
     assert equity.multiplier == 1
@@ -67,7 +67,7 @@ async def test_load_equity_contract_instrument(mocker, instrument_provider):
 @pytest.mark.asyncio()
 async def test_load_futures_contract_instrument(mocker, instrument_provider):
     # Arrange
-    instrument_id = InstrumentId.from_str("CLZ23.NYMEX")
+    instrument_id = InstrumentId.from_str("CLZ3=FUT.NYMEX")
     mock_ib_contract_calls(
         mocker=mocker,
         instrument_provider=instrument_provider,
@@ -75,7 +75,10 @@ async def test_load_futures_contract_instrument(mocker, instrument_provider):
     )
 
     # Act
-    await instrument_provider.load_async(IBContract(secType="FUT", symbol="CLZ3", exchange="NYMEX"))
+    await instrument_provider.load_async(
+        IBContract(secType="FUT", localSymbol="CLZ3", exchange="NYMEX"),
+    )
+    print(instrument_provider._instruments)
     future = instrument_provider.find(instrument_id)
     instrument_provider._client.stop()
 
@@ -90,7 +93,7 @@ async def test_load_futures_contract_instrument(mocker, instrument_provider):
 @pytest.mark.asyncio()
 async def test_load_options_contract_instrument(mocker, instrument_provider):
     # Arrange
-    instrument_id = InstrumentId.from_str("TSLA230120C00100000.MIAX")
+    instrument_id = InstrumentId.from_str("TSLA  230120C00100000=OPT.MIAX")
     mock_ib_contract_calls(
         mocker=mocker,
         instrument_provider=instrument_provider,
@@ -99,7 +102,7 @@ async def test_load_options_contract_instrument(mocker, instrument_provider):
 
     # Act
     await instrument_provider.load_async(
-        IBContract(secType="OPT", symbol="TSLA230120C00100000", exchange="MIAX"),
+        IBContract(secType="OPT", localSymbol="TSLA  230120C00100000", exchange="MIAX"),
     )
     option = instrument_provider.find(instrument_id)
     instrument_provider._client.stop()
@@ -118,7 +121,7 @@ async def test_load_options_contract_instrument(mocker, instrument_provider):
 @pytest.mark.asyncio()
 async def test_load_forex_contract_instrument(mocker, instrument_provider):
     # Arrange
-    instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
+    instrument_id = InstrumentId.from_str("EUR.USD=CASH.IDEALPRO")
     mock_ib_contract_calls(
         mocker=mocker,
         instrument_provider=instrument_provider,
@@ -148,18 +151,20 @@ async def test_contract_id_to_instrument_id(mocker, instrument_provider):
     )
 
     # Act
-    await instrument_provider.load_async(IBContract(secType="FUT", symbol="CLZ3", exchange="NYMEX"))
+    await instrument_provider.load_async(
+        IBContract(secType="FUT", localSymbol="CLZ23", exchange="NYMEX"),
+    )
     instrument_provider._client.stop()
 
     # Assert
-    expected = {174230596: InstrumentId.from_str("CLZ23.NYMEX")}
+    expected = {174230596: InstrumentId.from_str("CLZ3=FUT.NYMEX")}
     assert instrument_provider.contract_id_to_instrument_id == expected
 
 
 @pytest.mark.asyncio()
 async def test_load_instrument_using_contract_id(mocker, instrument_provider):
     # Arrange
-    instrument_id = InstrumentId.from_str("EUR/USD.IDEALPRO")
+    instrument_id = InstrumentId.from_str("EUR.USD=CASH.IDEALPRO")
     mock_ib_contract_calls(
         mocker=mocker,
         instrument_provider=instrument_provider,


### PR DESCRIPTION
# Pull Request

@rsmb7z
@benjaminsingleton 

The current implementation of `ib_contract_to_instrument_id`raises ValueError for many FUT & FOP contracts available on IB.

Specifically, the regex matching does not support and parse localSymbols:
- with no spaces between symbol, letter month, year, `SXAH24`
- with strikes as an int (no remainder) `DVIP40000L`
- in exchange specific notation, mexder=`DVCE91MR24`, oms=`4TLSN4L`
- with multiple spaces (in rare cases), `ISP   24L20`

Here are some other issues with the parsing I've encountered:
- contracts that expire in year 203X, with localSymbol formats containing year as a single digit, get parsed as year 202X
- OSE.JPN as exchange, a period in the exchange should be replaced to properly form an InstrumentId object

I've added test cases to this PR to show the failing localSymbol formats, and hopefully to open a discussion on how to improve it.

## Proposed Changes

This PR includes my proposed changes. All FUT & FOP Instruments have their InstrumentId changed to the value of the contract's localSymbol. The localSymbol uniquely identifies the contract and therefore the instrument in the nautilus environment, and the regex parsing is removed.

Some changes to [interactive_brokers/historic/client.py](https://github.com/nautechsystems/nautilus_trader/blob/990a3f8c89b1f3f0f3572c0eb93e3813538485e6/nautilus_trader/adapters/interactive_brokers/historic/client.py#L453) `request_ticks()` `request_bars()` would have to be considered, so the user can load instruments on request using IBContract() without a localSymbol.

## Type of change

- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)