### PR TITLE
Fix position closing on contract expiration

### DIFF
--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -1322,7 +1322,7 @@ cdef class OrderMatchingEngine:
                 self.cancel_order(order)
 
             # Close all open positions
-            for position in self.cache.positions(None, self.instrument.id):
+            for position in self.cache.positions_open(None, self.instrument.id):
                 order = MarketOrder(
                     trader_id=position.trader_id,
                     strategy_id=position.strategy_id,


### PR DESCRIPTION
# Pull Request

Fixes following bug when there are only closed positions.

```
nautilus_trader\\backtest\\matching_engine.pyx:1261: in nautilus_trader.backtest.matching_engine.OrderMatchingEngine.iterate
    ???
nautilus_trader\\backtest\\matching_engine.pyx:1331: in nautilus_trader.backtest.matching_engine.OrderMatchingEngine.iterate
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   ValueError: invalid `PositionSide`, was FLAT

nautilus_trader\\model\\orders\\base.pyx:807: ValueError
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Added test and resolved the exception.
