### PR TITLE
Fix venue_order_id issue for Sandbox

### DIFF
--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -109,7 +109,7 @@ class SandboxExecutionClient(LiveExecutionClient):
         )
         self.exchange = SimulatedExchange(
             venue=sandbox_venue,
-            oms_type=oms_type,
+            oms_type=OmsType.HEDGING if oms_type == OmsType.NETTING else OmsType.NETTING,
             account_type=self._account_type,
             base_currency=self._currency,
             starting_balances=[self.balance.free],


### PR DESCRIPTION
# Pull Request

Fixes `venue_order_id` error on order event.

```
ValueError(The 'self.venue_order_id' <class 'nautilus_trader.model.identifiers.VenueOrderId'> of PAXOS-1-001 was not equal to the 'event.venue_order_id' <class 'nautilus_trader.model.identifiers.VenueOrderId'> of PAXOS-1-002)
Traceback (most recent call last):
  File "nautilus_trader\\execution\\engine.pyx", line 1007, in nautilus_trader.execution.engine.ExecutionEngine._apply_event_to_order
  File "nautilus_trader\\model\\orders\\base.pyx", line 946, in nautilus_trader.model.orders.base.Order.apply
  File "nautilus_trader\\core\\correctness.pyx", line 306, in nautilus_trader.core.correctness.Condition.equal
```

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)