### PR TITLE
Fix IBKR resubscribing after disconnection

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -365,7 +365,7 @@ class InteractiveBrokersClient(
         """
         if self.is_running:
             self._degrade()
-        if not self._is_ib_connected.is_set():
+        if self._is_ib_connected.is_set():
             self._log.debug("`_is_ib_connected` unset by `_handle_disconnection`.", LogColor.BLUE)
             self._is_ib_connected.clear()
         await asyncio.sleep(5)

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -164,11 +164,11 @@ class InteractiveBrokersClient(
         """
         if not self._loop.is_running():
             self._log.warning("Started when loop is not running.")
-            self._loop.run_until_complete(self._async_start())
+            self._loop.run_until_complete(self._start_async())
         else:
-            self._create_task(self._async_start())
+            self._create_task(self._start_async())
 
-    async def _async_start(self):
+    async def _start_async(self):
         self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
         while not self._is_ib_connected.is_set():
             try:
@@ -200,7 +200,7 @@ class InteractiveBrokersClient(
                 self._log.exception("Unhandled exception in client startup", e)
                 self._stop()
         self._is_client_ready.set()
-        self._log.debug("`_is_client_ready` set by `_async_start`.", LogColor.BLUE)
+        self._log.debug("`_is_client_ready` set by `_start_async`.", LogColor.BLUE)
         self._connection_attempts = 0
 
     def _start_tws_incoming_msg_reader(self) -> None:
@@ -242,14 +242,14 @@ class InteractiveBrokersClient(
         """
         Stop the client and cancel running tasks.
         """
-        self._create_task(self._async_stop())
+        self._create_task(self._stop_async())
 
-    async def _async_stop(self) -> None:
+    async def _stop_async(self) -> None:
         self._log.info(f"Stopping InteractiveBrokersClient ({self._client_id})...")
 
         if self._is_client_ready.is_set():
             self._is_client_ready.clear()
-            self._log.debug("`_is_client_ready` unset by `_async_stop`.", LogColor.BLUE)
+            self._log.debug("`_is_client_ready` unset by `_stop_async`.", LogColor.BLUE)
 
         # Cancel tasks
         tasks = [
@@ -277,24 +277,24 @@ class InteractiveBrokersClient(
         Restart the client.
         """
 
-        async def _async_reset():
+        async def _reset_async():
             self._log.info(f"Resetting InteractiveBrokersClient ({self._client_id})...")
-            await self._async_stop()
-            await self._async_start()
+            await self._stop_async()
+            await self._start_async()
 
-        self._create_task(_async_reset())
+        self._create_task(_reset_async())
 
     def _resume(self) -> None:
         """
         Resume the client and resubscribe to all subscriptions.
         """
 
-        async def _async_resume():
+        async def _resume_async():
             await self._is_client_ready.wait()
             self._log.info(f"Resuming InteractiveBrokersClient ({self._client_id})...")
             await self._resubscribe_all()
 
-        self._create_task(_async_resume())
+        self._create_task(_resume_async())
 
     def _degrade(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -162,14 +162,14 @@ class InteractiveBrokersClient(
         message reader, and internal message queue processing tasks.
 
         """
-        self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
         if not self._loop.is_running():
             self._log.warning("Started when loop is not running.")
-            self._loop.run_until_complete(self._startup())
+            self._loop.run_until_complete(self._async_start())
         else:
-            self._create_task(self._startup())
+            self._create_task(self._async_start())
 
-    async def _startup(self):
+    async def _async_start(self):
+        self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
         while not self._is_ib_connected.is_set():
             try:
                 self._connection_attempts += 1
@@ -185,7 +185,6 @@ class InteractiveBrokersClient(
                         f"Attempt {self._connection_attempts}: Attempting to reconnect in {self._reconnect_delay} seconds...",
                     )
                     await asyncio.sleep(self._reconnect_delay)
-                self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
                 await self._connect()
                 self._start_tws_incoming_msg_reader()
                 self._start_internal_msg_queue_processor()
@@ -201,6 +200,7 @@ class InteractiveBrokersClient(
                 self._log.exception("Unhandled exception in client startup", e)
                 self._stop()
         self._is_client_ready.set()
+        self._log.debug("`_is_client_ready` set by `_async_start`.", LogColor.BLUE)
         self._connection_attempts = 0
 
     def _start_tws_incoming_msg_reader(self) -> None:
@@ -242,7 +242,15 @@ class InteractiveBrokersClient(
         """
         Stop the client and cancel running tasks.
         """
+        self._create_task(self._async_stop())
+
+    async def _async_stop(self) -> None:
         self._log.info(f"Stopping InteractiveBrokersClient ({self._client_id})...")
+
+        if self._is_client_ready.is_set():
+            self._is_client_ready.clear()
+            self._log.debug("`_is_client_ready` unset by `_async_stop`.", LogColor.BLUE)
+
         # Cancel tasks
         tasks = [
             self._connection_watchdog_task,
@@ -254,44 +262,60 @@ class InteractiveBrokersClient(
             if task and not task.cancelled():
                 task.cancel()
 
+        try:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._log.info("All tasks canceled successfully.")
+        except Exception as e:
+            self._log.exception(f"Error occurred while canceling tasks: {e}", e)
+
         self._eclient.disconnect()
-        self._is_client_ready.clear()
         self._account_ids = set()
-        for client in self.registered_nautilus_clients:
-            self._log.warning(f"Client {client} disconnected.")
         self.registered_nautilus_clients = set()
 
     def _reset(self) -> None:
         """
         Restart the client.
         """
-        self._log.info(f"Resetting InteractiveBrokersClient ({self._client_id})...")
-        self._stop()
-        self._start()
+
+        async def _async_reset():
+            self._log.info(f"Resetting InteractiveBrokersClient ({self._client_id})...")
+            await self._async_stop()
+            await self._async_start()
+
+        self._create_task(_async_reset())
 
     def _resume(self) -> None:
         """
         Resume the client and resubscribe to all subscriptions.
         """
-        self._log.info(f"Resuming InteractiveBrokersClient ({self._client_id})...")
-        self._is_client_ready.set()
+
+        async def _async_resume():
+            await self._is_client_ready.wait()
+            self._log.info(f"Resuming InteractiveBrokersClient ({self._client_id})...")
+            await self._resubscribe_all()
+
+        self._create_task(_async_resume())
 
     def _degrade(self) -> None:
         """
         Degrade the client when connectivity is lost.
         """
-        self._log.info(f"Degrading InteractiveBrokersClient ({self._client_id})...")
-        self._is_client_ready.clear()
-        self._account_ids = set()
+        if not self.is_degraded:
+            self._log.info(f"Degrading InteractiveBrokersClient ({self._client_id})...")
+            self._is_client_ready.clear()
+            self._account_ids = set()
 
     async def _resubscribe_all(self) -> None:
         """
         Cancel and restart all subscriptions.
         """
-        self._log.debug("Resubscribing all subscriptions...")
+        subscriptions = self._subscriptions.get_all()
+        subscription_names = ", ".join([str(subscription.name) for subscription in subscriptions])
+        self._log.info(f"Resubscribing to {len(subscriptions)} subscriptions: {subscription_names}")
+
         for subscription in self._subscriptions.get_all():
+            self._log.info(f"Resubscribing to {subscription.name} subscription...")
             try:
-                subscription.cancel()
                 if iscoroutinefunction(subscription.handle):
                     await subscription.handle()
                 else:
@@ -346,8 +370,6 @@ class InteractiveBrokersClient(
             self._is_ib_connected.clear()
         await asyncio.sleep(5)
         await self._handle_reconnect()
-
-        self._resume()
 
     def _create_task(
         self,
@@ -568,7 +590,7 @@ class InteractiveBrokersClient(
                     break
                 self._internal_msg_queue.task_done()
         except asyncio.CancelledError:
-            log_msg = f"Internal message queue processing stopped. (qsize={self._internal_msg_queue.qsize()})."
+            log_msg = f"Internal message queue processing was cancelled. (qsize={self._internal_msg_queue.qsize()})."
             (
                 self._log.warning(log_msg)
                 if not self._internal_msg_queue.empty()
@@ -630,9 +652,7 @@ class InteractiveBrokersClient(
                 await handler_task()
                 self._msg_handler_task_queue.task_done()
         except asyncio.CancelledError:
-            log_msg = (
-                f"Handler task processing stopped. (qsize={self._msg_handler_task_queue.qsize()})."
-            )
+            log_msg = f"Handler task processing was cancelled. (qsize={self._msg_handler_task_queue.qsize()})."
             (
                 self._log.warning(log_msg)
                 if not self._internal_msg_queue.empty()

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -92,10 +92,7 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         """
         Attempt to reconnect to TWS/Gateway.
         """
-        await self._startup()
-        self._log.info("Reconnection successful.")
-        self._connection_attempts = 0
-        await self._resubscribe_all()
+        self._reset()
         self._resume()
 
     def _initialize_connection_params(self) -> None:

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -21,7 +21,6 @@ from unittest.mock import patch
 
 import pytest
 
-from nautilus_trader.test_kit.functions import ensure_all_tasks_completed
 from nautilus_trader.test_kit.functions import eventually
 
 
@@ -32,7 +31,7 @@ def test_start(ib_client):
     ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
 
     # Act
-    ib_client.start()
+    ib_client._start()
 
     # Assert
     assert ib_client._is_client_ready.is_set()
@@ -57,48 +56,49 @@ def test_start_tasks(ib_client):
     assert not ib_client._connection_watchdog_task.done()
 
 
-def test_stop(ib_client):
+@pytest.mark.asyncio
+async def test_stop(ib_client_running):
     # Arrange
-    ib_client._connect = AsyncMock()
-    ib_client._eclient = MagicMock()
-    ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
-    ib_client.start()
 
     # Act
-    ib_client.stop()
-    ensure_all_tasks_completed()
+    ib_client_running.stop()
+    await asyncio.sleep(0.1)
 
     # Assert
-    assert ib_client.is_stopped
-    assert ib_client._connection_watchdog_task.done()
-    assert ib_client._tws_incoming_msg_reader_task.done()
-    assert ib_client._internal_msg_queue_processor_task.done()
-    assert not ib_client._is_client_ready.is_set()
-    assert len(ib_client.registered_nautilus_clients) == 0
+    assert ib_client_running.is_stopped
+    assert ib_client_running._connection_watchdog_task.done()
+    assert ib_client_running._tws_incoming_msg_reader_task.done()
+    assert ib_client_running._internal_msg_queue_processor_task.done()
+    assert not ib_client_running._is_client_ready.is_set()
+    assert len(ib_client_running.registered_nautilus_clients) == 0
 
 
-def test_reset(ib_client):
+@pytest.mark.asyncio
+async def test_reset(ib_client_running):
     # Arrange
-    ib_client._stop = Mock()
-    ib_client._start = Mock()
+    ib_client_running._async_start = AsyncMock()
+    ib_client_running._async_stop = AsyncMock()
 
     # Act
-    ib_client.reset()
+    ib_client_running._reset()
+    await asyncio.sleep(0.5)
 
     # Assert
-    assert ib_client._stop.called
-    assert ib_client._start.called
+    ib_client_running._async_start.assert_awaited_once()
+    ib_client_running._async_stop.assert_awaited_once()
 
 
-def test_resume(ib_client_running):
+@pytest.mark.asyncio
+async def test_resume(ib_client_running):
     # Arrange, Act, Assert
-    ib_client_running._degrade()
+    ib_client_running._resubscribe_all = MagicMock()
 
     # Act
     ib_client_running._resume()
+    await asyncio.sleep(0.1)
 
     # Assert
-    assert ib_client_running._is_client_ready.is_set()
+    ib_client_running._resubscribe_all.assert_called_once()
 
 
 def test_degrade(ib_client_running):

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -76,16 +76,16 @@ async def test_stop(ib_client_running):
 @pytest.mark.asyncio
 async def test_reset(ib_client_running):
     # Arrange
-    ib_client_running._async_start = AsyncMock()
-    ib_client_running._async_stop = AsyncMock()
+    ib_client_running._start_async = AsyncMock()
+    ib_client_running._stop_async = AsyncMock()
 
     # Act
     ib_client_running._reset()
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(0.1)
 
     # Assert
-    ib_client_running._async_start.assert_awaited_once()
-    ib_client_running._async_stop.assert_awaited_once()
+    ib_client_running._start_async.assert_awaited_once()
+    ib_client_running._stop_async.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

As reported in the Interactive Brokers Discord channel, resubscribing to subscriptions after a reconnect only worked for 1 of multiple subscriptions. This PR fixes that issue and also refactors the lifecycle methods, which are synchronous functions that need to call asynchronous functions. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tests pass and validated with live trading.