### PR TITLE
Refactor Postgres Rust cache database with sync pattern

### DIFF
--- a/nautilus_core/common/src/cache/core.rs
+++ b/nautilus_core/common/src/cache/core.rs
@@ -2404,10 +2404,10 @@ impl Cache {
 
     /// Returns references to all instrument IDs for the given `venue`.
     #[must_use]
-    pub fn instrument_ids(&self, venue: &Venue) -> Vec<&InstrumentId> {
+    pub fn instrument_ids(&self, venue: Option<&Venue>) -> Vec<&InstrumentId> {
         self.instruments
             .keys()
-            .filter(|i| &i.venue == venue)
+            .filter(|i| venue.is_none() || &i.venue == venue.unwrap())
             .collect()
     }
 

--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -59,9 +59,12 @@ pub trait CacheDatabaseAdapter {
 
     fn load_index_order_client(&mut self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>>;
 
-    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Currency>;
+    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Option<Currency>>;
 
-    fn load_instrument(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<InstrumentAny>;
+    fn load_instrument(
+        &mut self,
+        instrument_id: &InstrumentId,
+    ) -> anyhow::Result<Option<InstrumentAny>>;
 
     fn load_synthetic(
         &mut self,
@@ -70,7 +73,7 @@ pub trait CacheDatabaseAdapter {
 
     fn load_account(&mut self, account_id: &AccountId) -> anyhow::Result<Box<dyn Account>>;
 
-    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<OrderAny>;
+    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>>;
 
     fn load_position(&mut self, position_id: &PositionId) -> anyhow::Result<Position>;
 

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -703,10 +703,16 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         for key in self.database.keys(&format!("{CURRENCIES}*"))? {
             let parts: Vec<&str> = key.as_str().rsplitn(2, ':').collect();
             let currency_code = Ustr::from(parts.first().unwrap());
-            let currency = self.load_currency(&currency_code)?;
-            currencies.insert(currency_code, currency);
+            let result = self.load_currency(&currency_code)?;
+            match result {
+                Some(currency) => {
+                    currencies.insert(currency_code, currency);
+                }
+                None => {
+                    error!("Currency not found: {currency_code}");
+                }
+            }
         }
-
         Ok(currencies)
     }
 
@@ -716,8 +722,15 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         for key in self.database.keys(&format!("{INSTRUMENTS}*"))? {
             let parts: Vec<&str> = key.as_str().rsplitn(2, ':').collect();
             let instrument_id = InstrumentId::from_str(parts.first().unwrap())?;
-            let instrument = self.load_instrument(&instrument_id)?;
-            instruments.insert(instrument_id, instrument);
+            let result = self.load_instrument(&instrument_id)?;
+            match result {
+                Some(instrument) => {
+                    instruments.insert(instrument_id, instrument);
+                }
+                None => {
+                    error!("Instrument not found: {instrument_id}");
+                }
+            }
         }
 
         Ok(instruments)
@@ -755,10 +768,16 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         for key in self.database.keys(&format!("{ORDERS}*"))? {
             let parts: Vec<&str> = key.as_str().rsplitn(2, ':').collect();
             let client_order_id = ClientOrderId::from(*parts.first().unwrap());
-            let order = self.load_order(&client_order_id)?;
-            orders.insert(client_order_id, order);
+            let result = self.load_order(&client_order_id)?;
+            match result {
+                Some(order) => {
+                    orders.insert(client_order_id, order);
+                }
+                None => {
+                    error!("Order not found: {client_order_id}");
+                }
+            }
         }
-
         Ok(orders)
     }
 
@@ -783,11 +802,14 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         todo!()
     }
 
-    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Currency> {
+    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Option<Currency>> {
         todo!()
     }
 
-    fn load_instrument(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<InstrumentAny> {
+    fn load_instrument(
+        &mut self,
+        instrument_id: &InstrumentId,
+    ) -> anyhow::Result<Option<InstrumentAny>> {
         todo!()
     }
 
@@ -802,7 +824,7 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         todo!()
     }
 
-    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<OrderAny> {
+    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>> {
         todo!()
     }
 

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -157,7 +157,7 @@ impl DatabaseQueries {
 
     pub async fn load_instrument(
         pool: &PgPool,
-        instrument_id: InstrumentId,
+        instrument_id: &InstrumentId,
     ) -> anyhow::Result<Option<InstrumentAny>> {
         sqlx::query_as::<_, InstrumentAnyModel>("SELECT * FROM instrument WHERE id = $1")
             .bind(instrument_id.to_string())

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -59,9 +59,12 @@ pub async fn get_pg_cache_database() -> anyhow::Result<PostgresCacheDatabase> {
 #[cfg(test)]
 #[cfg(target_os = "linux")] // Databases only supported on Linux
 mod tests {
-    use std::time::Duration;
+    use std::{collections::HashSet, time::Duration};
 
-    use nautilus_common::testing::wait_until_async;
+    use nautilus_common::{
+        cache::database::CacheDatabaseAdapter,
+        testing::{wait_until, wait_until_async},
+    };
     use nautilus_core::equality::entirely_equal;
     use nautilus_model::{
         enums::{CurrencyType, OrderSide, OrderStatus},
@@ -80,17 +83,17 @@ mod tests {
         types::{currency::Currency, price::Price, quantity::Quantity},
     };
     use serial_test::serial;
+    use ustr::Ustr;
 
     use crate::get_pg_cache_database;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_add_general_object_adds_to_cache() {
-        let pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_pg_cache_database().await.unwrap();
         let test_id_value = String::from("test_value").into_bytes();
         pg_cache
             .add(String::from("test_id"), test_id_value.clone())
-            .await
             .unwrap();
         wait_until_async(
             || async {
@@ -109,21 +112,21 @@ mod tests {
         assert_eq!(result.get("test_id").unwrap().to_owned(), test_id_value);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_add_currency_and_instruments() {
         // 1. first define and add currencies as they are contain foreign keys for instruments
-        let pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_pg_cache_database().await.unwrap();
         // Define currencies
         let btc = Currency::new("BTC", 8, 0, "BTC", CurrencyType::Crypto).unwrap();
         let eth = Currency::new("ETH", 2, 0, "ETH", CurrencyType::Crypto).unwrap();
         let usd = Currency::new("USD", 2, 0, "USD", CurrencyType::Fiat).unwrap();
         let usdt = Currency::new("USDT", 2, 0, "USDT", CurrencyType::Crypto).unwrap();
         // Insert all the currencies
-        pg_cache.add_currency(btc).await.unwrap();
-        pg_cache.add_currency(eth).await.unwrap();
-        pg_cache.add_currency(usd).await.unwrap();
-        pg_cache.add_currency(usdt).await.unwrap();
+        pg_cache.add_currency(&btc).unwrap();
+        pg_cache.add_currency(&eth).unwrap();
+        pg_cache.add_currency(&usd).unwrap();
+        pg_cache.add_currency(&usdt).unwrap();
         // Define all the instruments
         let crypto_future =
             crypto_future_btcusdt(2, 6, Price::from("0.01"), Quantity::from("0.000001"));
@@ -134,115 +137,113 @@ mod tests {
         let options_contract = options_contract_appl();
         // Insert all the instruments
         pg_cache
-            .add_instrument(InstrumentAny::CryptoFuture(crypto_future))
-            .await
+            .add_instrument(&InstrumentAny::CryptoFuture(crypto_future))
             .unwrap();
         pg_cache
-            .add_instrument(InstrumentAny::CryptoPerpetual(crypto_perpetual))
-            .await
+            .add_instrument(&InstrumentAny::CryptoPerpetual(crypto_perpetual))
             .unwrap();
         pg_cache
-            .add_instrument(InstrumentAny::CurrencyPair(currency_pair))
-            .await
+            .add_instrument(&InstrumentAny::CurrencyPair(currency_pair))
             .unwrap();
         pg_cache
-            .add_instrument(InstrumentAny::Equity(equity))
-            .await
+            .add_instrument(&InstrumentAny::Equity(equity))
             .unwrap();
         pg_cache
-            .add_instrument(InstrumentAny::FuturesContract(futures_contract))
-            .await
+            .add_instrument(&InstrumentAny::FuturesContract(futures_contract))
             .unwrap();
         pg_cache
-            .add_instrument(InstrumentAny::OptionsContract(options_contract))
-            .await
+            .add_instrument(&InstrumentAny::OptionsContract(options_contract))
             .unwrap();
         // Wait for the cache to update
-        wait_until_async(
-            || async {
-                let currencies = pg_cache.load_currencies().await.unwrap();
-                let instruments = pg_cache.load_instruments().await.unwrap();
+        wait_until(
+            || {
+                let currencies = pg_cache.load_currencies().unwrap();
+                let instruments = pg_cache.load_instruments().unwrap();
                 currencies.len() >= 4 && instruments.len() >= 6
             },
             Duration::from_secs(2),
-        )
-        .await;
+        );
         // Check that currency list is correct
-        let currencies = pg_cache.load_currencies().await.unwrap();
+        let currencies = pg_cache.load_currencies().unwrap();
         assert_eq!(currencies.len(), 4);
         assert_eq!(
             currencies
                 .into_iter()
-                .map(|c| c.code.to_string())
-                .collect::<Vec<String>>(),
+                .map(|(_, c)| c.code.to_string())
+                .collect::<HashSet<String>>(),
             vec![
                 String::from("BTC"),
                 String::from("ETH"),
                 String::from("USD"),
                 String::from("USDT")
             ]
+            .into_iter()
+            .collect::<HashSet<String>>()
         );
         // Check individual currencies
-        assert_eq!(pg_cache.load_currency("BTC").await.unwrap().unwrap(), btc);
-        assert_eq!(pg_cache.load_currency("ETH").await.unwrap().unwrap(), eth);
-        assert_eq!(pg_cache.load_currency("USDT").await.unwrap().unwrap(), usdt);
+        assert_eq!(
+            pg_cache.load_currency(&Ustr::from("BTC")).unwrap().unwrap(),
+            btc
+        );
+        assert_eq!(
+            pg_cache.load_currency(&Ustr::from("ETH")).unwrap().unwrap(),
+            eth
+        );
+        assert_eq!(
+            pg_cache
+                .load_currency(&Ustr::from("USDT"))
+                .unwrap()
+                .unwrap(),
+            usdt
+        );
         // Check individual instruments
         assert_eq!(
             pg_cache
-                .load_instrument(crypto_future.id())
-                .await
+                .load_instrument(&crypto_future.id())
                 .unwrap()
                 .unwrap(),
             InstrumentAny::CryptoFuture(crypto_future)
         );
         assert_eq!(
             pg_cache
-                .load_instrument(crypto_perpetual.id())
-                .await
+                .load_instrument(&crypto_perpetual.id())
                 .unwrap()
                 .unwrap(),
             InstrumentAny::CryptoPerpetual(crypto_perpetual)
         );
         assert_eq!(
             pg_cache
-                .load_instrument(currency_pair.id())
-                .await
+                .load_instrument(&currency_pair.id())
                 .unwrap()
                 .unwrap(),
             InstrumentAny::CurrencyPair(currency_pair)
         );
         assert_eq!(
-            pg_cache
-                .load_instrument(equity.id())
-                .await
-                .unwrap()
-                .unwrap(),
+            pg_cache.load_instrument(&equity.id()).unwrap().unwrap(),
             InstrumentAny::Equity(equity)
         );
         assert_eq!(
             pg_cache
-                .load_instrument(futures_contract.id())
-                .await
+                .load_instrument(&futures_contract.id())
                 .unwrap()
                 .unwrap(),
             InstrumentAny::FuturesContract(futures_contract)
         );
         assert_eq!(
             pg_cache
-                .load_instrument(options_contract.id())
-                .await
+                .load_instrument(&options_contract.id())
                 .unwrap()
                 .unwrap(),
             InstrumentAny::OptionsContract(options_contract)
         );
         // Check that instrument list is correct
-        let instruments = pg_cache.load_instruments().await.unwrap();
+        let instruments = pg_cache.load_instruments().unwrap();
         assert_eq!(instruments.len(), 6);
         assert_eq!(
             instruments
                 .into_iter()
-                .map(|i| i.id())
-                .collect::<Vec<InstrumentId>>(),
+                .map(|(id, _)| id)
+                .collect::<HashSet<InstrumentId>>(),
             vec![
                 crypto_future.id(),
                 crypto_perpetual.id(),
@@ -251,16 +252,18 @@ mod tests {
                 futures_contract.id(),
                 options_contract.id()
             ]
+            .into_iter()
+            .collect::<HashSet<InstrumentId>>()
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_add_order() {
         let client_order_id_1 = ClientOrderId::new("O-19700101-0000-001-001-1").unwrap();
         let client_order_id_2 = ClientOrderId::new("O-19700101-0000-001-001-2").unwrap();
         let instrument = currency_pair_ethusdt();
-        let pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_pg_cache_database().await.unwrap();
         let market_order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Buy,
@@ -276,48 +279,38 @@ mod tests {
             Some(client_order_id_2),
             None,
         );
-        pg_cache.add_order(market_order.clone()).await.unwrap();
-        pg_cache.add_order(limit_order.clone()).await.unwrap();
-        wait_until_async(
-            || async {
+        pg_cache.add_order(&market_order).unwrap();
+        pg_cache.add_order(&limit_order).unwrap();
+        wait_until(
+            || {
                 pg_cache
                     .load_order(&market_order.client_order_id())
-                    .await
                     .unwrap()
                     .is_some()
                     && pg_cache
                         .load_order(&limit_order.client_order_id())
-                        .await
                         .unwrap()
                         .is_some()
             },
             Duration::from_secs(2),
-        )
-        .await;
+        );
         let market_order_result = pg_cache
             .load_order(&market_order.client_order_id())
-            .await
             .unwrap();
-        let limit_order_result = pg_cache
-            .load_order(&limit_order.client_order_id())
-            .await
-            .unwrap();
+        let limit_order_result = pg_cache.load_order(&limit_order.client_order_id()).unwrap();
         entirely_equal(market_order_result.unwrap(), market_order);
         entirely_equal(limit_order_result.unwrap(), limit_order);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_update_order_for_open_order() {
         let client_order_id_1 = ClientOrderId::new("O-19700101-0000-001-002-1").unwrap();
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
         let account = account_id();
-        let pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_pg_cache_database().await.unwrap();
         // Add the target currency of order
-        pg_cache
-            .add_currency(instrument.quote_currency())
-            .await
-            .unwrap();
+        pg_cache.add_currency(&instrument.quote_currency()).unwrap();
         // 1. Create the order
         let mut market_order = TestOrderStubs::market_order(
             instrument.id(),
@@ -326,10 +319,10 @@ mod tests {
             Some(client_order_id_1),
             None,
         );
-        pg_cache.add_order(market_order.clone()).await.unwrap();
+        pg_cache.add_order(&market_order).unwrap();
         let submitted = TestOrderEventStubs::order_submitted(&market_order, account);
         market_order.apply(submitted).unwrap();
-        pg_cache.update_order(market_order.clone()).await.unwrap();
+        pg_cache.update_order(&market_order).unwrap();
 
         let accepted = TestOrderEventStubs::order_accepted(
             &market_order,
@@ -337,7 +330,7 @@ mod tests {
             VenueOrderId::new("001").unwrap(),
         );
         market_order.apply(accepted).unwrap();
-        pg_cache.update_order(market_order.clone()).await.unwrap();
+        pg_cache.update_order(&market_order).unwrap();
 
         let filled = TestOrderEventStubs::order_filled(
             &market_order,
@@ -351,22 +344,19 @@ mod tests {
             Some(AccountId::new("SIM-001").unwrap()),
         );
         market_order.apply(filled).unwrap();
-        pg_cache.update_order(market_order.clone()).await.unwrap();
-        wait_until_async(
-            || async {
+        pg_cache.update_order(&market_order).unwrap();
+        wait_until(
+            || {
                 let result = pg_cache
                     .load_order(&market_order.client_order_id())
-                    .await
                     .unwrap();
                 result.is_some() && result.unwrap().status() == OrderStatus::Filled
             },
             Duration::from_secs(2),
-        )
-        .await;
+        );
         // Assert
         let market_order_result = pg_cache
             .load_order(&market_order.client_order_id())
-            .await
             .unwrap();
         entirely_equal(market_order_result.unwrap(), market_order);
     }


### PR DESCRIPTION
# Pull Request

- changing the signature of Rust cache `load_*` types of functions to return `Option`, and refactoring corresponding functions to work in both Postgres and Redis cache database adapter
- switched to unbounded channel in `PostgresCacheDatabase` for inter-thread communication to use sync interface
- starting to implement trait `CacheDatabaseAdapter` for `PostgresCacheDatabase` which has sync interfaces compared to `PostgresCacheDatabase` which is using async `sqlx` methods
- removed `await` in Postgres Rust E2E tests
