### PR TITLE
Finish position Rust tests

### DIFF
--- a/nautilus_core/model/src/lib.rs
+++ b/nautilus_core/model/src/lib.rs
@@ -29,3 +29,5 @@ pub mod types;
 pub mod ffi;
 #[cfg(feature = "python")]
 pub mod python;
+#[cfg(feature = "stubs")]
+pub mod stubs;

--- a/nautilus_core/model/src/orders/market.rs
+++ b/nautilus_core/model/src/orders/market.rs
@@ -367,17 +367,32 @@ impl From<OrderInitialized> for MarketOrder {
 mod tests {
     use rstest::rstest;
 
+    use crate::enums::OrderSide;
+    use crate::instruments::currency_pair::CurrencyPair;
+    use crate::instruments::stubs::*;
     use crate::{enums::TimeInForce, orders::stubs::*, types::quantity::Quantity};
 
     #[rstest]
     #[should_panic(expected = "Condition failed: invalid `Quantity`, should be positive and was 0")]
-    fn test_positive_quantity_condition() {
-        let _ = market_order(Quantity::from(0), None);
+    fn test_positive_quantity_condition(audusd_sim: CurrencyPair) {
+        let _ = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(0),
+            None,
+            None,
+        );
     }
 
     #[rstest]
     #[should_panic(expected = "GTD not supported for Market orders")]
-    fn test_gtd_condition() {
-        let _ = market_order(Quantity::from(100), Some(TimeInForce::Gtd));
+    fn test_gtd_condition(audusd_sim: CurrencyPair) {
+        let _ = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100),
+            None,
+            Some(TimeInForce::Gtd),
+        );
     }
 }

--- a/nautilus_core/model/src/orders/stubs.rs
+++ b/nautilus_core/model/src/orders/stubs.rs
@@ -17,6 +17,8 @@ use std::str::FromStr;
 
 use nautilus_core::uuid::UUID4;
 
+use crate::identifiers::client_order_id::ClientOrderId;
+use crate::identifiers::instrument_id::InstrumentId;
 use crate::{
     enums::{LiquiditySide, OrderSide, TimeInForce},
     events::order::filled::OrderFilled,
@@ -90,32 +92,42 @@ impl TestOrderEventStubs {
     }
 }
 
-// ---- MarketOrder ----
-pub fn market_order(quantity: Quantity, time_in_force: Option<TimeInForce>) -> MarketOrder {
-    let trader = trader_id();
-    let strategy = strategy_id_ema_cross();
-    let instrument = instrument_id_eth_usdt_binance();
-    let client_order_id = client_order_id();
-    MarketOrder::new(
-        trader,
-        strategy,
-        instrument,
-        client_order_id,
-        OrderSide::Buy,
-        quantity,
-        time_in_force.unwrap_or(TimeInForce::Gtc),
-        UUID4::new(),
-        12321312321312,
-        false,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap()
+pub struct TestOrderStubs;
+
+impl TestOrderStubs {
+    pub fn market_order(
+        instrument_id: InstrumentId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        client_order_id: Option<ClientOrderId>,
+        time_in_force: Option<TimeInForce>,
+    ) -> MarketOrder {
+        let trader = trader_id();
+        let strategy = strategy_id_ema_cross();
+        let client_order_id =
+            client_order_id.unwrap_or(ClientOrderId::from("O-20200814-102234-001-001-1"));
+        let time_in_force = time_in_force.unwrap_or(TimeInForce::Gtc);
+        MarketOrder::new(
+            trader,
+            strategy,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            time_in_force,
+            UUID4::new(),
+            12321312321312,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+    }
 }

--- a/nautilus_core/model/src/position.rs
+++ b/nautilus_core/model/src/position.rs
@@ -523,1951 +523,1562 @@ impl Display for Position {
 ////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
-// #[cfg(test)]
-// mod tests {
-//     use crate::account::cash::CashAccount;
-//     use crate::account::stubs::{calculate_commission, cash_account_million_usd};
-//     use crate::account::Account;
-//     use crate::position::Position;
-//     use crate::stubs::*;
-//     use nautilus_common::factories::OrderFactory;
-//     use nautilus_common::stubs::*;
-//     use nautilus_model::enums::{LiquiditySide, OrderSide, OrderType, PositionSide};
-//     use nautilus_model::events::order::filled::OrderFilled;
-//     use nautilus_model::identifiers::account_id::AccountId;
-//     use nautilus_model::identifiers::client_order_id::ClientOrderId;
-//     use nautilus_model::identifiers::position_id::PositionId;
-//     use nautilus_model::identifiers::strategy_id::StrategyId;
-//     use nautilus_model::identifiers::stubs::uuid4;
-//     use nautilus_model::identifiers::trade_id::TradeId;
-//     use nautilus_model::identifiers::venue_order_id::VenueOrderId;
-//     use nautilus_model::instruments::crypto_perpetual::CryptoPerpetual;
-//     use nautilus_model::instruments::currency_pair::CurrencyPair;
-//     use nautilus_model::instruments::stubs::*;
-//     use nautilus_model::orders::market::MarketOrder;
-//     use nautilus_model::orders::stubs::TestOrderEventStubs;
-//     use nautilus_model::types::currency::Currency;
-//     use nautilus_model::types::money::Money;
-//     use nautilus_model::types::price::Price;
-//     use nautilus_model::types::quantity::Quantity;
-//     use rstest::rstest;
-//     use std::str::FromStr;
-//
-//     #[rstest]
-//     fn test_position_long_display(test_position_long: Position) {
-//         let display = format!("{test_position_long}");
-//         assert_eq!(display, "Position(LONG 1 AUD/USD.SIM, id=1)");
-//     }
-//
-//     #[rstest]
-//     fn test_position_short_display(test_position_short: Position) {
-//         let display = format!("{test_position_short}");
-//         assert_eq!(display, "Position(SHORT 1 AUD/USD.SIM, id=1)");
-//     }
-//
-//     #[rstest]
-//     #[should_panic(expected = "`fill.trade_id` already contained in `trade_ids")]
-//     fn test_two_trades_with_same_trade_id_throws(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order1,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("1").unwrap()),
-//             None,
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order2,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("1").unwrap()),
-//             None,
-//             Some(Price::from("1.00002")),
-//             None,
-//             None,
-//             None,
-//         );
-//         // let last_price = Price::from_str("1.00050").unwrap();
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         position.apply(&fill2);
-//     }
-//
-//     #[rstest]
-//     fn test_ordering_of_client_order_ids(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order3 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled(
-//             &order1,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("1").unwrap()),
-//             None,
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("2").unwrap()),
-//             None,
-//             Some(Price::from("1.00002")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill3 = TestOrderEventStubs::order_filled(
-//             &order3,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("3").unwrap()),
-//             None,
-//             Some(Price::from("1.00003")),
-//             None,
-//             None,
-//             None,
-//         );
-//         // let last_price = Price::from_str("1.00050").unwrap();
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         position.apply(&fill2);
-//         position.apply(&fill3);
-//         assert_eq!(
-//             position.client_order_ids(),
-//             vec![
-//                 ClientOrderId::new("O-19700101-0000-001-001-1").unwrap(),
-//                 ClientOrderId::new("O-19700101-0000-001-001-2").unwrap(),
-//                 ClientOrderId::new("O-19700101-0000-001-001-3").unwrap(),
-//             ]
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_filled_with_buy_order(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             None,
-//             None,
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let last_price = Price::from_str("1.0005").unwrap();
-//         let position = Position::new(audusd_sim, fill).unwrap();
-//         assert_eq!(position.symbol(), audusd_sim.id.symbol);
-//         assert_eq!(position.venue(), audusd_sim.id.venue);
-//         assert!(!position.is_opposite_side(fill.order_side));
-//         assert_eq!(position, position); // equality operator test
-//         assert_eq!(
-//             position.opening_order_id,
-//             ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
-//         );
-//         assert!(position.closing_order_id.is_none());
-//         assert_eq!(position.quantity, Quantity::from(100_000));
-//         assert_eq!(position.peak_qty, Quantity::from(100_000));
-//         assert_eq!(position.size_precision, 0);
-//         assert_eq!(position.signed_qty, 100_000.0);
-//         assert_eq!(position.entry, OrderSide::Buy);
-//         assert_eq!(position.side, PositionSide::Long);
-//         assert_eq!(position.ts_opened, 0);
-//         assert_eq!(position.duration_ns, 0);
-//         assert_eq!(position.avg_px_open, 1.00001);
-//         assert_eq!(position.event_count(), 1);
-//         assert_eq!(
-//             position.client_order_ids(),
-//             vec![ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()]
-//         );
-//         assert_eq!(
-//             position.last_trade_id(),
-//             Some(TradeId::new("E-19700101-0000-001-001-1").unwrap())
-//         );
-//         assert_eq!(position.id, PositionId::new("1").unwrap());
-//         assert_eq!(position.events.len(), 1);
-//         assert!(position.is_long());
-//         assert!(!position.is_short());
-//         assert!(position.is_open());
-//         assert!(!position.is_closed());
-//         assert_eq!(position.realized_return, 0.0);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-2.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last_price),
-//             Money::from_str("49.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.total_pnl(last_price),
-//             Money::from_str("47.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("2.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(LONG 100_000 AUD/USD.SIM, id=1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_filled_with_sell_order(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Sell,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             None,
-//             None,
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let last_price = Price::from_str("1.00050").unwrap();
-//         let position = Position::new(audusd_sim, fill).unwrap();
-//         assert_eq!(position.symbol(), audusd_sim.id.symbol);
-//         assert_eq!(position.venue(), audusd_sim.id.venue);
-//         assert!(!position.is_opposite_side(fill.order_side));
-//         assert_eq!(position, position); // equality operator test
-//         assert_eq!(
-//             position.opening_order_id,
-//             ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()
-//         );
-//         assert!(position.closing_order_id.is_none());
-//         assert_eq!(position.quantity, Quantity::from(100_000));
-//         assert_eq!(position.peak_qty, Quantity::from(100_000));
-//         assert_eq!(position.signed_qty, -100_000.0);
-//         assert_eq!(position.entry, OrderSide::Sell);
-//         assert_eq!(position.side, PositionSide::Short);
-//         assert_eq!(position.ts_opened, 0);
-//         assert_eq!(position.avg_px_open, 1.00001);
-//         assert_eq!(position.event_count(), 1);
-//         assert_eq!(
-//             position.trade_ids,
-//             vec![TradeId::new("E-19700101-0000-001-001-1").unwrap()]
-//         );
-//         assert_eq!(
-//             position.last_trade_id(),
-//             Some(TradeId::new("E-19700101-0000-001-001-1").unwrap())
-//         );
-//         assert_eq!(position.id, PositionId::new("1").unwrap());
-//         assert_eq!(position.events.len(), 1);
-//         assert!(!position.is_long());
-//         assert!(position.is_short());
-//         assert!(position.is_open());
-//         assert!(!position.is_closed());
-//         assert_eq!(position.realized_return, 0.0);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-2.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last_price),
-//             Money::from_str("-49.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.total_pnl(last_price),
-//             Money::from_str("-51.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("2.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(SHORT 100_000 AUD/USD.SIM, id=1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_partial_fills_with_buy_order(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             None,
-//             None,
-//             Some(Price::from("1.00001")),
-//             Some(Quantity::from(50_000)),
-//             None,
-//             None,
-//         );
-//         let last_price = Price::from_str("1.00048").unwrap();
-//         let position = Position::new(audusd_sim, fill).unwrap();
-//         assert_eq!(position.quantity, Quantity::from(50_000));
-//         assert_eq!(position.peak_qty, Quantity::from(50_000));
-//         assert_eq!(position.side, PositionSide::Long);
-//         assert_eq!(position.signed_qty, 50000.0);
-//         assert_eq!(position.avg_px_open, 1.00001);
-//         assert_eq!(position.event_count(), 1);
-//         assert_eq!(position.ts_opened, 0);
-//         assert!(position.is_long());
-//         assert!(!position.is_short());
-//         assert!(position.is_open());
-//         assert!(!position.is_closed());
-//         assert_eq!(position.realized_return, 0.0);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-2.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last_price),
-//             Money::from_str("23.5 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.total_pnl(last_price),
-//             Money::from_str("21.5 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("2.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(LONG 50_000 AUD/USD.SIM, id=1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_partial_fills_with_two_sell_orders(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Sell,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("1").unwrap()),
-//             None,
-//             Some(Price::from("1.00001")),
-//             Some(Quantity::from(50_000)),
-//             None,
-//             None,
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("2").unwrap()),
-//             None,
-//             Some(Price::from("1.00002")),
-//             Some(Quantity::from(50_000)),
-//             None,
-//             None,
-//         );
-//         let last_price = Price::from_str("1.0005").unwrap();
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         position.apply(&fill2);
-//
-//         assert_eq!(position.quantity, Quantity::from(100_000));
-//         assert_eq!(position.peak_qty, Quantity::from(100_000));
-//         assert_eq!(position.side, PositionSide::Short);
-//         assert_eq!(position.signed_qty, -100_000.0);
-//         assert_eq!(position.avg_px_open, 1.000_015);
-//         assert_eq!(position.event_count(), 2);
-//         assert_eq!(position.ts_opened, 0);
-//         assert!(position.is_short());
-//         assert!(!position.is_long());
-//         assert!(position.is_open());
-//         assert!(!position.is_closed());
-//         assert_eq!(position.realized_return, 0.0);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-4.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last_price),
-//             Money::from_str("-48.5 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.total_pnl(last_price),
-//             Money::from_str("-52.5 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("4.0 USD").unwrap()]
-//         );
-//     }
-//
-//     #[rstest]
-//     pub fn test_position_filled_with_buy_order_then_sell_order(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(150_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &audusd_sim,
-//             Some(StrategyId::new("S-001").unwrap()),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-1").unwrap()),
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             Some(1_000_000_000),
-//         );
-//         let mut position = Position::new(audusd_sim, fill).unwrap();
-//
-//         let fill2 = OrderFilled::new(
-//             order.trader_id,
-//             StrategyId::new("S-001").unwrap(),
-//             order.instrument_id,
-//             order.client_order_id,
-//             VenueOrderId::from("2"),
-//             order
-//                 .account_id
-//                 .unwrap_or(AccountId::new("SIM-001").unwrap()),
-//             TradeId::new("2").unwrap(),
-//             OrderSide::Sell,
-//             OrderType::Market,
-//             order.quantity,
-//             Price::from("1.00011"),
-//             audusd_sim.quote_currency,
-//             LiquiditySide::Taker,
-//             uuid4(),
-//             2_000_000_000,
-//             0,
-//             false,
-//             Some(PositionId::new("T1").unwrap()),
-//             Some(Money::from_str("0.0 USD").unwrap()),
-//         )
-//         .unwrap();
-//         position.apply(&fill2);
-//         let last = Price::from_str("1.0005").unwrap();
-//
-//         assert!(position.is_opposite_side(fill2.order_side));
-//         assert_eq!(
-//             position.quantity,
-//             Quantity::zero(audusd_sim.price_precision)
-//         );
-//         assert_eq!(position.size_precision, 0);
-//         assert_eq!(position.signed_qty, 0.0);
-//         assert_eq!(position.side, PositionSide::Flat);
-//         assert_eq!(position.ts_opened, 1_000_000_000);
-//         assert_eq!(position.ts_closed, Some(2_000_000_000));
-//         assert_eq!(position.duration_ns, 1_000_000_000);
-//         assert_eq!(position.avg_px_open, 1.00001);
-//         assert_eq!(position.avg_px_close, Some(1.00011));
-//         assert!(!position.is_long());
-//         assert!(!position.is_short());
-//         assert!(!position.is_open());
-//         assert!(position.is_closed());
-//         assert_eq!(position.realized_return, 9.999_900_000_998_888e-5);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("13.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last),
-//             Money::from_str("0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("2 USD").unwrap()]
-//         );
-//         assert_eq!(position.total_pnl(last), Money::from_str("13 USD").unwrap());
-//         assert_eq!(format!("{position}"), "Position(FLAT AUD/USD.SIM, id=P-1)");
-//     }
-//
-//     #[rstest]
-//     pub fn test_position_filled_with_sell_order_then_buy_order(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Sell,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order1,
-//             &audusd_sim,
-//             None,
-//             None,
-//             Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
-//             Some(Price::from("1.0")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         // create closing from order from different venue but same strategy
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &audusd_sim,
-//             Some(StrategyId::new("S-001").unwrap()),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
-//             Some(Price::from("1.00001")),
-//             Some(Quantity::from(50_000)),
-//             None,
-//             None,
-//         );
-//         let fill3 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &audusd_sim,
-//             Some(StrategyId::new("S-001").unwrap()),
-//             Some(TradeId::new("2").unwrap()),
-//             Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
-//             Some(Price::from("1.00003")),
-//             Some(Quantity::from(50_000)),
-//             None,
-//             None,
-//         );
-//         let last = Price::from("1.0005");
-//         position.apply(&fill2);
-//         position.apply(&fill3);
-//
-//         assert_eq!(
-//             position.quantity,
-//             Quantity::zero(audusd_sim.price_precision)
-//         );
-//         assert_eq!(position.side, PositionSide::Flat);
-//         assert_eq!(position.ts_opened, 0);
-//         assert_eq!(position.avg_px_open, 1.0);
-//         assert_eq!(position.events.len(), 3);
-//         assert_eq!(
-//             position.client_order_ids(),
-//             vec![order1.client_order_id, order2.client_order_id]
-//         );
-//         assert_eq!(position.ts_closed, Some(0));
-//         assert_eq!(position.avg_px_close, Some(1.00002));
-//         assert!(!position.is_long());
-//         assert!(!position.is_short());
-//         assert!(!position.is_open());
-//         assert!(position.is_closed());
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("6.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last),
-//             Money::from_str("0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-8.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.total_pnl(last),
-//             Money::from_str("-8.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(FLAT AUD/USD.SIM, id=P-19700101-0000-000-001-1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_filled_with_no_change(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Sell,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled(
-//             &order1,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
-//             Some(Price::from("1.0")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &audusd_sim,
-//             None,
-//             Some(TradeId::new("2").unwrap()),
-//             Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
-//             Some(Price::from("1.0")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let last = Price::from("1.0005");
-//         position.apply(&fill2);
-//
-//         assert_eq!(
-//             position.quantity,
-//             Quantity::zero(audusd_sim.price_precision)
-//         );
-//         assert_eq!(position.side, PositionSide::Flat);
-//         assert_eq!(position.ts_opened, 0);
-//         assert_eq!(position.avg_px_open, 1.0);
-//         assert_eq!(position.events.len(), 2);
-//         assert_eq!(
-//             position.client_order_ids(),
-//             vec![order1.client_order_id, order2.client_order_id]
-//         );
-//         assert_eq!(position.trade_ids, vec![fill1.trade_id, fill2.trade_id]);
-//         assert_eq!(position.ts_closed, Some(0));
-//         assert_eq!(position.avg_px_close, Some(1.0));
-//         assert!(!position.is_long());
-//         assert!(!position.is_short());
-//         assert!(!position.is_open());
-//         assert!(position.is_closed());
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("4.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last),
-//             Money::from_str("0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-4.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.total_pnl(last),
-//             Money::from_str("-4.0 USD").unwrap()
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(FLAT AUD/USD.SIM, id=P-19700101-0000-000-001-1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_long_with_multiple_filled_orders(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             Quantity::from(100_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order3 = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Sell,
-//             Quantity::from(200_000),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled(
-//             &order1,
-//             &audusd_sim,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("1.0")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &audusd_sim,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("2").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("1.00001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill3 = TestOrderEventStubs::order_filled(
-//             &order3,
-//             &audusd_sim,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("3").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("1.0001")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//         let last = Price::from("1.0005");
-//         position.apply(&fill2);
-//         position.apply(&fill3);
-//
-//         assert_eq!(
-//             position.quantity,
-//             Quantity::zero(audusd_sim.price_precision)
-//         );
-//         assert_eq!(position.side, PositionSide::Flat);
-//         assert_eq!(position.ts_opened, 0);
-//         assert_eq!(position.avg_px_open, 1.000_005);
-//         assert_eq!(position.events.len(), 3);
-//         assert_eq!(
-//             position.client_order_ids(),
-//             vec![
-//                 order1.client_order_id,
-//                 order2.client_order_id,
-//                 order3.client_order_id
-//             ]
-//         );
-//         assert_eq!(
-//             position.trade_ids,
-//             vec![fill1.trade_id, fill2.trade_id, fill3.trade_id]
-//         );
-//         assert_eq!(position.ts_closed, Some(0));
-//         assert_eq!(position.avg_px_close, Some(1.0001));
-//         assert!(position.is_closed());
-//         assert!(!position.is_open());
-//         assert!(!position.is_long());
-//         assert!(!position.is_short());
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("6.0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("13.0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last),
-//             Money::from_str("0 USD").unwrap()
-//         );
-//         assert_eq!(position.total_pnl(last), Money::from_str("13 USD").unwrap());
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(FLAT AUD/USD.SIM, id=P-123456)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_pnl_calculation_from_trading_technologies_example(
-//         mut order_factory: OrderFactory,
-//         currency_pair_ethusdt: CurrencyPair,
-//         cash_account_million_usd: CashAccount,
-//     ) {
-//         let quantity1 = Quantity::from(12);
-//         let price1 = Price::from("100.0");
-//         let order1 = order_factory.market(
-//             currency_pair_ethusdt.id,
-//             OrderSide::Buy,
-//             quantity1,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission1 = cash_account_million_usd
-//             .calculate_commission(
-//                 currency_pair_ethusdt,
-//                 order1.quantity,
-//                 price1,
-//                 LiquiditySide::Taker,
-//                 None,
-//             )
-//             .unwrap();
-//         let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order1,
-//             &currency_pair_ethusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(price1),
-//             None,
-//             Some(commission1),
-//             None,
-//         );
-//         let mut position = Position::new(currency_pair_ethusdt, fill1).unwrap();
-//         let quantity2 = Quantity::from(17);
-//         let order2 = order_factory.market(
-//             currency_pair_ethusdt.id,
-//             OrderSide::Buy,
-//             quantity2,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let price2 = Price::from("99.0");
-//         let commission2 = cash_account_million_usd
-//             .calculate_commission(
-//                 currency_pair_ethusdt,
-//                 order2.quantity,
-//                 price2,
-//                 LiquiditySide::Taker,
-//                 None,
-//             )
-//             .unwrap();
-//         let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order2,
-//             &currency_pair_ethusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("2").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(price2),
-//             None,
-//             Some(commission2),
-//             None,
-//         );
-//         position.apply(&fill2);
-//         assert_eq!(position.quantity, Quantity::from(29));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-0.28830000 USDT").unwrap())
-//         );
-//         assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
-//         let quantity3 = Quantity::from(9);
-//         let order3 = order_factory.market(
-//             currency_pair_ethusdt.id,
-//             OrderSide::Sell,
-//             quantity3,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let price3 = Price::from("101.0");
-//         let commission3 = cash_account_million_usd
-//             .calculate_commission(
-//                 currency_pair_ethusdt,
-//                 order3.quantity,
-//                 price3,
-//                 LiquiditySide::Taker,
-//                 None,
-//             )
-//             .unwrap();
-//         let fill3 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order3,
-//             &currency_pair_ethusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("3").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(price3),
-//             None,
-//             Some(commission3),
-//             None,
-//         );
-//         position.apply(&fill3);
-//         assert_eq!(position.quantity, Quantity::from(20));
-//         assert_eq!(position.realized_pnl, Some(Money::from("13.89666207 USDT")));
-//         assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
-//         let quantity4 = Quantity::from("4");
-//         let price4 = Price::from("105.0");
-//         let order4 = order_factory.market(
-//             currency_pair_ethusdt.id,
-//             OrderSide::Sell,
-//             quantity4,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission4 = cash_account_million_usd
-//             .calculate_commission(
-//                 currency_pair_ethusdt,
-//                 order4.quantity,
-//                 price4,
-//                 LiquiditySide::Taker,
-//                 None,
-//             )
-//             .unwrap();
-//         let fill4 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order4,
-//             &currency_pair_ethusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("4").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(price4),
-//             None,
-//             Some(commission4),
-//             None,
-//         );
-//         position.apply(&fill4);
-//         assert_eq!(position.quantity, Quantity::from("16"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("36.19948966 USDT")));
-//         assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
-//         let quantity5 = Quantity::from("3");
-//         let price5 = Price::from("103.0");
-//         let order5 = order_factory.market(
-//             currency_pair_ethusdt.id,
-//             OrderSide::Buy,
-//             quantity5,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission5 =
-//             calculate_commission(currency_pair_ethusdt, order5.quantity, price5, None);
-//         let fill5 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order5,
-//             &currency_pair_ethusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("5").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(price5),
-//             None,
-//             Some(commission5),
-//             None,
-//         );
-//         position.apply(&fill5);
-//         assert_eq!(position.quantity, Quantity::from("19"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("36.16858966 USDT")));
-//         assert_eq!(position.avg_px_open, 99.980_036_297_640_65);
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(LONG 19.00000 ETHUSDT.BINANCE, id=P-123456)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_closed_and_reopened(
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let quantity1 = Quantity::from(150_000);
-//         let price1 = Price::from("1.00001");
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             OrderSide::Buy,
-//             quantity1,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission1 = calculate_commission(audusd_sim, quantity1, price1, None);
-//         let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
-//             &order,
-//             &audusd_sim,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("5").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("1.00001")),
-//             None,
-//             Some(commission1),
-//             Some(1_000_000_000),
-//         );
-//         let mut position = Position::new(audusd_sim, fill1).unwrap();
-//
-//         let fill2 = OrderFilled::new(
-//             order.trader_id,
-//             order.strategy_id,
-//             order.instrument_id,
-//             order.client_order_id,
-//             VenueOrderId::from("2"),
-//             order
-//                 .account_id
-//                 .unwrap_or(AccountId::new("SIM-001").unwrap()),
-//             TradeId::from("2"),
-//             OrderSide::Sell,
-//             OrderType::Market,
-//             order.quantity,
-//             Price::from("1.00011"),
-//             audusd_sim.quote_currency,
-//             LiquiditySide::Taker,
-//             uuid4(),
-//             2_000_000_000,
-//             0,
-//             false,
-//             Some(PositionId::from("P-123456")),
-//             Some(Money::from("0 USD")),
-//         )
-//         .unwrap();
-//         position.apply(&fill2);
-//         let fill3 = OrderFilled::new(
-//             order.trader_id,
-//             order.strategy_id,
-//             order.instrument_id,
-//             order.client_order_id,
-//             VenueOrderId::from("2"),
-//             order
-//                 .account_id
-//                 .unwrap_or(AccountId::new("SIM-001").unwrap()),
-//             TradeId::from("3"),
-//             OrderSide::Buy,
-//             OrderType::Market,
-//             order.quantity,
-//             Price::from("1.00012"),
-//             audusd_sim.quote_currency,
-//             LiquiditySide::Taker,
-//             uuid4(),
-//             3_000_000_000,
-//             0,
-//             false,
-//             Some(PositionId::from("P-123456")),
-//             Some(Money::from("0 USD")),
-//         )
-//         .unwrap();
-//         position.apply(&fill3);
-//         let last = Price::from("1.0003");
-//         assert!(position.is_opposite_side(fill2.order_side));
-//         assert_eq!(position.quantity, Quantity::from(150_000));
-//         assert_eq!(position.peak_qty, Quantity::from(150_000));
-//         assert_eq!(position.side, PositionSide::Long);
-//         assert_eq!(position.opening_order_id, fill3.client_order_id);
-//         assert_eq!(position.closing_order_id, None);
-//         assert_eq!(position.closing_order_id, None);
-//         assert_eq!(position.ts_opened, 3_000_000_000);
-//         assert_eq!(position.duration_ns, 0);
-//         assert_eq!(position.avg_px_open, 1.00012);
-//         assert_eq!(position.event_count(), 1);
-//         assert_eq!(position.ts_closed, None);
-//         assert_eq!(position.avg_px_close, None);
-//         assert!(position.is_long());
-//         assert!(!position.is_short());
-//         assert!(position.is_open());
-//         assert!(!position.is_closed());
-//         assert_eq!(position.realized_return, 0.0);
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("0 USD").unwrap())
-//         );
-//         assert_eq!(
-//             position.unrealized_pnl(last),
-//             Money::from_str("27 USD").unwrap()
-//         );
-//         assert_eq!(position.total_pnl(last), Money::from_str("27 USD").unwrap());
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from_str("0 USD").unwrap()]
-//         );
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(LONG 150_000 AUD/USD.SIM, id=P-123456)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_position_realised_pnl_with_interleaved_order_sides(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(12),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission1 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order1.quantity,
-//             Price::from("10000.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled(
-//             &order1,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-19700101-0000-000-001-1")),
-//             Some(Price::from("10000.0")),
-//             None,
-//             Some(commission1),
-//             None,
-//         );
-//         let mut position = Position::new(currency_pair_btcusdt, fill1).unwrap();
-//         let order2 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(17),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission2 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order2.quantity,
-//             Price::from("9999.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-19700101-0000-000-001-1")),
-//             Some(Price::from("9999.0")),
-//             None,
-//             Some(commission2),
-//             None,
-//         );
-//         position.apply(&fill2);
-//         assert_eq!(position.quantity, Quantity::from(29));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-289.98300000 USDT").unwrap())
-//         );
-//         assert_eq!(position.avg_px_open, 9_999.413_793_103_447);
-//         let order3 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Sell,
-//             Quantity::from(9),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission3 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order3.quantity,
-//             Price::from("10001.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill3 = TestOrderEventStubs::order_filled(
-//             &order3,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-19700101-0000-000-001-1")),
-//             Some(Price::from("10001.0")),
-//             None,
-//             Some(commission3),
-//             None,
-//         );
-//         position.apply(&fill3);
-//         assert_eq!(position.quantity, Quantity::from(20));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-365.71613793 USDT").unwrap())
-//         );
-//         assert_eq!(position.avg_px_open, 9_999.413_793_103_447);
-//         let order4 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(3),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission4 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order4.quantity,
-//             Price::from("10003.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill4 = TestOrderEventStubs::order_filled(
-//             &order4,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-19700101-0000-000-001-1")),
-//             Some(Price::from("10003.0")),
-//             None,
-//             Some(commission4),
-//             None,
-//         );
-//         position.apply(&fill4);
-//         assert_eq!(position.quantity, Quantity::from(23));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-395.72513793 USDT").unwrap())
-//         );
-//         assert_eq!(position.avg_px_open, 9_999.881_559_220_39);
-//         let order5 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Sell,
-//             Quantity::from(4),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission5 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order5.quantity,
-//             Price::from("10005.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill5 = TestOrderEventStubs::order_filled(
-//             &order5,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-19700101-0000-000-001-1")),
-//             Some(Price::from("10005.0")),
-//             None,
-//             Some(commission5),
-//             None,
-//         );
-//         position.apply(&fill5);
-//         assert_eq!(position.quantity, Quantity::from(19));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from_str("-415.27137481 USDT").unwrap())
-//         );
-//         assert_eq!(position.avg_px_open, 9_999.881_559_220_39);
-//         assert_eq!(
-//             format!("{position}"),
-//             "Position(LONG 19.000000 BTCUSDT.BINANCE, id=P-19700101-0000-000-001-1)"
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_when_given_position_side_flat_returns_zero(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(12),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10500.0")),
-//             None,
-//             None,
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let result = position.calculate_pnl(10500.0, 10500.0, Quantity::from("100000.0"));
-//         assert_eq!(result, Money::from("0 USDT"));
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_long_position_win(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(12),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             currency_pair_btcusdt,
-//             order.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10500.0")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let pnl = position.calculate_pnl(10500.0, 10510.0, Quantity::from("12.0"));
-//         assert_eq!(pnl, Money::from("120 USDT"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("-126 USDT")));
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("10510.0")),
-//             Money::from("120.0 USDT")
-//         );
-//         assert_eq!(
-//             position.total_pnl(Price::from("10510.0")),
-//             Money::from("-6 USDT")
-//         );
-//         assert_eq!(position.commissions(), vec![Money::from("126.0 USDT")]);
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_long_position_loss(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from(12),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             currency_pair_btcusdt,
-//             order.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10500.0")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let pnl = position.calculate_pnl(10500.0, 10480.5, Quantity::from("10.0"));
-//         assert_eq!(pnl, Money::from("-195 USDT"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("-126 USDT")));
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("10480.50")),
-//             Money::from("-234.0 USDT")
-//         );
-//         assert_eq!(
-//             position.total_pnl(Price::from("10480.50")),
-//             Money::from("-360 USDT")
-//         );
-//         assert_eq!(position.commissions(), vec![Money::from("126.0 USDT")]);
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_short_position_winning(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Sell,
-//             Quantity::from("10.15"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             currency_pair_btcusdt,
-//             order.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10500.0")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let pnl = position.calculate_pnl(10500.0, 10390.0, Quantity::from("10.15"));
-//         assert_eq!(pnl, Money::from("1116.5 USDT"));
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("10390.0")),
-//             Money::from("1116.5 USDT")
-//         );
-//         assert_eq!(position.realized_pnl, Some(Money::from("-106.575 USDT")));
-//         assert_eq!(position.commissions(), vec![Money::from("106.575 USDT")]);
-//         assert_eq!(
-//             position.notional_value(Price::from("10390.0")),
-//             Money::from("105458.5 USDT")
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_short_position_loss(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Sell,
-//             Quantity::from("10.0"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             currency_pair_btcusdt,
-//             order.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10500.0")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let pnl = position.calculate_pnl(10500.0, 10670.5, Quantity::from("10.0"));
-//         assert_eq!(pnl, Money::from("-1705 USDT"));
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("10670.5")),
-//             Money::from("-1705 USDT")
-//         );
-//         assert_eq!(position.realized_pnl, Some(Money::from("-105 USDT")));
-//         assert_eq!(position.commissions(), vec![Money::from("105 USDT")]);
-//         assert_eq!(
-//             position.notional_value(Price::from("10670.5")),
-//             Money::from("106705 USDT")
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_inverse1(
-//         mut order_factory: OrderFactory,
-//         xbtusd_bitmex: CryptoPerpetual,
-//     ) {
-//         let order = order_factory.market(
-//             xbtusd_bitmex.id,
-//             OrderSide::Sell,
-//             Quantity::from("100000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             xbtusd_bitmex,
-//             order.quantity,
-//             Price::from("10000.0"),
-//             Some(Currency::USD()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &xbtusd_bitmex,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("10000.0")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(xbtusd_bitmex, fill).unwrap();
-//         let pnl = position.calculate_pnl(10000.0, 11000.0, Quantity::from("100000.0"));
-//         assert_eq!(pnl, Money::from("-0.90909091 BTC"));
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("11000.0")),
-//             Money::from("-0.90909091 BTC")
-//         );
-//         assert_eq!(position.realized_pnl, Some(Money::from("-0.00750000 BTC")));
-//         assert_eq!(
-//             position.notional_value(Price::from("11000.0")),
-//             Money::from("9.09090909 BTC")
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_pnl_for_inverse2(
-//         mut order_factory: OrderFactory,
-//         ethusdt_bitmex: CryptoPerpetual,
-//     ) {
-//         let order = order_factory.market(
-//             ethusdt_bitmex.id,
-//             OrderSide::Sell,
-//             Quantity::from("100000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             ethusdt_bitmex,
-//             order.quantity,
-//             Price::from("375.95"),
-//             Some(Currency::USD()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &ethusdt_bitmex,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             Some(Price::from("375.95")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(ethusdt_bitmex, fill).unwrap();
-//
-//         assert_eq!(
-//             position.unrealized_pnl(Price::from("370.00")),
-//             Money::from("4.27745208 ETH")
-//         );
-//         assert_eq!(
-//             position.notional_value(Price::from("370.00")),
-//             Money::from("270.27027027 ETH")
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_unrealized_pnl_for_long(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order1 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from("2.000000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let order2 = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Buy,
-//             Quantity::from("2.000000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission1 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order1.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill1 = TestOrderEventStubs::order_filled(
-//             &order1,
-//             &currency_pair_btcusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("10500.00")),
-//             None,
-//             Some(commission1),
-//             None,
-//         );
-//         let commission2 = calculate_commission(
-//             currency_pair_btcusdt,
-//             order2.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill2 = TestOrderEventStubs::order_filled(
-//             &order2,
-//             &currency_pair_btcusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("2").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("10500.00")),
-//             None,
-//             Some(commission2),
-//             None,
-//         );
-//         let mut position = Position::new(currency_pair_btcusdt, fill1).unwrap();
-//         position.apply(&fill2);
-//         let pnl = position.unrealized_pnl(Price::from("11505.60"));
-//         assert_eq!(pnl, Money::from("4022.40000000 USDT"));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from("-42.00000000 USDT"))
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from("42.00000000 USDT")]
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_unrealized_pnl_for_short(
-//         mut order_factory: OrderFactory,
-//         currency_pair_btcusdt: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             currency_pair_btcusdt.id,
-//             OrderSide::Sell,
-//             Quantity::from("5.912000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             currency_pair_btcusdt,
-//             order.quantity,
-//             Price::from("10505.60"),
-//             Some(Currency::USDT()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &currency_pair_btcusdt,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("10505.60")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(currency_pair_btcusdt, fill).unwrap();
-//         let pnl = position.unrealized_pnl(Price::from("10407.15"));
-//         assert_eq!(pnl, Money::from("582.03640000 USDT"));
-//         assert_eq!(
-//             position.realized_pnl,
-//             Some(Money::from("-62.10910720 USDT"))
-//         );
-//         assert_eq!(
-//             position.commissions(),
-//             vec![Money::from("62.10910720 USDT")]
-//         );
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_unrealized_pnl_for_long_inverse(
-//         mut order_factory: OrderFactory,
-//         xbtusd_bitmex: CryptoPerpetual,
-//     ) {
-//         let order = order_factory.market(
-//             xbtusd_bitmex.id,
-//             OrderSide::Buy,
-//             Quantity::from("100000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             xbtusd_bitmex,
-//             order.quantity,
-//             Price::from("10500.0"),
-//             Some(Currency::USD()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &xbtusd_bitmex,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("10500.00")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//
-//         let position = Position::new(xbtusd_bitmex, fill).unwrap();
-//         let pnl = position.unrealized_pnl(Price::from("11505.60"));
-//         assert_eq!(pnl, Money::from("0.83238969 BTC"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("-0.00714286 BTC")));
-//         assert_eq!(position.commissions(), vec![Money::from("0.00714286 BTC")]);
-//     }
-//
-//     #[rstest]
-//     fn test_calculate_unrealized_pnl_for_short_inverse(
-//         mut order_factory: OrderFactory,
-//         xbtusd_bitmex: CryptoPerpetual,
-//     ) {
-//         let order = order_factory.market(
-//             xbtusd_bitmex.id,
-//             OrderSide::Sell,
-//             Quantity::from("1250000"),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//         let commission = calculate_commission(
-//             xbtusd_bitmex,
-//             order.quantity,
-//             Price::from("15500.00"),
-//             Some(Currency::USD()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &xbtusd_bitmex,
-//             Some(StrategyId::from("S-001")),
-//             Some(TradeId::new("1").unwrap()),
-//             Some(PositionId::new("P-123456").unwrap()),
-//             Some(Price::from("15500.00")),
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(xbtusd_bitmex, fill).unwrap();
-//         let pnl = position.unrealized_pnl(Price::from("12506.65"));
-//
-//         assert_eq!(pnl, Money::from("19.30166700 BTC"));
-//         assert_eq!(position.realized_pnl, Some(Money::from("-0.06048387 BTC")));
-//         assert_eq!(position.commissions(), vec![Money::from("0.06048387 BTC")]);
-//     }
-//
-//     #[rstest]
-//     #[case(OrderSide::Buy, 25, 25.0)]
-//     #[case(OrderSide::Sell,25,-25.0)]
-//     fn test_signed_qty_decimal_qty_for_equity(
-//         #[case] order_side: OrderSide,
-//         #[case] quantity: i64,
-//         #[case] expected: f64,
-//         mut order_factory: OrderFactory,
-//         audusd_sim: CurrencyPair,
-//     ) {
-//         let order = order_factory.market(
-//             audusd_sim.id,
-//             order_side,
-//             Quantity::from(quantity),
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//             None,
-//         );
-//
-//         let commission = calculate_commission(
-//             audusd_sim,
-//             order.quantity,
-//             Price::from("1.0"),
-//             Some(Currency::USD()),
-//         );
-//         let fill = TestOrderEventStubs::order_filled(
-//             &order,
-//             &audusd_sim,
-//             None,
-//             None,
-//             Some(PositionId::from("P-123456")),
-//             None,
-//             None,
-//             Some(commission),
-//             None,
-//         );
-//         let position = Position::new(audusd_sim, fill).unwrap();
-//         assert_eq!(position.signed_qty, expected);
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::enums::{LiquiditySide, OrderSide, OrderType, PositionSide};
+    use crate::events::order::filled::OrderFilled;
+    use crate::identifiers::account_id::AccountId;
+    use crate::identifiers::position_id::PositionId;
+    use crate::identifiers::strategy_id::StrategyId;
+    use crate::identifiers::stubs::uuid4;
+    use crate::identifiers::trade_id::TradeId;
+    use crate::identifiers::venue_order_id::VenueOrderId;
+    use crate::instruments::crypto_perpetual::CryptoPerpetual;
+    use crate::instruments::currency_pair::CurrencyPair;
+    use crate::instruments::stubs::*;
+    use crate::orders::market::MarketOrder;
+    use crate::orders::stubs::{TestOrderEventStubs, TestOrderStubs};
+    use crate::position::Position;
+    use crate::stubs::*;
+    use crate::types::money::Money;
+    use crate::types::price::Price;
+    use crate::types::quantity::Quantity;
+    use rstest::rstest;
+    use std::str::FromStr;
+
+    #[rstest]
+    fn test_position_long_display(test_position_long: Position) {
+        let display = format!("{test_position_long}");
+        assert_eq!(display, "Position(LONG 1 AUD/USD.SIM, id=1)");
+    }
+
+    #[rstest]
+    fn test_position_short_display(test_position_short: Position) {
+        let display = format!("{test_position_short}");
+        assert_eq!(display, "Position(SHORT 1 AUD/USD.SIM, id=1)");
+    }
+
+    #[rstest]
+    #[should_panic(expected = "`fill.trade_id` already contained in `trade_ids")]
+    fn test_two_trades_with_same_trade_id_throws(audusd_sim: CurrencyPair) {
+        let order1 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let order2 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order1,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("1").unwrap()),
+            None,
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            None,
+        );
+        let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order2,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("1").unwrap()),
+            None,
+            Some(Price::from("1.00002")),
+            None,
+            None,
+            None,
+        );
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+        position.apply(&fill2);
+    }
+
+    #[rstest]
+    fn test_position_filled_with_buy_order(audusd_sim: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &audusd_sim,
+            None,
+            None,
+            None,
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            None,
+        );
+        let last_price = Price::from_str("1.0005").unwrap();
+        let position = Position::new(audusd_sim, fill).unwrap();
+        assert_eq!(position.symbol(), audusd_sim.id.symbol);
+        assert_eq!(position.venue(), audusd_sim.id.venue);
+        assert!(!position.is_opposite_side(fill.order_side));
+        assert_eq!(position, position); // equality operator test
+        assert!(position.closing_order_id.is_none());
+        assert_eq!(position.quantity, Quantity::from(100_000));
+        assert_eq!(position.peak_qty, Quantity::from(100_000));
+        assert_eq!(position.size_precision, 0);
+        assert_eq!(position.signed_qty, 100_000.0);
+        assert_eq!(position.entry, OrderSide::Buy);
+        assert_eq!(position.side, PositionSide::Long);
+        assert_eq!(position.ts_opened, 0);
+        assert_eq!(position.duration_ns, 0);
+        assert_eq!(position.avg_px_open, 1.00001);
+        assert_eq!(position.event_count(), 1);
+        assert_eq!(position.id, PositionId::new("1").unwrap());
+        assert_eq!(position.events.len(), 1);
+        assert!(position.is_long());
+        assert!(!position.is_short());
+        assert!(position.is_open());
+        assert!(!position.is_closed());
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-2.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last_price),
+            Money::from_str("49.0 USD").unwrap()
+        );
+        assert_eq!(
+            position.total_pnl(last_price),
+            Money::from_str("47.0 USD").unwrap()
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("2.0 USD").unwrap()]
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(LONG 100_000 AUD/USD.SIM, id=1)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_filled_with_sell_order(audusd_sim: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Sell,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &audusd_sim,
+            None,
+            None,
+            None,
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            None,
+        );
+        let last_price = Price::from_str("1.00050").unwrap();
+        let position = Position::new(audusd_sim, fill).unwrap();
+        assert_eq!(position.symbol(), audusd_sim.id.symbol);
+        assert_eq!(position.venue(), audusd_sim.id.venue);
+        assert!(!position.is_opposite_side(fill.order_side));
+        assert_eq!(position, position); // equality operator test
+        assert!(position.closing_order_id.is_none());
+        assert_eq!(position.quantity, Quantity::from(100_000));
+        assert_eq!(position.peak_qty, Quantity::from(100_000));
+        assert_eq!(position.signed_qty, -100_000.0);
+        assert_eq!(position.entry, OrderSide::Sell);
+        assert_eq!(position.side, PositionSide::Short);
+        assert_eq!(position.ts_opened, 0);
+        assert_eq!(position.avg_px_open, 1.00001);
+        assert_eq!(position.event_count(), 1);
+        assert_eq!(position.id, PositionId::new("1").unwrap());
+        assert_eq!(position.events.len(), 1);
+        assert!(!position.is_long());
+        assert!(position.is_short());
+        assert!(position.is_open());
+        assert!(!position.is_closed());
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-2.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last_price),
+            Money::from_str("-49.0 USD").unwrap()
+        );
+        assert_eq!(
+            position.total_pnl(last_price),
+            Money::from_str("-51.0 USD").unwrap()
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("2.0 USD").unwrap()]
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(SHORT 100_000 AUD/USD.SIM, id=1)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_partial_fills_with_buy_order(audusd_sim: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &audusd_sim,
+            None,
+            None,
+            None,
+            Some(Price::from("1.00001")),
+            Some(Quantity::from(50_000)),
+            None,
+            None,
+        );
+        let last_price = Price::from_str("1.00048").unwrap();
+        let position = Position::new(audusd_sim, fill).unwrap();
+        assert_eq!(position.quantity, Quantity::from(50_000));
+        assert_eq!(position.peak_qty, Quantity::from(50_000));
+        assert_eq!(position.side, PositionSide::Long);
+        assert_eq!(position.signed_qty, 50000.0);
+        assert_eq!(position.avg_px_open, 1.00001);
+        assert_eq!(position.event_count(), 1);
+        assert_eq!(position.ts_opened, 0);
+        assert!(position.is_long());
+        assert!(!position.is_short());
+        assert!(position.is_open());
+        assert!(!position.is_closed());
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-2.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last_price),
+            Money::from_str("23.5 USD").unwrap()
+        );
+        assert_eq!(
+            position.total_pnl(last_price),
+            Money::from_str("21.5 USD").unwrap()
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("2.0 USD").unwrap()]
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(LONG 50_000 AUD/USD.SIM, id=1)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_partial_fills_with_two_sell_orders(audusd_sim: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Sell,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("1").unwrap()),
+            None,
+            Some(Price::from("1.00001")),
+            Some(Quantity::from(50_000)),
+            None,
+            None,
+        );
+        let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("2").unwrap()),
+            None,
+            Some(Price::from("1.00002")),
+            Some(Quantity::from(50_000)),
+            None,
+            None,
+        );
+        let last_price = Price::from_str("1.0005").unwrap();
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+        position.apply(&fill2);
+
+        assert_eq!(position.quantity, Quantity::from(100_000));
+        assert_eq!(position.peak_qty, Quantity::from(100_000));
+        assert_eq!(position.side, PositionSide::Short);
+        assert_eq!(position.signed_qty, -100_000.0);
+        assert_eq!(position.avg_px_open, 1.000_015);
+        assert_eq!(position.event_count(), 2);
+        assert_eq!(position.ts_opened, 0);
+        assert!(position.is_short());
+        assert!(!position.is_long());
+        assert!(position.is_open());
+        assert!(!position.is_closed());
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-4.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last_price),
+            Money::from_str("-48.5 USD").unwrap()
+        );
+        assert_eq!(
+            position.total_pnl(last_price),
+            Money::from_str("-52.5 USD").unwrap()
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("4.0 USD").unwrap()]
+        );
+    }
+
+    #[rstest]
+    pub fn test_position_filled_with_buy_order_then_sell_order(audusd_sim: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(150_000),
+            None,
+            None,
+        );
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &audusd_sim,
+            Some(StrategyId::new("S-001").unwrap()),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-1").unwrap()),
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            Some(1_000_000_000),
+        );
+        let mut position = Position::new(audusd_sim, fill).unwrap();
+
+        let fill2 = OrderFilled::new(
+            order.trader_id,
+            StrategyId::new("S-001").unwrap(),
+            order.instrument_id,
+            order.client_order_id,
+            VenueOrderId::from("2"),
+            order
+                .account_id
+                .unwrap_or(AccountId::new("SIM-001").unwrap()),
+            TradeId::new("2").unwrap(),
+            OrderSide::Sell,
+            OrderType::Market,
+            order.quantity,
+            Price::from("1.00011"),
+            audusd_sim.quote_currency,
+            LiquiditySide::Taker,
+            uuid4(),
+            2_000_000_000,
+            0,
+            false,
+            Some(PositionId::new("T1").unwrap()),
+            Some(Money::from_str("0.0 USD").unwrap()),
+        )
+        .unwrap();
+        position.apply(&fill2);
+        let last = Price::from_str("1.0005").unwrap();
+
+        assert!(position.is_opposite_side(fill2.order_side));
+        assert_eq!(
+            position.quantity,
+            Quantity::zero(audusd_sim.price_precision)
+        );
+        assert_eq!(position.size_precision, 0);
+        assert_eq!(position.signed_qty, 0.0);
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.ts_opened, 1_000_000_000);
+        assert_eq!(position.ts_closed, Some(2_000_000_000));
+        assert_eq!(position.duration_ns, 1_000_000_000);
+        assert_eq!(position.avg_px_open, 1.00001);
+        assert_eq!(position.avg_px_close, Some(1.00011));
+        assert!(!position.is_long());
+        assert!(!position.is_short());
+        assert!(!position.is_open());
+        assert!(position.is_closed());
+        assert_eq!(position.realized_return, 9.999_900_000_998_888e-5);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("13.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last),
+            Money::from_str("0 USD").unwrap()
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("2 USD").unwrap()]
+        );
+        assert_eq!(position.total_pnl(last), Money::from_str("13 USD").unwrap());
+        assert_eq!(format!("{position}"), "Position(FLAT AUD/USD.SIM, id=P-1)");
+    }
+
+    #[rstest]
+    pub fn test_position_filled_with_sell_order_then_buy_order(audusd_sim: CurrencyPair) {
+        let order1 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Sell,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let order2 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order1,
+            &audusd_sim,
+            None,
+            None,
+            Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
+            Some(Price::from("1.0")),
+            None,
+            None,
+            None,
+        );
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+        // create closing from order from different venue but same strategy
+        let fill2 = TestOrderEventStubs::order_filled(
+            &order2,
+            &audusd_sim,
+            Some(StrategyId::new("S-001").unwrap()),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
+            Some(Price::from("1.00001")),
+            Some(Quantity::from(50_000)),
+            None,
+            None,
+        );
+        let fill3 = TestOrderEventStubs::order_filled(
+            &order2,
+            &audusd_sim,
+            Some(StrategyId::new("S-001").unwrap()),
+            Some(TradeId::new("2").unwrap()),
+            Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
+            Some(Price::from("1.00003")),
+            Some(Quantity::from(50_000)),
+            None,
+            None,
+        );
+        let last = Price::from("1.0005");
+        position.apply(&fill2);
+        position.apply(&fill3);
+
+        assert_eq!(
+            position.quantity,
+            Quantity::zero(audusd_sim.price_precision)
+        );
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.ts_opened, 0);
+        assert_eq!(position.avg_px_open, 1.0);
+        assert_eq!(position.events.len(), 3);
+        assert_eq!(position.ts_closed, Some(0));
+        assert_eq!(position.avg_px_close, Some(1.00002));
+        assert!(!position.is_long());
+        assert!(!position.is_short());
+        assert!(!position.is_open());
+        assert!(position.is_closed());
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("6.0 USD").unwrap()]
+        );
+        assert_eq!(
+            position.unrealized_pnl(last),
+            Money::from_str("0 USD").unwrap()
+        );
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-8.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.total_pnl(last),
+            Money::from_str("-8.0 USD").unwrap()
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(FLAT AUD/USD.SIM, id=P-19700101-0000-000-001-1)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_filled_with_no_change(audusd_sim: CurrencyPair) {
+        let order1 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let order2 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Sell,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let fill1 = TestOrderEventStubs::order_filled(
+            &order1,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
+            Some(Price::from("1.0")),
+            None,
+            None,
+            None,
+        );
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+        let fill2 = TestOrderEventStubs::order_filled(
+            &order2,
+            &audusd_sim,
+            None,
+            Some(TradeId::new("2").unwrap()),
+            Some(PositionId::new("P-19700101-0000-000-001-1").unwrap()),
+            Some(Price::from("1.0")),
+            None,
+            None,
+            None,
+        );
+        let last = Price::from("1.0005");
+        position.apply(&fill2);
+
+        assert_eq!(
+            position.quantity,
+            Quantity::zero(audusd_sim.price_precision)
+        );
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.ts_opened, 0);
+        assert_eq!(position.avg_px_open, 1.0);
+        assert_eq!(position.events.len(), 2);
+        assert_eq!(position.trade_ids, vec![fill1.trade_id, fill2.trade_id]);
+        assert_eq!(position.ts_closed, Some(0));
+        assert_eq!(position.avg_px_close, Some(1.0));
+        assert!(!position.is_long());
+        assert!(!position.is_short());
+        assert!(!position.is_open());
+        assert!(position.is_closed());
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("4.0 USD").unwrap()]
+        );
+        assert_eq!(
+            position.unrealized_pnl(last),
+            Money::from_str("0 USD").unwrap()
+        );
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-4.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.total_pnl(last),
+            Money::from_str("-4.0 USD").unwrap()
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(FLAT AUD/USD.SIM, id=P-19700101-0000-000-001-1)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_long_with_multiple_filled_orders(audusd_sim: CurrencyPair) {
+        let order1 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let order2 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            None,
+            None,
+        );
+        let order3 = TestOrderStubs::market_order(
+            audusd_sim.id,
+            OrderSide::Sell,
+            Quantity::from(200_000),
+            None,
+            None,
+        );
+        let fill1 = TestOrderEventStubs::order_filled(
+            &order1,
+            &audusd_sim,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("1.0")),
+            None,
+            None,
+            None,
+        );
+        let fill2 = TestOrderEventStubs::order_filled(
+            &order2,
+            &audusd_sim,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("2").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            None,
+        );
+        let fill3 = TestOrderEventStubs::order_filled(
+            &order3,
+            &audusd_sim,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("3").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("1.0001")),
+            None,
+            None,
+            None,
+        );
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+        let last = Price::from("1.0005");
+        position.apply(&fill2);
+        position.apply(&fill3);
+
+        assert_eq!(
+            position.quantity,
+            Quantity::zero(audusd_sim.price_precision)
+        );
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.ts_opened, 0);
+        assert_eq!(position.avg_px_open, 1.000_005);
+        assert_eq!(position.events.len(), 3);
+        assert_eq!(
+            position.trade_ids,
+            vec![fill1.trade_id, fill2.trade_id, fill3.trade_id]
+        );
+        assert_eq!(position.ts_closed, Some(0));
+        assert_eq!(position.avg_px_close, Some(1.0001));
+        assert!(position.is_closed());
+        assert!(!position.is_open());
+        assert!(!position.is_long());
+        assert!(!position.is_short());
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("6.0 USD").unwrap()]
+        );
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("13.0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last),
+            Money::from_str("0 USD").unwrap()
+        );
+        assert_eq!(position.total_pnl(last), Money::from_str("13 USD").unwrap());
+        assert_eq!(
+            format!("{position}"),
+            "Position(FLAT AUD/USD.SIM, id=P-123456)"
+        );
+    }
+
+    #[rstest]
+    fn test_pnl_calculation_from_trading_technologies_example(currency_pair_ethusdt: CurrencyPair) {
+        let quantity1 = Quantity::from(12);
+        let price1 = Price::from("100.0");
+        let order1 = TestOrderStubs::market_order(
+            currency_pair_ethusdt.id,
+            OrderSide::Buy,
+            quantity1,
+            None,
+            None,
+        );
+        let commission1 =
+            calculate_commission(currency_pair_ethusdt, order1.quantity, price1, None).unwrap();
+        let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order1,
+            &currency_pair_ethusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(price1),
+            None,
+            Some(commission1),
+            None,
+        );
+        let mut position = Position::new(currency_pair_ethusdt, fill1).unwrap();
+        let quantity2 = Quantity::from(17);
+        let order2 = TestOrderStubs::market_order(
+            currency_pair_ethusdt.id,
+            OrderSide::Buy,
+            quantity2,
+            None,
+            None,
+        );
+        let price2 = Price::from("99.0");
+        let commission2 =
+            calculate_commission(currency_pair_ethusdt, order2.quantity, price2, None).unwrap();
+        let fill2 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order2,
+            &currency_pair_ethusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("2").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(price2),
+            None,
+            Some(commission2),
+            None,
+        );
+        position.apply(&fill2);
+        assert_eq!(position.quantity, Quantity::from(29));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-0.28830000 USDT").unwrap())
+        );
+        assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
+        let quantity3 = Quantity::from(9);
+        let order3 = TestOrderStubs::market_order(
+            currency_pair_ethusdt.id,
+            OrderSide::Sell,
+            quantity3,
+            None,
+            None,
+        );
+        let price3 = Price::from("101.0");
+        let commission3 =
+            calculate_commission(currency_pair_ethusdt, order3.quantity, price3, None).unwrap();
+        let fill3 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order3,
+            &currency_pair_ethusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("3").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(price3),
+            None,
+            Some(commission3),
+            None,
+        );
+        position.apply(&fill3);
+        assert_eq!(position.quantity, Quantity::from(20));
+        assert_eq!(position.realized_pnl, Some(Money::from("13.89666207 USDT")));
+        assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
+        let quantity4 = Quantity::from("4");
+        let price4 = Price::from("105.0");
+        let order4 = TestOrderStubs::market_order(
+            currency_pair_ethusdt.id,
+            OrderSide::Sell,
+            quantity4,
+            None,
+            None,
+        );
+        let commission4 =
+            calculate_commission(currency_pair_ethusdt, order4.quantity, price4, None).unwrap();
+        let fill4 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order4,
+            &currency_pair_ethusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("4").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(price4),
+            None,
+            Some(commission4),
+            None,
+        );
+        position.apply(&fill4);
+        assert_eq!(position.quantity, Quantity::from("16"));
+        assert_eq!(position.realized_pnl, Some(Money::from("36.19948966 USDT")));
+        assert_eq!(position.avg_px_open, 99.413_793_103_448_27);
+        let quantity5 = Quantity::from("3");
+        let price5 = Price::from("103.0");
+        let order5 = TestOrderStubs::market_order(
+            currency_pair_ethusdt.id,
+            OrderSide::Buy,
+            quantity5,
+            None,
+            None,
+        );
+        let commission5 =
+            calculate_commission(currency_pair_ethusdt, order5.quantity, price5, None).unwrap();
+        let fill5 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order5,
+            &currency_pair_ethusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("5").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(price5),
+            None,
+            Some(commission5),
+            None,
+        );
+        position.apply(&fill5);
+        assert_eq!(position.quantity, Quantity::from("19"));
+        assert_eq!(position.realized_pnl, Some(Money::from("36.16858966 USDT")));
+        assert_eq!(position.avg_px_open, 99.980_036_297_640_65);
+        assert_eq!(
+            format!("{position}"),
+            "Position(LONG 19.00000 ETHUSDT.BINANCE, id=P-123456)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_closed_and_reopened(audusd_sim: CurrencyPair) {
+        let quantity1 = Quantity::from(150_000);
+        let price1 = Price::from("1.00001");
+        let order =
+            TestOrderStubs::market_order(audusd_sim.id, OrderSide::Buy, quantity1, None, None);
+        let commission1 = calculate_commission(audusd_sim, quantity1, price1, None).unwrap();
+        let fill1 = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+            &order,
+            &audusd_sim,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("5").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("1.00001")),
+            None,
+            Some(commission1),
+            Some(1_000_000_000),
+        );
+        let mut position = Position::new(audusd_sim, fill1).unwrap();
+
+        let fill2 = OrderFilled::new(
+            order.trader_id,
+            order.strategy_id,
+            order.instrument_id,
+            order.client_order_id,
+            VenueOrderId::from("2"),
+            order
+                .account_id
+                .unwrap_or(AccountId::new("SIM-001").unwrap()),
+            TradeId::from("2"),
+            OrderSide::Sell,
+            OrderType::Market,
+            order.quantity,
+            Price::from("1.00011"),
+            audusd_sim.quote_currency,
+            LiquiditySide::Taker,
+            uuid4(),
+            2_000_000_000,
+            0,
+            false,
+            Some(PositionId::from("P-123456")),
+            Some(Money::from("0 USD")),
+        )
+        .unwrap();
+        position.apply(&fill2);
+        let fill3 = OrderFilled::new(
+            order.trader_id,
+            order.strategy_id,
+            order.instrument_id,
+            order.client_order_id,
+            VenueOrderId::from("2"),
+            order
+                .account_id
+                .unwrap_or(AccountId::new("SIM-001").unwrap()),
+            TradeId::from("3"),
+            OrderSide::Buy,
+            OrderType::Market,
+            order.quantity,
+            Price::from("1.00012"),
+            audusd_sim.quote_currency,
+            LiquiditySide::Taker,
+            uuid4(),
+            3_000_000_000,
+            0,
+            false,
+            Some(PositionId::from("P-123456")),
+            Some(Money::from("0 USD")),
+        )
+        .unwrap();
+        position.apply(&fill3);
+        let last = Price::from("1.0003");
+        assert!(position.is_opposite_side(fill2.order_side));
+        assert_eq!(position.quantity, Quantity::from(150_000));
+        assert_eq!(position.peak_qty, Quantity::from(150_000));
+        assert_eq!(position.side, PositionSide::Long);
+        assert_eq!(position.opening_order_id, fill3.client_order_id);
+        assert_eq!(position.closing_order_id, None);
+        assert_eq!(position.closing_order_id, None);
+        assert_eq!(position.ts_opened, 3_000_000_000);
+        assert_eq!(position.duration_ns, 0);
+        assert_eq!(position.avg_px_open, 1.00012);
+        assert_eq!(position.event_count(), 1);
+        assert_eq!(position.ts_closed, None);
+        assert_eq!(position.avg_px_close, None);
+        assert!(position.is_long());
+        assert!(!position.is_short());
+        assert!(position.is_open());
+        assert!(!position.is_closed());
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("0 USD").unwrap())
+        );
+        assert_eq!(
+            position.unrealized_pnl(last),
+            Money::from_str("27 USD").unwrap()
+        );
+        assert_eq!(position.total_pnl(last), Money::from_str("27 USD").unwrap());
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from_str("0 USD").unwrap()]
+        );
+        assert_eq!(
+            format!("{position}"),
+            "Position(LONG 150_000 AUD/USD.SIM, id=P-123456)"
+        );
+    }
+
+    #[rstest]
+    fn test_position_realised_pnl_with_interleaved_order_sides(
+        currency_pair_btcusdt: CurrencyPair,
+    ) {
+        let order1 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(12),
+            None,
+            None,
+        );
+        let commission1 = calculate_commission(
+            currency_pair_btcusdt,
+            order1.quantity,
+            Price::from("10000.0"),
+            None,
+        )
+        .unwrap();
+        let fill1 = TestOrderEventStubs::order_filled(
+            &order1,
+            &currency_pair_btcusdt,
+            None,
+            Some(TradeId::from("1")),
+            Some(PositionId::from("P-19700101-0000-000-001-1")),
+            Some(Price::from("10000.0")),
+            None,
+            Some(commission1),
+            None,
+        );
+        let mut position = Position::new(currency_pair_btcusdt, fill1).unwrap();
+        let order2 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(17),
+            None,
+            None,
+        );
+        let commission2 = calculate_commission(
+            currency_pair_btcusdt,
+            order2.quantity,
+            Price::from("9999.0"),
+            None,
+        )
+        .unwrap();
+        let fill2 = TestOrderEventStubs::order_filled(
+            &order2,
+            &currency_pair_btcusdt,
+            None,
+            Some(TradeId::from("2")),
+            Some(PositionId::from("P-19700101-0000-000-001-1")),
+            Some(Price::from("9999.0")),
+            None,
+            Some(commission2),
+            None,
+        );
+        position.apply(&fill2);
+        assert_eq!(position.quantity, Quantity::from(29));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-289.98300000 USDT").unwrap())
+        );
+        assert_eq!(position.avg_px_open, 9_999.413_793_103_447);
+        let order3 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Sell,
+            Quantity::from(9),
+            None,
+            None,
+        );
+        let commission3 = calculate_commission(
+            currency_pair_btcusdt,
+            order3.quantity,
+            Price::from("10001.0"),
+            None,
+        )
+        .unwrap();
+        let fill3 = TestOrderEventStubs::order_filled(
+            &order3,
+            &currency_pair_btcusdt,
+            None,
+            Some(TradeId::from("3")),
+            Some(PositionId::from("P-19700101-0000-000-001-1")),
+            Some(Price::from("10001.0")),
+            None,
+            Some(commission3),
+            None,
+        );
+        position.apply(&fill3);
+        assert_eq!(position.quantity, Quantity::from(20));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-365.71613793 USDT").unwrap())
+        );
+        assert_eq!(position.avg_px_open, 9_999.413_793_103_447);
+        let order4 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(3),
+            None,
+            None,
+        );
+        let commission4 = calculate_commission(
+            currency_pair_btcusdt,
+            order4.quantity,
+            Price::from("10003.0"),
+            None,
+        )
+        .unwrap();
+        let fill4 = TestOrderEventStubs::order_filled(
+            &order4,
+            &currency_pair_btcusdt,
+            None,
+            Some(TradeId::from("4")),
+            Some(PositionId::from("P-19700101-0000-000-001-1")),
+            Some(Price::from("10003.0")),
+            None,
+            Some(commission4),
+            None,
+        );
+        position.apply(&fill4);
+        assert_eq!(position.quantity, Quantity::from(23));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-395.72513793 USDT").unwrap())
+        );
+        assert_eq!(position.avg_px_open, 9_999.881_559_220_39);
+        let order5 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Sell,
+            Quantity::from(4),
+            None,
+            None,
+        );
+        let commission5 = calculate_commission(
+            currency_pair_btcusdt,
+            order5.quantity,
+            Price::from("10005.0"),
+            None,
+        )
+        .unwrap();
+        let fill5 = TestOrderEventStubs::order_filled(
+            &order5,
+            &currency_pair_btcusdt,
+            None,
+            Some(TradeId::from("5")),
+            Some(PositionId::from("P-19700101-0000-000-001-1")),
+            Some(Price::from("10005.0")),
+            None,
+            Some(commission5),
+            None,
+        );
+        position.apply(&fill5);
+        assert_eq!(position.quantity, Quantity::from(19));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from_str("-415.27137481 USDT").unwrap())
+        );
+        assert_eq!(position.avg_px_open, 9_999.881_559_220_39);
+        assert_eq!(
+            format!("{position}"),
+            "Position(LONG 19.000000 BTCUSDT.BINANCE, id=P-19700101-0000-000-001-1)"
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_when_given_position_side_flat_returns_zero(
+        currency_pair_btcusdt: CurrencyPair,
+    ) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(12),
+            None,
+            None,
+        );
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10500.0")),
+            None,
+            None,
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let result = position.calculate_pnl(10500.0, 10500.0, Quantity::from("100000.0"));
+        assert_eq!(result, Money::from("0 USDT"));
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_long_position_win(currency_pair_btcusdt: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(12),
+            None,
+            None,
+        );
+        let commission = calculate_commission(
+            currency_pair_btcusdt,
+            order.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10500.0")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let pnl = position.calculate_pnl(10500.0, 10510.0, Quantity::from("12.0"));
+        assert_eq!(pnl, Money::from("120 USDT"));
+        assert_eq!(position.realized_pnl, Some(Money::from("-126 USDT")));
+        assert_eq!(
+            position.unrealized_pnl(Price::from("10510.0")),
+            Money::from("120.0 USDT")
+        );
+        assert_eq!(
+            position.total_pnl(Price::from("10510.0")),
+            Money::from("-6 USDT")
+        );
+        assert_eq!(position.commissions(), vec![Money::from("126.0 USDT")]);
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_long_position_loss(currency_pair_btcusdt: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from(12),
+            None,
+            None,
+        );
+        let commission = calculate_commission(
+            currency_pair_btcusdt,
+            order.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10500.0")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let pnl = position.calculate_pnl(10500.0, 10480.5, Quantity::from("10.0"));
+        assert_eq!(pnl, Money::from("-195 USDT"));
+        assert_eq!(position.realized_pnl, Some(Money::from("-126 USDT")));
+        assert_eq!(
+            position.unrealized_pnl(Price::from("10480.50")),
+            Money::from("-234.0 USDT")
+        );
+        assert_eq!(
+            position.total_pnl(Price::from("10480.50")),
+            Money::from("-360 USDT")
+        );
+        assert_eq!(position.commissions(), vec![Money::from("126.0 USDT")]);
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_short_position_winning(currency_pair_btcusdt: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Sell,
+            Quantity::from("10.15"),
+            None,
+            None,
+        );
+        let commission = calculate_commission(
+            currency_pair_btcusdt,
+            order.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10500.0")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let pnl = position.calculate_pnl(10500.0, 10390.0, Quantity::from("10.15"));
+        assert_eq!(pnl, Money::from("1116.5 USDT"));
+        assert_eq!(
+            position.unrealized_pnl(Price::from("10390.0")),
+            Money::from("1116.5 USDT")
+        );
+        assert_eq!(position.realized_pnl, Some(Money::from("-106.575 USDT")));
+        assert_eq!(position.commissions(), vec![Money::from("106.575 USDT")]);
+        assert_eq!(
+            position.notional_value(Price::from("10390.0")),
+            Money::from("105458.5 USDT")
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_short_position_loss(currency_pair_btcusdt: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Sell,
+            Quantity::from("10.0"),
+            None,
+            None,
+        );
+        let commission = calculate_commission(
+            currency_pair_btcusdt,
+            order.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10500.0")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let pnl = position.calculate_pnl(10500.0, 10670.5, Quantity::from("10.0"));
+        assert_eq!(pnl, Money::from("-1705 USDT"));
+        assert_eq!(
+            position.unrealized_pnl(Price::from("10670.5")),
+            Money::from("-1705 USDT")
+        );
+        assert_eq!(position.realized_pnl, Some(Money::from("-105 USDT")));
+        assert_eq!(position.commissions(), vec![Money::from("105 USDT")]);
+        assert_eq!(
+            position.notional_value(Price::from("10670.5")),
+            Money::from("106705 USDT")
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_inverse1(xbtusd_bitmex: CryptoPerpetual) {
+        let order = TestOrderStubs::market_order(
+            xbtusd_bitmex.id,
+            OrderSide::Sell,
+            Quantity::from("100000"),
+            None,
+            None,
+        );
+        let commission =
+            calculate_commission(xbtusd_bitmex, order.quantity, Price::from("10000.0"), None)
+                .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &xbtusd_bitmex,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("10000.0")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(xbtusd_bitmex, fill).unwrap();
+        let pnl = position.calculate_pnl(10000.0, 11000.0, Quantity::from("100000.0"));
+        assert_eq!(pnl, Money::from("-0.90909091 BTC"));
+        assert_eq!(
+            position.unrealized_pnl(Price::from("11000.0")),
+            Money::from("-0.90909091 BTC")
+        );
+        assert_eq!(position.realized_pnl, Some(Money::from("-0.00750000 BTC")));
+        assert_eq!(
+            position.notional_value(Price::from("11000.0")),
+            Money::from("9.09090909 BTC")
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_pnl_for_inverse2(ethusdt_bitmex: CryptoPerpetual) {
+        let order = TestOrderStubs::market_order(
+            ethusdt_bitmex.id,
+            OrderSide::Sell,
+            Quantity::from("100000"),
+            None,
+            None,
+        );
+        let commission =
+            calculate_commission(ethusdt_bitmex, order.quantity, Price::from("375.95"), None)
+                .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &ethusdt_bitmex,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            Some(Price::from("375.95")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(ethusdt_bitmex, fill).unwrap();
+
+        assert_eq!(
+            position.unrealized_pnl(Price::from("370.00")),
+            Money::from("4.27745208 ETH")
+        );
+        assert_eq!(
+            position.notional_value(Price::from("370.00")),
+            Money::from("270.27027027 ETH")
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_unrealized_pnl_for_long(currency_pair_btcusdt: CurrencyPair) {
+        let order1 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from("2.000000"),
+            None,
+            None,
+        );
+        let order2 = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Buy,
+            Quantity::from("2.000000"),
+            None,
+            None,
+        );
+        let commission1 = calculate_commission(
+            currency_pair_btcusdt,
+            order1.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill1 = TestOrderEventStubs::order_filled(
+            &order1,
+            &currency_pair_btcusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("10500.00")),
+            None,
+            Some(commission1),
+            None,
+        );
+        let commission2 = calculate_commission(
+            currency_pair_btcusdt,
+            order2.quantity,
+            Price::from("10500.0"),
+            None,
+        )
+        .unwrap();
+        let fill2 = TestOrderEventStubs::order_filled(
+            &order2,
+            &currency_pair_btcusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("2").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("10500.00")),
+            None,
+            Some(commission2),
+            None,
+        );
+        let mut position = Position::new(currency_pair_btcusdt, fill1).unwrap();
+        position.apply(&fill2);
+        let pnl = position.unrealized_pnl(Price::from("11505.60"));
+        assert_eq!(pnl, Money::from("4022.40000000 USDT"));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from("-42.00000000 USDT"))
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from("42.00000000 USDT")]
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_unrealized_pnl_for_short(currency_pair_btcusdt: CurrencyPair) {
+        let order = TestOrderStubs::market_order(
+            currency_pair_btcusdt.id,
+            OrderSide::Sell,
+            Quantity::from("5.912000"),
+            None,
+            None,
+        );
+        let commission = calculate_commission(
+            currency_pair_btcusdt,
+            order.quantity,
+            Price::from("10505.60"),
+            None,
+        )
+        .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &currency_pair_btcusdt,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("10505.60")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(currency_pair_btcusdt, fill).unwrap();
+        let pnl = position.unrealized_pnl(Price::from("10407.15"));
+        assert_eq!(pnl, Money::from("582.03640000 USDT"));
+        assert_eq!(
+            position.realized_pnl,
+            Some(Money::from("-62.10910720 USDT"))
+        );
+        assert_eq!(
+            position.commissions(),
+            vec![Money::from("62.10910720 USDT")]
+        );
+    }
+
+    #[rstest]
+    fn test_calculate_unrealized_pnl_for_long_inverse(xbtusd_bitmex: CryptoPerpetual) {
+        let order = TestOrderStubs::market_order(
+            xbtusd_bitmex.id,
+            OrderSide::Buy,
+            Quantity::from("100000"),
+            None,
+            None,
+        );
+        let commission =
+            calculate_commission(xbtusd_bitmex, order.quantity, Price::from("10500.0"), None)
+                .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &xbtusd_bitmex,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("10500.00")),
+            None,
+            Some(commission),
+            None,
+        );
+
+        let position = Position::new(xbtusd_bitmex, fill).unwrap();
+        let pnl = position.unrealized_pnl(Price::from("11505.60"));
+        assert_eq!(pnl, Money::from("0.83238969 BTC"));
+        assert_eq!(position.realized_pnl, Some(Money::from("-0.00714286 BTC")));
+        assert_eq!(position.commissions(), vec![Money::from("0.00714286 BTC")]);
+    }
+
+    #[rstest]
+    fn test_calculate_unrealized_pnl_for_short_inverse(xbtusd_bitmex: CryptoPerpetual) {
+        let order = TestOrderStubs::market_order(
+            xbtusd_bitmex.id,
+            OrderSide::Sell,
+            Quantity::from("1250000"),
+            None,
+            None,
+        );
+        let commission =
+            calculate_commission(xbtusd_bitmex, order.quantity, Price::from("15500.00"), None)
+                .unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &xbtusd_bitmex,
+            Some(StrategyId::from("S-001")),
+            Some(TradeId::new("1").unwrap()),
+            Some(PositionId::new("P-123456").unwrap()),
+            Some(Price::from("15500.00")),
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(xbtusd_bitmex, fill).unwrap();
+        let pnl = position.unrealized_pnl(Price::from("12506.65"));
+
+        assert_eq!(pnl, Money::from("19.30166700 BTC"));
+        assert_eq!(position.realized_pnl, Some(Money::from("-0.06048387 BTC")));
+        assert_eq!(position.commissions(), vec![Money::from("0.06048387 BTC")]);
+    }
+
+    #[rstest]
+    #[case(OrderSide::Buy, 25, 25.0)]
+    #[case(OrderSide::Sell,25,-25.0)]
+    fn test_signed_qty_decimal_qty_for_equity(
+        #[case] order_side: OrderSide,
+        #[case] quantity: i64,
+        #[case] expected: f64,
+        audusd_sim: CurrencyPair,
+    ) {
+        let order = TestOrderStubs::market_order(
+            audusd_sim.id,
+            order_side,
+            Quantity::from(quantity),
+            None,
+            None,
+        );
+
+        let commission =
+            calculate_commission(audusd_sim, order.quantity, Price::from("1.0"), None).unwrap();
+        let fill = TestOrderEventStubs::order_filled(
+            &order,
+            &audusd_sim,
+            None,
+            None,
+            Some(PositionId::from("P-123456")),
+            None,
+            None,
+            Some(commission),
+            None,
+        );
+        let position = Position::new(audusd_sim, fill).unwrap();
+        assert_eq!(position.signed_qty, expected);
+    }
+}

--- a/nautilus_core/model/src/stubs.rs
+++ b/nautilus_core/model/src/stubs.rs
@@ -1,0 +1,99 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use crate::enums::{LiquiditySide, OrderSide};
+use crate::instruments::currency_pair::CurrencyPair;
+use crate::instruments::stubs::*;
+use crate::instruments::Instrument;
+use crate::orders::market::MarketOrder;
+use crate::orders::stubs::{TestOrderEventStubs, TestOrderStubs};
+use crate::position::Position;
+use crate::types::money::Money;
+use crate::types::price::Price;
+use crate::types::quantity::Quantity;
+use anyhow::Result;
+use rstest::fixture;
+use rust_decimal::prelude::ToPrimitive;
+
+/// Calculate commission for testing
+pub fn calculate_commission<T: Instrument>(
+    instrument: T,
+    last_qty: Quantity,
+    last_px: Price,
+    use_quote_for_inverse: Option<bool>,
+) -> Result<Money> {
+    let liquidity_side = LiquiditySide::Taker;
+    assert_ne!(
+        liquidity_side,
+        LiquiditySide::NoLiquiditySide,
+        "Invalid liquidity side"
+    );
+    let notional = instrument
+        .calculate_notional_value(last_qty, last_px, use_quote_for_inverse)
+        .as_f64();
+    let commission = if liquidity_side == LiquiditySide::Maker {
+        notional * instrument.maker_fee().to_f64().unwrap()
+    } else if liquidity_side == LiquiditySide::Taker {
+        notional * instrument.taker_fee().to_f64().unwrap()
+    } else {
+        panic!("Invalid liquid side {liquidity_side}")
+    };
+    if instrument.is_inverse() && !use_quote_for_inverse.unwrap_or(false) {
+        Ok(Money::new(commission, instrument.base_currency().unwrap()).unwrap())
+    } else {
+        Ok(Money::new(commission, instrument.quote_currency()).unwrap())
+    }
+}
+
+#[fixture]
+pub fn test_position_long(audusd_sim: CurrencyPair) -> Position {
+    let order =
+        TestOrderStubs::market_order(audusd_sim.id, OrderSide::Buy, Quantity::from(1), None, None);
+    let order_filled = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+        &order,
+        &audusd_sim,
+        None,
+        None,
+        None,
+        Some(Price::from("1.0002")),
+        None,
+        None,
+        None,
+    );
+    Position::new(audusd_sim, order_filled).unwrap()
+}
+
+#[fixture]
+pub fn test_position_short(audusd_sim: CurrencyPair) -> Position {
+    let order = TestOrderStubs::market_order(
+        audusd_sim.id,
+        OrderSide::Sell,
+        Quantity::from(1),
+        None,
+        None,
+    );
+    let order_filled = TestOrderEventStubs::order_filled::<MarketOrder, CurrencyPair>(
+        &order,
+        &audusd_sim,
+        None,
+        None,
+        None,
+        Some(Price::from("22000.0")),
+        None,
+        None,
+        None,
+    );
+    Position::new(audusd_sim, order_filled).unwrap()
+}


### PR DESCRIPTION
# Pull Request
- created a new `TestOrderStubs` Rust struct which will generate orders instead of order factory
- uncommented and fixed all position tests after move to `model` crate