### PR TITLE
Fix missing python feature in some Rust crates

### DIFF
--- a/nautilus_core/accounting/Cargo.toml
+++ b/nautilus_core/accounting/Cargo.toml
@@ -33,5 +33,5 @@ extension-module = [
   "nautilus-model/extension-module",
   "nautilus-common/extension-module",
 ]
-python = ["pyo3"]
+python = ["pyo3", "nautilus-core/python", "nautilus-model/python"]
 default = []

--- a/nautilus_core/indicators/Cargo.toml
+++ b/nautilus_core/indicators/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 nautilus-core = { path = "../core" }
-nautilus-model = { path = "../model" }
+nautilus-model = { path = "../model", features = ["stubs"] }
 anyhow = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 strum = { workspace = true }
@@ -26,5 +26,5 @@ extension-module = [
     "nautilus-core/extension-module",
     "nautilus-model/extension-module",
 ]
-python = ["pyo3"]
+python = ["pyo3", "nautilus-core/python", "nautilus-model/python"]
 default = []


### PR DESCRIPTION
# Pull Request

- We have missing `nautilus-core/python` and `nautilus-model/python` features in `accounting` and `indicator` crates


![Screenshot 2024-03-08 at 08 11 44](https://github.com/nautechsystems/nautilus_trader/assets/16453976/78f9eba3-07cc-400c-a5b2-bc8c9e2d6b6d)

