### PR TITLE
Fix InteractiveBrokers historical bar data bug

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import asyncio
+import functools
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Callable
@@ -70,7 +71,7 @@ class Subscription(msgspec.Struct, frozen=True):
 
     req_id: Annotated[int, msgspec.Meta(gt=0)]
     name: str | tuple
-    handle: Callable
+    handle: functools.partial | Callable
     cancel: Callable
     last: Any
 

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -815,14 +815,12 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         self.logAnswer(current_fn_name(), vars())
         if not (subscription := self._subscriptions.get(req_id=req_id)):
             return
-        if isinstance(subscription.handle, functools.partial):
-            handle_revised_bars = subscription.handle.keywords.get("handle_revised_bars", False)
-        else:
-            handle_revised_bars = False
+        if not isinstance(subscription.handle, functools.partial):
+            raise ValueError(f"Unexpected {subscription=}")
         if bar := self._process_bar_data(
             bar_type_str=str(subscription.name),
             bar=bar,
-            handle_revised_bars=handle_revised_bars,
+            handle_revised_bars=subscription.handle.keywords.get("handle_revised_bars", False),
         ):
             if bar.is_single_price() and bar.open.as_double() == 0:
                 self._log.debug(f"Ignoring Zero priced {bar=}")

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -816,7 +816,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         if not (subscription := self._subscriptions.get(req_id=req_id)):
             return
         if not isinstance(subscription.handle, functools.partial):
-            raise ValueError(f"Unexpected {subscription=}")
+            raise TypeError(f"Expecting partial type subscription method. {subscription=}")
         if bar := self._process_bar_data(
             bar_type_str=str(subscription.name),
             bar=bar,

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -78,7 +78,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
     async def _subscribe(
         self,
         name: str | tuple,
-        subscription_method: Callable,
+        subscription_method: Callable | functools.partial,
         cancellation_method: Callable,
         *args: Any,
         **kwargs: Any,
@@ -274,10 +274,10 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             name,
             self.subscribe_historical_bars,
             self._eclient.cancelHistoricalData,
-            bar_type,
-            contract,
-            use_rth,
-            handle_revised_bars,
+            bar_type=bar_type,
+            contract=contract,
+            use_rth=use_rth,
+            handle_revised_bars=handle_revised_bars,
         )
         if not subscription:
             return
@@ -815,10 +815,14 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         self.logAnswer(current_fn_name(), vars())
         if not (subscription := self._subscriptions.get(req_id=req_id)):
             return
+        if isinstance(subscription.handle, functools.partial):
+            handle_revised_bars = subscription.handle.keywords.get("handle_revised_bars", False)
+        else:
+            handle_revised_bars = False
         if bar := self._process_bar_data(
             bar_type_str=str(subscription.name),
             bar=bar,
-            handle_revised_bars=subscription.handle().keywords.get("handle_revised_bars", False),
+            handle_revised_bars=handle_revised_bars,
         ):
             if bar.is_single_price() and bar.open.as_double() == 0:
                 self._log.debug(f"Ignoring Zero priced {bar=}")


### PR DESCRIPTION
# Pull Request

User "d2b" in Discord reported the following error:

```
Error on `_run_internal_msg_queue`: AttributeError("'coroutine' object has no attribute 'keywords'")
```

The issue originates from a bug in the `historicalDataUpdate` EWrapper override method of the `InteractiveBrokersClientMarketDataMixin` class. The root cause  is the incorrect usage of a `functools.partial` object, which encapsulates the `subscribe_historical_bars` function. The `functools.partial` was being called rather than simply accessing the `keywords` attribute.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested locally.