### PR TITLE
Fix OrderUpdated arrow serialization

### DIFF
--- a/nautilus_trader/serialization/arrow/schema.py
+++ b/nautilus_trader/serialization/arrow/schema.py
@@ -343,7 +343,7 @@ NAUTILUS_ARROW_SCHEMA = {
             "venue_order_id": pa.string(),
             "price": pa.string(),
             "quantity": pa.string(),
-            "trigger_price": pa.float64(),
+            "trigger_price": pa.string(),
             "event_id": pa.string(),
             "ts_event": pa.uint64(),
             "ts_init": pa.uint64(),


### PR DESCRIPTION
# Pull Request

References #1441 . `"trigger_price"` is incorrectly set to data type `pa.float64()` instead of `pa.string()`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested locally. Awaiting validation from others.