### PR TITLE
Support optional strict_symbology for IB

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/config.py
+++ b/nautilus_trader/adapters/interactive_brokers/config.py
@@ -69,6 +69,12 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
 
     Parameters
     ----------
+    strict_symbology : bool, optional
+        Determines the symbology format used for identifying instruments. If set to True,
+        a strict symbology format is used, as provided by InteractiveBrokers where instrument symbols
+        are detailed in the format `localSymbol=secType.exchange` (e.g., `EUR.USD=CASH.IDEALPRO`).
+        If False, a simplified symbology format is applied, using a notation like `EUR/USD.IDEALPRO`.
+        The default value is False, favoring simplified symbology unless specified otherwise.
     build_options_chain: bool (default: None)
         Search for full option chain. Global setting for all applicable instruments.
     build_futures_chain: bool (default: None)
@@ -112,6 +118,7 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
             ),
         )
 
+    strict_symbology: bool = False
     load_contracts: frozenset[IBContract] | None = None
     build_options_chain: bool | None = None
     build_futures_chain: bool | None = None

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -128,19 +128,23 @@ def contract_details_to_ib_contract_details(details: ContractDetails) -> IBContr
 
 def parse_instrument(
     contract_details: IBContractDetails,
+    strict_symbology: bool = False,
 ) -> Instrument:
     security_type = contract_details.contract.secType
+    instrument_id = ib_contract_to_instrument_id(
+        contract=contract_details.contract,
+        strict_symbology=strict_symbology,
+    )
     if security_type == "STK":
-        return parse_equity_contract(details=contract_details)
+        return parse_equity_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type in ("FUT", "CONTFUT"):
-        return parse_futures_contract(details=contract_details)
+        return parse_futures_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type == "OPT":
-        return parse_options_contract(details=contract_details)
+        return parse_options_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type == "CASH":
-        print(contract_details)
-        return parse_forex_contract(details=contract_details)
+        return parse_forex_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type == "CRYPTO":
-        return parse_crypto_contract(details=contract_details)
+        return parse_crypto_contract(details=contract_details, instrument_id=instrument_id)
     else:
         raise ValueError(f"Unknown {security_type=}")
 
@@ -151,10 +155,12 @@ def contract_details_to_dict(details: IBContractDetails) -> dict:
     return dict_details
 
 
-def parse_equity_contract(details: IBContractDetails) -> Equity:
+def parse_equity_contract(
+    details: IBContractDetails,
+    instrument_id: InstrumentId,
+) -> Equity:
     price_precision: int = _tick_size_to_precision(details.minTick)
     timestamp = time.time_ns()
-    instrument_id = ib_contract_to_instrument_id(details.contract)
 
     return Equity(
         instrument_id=instrument_id,
@@ -185,10 +191,10 @@ def expiry_timestring_to_datetime(expiry: str) -> pd.Timestamp:
 
 def parse_futures_contract(
     details: IBContractDetails,
+    instrument_id: InstrumentId,
 ) -> FuturesContract:
     price_precision: int = _tick_size_to_precision(details.minTick)
     timestamp = time.time_ns()
-    instrument_id = ib_contract_to_instrument_id(details.contract)
     expiration = expiry_timestring_to_datetime(details.contract.lastTradeDateOrContractMonth)
     activation = expiration - pd.Timedelta(days=90)  # TODO: Make this more accurate
 
@@ -212,10 +218,10 @@ def parse_futures_contract(
 
 def parse_options_contract(
     details: IBContractDetails,
+    instrument_id: InstrumentId,
 ) -> OptionsContract:
     price_precision: int = _tick_size_to_precision(details.minTick)
     timestamp = time.time_ns()
-    instrument_id = ib_contract_to_instrument_id(details.contract)
     asset_class = sec_type_to_asset_class(details.underSecType)
     option_kind = {
         "C": OptionKind.CALL,
@@ -246,11 +252,11 @@ def parse_options_contract(
 
 def parse_forex_contract(
     details: IBContractDetails,
+    instrument_id: InstrumentId,
 ) -> CurrencyPair:
     price_precision: int = _tick_size_to_precision(details.minTick)
     size_precision: int = _tick_size_to_precision(details.minSize)
     timestamp = time.time_ns()
-    instrument_id = ib_contract_to_instrument_id(details.contract)
 
     return CurrencyPair(
         instrument_id=instrument_id,
@@ -280,11 +286,11 @@ def parse_forex_contract(
 
 def parse_crypto_contract(
     details: IBContractDetails,
+    instrument_id: InstrumentId,
 ) -> CryptoPerpetual:
     price_precision: int = _tick_size_to_precision(details.minTick)
     size_precision: int = _tick_size_to_precision(details.minSize)
     timestamp = time.time_ns()
-    instrument_id = ib_contract_to_instrument_id(details.contract)
 
     return CryptoPerpetual(
         instrument_id=instrument_id,
@@ -322,9 +328,25 @@ def decade_digit(last_digit: str, contract: IBContract) -> int:
         return int(repr(datetime.datetime.now().year)[-2])
 
 
-def ib_contract_to_instrument_id(contract: IBContract) -> InstrumentId:
+def ib_contract_to_instrument_id(
+    contract: IBContract,
+    strict_symbology: bool = False,
+) -> InstrumentId:
     PyCondition.type(contract, IBContract, "IBContract")
 
+    if strict_symbology:
+        return ib_contract_to_instrument_id_strict_symbology(contract)
+    else:
+        return ib_contract_to_instrument_id_simplified_symbology(contract)
+
+
+def ib_contract_to_instrument_id_strict_symbology(contract: IBContract) -> InstrumentId:
+    symbol = f"{contract.localSymbol}={contract.secType}"
+    venue = (contract.primaryExchange or contract.exchange).replace(".", "/")
+    return InstrumentId.from_str(f"{symbol}.{venue}")
+
+
+def ib_contract_to_instrument_id_simplified_symbology(contract: IBContract) -> InstrumentId:
     security_type = contract.secType
     if security_type == "STK":
         symbol = (contract.localSymbol or contract.symbol).replace(" ", "-")
@@ -358,9 +380,37 @@ def ib_contract_to_instrument_id(contract: IBContract) -> InstrumentId:
     raise ValueError(f"Unknown {contract=}")
 
 
-def instrument_id_to_ib_contract(instrument_id: InstrumentId) -> IBContract:
+def instrument_id_to_ib_contract(
+    instrument_id: InstrumentId,
+    strict_symbology: bool = False,
+) -> IBContract:
     PyCondition.type(instrument_id, InstrumentId, "InstrumentId")
 
+    if strict_symbology:
+        return instrument_id_to_ib_contract_strict_symbology(instrument_id)
+    else:
+        return instrument_id_to_ib_contract_simplified_symbology(instrument_id)
+
+
+def instrument_id_to_ib_contract_strict_symbology(instrument_id: InstrumentId) -> IBContract:
+    local_symbol, security_type = instrument_id.symbol.value.rsplit("=", 1)
+    exchange = instrument_id.venue.value.replace("/", ".")
+    if security_type == "STK":
+        return IBContract(
+            secType=security_type,
+            exchange="SMART",
+            primaryExchange=exchange,
+            localSymbol=local_symbol,
+        )
+    else:
+        return IBContract(
+            secType=security_type,
+            exchange=exchange,
+            localSymbol=local_symbol,
+        )
+
+
+def instrument_id_to_ib_contract_simplified_symbology(instrument_id: InstrumentId) -> IBContract:
     if instrument_id.venue.value in VENUES_CASH and (
         m := RE_CASH.match(instrument_id.symbol.value)
     ):

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -46,30 +46,76 @@ from nautilus_trader.model.identifiers import InstrumentId
 # fmt: on
 
 
-@pytest.mark.parametrize(
-    ("contract", "instrument_id"),
-    [
-        # fmt: off
-        (IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD"), "EUR/USD.IDEALPRO"),
-        (IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000"), "AAPL230217P00155000.SMART"),
-        (IBContract(secType="CONTFUT", exchange="CME", symbol="ES"), "ES.CME"),
-        (IBContract(secType="CONTFUT", exchange="CME", symbol="M6E"), "M6E.CME"),
-        (IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL"), "MCL.NYMEX"),
-        (IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI"), "SPI.SNFE"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH23.CME"),
-        (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH23.CME"),
-        (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYMM23.CBOT"),
-        (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV23.NYMEX"),
-        (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH23.SNFE"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G23P4080.NYBOT"),
-        (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH23P103.5.NYBOT"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY.ARCA"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL.NASDAQ"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF-B.NYSE"),
-        (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M.ASX"),
-        # fmt: on
-    ],
-)
+simplified_symbology_params = [
+    # fmt: off
+    (IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD"), "EUR/USD.IDEALPRO"),
+    (IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000"), "AAPL230217P00155000.SMART"),
+    (IBContract(secType="CONTFUT", exchange="CME", symbol="ES"), "ES.CME"),
+    (IBContract(secType="CONTFUT", exchange="CME", symbol="M6E"), "M6E.CME"),
+    (IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL"), "MCL.NYMEX"),
+    (IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI"), "SPI.SNFE"),
+    (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH23.CME"),
+    (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH23.CME"),
+    (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYMM23.CBOT"),
+    (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV23.NYMEX"),
+    (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH23.SNFE"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G23P4080.NYBOT"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH23P103.5.NYBOT"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY.ARCA"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL.NASDAQ"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF-B.NYSE"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M.ASX"),
+    (IBContract(secType="CRYPTO", exchange="PAXOS", localSymbol="BTC.USD"), "BTC/USD.PAXOS"),
+    # fmt: on
+]
+
+strict_symbology_params = [
+    # fmt: off
+    (IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD"), "EUR.USD=CASH.IDEALPRO"),
+    (IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000"), "AAPL  230217P00155000=OPT.SMART"),
+    (IBContract(secType="FUT", exchange="CME", localSymbol="ESH3"), "ESH3=FUT.CME"),
+    (IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3"), "M6EH3=FUT.CME"),
+    (IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23"), "MYM  JUN 23=FUT.CBOT"),
+    (IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3"), "MCLV3=FUT.NYMEX"),
+    (IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3"), "APH3=FUT.SNFE"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080=FOP.NYBOT"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5=FOP.NYBOT"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY"), "SPY=STK.ARCA"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL"), "AAPL=STK.NASDAQ"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B"), "BF B=STK.NYSE"),
+    (IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M"), "29M=STK.ASX"),
+    (IBContract(secType="FUT", exchange="EUREX", localSymbol="SCOI 20251219 M"), "SCOI 20251219 M=FUT.EUREX"),
+    (IBContract(secType="FUT", exchange="LMEOTC", localSymbol="AH_20240221"), "AH_20240221=FUT.LMEOTC"),
+    (IBContract(secType="FUT", exchange="NSE", localSymbol="INFY24FEBFUT"), "INFY24FEBFUT=FUT.NSE"),
+    (IBContract(secType="FUT", exchange="OMS", localSymbol="4TLSN4L"), "4TLSN4L=FUT.OMS"),
+    (IBContract(secType="FUT", exchange="OMS", localSymbol="3TLSN4N"), "3TLSN4N=FUT.OMS"),
+    (IBContract(secType="FUT", exchange="MEFFRV", localSymbol="M3FIDRM4P"), "M3FIDRM4P=FUT.MEFFRV"),
+    (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCE91MR24"), "DVCE91MR24=FUT.MEXDER"),
+    (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVCXC MR24"), "DVCXC MR24=FUT.MEXDER"),
+    (IBContract(secType="FUT", exchange="MEXDER", localSymbol="DVM3  JN24"), "DVM3  JN24=FUT.MEXDER"),
+    (IBContract(secType="FUT", exchange="CDE", localSymbol="SXAH24"), "SXAH24=FUT.CDE"),
+    (IBContract(secType="FUT", exchange="IPE", localSymbol="HOILN7"), "HOILN7=FUT.IPE"),
+    (IBContract(secType="FUT", exchange="CFE", localSymbol="IBHYH4"), "IBHYH4=FUT.CFE"),
+    (IBContract(secType="FUT", exchange="IDEM", localSymbol="ISP   24L20"), "ISP   24L20=FUT.IDEM"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080"), "EX2G3 P4080=FOP.NYBOT"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5"), "DXH3 P103.5=FOP.NYBOT"),
+    (IBContract(secType="FOP", exchange="CME", localSymbol="6NZ4 P0655"), "6NZ4 P0655=FOP.CME"),
+    (IBContract(secType="FOP", exchange="EUREX", localSymbol="C OEXD 20261218 50 M"), "C OEXD 20261218 50 M=FOP.EUREX"),
+    (IBContract(secType="FOP", exchange="IPE", localSymbol="WTIF5 C80"), "WTIF5 C80=FOP.IPE"),
+    (IBContract(secType="FOP", exchange="MEXDER", localSymbol="DVIP40000L"), "DVIP40000L=FOP.MEXDER"),
+    (IBContract(secType="FOP", exchange="NYBOT", localSymbol="OJF6 C1.3"), "OJF6 C1.3=FOP.NYBOT"),
+    (IBContract(secType="FOP", exchange="SGX", localSymbol="FCHZ24_C7000"), "FCHZ24_C7000=FOP.SGX"),
+    (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240125 D"), "FMEU 20240125 D=FUT.EUREX"),
+    (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240126 D"), "FMEU 20240126 D=FUT.EUREX"),
+    (IBContract(secType="FUT", exchange="EUREX", localSymbol="FMEU 20240129 D"), "FMEU 20240129 D=FUT.EUREX"),
+    (IBContract(secType="FOP", exchange="ENDEX", localSymbol="TFMG0"), "TFMG0=FOP.ENDEX"),
+    (IBContract(secType="FUT", exchange="OSE.JPN", localSymbol="1690200A1"), "1690200A1=FUT.OSE/JPN"),
+    (IBContract(secType="CRYPTO", exchange="PAXOS", localSymbol="BTC.USD"), "BTC.USD=CRYPTO.PAXOS"),
+    # fmt: on
+]
+
+
+@pytest.mark.parametrize("contract, instrument_id", simplified_symbology_params)
 def test_ib_contract_to_instrument_id(contract, instrument_id):
     # Arrange, Act
     result = ib_contract_to_instrument_id(contract)
@@ -79,31 +125,28 @@ def test_ib_contract_to_instrument_id(contract, instrument_id):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    ("instrument_id", "contract"),
-    [
-        # fmt: off
-        ("EUR/USD.IDEALPRO", IBContract(secType="CASH", exchange="IDEALPRO", localSymbol="EUR.USD")),
-        ("AAPL230217P00155000.SMART", IBContract(secType="OPT", exchange="SMART", localSymbol="AAPL  230217P00155000")),
-        ("ES.CME", IBContract(secType="CONTFUT", exchange="CME", symbol="ES")),
-        ("M6E.CME", IBContract(secType="CONTFUT", exchange="CME", symbol="M6E")),
-        ("MCL.NYMEX", IBContract(secType="CONTFUT", exchange="NYMEX", symbol="MCL")),
-        ("SPI.SNFE", IBContract(secType="CONTFUT", exchange="SNFE", symbol="SPI")),
-        ("ESH23.CME", IBContract(secType="FUT", exchange="CME", localSymbol="ESH3")),
-        ("M6EH23.CME", IBContract(secType="FUT", exchange="CME", localSymbol="M6EH3")),
-        ("MYMM23.CBOT", IBContract(secType="FUT", exchange="CBOT", localSymbol="MYM  JUN 23")),
-        ("MCLV23.NYMEX", IBContract(secType="FUT", exchange="NYMEX", localSymbol="MCLV3")),
-        ("APH23.SNFE", IBContract(secType="FUT", exchange="SNFE", localSymbol="APH3")),
-        ("EX2G23P4080.NYBOT", IBContract(secType="FOP", exchange="NYBOT", localSymbol="EX2G3 P4080")),
-        ("DXH23P103.5.NYBOT", IBContract(secType="FOP", exchange="NYBOT", localSymbol="DXH3 P103.5")),
-        ("SPY.ARCA", IBContract(secType="STK", exchange="SMART", primaryExchange="ARCA", localSymbol="SPY")),
-        ("AAPL.NASDAQ", IBContract(secType="STK", exchange="SMART", primaryExchange="NASDAQ", localSymbol="AAPL")),
-        ("BF-B.NYSE", IBContract(secType="STK", exchange="SMART", primaryExchange="NYSE", localSymbol="BF B")),
-        ("29M.ASX", IBContract(secType="STK", exchange="SMART", primaryExchange="ASX", localSymbol="29M")),
-        # fmt: on
-    ],
-)
+@pytest.mark.parametrize("contract, instrument_id", strict_symbology_params)
+def test_ib_contract_to_instrument_id_strict_symbology(contract, instrument_id):
+    # Arrange, Act
+    result = ib_contract_to_instrument_id(contract=contract, strict_symbology=True)
+
+    # Assert
+    expected = InstrumentId.from_str(instrument_id)
+    assert result == expected
+
+
+@pytest.mark.parametrize("contract, instrument_id", simplified_symbology_params)
 def test_instrument_id_to_ib_contract(instrument_id, contract):
+    # Arrange, Act
+    result = instrument_id_to_ib_contract(InstrumentId.from_str(instrument_id))
+
+    # Assert
+    expected = contract
+    assert result == expected
+
+
+@pytest.mark.parametrize("contract, instrument_id", simplified_symbology_params)
+def test_instrument_id_to_ib_contract_strict_symbology(instrument_id, contract):
     # Arrange, Act
     result = instrument_id_to_ib_contract(InstrumentId.from_str(instrument_id))
 


### PR DESCRIPTION
# Pull Request

The current symbology approach, while effective for a broad range of securities, encounters limitations with certain exchanges due to varied naming conventions that are not compatible with our existing parsing method. To address this, we are introducing a `strict_symbology` flag within the `InteractiveBrokersInstrumentProviderConfig`. When enabled (set to True), this flag mandates strict adherence to the `localSymbol=secType.exchange` format as stipulated by Interactive Brokers. This ensures comprehensive compatibility and eliminates parsing discrepancies.

For instance, with `strict_symbology` set to `True`, the symbology for instruments strictly follows the format provided by InteractiveBrokers, such as **EUR.USD=CASH.IDEALPRO**. Conversely, when set to `False`, the system applies a simplified symbology format, like **EUR/USD.IDEALPRO**. The default setting is False, which opts for the simplified symbology unless explicitly overridden.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tests proposed by @fhill2 passing when `strict_symbology=True` is set in `InteractiveBrokersInstrumentProviderConfig`.