### PR TITLE
Fix OrderMatchingEngine processing by book type for quotes and deltas

### DIFF
--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -369,7 +369,8 @@ cdef class OrderMatchingEngine:
         if is_logging_initialized():
             self._log.debug(f"Processing {repr(delta)}")
 
-        self._book.apply_delta(delta)
+        if self.book_type in (BookType.L2_MBP, BookType.L3_MBO):
+            self._book.apply_delta(delta)
 
         # TODO: WIP to introduce flags
         # if data.flags == TimeInForce.GTC:
@@ -398,7 +399,8 @@ cdef class OrderMatchingEngine:
         if is_logging_initialized():
             self._log.debug(f"Processing {repr(deltas)}")
 
-        self._book.apply_deltas(deltas)
+        if self.book_type in (BookType.L2_MBP, BookType.L3_MBO):
+            self._book.apply_deltas(deltas)
 
         # TODO: WIP to introduce flags
         # if data.flags == TimeInForce.GTC:


### PR DESCRIPTION
…der books

# Pull Request

When the strategy subscribes to both quote deltas and order book deltas, the matching engine applies both quotes as well as deltas to the order book which is incorrect.
In case of the Bybit venue, quote ticks are pushed at a higher frequency than deltas. Hence, some strategies would like to get the latest top of the book quotes, and also build indicators on top of the full order book.

The matching engine should use a L1_MBP order book when subscribing to both quotes and deltas, because the quotes are sent earlier introducing a lookahead bias.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Locally running backtests
