### PR TITLE
Refactor mocks in Interactive Brokers integration tests

### DIFF
--- a/tests/integration_tests/adapters/interactive_brokers/mock_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/mock_client.py
@@ -78,12 +78,6 @@ class MockEClient(EClient):
                     req_id=reqId,
                     contract_details=IBTestContractStubs.eurusd_forex_contract_details(),
                 )
-            case "EUR/USD.IDEALPRO":
-                self._handle_task(
-                    self.wrapper._client.process_contract_details,
-                    req_id=reqId,
-                    contract_details=IBTestContractStubs.eurusd_forex_contract_details(),
-                )
 
         self._handle_task(
             self.wrapper._client.process_contract_details_end,

--- a/tests/integration_tests/adapters/interactive_brokers/mock_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/mock_client.py
@@ -1,0 +1,153 @@
+import asyncio
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from ibapi.client import EClient
+
+# fmt: off
+from nautilus_trader.adapters.interactive_brokers.client.client import InteractiveBrokersClient
+from nautilus_trader.adapters.interactive_brokers.client.wrapper import InteractiveBrokersEWrapper
+from nautilus_trader.adapters.interactive_brokers.common import IBContract
+from nautilus_trader.adapters.interactive_brokers.parsing.instruments import ib_contract_to_instrument_id
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
+
+
+class MockEClient(EClient):
+    """
+    MockEClient is a subclass of EClient which is used for simulating Interactive
+    Brokers' client operations.
+
+    This class overloads a few methods of the parent class to better accommodate testing
+    needs. More methods can be added as and when needed, depending on the testing
+    requirements.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._next_valid_counter = 0
+
+    def _handle_task(self, handler: Callable, **kwargs):
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            loop.create_task(handler(**kwargs))  # noqa: RUF006
+        else:
+            loop.run_until_complete(handler(**kwargs))
+
+    #########################################################################
+    ################## Market Data
+    #########################################################################
+
+    #########################################################################
+    ################## Options
+    #########################################################################
+
+    #########################################################################
+    ################## Orders
+    #########################################################################
+
+    #########################################################################
+    ################## Account and Portfolio
+    #########################################################################
+
+    #########################################################################
+    ################## Daily PnL
+    #########################################################################
+
+    #########################################################################
+    ################## Executions
+    #########################################################################
+
+    #########################################################################
+    ################## Contract Details
+    #########################################################################
+
+    def reqContractDetails(self, reqId: int, contract: IBContract):
+        instrument_id = ib_contract_to_instrument_id(contract)
+        print(f"******************************* {reqId=} {instrument_id=}")
+        match instrument_id.value:
+            case "AAPL.NASDAQ":
+                self._handle_task(
+                    self.wrapper._client.process_contract_details,
+                    req_id=reqId,
+                    contract_details=IBTestContractStubs.aapl_equity_contract_details(),
+                )
+            case "EUR/USD.IDEALPRO":
+                self._handle_task(
+                    self.wrapper._client.process_contract_details,
+                    req_id=reqId,
+                    contract_details=IBTestContractStubs.eurusd_forex_contract_details(),
+                )
+            case "EUR/USD.IDEALPRO":
+                self._handle_task(
+                    self.wrapper._client.process_contract_details,
+                    req_id=reqId,
+                    contract_details=IBTestContractStubs.eurusd_forex_contract_details(),
+                )
+
+        self._handle_task(
+            self.wrapper._client.process_contract_details_end,
+            req_id=reqId,
+        )
+
+    #########################################################################
+    ################## Market Depth
+    #########################################################################
+
+    #########################################################################
+    ################## News Bulletins
+    #########################################################################
+
+    #########################################################################
+    ################## Financial Advisors
+    #########################################################################
+    def reqManagedAccts(self):
+        self._handle_task(
+            self.wrapper._client.process_managed_accounts,
+            accounts_list="DU1234567,",
+        )
+
+    #########################################################################
+    ################## Historical Data
+    #########################################################################
+
+    #########################################################################
+    ################## Market Scanners
+    #########################################################################
+
+    #########################################################################
+    ################## Real Time Bars
+    #########################################################################
+
+    #########################################################################
+    ################## Fundamental Data
+    #########################################################################
+
+    ########################################################################
+    ################## News
+    #########################################################################
+
+    #########################################################################
+    ################## Display Groups
+    #########################################################################
+
+
+class MockInteractiveBrokersClient(InteractiveBrokersClient):
+    """
+    MockInteractiveBrokersClient is a subclass of InteractiveBrokersClient used for
+    simulating client operations.
+
+    This class initializes the EClient with a mocked version for testing purposes.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._eclient = MockEClient(
+            wrapper=InteractiveBrokersEWrapper(
+                nautilus_logger=self._log,
+                client=self,
+            ),
+        )
+        self._start = MagicMock()

--- a/tests/integration_tests/adapters/interactive_brokers/mock_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/mock_client.py
@@ -64,7 +64,6 @@ class MockEClient(EClient):
 
     def reqContractDetails(self, reqId: int, contract: IBContract):
         instrument_id = ib_contract_to_instrument_id(contract)
-        print(f"******************************* {reqId=} {instrument_id=}")
         match instrument_id.value:
             case "AAPL.NASDAQ":
                 self._handle_task(

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.test_kit.stubs.data import TestInstrumentProvider
+from nautilus_trader.test_kit.stubs.execution import TestExecStubs
+
+
+_AAPL = TestInstrumentProvider.equity("AAPL", "NASDAQ")
+_EURUSD = TestInstrumentProvider.default_fx_ccy("EUR/USD", Venue("IDEALPRO"))
+
+
+@pytest.mark.parametrize(
+    "expected_order_type, expected_tif, nautilus_order",
+    [
+        # fmt: off
+        ("MKT", "GTC", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.GTC)),
+        ("MKT", "DAY", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.DAY)),
+        ("MKT", "IOC", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.IOC)),
+        ("MKT", "FOK", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.FOK)),
+        ("MKT", "OPG", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.AT_THE_OPEN)),
+        ("MOC", "DAY", TestExecStubs.market_order(instrument=_EURUSD, time_in_force=TimeInForce.AT_THE_CLOSE)),
+        # fmt: on
+    ],
+)
+@pytest.mark.asyncio
+async def test_transform_order_to_ib_order_market(
+    expected_order_type,
+    expected_tif,
+    nautilus_order,
+    exec_client,
+):
+    # Arrange
+    await exec_client._instrument_provider.load_async(nautilus_order.instrument_id)
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(nautilus_order)
+
+    # Assert
+    assert (
+        ib_order.orderType == expected_order_type
+    ), f"{expected_order_type=}, but got {ib_order.orderType=}"
+    assert ib_order.tif == expected_tif, f"{expected_tif=}, but got {ib_order.tif=}"
+
+
+@pytest.mark.parametrize(
+    "expected_order_type, expected_tif, nautilus_order",
+    [
+        # fmt: off
+        ("LMT", "GTC", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.GTC)),
+        ("LMT", "DAY", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.DAY)),
+        ("LMT", "IOC", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.IOC)),
+        ("LMT", "FOK", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.FOK)),
+        ("LMT", "OPG", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.AT_THE_OPEN)),
+        ("LOC", "DAY", TestExecStubs.limit_order(instrument=_EURUSD, time_in_force=TimeInForce.AT_THE_CLOSE)),
+        # fmt: on
+    ],
+)
+@pytest.mark.asyncio
+async def test_transform_order_to_ib_order_limit(
+    expected_order_type,
+    expected_tif,
+    nautilus_order,
+    exec_client,
+):
+    # Arrange
+    await exec_client._instrument_provider.load_async(nautilus_order.instrument_id)
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(nautilus_order)
+
+    # Assert
+    assert (
+        ib_order.orderType == expected_order_type
+    ), f"{expected_order_type=}, but got {ib_order.orderType=}"
+    assert ib_order.tif == expected_tif, f"{expected_tif=}, but got {ib_order.tif=}"


### PR DESCRIPTION
# Pull Request

This PR refines the mocking approach in the Interactive Brokers integration tests, enabling the creation of more sophisticated tests essential for all components of the Interactive Brokers adapter. Additionally, it includes new tests for order transformation.