### PR TITLE
Fix method from_pyo3_c in Currency pair for lot_size conversion 

### DIFF
--- a/nautilus_trader/model/instruments/currency_pair.pyx
+++ b/nautilus_trader/model/instruments/currency_pair.pyx
@@ -297,7 +297,7 @@ cdef class CurrencyPair(Instrument):
             size_precision=pyo3_instrument.size_precision,
             price_increment=Price.from_raw_c(pyo3_instrument.price_increment.raw, pyo3_instrument.price_precision),
             size_increment=Quantity.from_raw_c(pyo3_instrument.size_increment.raw, pyo3_instrument.size_precision),
-            lot_size=Quantity.from_str_c(pyo3_instrument.lot_size) if pyo3_instrument.lot_size is not None else None,
+            lot_size=Quantity.from_raw_c(pyo3_instrument.lot_size.raw,pyo3_instrument.lot_size.precision) if pyo3_instrument.lot_size is not None else None,
             max_quantity=Quantity.from_raw_c(pyo3_instrument.max_quantity.raw, pyo3_instrument.max_quantity.precision) if pyo3_instrument.max_quantity is not None else None,
             min_quantity=Quantity.from_raw_c(pyo3_instrument.min_quantity.raw, pyo3_instrument.min_quantity.precision) if pyo3_instrument.min_quantity is not None else None,
             max_notional=Money.from_str_c(str(pyo3_instrument.max_notional)) if pyo3_instrument.max_notional is not None else None,


### PR DESCRIPTION
# Pull Request

- in `CurrencyPair` class `lot_size` field should use `Quantity.from_raw_c` for the correct conversion

