### PR TITLE
Implement AverageTrueRange in Rust

### DIFF
--- a/nautilus_core/indicators/src/python/mod.rs
+++ b/nautilus_core/indicators/src/python/mod.rs
@@ -18,6 +18,7 @@ use pyo3::{prelude::*, pymodule};
 pub mod average;
 pub mod momentum;
 pub mod ratio;
+pub mod volatility;
 
 #[pymodule]
 pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -33,5 +34,7 @@ pub fn indicators(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     // momentum
     m.add_class::<crate::momentum::rsi::RelativeStrengthIndex>()?;
     m.add_class::<crate::momentum::aroon::AroonOscillator>()?;
+    // volatility
+    m.add_class::<crate::volatility::atr::AverageTrueRange>()?;
     Ok(())
 }

--- a/nautilus_core/indicators/src/python/volatility/atr.rs
+++ b/nautilus_core/indicators/src/python/volatility/atr.rs
@@ -1,0 +1,97 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::python::to_pyvalue_err;
+use nautilus_model::{
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
+};
+use pyo3::prelude::*;
+
+use crate::{
+    average::MovingAverageType, indicator::Indicator, volatility::atr::AverageTrueRange,
+};
+
+#[pymethods]
+impl AverageTrueRange {
+    #[new]
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>, use_previous: Option<bool>, value_floor: Option<f64>) -> PyResult<Self> {
+        Self::new(period, ma_type, use_previous, value_floor).map_err(to_pyvalue_err)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AverageTrueRange({},{},{},{})", self.period, self.ma_type, self.use_previous, self.value_floor)
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[getter]
+    #[pyo3(name = "period")]
+    fn py_period(&self) -> usize {
+        self.period
+    }
+
+    #[getter]
+    #[pyo3(name = "has_inputs")]
+    fn py_has_inputs(&self) -> bool {
+        self.has_inputs()
+    }
+
+    #[getter]
+    #[pyo3(name = "count")]
+    fn py_count(&self) -> usize {
+        self.count
+    }
+
+    #[getter]
+    #[pyo3(name = "value")]
+    fn py_value(&self) -> f64 {
+        self.value
+    }
+
+    #[getter]
+    #[pyo3(name = "initialized")]
+    fn py_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    #[pyo3(name = "update_raw")]
+    fn py_update_raw(&mut self, high: f64, low: f64, close: f64) {
+        self.update_raw(high, low, close);
+    }
+
+    #[pyo3(name = "handle_quote_tick")]
+    fn py_handle_quote_tick(&mut self, _tick: &QuoteTick) {
+        // Function body intentionally left blank.
+    }
+
+    #[pyo3(name = "handle_trade_tick")]
+    fn py_handle_trade_tick(&mut self, _tick: &TradeTick) {
+        // Function body intentionally left blank.
+    }
+
+    #[pyo3(name = "handle_bar")]
+    fn py_handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.high).into(), (&bar.low).into(), (&bar.close).into());
+    }
+
+    #[pyo3(name = "reset")]
+    fn py_reset(&mut self) {
+        self.reset();
+    }
+}

--- a/nautilus_core/indicators/src/python/volatility/mod.rs
+++ b/nautilus_core/indicators/src/python/volatility/mod.rs
@@ -13,14 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod average;
-pub mod indicator;
-pub mod momentum;
-pub mod ratio;
-pub mod volatility;
-
-#[cfg(test)]
-mod stubs;
-
-#[cfg(feature = "python")]
-pub mod python;
+pub mod atr;

--- a/nautilus_core/indicators/src/volatility/atr.rs
+++ b/nautilus_core/indicators/src/volatility/atr.rs
@@ -1,0 +1,136 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::{Debug, Display};
+
+use anyhow::Result;
+use nautilus_model::{
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
+};
+use pyo3::prelude::*;
+
+use crate::{
+    average::{MovingAverageFactory, MovingAverageType},
+    indicator::{Indicator, MovingAverage},
+};
+
+/// An indicator which calculates a Average True Range (ATR) across a rolling window.
+#[repr(C)]
+#[derive(Debug)]
+#[pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")]
+pub struct AverageTrueRange {
+    pub period: usize,
+    pub ma_type: MovingAverageType,
+    pub use_previous: bool,
+    pub value_floor: f64,
+    pub value: f64,
+    pub count: usize,
+    pub is_initialized: bool,
+    has_inputs: bool,
+    _previous_close: f64,
+    _ma: Box<dyn MovingAverage + Send + 'static>,
+}
+
+impl Display for AverageTrueRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({},{},{},{})", self.name(), self.period, self.ma_type, self.use_previous, self.value_floor)
+    }
+}
+
+impl Indicator for AverageTrueRange {
+    fn name(&self) -> String {
+        stringify!(AverageTrueRange).to_string()
+    }
+
+    fn has_inputs(&self) -> bool {
+        self.has_inputs
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+
+    fn handle_quote_tick(&mut self, _tick: &QuoteTick) {
+        // Function body intentionally left blank.
+    }
+
+    fn handle_trade_tick(&mut self, _tick: &TradeTick) {
+        // Function body intentionally left blank.
+    }
+
+    fn handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.high).into(), (&bar.low).into(), (&bar.close).into());
+    }
+
+    fn reset(&mut self) {
+        self._previous_close = 0.0;
+        self.value = 0.0;
+        self.count = 0;
+        self.has_inputs = false;
+        self.is_initialized = false;
+    }
+}
+
+impl AverageTrueRange {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>, use_previous: Option<bool>, value_floor: Option<f64>) -> Result<Self> {
+        Ok(Self {
+            period,
+            ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
+            use_previous: use_previous.unwrap_or(true),
+            value_floor: value_floor.unwrap_or(0.0),
+            value: 0.0,
+            count: 0,
+            _previous_close: 0.0,
+            _ma: MovingAverageFactory::create(MovingAverageType::Simple, period),
+            has_inputs: false,
+            is_initialized: false,
+        })
+    }
+
+    pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {
+        if self.use_previous {
+            if !self.has_inputs {
+                self._previous_close = close;
+            }
+            self._ma.update_raw(f64::max(self._previous_close, high) - f64::min(low, self._previous_close));
+            self._previous_close = close;
+        } else {
+            self._ma.update_raw(high - low);
+        }
+
+        self._floor_value();
+        self.increment_count();
+    }
+
+    fn _floor_value(&mut self) {
+        if self.value_floor == 0.0 || self.value_floor < self._ma.value() {
+            self.value = self._ma.value();
+        } else {
+            // Floor the value
+            self.value = self.value_floor;
+        }
+    }
+
+    fn increment_count(&mut self) {
+        self.count += 1;
+
+        if !self.is_initialized {
+            self.has_inputs = true;
+            if self.count >= self.period {
+                self.is_initialized = true;
+            }
+        }
+    }
+}

--- a/nautilus_core/indicators/src/volatility/mod.rs
+++ b/nautilus_core/indicators/src/volatility/mod.rs
@@ -13,14 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod average;
-pub mod indicator;
-pub mod momentum;
-pub mod ratio;
-pub mod volatility;
-
-#[cfg(test)]
-mod stubs;
-
-#[cfg(feature = "python")]
-pub mod python;
+pub mod atr;

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -754,6 +754,14 @@ class TriggerType(Enum):
     MARK_PRICE = "MARK_PRICE"
     INDEX_PRICE = "INDEX_PRICE"
 
+class MovingAverageType(Enum):
+    SIMPLE = "SIMPLE"
+    EXPONENTIAL = "EXPONENTIAL"
+    DOUBLE_EXPONENTIAL = "DOUBLE_EXPONENTIAL"
+    WILDER = "WILDER"
+    HULL = "HULL"
+
+
 ### Identifiers
 
 class AccountId:
@@ -1970,6 +1978,29 @@ class AroonOscillator:
     def handle_bar(self, bar: Bar) -> None: ...
     def reset(self) -> None: ...
 
+class AverageTrueRange:
+    def __init__(
+        self,
+        period: int,
+        ma_type: MovingAverageType = ...,
+        use_previous: bool = True,
+        value_floor: float = 0.0,
+    ) -> None: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def period(self) -> int: ...
+    @property
+    def count(self) -> int: ...
+    @property
+    def initialized(self) -> bool: ...
+    @property
+    def has_inputs(self) -> bool: ...
+    @property
+    def value(self) -> float: ...
+    def update_raw(self, high: float, low: float, close: float) -> None: ...
+    def handle_bar(self, bar: Bar) -> None: ...
+    def reset(self) -> None: ...
 
 ###################################################################################################
 # Adapters

--- a/tests/unit_tests/indicators/rust/test_atr_pyo3.py
+++ b/tests/unit_tests/indicators/rust/test_atr_pyo3.py
@@ -1,0 +1,182 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import sys
+
+import pytest
+
+from nautilus_trader.core.nautilus_pyo3 import AverageTrueRange
+from nautilus_trader.test_kit.rust.data_pyo3 import TestDataProviderPyo3
+
+
+@pytest.fixture(scope="function")
+def atr():
+    return AverageTrueRange(10)
+
+
+def test_name_returns_expected_string(atr):
+    # Arrange, Act, Assert
+    assert atr.name == "AverageTrueRange"
+
+
+def test_str_repr_returns_expected_string(atr):
+    # Arrange, Act, Assert
+    assert str(atr) == "AverageTrueRange(10,SIMPLE,true,0)"
+    assert repr(atr) == "AverageTrueRange(10,SIMPLE,true,0)"
+
+
+def test_period(atr):
+    # Arrange, Act, Assert
+    assert atr.period == 10
+
+
+def test_initialized_without_inputs_returns_false(atr):
+    # Arrange, Act, Assert
+    assert atr.initialized is False
+
+
+def test_initialized_with_required_inputs_returns_true(atr):
+    # Arrange, Act
+    for _i in range(10):
+        atr.update_raw(1.00000, 1.00000, 1.00000)
+
+    # Assert
+    assert atr.initialized is True
+
+
+def test_handle_bar_updates_indicator(atr):
+    # Arrange
+    bar = TestDataProviderPyo3.bar_5decimal()
+
+    # Act
+    atr.handle_bar(bar)
+
+    # Assert
+    assert atr.has_inputs
+    assert atr.value == 2.999999999997449e-05
+
+
+def test_value_with_no_inputs_returns_zero(atr):
+    # Arrange, Act, Assert
+    assert atr.value == 0.0
+
+
+def test_value_with_epsilon_input(atr):
+    # Arrange
+    epsilon = sys.float_info.epsilon
+    atr.update_raw(epsilon, epsilon, epsilon)
+
+    # Act, Assert
+    assert atr.value == 0.0
+
+
+def test_value_with_one_ones_input(atr):
+    # Arrange
+    atr.update_raw(1.00000, 1.00000, 1.00000)
+
+    # Act, Assert
+    assert atr.value == 0.0
+
+
+def test_value_with_one_input(atr):
+    # Arrange
+    atr.update_raw(1.00020, 1.00000, 1.00010)
+
+    # Act, Assert
+    assert atr.value == pytest.approx(0.00020)
+
+
+def test_value_with_three_inputs(atr):
+    # Arrange
+    atr.update_raw(1.00020, 1.00000, 1.00010)
+    atr.update_raw(1.00020, 1.00000, 1.00010)
+    atr.update_raw(1.00020, 1.00000, 1.00010)
+
+    # Act, Assert
+    assert atr.value == pytest.approx(0.00020)
+
+
+def test_value_with_close_on_high(atr):
+    # Arrange
+    high = 1.00010
+    low = 1.00000
+
+    # Act
+    for _i in range(1000):
+        high += 0.00010
+        low += 0.00010
+        close = high
+        atr.update_raw(high, low, close)
+
+    # Assert
+    assert atr.value == pytest.approx(0.00010, 2)
+
+
+def test_value_with_close_on_low(atr):
+    # Arrange
+    high = 1.00010
+    low = 1.00000
+
+    # Act
+    for _i in range(1000):
+        high -= 0.00010
+        low -= 0.00010
+        close = low
+        atr.update_raw(high, low, close)
+
+    # Assert
+    assert atr.value == pytest.approx(0.00010)
+
+
+def test_floor_with_ten_ones_inputs():
+    # Arrange
+    floor = 0.00005
+    floored_atr = AverageTrueRange(10, value_floor=floor)
+
+    for _i in range(20):
+        floored_atr.update_raw(1.00000, 1.00000, 1.00000)
+
+    # Act, Assert
+    assert floored_atr.value == 5e-05
+
+
+def test_floor_with_exponentially_decreasing_high_inputs():
+    # Arrange
+    floor = 0.00005
+    floored_atr = AverageTrueRange(10, value_floor=floor)
+
+    high = 1.00020
+    low = 1.00000
+    close = 1.00000
+
+    for _i in range(20):
+        high -= (high - low) / 2
+        floored_atr.update_raw(high, low, close)
+
+    # Act, Assert
+    assert floored_atr.value == 5e-05
+
+
+def test_reset_successfully_returns_indicator_to_fresh_state(atr):
+    # Arrange
+    for _i in range(1000):
+        atr.update_raw(1.00010, 1.00000, 1.00005)
+
+    # Act
+    atr.reset()
+
+    # Assert
+    assert not atr.initialized
+    assert atr.value == 0


### PR DESCRIPTION
# Pull Request

Implement AverageTrueRange in Rust with pyo3 tests.

## Type of change

Delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Implemented pyo3 tests from existing implementation.