### PR TITLE
Enhancement: Changed <Arc<Mutex<bool>> to AtomicBool

### DIFF
--- a/nautilus_core/network/src/socket.rs
+++ b/nautilus_core/network/src/socket.rs
@@ -456,14 +456,14 @@ impl SocketClient {
     /// - Any auto-reconnect job should be aborted before closing the client
     #[pyo3(name = "disconnect")]
     fn py_disconnect<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-    let disconnect_mode = &slf.disconnect_mode;
-    debug!("Setting disconnect mode to true");
+        let disconnect_mode = &slf.disconnect_mode;
+        debug!("Setting disconnect mode to true");
 
-    pyo3_asyncio_0_21::tokio::future_into_py(py, async move {
-        disconnect_mode.store(true, Ordering::SeqCst);
-        Ok(())
-    })
-}
+        pyo3_asyncio_0_21::tokio::future_into_py(py, async move {
+            disconnect_mode.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+    }
 
     /// Check if the client is still alive.
     ///

--- a/nautilus_core/network/src/socket.rs
+++ b/nautilus_core/network/src/socket.rs
@@ -15,7 +15,13 @@
 
 //! A high-performance raw TCP client implementation with TLS capability.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use nautilus_core::python::to_pyruntime_err;
 use pyo3::prelude::*;
@@ -36,7 +42,6 @@ use tracing::{debug, error};
 type TcpWriter = WriteHalf<MaybeTlsStream<TcpStream>>;
 type SharedTcpWriter = Arc<Mutex<WriteHalf<MaybeTlsStream<TcpStream>>>>;
 type TcpReader = ReadHalf<MaybeTlsStream<TcpStream>>;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Configuration for TCP socket connection.
 #[derive(Debug, Clone)]
@@ -302,7 +307,7 @@ impl Drop for SocketClientInner {
 pub struct SocketClient {
     writer: SharedTcpWriter,
     controller_task: task::JoinHandle<()>,
-    disconnect_mode: AtomicBool,
+    disconnect_mode: Arc<AtomicBool>,
     suffix: Vec<u8>,
 }
 
@@ -316,7 +321,7 @@ impl SocketClient {
         let suffix = config.suffix.clone();
         let inner = SocketClientInner::connect_url(config).await?;
         let writer = inner.writer.clone();
-        let disconnect_mode = AtomicBool::new(false);
+        let disconnect_mode = Arc::new(AtomicBool::new(false));
         let controller_task = Self::spawn_controller_task(
             inner,
             disconnect_mode.clone(),
@@ -343,7 +348,7 @@ impl SocketClient {
     ///
     /// Controller task will periodically check the disconnect mode
     /// and shutdown the client if it is not alive.
-    pub fn disconnect(&self) {
+    pub async fn disconnect(&self) {
         self.disconnect_mode.store(true, Ordering::SeqCst);
     }
 
@@ -360,20 +365,17 @@ impl SocketClient {
 
     fn spawn_controller_task(
         mut inner: SocketClientInner,
-        disconnect_mode: AtomicBool,
+        disconnect_mode: Arc<AtomicBool>,
         post_reconnection: Option<PyObject>,
         post_disconnection: Option<PyObject>,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
-            let mut disconnect_flag;
+            let disconnect_flag = disconnect_mode.load(Ordering::SeqCst);
             loop {
                 sleep(Duration::from_secs(1)).await;
 
                 // Check if client needs to disconnect
-                let guard = disconnect_mode.lock().await;
-                disconnect_flag = *guard;
-                drop(guard);
-
+                let disconnected = disconnect_mode.load(Ordering::SeqCst);
                 match (disconnect_flag, inner.is_alive()) {
                     (false, false) => match inner.reconnect().await {
                         Ok(()) => {
@@ -456,7 +458,7 @@ impl SocketClient {
     /// - Any auto-reconnect job should be aborted before closing the client
     #[pyo3(name = "disconnect")]
     fn py_disconnect<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let disconnect_mode = &slf.disconnect_mode;
+        let disconnect_mode = slf.disconnect_mode.clone();
         debug!("Setting disconnect mode to true");
 
         pyo3_asyncio_0_21::tokio::future_into_py(py, async move {

--- a/nautilus_core/network/src/socket.rs
+++ b/nautilus_core/network/src/socket.rs
@@ -345,7 +345,7 @@ impl SocketClient {
     /// and shutdown the client if it is not alive.
     pub fn disconnect(&self) {
         self.disconnect_mode.store(true, Ordering::SeqCst);
-    }    
+    }
 
     pub async fn send_bytes(&self, data: &[u8]) -> Result<(), std::io::Error> {
         let mut writer = self.writer.lock().await;

--- a/nautilus_core/network/src/websocket.rs
+++ b/nautilus_core/network/src/websocket.rs
@@ -14,9 +14,13 @@
 // -------------------------------------------------------------------------------------------------
 
 //! A high-performance WebSocket client implementation.
-
-use std::{str::FromStr, sync::Arc, time::Duration};
-
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use futures_util::{
     stream::{SplitSink, SplitStream},
     SinkExt, StreamExt,
@@ -31,7 +35,7 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
 };
 use tracing::{debug, error};
-use std::sync::atomic::{AtomicBool, Ordering};
+
 type MessageWriter = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 type SharedMessageWriter =
     Arc<Mutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>>;
@@ -134,7 +138,8 @@ impl WebSocketClientInner {
         // Hacky solution to overcome the new `http` trait bounds
         for (key, val) in headers {
             let header_value = HeaderValue::from_str(&val).unwrap();
-            let header_name = HeaderName::from_str(&key).unwrap();
+            use http::header::HeaderName;
+            let header_name: HeaderName = key.parse().unwrap();
             let header_name_string = header_name.to_string();
             let header_name_str: &'static str = Box::leak(header_name_string.into_boxed_str());
             req_headers.insert(header_name_str, header_value);
@@ -322,7 +327,7 @@ impl Drop for WebSocketClientInner {
 pub struct WebSocketClient {
     writer: SharedMessageWriter,
     controller_task: task::JoinHandle<()>,
-    disconnect_mode: AtomicBool,
+    disconnect_mode: Arc<AtomicBool>,
 }
 
 impl WebSocketClient {
@@ -339,7 +344,7 @@ impl WebSocketClient {
         debug!("Connecting");
         let inner = WebSocketClientInner::connect_url(config).await?;
         let writer = inner.writer.clone();
-        let disconnect_mode = AtomicBool::new(false);
+        let disconnect_mode = Arc::new(AtomicBool::new(false));
         let controller_task = Self::spawn_controller_task(
             inner,
             disconnect_mode.clone(),
@@ -370,7 +375,7 @@ impl WebSocketClient {
     ///
     /// Controller task will periodically check the disconnect mode
     /// and shutdown the client if it is alive
-    pub fn disconnect(&self) {
+    pub async fn disconnect(&self) {
         debug!("Disconnecting");
         self.disconnect_mode.store(true, Ordering::SeqCst);
     }
@@ -391,20 +396,17 @@ impl WebSocketClient {
 
     fn spawn_controller_task(
         mut inner: WebSocketClientInner,
-        disconnect_mode: AtomicBool,
+        disconnect_mode: Arc<AtomicBool>,
         post_reconnection: Option<PyObject>,
         post_disconnection: Option<PyObject>,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
-            let mut disconnect_flag;
+            let disconnect_flag = disconnect_mode.load(Ordering::SeqCst);
             loop {
                 sleep(Duration::from_secs(1)).await;
 
                 // Check if client needs to disconnect
-                let guard = disconnect_mode.lock().await;
-                disconnect_flag = *guard;
-                drop(guard);
-
+                let disconnected = disconnect_mode.load(Ordering::SeqCst);
                 match (disconnect_flag, inner.is_alive()) {
                     (false, false) => match inner.reconnect().await {
                         Ok(()) => {
@@ -498,7 +500,7 @@ impl WebSocketClient {
     /// - Any auto-reconnect job should be aborted before closing the client
     #[pyo3(name = "disconnect")]
     fn py_disconnect<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let disconnect_mode = &slf.disconnect_mode;
+        let disconnect_mode = slf.disconnect_mode.clone();
         pyo3_asyncio_0_21::tokio::future_into_py(py, async move {
             disconnect_mode.store(true, Ordering::SeqCst);
             Ok(())

--- a/nautilus_core/network/src/websocket.rs
+++ b/nautilus_core/network/src/websocket.rs
@@ -373,7 +373,7 @@ impl WebSocketClient {
     pub fn disconnect(&self) {
         debug!("Disconnecting");
         self.disconnect_mode.store(true, Ordering::SeqCst);
-    }    
+    }
 
     pub async fn send_bytes(&self, data: Vec<u8>) -> Result<(), Error> {
         debug!("Sending bytes: {:?}", data);
@@ -503,7 +503,7 @@ impl WebSocketClient {
             disconnect_mode.store(true, Ordering::SeqCst);
             Ok(())
         })
-    }    
+    }
 
     /// Send bytes data to the server.
     ///


### PR DESCRIPTION
# Pull Request

Include a summary of the changes.
Fixes #1732 : Network clients can use AtomicBool instead of <Arc<Mutex<bool>>
## Type of change

Delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?
`make pre-commit`
Describe how this code was/is tested.
