### PR TITLE
Add CFD and Commodity support for Interactive Brokers

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -102,7 +102,16 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
     """
 
     secType: Literal[
-        "CASH", "STK", "OPT", "FUT", "FOP", "CONTFUT", "CRYPTO", "CFD", "CMDTY", ""
+        "CASH",
+        "STK",
+        "OPT",
+        "FUT",
+        "FOP",
+        "CONTFUT",
+        "CRYPTO",
+        "CFD",
+        "CMDTY",
+        "",
     ] = ""
     conId: int = 0
     exchange: str = ""

--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -101,7 +101,9 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
 
     """
 
-    secType: Literal["CASH", "STK", "OPT", "FUT", "FOP", "CONTFUT", "CRYPTO", ""] = ""
+    secType: Literal[
+        "CASH", "STK", "OPT", "FUT", "FOP", "CONTFUT", "CRYPTO", "CFD", "CMDTY", ""
+    ] = ""
     conId: int = 0
     exchange: str = ""
     primaryExchange: str = ""

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -32,6 +32,8 @@ from nautilus_trader.model.enums import asset_class_from_str
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments import Cfd
+from nautilus_trader.model.instruments import Commodity
 from nautilus_trader.model.instruments import CryptoPerpetual
 from nautilus_trader.model.instruments import CurrencyPair
 from nautilus_trader.model.instruments import Equity
@@ -74,8 +76,16 @@ VENUES_FUT = [
     "NYBOT",  # US
     "SNFE",  # AU
 ]
+VENUES_CFD = [
+    "IBCFD",  # self named, in fact mapping to "SMART" when parsing
+    "IBUSCFD",  # US
+    "IBCFD",  # EU
+    "IBAPCFD",  # Asia-Pacific
+]
+VENUES_CMDTY = ["IBCMDTY"]  # self named, in fact mapping to "SMART" when parsing
 
 RE_CASH = re.compile(r"^(?P<symbol>[A-Z]{3})\/(?P<currency>[A-Z]{3})$")
+RE_CFD_CASH = re.compile(r"^(?P<symbol>[A-Z]{3})\.(?P<currency>[A-Z]{3})$")
 RE_OPT = re.compile(
     r"^(?P<symbol>^[A-Z]{1,6})(?P<expiry>\d{6})(?P<right>[CP])(?P<strike>\d{5})(?P<decimal>\d{3})$",
 )
@@ -116,6 +126,7 @@ def sec_type_to_asset_class(sec_type: str) -> AssetClass:
         "IND": "INDEX",
         "CASH": "FX",
         "BOND": "DEBT",
+        "CMDTY": "COMMODITY",
     }
     return asset_class_from_str(mapping.get(sec_type, sec_type))
 
@@ -145,6 +156,10 @@ def parse_instrument(
         return parse_forex_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type == "CRYPTO":
         return parse_crypto_contract(details=contract_details, instrument_id=instrument_id)
+    elif security_type == "CFD":
+        return parse_cfd_contract(details=contract_details, instrument_id=instrument_id)
+    elif security_type == "CMDTY":
+        return parse_commodity_contract(details=contract_details, instrument_id=instrument_id)
     else:
         raise ValueError(f"Unknown {security_type=}")
 
@@ -319,6 +334,99 @@ def parse_crypto_contract(
     )
 
 
+def parse_cfd_contract(
+    details: IBContractDetails,
+    instrument_id: InstrumentId,
+) -> Cfd:
+    price_precision: int = _tick_size_to_precision(details.minTick)
+    size_precision: int = _tick_size_to_precision(details.minSize)
+    timestamp = time.time_ns()
+    if RE_CFD_CASH.match(details.contract.localSymbol):
+        return Cfd(
+            instrument_id=instrument_id,
+            raw_symbol=Symbol(details.contract.localSymbol),
+            asset_class=sec_type_to_asset_class(details.underSecType),
+            base_currency=Currency.from_str(details.contract.symbol),
+            quote_currency=Currency.from_str(details.contract.currency),
+            price_precision=price_precision,
+            size_precision=size_precision,
+            price_increment=Price(details.minTick, price_precision),
+            size_increment=Quantity(details.sizeIncrement, size_precision),
+            lot_size=None,
+            max_quantity=None,
+            min_quantity=None,
+            max_notional=None,
+            min_notional=None,
+            max_price=None,
+            min_price=None,
+            margin_init=Decimal(0),
+            margin_maint=Decimal(0),
+            maker_fee=Decimal(0),
+            taker_fee=Decimal(0),
+            ts_event=timestamp,
+            ts_init=timestamp,
+            info=contract_details_to_dict(details),
+        )
+    else:
+        return Cfd(
+            instrument_id=instrument_id,
+            raw_symbol=Symbol(details.contract.localSymbol),
+            asset_class=sec_type_to_asset_class(details.underSecType),
+            quote_currency=Currency.from_str(details.contract.currency),
+            price_precision=price_precision,
+            size_precision=size_precision,
+            price_increment=Price(details.minTick, price_precision),
+            size_increment=Quantity(details.sizeIncrement, size_precision),
+            lot_size=None,
+            max_quantity=None,
+            min_quantity=None,
+            max_notional=None,
+            min_notional=None,
+            max_price=None,
+            min_price=None,
+            margin_init=Decimal(0),
+            margin_maint=Decimal(0),
+            maker_fee=Decimal(0),
+            taker_fee=Decimal(0),
+            ts_event=timestamp,
+            ts_init=timestamp,
+            info=contract_details_to_dict(details),
+        )
+
+
+def parse_commodity_contract(
+    details: IBContractDetails,
+    instrument_id: InstrumentId,
+) -> Commodity:
+    price_precision: int = _tick_size_to_precision(details.minTick)
+    size_precision: int = _tick_size_to_precision(details.minSize)
+    timestamp = time.time_ns()
+    return Commodity(
+        instrument_id=instrument_id,
+        raw_symbol=Symbol(details.contract.localSymbol),
+        asset_class=AssetClass.COMMODITY,
+        quote_currency=Currency.from_str(details.contract.currency),
+        price_precision=price_precision,
+        size_precision=size_precision,
+        price_increment=Price(details.minTick, price_precision),
+        size_increment=Quantity(details.sizeIncrement, size_precision),
+        lot_size=None,
+        max_quantity=None,
+        min_quantity=None,
+        max_notional=None,
+        min_notional=None,
+        max_price=None,
+        min_price=None,
+        margin_init=Decimal(0),
+        margin_maint=Decimal(0),
+        maker_fee=Decimal(0),
+        taker_fee=Decimal(0),
+        ts_event=timestamp,
+        ts_init=timestamp,
+        info=contract_details_to_dict(details),
+    )
+
+
 def decade_digit(last_digit: str, contract: IBContract) -> int:
     if year := contract.lastTradeDateOrContractMonth[:4]:
         return int(year[2:3])
@@ -341,8 +449,15 @@ def ib_contract_to_instrument_id(
 
 
 def ib_contract_to_instrument_id_strict_symbology(contract: IBContract) -> InstrumentId:
-    symbol = f"{contract.localSymbol}={contract.secType}"
-    venue = (contract.primaryExchange or contract.exchange).replace(".", "/")
+    if contract.secType == "CFD":
+        symbol = f"{contract.localSymbol}={contract.secType}"
+        venue = "IBCFD"
+    elif contract.secType == "CMDTY":
+        symbol = f"{contract.localSymbol}={contract.secType}"
+        venue = "IBCMDTY"
+    else:
+        symbol = f"{contract.localSymbol}={contract.secType}"
+        venue = (contract.primaryExchange or contract.exchange).replace("/", ".")
     return InstrumentId.from_str(f"{symbol}.{venue}")
 
 
@@ -372,6 +487,19 @@ def ib_contract_to_instrument_id_simplified_symbology(contract: IBContract) -> I
             f"{contract.localSymbol}".replace(".", "/") or f"{contract.symbol}/{contract.currency}"
         )
         venue = contract.exchange
+    elif security_type == "CFD":
+        if m := RE_CFD_CASH.match(contract.localSymbol):
+            symbol = (
+                f"{contract.localSymbol}".replace(".", "/")
+                or f"{contract.symbol}/{contract.currency}"
+            )
+            venue = "IBCFD"
+        else:
+            symbol = (contract.symbol).replace(" ", "-")
+            venue = "IBCFD"
+    elif security_type == "CMDTY":
+        symbol = (contract.symbol).replace(" ", "-")
+        venue = "IBCMDTY"
     else:
         symbol = None
         venue = None
@@ -400,6 +528,18 @@ def instrument_id_to_ib_contract_strict_symbology(instrument_id: InstrumentId) -
             secType=security_type,
             exchange="SMART",
             primaryExchange=exchange,
+            localSymbol=local_symbol,
+        )
+    elif security_type == "CFD":
+        return IBContract(
+            secType=security_type,
+            exchange="SMART",
+            localSymbol=local_symbol,  # by IB is a cfd's local symbol of STK with a "n" as tail, e.g. "NVDAn". "
+        )
+    elif security_type == "CMDTY":
+        return IBContract(
+            secType=security_type,
+            exchange="SMART",
             localSymbol=local_symbol,
         )
     else:
@@ -464,6 +604,26 @@ def instrument_id_to_ib_contract_simplified_symbology(instrument_id: InstrumentI
             )
         else:
             raise ValueError(f"Cannot parse {instrument_id}, use 2-digit year for FUT and FOP")
+    elif instrument_id.venue.value in VENUES_CFD:
+        if m := RE_CASH.match(instrument_id.symbol.value):
+            return IBContract(
+                secType="CFD",
+                exchange="SMART",
+                symbol=m["symbol"],
+                localSymbol=f"{m['symbol']}.{m['currency']}",
+            )
+        else:
+            return IBContract(
+                secType="CFD",
+                exchange="SMART",
+                symbol=f"{instrument_id.symbol.value}".replace("-", " "),
+            )
+    elif instrument_id.venue.value in VENUES_CMDTY:
+        return IBContract(
+            secType="CMDTY",
+            exchange="SMART",
+            symbol=f"{instrument_id.symbol.value}".replace("-", " "),
+        )
     elif instrument_id.venue.value == "InteractiveBrokers":  # keep until a better approach
         # This will allow to make Instrument request using IBContract from within Strategy
         # and depending on the Strategy requirement

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -458,9 +458,9 @@ def ib_contract_to_instrument_id_strict_symbology(contract: IBContract) -> Instr
     return InstrumentId.from_str(f"{symbol}.{venue}")
 
 
-def ib_contract_to_instrument_id_simplified_symbology(
+def ib_contract_to_instrument_id_simplified_symbology(  # noqa: C901 (too complex)
     contract: IBContract,
-) -> InstrumentId: # noqa: C901 (too complex)
+) -> InstrumentId:
     security_type = contract.secType
     if security_type == "STK":
         symbol = (contract.localSymbol or contract.symbol).replace(" ", "-")
@@ -549,9 +549,9 @@ def instrument_id_to_ib_contract_strict_symbology(instrument_id: InstrumentId) -
         )
 
 
-def instrument_id_to_ib_contract_simplified_symbology(
+def instrument_id_to_ib_contract_simplified_symbology(  # noqa: C901 (too complex)
     instrument_id: InstrumentId,
-) -> IBContract: # noqa: C901 (too complex)
+) -> IBContract:
     if instrument_id.venue.value in VENUES_CASH and (
         m := RE_CASH.match(instrument_id.symbol.value)
     ):

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -458,7 +458,9 @@ def ib_contract_to_instrument_id_strict_symbology(contract: IBContract) -> Instr
     return InstrumentId.from_str(f"{symbol}.{venue}")
 
 
-def ib_contract_to_instrument_id_simplified_symbology(contract: IBContract) -> InstrumentId:
+def ib_contract_to_instrument_id_simplified_symbology(
+    contract: IBContract,
+) -> InstrumentId: # noqa: C901 (too complex)
     security_type = contract.secType
     if security_type == "STK":
         symbol = (contract.localSymbol or contract.symbol).replace(" ", "-")
@@ -547,7 +549,9 @@ def instrument_id_to_ib_contract_strict_symbology(instrument_id: InstrumentId) -
         )
 
 
-def instrument_id_to_ib_contract_simplified_symbology(instrument_id: InstrumentId) -> IBContract:
+def instrument_id_to_ib_contract_simplified_symbology(
+    instrument_id: InstrumentId,
+) -> IBContract: # noqa: C901 (too complex)
     if instrument_id.venue.value in VENUES_CASH and (
         m := RE_CASH.match(instrument_id.symbol.value)
     ):

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -454,7 +454,7 @@ def ib_contract_to_instrument_id_strict_symbology(contract: IBContract) -> Instr
         venue = "IBCMDTY"
     else:
         symbol = f"{contract.localSymbol}={contract.secType}"
-        venue = (contract.primaryExchange or contract.exchange).replace("/", ".")
+        venue = (contract.primaryExchange or contract.exchange).replace(".", "/")
     return InstrumentId.from_str(f"{symbol}.{venue}")
 
 

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -78,9 +78,6 @@ VENUES_FUT = [
 ]
 VENUES_CFD = [
     "IBCFD",  # self named, in fact mapping to "SMART" when parsing
-    "IBUSCFD",  # US
-    "IBCFD",  # EU
-    "IBAPCFD",  # Asia-Pacific
 ]
 VENUES_CMDTY = ["IBCMDTY"]  # self named, in fact mapping to "SMART" when parsing
 

--- a/nautilus_trader/model/instruments/__init__.py
+++ b/nautilus_trader/model/instruments/__init__.py
@@ -20,6 +20,8 @@ asset class and instrument class.
 from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.model.instruments.base import instruments_from_pyo3
 from nautilus_trader.model.instruments.betting import BettingInstrument
+from nautilus_trader.model.instruments.cfd import Cfd
+from nautilus_trader.model.instruments.commodity import Commodity
 from nautilus_trader.model.instruments.crypto_future import CryptoFuture
 from nautilus_trader.model.instruments.crypto_perpetual import CryptoPerpetual
 from nautilus_trader.model.instruments.currency_pair import CurrencyPair
@@ -42,6 +44,8 @@ __all__ = [
     "FuturesSpread",
     "OptionsContract",
     "OptionsSpread",
+    "Cfd",
+    "Commodity",
     "SyntheticInstrument",
     "instruments_from_pyo3",
 ]

--- a/nautilus_trader/model/instruments/cfd.pxd
+++ b/nautilus_trader/model/instruments/cfd.pxd
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.model.instruments.base cimport Instrument
+
+
+cdef class Cfd(Instrument):
+    cdef readonly str isin
+    """The instruments International Securities Identification Number (ISIN).\n\n:returns: `str` or ``None``"""
+
+    @staticmethod
+    cdef Cfd from_dict_c(dict values)
+
+    @staticmethod
+    cdef dict to_dict_c(Cfd obj)
+
+    @staticmethod
+    cdef Cfd from_pyo3_c(pyo3_instrument)

--- a/nautilus_trader/model/instruments/cfd.pyx
+++ b/nautilus_trader/model/instruments/cfd.pyx
@@ -19,10 +19,10 @@ from libc.stdint cimport uint64_t
 
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.rust.model cimport AssetClass
-from nautilus_trader.model.functions cimport asset_class_from_str
-from nautilus_trader.model.functions cimport asset_class_to_str
 from nautilus_trader.core.rust.model cimport CurrencyType
 from nautilus_trader.core.rust.model cimport InstrumentClass
+from nautilus_trader.model.functions cimport asset_class_from_str
+from nautilus_trader.model.functions cimport asset_class_to_str
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport Symbol
 from nautilus_trader.model.instruments.base cimport Instrument
@@ -148,7 +148,7 @@ cdef class Cfd(Instrument):
         str tick_scheme_name = None,
         dict info = None,
     ):
-        
+
         super().__init__(
             instrument_id=instrument_id,
             raw_symbol=raw_symbol,
@@ -198,7 +198,7 @@ cdef class Cfd(Instrument):
             size_precision=values["size_precision"],
             price_increment=Price.from_str_c(values["price_increment"]),
             size_increment=Quantity.from_str_c(values["size_increment"]),
-            base_currency=Currency.from_str_c(values["base_currency"]) if base_c is not None else None,            
+            base_currency=Currency.from_str_c(values["base_currency"]) if base_c is not None else None,
             lot_size=Quantity.from_str_c(lot_s) if lot_s is not None else None,
             max_quantity=Quantity.from_str_c(max_q) if max_q is not None else None,
             min_quantity=Quantity.from_str_c(min_q) if min_q is not None else None,

--- a/nautilus_trader/model/instruments/cfd.pyx
+++ b/nautilus_trader/model/instruments/cfd.pyx
@@ -1,0 +1,306 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from decimal import Decimal
+
+from libc.stdint cimport uint64_t
+
+from nautilus_trader.core.correctness cimport Condition
+from nautilus_trader.core.rust.model cimport AssetClass
+from nautilus_trader.model.functions cimport asset_class_from_str
+from nautilus_trader.model.functions cimport asset_class_to_str
+from nautilus_trader.core.rust.model cimport CurrencyType
+from nautilus_trader.core.rust.model cimport InstrumentClass
+from nautilus_trader.model.identifiers cimport InstrumentId
+from nautilus_trader.model.identifiers cimport Symbol
+from nautilus_trader.model.instruments.base cimport Instrument
+from nautilus_trader.model.objects cimport Currency
+from nautilus_trader.model.objects cimport Money
+from nautilus_trader.model.objects cimport Price
+from nautilus_trader.model.objects cimport Quantity
+
+
+cdef class Cfd(Instrument):
+    """
+    Represents a generic currency pair instrument in a spot/cash market.
+
+    Can represent both Fiat FX and Cryptocurrency pairs.
+
+    Parameters
+    ----------
+    instrument_id : InstrumentId
+        The instrument ID for the instrument.
+    raw_symbol : Symbol
+        The raw/local/native symbol for the instrument, assigned by the venue.
+    asset_class : AssetClass
+        The cfd contract asset class.
+    base_currency : Currency, optional
+        The base currency.
+    quote_currency : Currency
+        The quote currency.
+    price_precision : int
+        The price decimal precision.
+    size_precision : int
+        The trading size decimal precision.
+    price_increment : Price
+        The minimum price increment (tick size).
+    size_increment : Quantity
+        The minimum size increment.
+    margin_init : Decimal
+        The initial (order) margin requirement in percentage of order value.
+    margin_maint : Decimal
+        The maintenance (position) margin in percentage of position value.
+    maker_fee : Decimal
+        The fee rate for liquidity makers as a percentage of order value.
+    taker_fee : Decimal
+        The fee rate for liquidity takers as a percentage of order value.
+    ts_event : uint64_t
+        The UNIX timestamp (nanoseconds) when the data event occurred.
+    ts_init : uint64_t
+        The UNIX timestamp (nanoseconds) when the data object was initialized.
+    lot_size : Quantity, optional
+        The rounded lot unit size.
+    max_quantity : Quantity, optional
+        The maximum allowable order quantity.
+    min_quantity : Quantity, optional
+        The minimum allowable order quantity.
+    max_notional : Money, optional
+        The maximum allowable order notional value.
+    min_notional : Money, optional
+        The minimum allowable order notional value.
+    max_price : Price, optional
+        The maximum allowable quoted price.
+    min_price : Price, optional
+        The minimum allowable quoted price.
+    tick_scheme_name : str, optional
+        The name of the tick scheme.
+    info : dict[str, object], optional
+        The additional instrument information.
+
+    Raises
+    ------
+    ValueError
+        If `tick_scheme_name` is not a valid string.
+    ValueError
+        If `price_precision` is negative (< 0).
+    ValueError
+        If `size_precision` is negative (< 0).
+    ValueError
+        If `price_increment` is not positive (> 0).
+    ValueError
+        If `size_increment` is not positive (> 0).
+    ValueError
+        If `price_precision` is not equal to price_increment.precision.
+    ValueError
+        If `size_increment` is not equal to size_increment.precision.
+    ValueError
+        If `lot_size` is not positive (> 0).
+    ValueError
+        If `max_quantity` is not positive (> 0).
+    ValueError
+        If `min_quantity` is negative (< 0).
+    ValueError
+        If `max_notional` is not positive (> 0).
+    ValueError
+        If `min_notional` is negative (< 0).
+    ValueError
+        If `max_price` is not positive (> 0).
+    ValueError
+        If `min_price` is negative (< 0).
+    """
+
+    def __init__(
+        self,
+        InstrumentId instrument_id not None,
+        Symbol raw_symbol not None,
+        AssetClass asset_class,
+        Currency quote_currency not None,
+        int price_precision,
+        int size_precision,
+        Price price_increment not None,
+        Quantity size_increment not None,
+        margin_init not None: Decimal,
+        margin_maint not None: Decimal,
+        maker_fee not None: Decimal,
+        taker_fee not None: Decimal,
+        uint64_t ts_event,
+        uint64_t ts_init,
+        Currency base_currency: Currency | None = None,
+        Quantity lot_size: Quantity | None = None,
+        Quantity max_quantity: Quantity | None = None,
+        Quantity min_quantity: Quantity | None = None,
+        Money max_notional: Money | None = None,
+        Money min_notional: Money | None = None,
+        Price max_price: Price | None = None,
+        Price min_price: Price | None = None,
+        str tick_scheme_name = None,
+        dict info = None,
+    ):
+        
+        super().__init__(
+            instrument_id=instrument_id,
+            raw_symbol=raw_symbol,
+            asset_class=asset_class,
+            instrument_class=InstrumentClass.CFD,
+            quote_currency=quote_currency,
+            is_inverse=False,
+            price_precision=price_precision,
+            size_precision=size_precision,
+            price_increment=price_increment,
+            size_increment=size_increment,
+            multiplier=Quantity.from_int_c(1),
+            lot_size=lot_size,
+            max_quantity=max_quantity,
+            min_quantity=min_quantity,
+            max_notional=max_notional,
+            min_notional=min_notional,
+            max_price=max_price,
+            min_price=min_price,
+            margin_init=margin_init,
+            margin_maint=margin_maint,
+            maker_fee=maker_fee,
+            taker_fee=taker_fee,
+            tick_scheme_name=tick_scheme_name,
+            ts_event=ts_event,
+            ts_init=ts_init,
+            info=info,
+        )
+
+    @staticmethod
+    cdef Cfd from_dict_c(dict values):
+        Condition.not_none(values, "values")
+        cdef str base_c = values["base_currency"]
+        cdef str lot_s = values["lot_size"]
+        cdef str max_q = values["max_quantity"]
+        cdef str min_q = values["min_quantity"]
+        cdef str max_n = values["max_notional"]
+        cdef str min_n = values["min_notional"]
+        cdef str max_p = values["max_price"]
+        cdef str min_p = values["min_price"]
+        return Cfd(
+            instrument_id=InstrumentId.from_str_c(values["id"]),
+            raw_symbol=Symbol(values["raw_symbol"]),
+            asset_class=asset_class_from_str(values["asset_class"]),
+            quote_currency=Currency.from_str_c(values["quote_currency"]),
+            price_precision=values["price_precision"],
+            size_precision=values["size_precision"],
+            price_increment=Price.from_str_c(values["price_increment"]),
+            size_increment=Quantity.from_str_c(values["size_increment"]),
+            base_currency=Currency.from_str_c(values["base_currency"]) if base_c is not None else None,            
+            lot_size=Quantity.from_str_c(lot_s) if lot_s is not None else None,
+            max_quantity=Quantity.from_str_c(max_q) if max_q is not None else None,
+            min_quantity=Quantity.from_str_c(min_q) if min_q is not None else None,
+            max_notional=Money.from_str_c(max_n) if max_n is not None else None,
+            min_notional=Money.from_str_c(min_n) if min_n is not None else None,
+            max_price=Price.from_str_c(max_p) if max_p is not None else None,
+            min_price=Price.from_str_c(min_p) if min_p is not None else None,
+            margin_init=Decimal(values["margin_init"]),
+            margin_maint=Decimal(values["margin_maint"]),
+            maker_fee=Decimal(values["maker_fee"]),
+            taker_fee=Decimal(values["taker_fee"]),
+            ts_event=values["ts_event"],
+            ts_init=values["ts_init"],
+            info=values["info"],
+        )
+
+    @staticmethod
+    cdef dict to_dict_c(Cfd obj):
+        Condition.not_none(obj, "obj")
+        return {
+            "type": "Cfd",
+            "id": obj.id.to_str(),
+            "raw_symbol": obj.raw_symbol.to_str(),
+            "asset_class": asset_class_to_str(obj.asset_class),
+            "quote_currency": obj.quote_currency.code,
+            "price_precision": obj.price_precision,
+            "price_increment": str(obj.price_increment),
+            "size_precision": obj.size_precision,
+            "size_increment": str(obj.size_increment),
+            "lot_size": str(obj.lot_size) if obj.lot_size is not None else None,
+            "max_quantity": str(obj.max_quantity) if obj.max_quantity is not None else None,
+            "min_quantity": str(obj.min_quantity) if obj.min_quantity is not None else None,
+            "max_notional": obj.max_notional.to_str() if obj.max_notional is not None else None,
+            "min_notional": obj.min_notional.to_str() if obj.min_notional is not None else None,
+            "max_price": str(obj.max_price) if obj.max_price is not None else None,
+            "min_price": str(obj.min_price) if obj.min_price is not None else None,
+            "margin_init": str(obj.margin_init),
+            "margin_maint": str(obj.margin_maint),
+            "maker_fee": str(obj.maker_fee),
+            "taker_fee": str(obj.taker_fee),
+            "ts_event": obj.ts_event,
+            "ts_init": obj.ts_init,
+            "info": obj.info,
+        }
+
+    @staticmethod
+    def from_dict(dict values) -> Cfd:
+        """
+        Return an instrument from the given initialization values.
+
+        Parameters
+        ----------
+        values : dict[str, object]
+            The values to initialize the instrument with.
+
+        Returns
+        -------
+        Cfd
+
+        """
+        return Cfd.from_dict_c(values)
+
+    @staticmethod
+    def to_dict(Cfd obj) -> dict[str, object]:
+        """
+        Return a dictionary representation of this object.
+
+        Returns
+        -------
+        dict[str, object]
+
+        """
+        return Cfd.to_dict_c(obj)
+
+    @staticmethod
+    cdef Cfd from_pyo3_c(pyo3_instrument):
+        return Cfd(
+            instrument_id=InstrumentId.from_str_c(pyo3_instrument.id.value),
+            raw_symbol=Symbol(pyo3_instrument.id.symbol.value),
+            asset_class=asset_class_from_str(str(pyo3_instrument.asset_class)),
+            quote_currency=Currency.from_str_c(pyo3_instrument.quote_currency.code),
+            price_precision=pyo3_instrument.price_precision,
+            size_precision=pyo3_instrument.size_precision,
+            price_increment=Price.from_raw_c(pyo3_instrument.price_increment.raw, pyo3_instrument.price_precision),
+            size_increment=Quantity.from_raw_c(pyo3_instrument.size_increment.raw, pyo3_instrument.size_precision),
+            base_currency=Currency.from_str_c(pyo3_instrument.base_currency.code) if pyo3_instrument.base_currency is not None else None,
+            lot_size=Quantity.from_str_c(pyo3_instrument.lot_size) if pyo3_instrument.lot_size is not None else None,
+            max_quantity=Quantity.from_raw_c(pyo3_instrument.max_quantity.raw, pyo3_instrument.max_quantity.precision) if pyo3_instrument.max_quantity is not None else None,
+            min_quantity=Quantity.from_raw_c(pyo3_instrument.min_quantity.raw, pyo3_instrument.min_quantity.precision) if pyo3_instrument.min_quantity is not None else None,
+            max_notional=Money.from_str_c(str(pyo3_instrument.max_notional)) if pyo3_instrument.max_notional is not None else None,
+            min_notional=Money.from_str_c(str(pyo3_instrument.min_notional)) if pyo3_instrument.min_notional is not None else None,
+            max_price=Price.from_raw_c(pyo3_instrument.max_price.raw,pyo3_instrument.max_price.precision) if pyo3_instrument.max_price is not None else None,
+            min_price=Price.from_raw_c(pyo3_instrument.min_price.raw,pyo3_instrument.min_price.precision) if pyo3_instrument.min_price is not None else None,
+            margin_init=Decimal(pyo3_instrument.margin_init),
+            margin_maint=Decimal(pyo3_instrument.margin_maint),
+            maker_fee=Decimal(pyo3_instrument.maker_fee),
+            taker_fee=Decimal(pyo3_instrument.taker_fee),
+            ts_event=pyo3_instrument.ts_event,
+            ts_init=pyo3_instrument.ts_init,
+            info=pyo3_instrument.info,
+        )
+
+    @staticmethod
+    def from_pyo3(pyo3_instrument):
+        return Cfd.from_pyo3_c(pyo3_instrument)

--- a/nautilus_trader/model/instruments/commodity.pxd
+++ b/nautilus_trader/model/instruments/commodity.pxd
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.model.instruments.base cimport Instrument
+
+
+cdef class Commodity(Instrument):
+    cdef readonly str isin
+    """The instruments International Securities Identification Number (ISIN).\n\n:returns: `str` or ``None``"""
+
+    @staticmethod
+    cdef Commodity from_dict_c(dict values)
+
+    @staticmethod
+    cdef dict to_dict_c(Commodity obj)
+
+    @staticmethod
+    cdef Commodity from_pyo3_c(pyo3_instrument)

--- a/nautilus_trader/model/instruments/commodity.pyx
+++ b/nautilus_trader/model/instruments/commodity.pyx
@@ -1,0 +1,301 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from decimal import Decimal
+
+from libc.stdint cimport uint64_t
+
+from nautilus_trader.core.correctness cimport Condition
+from nautilus_trader.core.rust.model cimport AssetClass
+from nautilus_trader.model.functions cimport asset_class_from_str
+from nautilus_trader.model.functions cimport asset_class_to_str
+from nautilus_trader.core.rust.model cimport CurrencyType
+from nautilus_trader.core.rust.model cimport InstrumentClass
+from nautilus_trader.model.identifiers cimport InstrumentId
+from nautilus_trader.model.identifiers cimport Symbol
+from nautilus_trader.model.instruments.base cimport Instrument
+from nautilus_trader.model.objects cimport Currency
+from nautilus_trader.model.objects cimport Money
+from nautilus_trader.model.objects cimport Price
+from nautilus_trader.model.objects cimport Quantity
+
+
+cdef class Commodity(Instrument):
+    """
+    Represents a generic currency pair instrument in a spot/cash market.
+
+    Can represent both Fiat FX and Cryptocurrency pairs.
+
+    Parameters
+    ----------
+    instrument_id : InstrumentId
+        The instrument ID for the instrument.
+    raw_symbol : Symbol
+        The raw/local/native symbol for the instrument, assigned by the venue.
+    asset_class : AssetClass
+        The Commodity contract asset class.
+    quote_currency : Currency
+        The quote currency.
+    price_precision : int
+        The price decimal precision.
+    size_precision : int
+        The trading size decimal precision.
+    price_increment : Price
+        The minimum price increment (tick size).
+    size_increment : Quantity
+        The minimum size increment.
+    margin_init : Decimal
+        The initial (order) margin requirement in percentage of order value.
+    margin_maint : Decimal
+        The maintenance (position) margin in percentage of position value.
+    maker_fee : Decimal
+        The fee rate for liquidity makers as a percentage of order value.
+    taker_fee : Decimal
+        The fee rate for liquidity takers as a percentage of order value.
+    ts_event : uint64_t
+        The UNIX timestamp (nanoseconds) when the data event occurred.
+    ts_init : uint64_t
+        The UNIX timestamp (nanoseconds) when the data object was initialized.
+    lot_size : Quantity, optional
+        The rounded lot unit size.
+    max_quantity : Quantity, optional
+        The maximum allowable order quantity.
+    min_quantity : Quantity, optional
+        The minimum allowable order quantity.
+    max_notional : Money, optional
+        The maximum allowable order notional value.
+    min_notional : Money, optional
+        The minimum allowable order notional value.
+    max_price : Price, optional
+        The maximum allowable quoted price.
+    min_price : Price, optional
+        The minimum allowable quoted price.
+    tick_scheme_name : str, optional
+        The name of the tick scheme.
+    info : dict[str, object], optional
+        The additional instrument information.
+
+    Raises
+    ------
+    ValueError
+        If `tick_scheme_name` is not a valid string.
+    ValueError
+        If `price_precision` is negative (< 0).
+    ValueError
+        If `size_precision` is negative (< 0).
+    ValueError
+        If `price_increment` is not positive (> 0).
+    ValueError
+        If `size_increment` is not positive (> 0).
+    ValueError
+        If `price_precision` is not equal to price_increment.precision.
+    ValueError
+        If `size_increment` is not equal to size_increment.precision.
+    ValueError
+        If `lot_size` is not positive (> 0).
+    ValueError
+        If `max_quantity` is not positive (> 0).
+    ValueError
+        If `min_quantity` is negative (< 0).
+    ValueError
+        If `max_notional` is not positive (> 0).
+    ValueError
+        If `min_notional` is negative (< 0).
+    ValueError
+        If `max_price` is not positive (> 0).
+    ValueError
+        If `min_price` is negative (< 0).
+    """
+
+    def __init__(
+        self,
+        InstrumentId instrument_id not None,
+        Symbol raw_symbol not None,
+        AssetClass asset_class,
+        Currency quote_currency not None,
+        int price_precision,
+        int size_precision,
+        Price price_increment not None,
+        Quantity size_increment not None,
+        margin_init not None: Decimal,
+        margin_maint not None: Decimal,
+        maker_fee not None: Decimal,
+        taker_fee not None: Decimal,
+        uint64_t ts_event,
+        uint64_t ts_init,
+        Currency base_currency: Currency | None = None,
+        Quantity lot_size: Quantity | None = None,
+        Quantity max_quantity: Quantity | None = None,
+        Quantity min_quantity: Quantity | None = None,
+        Money max_notional: Money | None = None,
+        Money min_notional: Money | None = None,
+        Price max_price: Price | None = None,
+        Price min_price: Price | None = None,
+        str tick_scheme_name = None,
+        dict info = None,
+    ):
+
+        super().__init__(
+            instrument_id=instrument_id,
+            raw_symbol=raw_symbol,
+            asset_class=asset_class,
+            instrument_class=InstrumentClass.SPOT,
+            quote_currency=quote_currency,
+            is_inverse=False,
+            price_precision=price_precision,
+            size_precision=size_precision,
+            price_increment=price_increment,
+            size_increment=size_increment,
+            multiplier=Quantity.from_int_c(1),
+            lot_size=lot_size,
+            max_quantity=max_quantity,
+            min_quantity=min_quantity,
+            max_notional=max_notional,
+            min_notional=min_notional,
+            max_price=max_price,
+            min_price=min_price,
+            margin_init=margin_init,
+            margin_maint=margin_maint,
+            maker_fee=maker_fee,
+            taker_fee=taker_fee,
+            tick_scheme_name=tick_scheme_name,
+            ts_event=ts_event,
+            ts_init=ts_init,
+            info=info,
+        )
+
+    @staticmethod
+    cdef Commodity from_dict_c(dict values):
+        Condition.not_none(values, "values")
+        cdef str lot_s = values["lot_size"]
+        cdef str max_q = values["max_quantity"]
+        cdef str min_q = values["min_quantity"]
+        cdef str max_n = values["max_notional"]
+        cdef str min_n = values["min_notional"]
+        cdef str max_p = values["max_price"]
+        cdef str min_p = values["min_price"]
+        return Commodity(
+            instrument_id=InstrumentId.from_str_c(values["id"]),
+            raw_symbol=Symbol(values["raw_symbol"]),
+            asset_class=asset_class_from_str(values["asset_class"]),
+            quote_currency=Currency.from_str_c(values["quote_currency"]),
+            price_precision=values["price_precision"],
+            size_precision=values["size_precision"],
+            price_increment=Price.from_str_c(values["price_increment"]),
+            size_increment=Quantity.from_str_c(values["size_increment"]),
+            lot_size=Quantity.from_str_c(lot_s) if lot_s is not None else None,
+            max_quantity=Quantity.from_str_c(max_q) if max_q is not None else None,
+            min_quantity=Quantity.from_str_c(min_q) if min_q is not None else None,
+            max_notional=Money.from_str_c(max_n) if max_n is not None else None,
+            min_notional=Money.from_str_c(min_n) if min_n is not None else None,
+            max_price=Price.from_str_c(max_p) if max_p is not None else None,
+            min_price=Price.from_str_c(min_p) if min_p is not None else None,
+            margin_init=Decimal(values["margin_init"]),
+            margin_maint=Decimal(values["margin_maint"]),
+            maker_fee=Decimal(values["maker_fee"]),
+            taker_fee=Decimal(values["taker_fee"]),
+            ts_event=values["ts_event"],
+            ts_init=values["ts_init"],
+            info=values["info"],
+        )
+
+    @staticmethod
+    cdef dict to_dict_c(Commodity obj):
+        Condition.not_none(obj, "obj")
+        return {
+            "type": "Commodity",
+            "id": obj.id.to_str(),
+            "raw_symbol": obj.raw_symbol.to_str(),
+            "asset_class": asset_class_to_str(obj.asset_class),
+            "quote_currency": obj.quote_currency.code,
+            "price_precision": obj.price_precision,
+            "price_increment": str(obj.price_increment),
+            "size_precision": obj.size_precision,
+            "size_increment": str(obj.size_increment),
+            "lot_size": str(obj.lot_size) if obj.lot_size is not None else None,
+            "max_quantity": str(obj.max_quantity) if obj.max_quantity is not None else None,
+            "min_quantity": str(obj.min_quantity) if obj.min_quantity is not None else None,
+            "max_notional": obj.max_notional.to_str() if obj.max_notional is not None else None,
+            "min_notional": obj.min_notional.to_str() if obj.min_notional is not None else None,
+            "max_price": str(obj.max_price) if obj.max_price is not None else None,
+            "min_price": str(obj.min_price) if obj.min_price is not None else None,
+            "margin_init": str(obj.margin_init),
+            "margin_maint": str(obj.margin_maint),
+            "maker_fee": str(obj.maker_fee),
+            "taker_fee": str(obj.taker_fee),
+            "ts_event": obj.ts_event,
+            "ts_init": obj.ts_init,
+            "info": obj.info,
+        }
+
+    @staticmethod
+    def from_dict(dict values) -> Commodity:
+        """
+        Return an instrument from the given initialization values.
+
+        Parameters
+        ----------
+        values : dict[str, object]
+            The values to initialize the instrument with.
+
+        Returns
+        -------
+        Commodity
+
+        """
+        return Commodity.from_dict_c(values)
+
+    @staticmethod
+    def to_dict(Commodity obj) -> dict[str, object]:
+        """
+        Return a dictionary representation of this object.
+
+        Returns
+        -------
+        dict[str, object]
+
+        """
+        return Commodity.to_dict_c(obj)
+
+    @staticmethod
+    cdef Commodity from_pyo3_c(pyo3_instrument):
+        return Commodity(
+            instrument_id=InstrumentId.from_str_c(pyo3_instrument.id.value),
+            raw_symbol=Symbol(pyo3_instrument.id.symbol.value),
+            asset_class=asset_class_from_str(str(pyo3_instrument.asset_class)),
+            quote_currency=Currency.from_str_c(pyo3_instrument.quote_currency.code),
+            price_precision=pyo3_instrument.price_precision,
+            size_precision=pyo3_instrument.size_precision,
+            price_increment=Price.from_raw_c(pyo3_instrument.price_increment.raw, pyo3_instrument.price_precision),
+            size_increment=Quantity.from_raw_c(pyo3_instrument.size_increment.raw, pyo3_instrument.size_precision),
+            lot_size=Quantity.from_str_c(pyo3_instrument.lot_size) if pyo3_instrument.lot_size is not None else None,
+            max_quantity=Quantity.from_raw_c(pyo3_instrument.max_quantity.raw, pyo3_instrument.max_quantity.precision) if pyo3_instrument.max_quantity is not None else None,
+            min_quantity=Quantity.from_raw_c(pyo3_instrument.min_quantity.raw, pyo3_instrument.min_quantity.precision) if pyo3_instrument.min_quantity is not None else None,
+            max_notional=Money.from_str_c(str(pyo3_instrument.max_notional)) if pyo3_instrument.max_notional is not None else None,
+            min_notional=Money.from_str_c(str(pyo3_instrument.min_notional)) if pyo3_instrument.min_notional is not None else None,
+            max_price=Price.from_raw_c(pyo3_instrument.max_price.raw,pyo3_instrument.max_price.precision) if pyo3_instrument.max_price is not None else None,
+            min_price=Price.from_raw_c(pyo3_instrument.min_price.raw,pyo3_instrument.min_price.precision) if pyo3_instrument.min_price is not None else None,
+            margin_init=Decimal(pyo3_instrument.margin_init),
+            margin_maint=Decimal(pyo3_instrument.margin_maint),
+            maker_fee=Decimal(pyo3_instrument.maker_fee),
+            taker_fee=Decimal(pyo3_instrument.taker_fee),
+            ts_event=pyo3_instrument.ts_event,
+            ts_init=pyo3_instrument.ts_init,
+            info=pyo3_instrument.info,
+        )
+
+    @staticmethod
+    def from_pyo3(pyo3_instrument):
+        return Commodity.from_pyo3_c(pyo3_instrument)

--- a/nautilus_trader/model/instruments/commodity.pyx
+++ b/nautilus_trader/model/instruments/commodity.pyx
@@ -19,10 +19,10 @@ from libc.stdint cimport uint64_t
 
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.rust.model cimport AssetClass
-from nautilus_trader.model.functions cimport asset_class_from_str
-from nautilus_trader.model.functions cimport asset_class_to_str
 from nautilus_trader.core.rust.model cimport CurrencyType
 from nautilus_trader.core.rust.model cimport InstrumentClass
+from nautilus_trader.model.functions cimport asset_class_from_str
+from nautilus_trader.model.functions cimport asset_class_to_str
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport Symbol
 from nautilus_trader.model.instruments.base cimport Instrument

--- a/nautilus_trader/serialization/arrow/implementations/instruments.py
+++ b/nautilus_trader/serialization/arrow/implementations/instruments.py
@@ -17,6 +17,8 @@ import msgspec
 import pyarrow as pa
 
 from nautilus_trader.model.instruments import BettingInstrument
+from nautilus_trader.model.instruments import Cfd
+from nautilus_trader.model.instruments import Commodity
 from nautilus_trader.model.instruments import CryptoFuture
 from nautilus_trader.model.instruments import CryptoPerpetual
 from nautilus_trader.model.instruments import CurrencyPair
@@ -241,6 +243,42 @@ SCHEMAS = {
             "activation_ns": pa.uint64(),
             "expiration_ns": pa.uint64(),
             "info": pa.binary(),
+            "ts_event": pa.uint64(),
+            "ts_init": pa.uint64(),
+        },
+    ),
+    Cfd: pa.schema(
+        {
+            "id": pa.dictionary(pa.int64(), pa.string()),
+            "raw_symbol": pa.string(),
+            "asset_class": pa.dictionary(pa.int8(), pa.string()),
+            "currency": pa.dictionary(pa.int16(), pa.string()),
+            "base_currency": pa.dictionary(pa.int16(), pa.string()),
+            "quote_currency": pa.dictionary(pa.int16(), pa.string()),
+            "price_precision": pa.uint8(),
+            "size_precision": pa.uint8(),
+            "price_increment": pa.dictionary(pa.int16(), pa.string()),
+            "size_increment": pa.dictionary(pa.int16(), pa.string()),
+            "multiplier": pa.dictionary(pa.int16(), pa.string()),
+            "lot_size": pa.dictionary(pa.int16(), pa.string()),
+            "underlying": pa.dictionary(pa.int16(), pa.string()),
+            "ts_event": pa.uint64(),
+            "ts_init": pa.uint64(),
+        },
+    ),
+    Commodity: pa.schema(
+        {
+            "id": pa.dictionary(pa.int64(), pa.string()),
+            "raw_symbol": pa.string(),
+            "asset_class": pa.dictionary(pa.int8(), pa.string()),
+            "currency": pa.dictionary(pa.int16(), pa.string()),
+            "quote_currency": pa.dictionary(pa.int16(), pa.string()),
+            "price_precision": pa.uint8(),
+            "size_precision": pa.uint8(),
+            "price_increment": pa.dictionary(pa.int16(), pa.string()),
+            "size_increment": pa.dictionary(pa.int16(), pa.string()),
+            "multiplier": pa.dictionary(pa.int16(), pa.string()),
+            "lot_size": pa.dictionary(pa.int16(), pa.string()),
             "ts_event": pa.uint64(),
             "ts_init": pa.uint64(),
         },


### PR DESCRIPTION
# Pull Request

add CFD and Commodity support for Interactivebrokers;
fix the strict_symbology for parsing Instrument/contract of Interactivebrokers

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested?

Tested with "XAUUSD.IBCMDTY", "XAUUSD.IBCFD", "IBUS30.IBCFD", "TSLA.IBCFD", "EUD/USD.IBCFD" by live trading and historical data downloading. 
a doc that "IBCFD" and "IBCMDTY" used as venue (mapping to "SMART") might be updated.
Although it works with no bugs as far as i tested it, the cfd.pyx and commodity.pyx may need to be refined.

Thanks @rsmb7z for advice.