### PR TITLE
Order event from and to PyObject conversion

### DIFF
--- a/nautilus_core/model/src/python/events/order/accepted.rs
+++ b/nautilus_core/model/src/python/events/order/accepted.rs
@@ -96,6 +96,12 @@ impl OrderAccepted {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderAccepted)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/cancel_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/cancel_rejected.rs
@@ -104,6 +104,12 @@ impl OrderCancelRejected {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderCancelRejected)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/canceled.rs
+++ b/nautilus_core/model/src/python/events/order/canceled.rs
@@ -96,6 +96,12 @@ impl OrderCanceled {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderCanceled)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/denied.rs
+++ b/nautilus_core/model/src/python/events/order/denied.rs
@@ -92,6 +92,12 @@ impl OrderDenied {
         }
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderDenied)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/emulated.rs
+++ b/nautilus_core/model/src/python/events/order/emulated.rs
@@ -81,6 +81,12 @@ impl OrderEmulated {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderEmulated)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/expired.rs
+++ b/nautilus_core/model/src/python/events/order/expired.rs
@@ -96,6 +96,12 @@ impl OrderExpired {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderExpired)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/filled.rs
+++ b/nautilus_core/model/src/python/events/order/filled.rs
@@ -174,6 +174,12 @@ impl OrderFilled {
     }
 
     #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderFilled)
+    }
+
+    #[getter]
     #[pyo3(name = "is_buy")]
     fn py_is_buy(&self) -> bool {
         self.is_buy()

--- a/nautilus_core/model/src/python/events/order/initialized.rs
+++ b/nautilus_core/model/src/python/events/order/initialized.rs
@@ -214,6 +214,12 @@ impl OrderInitialized {
         format!("{self}")
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderInitialized)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -13,6 +13,99 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use nautilus_core::python::to_pyvalue_err;
+use pyo3::{IntoPy, PyObject, PyResult, Python};
+
+use crate::events::order::{
+    accepted::OrderAccepted, cancel_rejected::OrderCancelRejected, canceled::OrderCanceled,
+    denied::OrderDenied, emulated::OrderEmulated, event::OrderEvent, expired::OrderExpired,
+    filled::OrderFilled, initialized::OrderInitialized, modify_rejected::OrderModifyRejected,
+    pending_cancel::OrderPendingCancel, pending_update::OrderPendingUpdate,
+    rejected::OrderRejected, released::OrderReleased, submitted::OrderSubmitted,
+    triggered::OrderTriggered, updated::OrderUpdated,
+};
+
+pub fn convert_order_event_to_pyobject(py: Python, order_event: OrderEvent) -> PyResult<PyObject> {
+    match order_event {
+        OrderEvent::OrderInitialized(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderDenied(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderEmulated(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderReleased(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderSubmitted(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderAccepted(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderRejected(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderCanceled(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderExpired(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderTriggered(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderPendingUpdate(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderPendingCancel(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderModifyRejected(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderCancelRejected(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderUpdated(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderPartiallyFilled(event) => Ok(event.into_py(py)),
+        OrderEvent::OrderFilled(event) => Ok(event.into_py(py)),
+    }
+}
+
+pub fn convert_pyobject_to_order_event(py: Python, order_event: PyObject) -> PyResult<OrderEvent> {
+    let order_event_type = order_event
+        .getattr(py, "order_event_type")?
+        .extract::<String>(py)?;
+    if order_event_type == "OrderAccepted" {
+        let order_accepted = order_event.extract::<OrderAccepted>(py)?;
+        Ok(OrderEvent::OrderAccepted(order_accepted))
+    } else if order_event_type == "OrderCanceled" {
+        let order_canceled = order_event.extract::<OrderCanceled>(py)?;
+        Ok(OrderEvent::OrderCanceled(order_canceled))
+    } else if order_event_type == "OrderCancelRejected" {
+        let order_cancel_rejected = order_event.extract::<OrderCancelRejected>(py)?;
+        Ok(OrderEvent::OrderCancelRejected(order_cancel_rejected))
+    } else if order_event_type == "OrderDenied" {
+        let order_denied = order_event.extract::<OrderDenied>(py)?;
+        Ok(OrderEvent::OrderDenied(order_denied))
+    } else if order_event_type == "OrderEmulated" {
+        let order_emulated = order_event.extract::<OrderEmulated>(py)?;
+        Ok(OrderEvent::OrderEmulated(order_emulated))
+    } else if order_event_type == "OrderExpired" {
+        let order_expired = order_event.extract::<OrderExpired>(py)?;
+        Ok(OrderEvent::OrderExpired(order_expired))
+    } else if order_event_type == "OrderFilled" {
+        let order_filled = order_event.extract::<OrderFilled>(py)?;
+        Ok(OrderEvent::OrderFilled(order_filled))
+    } else if order_event_type == "OrderInitialized" {
+        let order_initialized = order_event.extract::<OrderInitialized>(py)?;
+        Ok(OrderEvent::OrderInitialized(order_initialized))
+    } else if order_event_type == "OrderModifyRejected" {
+        let order_modify_rejected = order_event.extract::<OrderModifyRejected>(py)?;
+        Ok(OrderEvent::OrderModifyRejected(order_modify_rejected))
+    } else if order_event_type == "OrderPendingCancel" {
+        let order_pending_cancel = order_event.extract::<OrderPendingCancel>(py)?;
+        Ok(OrderEvent::OrderPendingCancel(order_pending_cancel))
+    } else if order_event_type == "OrderPendingUpdate" {
+        let order_pending_update = order_event.extract::<OrderPendingUpdate>(py)?;
+        Ok(OrderEvent::OrderPendingUpdate(order_pending_update))
+    } else if order_event_type == "OrderRejected" {
+        let order_rejected = order_event.extract::<OrderRejected>(py)?;
+        Ok(OrderEvent::OrderRejected(order_rejected))
+    } else if order_event_type == "OrderReleased" {
+        let order_released = order_event.extract::<OrderReleased>(py)?;
+        Ok(OrderEvent::OrderReleased(order_released))
+    } else if order_event_type == "OrderSubmitted" {
+        let order_submitted = order_event.extract::<OrderSubmitted>(py)?;
+        Ok(OrderEvent::OrderSubmitted(order_submitted))
+    } else if order_event_type == "OrderTriggered" {
+        let order_triggered = order_event.extract::<OrderTriggered>(py)?;
+        Ok(OrderEvent::OrderTriggered(order_triggered))
+    } else if order_event_type == "OrderUpdated" {
+        let order_updated = order_event.extract::<OrderUpdated>(py)?;
+        Ok(OrderEvent::OrderUpdated(order_updated))
+    } else {
+        Err(to_pyvalue_err(
+            "Error in conversion from pyobject to order event",
+        ))
+    }
+}
+
 pub mod accepted;
 pub mod cancel_rejected;
 pub mod canceled;

--- a/nautilus_core/model/src/python/events/order/modify_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/modify_rejected.rs
@@ -105,6 +105,12 @@ impl OrderModifyRejected {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderModifyRejected)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/pending_cancel.rs
+++ b/nautilus_core/model/src/python/events/order/pending_cancel.rs
@@ -96,6 +96,12 @@ impl OrderPendingCancel {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderPendingCancel)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/pending_update.rs
+++ b/nautilus_core/model/src/python/events/order/pending_update.rs
@@ -96,6 +96,12 @@ impl OrderPendingUpdate {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderPendingUpdate)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/rejected.rs
+++ b/nautilus_core/model/src/python/events/order/rejected.rs
@@ -99,6 +99,12 @@ impl OrderRejected {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderRejected)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/released.rs
+++ b/nautilus_core/model/src/python/events/order/released.rs
@@ -89,6 +89,12 @@ impl OrderReleased {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderReleased)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/submitted.rs
+++ b/nautilus_core/model/src/python/events/order/submitted.rs
@@ -90,6 +90,12 @@ impl OrderSubmitted {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderSubmitted)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/triggered.rs
+++ b/nautilus_core/model/src/python/events/order/triggered.rs
@@ -97,6 +97,12 @@ impl OrderTriggered {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderTriggered)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/updated.rs
+++ b/nautilus_core/model/src/python/events/order/updated.rs
@@ -110,6 +110,12 @@ impl OrderUpdated {
         )
     }
 
+    #[getter]
+    #[pyo3(name = "order_event_type")]
+    fn py_order_event_type(&self) -> &str {
+        stringify!(OrderUpdated)
+    }
+
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {


### PR DESCRIPTION
# Pull Request

- attached `order_event_type` attribute to all pyo3 order events
- create two utils function `convert_order_event_to_pyobject` and `convert_pyobject_to_order_event` to help with conversion
