### PR TITLE
Add base coin for fee rate parsing in Bybit adapter

### DIFF
--- a/nautilus_trader/adapters/bybit/providers.py
+++ b/nautilus_trader/adapters/bybit/providers.py
@@ -101,13 +101,17 @@ class BybitInstrumentProvider(InstrumentProvider):
             )
 
         for product_type in instrument_infos:
-            if product_type == BybitProductType.OPTION:
-                self._log.warning("Options not currently supported")
-                continue
-
             for instrument in instrument_infos[product_type]:
                 target_fee_rate = next(
-                    (item for item in fee_rates[product_type] if item.symbol == instrument.symbol),
+                    (
+                        item
+                        for item in fee_rates[product_type]
+                        if item.symbol == instrument.symbol
+                        or (
+                            product_type == BybitProductType.OPTION
+                            and instrument.baseCoin == item.baseCoin
+                        )
+                    ),
                     None,
                 )
                 if target_fee_rate:
@@ -273,6 +277,7 @@ class BybitInstrumentProvider(InstrumentProvider):
         instrument: BybitInstrumentOption,
         fee_rate: BybitFeeRate,
     ) -> None:
+        self._log.warning("Parsing of instrument Options is currently not supported")
         try:
             pass
         except ValueError as e:

--- a/nautilus_trader/adapters/bybit/schemas/account/fee_rate.py
+++ b/nautilus_trader/adapters/bybit/schemas/account/fee_rate.py
@@ -22,6 +22,7 @@ class BybitFeeRate(msgspec.Struct):
     symbol: str
     takerFeeRate: str
     makerFeeRate: str
+    baseCoin: str | None = None
 
 
 class BybitFeeRateResponse(msgspec.Struct):


### PR DESCRIPTION
# Pull Request

- added `baseCoin` field for `BybitFeeRate` struct
- target fee rate in Bybit instrument parsing now also searches for base coin check for options parsing
- after that fee rates for all instrument types are defined and can depend on symbol or base coin
- removed bybit option parsing log warning and skip and pushed it further in parse_option_instrument which will be done in later PRs

https://bybit-exchange.github.io/docs/v5/account/fee-rate

**All Bybit instrument fee rates**

![All bybit instrument fee rates](https://github.com/nautechsystems/nautilus_trader/assets/16453976/ff427c8d-85d9-4100-94f2-50d56b3028d9)

**Option log warning** 

![Screenshot 2024-06-05 at 05 02 40](https://github.com/nautechsystems/nautilus_trader/assets/16453976/2f2c9756-e13d-4ee3-9b87-ded9d47e493d)

