### PR TITLE
Fix bug in IB connection error logging

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -262,7 +262,7 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         if self._eclient.wrapper:
             self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
         self._eclient.disconnect()
-        self._log.error("Connection failed", e)
+        self._log.error(f"Connection failed: {e}")
 
     # -- EWrapper overrides -----------------------------------------------------------------------
     def connectionClosed(self) -> None:


### PR DESCRIPTION
# Pull Request

When an IB connection was broken, the following error was being thrown:

```
02T21:11:30.288768001Z [ERROR] TESTER-001.InteractiveBrokersClient-002: Error on `_run_watch_dog`: TypeError('an integer is required')
```
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Started a dummy strategy then killed IB gateway, which did not result in the exception above. After restarting IB gateway, NT reestablished the connection without user intervention.