### PR TITLE
Conversion between instrument type and PyObject refactor

### DIFF
--- a/nautilus_core/accounting/src/python/cash.rs
+++ b/nautilus_core/accounting/src/python/cash.rs
@@ -20,15 +20,12 @@ use nautilus_model::{
     enums::{AccountType, LiquiditySide, OrderSide},
     events::{account::state::AccountState, order::filled::OrderFilled},
     identifiers::account_id::AccountId,
-    instruments::{
-        crypto_future::CryptoFuture, crypto_perpetual::CryptoPerpetual,
-        currency_pair::CurrencyPair, equity::Equity, futures_contract::FuturesContract,
-        options_contract::OptionsContract,
-    },
     position::Position,
     types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
 };
 use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use nautilus_model::instruments::InstrumentType;
+use nautilus_model::python::instruments::convert_pyobject_to_instrument_type;
 
 use crate::account::{cash::CashAccount, Account};
 
@@ -158,80 +155,14 @@ impl CashAccount {
         use_quote_for_inverse: Option<bool>,
         py: Python,
     ) -> PyResult<Money> {
-        // extract instrument from PyObject
-        let instrument_type = instrument
-            .getattr(py, "instrument_type")?
-            .extract::<String>(py)?;
-        if instrument_type == "CryptoFuture" {
-            let instrument_rust = instrument.extract::<CryptoFuture>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "CryptoPerpetual" {
-            let instrument_rust = instrument.extract::<CryptoPerpetual>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "CurrencyPair" {
-            let instrument_rust = instrument.extract::<CurrencyPair>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "Equity" {
-            let instrument_rust = instrument.extract::<Equity>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "FuturesContract" {
-            let instrument_rust = instrument.extract::<FuturesContract>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "OptionsContract" {
-            let instrument_rust = instrument.extract::<OptionsContract>(py)?;
-            Ok(self
-                .calculate_balance_locked(
-                    instrument_rust,
-                    side,
-                    quantity,
-                    price,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else {
-            // throw error unsupported instrument
-            Err(to_pyvalue_err("Unsupported instrument type"))
-        }
+        let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
+        Ok(self.calculate_balance_locked(
+            instrument_type,
+            side,
+            quantity,
+            price,
+            use_quote_for_inverse,
+        ).unwrap())
     }
 
     #[pyo3(name = "calculate_commission")]
@@ -247,79 +178,16 @@ impl CashAccount {
         if liquidity_side == LiquiditySide::NoLiquiditySide {
             return Err(to_pyvalue_err("Invalid liquidity side"));
         }
-        // extract instrument from PyObject
-        let instrument_type = instrument
-            .getattr(py, "instrument_type")?
-            .extract::<String>(py)?;
-        if instrument_type == "CryptoFuture" {
-            let instrument_rust = instrument.extract::<CryptoFuture>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "CurrencyPair" {
-            let instrument_rust = instrument.extract::<CurrencyPair>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "CryptoPerpetual" {
-            let instrument_rust = instrument.extract::<CryptoPerpetual>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "Equity" {
-            let instrument_rust = instrument.extract::<Equity>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "FuturesContract" {
-            let instrument_rust = instrument.extract::<FuturesContract>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else if instrument_type == "OptionsContract" {
-            let instrument_rust = instrument.extract::<OptionsContract>(py)?;
-            Ok(self
-                .calculate_commission(
-                    instrument_rust,
-                    last_qty,
-                    last_px,
-                    liquidity_side,
-                    use_quote_for_inverse,
-                )
-                .unwrap())
-        } else {
-            // throw error unsupported instrument
-            Err(to_pyvalue_err("Unsupported instrument type"))
+        let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
+        match instrument_type {
+            InstrumentType::CryptoFuture(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::CryptoPerpetual(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::CurrencyPair(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::Equity(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::FuturesContract(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::FuturesSpread(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::OptionsContract(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::OptionsSpread(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
         }
     }
 
@@ -331,43 +199,16 @@ impl CashAccount {
         position: Option<Position>,
         py: Python,
     ) -> PyResult<Vec<Money>> {
-        // extract instrument from PyObject
-        let instrument_type = instrument
-            .getattr(py, "instrument_type")?
-            .extract::<String>(py)?;
-        if instrument_type == "CryptoFuture" {
-            let instrument_rust = instrument.extract::<CryptoFuture>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else if instrument_type == "CurrencyPair" {
-            let instrument_rust = instrument.extract::<CurrencyPair>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else if instrument_type == "CryptoPerpetual" {
-            let instrument_rust = instrument.extract::<CryptoPerpetual>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else if instrument_type == "Equity" {
-            let instrument_rust = instrument.extract::<Equity>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else if instrument_type == "FuturesContract" {
-            let instrument_rust = instrument.extract::<FuturesContract>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else if instrument_type == "OptionsContract" {
-            let instrument_rust = instrument.extract::<OptionsContract>(py)?;
-            Ok(self
-                .calculate_pnls(instrument_rust, fill, position)
-                .unwrap())
-        } else {
-            // throw error unsupported instrument
-            Err(to_pyvalue_err("Unsupported instrument type"))
+        let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
+        match instrument_type {
+            InstrumentType::CryptoFuture(inst) => Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::CryptoPerpetual(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::CurrencyPair(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::Equity(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::FuturesContract(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::FuturesSpread(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::OptionsContract(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::OptionsSpread(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
         }
     }
 

--- a/nautilus_core/accounting/src/python/cash.rs
+++ b/nautilus_core/accounting/src/python/cash.rs
@@ -20,12 +20,12 @@ use nautilus_model::{
     enums::{AccountType, LiquiditySide, OrderSide},
     events::{account::state::AccountState, order::filled::OrderFilled},
     identifiers::account_id::AccountId,
+    instruments::InstrumentType,
     position::Position,
+    python::instruments::convert_pyobject_to_instrument_type,
     types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
 };
 use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
-use nautilus_model::instruments::InstrumentType;
-use nautilus_model::python::instruments::convert_pyobject_to_instrument_type;
 
 use crate::account::{cash::CashAccount, Account};
 
@@ -156,13 +156,32 @@ impl CashAccount {
         py: Python,
     ) -> PyResult<Money> {
         let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
-        Ok(self.calculate_balance_locked(
-            instrument_type,
-            side,
-            quantity,
-            price,
-            use_quote_for_inverse,
-        ).unwrap())
+        match instrument_type {
+            InstrumentType::CryptoFuture(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::CryptoPerpetual(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::CurrencyPair(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::Equity(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::FuturesContract(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::FuturesSpread(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::OptionsContract(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+            InstrumentType::OptionsSpread(inst) => Ok(self
+                .calculate_balance_locked(inst, side, quantity, price, use_quote_for_inverse)
+                .unwrap()),
+        }
     }
 
     #[pyo3(name = "calculate_commission")]
@@ -180,14 +199,78 @@ impl CashAccount {
         }
         let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
         match instrument_type {
-            InstrumentType::CryptoFuture(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::CryptoPerpetual(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::CurrencyPair(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::Equity(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::FuturesContract(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::FuturesSpread(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::OptionsContract(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
-            InstrumentType::OptionsSpread(inst) => Ok(self.calculate_commission(inst, last_qty, last_px, liquidity_side, use_quote_for_inverse, ).unwrap()),
+            InstrumentType::CryptoFuture(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::CryptoPerpetual(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::CurrencyPair(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::Equity(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::FuturesContract(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::FuturesSpread(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::OptionsContract(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
+            InstrumentType::OptionsSpread(inst) => Ok(self
+                .calculate_commission(
+                    inst,
+                    last_qty,
+                    last_px,
+                    liquidity_side,
+                    use_quote_for_inverse,
+                )
+                .unwrap()),
         }
     }
 
@@ -201,14 +284,28 @@ impl CashAccount {
     ) -> PyResult<Vec<Money>> {
         let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
         match instrument_type {
-            InstrumentType::CryptoFuture(inst) => Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::CryptoPerpetual(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::CurrencyPair(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::Equity(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::FuturesContract(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::FuturesSpread(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::OptionsContract(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
-            InstrumentType::OptionsSpread(inst) =>  Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::CryptoFuture(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::CryptoPerpetual(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::CurrencyPair(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::Equity(inst) => Ok(self.calculate_pnls(inst, fill, position).unwrap()),
+            InstrumentType::FuturesContract(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::FuturesSpread(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::OptionsContract(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
+            InstrumentType::OptionsSpread(inst) => {
+                Ok(self.calculate_pnls(inst, fill, position).unwrap())
+            }
         }
     }
 

--- a/nautilus_core/accounting/src/python/margin.rs
+++ b/nautilus_core/accounting/src/python/margin.rs
@@ -17,14 +17,11 @@ use nautilus_core::python::to_pyvalue_err;
 use nautilus_model::{
     events::account::state::AccountState,
     identifiers::{account_id::AccountId, instrument_id::InstrumentId},
-    instruments::{
-        crypto_future::CryptoFuture, crypto_perpetual::CryptoPerpetual,
-        currency_pair::CurrencyPair, equity::Equity, futures_contract::FuturesContract,
-        options_contract::OptionsContract,
-    },
     types::{money::Money, price::Price, quantity::Quantity},
 };
 use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
+use nautilus_model::instruments::InstrumentType;
+use nautilus_model::python::instruments::convert_pyobject_to_instrument_type;
 
 use crate::account::margin::MarginAccount;
 
@@ -171,61 +168,27 @@ impl MarginAccount {
         use_quote_for_inverse: Option<bool>,
         py: Python,
     ) -> PyResult<Money> {
-        // extract instrument from PyObject
-        let instrument_type = instrument
-            .getattr(py, "instrument_type")?
-            .extract::<String>(py)?;
-        if instrument_type == "CryptoFuture" {
-            let instrument_rust = instrument.extract::<CryptoFuture>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "CryptoPerpetual" {
-            let instrument_rust = instrument.extract::<CryptoPerpetual>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "CurrencyPair" {
-            let instrument_rust = instrument.extract::<CurrencyPair>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "Equity" {
-            let instrument_rust = instrument.extract::<Equity>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "FuturesContract" {
-            let instrument_rust = instrument.extract::<FuturesContract>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "OptionsContract" {
-            let instrument_rust = instrument.extract::<OptionsContract>(py)?;
-            Ok(self.calculate_initial_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else {
-            // throw error unsupported instrument
-            Err(to_pyvalue_err("Unsupported instrument type"))
+        let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
+        match instrument_type {
+            InstrumentType::CryptoFuture(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::CryptoPerpetual(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::CurrencyPair(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::Equity(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::FuturesContract(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::OptionsContract(inst) => {
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse).unwrap())
+            }
+            _ => Err(to_pyvalue_err("Unsupported instrument type")),
         }
     }
 
@@ -238,63 +201,30 @@ impl MarginAccount {
         use_quote_for_inverse: Option<bool>,
         py: Python,
     ) -> PyResult<Money> {
-        // extract instrument from PyObject
-        let instrument_type = instrument
-            .getattr(py, "instrument_type")?
-            .extract::<String>(py)?;
-        if instrument_type == "CryptoFuture" {
-            let instrument_rust = instrument.extract::<CryptoFuture>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "CryptoPerpetual" {
-            let instrument_rust = instrument.extract::<CryptoPerpetual>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "CurrencyPair" {
-            let instrument_rust = instrument.extract::<CurrencyPair>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "Equity" {
-            let instrument_rust = instrument.extract::<Equity>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "FuturesContract" {
-            let instrument_rust = instrument.extract::<FuturesContract>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else if instrument_type == "OptionsContract" {
-            let instrument_rust = instrument.extract::<OptionsContract>(py)?;
-            Ok(self.calculate_maintenance_margin(
-                instrument_rust,
-                quantity,
-                price,
-                use_quote_for_inverse,
-            ))
-        } else {
-            // throw error unsupported instrument
-            Err(to_pyvalue_err("Unsupported instrument type"))
+        let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
+        match instrument_type {
+            InstrumentType::CryptoFuture(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::CryptoPerpetual(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::CurrencyPair(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::Equity(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::FuturesContract(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            InstrumentType::OptionsContract(inst) => {
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+            }
+            _ => Err(to_pyvalue_err("Unsupported instrument type")),
         }
     }
+
     #[pyo3(name = "to_dict")]
     fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let dict = PyDict::new(py);

--- a/nautilus_core/accounting/src/python/margin.rs
+++ b/nautilus_core/accounting/src/python/margin.rs
@@ -17,11 +17,11 @@ use nautilus_core::python::to_pyvalue_err;
 use nautilus_model::{
     events::account::state::AccountState,
     identifiers::{account_id::AccountId, instrument_id::InstrumentId},
+    instruments::InstrumentType,
+    python::instruments::convert_pyobject_to_instrument_type,
     types::{money::Money, price::Price, quantity::Quantity},
 };
 use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
-use nautilus_model::instruments::InstrumentType;
-use nautilus_model::python::instruments::convert_pyobject_to_instrument_type;
 
 use crate::account::margin::MarginAccount;
 
@@ -171,22 +171,22 @@ impl MarginAccount {
         let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
         match instrument_type {
             InstrumentType::CryptoFuture(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::CryptoPerpetual(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::CurrencyPair(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::Equity(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::FuturesContract(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::OptionsContract(inst) => {
-                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse).unwrap())
+                Ok(self.calculate_initial_margin(inst, quantity, price, use_quote_for_inverse))
             }
             _ => Err(to_pyvalue_err("Unsupported instrument type")),
         }
@@ -204,22 +204,22 @@ impl MarginAccount {
         let instrument_type = convert_pyobject_to_instrument_type(py, instrument)?;
         match instrument_type {
             InstrumentType::CryptoFuture(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::CryptoPerpetual(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::CurrencyPair(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::Equity(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::FuturesContract(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             InstrumentType::OptionsContract(inst) => {
-                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse, ).unwrap())
+                Ok(self.calculate_maintenance_margin(inst, quantity, price, use_quote_for_inverse))
             }
             _ => Err(to_pyvalue_err("Unsupported instrument type")),
         }

--- a/nautilus_core/adapters/src/databento/python/historical.rs
+++ b/nautilus_core/adapters/src/databento/python/historical.rs
@@ -28,6 +28,7 @@ use nautilus_model::{
     data::{bar::Bar, quote::QuoteTick, trade::TradeTick, Data},
     enums::BarAggregation,
     identifiers::{instrument_id::InstrumentId, symbol::Symbol, venue::Venue},
+    python::instruments::convert_instrument_to_pyobject,
     types::currency::Currency,
 };
 use pyo3::{
@@ -38,7 +39,6 @@ use pyo3::{
 use tokio::sync::Mutex;
 use tracing::error;
 
-use super::loader::convert_instrument_to_pyobject;
 use crate::databento::{
     common::get_date_time_range,
     decode::{

--- a/nautilus_core/adapters/src/databento/python/live.rs
+++ b/nautilus_core/adapters/src/databento/python/live.rs
@@ -21,12 +21,14 @@ use nautilus_core::{
     python::{to_pyruntime_err, to_pyvalue_err},
     time::UnixNanos,
 };
-use nautilus_model::{identifiers::venue::Venue, python::data::data_to_pycapsule};
+use nautilus_model::{
+    identifiers::venue::Venue,
+    python::{data::data_to_pycapsule, instruments::convert_instrument_to_pyobject},
+};
 use pyo3::prelude::*;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
-use nautilus_model::python::instruments::convert_instrument_to_pyobject;
 
 use crate::databento::{
     live::{DatabentoFeedHandler, LiveCommand, LiveMessage},

--- a/nautilus_core/adapters/src/databento/python/live.rs
+++ b/nautilus_core/adapters/src/databento/python/live.rs
@@ -26,8 +26,8 @@ use pyo3::prelude::*;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
+use nautilus_model::python::instruments::convert_instrument_to_pyobject;
 
-use super::loader::convert_instrument_to_pyobject;
 use crate::databento::{
     live::{DatabentoFeedHandler, LiveCommand, LiveMessage},
     symbology::{check_consistent_symbology, infer_symbology_type},

--- a/nautilus_core/adapters/src/databento/python/loader.rs
+++ b/nautilus_core/adapters/src/databento/python/loader.rs
@@ -29,7 +29,7 @@ use pyo3::{
     prelude::*,
     types::{PyCapsule, PyList},
 };
-use tracing::error;
+use nautilus_model::python::instruments::convert_instrument_to_pyobject;
 
 use crate::databento::{
     loader::DatabentoDataLoader,
@@ -93,7 +93,7 @@ impl DatabentoDataLoader {
                     data.push(py_object);
                 }
                 Err(e) => {
-                    error!("{e}");
+                    eprintln!("{e}");
                 }
             }
         }
@@ -401,19 +401,6 @@ impl DatabentoDataLoader {
     }
 }
 
-pub fn convert_instrument_to_pyobject(
-    py: Python,
-    instrument: InstrumentType,
-) -> PyResult<PyObject> {
-    match instrument {
-        InstrumentType::Equity(inst) => Ok(inst.into_py(py)),
-        InstrumentType::FuturesContract(inst) => Ok(inst.into_py(py)),
-        InstrumentType::FuturesSpread(inst) => Ok(inst.into_py(py)),
-        InstrumentType::OptionsContract(inst) => Ok(inst.into_py(py)),
-        InstrumentType::OptionsSpread(inst) => Ok(inst.into_py(py)),
-        _ => Err(to_pyvalue_err("Unsupported instrument type")),
-    }
-}
 
 fn exhaust_data_iter_to_pycapsule(
     py: Python,

--- a/nautilus_core/adapters/src/databento/python/loader.rs
+++ b/nautilus_core/adapters/src/databento/python/loader.rs
@@ -23,13 +23,12 @@ use nautilus_model::{
         trade::TradeTick, Data,
     },
     identifiers::{instrument_id::InstrumentId, venue::Venue},
-    instruments::InstrumentType,
+    python::instruments::convert_instrument_to_pyobject,
 };
 use pyo3::{
     prelude::*,
     types::{PyCapsule, PyList},
 };
-use nautilus_model::python::instruments::convert_instrument_to_pyobject;
 
 use crate::databento::{
     loader::DatabentoDataLoader,
@@ -400,7 +399,6 @@ impl DatabentoDataLoader {
         Ok(data)
     }
 }
-
 
 fn exhaust_data_iter_to_pycapsule(
     py: Python,

--- a/nautilus_core/model/src/python/instruments/mod.rs
+++ b/nautilus_core/model/src/python/instruments/mod.rs
@@ -13,6 +13,36 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use pyo3::{IntoPy, PyObject, PyResult, Python};
+use nautilus_core::python::to_pyvalue_err;
+use crate::instruments::crypto_future::CryptoFuture;
+use crate::instruments::crypto_perpetual::CryptoPerpetual;
+use crate::instruments::currency_pair::CurrencyPair;
+use crate::instruments::equity::Equity;
+use crate::instruments::futures_contract::FuturesContract;
+use crate::instruments::futures_spread::FuturesSpread;
+use crate::instruments::InstrumentType;
+use crate::instruments::options_contract::OptionsContract;
+
+pub fn convert_instrument_to_pyobject(
+    py: Python,
+    instrument: InstrumentType,
+) -> PyResult<PyObject> {
+    match instrument {
+        InstrumentType::CurrencyPair(inst)=> Ok(inst.into_py(py)),
+        InstrumentType::Equity(inst) => Ok(inst.into_py(py)),
+        InstrumentType::FuturesContract(inst) => Ok(inst.into_py(py)),
+        InstrumentType::FuturesSpread(inst) => Ok(inst.into_py(py)),
+        InstrumentType::OptionsContract(inst) => Ok(inst.into_py(py)),
+        InstrumentType::OptionsSpread(inst) => Ok(inst.into_py(py)),
+        _ => Err(to_pyvalue_err("Unsupported instrument type")),
+    }
+}
+
+
+    
+
+
 pub mod crypto_future;
 pub mod crypto_perpetual;
 pub mod currency_pair;

--- a/nautilus_core/model/src/python/instruments/mod.rs
+++ b/nautilus_core/model/src/python/instruments/mod.rs
@@ -13,23 +13,21 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use pyo3::{IntoPy, PyObject, PyResult, Python};
 use nautilus_core::python::to_pyvalue_err;
-use crate::instruments::crypto_future::CryptoFuture;
-use crate::instruments::crypto_perpetual::CryptoPerpetual;
-use crate::instruments::currency_pair::CurrencyPair;
-use crate::instruments::equity::Equity;
-use crate::instruments::futures_contract::FuturesContract;
-use crate::instruments::futures_spread::FuturesSpread;
-use crate::instruments::InstrumentType;
-use crate::instruments::options_contract::OptionsContract;
+use pyo3::{IntoPy, PyObject, PyResult, Python};
+
+use crate::instruments::{
+    crypto_future::CryptoFuture, crypto_perpetual::CryptoPerpetual, currency_pair::CurrencyPair,
+    equity::Equity, futures_contract::FuturesContract, futures_spread::FuturesSpread,
+    options_contract::OptionsContract, InstrumentType,
+};
 
 pub fn convert_instrument_to_pyobject(
     py: Python,
     instrument: InstrumentType,
 ) -> PyResult<PyObject> {
     match instrument {
-        InstrumentType::CurrencyPair(inst)=> Ok(inst.into_py(py)),
+        InstrumentType::CurrencyPair(inst) => Ok(inst.into_py(py)),
         InstrumentType::Equity(inst) => Ok(inst.into_py(py)),
         InstrumentType::FuturesContract(inst) => Ok(inst.into_py(py)),
         InstrumentType::FuturesSpread(inst) => Ok(inst.into_py(py)),
@@ -43,7 +41,9 @@ pub fn convert_pyobject_to_instrument_type(
     py: Python,
     instrument: PyObject,
 ) -> PyResult<InstrumentType> {
-    let instrument_type = instrument.getattr(py, "instrument_type")?.extract::<String>(py)?;
+    let instrument_type = instrument
+        .getattr(py, "instrument_type")?
+        .extract::<String>(py)?;
     if instrument_type == "CryptoFuture" {
         let crypto_future = instrument.extract::<CryptoFuture>(py)?;
         Ok(InstrumentType::CryptoFuture(crypto_future))
@@ -68,11 +68,12 @@ pub fn convert_pyobject_to_instrument_type(
     } else if instrument_type == "OptionsSpread" {
         let options_spread = instrument.extract::<CryptoFuture>(py)?;
         Ok(InstrumentType::CryptoFuture(options_spread))
-    } else{
-        Err(to_pyvalue_err("Error in conversion from pyobject to instrument type"))
+    } else {
+        Err(to_pyvalue_err(
+            "Error in conversion from pyobject to instrument type",
+        ))
     }
 }
-    
 
 pub mod crypto_future;
 pub mod crypto_perpetual;

--- a/nautilus_core/model/src/python/instruments/mod.rs
+++ b/nautilus_core/model/src/python/instruments/mod.rs
@@ -39,9 +39,40 @@ pub fn convert_instrument_to_pyobject(
     }
 }
 
-
+pub fn convert_pyobject_to_instrument_type(
+    py: Python,
+    instrument: PyObject,
+) -> PyResult<InstrumentType> {
+    let instrument_type = instrument.getattr(py, "instrument_type")?.extract::<String>(py)?;
+    if instrument_type == "CryptoFuture" {
+        let crypto_future = instrument.extract::<CryptoFuture>(py)?;
+        Ok(InstrumentType::CryptoFuture(crypto_future))
+    } else if instrument_type == "CryptoPerpetual" {
+        let crypto_perpetual = instrument.extract::<CryptoPerpetual>(py)?;
+        Ok(InstrumentType::CryptoPerpetual(crypto_perpetual))
+    } else if instrument_type == "CurrencyPair" {
+        let currency_pair = instrument.extract::<CurrencyPair>(py)?;
+        Ok(InstrumentType::CurrencyPair(currency_pair))
+    } else if instrument_type == "Equity" {
+        let equity = instrument.extract::<Equity>(py)?;
+        Ok(InstrumentType::Equity(equity))
+    } else if instrument_type == "FuturesContract" {
+        let futures_contract = instrument.extract::<FuturesContract>(py)?;
+        Ok(InstrumentType::FuturesContract(futures_contract))
+    } else if instrument_type == "FuturesSpread" {
+        let futures_spread = instrument.extract::<FuturesSpread>(py)?;
+        Ok(InstrumentType::FuturesSpread(futures_spread))
+    } else if instrument_type == "OptionsContract" {
+        let options_contract = instrument.extract::<OptionsContract>(py)?;
+        Ok(InstrumentType::OptionsContract(options_contract))
+    } else if instrument_type == "OptionsSpread" {
+        let options_spread = instrument.extract::<CryptoFuture>(py)?;
+        Ok(InstrumentType::CryptoFuture(options_spread))
+    } else{
+        Err(to_pyvalue_err("Error in conversion from pyobject to instrument type"))
+    }
+}
     
-
 
 pub mod crypto_future;
 pub mod crypto_perpetual;


### PR DESCRIPTION
# Pull Request

 - created new util function `convert_pyobject_to_instrument_type`  that gives enum `InstrumentType` for given `PyObject` based on the `instrument_type` property inside class
 - refactor various python function that uses this pattern (in accounting + position)
 - moved `convert_instrument_to_pyobject` from `adapters` crate to `model` crate
