### PR TITLE
throttler: fix the throttler when sending messages after messages are dropped

### DIFF
--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -2727,7 +2727,7 @@ cdef class Throttler:
                 return 0
             self._warm = True
 
-        cdef int64_t diff = self._timestamps[0] - self._timestamps[-1]
+        cdef int64_t diff = self._clock.timestamp_ns() - self._timestamps[-1]
         return self._interval_ns - diff
 
     cdef void _limit_msg(self, msg):

--- a/tests/unit_tests/common/test_throttler.py
+++ b/tests/unit_tests/common/test_throttler.py
@@ -244,7 +244,7 @@ class TestDroppingThrottler:
         assert self.throttler.used() == 0
         assert self.throttler.recv_count == 6
         assert self.throttler.sent_count == 5
-    
+
     def test_send_message_after_dropping_message(self):
         # Arrange
         item = "MESSAGE"

--- a/tests/unit_tests/common/test_throttler.py
+++ b/tests/unit_tests/common/test_throttler.py
@@ -244,3 +244,32 @@ class TestDroppingThrottler:
         assert self.throttler.used() == 0
         assert self.throttler.recv_count == 6
         assert self.throttler.sent_count == 5
+    
+    def test_send_message_after_dropping_message(self):
+        # Arrange
+        item = "MESSAGE"
+
+        # Act: Send 6 items
+        self.throttler.send(item)
+        self.throttler.send(item)
+        self.throttler.send(item)
+        self.throttler.send(item)
+        self.throttler.send(item)
+        self.throttler.send(item)
+
+        # Act: Trigger refresh token time alert
+        events = self.clock.advance_time(1_000_000_000)
+        events[0].handle()
+
+        # Act: send a message after a previous message is throttled
+        self.throttler.send(item)
+
+        # Assert: Remaining items sent
+        assert self.clock.timer_count == 1  # No longer timing to process
+        assert self.throttler.is_limiting is False
+        assert self.handler == ["MESSAGE"] * 6
+        assert self.dropped == ["MESSAGE"]
+        assert self.throttler.qsize == 0
+        assert self.throttler.used() == 0
+        assert self.throttler.recv_count == 7
+        assert self.throttler.sent_count == 6


### PR DESCRIPTION
Fixes #1526 

# Pull Request

The throttler is dropping messages even after a sufficiently long quiet period. Instead of using the timestamp of the latest message, and the clock instead.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Adding unit tests and ran a backtest.