### PR TITLE
Fix timer cancel when it is already expired

### DIFF
--- a/nautilus_core/common/src/timer.rs
+++ b/nautilus_core/common/src/timer.rs
@@ -342,9 +342,11 @@ impl LiveTimer {
     /// Cancels the timer (the timer will not generate an event).
     pub fn cancel(&mut self) -> anyhow::Result<()> {
         debug!("Cancel timer '{}'", self.name);
-        if let Some(sender) = self.canceler.take() {
-            // Send cancellation signal
-            sender.send(()).map_err(|e| anyhow::anyhow!("{:?}", e))?;
+        if !self.is_expired.load(atomic::Ordering::SeqCst) {
+            if let Some(sender) = self.canceler.take() {
+                // Send cancellation signal
+                sender.send(()).map_err(|e| anyhow::anyhow!("{:?}", e))?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
# Pull Request

Fix timer canceling when it is already expired.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested

Paper trading with a throttler ran into an issue as discussed on Discord. Error is now resolved.
