### PR TITLE
Refine ts_init Query to Exclude Start Timestamp

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -541,7 +541,7 @@ class ParquetDataCatalog(BaseDataCatalog):
 
         if start:
             start_ts = dt_to_unix_nanos(start)
-            conditions.append(f"ts_init >= {start_ts}")
+            conditions.append(f"ts_init > {start_ts}")
         if end:
             end_ts = dt_to_unix_nanos(end)
             conditions.append(f"ts_init <= {end_ts}")

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -70,7 +70,7 @@ def test_catalog_query_filtered(
     assert len(trades) == 121
 
     trades = catalog_betfair.trade_ticks(start=1576875378384999936)
-    assert len(trades) == 121
+    assert len(trades) == 120
 
     trades = catalog_betfair.trade_ticks(start=datetime.datetime(2019, 12, 20, 20, 56, 18))
     assert len(trades) == 121


### PR DESCRIPTION
# Pull Request

Updated the `ts_init` query condition to exclude the `start` timestamp (ts_init > {start_ts}), mitigating duplicate records in sequential queries. For flexibility, an optional flag for including/excluding the start timestamp maybe added in case keeping current use case is necessary.