### PR TITLE
Deserialize bool to u8 in Rust order events

### DIFF
--- a/nautilus_core/core/src/deserialization.rs
+++ b/nautilus_core/core/src/deserialization.rs
@@ -1,0 +1,91 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt;
+
+use serde::{
+    de::{Unexpected, Visitor},
+    Deserializer,
+};
+
+struct BoolVisitor;
+
+impl<'de> Visitor<'de> for BoolVisitor {
+    type Value = u8;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a boolean as u8")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(if value { 1 } else { 0 })
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if value > u8::MAX as u64 {
+            Err(E::invalid_value(Unexpected::Unsigned(value), &self))
+        } else {
+            Ok(value as u8)
+        }
+    }
+}
+
+pub fn from_bool_as_u8<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(BoolVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::from_bool_as_u8;
+
+    #[derive(Deserialize)]
+    pub struct TestStruct {
+        #[serde(deserialize_with = "from_bool_as_u8")]
+        pub value: u8,
+    }
+
+    #[test]
+    fn test_deserialize_bool_as_u8_with_boolean() {
+        let json_true = r#"{"value": true}"#;
+        let test_struct: TestStruct = serde_json::from_str(json_true).unwrap();
+        assert_eq!(test_struct.value, 1);
+
+        let json_false = r#"{"value": false}"#;
+        let test_struct: TestStruct = serde_json::from_str(json_false).unwrap();
+        assert_eq!(test_struct.value, 0);
+    }
+
+    #[test]
+    fn test_deserialize_bool_as_u8_with_u64() {
+        let json_true = r#"{"value": 1}"#;
+        let test_struct: TestStruct = serde_json::from_str(json_true).unwrap();
+        assert_eq!(test_struct.value, 1);
+
+        let json_false = r#"{"value": 0}"#;
+        let test_struct: TestStruct = serde_json::from_str(json_false).unwrap();
+        assert_eq!(test_struct.value, 0);
+    }
+}

--- a/nautilus_core/core/src/lib.rs
+++ b/nautilus_core/core/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub mod correctness;
 pub mod datetime;
+pub mod deserialization;
 pub mod equality;
 pub mod message;
 pub mod nanos;

--- a/nautilus_core/model/src/events/order/accepted.rs
+++ b/nautilus_core/model/src/events/order/accepted.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -49,6 +49,7 @@ pub struct OrderAccepted {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
 }
 

--- a/nautilus_core/model/src/events/order/cancel_rejected.rs
+++ b/nautilus_core/model/src/events/order/cancel_rejected.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -48,6 +48,7 @@ pub struct OrderCancelRejected {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,

--- a/nautilus_core/model/src/events/order/canceled.rs
+++ b/nautilus_core/model/src/events/order/canceled.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -47,6 +47,7 @@ pub struct OrderCanceled {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,

--- a/nautilus_core/model/src/events/order/expired.rs
+++ b/nautilus_core/model/src/events/order/expired.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -47,6 +47,7 @@ pub struct OrderExpired {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,

--- a/nautilus_core/model/src/events/order/modify_rejected.rs
+++ b/nautilus_core/model/src/events/order/modify_rejected.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -48,6 +48,7 @@ pub struct OrderModifyRejected {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,

--- a/nautilus_core/model/src/events/order/pending_cancel.rs
+++ b/nautilus_core/model/src/events/order/pending_cancel.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -48,6 +48,7 @@ pub struct OrderPendingCancel {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
 }

--- a/nautilus_core/model/src/events/order/pending_update.rs
+++ b/nautilus_core/model/src/events/order/pending_update.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -48,6 +48,7 @@ pub struct OrderPendingUpdate {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
 }

--- a/nautilus_core/model/src/events/order/rejected.rs
+++ b/nautilus_core/model/src/events/order/rejected.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -49,6 +49,7 @@ pub struct OrderRejected {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
 }
 

--- a/nautilus_core/model/src/events/order/triggered.rs
+++ b/nautilus_core/model/src/events/order/triggered.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -47,6 +47,7 @@ pub struct OrderTriggered {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
     pub venue_order_id: Option<VenueOrderId>,
     pub account_id: Option<AccountId>,

--- a/nautilus_core/model/src/events/order/updated.rs
+++ b/nautilus_core/model/src/events/order/updated.rs
@@ -16,7 +16,7 @@
 use std::fmt::{Debug, Display};
 
 use derive_builder::Builder;
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{deserialization::from_bool_as_u8, nanos::UnixNanos, uuid::UUID4};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -52,6 +52,7 @@ pub struct OrderUpdated {
     pub event_id: UUID4,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
+    #[serde(deserialize_with = "from_bool_as_u8")]
     pub reconciliation: u8, // TODO: Change to bool once Cython removed
 }
 


### PR DESCRIPTION
# Pull Request

 Because of the Rust migration, some of these Rust structs have bool fields set as `u8` to be compatible with C representation of boolean with FFI. This can also happen pretty often in Cython <-> Rust conversion that is being done in Postgres adapter.
 This poses some problems in deserialization from dicts or strings to these native Rust types. One way to handle this discrepancy is to create a custom deserializer that will convert bools to `u8` 
We also have to take into account that we can receive bool and normal integer

- created `BoolVisitor` which will be used as a deserializer with `serde`attribute `deserialize_with` on most of the `reconciliation` `u8` fields
