### PR TITLE
Change id as column name for primary key on all Postgres tables

### DIFF
--- a/nautilus_core/infrastructure/src/sql/cache_database.rs
+++ b/nautilus_core/infrastructure/src/sql/cache_database.rs
@@ -221,7 +221,7 @@ impl PostgresCacheDatabase {
             Ok(rows) => {
                 let mut cache: HashMap<String, Vec<u8>> = HashMap::new();
                 for row in rows {
-                    cache.insert(row.key, row.value);
+                    cache.insert(row.id, row.value);
                 }
                 Ok(cache)
             }

--- a/nautilus_core/infrastructure/src/sql/models/general.rs
+++ b/nautilus_core/infrastructure/src/sql/models/general.rs
@@ -15,6 +15,6 @@
 
 #[derive(Debug, sqlx::FromRow)]
 pub struct GeneralRow {
-    pub key: String,
+    pub id: String,
     pub value: Vec<u8>,
 }

--- a/nautilus_core/infrastructure/src/sql/models/types.rs
+++ b/nautilus_core/infrastructure/src/sql/models/types.rs
@@ -22,7 +22,7 @@ pub struct CurrencyModel(pub Currency);
 
 impl<'r> FromRow<'r, PgRow> for CurrencyModel {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let code = row.try_get::<String, _>("code")?;
+        let id = row.try_get::<String, _>("id")?;
         let precision = row.try_get::<i32, _>("precision")?;
         let iso4217 = row.try_get::<i32, _>("iso4217")?;
         let name = row.try_get::<String, _>("name")?;
@@ -31,7 +31,7 @@ impl<'r> FromRow<'r, PgRow> for CurrencyModel {
             .map(|res| CurrencyType::from_str(res.as_str()).unwrap())?;
 
         let currency = Currency::new(
-            code.as_str(),
+            id.as_str(),
             precision as u8,
             iso4217 as u16,
             name.as_str(),

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -33,7 +33,7 @@ pub struct DatabaseQueries;
 
 impl DatabaseQueries {
     pub async fn add(pool: &PgPool, key: String, value: Vec<u8>) -> anyhow::Result<()> {
-        sqlx::query("INSERT INTO general (key, value) VALUES ($1, $2)")
+        sqlx::query("INSERT INTO general (id, value) VALUES ($1, $2)")
             .bind(key)
             .bind(value)
             .execute(pool)
@@ -49,7 +49,7 @@ impl DatabaseQueries {
             .map(|rows| {
                 let mut cache: HashMap<String, Vec<u8>> = HashMap::new();
                 for row in rows {
-                    cache.insert(row.key, row.value);
+                    cache.insert(row.id, row.value);
                 }
                 cache
             })
@@ -58,7 +58,7 @@ impl DatabaseQueries {
 
     pub async fn add_currency(pool: &PgPool, currency: Currency) -> anyhow::Result<()> {
         sqlx::query(
-            "INSERT INTO currency (code, precision, iso4217, name, currency_type) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (code) DO NOTHING"
+            "INSERT INTO currency (id, precision, iso4217, name, currency_type) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (id) DO NOTHING"
         )
             .bind(currency.code.as_str())
             .bind(currency.precision as i32)
@@ -72,7 +72,7 @@ impl DatabaseQueries {
     }
 
     pub async fn load_currencies(pool: &PgPool) -> anyhow::Result<Vec<Currency>> {
-        sqlx::query_as::<_, CurrencyModel>("SELECT * FROM currency ORDER BY code ASC")
+        sqlx::query_as::<_, CurrencyModel>("SELECT * FROM currency ORDER BY id ASC")
             .fetch_all(pool)
             .await
             .map(|rows| rows.into_iter().map(|row| row.0).collect())
@@ -80,7 +80,7 @@ impl DatabaseQueries {
     }
 
     pub async fn load_currency(pool: &PgPool, code: &str) -> anyhow::Result<Option<Currency>> {
-        sqlx::query_as::<_, CurrencyModel>("SELECT * FROM currency WHERE code = $1")
+        sqlx::query_as::<_, CurrencyModel>("SELECT * FROM currency WHERE id = $1")
             .bind(code)
             .fetch_optional(pool)
             .await

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -13,7 +13,7 @@ CREATE TYPE ORDER_STATUS AS ENUM ('Initialized', 'Denied', 'Emulated', 'Released
 ------------------- TABLES -------------------
 
 CREATE TABLE IF NOT EXISTS "general" (
-    key TEXT PRIMARY KEY NOT NULL,
+    id TEXT PRIMARY KEY NOT NULL,
     value bytea not null
 );
 
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS "strategy" (
 );
 
 CREATE TABLE IF NOT EXISTS "currency" (
-    code TEXT PRIMARY KEY NOT NULL,
+    id TEXT PRIMARY KEY NOT NULL,
     precision INTEGER,
     iso4217 INTEGER,
     name TEXT,
@@ -43,10 +43,10 @@ CREATE TABLE IF NOT EXISTS "instrument" (
     id TEXT PRIMARY KEY NOT NULL,
     kind TEXT,
     raw_symbol TEXT NOT NULL,
-    base_currency TEXT REFERENCES currency(code),
+    base_currency TEXT REFERENCES currency(id),
     underlying TEXT,
-    quote_currency TEXT REFERENCES currency(code),
-    settlement_currency TEXT REFERENCES currency(code),
+    quote_currency TEXT REFERENCES currency(id),
+    settlement_currency TEXT REFERENCES currency(id),
     isin TEXT,
     asset_class TEXT,
     exchange TEXT,
@@ -101,7 +101,7 @@ CREATE TABLE IF NOT EXISTS "order_event" (
     instrument_id TEXT NOT NULL,
     order_id TEXT DEFAULT NULL,
     trade_id TEXT,
-    currency TEXT REFERENCES currency(code),
+    currency TEXT REFERENCES currency(id),
     order_type TEXT,
     order_side TEXT,
     quantity TEXT,


### PR DESCRIPTION
# Pull Request

It is a good practice to keep the same name for the primary key column, for example `id`. It keeps schema clean and organized, and follows best practices. This can also help later for possible parametrized queries or CRUD generators as you know `id` column name is reserved for the primary identifier name.

- refactor `general` and `currency` tables to have `id` as the primary column name and propagated these changes in Postgres rust code and tests

