### PR TITLE
Temporal fix for the bug that leads to endless loop at the end of day when downloading tick-level historical data from Interactive Brokers.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,23 @@
+name: pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'  
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,3 +21,13 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files
+      - name: Commit and push changes
+        if: github.event_name == 'push'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Apply pre-commit fixes"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/nautilus_trader/adapters/interactive_brokers/historic/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/historic/client.py
@@ -429,7 +429,8 @@ class HistoricInteractiveBrokersClient:
 
         if min_timestamp.floor("S") == max_timestamp.floor("S"):
             max_timestamp = max_timestamp.floor("S") + pd.Timedelta(seconds=1)
-
+        if len(ticks)<=50:
+            max_timestamp = max_timestamp.floor("S") + pd.Timedelta(minutes=1)
         if max_timestamp >= end_date_time:
             return None, False
 


### PR DESCRIPTION
# Pull Request

Temporal fix for the bug that leads to endless loop at the end of day when downloading tick-level historical data from Interactive Brokers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

        if min_timestamp.floor("S") == max_timestamp.floor("S"):
            max_timestamp = max_timestamp.floor("S") + pd.Timedelta(seconds=1)
the original related code here only works in the following situation:
![nt bug 1](https://github.com/nautechsystems/nautilus_trader/assets/78084335/c23b267e-ba93-4a7f-9b0f-2b7d732f2080)
but doesn't work in the following situation:
![nt bug 2](https://github.com/nautechsystems/nautilus_trader/assets/78084335/87367edd-afd7-424f-8a01-e17ccdf523b4)

Temporal fix. There must be better way than mine...