### PR TITLE
Fix Binance active_symbols type miss matching

### DIFF
--- a/nautilus_trader/adapters/binance/common/execution.py
+++ b/nautilus_trader/adapters/binance/common/execution.py
@@ -406,9 +406,9 @@ class BinanceCommonExecutionClient(LiveExecutionClient):
         open_positions: list[Position] = self._cache.positions_open(venue=self.venue)
         active_symbols: set[str] = set()
         for o in open_orders:
-            active_symbols.add(BinanceSymbol(o.instrument_id.symbol.value))
+            active_symbols.add(o.instrument_id.symbol.value)
         for p in open_positions:
-            active_symbols.add(BinanceSymbol(p.instrument_id.symbol.value))
+            active_symbols.add(p.instrument_id.symbol.value)
         return active_symbols
 
     async def _get_binance_position_status_reports(


### PR DESCRIPTION
# Pull Request
fix bug for BinanceSymbol for live trading. 

_get_cache_active_symbols adds BinanceSymbol to active_symbols, when instantiating BinanceSymbol, BinanceSymbol was passed in instead of str type, which caused an error at checking symbol by `PyCondition.valid_string(symbol, "symbol")`

```python
TypeError(Argument 'argument' has incorrect type (expected str, got BinanceSymbol))
Traceback (most recent call last):
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/live/execution_client.py", line 467, in generate_mass_status
    reports = await asyncio.gather(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/common/execution.py", line 502, in generate_fill_reports
    response = await self._http_account.query_user_trades(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/http/account.py", line 755, in query_user_trades
    symbol=BinanceSymbol(symbol),
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/common/symbol.py", line 36, in __new__
    PyCondition.valid_string(symbol, "symbol")
```

```python
TypeError(Argument 'argument' has incorrect type (expected str, got BinanceSymbol))
Traceback (most recent call last):
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/live/execution_client.py", line 467, in generate_mass_status
    reports = await asyncio.gather(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/common/execution.py", line 502, in generate_fill_reports
    response = await self._http_account.query_user_trades(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/http/account.py", line 755, in query_user_trades
    symbol=BinanceSymbol(symbol),
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ross/miniconda3/lib/python3.11/site-packages/nautilus_trader/adapters/binance/common/symbol.py", line 36, in __new__
    PyCondition.valid_string(symbol, "symbol")
```

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## How has this change been tested?
