### PR TITLE
Refactor PSQL cache database test factory

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -2680,6 +2680,7 @@ name = "nautilus-infrastructure"
 version = "0.26.0"
 dependencies = [
  "anyhow",
+ "derive_builder",
  "log",
  "nautilus-common",
  "nautilus-core",

--- a/nautilus_core/infrastructure/Cargo.toml
+++ b/nautilus_core/infrastructure/Cargo.toml
@@ -15,6 +15,7 @@ nautilus-common = { path = "../common", features = ["python"] }
 nautilus-core = { path = "../core" , features = ["python"] }
 nautilus-model = { path = "../model" , features = ["python", "stubs"] }
 anyhow = { workspace = true }
+derive_builder = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 log = { workspace = true }  # Required until Cython gone
 rmp-serde = { workspace = true }

--- a/nautilus_core/infrastructure/src/sql/pg.rs
+++ b/nautilus_core/infrastructure/src/sql/pg.rs
@@ -13,12 +13,14 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use derive_builder::Builder;
 use sqlx::{postgres::PgConnectOptions, query, ConnectOptions, PgPool};
 use tracing::log::{error, info};
 
 use crate::sql::NAUTILUS_TABLES;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
+#[builder(default)]
 pub struct PostgresConnectOptions {
     pub host: String,
     pub port: u16,
@@ -43,6 +45,18 @@ impl PostgresConnectOptions {
             password,
             database,
         }
+    }
+}
+
+impl Default for PostgresConnectOptions {
+    fn default() -> Self {
+        PostgresConnectOptions::new(
+            String::from("localhost"),
+            5432,
+            String::from("nautilus"),
+            String::from("pass"),
+            String::from("nautilus"),
+        )
     }
 }
 


### PR DESCRIPTION
# Pull Request

Small cosmetical changes that include:
- adding the `Copy` trait to `PostgresCacheDatabase`
- introducing `derive_builder` and `Default` trait impl to `PostgresConnectOptions`
- moving factory functions `test_cache_database_postgres.rs` closer to project source in `sql/cache_database.rs` so that they can be resued by other E2E Rust pg tests