### PR TITLE
Add DataEngine deltas buffering until F_LAST flag

### DIFF
--- a/nautilus_trader/data/config.py
+++ b/nautilus_trader/data/config.py
@@ -35,6 +35,8 @@ class DataEngineConfig(NautilusConfig, frozen=True):
         - 'right-open': start time is included and end time is excluded.
     validate_data_sequence : bool, default False
         If data objects timestamp sequencing will be validated and handled.
+    buffer_deltas : bool, default False
+        Buffer deltas until the F_LAST flag is set for a delta
     debug : bool, default False
         If debug mode is active (will provide extra debug logging).
 
@@ -44,4 +46,5 @@ class DataEngineConfig(NautilusConfig, frozen=True):
     time_bars_timestamp_on_close: bool = True
     time_bars_interval_type: str = "left-open"
     validate_data_sequence: bool = False
+    buffer_deltas: bool = False
     debug: bool = False

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -57,10 +57,12 @@ cdef class DataEngine(Component):
     cdef readonly dict[InstrumentId, list[SyntheticInstrument]] _synthetic_trade_feeds
     cdef readonly list[InstrumentId] _subscribed_synthetic_quotes
     cdef readonly list[InstrumentId] _subscribed_synthetic_trades
+    cdef readonly dict[InstrumentId, list[OrderBookDelta]] _buffer_deltas_map
     cdef readonly bint _time_bars_build_with_no_updates
     cdef readonly bint _time_bars_timestamp_on_close
     cdef readonly str _time_bars_interval_type
     cdef readonly bint _validate_data_sequence
+    cdef readonly bint _buffer_deltas
 
     cdef readonly bint debug
     """If debug mode is active (will provide extra debug logging).\n\n:returns: `bool`"""

--- a/nautilus_trader/test_kit/stubs/data.py
+++ b/nautilus_trader/test_kit/stubs/data.py
@@ -427,10 +427,11 @@ class TestDataStubs:
     def order_book_deltas(
         instrument_id: InstrumentId | None = None,
         deltas: list[OrderBookDelta] | None = None,
+        flags: int = 0,
     ) -> OrderBookDeltas:
         return OrderBookDeltas(
             instrument_id=instrument_id or TestIdStubs.audusd_id(),
-            deltas=deltas or [TestDataStubs.order_book_delta()],
+            deltas=deltas or [TestDataStubs.order_book_delta(flags=flags)],
         )
 
     @staticmethod

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("ec9a8febb3af4a4b3f7155b9a2c6f9e86597d97a3d62e568a01cd40565a2a7a3",),
+                ("882b85369baccfa23783b986b9b62a0cf396a9488d8e2e3057bc851c812ee6f6",),
             ),
             (
                 TestConfigStubs.risk_engine_config,


### PR DESCRIPTION
# Pull Request

Buffer deltas until the F_LAST flag is set for a delta. This option is configurable and disabled by default to keep the current behavior.

Fixes #1578

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Adding unit tests