### PR TITLE
Refactor InteractiveBrokers client and gateway configuration

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,7 +5,7 @@ Released on TBD (UTC).
 ### Enhancements
 - Added Bybit base coin for fee rate parsing (#1696), thanks @filipmacek
 - Updated installation from source docs for Clang dependency (#1690), thanks @Troubladore
-- Updated `InteractiveBrokersGatewayConfig` docs (#1691), thanks @Troubladore
+- Updated `DockerizedIBGatewayConfig` docs (#1691), thanks @Troubladore
 
 ### Breaking Changes
 None

--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -31,23 +31,30 @@ Because IB does not provide wheels for `ibapi`, NautilusTrader [repackages]( htt
 
 ## Getting Started
 
-Before deploying strategies, ensure that TWS / IB Gateway is running. Launch one of the standalone applications and log in with your credentials, or start the dockerized IB Gateway using `InteractiveBrokersGateway`:
+Before implementing your trading strategies, please ensure that either TWS (Trader Workstation) or IB Gateway is currently running. You have the option to log in to one of these standalone applications using your personal credentials or alternatively, via `DockerizedIBGateway`.
+
+### Establish Connection to an Existing Gateway or TWS:
+Should you choose to connect to a pre-existing Gateway or TWS, it is crucial that you specify the `host` and `port` parameters in both the `InteractiveBrokersDataClientConfig` and `InteractiveBrokersExecClientConfig` to guarantee a successful connection.
+
+### Establish Connection to DockerizedIBGateway:
+In this case, it's essential to supply `dockerized_gateway` with an instance of `DockerizedIBGatewayConfig` in both the `InteractiveBrokersDataClientConfig` and `InteractiveBrokersExecClientConfig`. It's important to stress, however, that `host` and `port` parameters aren't necessary in this context.
+The following example provides a clear illustration of how to establish a connection to a Dockerized Gateway, which is judiciously managed internally by the Factories.
 
 ```python
-from nautilus_trader.adapters.interactive_brokers.gateway import InteractiveBrokersGateway
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
+from nautilus_trader.adapters.interactive_brokers.gateway import DockerizedIBGateway
 
-
-gateway_config = InteractiveBrokersGatewayConfig(
+gateway_config = DockerizedIBGatewayConfig(
     username="test",
     password="test",
     trading_mode="paper",
-    start=True
 )
 
 # This may take a short while to start up, especially the first time
-gateway = InteractiveBrokersGateway(
+gateway = DockerizedIBGateway(
     config=gateway_config
 )
+gateway.start()
 
 # Confirm you are logged in
 print(gateway.is_logged_in(gateway.container))
@@ -56,7 +63,7 @@ print(gateway.is_logged_in(gateway.container))
 print(gateway.container.logs())
 ```
 
-**Note:** To supply credentials to the Interactive Brokers Gateway, either pass the `username` and `password` to the config dictionaries, or set the following environment variables:
+**Note:** To supply credentials to the Interactive Brokers Gateway, either pass the `username` and `password` to the `DockerizedIBGatewayConfig`, or set the following environment variables:
 - `TWS_USERNAME`
 - `TWS_PASSWORD`
 
@@ -210,7 +217,7 @@ data_client_config = InteractiveBrokersDataClientConfig(
     use_regular_trading_hours=True,
     market_data_type=IBMarketDataTypeEnum.DELAYED_FROZEN,  # Default is REALTIME if not set
     instrument_provider=instrument_provider_config,
-    gateway=gateway_config,
+    dockerized_gateway=dockerized_gateway_config,
 )
 ```
 
@@ -226,7 +233,7 @@ from nautilus_trader.config import RoutingConfig
 exec_client_config = InteractiveBrokersExecClientConfig(
     ibg_port=4002,
     account_id="DU123456",  # Must match the connected IB Gateway/TWS
-    gateway=gateway_config,
+    dockerized_gateway=dockerized_gateway_config,
     instrument_provider=instrument_provider_config,
     routing=RoutingConfig(
         default=True,

--- a/examples/live/interactive_brokers/connect_with_dockerized_gateway.py
+++ b/examples/live/interactive_brokers/connect_with_dockerized_gateway.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+# fmt: off
+
+import os
+
+from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
+from nautilus_trader.adapters.interactive_brokers.common import IBContract
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
+from nautilus_trader.adapters.interactive_brokers.config import IBMarketDataTypeEnum
+from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
+from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersExecClientConfig
+from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersInstrumentProviderConfig
+from nautilus_trader.adapters.interactive_brokers.factories import InteractiveBrokersLiveDataClientFactory
+from nautilus_trader.adapters.interactive_brokers.factories import InteractiveBrokersLiveExecClientFactory
+from nautilus_trader.config import LiveDataEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import RoutingConfig
+from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.examples.strategies.subscribe import SubscribeStrategy
+from nautilus_trader.examples.strategies.subscribe import SubscribeStrategyConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.model.identifiers import InstrumentId
+
+
+# fmt: on
+
+# *** THIS IS A TEST STRATEGY WITH NO ALPHA ADVANTAGE WHATSOEVER. ***
+# *** IT IS NOT INTENDED TO BE USED TO TRADE LIVE WITH REAL MONEY. ***
+
+# *** THIS INTEGRATION IS STILL UNDER CONSTRUCTION. ***
+# *** CONSIDER IT TO BE IN AN UNSTABLE BETA PHASE AND EXERCISE CAUTION. ***
+
+ib_contracts = [
+    IBContract(
+        secType="STK",
+        symbol="SPY",
+        exchange="SMART",
+        primaryExchange="ARCA",
+        build_options_chain=True,
+        min_expiry_days=7,
+        max_expiry_days=14,
+    ),
+    IBContract(
+        secType="CONTFUT",
+        exchange="CME",
+        symbol="ES",
+        build_futures_chain=True,
+    ),
+    IBContract(secType="FUT", exchange="NYMEX", localSymbol="CLV3", build_futures_chain=False),
+]
+
+dockerized_gateway = DockerizedIBGatewayConfig(
+    username=os.environ["TWS_USERNAME"],
+    password=os.environ["TWS_PASSWORD"],
+    trading_mode="paper",
+    read_only_api=True,
+)
+
+instrument_provider = InteractiveBrokersInstrumentProviderConfig(
+    build_futures_chain=False,
+    build_options_chain=False,
+    min_expiry_days=10,
+    max_expiry_days=60,
+    load_ids=frozenset(
+        [
+            "EUR/USD.IDEALPRO",
+            "BTC/USD.PAXOS",
+            "SPY.ARCA",
+            "V.NYSE",
+            "YMH24.CBOT",
+            "CLZ27.NYMEX",
+            "ESZ27.CME",
+        ],
+    ),
+    load_contracts=frozenset(ib_contracts),
+)
+
+# Configure the trading node
+
+config_node = TradingNodeConfig(
+    trader_id="TESTER-001",
+    logging=LoggingConfig(log_level="INFO"),
+    data_clients={
+        "IB": InteractiveBrokersDataClientConfig(
+            ibg_client_id=1,
+            handle_revised_bars=False,
+            use_regular_trading_hours=True,
+            market_data_type=IBMarketDataTypeEnum.DELAYED_FROZEN,  # If unset default is REALTIME
+            instrument_provider=instrument_provider,
+            dockerized_gateway=dockerized_gateway,
+        ),
+    },
+    exec_clients={
+        "IB": InteractiveBrokersExecClientConfig(
+            ibg_client_id=1,
+            account_id="DU123456",  # This must match with the IB Gateway/TWS node is connecting to
+            dockerized_gateway=dockerized_gateway,
+            instrument_provider=instrument_provider,
+            routing=RoutingConfig(
+                default=True,
+            ),
+        ),
+    },
+    data_engine=LiveDataEngineConfig(
+        time_bars_timestamp_on_close=False,  # Will use opening time as `ts_event` (same like IB)
+        validate_data_sequence=True,  # Will make sure DataEngine discards any Bars received out of sequence
+    ),
+    timeout_connection=90.0,
+    timeout_reconciliation=5.0,
+    timeout_portfolio=5.0,
+    timeout_disconnection=5.0,
+    timeout_post_stop=2.0,
+)
+
+# Instantiate the node with a configuration
+node = TradingNode(config=config_node)
+
+# Configure your strategy
+strategy_config = SubscribeStrategyConfig(
+    instrument_id=InstrumentId.from_str("EUR/USD.IDEALPRO"),
+    # book_type=None,
+    # snapshots=True,
+    trade_ticks=False,
+    quote_ticks=True,
+    # bars=True,
+)
+# Instantiate your strategy
+strategy = SubscribeStrategy(config=strategy_config)
+
+# Add your strategies and modules
+node.trader.add_strategy(strategy)
+
+# Register your client factories with the node (can take user defined factories)
+node.add_data_client_factory("IB", InteractiveBrokersLiveDataClientFactory)
+node.add_exec_client_factory("IB", InteractiveBrokersLiveExecClientFactory)
+node.build()
+node.portfolio.set_specific_venue(IB_VENUE)
+
+# Stop and dispose of the node with SIGINT/CTRL+C
+if __name__ == "__main__":
+    try:
+        node.run()
+    finally:
+        node.dispose()

--- a/examples/live/interactive_brokers/historic_download.py
+++ b/examples/live/interactive_brokers/historic_download.py
@@ -19,20 +19,33 @@ import datetime
 import os
 
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersGatewayConfig
-from nautilus_trader.adapters.interactive_brokers.gateway import InteractiveBrokersGateway
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
+from nautilus_trader.adapters.interactive_brokers.gateway import DockerizedIBGateway
 from nautilus_trader.adapters.interactive_brokers.historic import HistoricInteractiveBrokersClient
+from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.persistence.catalog import ParquetDataCatalog
 
 
-async def main():
-    gateway_config = InteractiveBrokersGatewayConfig(
-        username=os.environ["TWS_USERNAME"],
-        password=os.environ["TWS_PASSWORD"],
-        port=4002,
-    )
-    gateway = InteractiveBrokersGateway(config=gateway_config)
-    gateway.start()
+async def main(
+    host: str | None = None,
+    port: int | None = None,
+    dockerized_gateway: DockerizedIBGatewayConfig | None = None,
+):
+    if dockerized_gateway:
+        PyCondition.none(host, "Ensure `host` is set to None when using DockerizedIBGatewayConfig.")
+        PyCondition.none(port, "Ensure `port` is set to None when using DockerizedIBGatewayConfig.")
+        PyCondition.type(dockerized_gateway, DockerizedIBGatewayConfig, "dockerized_gateway")
+        gateway = DockerizedIBGateway(config=dockerized_gateway)
+        gateway.start(dockerized_gateway.timeout)
+        host = gateway.host
+        port = gateway.port
+    else:
+        gateway = None
+        PyCondition.not_none(
+            host,
+            "Please provide the `host` IP address for the IB TWS or Gateway.",
+        )
+        PyCondition.not_none(port, "Please provide the `port` for the IB TWS or Gateway.")
 
     contract = IBContract(
         secType="STK",
@@ -42,8 +55,8 @@ async def main():
     )
     instrument_id = "TSLA.NASDAQ"
 
-    client = HistoricInteractiveBrokersClient(port=4002, client_id=5)
-    await client._connect()
+    client = HistoricInteractiveBrokersClient(host=host, port=port, client_id=5)
+    await client.connect()
     await asyncio.sleep(2)
 
     instruments = await client.request_instruments(
@@ -78,7 +91,8 @@ async def main():
         instrument_ids=[instrument_id],
     )
 
-    gateway.stop()
+    if gateway:
+        gateway.stop()
 
     catalog = ParquetDataCatalog("./catalog")
     catalog.write_data(instruments)
@@ -88,4 +102,13 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    gateway_config = DockerizedIBGatewayConfig(
+        username=os.environ["TWS_USERNAME"],
+        password=os.environ["TWS_PASSWORD"],
+        trading_mode="paper",
+    )
+    asyncio.run(main(dockerized_gateway=gateway_config))
+
+    # To connect to an existing TWS or Gateway instance without the use of automated dockerized gateway,
+    # follow this format:
+    # asyncio.run(main(host="127.0.0.1", port=7497))

--- a/examples/sandbox/interactive_brokers_sandbox.py
+++ b/examples/sandbox/interactive_brokers_sandbox.py
@@ -16,9 +16,10 @@
 
 from decimal import Decimal
 
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
+
 # fmt: off
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersGatewayConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersInstrumentProviderConfig
 from nautilus_trader.adapters.interactive_brokers.factories import InteractiveBrokersLiveDataClientFactory
 from nautilus_trader.adapters.sandbox.config import SandboxExecutionClientConfig
@@ -41,8 +42,7 @@ catalog = ParquetDataCatalog(CATALOG_PATH)
 SANDBOX_INSTRUMENTS = catalog.instruments(instrument_ids=["EUR/USD.IDEALPRO"])
 
 # Set up the Interactive Brokers gateway configuration, this is applicable only when using Docker.
-gateway = InteractiveBrokersGatewayConfig(
-    start=False,
+dockerized_gateway = DockerizedIBGatewayConfig(
     username=None,
     password=None,
     trading_mode="paper",
@@ -80,7 +80,7 @@ config_node = TradingNodeConfig(
             ibg_client_id=1,
             use_regular_trading_hours=True,
             instrument_provider=instrument_provider,
-            gateway=gateway,
+            dockerized_gateway=dockerized_gateway,
         ),
     },
     exec_clients=exec_clients,  # type: ignore

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -20,17 +20,18 @@ from functools import lru_cache
 # fmt: off
 from nautilus_trader.adapters.interactive_brokers.client import InteractiveBrokersClient
 from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersExecClientConfig
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersGatewayConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersInstrumentProviderConfig
 from nautilus_trader.adapters.interactive_brokers.data import InteractiveBrokersDataClient
 from nautilus_trader.adapters.interactive_brokers.execution import InteractiveBrokersExecutionClient
-from nautilus_trader.adapters.interactive_brokers.gateway import InteractiveBrokersGateway
+from nautilus_trader.adapters.interactive_brokers.gateway import DockerizedIBGateway
 from nautilus_trader.adapters.interactive_brokers.providers import InteractiveBrokersInstrumentProvider
 from nautilus_trader.cache.cache import Cache
 from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import MessageBus
+from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.live.factories import LiveDataClientFactory
 from nautilus_trader.live.factories import LiveExecClientFactory
 from nautilus_trader.model.identifiers import AccountId
@@ -50,13 +51,13 @@ def get_cached_ib_client(
     host: str = "127.0.0.1",
     port: int | None = None,
     client_id: int = 1,
-    gateway: InteractiveBrokersGatewayConfig = InteractiveBrokersGatewayConfig(),
+    dockerized_gateway: DockerizedIBGatewayConfig | None = None,
 ) -> InteractiveBrokersClient:
     """
-    Cache and return a InteractiveBrokers HTTP client with the given key and secret.
+    Retrieve or create a cached InteractiveBrokersClient using the provided key.
 
-    If a cached client with matching key and secret already exists, then that
-    cached client will be returned.
+    Should a keyed client already exist within the cache, the function will return this instance. It's important
+    to note that the key comprises a combination of the host, port, and client_id.
 
     Parameters
     ----------
@@ -68,14 +69,16 @@ def get_cached_ib_client(
         cache
     clock: LiveClock,
         clock
-    host : str, optional
-        The IB host to connect to
-    port : int, optional
-        The IB port to connect to
-    client_id: int, optional
-        The client_id to connect with
-    gateway: InteractiveBrokersGatewayConfig
-        Configuration for the gateway.
+    host: str
+        The IB host to connect to.This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
+    port: int
+        The IB port to connect to.This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
+    client_id: int
+        The unique session identifier for the TWS or Gateway.A single host can support multiple connections;
+        however, each must use a different client_id.
+    dockerized_gateway: DockerizedIBGatewayConfig, optional
+        The configuration for the dockerized gateway.If this is provided, Nautilus will oversee the docker
+        environment, facilitating the operation of the IB Gateway within.
 
     Returns
     -------
@@ -83,13 +86,19 @@ def get_cached_ib_client(
 
     """
     global GATEWAY
-    if gateway.start:
-        # Start gateway
+    if dockerized_gateway:
+        PyCondition.equal(host, "127.0.0.1", "host", "127.0.0.1")
+        PyCondition.none(port, "Ensure `port` is set to None when using DockerizedIBGatewayConfig.")
         if GATEWAY is None:
-            GATEWAY = InteractiveBrokersGateway(**gateway.dict())
-            # GATEWAY.safe_start(wait=config.timeout)
-            port = port or GATEWAY.port
-    port = port or InteractiveBrokersGateway.PORTS[gateway.trading_mode]
+            GATEWAY = DockerizedIBGateway(dockerized_gateway)
+            GATEWAY.safe_start(wait=dockerized_gateway.timeout)
+            port = GATEWAY.port
+    else:
+        PyCondition.not_none(
+            host,
+            "Please provide the `host` IP address for the IB TWS or Gateway.",
+        )
+        PyCondition.not_none(port, "Please provide the `port` for the IB TWS or Gateway.")
 
     client_key: tuple = (host, port, client_id)
 
@@ -178,7 +187,7 @@ class InteractiveBrokersLiveDataClientFactory(LiveDataClientFactory):
             host=config.ibg_host,
             port=config.ibg_port,
             client_id=config.ibg_client_id,
-            gateway=config.gateway,
+            dockerized_gateway=config.dockerized_gateway,
         )
 
         # Get instrument provider singleton
@@ -247,7 +256,7 @@ class InteractiveBrokersLiveExecClientFactory(LiveExecClientFactory):
             host=config.ibg_host,
             port=config.ibg_port,
             client_id=config.ibg_client_id,
-            gateway=config.gateway,
+            dockerized_gateway=config.dockerized_gateway,
         )
 
         # Get instrument provider singleton

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -70,9 +70,9 @@ def get_cached_ib_client(
     clock: LiveClock,
         clock
     host: str
-        The IB host to connect to.This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
+        The IB host to connect to. This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
     port: int
-        The IB port to connect to.This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
+        The IB port to connect to. This is optional if using DockerizedIBGatewayConfig, but is required otherwise.
     client_id: int
         The unique session identifier for the TWS or Gateway.A single host can support multiple connections;
         however, each must use a different client_id.

--- a/nautilus_trader/adapters/interactive_brokers/gateway.py
+++ b/nautilus_trader/adapters/interactive_brokers/gateway.py
@@ -17,9 +17,10 @@ import logging
 import os
 from enum import IntEnum
 from time import sleep
-from typing import ClassVar, Literal
+from typing import ClassVar
 
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersGatewayConfig
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
+from nautilus_trader.common.component import Logger as NautilusLogger
 
 
 class ContainerStatus(IntEnum):
@@ -32,7 +33,7 @@ class ContainerStatus(IntEnum):
     UNKNOWN = 7
 
 
-class InteractiveBrokersGateway:
+class DockerizedIBGateway:
     """
     A class to manage starting an Interactive Brokers Gateway docker container.
     """
@@ -41,41 +42,22 @@ class InteractiveBrokersGateway:
     CONTAINER_NAME: ClassVar[str] = "nautilus-ib-gateway"
     PORTS: ClassVar[dict[str, int]] = {"paper": 4002, "live": 4001}
 
-    def __init__(
-        self,
-        username: str | None = None,
-        password: str | None = None,
-        host: str | None = "127.0.0.1",
-        port: int | None = None,
-        trading_mode: Literal["paper", "live"] | None = "paper",
-        start: bool = False,
-        read_only_api: bool = True,
-        timeout: int = 90,
-        logger: logging.Logger | None = None,
-        config: InteractiveBrokersGatewayConfig | None = None,
-    ):
-        if config:
-            username = config.username
-            password = config.password
-            host = config.host
-            port = config.port
-            trading_mode = config.trading_mode
-            start = config.start
-            read_only_api = config.read_only_api
-            timeout = config.timeout
-
-        self.username = username or os.getenv("TWS_USERNAME")
-        self.password = password or os.getenv("TWS_PASSWORD")
+    def __init__(self, config: DockerizedIBGatewayConfig):
+        self.log = NautilusLogger(repr(self))
+        self.username = config.username or os.getenv("TWS_USERNAME")
+        self.password = config.password or os.getenv("TWS_PASSWORD")
         if self.username is None:
+            self.log.error("`username` not set nor available in env `TWS_USERNAME`")
             raise ValueError("`username` not set nor available in env `TWS_USERNAME`")
         if self.password is None:
+            self.log.error("`password` not set nor available in env `TWS_PASSWORD`")
             raise ValueError("`password` not set nor available in env `TWS_PASSWORD`")
 
-        self.trading_mode = trading_mode
-        self.read_only_api = read_only_api
-        self.host = host
-        self.port = port or self.PORTS[trading_mode]
-        self.log = logger or logging.getLogger("nautilus_trader")
+        self.trading_mode = config.trading_mode
+        self.read_only_api = config.read_only_api
+        self.host = "127.0.0.1"
+        self.port = self.PORTS[config.trading_mode]
+        self.timeout = config.timeout
 
         try:
             import docker
@@ -88,15 +70,9 @@ class InteractiveBrokersGateway:
 
         self._docker = docker.from_env()
         self._container = None
-        if start:
-            self.start(timeout)
 
-    @classmethod
-    def from_container(cls, **kwargs) -> "InteractiveBrokersGateway":
-        """Connect to an already running container - don't stop/start"""
-        self = cls(username="", password="", **kwargs)
-        assert self.container, "Container does not exist"
-        return self
+    def __repr__(self):
+        return f"{type(self).__name__}"
 
     @property
     def container_status(self) -> ContainerStatus:
@@ -128,13 +104,13 @@ class InteractiveBrokersGateway:
             return False
         return any(b"Forking :::" in line for line in logs.split(b"\n"))
 
-    def start(self, wait: int | None = 90) -> None:
+    def start(self, wait: int | None = None) -> None:
         """
         Start the gateway.
 
         Parameters
         ----------
-        wait : int, default 90
+        wait : int, optional
             The seconds to wait until container is ready.
 
         """
@@ -177,20 +153,19 @@ class InteractiveBrokersGateway:
         )
         self.log.info(f"Container `{self.CONTAINER_NAME}-{self.port}` starting, waiting for ready")
 
-        if wait is not None:
-            for _ in range(wait):
-                if self.is_logged_in(container=self._container):
-                    break
-                self.log.debug("Waiting for IB Gateway to start")
-                sleep(1)
-            else:
-                raise RuntimeError(f"Gateway `{self.CONTAINER_NAME}-{self.port}` not ready")
+        for _ in range(wait or self.timeout):
+            if self.is_logged_in(container=self._container):
+                break
+            self.log.debug("Waiting for IB Gateway to start")
+            sleep(1)
+        else:
+            raise RuntimeError(f"Gateway `{self.CONTAINER_NAME}-{self.port}` not ready")
 
         self.log.info(
             f"Gateway `{self.CONTAINER_NAME}-{self.port}` ready. VNC port is {self.port + 100}",
         )
 
-    def safe_start(self, wait: int = 90) -> None:
+    def safe_start(self, wait: int | None = None) -> None:
         try:
             self.start(wait=wait)
         except self._docker_module.errors.APIError as e:
@@ -230,4 +205,4 @@ class GatewayLoginFailure(Exception):
     pass
 
 
-__all__ = ["InteractiveBrokersGateway"]
+__all__ = ["DockerizedIBGateway"]

--- a/nautilus_trader/adapters/interactive_brokers/historic/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/historic/client.py
@@ -86,7 +86,7 @@ class HistoricInteractiveBrokersClient:
         )
         self._client.start()
 
-    async def _connect(self) -> None:
+    async def connect(self) -> None:
         # Connect client
         await self._client.wait_until_ready()
         self._client.registered_nautilus_clients.add(1)

--- a/nautilus_trader/examples/strategies/subscribe.py
+++ b/nautilus_trader/examples/strategies/subscribe.py
@@ -102,7 +102,7 @@ class SubscribeStrategy(Strategy):
             bar_type: BarType = BarType(
                 instrument_id=self.instrument_id,
                 bar_spec=BarSpecification(
-                    step=1,
+                    step=5,
                     aggregation=BarAggregation.SECOND,
                     price_type=PriceType.LAST,
                 ),

--- a/tests/integration_tests/adapters/conftest.py
+++ b/tests/integration_tests/adapters/conftest.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -34,6 +35,7 @@ from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.portfolio.portfolio import Portfolio
 from nautilus_trader.risk.engine import RiskEngine
+from nautilus_trader.test_kit.functions import ensure_all_tasks_completed
 from nautilus_trader.test_kit.stubs.component import TestComponentStubs
 from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 from nautilus_trader.trading.strategy import Strategy
@@ -49,6 +51,15 @@ def account_id(venue):
 def has_live_components_marker(request) -> bool:
     marker_names = [mark.name for mark in request.node.iter_markers()]
     return "live_components" in marker_names
+
+
+@pytest.fixture()
+def event_loop():
+    loop = asyncio.get_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.set_debug(True)
+    yield loop
+    ensure_all_tasks_completed()
 
 
 @pytest.fixture()
@@ -118,10 +129,10 @@ def data_engine(msgbus, cache, clock, data_client):
 
 
 @pytest.fixture()
-def exec_engine(request, loop, msgbus, cache, clock, exec_client):
+def exec_engine(request, event_loop, msgbus, cache, clock, exec_client):
     if has_live_components_marker(request):
         engine = LiveExecutionEngine(
-            loop,
+            event_loop,
             msgbus,
             cache,
             clock,

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -26,7 +26,7 @@ from nautilus_trader.test_kit.functions import eventually
 
 def test_start(ib_client):
     # Arrange
-    ib_client._connect = AsyncMock()
+    ib_client.connect = AsyncMock()
     ib_client._eclient = MagicMock()
     ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -24,14 +24,15 @@ import pytest
 from nautilus_trader.test_kit.functions import eventually
 
 
-def test_start(ib_client):
+@pytest.mark.asyncio
+async def test_start(event_loop, ib_client):
     # Arrange
     ib_client.connect = AsyncMock()
     ib_client._eclient = MagicMock()
     ib_client._eclient.startApi = MagicMock(side_effect=ib_client._is_ib_connected.set)
 
     # Act
-    ib_client._start()
+    await ib_client._start_async()
 
     # Assert
     assert ib_client._is_client_ready.is_set()

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -22,9 +22,9 @@ import pytest
 # fmt: off
 from nautilus_trader.adapters.interactive_brokers.client import InteractiveBrokersClient
 from nautilus_trader.adapters.interactive_brokers.common import IB_VENUE
+from nautilus_trader.adapters.interactive_brokers.config import DockerizedIBGatewayConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersExecClientConfig
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersGatewayConfig
 from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersInstrumentProviderConfig
 from nautilus_trader.adapters.interactive_brokers.factories import InteractiveBrokersLiveDataClientFactory
 from nautilus_trader.adapters.interactive_brokers.factories import InteractiveBrokersLiveExecClientFactory
@@ -84,7 +84,7 @@ def instrument():
 
 @pytest.fixture()
 def gateway_config():
-    return InteractiveBrokersGatewayConfig(
+    return DockerizedIBGatewayConfig(
         username="test",
         password="test",
     )

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
-import asyncio
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -32,7 +31,6 @@ from nautilus_trader.adapters.interactive_brokers.providers import InteractiveBr
 from nautilus_trader.model.events import AccountState
 from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import Venue
-from nautilus_trader.test_kit.functions import ensure_all_tasks_completed
 from nautilus_trader.test_kit.stubs.events import TestEventStubs
 from tests.integration_tests.adapters.interactive_brokers.mock_client import MockInteractiveBrokersClient
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
@@ -61,15 +59,6 @@ def mocked_ib_client(
         client_id=client_id,
     )
     return client
-
-
-@pytest.fixture()
-def event_loop():
-    loop = asyncio.get_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.set_debug(True)
-    yield loop
-    ensure_all_tasks_completed()
 
 
 @pytest.fixture()

--- a/tests/integration_tests/adapters/interactive_brokers/mock_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/mock_client.py
@@ -8,6 +8,7 @@ from nautilus_trader.adapters.interactive_brokers.client.client import Interacti
 from nautilus_trader.adapters.interactive_brokers.client.wrapper import InteractiveBrokersEWrapper
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import ib_contract_to_instrument_id
+from nautilus_trader.common.enums import LogColor
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
 
 
@@ -147,3 +148,7 @@ class MockInteractiveBrokersClient(InteractiveBrokersClient):
         self._start_tws_incoming_msg_reader()
         self._start_internal_msg_queue_processor()
         self._eclient.startApi()
+
+        self._is_client_ready.set()
+        self._log.debug("`_is_client_ready` set by `_start_async`.", LogColor.BLUE)
+        self._connection_attempts = 0

--- a/tests/integration_tests/adapters/interactive_brokers/mock_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/mock_client.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections.abc import Callable
-from unittest.mock import MagicMock
 
 from ibapi.client import EClient
 
@@ -143,4 +142,8 @@ class MockInteractiveBrokersClient(InteractiveBrokersClient):
                 client=self,
             ),
         )
-        self._start = MagicMock()
+
+    async def _start_async(self):
+        self._start_tws_incoming_msg_reader()
+        self._start_internal_msg_queue_processor()
+        self._eclient.startApi()

--- a/tests/integration_tests/adapters/interactive_brokers/test_gateway.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_gateway.py
@@ -16,7 +16,7 @@
 import pytest
 from docker.models.containers import ContainerCollection
 
-from nautilus_trader.adapters.interactive_brokers.gateway import InteractiveBrokersGateway
+from nautilus_trader.adapters.interactive_brokers.gateway import DockerizedIBGateway
 
 
 pytestmark = pytest.mark.skip(reason="Skip due currently flaky mocks")
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skip(reason="Skip due currently flaky mocks")
 def test_gateway_start_no_container(mocker):
     # Arrange
     mock_docker = mocker.patch.object(ContainerCollection, "run")
-    gateway = InteractiveBrokersGateway(username="test", password="test")
+    gateway = DockerizedIBGateway(username="test", password="test")
 
     # Act
     gateway.start(wait=None)


### PR DESCRIPTION
# Pull Request

The InteractiveBrokersGateway has been renamed to `DockerizedIBGateway` to better reflect its purpose. Additionally, the start parameter has been removed. This commit also updates how it manages the connection to TWS or Gateway, which now requires explicit connection parameters unless using `DockerizedIBGatewayConfig`. The documentation has been updated, and a simplified example has been added.


## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this change been tested?

Existing tests pass and tested live.
