### PR TITLE
Fixed Commission Charging Behavior in FixedFeeModel

### DIFF
--- a/nautilus_trader/backtest/models.pxd
+++ b/nautilus_trader/backtest/models.pxd
@@ -57,3 +57,5 @@ cdef class MakerTakerFeeModel(FeeModel):
 
 cdef class FixedFeeModel(FeeModel):
     cdef Money _commission
+    cdef Money _zero_commission
+    cdef bint _charge_commission_once


### PR DESCRIPTION
# Pull Request

This PR addresses a bug in the `FixedFeeModel` where a commission was incorrectly charged for every fill. The default behavior has now been corrected to charge a commission per order. Additionally, users can opt to set `charge_commission_once=True` to enable commission charges per fill.

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Updated tests.