### PR TITLE
bybit: add trade spot and trade option websocket msgspec schemas

### DIFF
--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -15,6 +15,7 @@
 
 import asyncio
 from collections import defaultdict
+from functools import partial
 
 import msgspec
 import pandas as pd
@@ -138,7 +139,7 @@ class BybitDataClient(LiveMarketDataClient):
         for instrument_type in instrument_types:
             self._ws_clients[instrument_type] = BybitWebsocketClient(
                 clock=clock,
-                handler=lambda x: self._handle_ws_message(instrument_type, x),
+                handler=partial(self._handle_ws_message, instrument_type),
                 base_url=ws_urls[instrument_type],
                 api_key=config.api_key or get_api_key(config.testnet),
                 api_secret=config.api_secret or get_api_secret(config.testnet),

--- a/tests/integration_tests/adapters/bybit/test_ws_decoders.py
+++ b/tests/integration_tests/adapters/bybit/test_ws_decoders.py
@@ -44,8 +44,8 @@ from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerOption
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerOptionMsg
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpot
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpotMsg
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTrade
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinear
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinearMsg
 
 
 class TestBybitWsDecoders:
@@ -262,9 +262,9 @@ class TestBybitWsDecoders:
             "ws_trade.json",
         )
         assert item is not None
-        decoder = msgspec.json.Decoder(BybitWsTradeMsg)
+        decoder = msgspec.json.Decoder(BybitWsTradeLinearMsg)
         result = decoder.decode(item)
-        target_trade = BybitWsTrade(
+        target_trade = BybitWsTradeLinear(
             T=1672304486865,
             s="BTCUSDT",
             S="Buy",

--- a/tests/integration_tests/adapters/bybit/test_ws_decoders.py
+++ b/tests/integration_tests/adapters/bybit/test_ws_decoders.py
@@ -46,6 +46,8 @@ from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpot
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpotMsg
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinear
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinearMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeSpot
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeSpotMsg
 
 
 class TestBybitWsDecoders:
@@ -271,6 +273,28 @@ class TestBybitWsDecoders:
             v="0.001",
             p="16578.50",
             L="PlusTick",
+            i="20f43950-d8dd-5b31-9112-a178eb6023af",
+            BT=False,
+        )
+        assert result.data == [target_trade]
+        assert result.topic == "publicTrade.BTCUSDT"
+        assert result.type == "snapshot"
+        assert result.ts == 1672304486868
+
+    def test_ws_public_trade_spot(self):
+        item = pkgutil.get_data(
+            "tests.integration_tests.adapters.bybit.resources.ws_messages.public",
+            "ws_trade.json",
+        )
+        assert item is not None
+        decoder = msgspec.json.Decoder(BybitWsTradeSpotMsg)
+        result = decoder.decode(item)
+        target_trade = BybitWsTradeSpot(
+            T=1672304486865,
+            s="BTCUSDT",
+            S="Buy",
+            v="0.001",
+            p="16578.50",
             i="20f43950-d8dd-5b31-9112-a178eb6023af",
             BT=False,
         )


### PR DESCRIPTION
# Pull Request

Add msgspec schema's for trade messages for spot and option instruments, due to the `L` field being unique to futures and `id` being unique to options.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Locally listening to trade and quote ticks for the Bybit exchange.
