### PR TITLE
Nautilus CLI

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.5'
+
+services:
+  postgres:
+    container_name: nautilus-database
+    image: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-postgres}
+      PGDATA: /data/postgres
+    volumes:
+      - nautilus-database:/data/postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - nautilus-network
+    restart: unless-stopped
+
+  pgadmin:
+    container_name: nautilus-pgadmin
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@mail.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+    volumes:
+      - pgadmin:/root/.pgadmin
+    ports:
+      - "${PGADMIN_PORT:-5051}:80"
+    networks:
+      - nautilus-network
+    restart: unless-stopped
+
+  redis:
+    container_name: nautilus-redis
+    image: redis
+    ports:
+      - 6379:6379
+    restart: unless-stopped
+    networks:
+      - nautilus-network
+
+networks:
+  nautilus-network:
+
+volumes:
+  nautilus-database:
+  pgadmin:

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,8 @@ test-examples:
 install-talib:
 	bash scripts/install-talib.sh
 
-.PHONY: init-db
-init-db:
-	(cd nautilus_core && cargo run --bin init-db)
+.PHONY: install-cli
+install-cli:
+	(cd nautilus_core && cargo install --path cli  --bin nautilus)
 
-.PHONY: drop-db
-drop-db:
-	(cd nautilus_core && cargo run --bin drop-db)
 

--- a/docs/developer_guide/environment_setup.md
+++ b/docs/developer_guide/environment_setup.md
@@ -32,3 +32,93 @@ Following any changes to `.pyx` or `.pxd` files, you can re-compile by running:
 or
 
     make build
+
+## Services
+You can use `docker-compose.yml` file located in `.docker` directory 
+to bootstrap the Nautilus working environment. This will start the following services:
+
+```bash
+docker-compose up -d
+```
+
+If you only want specific services running (like `postgres` for example), you can start them with command:
+
+```bash
+docker-compose up -d postgres
+```
+
+Used services are:
+
+- `postgres` - Postgres database with root user `POSTRES_USER` which defaults to `postgres`, `POSTGRES_PASSWORD` which defaults to `pass` and `POSTGRES_DB` which defaults to `postgres`
+- `redis` - Redis server
+- `pgadmin` - PgAdmin4 for database management and administration
+
+> **Note:** Please use this as development environment only. For production, use a proper and  more secure setup.
+
+After the services has been started, you must log in with `psql` cli to create `nautilus` Postgres database.
+To do that you can run, and type `POSTGRES_PASSWORD` from docker service setup
+
+```bash
+psql -h localhost -p 5432 -U postgres
+```
+
+After you have logged in as `postgres` administrator, run `CREATE DATABASE` command with target db name (we use `nautilus`): 
+
+```
+psql (16.2, server 15.2 (Debian 15.2-1.pgdg110+1))
+Type "help" for help.
+
+postgres=# CREATE DATABASE nautilus;
+CREATE DATABASE
+
+```
+
+## Nautilus CLI Developer Guide
+
+## Introduction
+
+The Nautilus CLI is a command-line interface tool designed to interact
+with the Nautilus Trader ecosystem. It provides commands for managing the Postgres database and other trading operations.
+
+> **Note:** The Nautilus CLI command is only supported on UNIX-like systems.
+
+
+## Install 
+
+You can install nautilus cli command with from Make file target, which will use `cargo install` under the hood.
+And this command will install `nautilus` bin executable in your path if Rust `cargo` is properly configured.
+
+```bash
+make install-cli
+```
+
+## Commands
+You can run `nautilus --help` to inspect structure of CLI and groups of commands:
+
+### Database
+These are commands related to the bootstrapping the Postgres database.
+For that you work, you need to supply right connection configuration. You can do that through 
+command line arguments or `.env` file in the root directory or where the commands is being run.
+
+- `--host` arg or `POSTGRES_HOST` for database host
+- `--port` arg or `POSTGRES_PORT` for database port
+- `--user` arg or `POSTGRES_USER` for root administrator user to run command with (namely `postgres` root user here)
+- `--password` arg or `POSTGRES_PASSWORD` for root administrator password
+- `--database` arg or `POSTGRES_DATABASE` for both database **name and new user** that will have privileges of this database
+  ( if you provided `nautilus` as value, then new user will be created with name `nautilus` that will inherit the password from `POSTGRES_PASSWORD`
+ and `nautilus` database with be bootstrapped with this user as owner)
+
+Example of `.env` file
+
+```
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USERNAME=postgres
+POSTGRES_DATABASE=nautilus
+POSTGRES_PASSWORD=pass
+```
+
+List of commands are:
+
+1. `nautilus database init` - it will bootstrap schema, roles and all sql files located in `schema` root directory (like `tables.sql`)
+2. `nautilus database drop` - it will drop all tables, role and data in target Postgres database

--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -94,10 +94,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -788,7 +830,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
 ]
@@ -800,6 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -808,8 +851,22 @@ version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex 0.7.0",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -826,6 +883,22 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "combine"
@@ -1066,7 +1139,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.60",
 ]
 
@@ -2543,6 +2616,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nautilus-cli"
+version = "0.22.0"
+dependencies = [
+ "anyhow",
+ "clap 4.5.4",
+ "clap_derive",
+ "dotenvy",
+ "log",
+ "nautilus-common",
+ "nautilus-core",
+ "nautilus-infrastructure",
+ "nautilus-model",
+ "simple_logger",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "nautilus-common"
 version = "0.22.0"
 dependencies = [
@@ -2901,6 +2992,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4143,6 +4243,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,6 +4594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4709,7 +4827,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5159,6 +5279,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/nautilus_core/Cargo.toml
+++ b/nautilus_core/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "network/tokio-tungstenite",
     "persistence",
     "pyo3",
+    "cli"
 ]
 
 [workspace.package]
@@ -49,6 +50,7 @@ tracing = "0.1.40"
 tokio = { version = "1.37.0", features = ["full"] }
 ustr = { version = "1.0.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["v4"] }
+sqlx = { version = "0.7.4", features = ["postgres", "runtime-tokio"] }
 
 # dev-dependencies
 criterion = "0.5.1"

--- a/nautilus_core/cli/Cargo.toml
+++ b/nautilus_core/cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nautilus-cli"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[[bin]]
+name = "nautilus"
+path = "src/bin/cli.rs"
+
+[dependencies]
+nautilus-common = { path = "../common"}
+nautilus-model = { path = "../model" }
+nautilus-core = { path = "../core" }
+nautilus-infrastructure = { path = "../infrastructure" , features = ['sql']}
+anyhow = { workspace = true }
+tokio = {workspace = true}
+log = { workspace = true }
+clap = { version = "4.5.4", features = ["derive", "env"] }
+clap_derive = { version = "4.5.4" }
+dotenvy = { version = "0.15.7" }
+sqlx = {workspace = true }
+simple_logger = "4.3.3"

--- a/nautilus_core/cli/src/bin/cli.rs
+++ b/nautilus_core/cli/src/bin/cli.rs
@@ -13,12 +13,18 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-/// Be careful about ordering and foreign key constraints when deleting data.
-/// We can use this list for manual truncation of tables.
-pub const NAUTILUS_TABLES: [&str; 5] =
-    ["general", "instrument", "currency", "order", "order_event"];
+use clap::Parser;
+use log::{error, LevelFilter};
+use nautilus_cli::opt::NautilusCli;
 
-pub mod database;
-pub mod models;
-pub mod pg;
-pub mod schema;
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    simple_logger::SimpleLogger::new()
+        .with_module_level("sqlx", LevelFilter::Off)
+        .init()
+        .unwrap();
+    if let Err(err) = nautilus_cli::run(NautilusCli::parse()).await {
+        error!("Error executing Nautilus CLI: {}", err);
+    }
+}

--- a/nautilus_core/cli/src/database/mod.rs
+++ b/nautilus_core/cli/src/database/mod.rs
@@ -13,12 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-/// Be careful about ordering and foreign key constraints when deleting data.
-/// We can use this list for manual truncation of tables.
-pub const NAUTILUS_TABLES: [&str; 5] =
-    ["general", "instrument", "currency", "order", "order_event"];
-
-pub mod database;
-pub mod models;
-pub mod pg;
-pub mod schema;
+pub mod postgres;

--- a/nautilus_core/cli/src/database/postgres.rs
+++ b/nautilus_core/cli/src/database/postgres.rs
@@ -1,0 +1,239 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use log::{error, info};
+use nautilus_infrastructure::sql::pg::{connect_pg, get_postgres_connect_options};
+use sqlx::PgPool;
+
+use crate::opt::{DatabaseCommand, DatabaseOpt};
+
+/// Scans current path with keyword nautilus_trader and build schema dir
+fn get_schema_dir() -> anyhow::Result<String> {
+    std::env::var("SCHEMA_DIR").or_else(|_| {
+        let nautilus_git_repo_name = "nautilus_trader";
+        let binding = std::env::current_dir().unwrap();
+        let current_dir = binding.to_str().unwrap();
+        match current_dir.find(nautilus_git_repo_name){
+            Some(index) => {
+                let schema_path = current_dir[0..index + nautilus_git_repo_name.len()].to_string() + "/schema";
+                Ok(schema_path)
+            }
+            None => anyhow::bail!("Could not calculate schema dir from current directory path or SCHEMA_DIR env variable")
+        }
+    })
+}
+
+pub async fn init_postgres(pg: &PgPool, database: String, password: String) -> anyhow::Result<()> {
+    info!("Initializing Postgres database with target permissions and schema");
+    // create public schema
+    match sqlx::query("CREATE SCHEMA IF NOT EXISTS public;")
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Schema public created successfully"),
+        Err(err) => error!("Error creating schema public: {:?}", err),
+    }
+    // create role if not exists
+    match sqlx::query(format!("CREATE ROLE {} PASSWORD '{}' LOGIN;", database, password).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Role {} created successfully", database),
+        Err(err) => {
+            if err.to_string().contains("already exists") {
+                info!("Role {} already exists", database);
+            } else {
+                error!("Error creating role {}: {:?}", database, err);
+            }
+        }
+    }
+    // execute all the sql files in schema dir
+    let schema_dir = get_schema_dir()?;
+    let mut sql_files =
+        std::fs::read_dir(schema_dir)?.collect::<Result<Vec<_>, std::io::Error>>()?;
+    for file in &mut sql_files {
+        let file_name = file.file_name();
+        info!("Executing schema file: {:?}", file_name);
+        let file_path = file.path();
+        let sql_content = std::fs::read_to_string(file_path.clone())?;
+        for sql_statement in sql_content.split(';').filter(|s| !s.trim().is_empty()) {
+            sqlx::query(sql_statement).execute(pg).await?;
+        }
+    }
+
+    // grant connect
+    match sqlx::query(format!("GRANT CONNECT ON DATABASE {0} TO {0};", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Connect privileges granted to role {}", database),
+        Err(err) => error!(
+            "Error granting connect privileges to role {}: {:?}",
+            database, err
+        ),
+    }
+
+    // grant all schema privileges to the role
+    match sqlx::query(format!("GRANT ALL PRIVILEGES ON SCHEMA public TO {};", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("All schema privileges granted to role {}", database),
+        Err(err) => error!(
+            "Error granting all privileges to role {}: {:?}",
+            database, err
+        ),
+    }
+    // grant all table privileges to the role
+    match sqlx::query(
+        format!(
+            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {};",
+            database
+        )
+        .as_str(),
+    )
+    .execute(pg)
+    .await
+    {
+        Ok(_) => info!("All tables privileges granted to role {}", database),
+        Err(err) => error!(
+            "Error granting all privileges to role {}: {:?}",
+            database, err
+        ),
+    }
+    // grant all sequence privileges to the role
+    match sqlx::query(
+        format!(
+            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {};",
+            database
+        )
+        .as_str(),
+    )
+    .execute(pg)
+    .await
+    {
+        Ok(_) => info!("All sequences privileges granted to role {}", database),
+        Err(err) => error!(
+            "Error granting all privileges to role {}: {:?}",
+            database, err
+        ),
+    }
+    // grant all function privileges to the role
+    match sqlx::query(
+        format!(
+            "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {};",
+            database
+        )
+        .as_str(),
+    )
+    .execute(pg)
+    .await
+    {
+        Ok(_) => info!("All functions privileges granted to role {}", database),
+        Err(err) => error!(
+            "Error granting all privileges to role {}: {:?}",
+            database, err
+        ),
+    }
+
+    Ok(())
+}
+
+pub async fn drop_postgres(pg: &PgPool, database: String) -> anyhow::Result<()> {
+    // execute drop owned
+    match sqlx::query(format!("DROP OWNED BY {}", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Dropped owned objects by role {}", database),
+        Err(err) => error!("Error dropping owned by role {}: {:?}", database, err),
+    }
+    // revoke connect
+    match sqlx::query(format!("REVOKE CONNECT ON DATABASE {0} FROM {0};", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Revoked connect privileges from role {}", database),
+        Err(err) => error!(
+            "Error revoking connect privileges from role {}: {:?}",
+            database, err
+        ),
+    }
+    // revoke privileges
+    match sqlx::query(format!("REVOKE ALL PRIVILEGES ON DATABASE {0} FROM {0};", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Revoked all privileges from role {}", database),
+        Err(err) => error!(
+            "Error revoking all privileges from role {}: {:?}",
+            database, err
+        ),
+    }
+    // execute drop schema
+    match sqlx::query("DROP SCHEMA IF EXISTS public CASCADE")
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Dropped schema public"),
+        Err(err) => error!("Error dropping schema public: {:?}", err),
+    }
+    // drop role
+    match sqlx::query(format!("DROP ROLE IF EXISTS {};", database).as_str())
+        .execute(pg)
+        .await
+    {
+        Ok(_) => info!("Dropped role {}", database),
+        Err(err) => error!("Error dropping role {}: {:?}", database, err),
+    }
+    Ok(())
+}
+
+pub async fn run_database_command(opt: DatabaseOpt) -> anyhow::Result<()> {
+    let command = opt.command.clone();
+
+    match command {
+        DatabaseCommand::Init(config) => {
+            let pg_connect_options = get_postgres_connect_options(
+                config.host,
+                config.port,
+                config.username,
+                config.password,
+                config.database,
+            )
+            .unwrap();
+            let pg = connect_pg(pg_connect_options.clone().into()).await?;
+            init_postgres(
+                &pg,
+                pg_connect_options.database,
+                pg_connect_options.password,
+            )
+            .await?
+        }
+        DatabaseCommand::Drop(config) => {
+            let pg_connect_options = get_postgres_connect_options(
+                config.host,
+                config.port,
+                config.username,
+                config.password,
+                config.database,
+            )
+            .unwrap();
+            let pg = connect_pg(pg_connect_options.clone().into()).await?;
+            drop_postgres(&pg, pg_connect_options.database).await?
+        }
+    }
+    Ok(())
+}

--- a/nautilus_core/cli/src/database/postgres.rs
+++ b/nautilus_core/cli/src/database/postgres.rs
@@ -72,7 +72,6 @@ pub async fn init_postgres(pg: &PgPool, database: String, password: String) -> a
             sqlx::query(sql_statement).execute(pg).await?;
         }
     }
-
     // grant connect
     match sqlx::query(format!("GRANT CONNECT ON DATABASE {0} TO {0};", database).as_str())
         .execute(pg)
@@ -84,7 +83,6 @@ pub async fn init_postgres(pg: &PgPool, database: String, password: String) -> a
             database, err
         ),
     }
-
     // grant all schema privileges to the role
     match sqlx::query(format!("GRANT ALL PRIVILEGES ON SCHEMA public TO {};", database).as_str())
         .execute(pg)

--- a/nautilus_core/cli/src/lib.rs
+++ b/nautilus_core/cli/src/lib.rs
@@ -13,12 +13,17 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-/// Be careful about ordering and foreign key constraints when deleting data.
-/// We can use this list for manual truncation of tables.
-pub const NAUTILUS_TABLES: [&str; 5] =
-    ["general", "instrument", "currency", "order", "order_event"];
+use crate::{
+    database::postgres::run_database_command,
+    opt::{Commands, NautilusCli},
+};
 
-pub mod database;
-pub mod models;
-pub mod pg;
-pub mod schema;
+mod database;
+pub mod opt;
+
+pub async fn run(opt: NautilusCli) -> anyhow::Result<()> {
+    match opt.command {
+        Commands::Database(database_opt) => run_database_command(database_opt).await?,
+    }
+    Ok(())
+}

--- a/nautilus_core/cli/src/opt.rs
+++ b/nautilus_core/cli/src/opt.rs
@@ -1,0 +1,63 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(version, about, author)]
+pub struct NautilusCli {
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Parser, Debug)]
+pub enum Commands {
+    Database(DatabaseOpt),
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "Postgres database operations", long_about = None)]
+pub struct DatabaseOpt {
+    #[clap(subcommand)]
+    pub command: DatabaseCommand,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct DatabaseConfig {
+    /// Hostname or IP address of the database server
+    #[arg(long)]
+    pub host: Option<String>,
+    /// Port number of the database server
+    #[arg(long)]
+    pub port: Option<u16>,
+    /// Username for connecting to the database
+    #[arg(long)]
+    pub username: Option<String>,
+    /// Name of the database
+    #[arg(long)]
+    pub database: Option<String>,
+    /// Password for connecting to the database
+    #[arg(long)]
+    pub password: Option<String>,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Postgres database operations", long_about = None)]
+pub enum DatabaseCommand {
+    /// Initializes a new Postgres database with the latest schema
+    Init(DatabaseConfig),
+    /// Drops roles, privileges and deletes all data from the database
+    Drop(DatabaseConfig),
+}

--- a/nautilus_core/common/build.rs
+++ b/nautilus_core/common/build.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "ffi")]
 use std::env;
 
 #[allow(clippy::expect_used)] // OK in build script

--- a/nautilus_core/core/build.rs
+++ b/nautilus_core/core/build.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "ffi")]
 use std::env;
 
 #[allow(clippy::expect_used)] // OK in build script

--- a/nautilus_core/infrastructure/src/sql/pg.rs
+++ b/nautilus_core/infrastructure/src/sql/pg.rs
@@ -1,0 +1,114 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use sqlx::{postgres::PgConnectOptions, query, ConnectOptions, PgPool};
+
+use crate::sql::NAUTILUS_TABLES;
+
+#[derive(Debug, Clone)]
+pub struct PostgresConnectOptions {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub database: String,
+}
+
+impl PostgresConnectOptions {
+    pub fn new(
+        host: String,
+        port: u16,
+        username: String,
+        password: String,
+        database: String,
+    ) -> Self {
+        Self {
+            host,
+            port,
+            username,
+            password,
+            database,
+        }
+    }
+}
+
+impl From<PostgresConnectOptions> for PgConnectOptions {
+    fn from(opt: PostgresConnectOptions) -> Self {
+        PgConnectOptions::new()
+            .host(opt.host.as_str())
+            .port(opt.port)
+            .username(opt.username.as_str())
+            .password(opt.password.as_str())
+            .database(opt.database.as_str())
+            .disable_statement_logging()
+    }
+}
+
+pub fn get_postgres_connect_options(
+    host: Option<String>,
+    port: Option<u16>,
+    username: Option<String>,
+    password: Option<String>,
+    database: Option<String>,
+) -> anyhow::Result<PostgresConnectOptions> {
+    let host = match host.or_else(|| std::env::var("POSTGRES_HOST").ok()) {
+        Some(host) => host,
+        None => anyhow::bail!("No host provided from argument or POSTGRES_HOST env variable"),
+    };
+    let port = match port.or_else(|| {
+        std::env::var("POSTGRES_PORT")
+            .map(|port| port.parse::<u16>().unwrap())
+            .ok()
+    }) {
+        Some(port) => port,
+        None => anyhow::bail!("No port provided from argument or POSTGRES_PORT env variable"),
+    };
+    let username = match username.or_else(|| std::env::var("POSTGRES_USERNAME").ok()) {
+        Some(username) => username,
+        None => {
+            anyhow::bail!("No username provided from argument or POSTGRES_USERNAME env variable")
+        }
+    };
+    let database = match database.or_else(|| std::env::var("POSTGRES_DATABASE").ok()) {
+        Some(database) => database,
+        None => {
+            anyhow::bail!("No database provided from argument or POSTGRES_DATABASE env variable")
+        }
+    };
+    let password = match password.or_else(|| std::env::var("POSTGRES_PASSWORD").ok()) {
+        Some(password) => password,
+        None => {
+            anyhow::bail!("No password provided from argument or POSTGRES_PASSWORD env variable")
+        }
+    };
+    Ok(PostgresConnectOptions::new(
+        host, port, username, password, database,
+    ))
+}
+
+pub async fn delete_nautilus_postgres_tables(db: &PgPool) -> anyhow::Result<()> {
+    // iterate over NAUTILUS_TABLES and delete all rows
+    for table in NAUTILUS_TABLES {
+        query(format!("DELETE FROM \"{}\" WHERE true", table).as_str())
+            .execute(db)
+            .await
+            .unwrap_or_else(|_| panic!("Failed to delete table {}", table));
+    }
+    Ok(())
+}
+
+pub async fn connect_pg(options: PgConnectOptions) -> anyhow::Result<PgPool> {
+    Ok(PgPool::connect_with(options).await.unwrap())
+}

--- a/nautilus_core/model/build.rs
+++ b/nautilus_core/model/build.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "ffi")]
 use std::env;
 
 #[allow(clippy::expect_used)] // OK in build script

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -1,4 +1,128 @@
-CREATE TABLE IF NOT EXISTS general (
-    key SERIAL PRIMARY KEY,
-    value TEXT NOT NULL
+------------------- ENUMS -------------------
+
+CREATE TYPE ACCOUNT_TYPE AS ENUM ('Cash', 'Margin', 'Betting');
+CREATE TYPE AGGREGATION_SOURCE AS ENUM ('External', 'Internal');
+CREATE TYPE AGGRESSOR_SIDE AS ENUM ('NoAggressor', 'Buyer', 'Seller');
+CREATE TYPE ASSET_CLASS AS ENUM ('Fx', 'Equity', 'Commodity', 'Debt', 'Index', 'Cryptocurrency', 'Alternative');
+CREATE TYPE INSTRUMENT_CLASS AS ENUM ('Spot', 'Swap', 'Future', 'FutureSpread', 'Forward', 'Cfg', 'Bond', 'Option', 'OptionSpread', 'Warrant', 'SportsBetting');
+CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volume', 'VolumeImbalance', 'VolumeRuns', 'Value', 'ValueImbalance', 'ValueRuns', 'Millisecond', 'Second', 'Minute', 'Hour', 'Day', 'Week', 'Month');
+CREATE TYPE BOOK_ACTION AS ENUM ('Add', 'Update', 'Delete','Clear');
+CREATE TYPE ORDER_STATUS AS ENUM ('Initialized', 'Denied', 'Emulated', 'Released', 'Submitted', 'Accepted', 'Rejected', 'Canceled', 'Expired', 'Triggered', 'PendingUpdate', 'PendingCancel', 'PartiallyFilled', 'Filled');
+
+
+------------------- TABLES -------------------
+
+CREATE TABLE IF NOT EXISTS "general" (
+    key TEXT PRIMARY KEY NOT NULL,
+    value bytea not null
+);
+
+CREATE TABLE IF NOT EXISTS "trader" (
+    id TEXT PRIMARY KEY NOT NULL,
+    instance_id UUID NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "strategy" (
+  id TEXT PRIMARY KEY NOT NULL,
+  order_id_tag TEXT,
+  oms_type TEXT,
+  manage_contingent_orders BOOLEAN,
+  manage_gtd_expiry BOOLEAN
+
+);
+
+CREATE TABLE IF NOT EXISTS "currency" (
+    code TEXT PRIMARY KEY NOT NULL,
+    precision INTEGER,
+    iso4217 INTEGER,
+    name TEXT,
+    currency_type TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "instrument" (
+    id TEXT PRIMARY KEY NOT NULL,
+    kind TEXT,
+    raw_symbol TEXT NOT NULL,
+    base_currency TEXT REFERENCES currency(code),
+    underlying TEXT,
+    quote_currency TEXT REFERENCES currency(code),
+    settlement_currency TEXT REFERENCES currency(code),
+    isin TEXT,
+    asset_class TEXT,
+    exchange TEXT,
+    multiplier TEXT,
+    option_kind TEXT,
+    is_inverse BOOLEAN DEFAULT FALSE,
+    strike_price TEXT,
+    activation_ns TEXT,
+    expiration_ns TEXT,
+    price_precision INTEGER NOT NULL ,
+    size_precision INTEGER,
+    price_increment TEXT NOT NULL,
+    size_increment TEXT,
+    maker_fee TEXT NULL,
+    taker_fee TEXT NULL,
+    margin_init TEXT NOT NULL,
+    margin_maint TEXT NOT NULL,
+    lot_size TEXT,
+    max_quantity TEXT,
+    min_quantity TEXT,
+    max_notional TEXT,
+    min_notional TEXT,
+    max_price TEXT,
+    min_price TEXT,
+    ts_init TEXT NOT NULL,
+    ts_event TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "order" (
+    id TEXT PRIMARY KEY NOT NULL,
+    kind TEXT NOT NULL,
+    order_type TEXT,
+    status TEXT,
+--     trader_id TEXT REFERENCES trader(id) ON DELETE CASCADE,
+--     strategy_id TEXT REFERENCES strategy(id) ON DELETE CASCADE,
+--     instrument_id TEXT REFERENCES instrument(id) ON DELETE CASCADE,
+    symbol TEXT,
+    venue TEXT,
+    venue_order_id TEXT,
+    position_id TEXT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "order_event" (
+    id TEXT PRIMARY KEY NOT NULL,
+    kind TEXT NOT NULL,
+    order_id TEXT DEFAULT NULL,
+    order_type TEXT,
+    trader_id TEXT NOT NULL,
+    strategy_id TEXT NOT NULL,
+    instrument_id TEXT NOT NULL,
+    quantity TEXT,
+    post_only BOOLEAN DEFAULT FALSE,
+    reduce_only BOOLEAN DEFAULT FALSE,
+    quote_quantity BOOLEAN DEFAULT FALSE,
+    reconciliation BOOLEAN DEFAULT FALSE,
+    price TEXT,
+    trigger_price TEXT,
+    limit_offset TEXT,
+    trailing_offset TEXT,
+    expire_time TEXT,
+    display_qty TEXT,
+    trigger_instrument_id TEXT,
+    order_list_id TEXT,
+    linked_order_ids TEXT[],
+    parent_order_id TEXT,
+    exec_algorithm_id TEXT,
+    exec_spawn_id TEXT,
+    venue_order_id TEXT,
+    account_id TEXT,
+    tags TEXT,
+    ts_event TEXT NOT NULL,
+    ts_init TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
# Pull Request

- created a `docker-compose.yml` file in `.docker` directory to help bootstrap all the services used by nautilus system
- added new `Makefile` target `install-cli` that build and install `nautilus` CLI executable 
- updated `docs/developer_guide/environment_setup.md` with documentation around running services with `docker-compose`, how to build and use `nautilus` cli, and which commands are currently implemented
- created a new `cli` rust crate that contains Rust CLI design with target commands 
- fixed `build.rs` warning when running `install-cli` by conditionally importing std env based on FFI feature (to suppress warnings)
- WIP SQL Nautilus in `schema/tables.sql` that is being heavy developed 

## Demo

<img width="1134" alt="Screenshot 2024-04-21 at 12 36 16" src="https://github.com/nautechsystems/nautilus_trader/assets/16453976/c3c0b63c-1f5e-4d66-9b08-d571eb84b357">


## Steps to reproduce and try

## Services
You can use `docker-compose.yml` file located in `.docker` directory 
to bootstrap the Nautilus working environment. This will start the following services:

```bash
docker-compose up -d
```

If you only want specific services running (like `postgres` for example), you can start them with command:

```bash
docker-compose up -d postgres
```

Used services are:

- `postgres` - Postgres database with root user `POSTRES_USER` which defaults to `postgres`, `POSTGRES_PASSWORD` which defaults to `pass` and `POSTGRES_DB` which defaults to `postgres`
- `redis` - Redis server
- `pgadmin` - PgAdmin4 for database management and administration

> **Note:** Please use this as development environment only. For production, use a proper and  more secure setup.
After the services has been started, you must login with `psql` cli to create `nautilus` Postgres database.
To do that you can run, and type `POSTGRES_PASSWORD` from docker service setup

```bash
psql -h localhost -p 5432 -U postgres
```

After you have long as `postgres` administrator, run `CREATE DATABASE` command with target name( we use `nautilus`): 

```
psql (16.2, server 15.2 (Debian 15.2-1.pgdg110+1))
Type "help" for help.
postgres=# CREATE DATABASE nautilus;
CREATE DATABASE
```

## Nautilus CLI Developer Guide

## Introduction

The Nautilus CLI is a command-line interface tool designed to interact
with the Nautilus Trader ecosystem. It provides commands for managing the Postgres database and other trading operations.

> **Note:** The Nautilus CLI command is only supported on UNIX-like systems.

## Install 

You can install nautilus cli command with from Make file target, which will use `cargo install` under the hood.
And this command will install `nautilus` bin executable in your path if Rust `cargo` is properly configured.

```bash
make install-cli
```

## Commands
You can run `nautilus --help` to inspect structure of CLI and groups of commands:

### Database
These are commands related to the bootstrapping the Postgres database.
For that you work, you need to supply right connection configuration. You can do that through 
command line arguments or `.env` file in the root directory or where the commands is being run.

- `--host` arg or `POSTGRES_HOST` for database host
- `--port` arg or `POSTGRES_PORT` for database port
- `--user` arg or `POSTGRES_USER` for root administrator user to run command with (namely `postgres` root user here)
- `--password` arg or `POSTGRES_PASSWORD` for root administrator password
- `--database` arg or `POSTGRES_DATABASE` for both database **name and new user** that will have privileges of this database
  ( if you provided `nautilus` as value, then new user will be created with name `nautilus` that will inherit the password from `POSTGRES_PASSWORD`
 and `nautilus` database with be bootstrapped with this user as owner)

Example of `.env` file

```
POSTGRES_HOST=localhost
POSTGRES_PORT=5432
POSTGRES_USERNAME=postgres
POSTGRES_DATABASE=nautilus
POSTGRES_PASSWORD=pass
```

List of commands are:

1. `nautilus database init` - it will bootstrap schema, roles and all sql files located in `schema` root directory (like `tables.sql`)
2. `nautilus database drop` - it will drop all tables, role and data in target Postgres database