### PR TITLE
Add PYO3_PATH configuration to reduce spurious compiles

### DIFF
--- a/docs/developer_guide/environment_setup.md
+++ b/docs/developer_guide/environment_setup.md
@@ -23,6 +23,18 @@ The following steps are for UNIX-like systems, and only need to be completed onc
 
        pre-commit install
 
+3. In case of large recompiles for small changes, configure the the `PYO3_PYTHON` variable in `nautilus_core/.cargo/config.toml` with the path to the Python interpreter in the poetry managed environment. This is primarily useful for rust developers working on core and experience frequent recompiles from IDE/rust analyzer based `cargo check`.
+
+    ```
+    poetry shell
+    PYTHON_PATH=$(which python)
+    echo -e "[env]\nPYO3_PYTHON = \"$PYTHON_PATH\"" >> nautilus_core/.cargo/config.toml
+    ```
+
+    Since `.cargo/config.toml` is a tracked file, configure git to skip local modifications to it with `git update-index --skip-worktree nautilus_core/.cargo/config.toml`. Git will still pull remote modifications. To push modifications track local modifications using `git update-index --no-skip-worktree nautilus_core/.cargo/config.toml`.
+    
+    The git hack is needed till [local cargo config](https://github.com/rust-lang/cargo/issues/7723) feature is merged.
+
 ## Builds
 
 Following any changes to `.pyx` or `.pxd` files, you can re-compile by running:


### PR DESCRIPTION
# Pull Request

cargo performs frequent recompiles because of a difference in Python path between CLI and rust analyzer environments. [^1]

## Type of change

- [x] This change requires a documentation update

## How has this change been tested?

Ran cli cargo build and made then cargo check using rust analyzer in vs code, only relevant changes were compiled.

[^1]: https://github.com/PyO3/pyo3/issues/1708
