### PR TITLE
Implement Fallback to Bar Price in Cache and Portfolio when Ticks unavailable

### DIFF
--- a/nautilus_trader/cache/cache.pxd
+++ b/nautilus_trader/cache/cache.pxd
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 from cpython.datetime cimport datetime
+from cpython.datetime cimport timedelta
 from libc.stdint cimport uint64_t
 
 from nautilus_trader.accounting.accounts.base cimport Account
@@ -22,6 +23,7 @@ from nautilus_trader.cache.base cimport CacheFacade
 from nautilus_trader.cache.facade cimport CacheDatabaseFacade
 from nautilus_trader.common.actor cimport Actor
 from nautilus_trader.common.component cimport Logger
+from nautilus_trader.core.rust.model cimport AggregationSource
 from nautilus_trader.core.rust.model cimport OmsType
 from nautilus_trader.core.rust.model cimport OrderSide
 from nautilus_trader.core.rust.model cimport PositionSide
@@ -29,6 +31,7 @@ from nautilus_trader.execution.messages cimport SubmitOrder
 from nautilus_trader.execution.messages cimport SubmitOrderList
 from nautilus_trader.model.book cimport OrderBook
 from nautilus_trader.model.data cimport Bar
+from nautilus_trader.model.data cimport BarType
 from nautilus_trader.model.data cimport QuoteTick
 from nautilus_trader.model.data cimport TradeTick
 from nautilus_trader.model.identifiers cimport AccountId
@@ -175,3 +178,12 @@ cdef class Cache(CacheFacade):
     cpdef void delete_strategy(self, Strategy strategy)
 
     cpdef void heartbeat(self, datetime timestamp)
+
+    cdef timedelta _get_timedelta(self, BarType bar_type)
+
+    cpdef list bar_types(
+        self,
+        InstrumentId instrument_id=*,
+        object price_type=*,
+        AggregationSource aggregation_source=*,
+    )

--- a/nautilus_trader/test_kit/stubs/data.py
+++ b/nautilus_trader/test_kit/stubs/data.py
@@ -121,6 +121,10 @@ class TestDataStubs:
         return BarSpecification(1, BarAggregation.MINUTE, PriceType.BID)
 
     @staticmethod
+    def bar_spec_5min_bid() -> BarSpecification:
+        return BarSpecification(5, BarAggregation.MINUTE, PriceType.BID)
+
+    @staticmethod
     def bar_spec_1min_ask() -> BarSpecification:
         return BarSpecification(1, BarAggregation.MINUTE, PriceType.ASK)
 
@@ -143,6 +147,10 @@ class TestDataStubs:
     @staticmethod
     def bartype_audusd_1min_bid() -> BarType:
         return BarType(TestIdStubs.audusd_id(), TestDataStubs.bar_spec_1min_bid())
+
+    @staticmethod
+    def bartype_audusd_5min_bid() -> BarType:
+        return BarType(TestIdStubs.audusd_id(), TestDataStubs.bar_spec_5min_bid())
 
     @staticmethod
     def bartype_audusd_1min_ask() -> BarType:
@@ -184,6 +192,19 @@ class TestDataStubs:
             high=Price.from_str("1.00004"),
             low=Price.from_str("1.00001"),
             close=Price.from_str("1.00003"),
+            volume=Quantity.from_int(1_000_000),
+            ts_event=0,
+            ts_init=0,
+        )
+
+    @staticmethod
+    def bar_5decimal_5min_bid() -> Bar:
+        return Bar(
+            bar_type=TestDataStubs.bartype_audusd_5min_bid(),
+            open=Price.from_str("1.00101"),
+            high=Price.from_str("1.00208"),
+            low=Price.from_str("1.00100"),
+            close=Price.from_str("1.00205"),
             volume=Quantity.from_int(1_000_000),
             ts_event=0,
             ts_init=0,


### PR DESCRIPTION
# Pull Request

Implement Fallback to Bar Price in Cache and Portfolio when Ticks unavailable as proposed in #1480.

## Type of change

Delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added tests.
