### PR TITLE
Filter SANDBOX_INSTRUMENTS to match the execution venue

### DIFF
--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -111,7 +111,7 @@ class SandboxExecutionClient(LiveExecutionClient):
             base_currency=base_currency,
             default_leverage=config.default_leverage,
             leverages=config.leverages or {},
-            instruments=self.INSTRUMENTS,
+            instruments=[i for i in self.INSTRUMENTS if i.venue == sandbox_venue],
             modules=[],
             portfolio=portfolio,
             msgbus=self._msgbus,


### PR DESCRIPTION
# Pull Request

The current implementation of the sandbox execution adapter depends on a global variable called SANDBOX_INSTRUMENTS
In the IBKR example it mentions that all the instruments must be from the same venue
Indeed this is true and the sandbox adapter will fail if you have adapters for more than one venue.
This is problematic for IBKR because the venues are often different e.g. NASDAQ, NYSE, CME etc.
I have modified the execution adapter when its loading to filter the global SANDBOX_INSTRUMENTS to just those instruments that match the venue the adapter is being configured for.


## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?

Describe how this code was/is tested.

I have a local sandbox designed to work with IB that loads instruments on multiple venues (ARCA, NASDAQ) because it trades multiple stocks that have different primary exchanges via IBKR

following the example in the repo, i create multiple sandbox execution adapters - one for each venue that exists in my list of instruments
