### PR TITLE
Refactor create method method in orders for Cython and Rust

### DIFF
--- a/nautilus_core/model/src/python/orders/limit.rs
+++ b/nautilus_core/model/src/python/orders/limit.rs
@@ -28,6 +28,7 @@ use crate::{
         ContingencyType, LiquiditySide, OrderSide, OrderStatus, OrderType, PositionSide,
         TimeInForce, TriggerType,
     },
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -116,6 +117,12 @@ impl LimitOrder {
 
     fn __repr__(&self) -> String {
         self.to_string()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(LimitOrder::from(init))
     }
 
     #[getter]

--- a/nautilus_core/model/src/python/orders/limit_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/limit_if_touched.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -94,5 +95,11 @@ impl LimitIfTouchedOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(LimitIfTouchedOrder::from(init))
     }
 }

--- a/nautilus_core/model/src/python/orders/market.rs
+++ b/nautilus_core/model/src/python/orders/market.rs
@@ -27,6 +27,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, OrderType, PositionSide, TimeInForce},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         account_id::AccountId, client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -103,6 +104,12 @@ impl MarketOrder {
 
     fn __repr__(&self) -> String {
         self.to_string()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(MarketOrder::from(init))
     }
 
     #[pyo3(name = "signed_decimal_qty")]

--- a/nautilus_core/model/src/python/orders/market_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/market_if_touched.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -90,5 +91,11 @@ impl MarketIfTouchedOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(MarketIfTouchedOrder::from(init))
     }
 }

--- a/nautilus_core/model/src/python/orders/market_to_limit.rs
+++ b/nautilus_core/model/src/python/orders/market_to_limit.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -84,5 +85,11 @@ impl MarketToLimitOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(MarketToLimitOrder::from(init))
     }
 }

--- a/nautilus_core/model/src/python/orders/stop_limit.rs
+++ b/nautilus_core/model/src/python/orders/stop_limit.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, OrderStatus, OrderType, TimeInForce, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -113,6 +114,12 @@ impl StopLimitOrder {
 
     fn __repr__(&self) -> String {
         self.to_string()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(StopLimitOrder::from(init))
     }
 
     #[getter]

--- a/nautilus_core/model/src/python/orders/stop_market.rs
+++ b/nautilus_core/model/src/python/orders/stop_market.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -90,5 +91,11 @@ impl StopMarketOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(StopMarketOrder::from(init))
     }
 }

--- a/nautilus_core/model/src/python/orders/trailing_stop_limit.rs
+++ b/nautilus_core/model/src/python/orders/trailing_stop_limit.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce, TrailingOffsetType, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -100,5 +101,11 @@ impl TrailingStopLimitOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(TrailingStopLimitOrder::from(init))
     }
 }

--- a/nautilus_core/model/src/python/orders/trailing_stop_market.rs
+++ b/nautilus_core/model/src/python/orders/trailing_stop_market.rs
@@ -21,6 +21,7 @@ use ustr::Ustr;
 
 use crate::{
     enums::{ContingencyType, OrderSide, TimeInForce, TrailingOffsetType, TriggerType},
+    events::order::initialized::OrderInitialized,
     identifiers::{
         client_order_id::ClientOrderId, exec_algorithm_id::ExecAlgorithmId,
         instrument_id::InstrumentId, order_list_id::OrderListId, strategy_id::StrategyId,
@@ -94,5 +95,11 @@ impl TrailingStopMarketOrder {
             ts_init.into(),
         )
         .unwrap())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "create")]
+    fn py_create(init: OrderInitialized) -> PyResult<Self> {
+        Ok(TrailingStopMarketOrder::from(init))
     }
 }

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -909,6 +909,8 @@ class LimitOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> LimitOrder: ...
     def to_dict(self) -> dict[str, str]: ...
     @property
     def trader_id(self) -> TraderId: ...
@@ -993,6 +995,8 @@ class LimitIfTouchedOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ) -> None: ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> LimitIfTouchedOrder: ...
 
 class MarketOrder:
     def __init__(
@@ -1017,6 +1021,8 @@ class MarketOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ) -> None: ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> MarketOrder: ...
     def to_dict(self) -> dict[str, str]: ...
     @classmethod
     def from_dict(cls, values: dict[str, str]) -> MarketOrder: ...
@@ -1079,6 +1085,8 @@ class MarketToLimitOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> MarketToLimitOrder: ...
 
 class MarketIfTouchedOrder:
     def __init__(
@@ -1109,6 +1117,9 @@ class MarketIfTouchedOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> MarketIfTouchedOrder: ...
+
 class StopLimitOrder:
     def __init__(
         self,
@@ -1140,6 +1151,8 @@ class StopLimitOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> StopLimitOrder: ...
     @classmethod
     def from_dict(cls, values: dict[str, str]) -> StopLimitOrder: ...
     def to_dict(self) -> dict[str, str]: ...
@@ -1217,6 +1230,8 @@ class StopMarketOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> StopMarketOrder: ...
 class TrailingStopLimitOrder:
     def __init__(
         self,
@@ -1251,6 +1266,8 @@ class TrailingStopLimitOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> TrailingStopLimitOrder: ...
 class TrailingStopMarketOrder:
     def __init__(
         self,
@@ -1282,6 +1299,8 @@ class TrailingStopMarketOrder:
         exec_spawn_id: ClientOrderId | None = None,
         tags: str | None = None,
     ): ...
+    @classmethod
+    def create(cls, init: OrderInitialized) -> TrailingStopMarketOrder: ...
 
 ### Objects
 

--- a/nautilus_trader/model/orders/limit.pxd
+++ b/nautilus_trader/model/orders/limit.pxd
@@ -30,7 +30,7 @@ cdef class LimitOrder(Order):
     """The quantity of the order to display on the public book (iceberg).\n\n:returns: `Quantity` or ``None``"""
 
     @staticmethod
-    cdef LimitOrder create(OrderInitialized init)
+    cdef LimitOrder create_c(OrderInitialized init)
 
     @staticmethod
     cdef LimitOrder transform(Order order, uint64_t ts_init, Price price=*)

--- a/nautilus_trader/model/orders/limit.pyx
+++ b/nautilus_trader/model/orders/limit.pyx
@@ -346,7 +346,7 @@ cdef class LimitOrder(Order):
         }
 
     @staticmethod
-    cdef LimitOrder create(OrderInitialized init):
+    cdef LimitOrder create_c(OrderInitialized init):
         """
         Return a `Limit` order from the given initialized event.
 
@@ -397,6 +397,10 @@ cdef class LimitOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(OrderInitialized init):
+        return LimitOrder.create_c(init)
 
     @staticmethod
     cdef LimitOrder transform(Order order, uint64_t ts_init, Price price = None):

--- a/nautilus_trader/model/orders/limit_if_touched.pxd
+++ b/nautilus_trader/model/orders/limit_if_touched.pxd
@@ -39,4 +39,4 @@ cdef class LimitIfTouchedOrder(Order):
     """The UNIX timestamp (nanoseconds) when the order was triggered (0 if not triggered).\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef LimitIfTouchedOrder create(OrderInitialized init)
+    cdef LimitIfTouchedOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/limit_if_touched.pyx
+++ b/nautilus_trader/model/orders/limit_if_touched.pyx
@@ -339,7 +339,7 @@ cdef class LimitIfTouchedOrder(Order):
         }
 
     @staticmethod
-    cdef LimitIfTouchedOrder create(OrderInitialized init):
+    cdef LimitIfTouchedOrder create_c(OrderInitialized init):
         """
         Return a `Limit-If-Touched` order from the given initialized event.
 
@@ -392,3 +392,7 @@ cdef class LimitIfTouchedOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return LimitIfTouchedOrder.create_c(init)

--- a/nautilus_trader/model/orders/market.pxd
+++ b/nautilus_trader/model/orders/market.pxd
@@ -21,7 +21,7 @@ from nautilus_trader.model.orders.base cimport Order
 
 cdef class MarketOrder(Order):
     @staticmethod
-    cdef MarketOrder create(OrderInitialized init)
+    cdef MarketOrder create_c(OrderInitialized init)
 
     @staticmethod
     cdef MarketOrder transform(Order order, uint64_t ts_init)

--- a/nautilus_trader/model/orders/market.pyx
+++ b/nautilus_trader/model/orders/market.pyx
@@ -266,7 +266,7 @@ cdef class MarketOrder(Order):
         }
 
     @staticmethod
-    cdef MarketOrder create(OrderInitialized init):
+    cdef MarketOrder create_c(OrderInitialized init):
         """
         Return a `market` order from the given initialized event.
 
@@ -309,6 +309,10 @@ cdef class MarketOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return MarketOrder.create_c(init)
 
     @staticmethod
     cdef MarketOrder transform(Order order, uint64_t ts_init):

--- a/nautilus_trader/model/orders/market_if_touched.pxd
+++ b/nautilus_trader/model/orders/market_if_touched.pxd
@@ -30,4 +30,4 @@ cdef class MarketIfTouchedOrder(Order):
     """The order expiration (UNIX epoch nanoseconds), zero for no expiration.\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef MarketIfTouchedOrder create(OrderInitialized init)
+    cdef MarketIfTouchedOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/market_if_touched.pyx
+++ b/nautilus_trader/model/orders/market_if_touched.pyx
@@ -305,7 +305,7 @@ cdef class MarketIfTouchedOrder(Order):
         }
 
     @staticmethod
-    cdef MarketIfTouchedOrder create(OrderInitialized init):
+    cdef MarketIfTouchedOrder create_c(OrderInitialized init):
         """
         Return a `Market-If-Touched` order from the given initialized event.
 
@@ -353,3 +353,7 @@ cdef class MarketIfTouchedOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return MarketIfTouchedOrder.create_c(init)

--- a/nautilus_trader/model/orders/market_to_limit.pxd
+++ b/nautilus_trader/model/orders/market_to_limit.pxd
@@ -30,4 +30,4 @@ cdef class MarketToLimitOrder(Order):
     """The quantity of the limit order to display on the public book (iceberg).\n\n:returns: `Quantity` or ``None``"""
 
     @staticmethod
-    cdef MarketToLimitOrder create(OrderInitialized init)
+    cdef MarketToLimitOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/market_to_limit.pyx
+++ b/nautilus_trader/model/orders/market_to_limit.pyx
@@ -282,7 +282,7 @@ cdef class MarketToLimitOrder(Order):
         }
 
     @staticmethod
-    cdef MarketToLimitOrder create(OrderInitialized init):
+    cdef MarketToLimitOrder create_c(OrderInitialized init):
         """
         Return a `Market-To-Limit` order from the given initialized event.
 
@@ -329,3 +329,7 @@ cdef class MarketToLimitOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return MarketToLimitOrder.create_c(init)

--- a/nautilus_trader/model/orders/stop_limit.pxd
+++ b/nautilus_trader/model/orders/stop_limit.pxd
@@ -39,7 +39,7 @@ cdef class StopLimitOrder(Order):
     """The UNIX timestamp (nanoseconds) when the order was triggered (0 if not triggered).\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef StopLimitOrder create(OrderInitialized init)
+    cdef StopLimitOrder create_c(OrderInitialized init)
 
     @staticmethod
     cdef StopLimitOrder from_pyo3_c(pyo3_order)

--- a/nautilus_trader/model/orders/stop_limit.pyx
+++ b/nautilus_trader/model/orders/stop_limit.pyx
@@ -381,7 +381,7 @@ cdef class StopLimitOrder(Order):
         }
 
     @staticmethod
-    cdef StopLimitOrder create(OrderInitialized init):
+    cdef StopLimitOrder create_c(OrderInitialized init):
         """
         Return a `Stop-Limit` order from the given initialized event.
 
@@ -434,3 +434,7 @@ cdef class StopLimitOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return StopLimitOrder.create_c(init)

--- a/nautilus_trader/model/orders/stop_market.pxd
+++ b/nautilus_trader/model/orders/stop_market.pxd
@@ -30,4 +30,4 @@ cdef class StopMarketOrder(Order):
     """The order expiration (UNIX epoch nanoseconds), zero for no expiration.\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef StopMarketOrder create(OrderInitialized init)
+    cdef StopMarketOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/stop_market.pyx
+++ b/nautilus_trader/model/orders/stop_market.pyx
@@ -310,7 +310,7 @@ cdef class StopMarketOrder(Order):
         }
 
     @staticmethod
-    cdef StopMarketOrder create(OrderInitialized init):
+    cdef StopMarketOrder create_c(OrderInitialized init):
         """
         Return a `Stop-Market` order from the given initialized event.
 
@@ -358,3 +358,7 @@ cdef class StopMarketOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return StopMarketOrder.create_c(init)

--- a/nautilus_trader/model/orders/trailing_stop_limit.pxd
+++ b/nautilus_trader/model/orders/trailing_stop_limit.pxd
@@ -46,4 +46,4 @@ cdef class TrailingStopLimitOrder(Order):
     """The UNIX timestamp (nanoseconds) when the order was triggered (0 if not triggered).\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef TrailingStopLimitOrder create(OrderInitialized init)
+    cdef TrailingStopLimitOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/trailing_stop_limit.pyx
+++ b/nautilus_trader/model/orders/trailing_stop_limit.pyx
@@ -356,7 +356,7 @@ cdef class TrailingStopLimitOrder(Order):
         }
 
     @staticmethod
-    cdef TrailingStopLimitOrder create(OrderInitialized init):
+    cdef TrailingStopLimitOrder create_c(OrderInitialized init):
         """
         Return a `Trailing-Stop-Limit` order from the given initialized event.
 
@@ -414,3 +414,7 @@ cdef class TrailingStopLimitOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return TrailingStopLimitOrder.create_c(init)

--- a/nautilus_trader/model/orders/trailing_stop_market.pxd
+++ b/nautilus_trader/model/orders/trailing_stop_market.pxd
@@ -35,4 +35,4 @@ cdef class TrailingStopMarketOrder(Order):
     """The order expiration (UNIX epoch nanoseconds), zero for no expiration.\n\n:returns: `uint64_t`"""
 
     @staticmethod
-    cdef TrailingStopMarketOrder create(OrderInitialized init)
+    cdef TrailingStopMarketOrder create_c(OrderInitialized init)

--- a/nautilus_trader/model/orders/trailing_stop_market.pyx
+++ b/nautilus_trader/model/orders/trailing_stop_market.pyx
@@ -319,7 +319,7 @@ cdef class TrailingStopMarketOrder(Order):
         }
 
     @staticmethod
-    cdef TrailingStopMarketOrder create(OrderInitialized init):
+    cdef TrailingStopMarketOrder create_c(OrderInitialized init):
         """
         Return a `Trailing-Stop-Market` order from the given initialized event.
 
@@ -371,3 +371,7 @@ cdef class TrailingStopMarketOrder(Order):
             exec_spawn_id=init.exec_spawn_id,
             tags=init.tags,
         )
+
+    @staticmethod
+    def create(init):
+        return TrailingStopMarketOrder.create_c(init)

--- a/nautilus_trader/model/orders/unpacker.pyx
+++ b/nautilus_trader/model/orders/unpacker.pyx
@@ -42,23 +42,23 @@ cdef class OrderUnpacker:
     @staticmethod
     cdef Order from_init_c(OrderInitialized init):
         if init.order_type == OrderType.MARKET:
-            return MarketOrder.create(init=init)
+            return MarketOrder.create_c(init=init)
         elif init.order_type == OrderType.LIMIT:
-            return LimitOrder.create(init=init)
+            return LimitOrder.create_c(init=init)
         elif init.order_type == OrderType.STOP_MARKET:
-            return StopMarketOrder.create(init=init)
+            return StopMarketOrder.create_c(init=init)
         elif init.order_type == OrderType.STOP_LIMIT:
-            return StopLimitOrder.create(init=init)
+            return StopLimitOrder.create_c(init=init)
         elif init.order_type == OrderType.MARKET_TO_LIMIT:
-            return MarketToLimitOrder.create(init=init)
+            return MarketToLimitOrder.create_c(init=init)
         elif init.order_type == OrderType.MARKET_IF_TOUCHED:
-            return MarketIfTouchedOrder.create(init=init)
+            return MarketIfTouchedOrder.create_c(init=init)
         elif init.order_type == OrderType.LIMIT_IF_TOUCHED:
-            return LimitIfTouchedOrder.create(init=init)
+            return LimitIfTouchedOrder.create_c(init=init)
         elif init.order_type == OrderType.TRAILING_STOP_MARKET:
-            return TrailingStopMarketOrder.create(init=init)
+            return TrailingStopMarketOrder.create_c(init=init)
         elif init.order_type == OrderType.TRAILING_STOP_LIMIT:
-            return TrailingStopLimitOrder.create(init=init)
+            return TrailingStopLimitOrder.create_c(init=init)
         else:
             raise RuntimeError("invalid `OrderType`")  # pragma: no cover (design-time error)
 


### PR DESCRIPTION
# Pull Request

- follow Cython convention and call function which are call from C code with `_c`, with that refactor which can add python functions `create` on orders classes
- add Rust `create` method and export it with pyo3