### PR TITLE
Remove major version outdated dependencies

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -4796,7 +4796,6 @@ dependencies = [
  "env_logger 0.10.2",
  "futures-channel",
  "futures-util",
- "hyper 0.14.28",
  "log",
  "native-tls",
  "rustls 0.21.10",

--- a/nautilus_core/network/tokio-tungstenite/Cargo.toml
+++ b/nautilus_core/network/tokio-tungstenite/Cargo.toml
@@ -65,7 +65,6 @@ version = "0.23.0"
 
 [dev-dependencies]
 futures-channel = "0.3.28"
-hyper = { version = "0.14.25", default-features = false, features = ["http1", "server", "tcp"] }
 tokio = { version = "1.27.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 url = "2.3.1"
 env_logger = "0.10.0"


### PR DESCRIPTION
# Pull Request

Remove outdated hyper from tokio tungstenite

## Type of change

- [x] Dependency refactor


## How has this change been tested?

tokio-tungstenite and websocket tests were run
