### PR TITLE
Add bar_execution option to SandboxExecutionClient (fixes #1645)

### DIFF
--- a/nautilus_trader/adapters/sandbox/config.py
+++ b/nautilus_trader/adapters/sandbox/config.py
@@ -28,9 +28,12 @@ class SandboxExecutionClientConfig(LiveExecClientConfig, frozen=True, kw_only=Tr
         The currency for this venue
     balance : int
         The starting balance for this venue
+    bar_execution: bool
+        If bars should be processed by the matching engine(s) (and move the market).
 
     """
 
     venue: str
     currency: str
     balance: int
+    bar_execution: bool = True

--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -87,6 +87,7 @@ class SandboxExecutionClient(LiveExecutionClient):
         oms_type: OmsType = OmsType.NETTING,
         account_type: AccountType = AccountType.MARGIN,
         default_leverage: Decimal = Decimal(10),
+        bar_execution: bool = True,
     ) -> None:
         self._currency = Currency.from_str(currency)
         money = Money(value=balance, currency=self._currency)
@@ -124,6 +125,7 @@ class SandboxExecutionClient(LiveExecutionClient):
             fee_model=MakerTakerFeeModel(),
             latency_model=LatencyModel(0),
             clock=self.test_clock,
+            bar_execution=bar_execution,
             frozen_account=True,  # <-- Freezing account
         )
         self._client = BacktestExecClient(

--- a/nautilus_trader/adapters/sandbox/factory.py
+++ b/nautilus_trader/adapters/sandbox/factory.py
@@ -73,5 +73,6 @@ class SandboxLiveExecClientFactory(LiveExecClientFactory):
             venue=name or config.venue,
             balance=config.balance,
             currency=config.currency,
+            bar_execution=config.bar_execution,
         )
         return exec_client


### PR DESCRIPTION
# Pull Request

Add `bar_execution` option to the `SandboxExecutionClient` to disable processing internally aggregated bars by the matching engine.

The default is set to use the bars to be consistent with the current behaviour.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Locally running paper trading with the Bybit exchange. Subscribing to quote ticks, trade ticks and internally aggregated bars.
