### PR TITLE
Fix Binance non-existing method name

### DIFF
--- a/nautilus_trader/adapters/binance/spot/execution.py
+++ b/nautilus_trader/adapters/binance/spot/execution.py
@@ -224,4 +224,4 @@ class BinanceSpotExecutionClient(BinanceCommonExecutionClient):
         self._log.warning("List status (OCO) received.")  # Implement
 
     def _handle_balance_update(self, raw: bytes) -> None:
-        self.create_task(self._update_account_state_async())
+        self.create_task(self._update_account_state())


### PR DESCRIPTION
FIX `nautilus_trader/adapters/binance/spot/execution.py`
```text
AttributeError('BinanceSpotExecutionClient' object has no attribute '_update_account_state_async')
```

# Pull Request

Include a summary of the changes.

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Describe how this code was/is tested.
