### PR TITLE
Order by ts_init to read row groups in order

### DIFF
--- a/nautilus_core/persistence/src/backend/session.rs
+++ b/nautilus_core/persistence/src/backend/session.rs
@@ -125,7 +125,7 @@ impl DataBackendSession {
             parquet_options,
         ))?;
 
-        let default_query = format!("SELECT * FROM {}", &table_name);
+        let default_query = format!("SELECT * FROM {} ORDER BY ts_init", &table_name);
         let sql_query = sql_query.unwrap_or(&default_query);
         let query = self.runtime.block_on(self.session_ctx.sql(sql_query))?;
 


### PR DESCRIPTION
# Pull Request

Use `ORDER BY ts_init` in default sql query. Closes #1515 

By default datafusion reads row groups out of order for large files. The test files use in CI are small and don't show this so it was missed. From discussion in https://github.com/apache/datafusion/issues/10572, there are two ways to fix this and using ORDER BY clause is the recommended way.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested with sample data to ensure ordering is maintained.
