### PR TITLE
Finish missing pyo3 Rust Orders

### DIFF
--- a/nautilus_core/core/src/nanos.rs
+++ b/nautilus_core/core/src/nanos.rs
@@ -17,6 +17,7 @@ use std::{
     cmp::Ordering,
     fmt::Display,
     ops::{Add, AddAssign, Deref, MulAssign, Sub, SubAssign},
+    str::FromStr,
 };
 
 use serde::{Deserialize, Serialize};
@@ -73,6 +74,20 @@ impl PartialOrd<Option<u64>> for UnixNanos {
 impl From<u64> for UnixNanos {
     fn from(value: u64) -> Self {
         UnixNanos(value)
+    }
+}
+
+impl From<&str> for UnixNanos {
+    fn from(value: &str) -> Self {
+        UnixNanos(value.parse().unwrap())
+    }
+}
+
+impl FromStr for UnixNanos {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(UnixNanos)
     }
 }
 

--- a/nautilus_core/model/src/python/orders/limit_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/limit_if_touched.rs
@@ -1,0 +1,99 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+
+use std::collections::HashMap;
+use pyo3::prelude::*;
+use ustr::Ustr;
+use nautilus_core::uuid::UUID4;
+use crate::enums::{ContingencyType, OrderSide, TimeInForce, TriggerType};
+use crate::identifiers::client_order_id::ClientOrderId;
+use crate::identifiers::exec_algorithm_id::ExecAlgorithmId;
+use crate::identifiers::instrument_id::InstrumentId;
+use crate::identifiers::order_list_id::OrderListId;
+use crate::identifiers::strategy_id::StrategyId;
+use crate::identifiers::trader_id::TraderId;
+use crate::orders::base::str_hashmap_to_ustr;
+use crate::orders::limit_if_touched::LimitIfTouchedOrder;
+use crate::types::price::Price;
+use crate::types::quantity::Quantity;
+
+#[pymethods]
+impl LimitIfTouchedOrder{
+    #[new]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(
+            Self::new(
+                trader_id,
+                strategy_id,
+                instrument_id,
+                client_order_id,
+                order_side,
+                quantity,
+                price,
+                trigger_price,
+                trigger_type,
+                time_in_force,
+                expire_time.map(|x| x.into()),
+                post_only,
+                reduce_only,
+                quote_quantity,
+                display_qty,
+                emulation_trigger,
+                trigger_instrument_id,
+                contingency_type,
+                order_list_id,
+                linked_order_ids,
+                parent_order_id,
+                exec_algorithm_id,
+                exec_algorithm_params,
+                exec_spawn_id,
+                tags.map(|s| Ustr::from(&s)),
+                init_id,
+                ts_init.into(),
+            ).unwrap()
+        )
+    }
+}

--- a/nautilus_core/model/src/python/orders/limit_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/limit_if_touched.rs
@@ -13,26 +13,27 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-
 use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
 use pyo3::prelude::*;
 use ustr::Ustr;
-use nautilus_core::uuid::UUID4;
-use crate::enums::{ContingencyType, OrderSide, TimeInForce, TriggerType};
-use crate::identifiers::client_order_id::ClientOrderId;
-use crate::identifiers::exec_algorithm_id::ExecAlgorithmId;
-use crate::identifiers::instrument_id::InstrumentId;
-use crate::identifiers::order_list_id::OrderListId;
-use crate::identifiers::strategy_id::StrategyId;
-use crate::identifiers::trader_id::TraderId;
-use crate::orders::base::str_hashmap_to_ustr;
-use crate::orders::limit_if_touched::LimitIfTouchedOrder;
-use crate::types::price::Price;
-use crate::types::quantity::Quantity;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, limit_if_touched::LimitIfTouchedOrder},
+    types::{price::Price, quantity::Quantity},
+};
 
 #[pymethods]
-impl LimitIfTouchedOrder{
+impl LimitIfTouchedOrder {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     fn py_new(
         trader_id: TraderId,
         strategy_id: StrategyId,
@@ -61,39 +62,37 @@ impl LimitIfTouchedOrder{
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<String>,
-
     ) -> PyResult<Self> {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Ok(
-            Self::new(
-                trader_id,
-                strategy_id,
-                instrument_id,
-                client_order_id,
-                order_side,
-                quantity,
-                price,
-                trigger_price,
-                trigger_type,
-                time_in_force,
-                expire_time.map(|x| x.into()),
-                post_only,
-                reduce_only,
-                quote_quantity,
-                display_qty,
-                emulation_trigger,
-                trigger_instrument_id,
-                contingency_type,
-                order_list_id,
-                linked_order_ids,
-                parent_order_id,
-                exec_algorithm_id,
-                exec_algorithm_params,
-                exec_spawn_id,
-                tags.map(|s| Ustr::from(&s)),
-                init_id,
-                ts_init.into(),
-            ).unwrap()
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            price,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            post_only,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
         )
+        .unwrap())
     }
 }

--- a/nautilus_core/model/src/python/orders/market.rs
+++ b/nautilus_core/model/src/python/orders/market.rs
@@ -64,6 +64,7 @@ impl MarketOrder {
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<String>,
     ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
         Self::new(
             trader_id,
             strategy_id,
@@ -81,7 +82,7 @@ impl MarketOrder {
             linked_order_ids,
             parent_order_id,
             exec_algorithm_id,
-            exec_algorithm_params.map(str_hashmap_to_ustr),
+            exec_algorithm_params,
             exec_spawn_id,
             tags.map(|s| Ustr::from(&s)),
         )

--- a/nautilus_core/model/src/python/orders/market_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/market_if_touched.rs
@@ -1,0 +1,94 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
+use pyo3::prelude::*;
+use ustr::Ustr;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, market_if_touched::MarketIfTouchedOrder},
+    types::{price::Price, quantity::Quantity},
+};
+
+#[pymethods]
+impl MarketIfTouchedOrder {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
+        )
+        .unwrap())
+    }
+}

--- a/nautilus_core/model/src/python/orders/market_to_limit.rs
+++ b/nautilus_core/model/src/python/orders/market_to_limit.rs
@@ -1,0 +1,88 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
+use pyo3::prelude::*;
+use ustr::Ustr;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, market_to_limit::MarketToLimitOrder},
+    types::quantity::Quantity,
+};
+
+#[pymethods]
+impl MarketToLimitOrder {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            post_only,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
+        )
+        .unwrap())
+    }
+}

--- a/nautilus_core/model/src/python/orders/mod.rs
+++ b/nautilus_core/model/src/python/orders/mod.rs
@@ -14,11 +14,11 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod limit;
+pub mod limit_if_touched;
 pub mod market;
+pub mod market_if_touched;
+pub mod market_to_limit;
 pub mod stop_limit;
-mod limit_if_touched;
-mod market_if_touched;
-mod market_to_limit;
-mod stop_market;
-mod trailing_stop_market;
-mod trailing_stop_limit;
+pub mod stop_market;
+pub mod trailing_stop_limit;
+pub mod trailing_stop_market;

--- a/nautilus_core/model/src/python/orders/mod.rs
+++ b/nautilus_core/model/src/python/orders/mod.rs
@@ -16,3 +16,9 @@
 pub mod limit;
 pub mod market;
 pub mod stop_limit;
+mod limit_if_touched;
+mod market_if_touched;
+mod market_to_limit;
+mod stop_market;
+mod trailing_stop_market;
+mod trailing_stop_limit;

--- a/nautilus_core/model/src/python/orders/stop_limit.rs
+++ b/nautilus_core/model/src/python/orders/stop_limit.rs
@@ -79,7 +79,7 @@ impl StopLimitOrder {
             trigger_price,
             trigger_type,
             time_in_force,
-            expire_time.map(UnixNanos::from),
+            expire_time.map(|x| x.into()),
             post_only,
             reduce_only,
             quote_quantity,

--- a/nautilus_core/model/src/python/orders/stop_market.rs
+++ b/nautilus_core/model/src/python/orders/stop_market.rs
@@ -1,0 +1,94 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
+use pyo3::prelude::*;
+use ustr::Ustr;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, stop_market::StopMarketOrder},
+    types::{price::Price, quantity::Quantity},
+};
+
+#[pymethods]
+impl StopMarketOrder {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
+        )
+        .unwrap())
+    }
+}

--- a/nautilus_core/model/src/python/orders/trailing_stop_limit.rs
+++ b/nautilus_core/model/src/python/orders/trailing_stop_limit.rs
@@ -1,0 +1,104 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
+use pyo3::prelude::*;
+use ustr::Ustr;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce, TrailingOffsetType, TriggerType},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, trailing_stop_limit::TrailingStopLimitOrder},
+    types::{price::Price, quantity::Quantity},
+};
+
+#[pymethods]
+impl TrailingStopLimitOrder {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        limit_offset: Price,
+        trailing_offset: Price,
+        trailing_offset_type: TrailingOffsetType,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            price,
+            trigger_price,
+            trigger_type,
+            limit_offset,
+            trailing_offset,
+            trailing_offset_type,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            post_only,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
+        )
+        .unwrap())
+    }
+}

--- a/nautilus_core/model/src/python/orders/trailing_stop_market.rs
+++ b/nautilus_core/model/src/python/orders/trailing_stop_market.rs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use nautilus_core::uuid::UUID4;
+use pyo3::prelude::*;
+use ustr::Ustr;
+
+use crate::{
+    enums::{ContingencyType, OrderSide, TimeInForce, TrailingOffsetType, TriggerType},
+    identifiers::{
+        client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
+        instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
+        trader_id::TraderId,
+    },
+    orders::{base::str_hashmap_to_ustr, trailing_stop_market::TrailingStopMarketOrder},
+    types::{price::Price, quantity::Quantity},
+};
+
+#[pymethods]
+impl TrailingStopMarketOrder {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        trailing_offset: Price,
+        trailing_offset_type: TrailingOffsetType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: u64,
+        expire_time: Option<u64>,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<String, String>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<String>,
+    ) -> PyResult<Self> {
+        let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
+        Ok(Self::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type,
+            trailing_offset,
+            trailing_offset_type,
+            time_in_force,
+            expire_time.map(|x| x.into()),
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags.map(|s| Ustr::from(&s)),
+            init_id,
+            ts_init.into(),
+        )
+        .unwrap())
+    }
+}

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -962,7 +962,37 @@ class LimitOrder:
     def from_dict(cls, values: dict[str, str]) -> LimitOrder: ...
 
 
-class LimitIfTouchedOrder: ...
+class LimitIfTouchedOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        emulation_trigger: TriggerType | None = None,
+        trigger_instrument_id: InstrumentId | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ) -> None: ...
 
 class MarketOrder:
     def __init__(
@@ -975,13 +1005,13 @@ class MarketOrder:
         quantity: Quantity,
         init_id: UUID4,
         ts_init: int,
-        time_in_force: TimeInForce = ...,
-        reduce_only: bool = False,
-        quote_quantity: bool = False,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
         contingency_type: ContingencyType | None = None,
         order_list_id: OrderListId | None = None,
         linked_order_ids: list[ClientOrderId] | None = None,
-        parent_order_id: ClientOrderId | None = None,
+        parent_order_id: ClientOrderId | None  = None,
         exec_algorithm_id: ExecAlgorithmId | None = None,
         exec_algorithm_params: dict[str, str] | None = None,
         exec_spawn_id: ClientOrderId | None = None,
@@ -1023,7 +1053,62 @@ class MarketOrder:
     @property
     def price(self) -> Price | None: ...
 
-class MarketToLimitOrder: ...
+class MarketToLimitOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ): ...
+
+class MarketIfTouchedOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        emulation_trigger: TriggerType | None = None,
+        trigger_instrument_id: InstrumentId | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ): ...
 class StopLimitOrder:
     def __init__(
         self,
@@ -1103,9 +1188,100 @@ class StopLimitOrder:
     @property
     def expire_time(self) -> int | None: ...
 
-class StopMarketOrder: ...
-class TrailingStopLimitOrder: ...
-class TrailingStopMarketOrder: ...
+class StopMarketOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        emulation_trigger: TriggerType | None = None,
+        trigger_instrument_id: InstrumentId | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ): ...
+class TrailingStopLimitOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        limit_offset: Price,
+        trailing_offset: Price,
+        trailing_offset_type: TrailingOffsetType,
+        time_in_force: TimeInForce,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        emulation_trigger: TriggerType | None = None,
+        trigger_instrument_id: InstrumentId | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ): ...
+class TrailingStopMarketOrder:
+    def __init__(
+        self,
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        trailing_offset: Price,
+        trailing_offset_type: TrailingOffsetType,
+        time_in_force: TimeInForce,
+        reduce_only: bool,
+        quote_quantity: bool,
+        init_id: UUID4,
+        ts_init: int,
+        expire_time: int | None = None,
+        display_qty: Quantity | None = None,
+        emulation_trigger: TriggerType | None = None,
+        trigger_instrument_id: InstrumentId | None = None,
+        contingency_type: ContingencyType | None = None,
+        order_list_id: OrderListId | None = None,
+        linked_order_ids: list[ClientOrderId] | None = None,
+        parent_order_id: ClientOrderId | None = None,
+        exec_algorithm_id: ExecAlgorithmId | None = None,
+        exec_algorithm_params: dict[str, str] | None = None,
+        exec_spawn_id: ClientOrderId | None = None,
+        tags: str | None = None,
+    ): ...
 
 ### Objects
 


### PR DESCRIPTION
# Pull Request

- added `From<&str>` and `FromStr` traits for `UnixNanos`
- added remaining pyo3 orders and type them in `nautilus_pyo3.pyi` file
