### PR TITLE
Fix streaming backend mem usage

### DIFF
--- a/nautilus_core/persistence/src/backend/kmerge_batch.rs
+++ b/nautilus_core/persistence/src/backend/kmerge_batch.rs
@@ -60,8 +60,8 @@ impl<T> Iterator for EagerStream<T> {
 
 impl<T> Drop for EagerStream<T> {
     fn drop(&mut self) {
-        self.task.abort();
         self.rx.close();
+        self.task.abort();
     }
 }
 
@@ -118,6 +118,10 @@ where
         if let Some(heap_elem) = ElementBatchIter::new_from_iter(s) {
             self.heap.push(heap_elem);
         }
+    }
+
+    pub fn clear(&mut self) {
+        self.heap.clear()
     }
 }
 


### PR DESCRIPTION
# Pull Request

Choosing the right combination of query and config to achieve high perf with constant mem usage. This gives a 50% improvement over single and multi stream benchmarks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Ran benchmarks and smaller tests in experiments repo[^1]. The best combination is no order by clause and turning off repartitioning.

| order | repartition | wall time (s) | memory (mb) | read sorted order |
| -- | -- | -- | -- | -- |
| true | true | 1.24 | 654 | ✅ |
| true | false | 1.65 | 944 | ✅ |
| false | false | 0.55 | 45 | ✅ |
| false | true | 0.41 | 151 | ❌ |



[^1]: https://github.com/nautechsystems/nautilus_experiments/tree/efficient-query