### PR TITLE
Add serial test group to Rust nextest runner for Postgres E2E tests

### DIFF
--- a/nautilus_core/.config/nextest.toml
+++ b/nautilus_core/.config/nextest.toml
@@ -1,0 +1,6 @@
+[test-groups]
+serial-tests = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(serial_tests::)'
+test-group = 'serial-tests'

--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -2692,7 +2692,6 @@ dependencies = [
  "rust_decimal",
  "semver",
  "serde_json",
- "serial_test",
  "sqlx",
  "tokio",
  "tracing",
@@ -4019,15 +4018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4041,12 +4031,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "seahash"
@@ -4140,31 +4124,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
 ]
 
 [[package]]

--- a/nautilus_core/infrastructure/Cargo.toml
+++ b/nautilus_core/infrastructure/Cargo.toml
@@ -43,7 +43,6 @@ sqlx = { version = "0.7.4", features = [
 
 [dev-dependencies]
 rstest = { workspace = true }
-serial_test = { version = "3.1.1" }
 
 [features]
 default = ["redis"]  # redis needed by `nautilus_trader` by default for now

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -15,7 +15,7 @@
 
 #[cfg(test)]
 #[cfg(target_os = "linux")] // Databases only supported on Linux
-mod tests {
+mod serial_tests {
     use std::{collections::HashSet, time::Duration};
 
     use nautilus_common::{
@@ -40,11 +40,9 @@ mod tests {
         orders::stubs::{TestOrderEventStubs, TestOrderStubs},
         types::{currency::Currency, price::Price, quantity::Quantity},
     };
-    use serial_test::serial;
     use ustr::Ustr;
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_add_general_object_adds_to_cache() {
         let mut pg_cache = get_pg_cache_database().await.unwrap();
         let test_id_value = String::from("test_value").into_bytes();
@@ -69,7 +67,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_add_currency_and_instruments() {
         // 1. first define and add currencies as they are contain foreign keys for instruments
         let mut pg_cache = get_pg_cache_database().await.unwrap();
@@ -211,7 +208,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_add_order() {
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-001-1").unwrap();
         let client_order_id_2 = ClientOrderId::new("O-19700101-000000-001-001-2").unwrap();
@@ -256,7 +252,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_update_order_for_open_order() {
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-002-1").unwrap();
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());


### PR DESCRIPTION
# Pull Request

Nextest supports test groups to specify concurrency and the number of threads to target test groups, basically mimicking serial execution of certain groups of tests. This is exactly what we need as Postgres Rust E2E tests are using shared resource and state with parallel tests execution might be different from what we expect

- created new file `.config/nextest.toml` in `nautilus_core` to add `serial-tests` test group
- removed `serial_test` crate and corresponding attribute in `test_cache_database_postgres`
- rename tests to `serial_tests` 

Running `cargo nextest show-config test-groups` now shows 

<img width="862" alt="Screenshot 2024-06-29 at 11 35 22" src="https://github.com/nautechsystems/nautilus_trader/assets/16453976/ee327b14-28e4-45d5-8c27-fb29cc0ad8c8">

