### PR TITLE
Fix IBKR reconnection after gateway/TWS disconnection

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -135,7 +135,7 @@ class InteractiveBrokersClient(
 
         # ConnectionMixin
         self._connection_attempts: int = 0
-        self._max_connection_attempts: int = int(os.getenv("IB_MAX_connection_attempts", 0))
+        self._max_connection_attempts: int = int(os.getenv("IB_MAX_CONNECTION_ATTEMPTS", 0))
         self._indefinite_reconnect: bool = False if self._max_connection_attempts else True
         self._reconnect_delay: int = 5  # seconds
 

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -134,9 +134,9 @@ class InteractiveBrokersClient(
         self._account_ids: set[str] = set()
 
         # ConnectionMixin
-        self._reconnect_attempts: int = 0
-        self._max_reconnect_attempts: int = int(os.getenv("IB_MAX_RECONNECT_ATTEMPTS", 0))
-        self._indefinite_reconnect: bool = False if self._max_reconnect_attempts else True
+        self._connection_attempts: int = 0
+        self._max_connection_attempts: int = int(os.getenv("IB_MAX_connection_attempts", 0))
+        self._indefinite_reconnect: bool = False if self._max_connection_attempts else True
         self._reconnect_delay: int = 5  # seconds
 
         # MarketDataMixin
@@ -170,24 +170,38 @@ class InteractiveBrokersClient(
             self._create_task(self._startup())
 
     async def _startup(self):
-        try:
-            self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
-            await self._connect()
-            self._start_tws_incoming_msg_reader()
-            self._start_internal_msg_queue_processor()
-            self._eclient.startApi()
-            # TWS/Gateway will send a managedAccounts message upon successful connection,
-            # which will set the `_is_ib_connected` event. This typically takes a few
-            # seconds, so we wait for it here.
-            await asyncio.wait_for(self._is_ib_connected.wait(), 15)
-            self._start_connection_watchdog()
-            self._is_client_ready.set()
-        except asyncio.TimeoutError:
-            self._log.error("Client failed to initialize. Connection timeout.")
-            self._stop()
-        except Exception as e:
-            self._log.exception("Unhandled exception in client startup", e)
-            self._stop()
+        while not self._is_ib_connected.is_set():
+            try:
+                self._connection_attempts += 1
+                if (
+                    not self._indefinite_reconnect
+                    and self._connection_attempts > self._max_connection_attempts
+                ):
+                    self._log.error("Max connection attempts reached. Connection failed.")
+                    self._stop()
+                    break
+                if self._connection_attempts > 1:
+                    self._log.info(
+                        f"Attempt {self._connection_attempts}: Attempting to reconnect in {self._reconnect_delay} seconds...",
+                    )
+                    await asyncio.sleep(self._reconnect_delay)
+                self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
+                await self._connect()
+                self._start_tws_incoming_msg_reader()
+                self._start_internal_msg_queue_processor()
+                self._eclient.startApi()
+                # TWS/Gateway will send a managedAccounts message upon successful connection,
+                # which will set the `_is_ib_connected` event. This typically takes a few
+                # seconds, so we wait for it here.
+                await asyncio.wait_for(self._is_ib_connected.wait(), 15)
+                self._start_connection_watchdog()
+            except asyncio.TimeoutError:
+                self._log.error("Client failed to initialize. Connection timeout.")
+            except Exception as e:
+                self._log.exception("Unhandled exception in client startup", e)
+                self._stop()
+        self._is_client_ready.set()
+        self._connection_attempts = 0
 
     def _start_tws_incoming_msg_reader(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -92,23 +92,9 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         """
         Attempt to reconnect to TWS/Gateway.
         """
-        while not self._is_ib_connected.is_set():
-            if (
-                not self._indefinite_reconnect
-                and self._reconnect_attempts > self._max_reconnect_attempts
-            ):
-                self._log.error("Max reconnection attempts reached. Connection failed.")
-                self._stop()
-                break
-            self._reconnect_attempts += 1
-            self._log.info(
-                f"Attempt {self._reconnect_attempts}: Attempting to reconnect in {self._reconnect_delay} seconds...",
-            )
-            await asyncio.sleep(self._reconnect_delay)
-            await self._startup()
-
+        await self._startup()
         self._log.info("Reconnection successful.")
-        self._reconnect_attempts = 0
+        self._connection_attempts = 0
         await self._resubscribe_all()
         self._resume()
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -27,9 +27,9 @@ from nautilus_trader.test_kit.functions import eventually
 
 def test_start(ib_client):
     # Arrange
-    ib_client._is_ib_connected.set()
     ib_client._connect = AsyncMock()
     ib_client._eclient = MagicMock()
+    ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
 
     # Act
     ib_client.start()
@@ -59,9 +59,9 @@ def test_start_tasks(ib_client):
 
 def test_stop(ib_client):
     # Arrange
-    ib_client._is_ib_connected.set()
     ib_client._connect = AsyncMock()
     ib_client._eclient = MagicMock()
+    ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
     ib_client.start()
 
     # Act

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -103,9 +103,9 @@ def ib_client(data_client_config, event_loop, msgbus, cache, clock):
 
 @pytest.fixture()
 def ib_client_running(ib_client):
-    ib_client._is_ib_connected.set()
     ib_client._connect = AsyncMock()
     ib_client._eclient = MagicMock()
+    ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
     ib_client._account_ids = {"DU123456,"}
     ib_client.start()
     yield ib_client


### PR DESCRIPTION
# Pull Request

This pull request addresses an issue with the Interactive Brokers (IBKR) reconnection mechanism. Previously, if the connection to the IB gateway or TWS was lost, either due to the nightly restart or a disrupted connection, the system was unable to successfully reestablish the connection. The changes introduced in this PR resolve this bug, ensuring that the connection can be properly restored after such interruptions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Passes all integration tests. Also worked as anticipated while paper trading.