### PR TITLE
Betfair bugfix: Reload cache as a dict of venue and client order ids

### DIFF
--- a/nautilus_trader/adapters/betfair/execution.py
+++ b/nautilus_trader/adapters/betfair/execution.py
@@ -602,7 +602,8 @@ class BetfairExecutionClient(LiveExecutionClient):
         self._log.info("Loading venue_id mapping from cache")
         raw = self._cache.get("betfair_execution_client.venue_order_id_to_client_order_id") or b"{}"
         self._log.info(f"venue_id_mapping: {raw.decode()=}")
-        self.venue_order_id_to_client_order_id = msgspec.json.decode(raw)
+        self.venue_order_id_to_client_order_id = \
+            {VenueOrderId(k): ClientOrderId(v) for k, v in msgspec.json.decode(raw).items()}
 
     def set_venue_id_mapping(
         self,

--- a/nautilus_trader/adapters/betfair/execution.py
+++ b/nautilus_trader/adapters/betfair/execution.py
@@ -602,8 +602,9 @@ class BetfairExecutionClient(LiveExecutionClient):
         self._log.info("Loading venue_id mapping from cache")
         raw = self._cache.get("betfair_execution_client.venue_order_id_to_client_order_id") or b"{}"
         self._log.info(f"venue_id_mapping: {raw.decode()=}")
-        self.venue_order_id_to_client_order_id = \
-            {VenueOrderId(k): ClientOrderId(v) for k, v in msgspec.json.decode(raw).items()}
+        self.venue_order_id_to_client_order_id = {
+            VenueOrderId(k): ClientOrderId(v) for k, v in msgspec.json.decode(raw).items()
+        }
 
     def set_venue_id_mapping(
         self,


### PR DESCRIPTION
# Pull Request
Reload venue order and client order id cache correctly after a reconnection event. Please see #betfair (discord) where the issue highlighted a bit better

## Type of change
[x] Bug fix

## How has this change been tested?
In production
