### PR TITLE
Fix order event object conversion

### DIFF
--- a/nautilus_core/model/src/python/events/order/accepted.rs
+++ b/nautilus_core/model/src/python/events/order/accepted.rs
@@ -74,10 +74,6 @@ impl OrderAccepted {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderAccepted)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/cancel_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/cancel_rejected.rs
@@ -80,10 +80,6 @@ impl OrderCancelRejected {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderCancelRejected)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/canceled.rs
+++ b/nautilus_core/model/src/python/events/order/canceled.rs
@@ -74,10 +74,6 @@ impl OrderCanceled {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderCanceled)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/denied.rs
+++ b/nautilus_core/model/src/python/events/order/denied.rs
@@ -74,10 +74,6 @@ impl OrderDenied {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderDenied)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/emulated.rs
+++ b/nautilus_core/model/src/python/events/order/emulated.rs
@@ -68,10 +68,6 @@ impl OrderEmulated {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderEmulated)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/expired.rs
+++ b/nautilus_core/model/src/python/events/order/expired.rs
@@ -74,10 +74,6 @@ impl OrderExpired {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderExpired)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/filled.rs
+++ b/nautilus_core/model/src/python/events/order/filled.rs
@@ -95,10 +95,6 @@ impl OrderFilled {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderFilled)
-    }
-
     #[getter]
     #[pyo3(name = "is_buy")]
     fn py_is_buy(&self) -> bool {

--- a/nautilus_core/model/src/python/events/order/initialized.rs
+++ b/nautilus_core/model/src/python/events/order/initialized.rs
@@ -144,10 +144,6 @@ impl OrderInitialized {
         from_dict_pyo3(py, values)
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderInitiliazed)
-    }
-
     #[pyo3(name = "to_dict")]
     fn py_to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let dict = PyDict::new(py);

--- a/nautilus_core/model/src/python/events/order/mod.rs
+++ b/nautilus_core/model/src/python/events/order/mod.rs
@@ -65,7 +65,8 @@ pub fn order_event_to_pyobject(py: Python, order_event: OrderEventAny) -> PyResu
 }
 
 pub fn pyobject_to_order_event(py: Python, order_event: PyObject) -> PyResult<OrderEventAny> {
-    match order_event.getattr(py, "type_str")?.extract::<&str>(py)? {
+    let class = order_event.getattr(py, "__class__")?;
+    match class.getattr(py, "__name__")?.extract::<&str>(py)? {
         stringify!(OrderAccepted) => Ok(OrderEventAny::Accepted(
             order_event.extract::<OrderAccepted>(py)?,
         )),

--- a/nautilus_core/model/src/python/events/order/modify_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/modify_rejected.rs
@@ -80,10 +80,6 @@ impl OrderModifyRejected {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderModifyRejected)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/pending_cancel.rs
+++ b/nautilus_core/model/src/python/events/order/pending_cancel.rs
@@ -74,10 +74,6 @@ impl OrderPendingCancel {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderPendingCancel)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/pending_update.rs
+++ b/nautilus_core/model/src/python/events/order/pending_update.rs
@@ -74,10 +74,6 @@ impl OrderPendingUpdate {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderPendingUpdate)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/rejected.rs
+++ b/nautilus_core/model/src/python/events/order/rejected.rs
@@ -77,10 +77,6 @@ impl OrderRejected {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderRejected)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/released.rs
+++ b/nautilus_core/model/src/python/events/order/released.rs
@@ -71,10 +71,6 @@ impl OrderReleased {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderReleased)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/submitted.rs
+++ b/nautilus_core/model/src/python/events/order/submitted.rs
@@ -70,10 +70,6 @@ impl OrderSubmitted {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderSubmitted)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/triggered.rs
+++ b/nautilus_core/model/src/python/events/order/triggered.rs
@@ -74,10 +74,6 @@ impl OrderTriggered {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderTriggered)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {

--- a/nautilus_core/model/src/python/events/order/updated.rs
+++ b/nautilus_core/model/src/python/events/order/updated.rs
@@ -81,10 +81,6 @@ impl OrderUpdated {
         self.to_string()
     }
 
-    fn type_str(&self) -> &str {
-        stringify!(OrderUpdated)
-    }
-
     #[staticmethod]
     #[pyo3(name = "from_dict")]
     fn py_from_dict(py: Python<'_>, values: Py<PyDict>) -> PyResult<Self> {


### PR DESCRIPTION
# Pull Request

After the recent changes https://github.com/nautechsystems/nautilus_trader/commit/2526448a5d9b2783b78d6468de31a81b7af992ef in order event  pyo3 conversion `getter` attribute was missing as you cannot use `.getattr` on function `type_str`. Instead of that we can use `__name__` or `__class__` attribute, and remove all `type_str` function from pyo3 classes

```
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: PyErr
 { type: <class 'TypeError'>, 
value: TypeError("'builtin_function_or_method' object cannot be converted to 'PyString'"), 
traceback: None }

```
