### PR TITLE
Fix sandbox account initialization

### DIFF
--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -86,6 +86,7 @@ class SandboxExecutionClient(LiveExecutionClient):
         balance: int,
         oms_type: OmsType = OmsType.NETTING,
         account_type: AccountType = AccountType.MARGIN,
+        default_leverage: Decimal = Decimal(10),
     ) -> None:
         self._currency = Currency.from_str(currency)
         money = Money(value=balance, currency=self._currency)
@@ -112,7 +113,7 @@ class SandboxExecutionClient(LiveExecutionClient):
             account_type=self._account_type,
             base_currency=self._currency,
             starting_balances=[self.balance.free],
-            default_leverage=Decimal(10),
+            default_leverage=default_leverage,
             leverages={},
             instruments=self.INSTRUMENTS,
             modules=[],

--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -132,6 +132,7 @@ class SandboxExecutionClient(LiveExecutionClient):
             clock=self.test_clock,
         )
         self.exchange.register_client(self._client)
+        self.exchange.initialize_account()
 
     def connect(self) -> None:
         """

--- a/tests/integration_tests/adapters/sandbox/conftest.py
+++ b/tests/integration_tests/adapters/sandbox/conftest.py
@@ -13,9 +13,12 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from decimal import Decimal
+
 import pytest
 
 from nautilus_trader.adapters.sandbox.execution import SandboxExecutionClient
+from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.events import AccountState
 from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import Venue
@@ -48,6 +51,8 @@ def exec_client(
         venue=venue.value,
         currency="USD",
         balance=100_000,
+        account_type=AccountType.CASH,
+        default_leverage=Decimal(1),
     )
 
 


### PR DESCRIPTION
…ation

# Pull Request

The account is initialized when creating a new SandboxExecutionClient. The account is needed in the strategy to set the leverage and determine if a margin or cash account is used.

## Type of change

Delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Locally using the sandbox with the bybit data feed.
