### PR TITLE
Fix type assignment in StrategyFactory for ImportableStrategyConfig

### DIFF
--- a/nautilus_trader/config/common.py
+++ b/nautilus_trader/config/common.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import json
 from collections.abc import Callable
 from decimal import Decimal
 from typing import Any
@@ -677,7 +678,8 @@ class StrategyFactory:
         PyCondition.type(config, ImportableStrategyConfig, "config")
         strategy_cls = resolve_path(config.strategy_path)
         config_cls = resolve_path(config.config_path)
-        return strategy_cls(config=config_cls(**config.config))
+        strategy_config = config_cls.parse(json.dumps(config.config))  # type: ignore
+        return strategy_cls(config=strategy_config)
 
 
 class ImportableControllerConfig(NautilusConfig, frozen=True):

--- a/tests/integration_tests/adapters/betfair/test_kit.py
+++ b/tests/integration_tests/adapters/betfair/test_kit.py
@@ -239,7 +239,7 @@ class BetfairTestStubs:
                     strategy_path="nautilus_trader.examples.strategies.orderbook_imbalance:OrderBookImbalance",
                     config_path="nautilus_trader.examples.strategies.orderbook_imbalance:OrderBookImbalanceConfig",
                     config={
-                        "instrument_id": instrument_id,
+                        "instrument_id": instrument_id.value,
                         "max_trade_size": 50,
                     },
                 ),

--- a/tests/unit_tests/backtest/test_node.py
+++ b/tests/unit_tests/backtest/test_node.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-from decimal import Decimal
 
 import msgspec
 import pytest
@@ -25,7 +24,6 @@ from nautilus_trader.config import BacktestRunConfig
 from nautilus_trader.config import BacktestVenueConfig
 from nautilus_trader.config import ImportableStrategyConfig
 from nautilus_trader.config import LoggingConfig
-from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.persistence.funcs import parse_bytes
@@ -57,11 +55,11 @@ class TestBacktestNode:
                 strategy_path="nautilus_trader.examples.strategies.ema_cross:EMACross",
                 config_path="nautilus_trader.examples.strategies.ema_cross:EMACrossConfig",
                 config={
-                    "instrument_id": InstrumentId.from_str("AUD/USD.SIM"),
-                    "bar_type": BarType.from_str("AUD/USD.SIM-100-TICK-MID-INTERNAL"),
+                    "instrument_id": "AUD/USD.SIM",
+                    "bar_type": "AUD/USD.SIM-100-TICK-MID-INTERNAL",
                     "fast_ema_period": 10,
                     "slow_ema_period": 20,
-                    "trade_size": Decimal(1_000_000),
+                    "trade_size": "1_000_000",
                     "order_id_tag": "001",
                 },
             ),

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -14,7 +14,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import copy
-import sys
 from collections import Counter
 
 import pytest
@@ -40,7 +39,6 @@ from nautilus_trader.test_kit.stubs.persistence import TestPersistenceStubs
 from tests.integration_tests.adapters.betfair.test_kit import BetfairTestStubs
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="failing on Windows")
 class TestPersistenceStreaming:
     def setup(self) -> None:
         self.catalog: ParquetDataCatalog | None = None
@@ -165,7 +163,7 @@ class TestPersistenceStreaming:
                     ImportableStrategyConfig(
                         strategy_path="nautilus_trader.examples.strategies.signal_strategy:SignalStrategy",
                         config_path="nautilus_trader.examples.strategies.signal_strategy:SignalStrategyConfig",
-                        config={"instrument_id": instrument_id},
+                        config={"instrument_id": instrument_id.value},
                     ),
                 ],
             ),
@@ -223,7 +221,7 @@ class TestPersistenceStreaming:
                     ImportableStrategyConfig(
                         strategy_path="nautilus_trader.examples.strategies.signal_strategy:SignalStrategy",
                         config_path="nautilus_trader.examples.strategies.signal_strategy:SignalStrategyConfig",
-                        config={"instrument_id": instrument_id},
+                        config={"instrument_id": instrument_id.value},
                     ),
                 ],
             ),


### PR DESCRIPTION
# Pull Request

This PR addresses a typing inconsistency observed in the `ImportableStrategyConfig`, a subclass of `NautilusConfig`. The core functionality expected from these configurations is the ability to be stored and parsed as JSON/YAML files. However, it was identified that while loading the strategy configurations as part of `ImportableStrategyConfig`, they were not receiving the correct type assignments.

To resolve this issue, the PR implements a fix ensuring that the strategy configuration is correctly parsed with appropriate types when creating strategies using `StrategyFactory`. This enhancement aligns `ImportableStrategyConfig` with the intended design of being fully compatible and operable with JSON/YAML file formats, thereby improving reliability and consistency in configuration handling.

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Included the test.
