### PR TITLE
Margin account pyo3 Rust Cython conversion

### DIFF
--- a/nautilus_core/accounting/src/python/margin.rs
+++ b/nautilus_core/accounting/src/python/margin.rs
@@ -295,4 +295,13 @@ impl MarginAccount {
             Err(to_pyvalue_err("Unsupported instrument type"))
         }
     }
+    #[pyo3(name = "to_dict")]
+    fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("calculate_account_state", self.calculate_account_state)?;
+        let events_list: PyResult<Vec<PyObject>> =
+            self.events.iter().map(|item| item.py_to_dict(py)).collect();
+        dict.set_item("events", events_list.unwrap())?;
+        Ok(dict.into())
+    }
 }

--- a/nautilus_core/accounting/src/python/mod.rs
+++ b/nautilus_core/accounting/src/python/mod.rs
@@ -23,6 +23,13 @@ pub mod transformer;
 pub fn accounting(_: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::account::cash::CashAccount>()?;
     m.add_class::<crate::account::margin::MarginAccount>()?;
-    m.add_class::<crate::python::transformer::AccountingTransformer>()?;
+    m.add_function(wrap_pyfunction!(
+        crate::python::transformer::cash_account_from_account_events,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        crate::python::transformer::margin_account_from_account_events,
+        m
+    )?)?;
     Ok(())
 }

--- a/nautilus_core/accounting/src/python/transformer.rs
+++ b/nautilus_core/accounting/src/python/transformer.rs
@@ -14,36 +14,53 @@
 // -------------------------------------------------------------------------------------------------
 
 use crate::account::cash::CashAccount;
+use crate::account::margin::MarginAccount;
 use crate::account::Account;
 use nautilus_core::python::to_pyvalue_err;
 use nautilus_model::events::account::state::AccountState;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-#[pyclass]
-pub struct AccountingTransformer {}
-
-#[pymethods]
-impl AccountingTransformer {
-    #[staticmethod]
-    fn cash_account_from_account_events(
-        py: Python<'_>,
-        events: Vec<Py<PyDict>>,
-        calculate_account_state: bool,
-    ) -> PyResult<CashAccount> {
-        let account_events = events
-            .into_iter()
-            .map(|obj| AccountState::py_from_dict(py, obj))
-            .collect::<PyResult<Vec<AccountState>>>()
-            .unwrap();
-        if account_events.is_empty() {
-            return Err(to_pyvalue_err("No account events"));
-        }
-        let init_event = account_events[0].clone();
-        let mut cash_account = CashAccount::new(init_event, calculate_account_state)?;
-        for event in account_events.iter().skip(1) {
-            cash_account.apply(event.clone());
-        }
-        Ok(cash_account)
+#[pyfunction]
+pub fn cash_account_from_account_events(
+    py: Python<'_>,
+    events: Vec<Py<PyDict>>,
+    calculate_account_state: bool,
+) -> PyResult<CashAccount> {
+    let account_events = events
+        .into_iter()
+        .map(|obj| AccountState::py_from_dict(py, obj))
+        .collect::<PyResult<Vec<AccountState>>>()
+        .unwrap();
+    if account_events.is_empty() {
+        return Err(to_pyvalue_err("No account events"));
     }
+    let init_event = account_events[0].clone();
+    let mut cash_account = CashAccount::new(init_event, calculate_account_state)?;
+    for event in account_events.iter().skip(1) {
+        cash_account.apply(event.clone());
+    }
+    Ok(cash_account)
+}
+
+#[pyfunction]
+pub fn margin_account_from_account_events(
+    py: Python<'_>,
+    events: Vec<Py<PyDict>>,
+    calculate_account_state: bool,
+) -> PyResult<MarginAccount> {
+    let account_events = events
+        .into_iter()
+        .map(|obj| AccountState::py_from_dict(py, obj))
+        .collect::<PyResult<Vec<AccountState>>>()
+        .unwrap();
+    if account_events.is_empty() {
+        return Err(to_pyvalue_err("No account events"));
+    }
+    let init_event = account_events[0].clone();
+    let mut margin_account = MarginAccount::new(init_event, calculate_account_state)?;
+    for event in account_events.iter().skip(1) {
+        margin_account.apply(event.clone());
+    }
+    Ok(margin_account)
 }

--- a/nautilus_trader/accounting/accounts/margin.pxd
+++ b/nautilus_trader/accounting/accounts/margin.pxd
@@ -72,3 +72,9 @@ cdef class MarginAccount(Account):
         Price price,
         bint use_quote_for_inverse=*,
     )
+
+    @staticmethod
+    cdef dict to_dict_c(MarginAccount obj)
+
+    @staticmethod
+    cdef MarginAccount from_dict_c(dict values)

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -305,11 +305,6 @@ class Position:
     def notional_value(self, price: Price) -> Money: ...
 
 
-class AccountingTransformer:
-    @classmethod
-    def cash_account_from_account_events(cls, events: list[dict],calculate_account_state) -> CashAccount: ...
-
-
 class MarginAccount:
     def __init__(
         self,
@@ -399,6 +394,11 @@ class CashAccount:
         fill: OrderFilled,
         position: Position | None = None
     ) -> list[Money]: ...
+
+### Accounting transformers
+def cash_account_from_account_events(events: list[dict],calculate_account_state) -> CashAccount: ...
+
+def margin_account_from_account_events(events: list[dict],calculate_account_state) -> MarginAccount: ...
 
 
 ### Data types

--- a/tests/unit_tests/accounting/test_cash_pyo3.py
+++ b/tests/unit_tests/accounting/test_cash_pyo3.py
@@ -16,7 +16,6 @@ import pytest
 
 from nautilus_trader.accounting.accounts.cash import CashAccount
 from nautilus_trader.core.nautilus_pyo3 import AccountId
-from nautilus_trader.core.nautilus_pyo3 import AccountingTransformer
 from nautilus_trader.core.nautilus_pyo3 import Currency
 from nautilus_trader.core.nautilus_pyo3 import LiquiditySide
 from nautilus_trader.core.nautilus_pyo3 import Money
@@ -24,6 +23,7 @@ from nautilus_trader.core.nautilus_pyo3 import OrderSide
 from nautilus_trader.core.nautilus_pyo3 import Position
 from nautilus_trader.core.nautilus_pyo3 import Price
 from nautilus_trader.core.nautilus_pyo3 import Quantity
+from nautilus_trader.core.nautilus_pyo3 import cash_account_from_account_events
 from nautilus_trader.test_kit.rust.accounting_pyo3 import TestAccountingProviderPyo3
 from nautilus_trader.test_kit.rust.events_pyo3 import TestEventsProviderPyo3
 from nautilus_trader.test_kit.rust.identifiers_pyo3 import TestIdProviderPyo3
@@ -250,7 +250,7 @@ def test_pyo3_cython_conversion():
     account_pyo3 = TestAccountingProviderPyo3.cash_account_million_usd()
     account_cython = CashAccount.from_dict(account_pyo3.to_dict())
     account_cython_dict = CashAccount.to_dict(account_cython)
-    account_pyo3_back = AccountingTransformer.cash_account_from_account_events(
+    account_pyo3_back = cash_account_from_account_events(
         events=account_cython_dict["events"],
         calculate_account_state=account_cython_dict["calculate_account_state"],
     )

--- a/tests/unit_tests/accounting/test_margin_pyo3.py
+++ b/tests/unit_tests/accounting/test_margin_pyo3.py
@@ -15,11 +15,13 @@
 
 import pytest
 
+from nautilus_trader.accounting.accounts.margin import MarginAccount
 from nautilus_trader.core.nautilus_pyo3 import AccountId
 from nautilus_trader.core.nautilus_pyo3 import Currency
 from nautilus_trader.core.nautilus_pyo3 import Money
 from nautilus_trader.core.nautilus_pyo3 import Price
 from nautilus_trader.core.nautilus_pyo3 import Quantity
+from nautilus_trader.core.nautilus_pyo3 import margin_account_from_account_events
 from nautilus_trader.test_kit.rust.accounting_pyo3 import TestAccountingProviderPyo3
 from nautilus_trader.test_kit.rust.identifiers_pyo3 import TestIdProviderPyo3
 from nautilus_trader.test_kit.rust.instruments_pyo3 import TestInstrumentProviderPyo3
@@ -162,3 +164,14 @@ def test_calculate_maintenance_margin_with_no_leverage():
     )
 
     assert result == Money(0.03697710, BTC)
+
+
+def test_pyo3_cython_conversion():
+    account_pyo3 = TestAccountingProviderPyo3.margin_account()
+    account_cython = MarginAccount.from_dict(account_pyo3.to_dict())
+    account_cython_dict = MarginAccount.to_dict(account_cython)
+    account_pyo3_back = margin_account_from_account_events(
+        events=account_cython_dict["events"],
+        calculate_account_state=account_cython_dict["calculate_account_state"],
+    )
+    assert account_pyo3 == account_pyo3_back


### PR DESCRIPTION
# Pull Request

- removed `AccountingTransformer` and refactored to a functional approach
- added to to and from dict methods in `MarginAccount` cython class
- new transform function `margin_account_from_account_events` that will be used for Rust Cython conversion


