### PR TITLE
Fix Interactive Brokers multiple gateway clients

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -93,6 +93,8 @@ def get_cached_ib_client(
             GATEWAY = DockerizedIBGateway(dockerized_gateway)
             GATEWAY.safe_start(wait=dockerized_gateway.timeout)
             port = GATEWAY.port
+        else:
+            port = GATEWAY.port
     else:
         PyCondition.not_none(
             host,


### PR DESCRIPTION
This caused the exec-client to stop working. (or any second client being created through the gateway). This made the bot completely nonfunctional.

The factories use `get_cached_ib_client`, but since the port value was being set only on the first run of the function (due to the global `GATEWAY` variable). On the second run of the function, e.g. if another factory tried to create a new client, it was causing the port to be set to the default value `None`. This caused that a different client_key was created with the port value being `None`, as a result the code creates a new `InteractiveBrokersClient` with the port `None`, this obviously fails and the bot can't start the execution client.