### PR TITLE
Refactor Bybit trade schema and improve websocket reconnects

### DIFF
--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -143,6 +143,7 @@ class BybitDataClient(LiveMarketDataClient):
                 base_url=ws_urls[product_type],
                 api_key=config.api_key or get_api_key(config.testnet),
                 api_secret=config.api_secret or get_api_secret(config.testnet),
+                loop=loop,
             )
 
             # WebSocket decoders

--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -147,7 +147,7 @@ class BybitDataClient(LiveMarketDataClient):
 
             # WebSocket decoders
             self._decoders["orderbook"][product_type] = decoder_ws_orderbook()
-            self._decoders["trade"][product_type] = decoder_ws_trade(product_type)
+            self._decoders["trade"][product_type] = decoder_ws_trade()
             self._decoders["ticker"][product_type] = decoder_ws_ticker(product_type)
             self._decoders["kline"][product_type] = decoder_ws_kline()
 
@@ -158,7 +158,9 @@ class BybitDataClient(LiveMarketDataClient):
         self._topic_bar_type: dict[str, BarType] = {}
 
         self._update_instrument_interval: int = 60 * 60  # Once per hour (hardcode)
+        self._ping_interval: int = 20  # Once every 20 seconds (hardcode)
         self._update_instruments_task: asyncio.Task | None = None
+        self._ping_task: asyncio.Task | None = None
 
         # Register custom endpoint for fetching tickers
         self._msgbus.register(
@@ -215,6 +217,9 @@ class BybitDataClient(LiveMarketDataClient):
         self._log.info("Initializing websocket connections")
         for ws_client in self._ws_clients.values():
             await ws_client.connect()
+
+        self._ping_task = self.create_task(self._send_ping())
+
         self._log.info("Data client connected")
 
     async def _disconnect(self) -> None:
@@ -222,6 +227,10 @@ class BybitDataClient(LiveMarketDataClient):
             self._log.debug("Cancelling `update_instruments` task")
             self._update_instruments_task.cancel()
             self._update_instruments_task = None
+
+            self._log.debug("Cancelling `ping` task")
+            self._ping_task.cancel()
+            self._ping_task = None
         for ws_client in self._ws_clients.values():
             await ws_client.disconnect()
 
@@ -244,6 +253,19 @@ class BybitDataClient(LiveMarketDataClient):
                 self._send_all_instruments_to_data_engine()
         except asyncio.CancelledError:
             self._log.debug("Canceled `update_instruments` task")
+
+    async def _send_ping(self) -> None:
+        try:
+            while True:
+                self._log.debug(
+                    f"Scheduled `ping` to run in {self._ping_interval}s",
+                )
+                await asyncio.sleep(self._ping_interval)
+
+                for ws_client in self._ws_clients.values():
+                    await ws_client.ping()
+        except asyncio.CancelledError:
+            self._log.debug("Canceled `ping` task")
 
     async def _subscribe_order_book_deltas(
         self,

--- a/nautilus_trader/adapters/bybit/execution.py
+++ b/nautilus_trader/adapters/bybit/execution.py
@@ -157,6 +157,7 @@ class BybitExecutionClient(LiveExecutionClient):
             is_private=True,
             api_key=config.api_key or get_api_key(config.testnet),
             api_secret=config.api_secret or get_api_secret(config.testnet),
+            loop=loop,
         )
 
         # Http API

--- a/nautilus_trader/adapters/bybit/schemas/ws.py
+++ b/nautilus_trader/adapters/bybit/schemas/ws.py
@@ -480,7 +480,7 @@ class BybitWsTradeSpot(msgspec.Struct):
         )
 
 
-class BybitWsTradeLinear(msgspec.Struct):
+class BybitWsTrade(msgspec.Struct):
     # The timestamp (ms) that the order is filled
     T: int
     # Symbol name
@@ -491,46 +491,22 @@ class BybitWsTradeLinear(msgspec.Struct):
     v: str
     # Trade price
     p: str
+    # Trade id
+    i: str
+    # Whether is a block trade or not
+    BT: bool
     # Direction of price change
-    L: str
-    # Trade id
-    i: str
-    # Whether is a block trade or not
-    BT: bool
-
-    def parse_to_trade_tick(
-        self,
-        instrument_id: InstrumentId,
-        ts_init: int,
-    ) -> TradeTick:
-        return TradeTick(
-            instrument_id=instrument_id,
-            price=Price.from_str(self.p),
-            size=Quantity.from_str(self.v),
-            aggressor_side=AggressorSide.SELLER if self.S == "Sell" else AggressorSide.BUYER,
-            trade_id=TradeId(str(self.i)),
-            ts_event=millis_to_nanos(self.T),
-            ts_init=ts_init,
-        )
-
-
-class BybitWsTradeOption(msgspec.Struct):
+    L: str | None = None
     # Message id unique to options
-    id: str
-    # The timestamp (ms) that the order is filled
-    T: int
-    # Symbol name
-    s: str
-    # Side of taker. Buy,Sell
-    S: str
-    # Trade size
-    v: str
-    # Trade price
-    p: str
-    # Trade id
-    i: str
-    # Whether is a block trade or not
-    BT: bool
+    id: str | None = None
+    # Mark price, unique field for option
+    mP: str | None = None
+    # Index price, unique field for option
+    iP: str | None = None
+    # Mark iv, unique field for option
+    mIv: str | None = None
+    # iv, unique field for option
+    iv: str | None = None
 
     def parse_to_trade_tick(
         self,
@@ -548,36 +524,15 @@ class BybitWsTradeOption(msgspec.Struct):
         )
 
 
-class BybitWsTradeSpotMsg(msgspec.Struct):
+class BybitWsTradeMsg(msgspec.Struct):
     topic: str
     type: str
     ts: int
-    data: list[BybitWsTradeSpot]
+    data: list[BybitWsTrade]
 
 
-class BybitWsTradeLinearMsg(msgspec.Struct):
-    topic: str
-    type: str
-    ts: int
-    data: list[BybitWsTradeLinear]
-
-
-class BybitWsTradeOptionMsg(msgspec.Struct):
-    topic: str
-    type: str
-    ts: int
-    data: list[BybitWsTradeOption]
-
-
-def decoder_ws_trade(product_type: BybitProductType) -> msgspec.json.Decoder:
-    if product_type == BybitProductType.SPOT:
-        return msgspec.json.Decoder(BybitWsTradeSpotMsg)
-    elif product_type == BybitProductType.LINEAR:
-        return msgspec.json.Decoder(BybitWsTradeLinearMsg)
-    elif product_type == BybitProductType.OPTION:
-        return msgspec.json.Decoder(BybitWsTradeOptionMsg)
-    else:
-        raise ValueError(f"Invalid product type: {product_type}")
+def decoder_ws_trade() -> msgspec.json.Decoder:
+    return msgspec.json.Decoder(BybitWsTradeMsg)
 
 
 def decoder_ws_ticker(product_type: BybitProductType) -> msgspec.json.Decoder:

--- a/nautilus_trader/adapters/bybit/websocket/client.py
+++ b/nautilus_trader/adapters/bybit/websocket/client.py
@@ -184,6 +184,13 @@ class BybitWebsocketClient:
     #     await self._client.send_text(json.dumps(sub))
     #     self._subscriptions.append(subsscription)
 
+    async def ping(self) -> None:
+        if self._client is None:
+            self._log.warning("Cannot ping: not connected")
+            return
+
+        await self._client.send_text(json.dumps({"op": "ping"}))
+
     async def subscribe_orders_update(self) -> None:
         if self._client is None:
             self._log.warning("Cannot subscribe: not connected")

--- a/nautilus_trader/adapters/bybit/websocket/client.py
+++ b/nautilus_trader/adapters/bybit/websocket/client.py
@@ -184,13 +184,6 @@ class BybitWebsocketClient:
     #     await self._client.send_text(json.dumps(sub))
     #     self._subscriptions.append(subsscription)
 
-    async def ping(self) -> None:
-        if self._client is None:
-            self._log.warning("Cannot ping: not connected")
-            return
-
-        await self._client.send_text(json.dumps({"op": "ping"}))
-
     async def subscribe_orders_update(self) -> None:
         if self._client is None:
             self._log.warning("Cannot subscribe: not connected")

--- a/tests/integration_tests/adapters/bybit/test_ws_decoders.py
+++ b/tests/integration_tests/adapters/bybit/test_ws_decoders.py
@@ -44,10 +44,8 @@ from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerOption
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerOptionMsg
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpot
 from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTickerSpotMsg
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinear
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeLinearMsg
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeSpot
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeSpotMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTrade
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeMsg
 
 
 class TestBybitWsDecoders:
@@ -264,37 +262,15 @@ class TestBybitWsDecoders:
             "ws_trade.json",
         )
         assert item is not None
-        decoder = msgspec.json.Decoder(BybitWsTradeLinearMsg)
+        decoder = msgspec.json.Decoder(BybitWsTradeMsg)
         result = decoder.decode(item)
-        target_trade = BybitWsTradeLinear(
+        target_trade = BybitWsTrade(
             T=1672304486865,
             s="BTCUSDT",
             S="Buy",
             v="0.001",
             p="16578.50",
             L="PlusTick",
-            i="20f43950-d8dd-5b31-9112-a178eb6023af",
-            BT=False,
-        )
-        assert result.data == [target_trade]
-        assert result.topic == "publicTrade.BTCUSDT"
-        assert result.type == "snapshot"
-        assert result.ts == 1672304486868
-
-    def test_ws_public_trade_spot(self):
-        item = pkgutil.get_data(
-            "tests.integration_tests.adapters.bybit.resources.ws_messages.public",
-            "ws_trade.json",
-        )
-        assert item is not None
-        decoder = msgspec.json.Decoder(BybitWsTradeSpotMsg)
-        result = decoder.decode(item)
-        target_trade = BybitWsTradeSpot(
-            T=1672304486865,
-            s="BTCUSDT",
-            S="Buy",
-            v="0.001",
-            p="16578.50",
             i="20f43950-d8dd-5b31-9112-a178eb6023af",
             BT=False,
         )


### PR DESCRIPTION
# Pull Request

Refactor the data schema for the trade message using optional fields for futures and option messages.

Resubscribe to all subscription feeds when reconnecting. 

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

pre-commit and locally subscribing to the trade and quote ticks.