### PR TITLE
Implement PSQL Rust cache database adding accounts

### DIFF
--- a/nautilus_core/infrastructure/src/sql/mod.rs
+++ b/nautilus_core/infrastructure/src/sql/mod.rs
@@ -14,8 +14,14 @@
 // -------------------------------------------------------------------------------------------------
 
 // Be careful about ordering and foreign key constraints when deleting data.
-pub const NAUTILUS_TABLES: [&str; 5] =
-    ["general", "instrument", "order_event", "order", "currency"];
+pub const NAUTILUS_TABLES: [&str; 6] = [
+    "general",
+    "instrument",
+    "account_event",
+    "order_event",
+    "order",
+    "currency",
+];
 
 pub mod cache_database;
 pub mod models;

--- a/nautilus_core/infrastructure/src/sql/models/accounts.rs
+++ b/nautilus_core/infrastructure/src/sql/models/accounts.rs
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::str::FromStr;
+
+use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_model::{
+    enums::AccountType, events::account::state::AccountState, identifiers::AccountId,
+    types::currency::Currency,
+};
+use sqlx::{postgres::PgRow, FromRow, Row};
+
+pub struct AccountEventModel(pub AccountState);
+
+impl<'r> FromRow<'r, PgRow> for AccountEventModel {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        let event_id = row.try_get::<&str, _>("id").map(UUID4::from)?;
+        let account_id = row.try_get::<&str, _>("account_id").map(AccountId::from)?;
+        let account_type = AccountType::from_str(row.try_get::<&str, _>("kind")?).unwrap();
+        let is_reported = row.try_get::<bool, _>("is_reported")?;
+        let ts_event = row.try_get::<&str, _>("ts_event").map(UnixNanos::from)?;
+        let ts_init = row.try_get::<&str, _>("ts_init").map(UnixNanos::from)?;
+        let base_currency = row
+            .try_get::<Option<&str>, _>("base_currency")
+            .map(|res| res.map(Currency::from))?;
+        let balances: serde_json::Value = row.try_get("balances")?;
+        let margins: serde_json::Value = row.try_get("margins")?;
+        let account_event = AccountState::new(
+            account_id,
+            account_type,
+            serde_json::from_value(balances).unwrap(),
+            serde_json::from_value(margins).unwrap(),
+            is_reported,
+            event_id,
+            ts_event,
+            ts_init,
+            base_currency,
+        )
+        .unwrap();
+        Ok(AccountEventModel(account_event))
+    }
+}

--- a/nautilus_core/infrastructure/src/sql/models/mod.rs
+++ b/nautilus_core/infrastructure/src/sql/models/mod.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+pub mod accounts;
 pub mod general;
 pub mod instruments;
 pub mod orders;

--- a/nautilus_core/model/src/accounts/any.rs
+++ b/nautilus_core/model/src/accounts/any.rs
@@ -16,7 +16,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    accounts::{cash::CashAccount, margin::MarginAccount},
+    accounts::{base::Account, cash::CashAccount, margin::MarginAccount},
+    enums::AccountType,
+    events::account::state::AccountState,
     identifiers::AccountId,
 };
 
@@ -32,6 +34,43 @@ impl AccountAny {
         match self {
             AccountAny::Margin(margin) => margin.id,
             AccountAny::Cash(cash) => cash.id,
+        }
+    }
+
+    pub fn last_event(&self) -> Option<AccountState> {
+        match self {
+            AccountAny::Margin(margin) => margin.last_event(),
+            AccountAny::Cash(cash) => cash.last_event(),
+        }
+    }
+
+    pub fn apply(&mut self, event: AccountState) {
+        match self {
+            AccountAny::Margin(margin) => margin.apply(event),
+            AccountAny::Cash(cash) => cash.apply(event),
+        }
+    }
+
+    pub fn from_events(events: Vec<AccountState>) -> anyhow::Result<Self> {
+        if events.is_empty() {
+            anyhow::bail!("No order events provided to create AccountAny");
+        }
+
+        let init_event = events.first().unwrap();
+        let mut account = Self::from(init_event.clone());
+        for event in events.iter().skip(1) {
+            account.apply(event.clone());
+        }
+        Ok(account)
+    }
+}
+
+impl From<AccountState> for AccountAny {
+    fn from(event: AccountState) -> Self {
+        match event.account_type {
+            AccountType::Margin => AccountAny::Margin(MarginAccount::new(event, false).unwrap()),
+            AccountType::Cash => AccountAny::Cash(CashAccount::new(event, false).unwrap()),
+            AccountType::Betting => todo!("Betting account not implemented"),
         }
     }
 }

--- a/nautilus_core/model/src/orders/any.rs
+++ b/nautilus_core/model/src/orders/any.rs
@@ -117,7 +117,7 @@ impl OrderAny {
 
     pub fn from_events(events: Vec<OrderEventAny>) -> anyhow::Result<Self> {
         if events.is_empty() {
-            anyhow::bail!("No events provided");
+            anyhow::bail!("No order events provided to create OrderAny");
         }
 
         // Pop the first event

--- a/nautilus_core/model/src/types/currency.rs
+++ b/nautilus_core/model/src/types/currency.rs
@@ -160,8 +160,8 @@ impl<'de> Deserialize<'de> for Currency {
     where
         D: serde::Deserializer<'de>,
     {
-        let currency_str: &str = Deserialize::deserialize(deserializer)?;
-        Self::from_str(currency_str).map_err(serde::de::Error::custom)
+        let currency_str: String = Deserialize::deserialize(deserializer)?;
+        Self::from_str(&currency_str).map_err(serde::de::Error::custom)
     }
 }
 

--- a/nautilus_core/model/src/types/money.rs
+++ b/nautilus_core/model/src/types/money.rs
@@ -295,8 +295,8 @@ impl<'de> Deserialize<'de> for Money {
     where
         D: Deserializer<'de>,
     {
-        let money_str: &str = Deserialize::deserialize(deserializer)?;
-        Money::from_str(money_str)
+        let money_str: String = Deserialize::deserialize(deserializer)?;
+        Money::from_str(&money_str)
             .map_err(|_| serde::de::Error::custom("Failed to parse Money amount"))
     }
 }

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -22,6 +22,10 @@ CREATE TABLE IF NOT EXISTS "trader" (
     instance_id UUID NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS "account" (
+  id TEXT PRIMARY KEY NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS "strategy" (
   id TEXT PRIMARY KEY NOT NULL,
   order_id_tag TEXT,
@@ -135,6 +139,20 @@ CREATE TABLE IF NOT EXISTS "order_event" (
     position_id TEXT,
     commission TEXT,
     tags TEXT[],
+    ts_event TEXT NOT NULL,
+    ts_init TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "account_event"(
+    id TEXT PRIMARY KEY NOT NULL,
+    kind TEXT NOT NULL,
+    account_id TEXT REFERENCES account(id) ON DELETE CASCADE,
+    base_currency TEXT REFERENCES currency(id),
+    balances JSONB,
+    margins JSONB,
+    is_reported BOOLEAN DEFAULT FALSE,
     ts_event TEXT NOT NULL,
     ts_init TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# Pull Request

- added new `DatabaseQuery` command for Postgres Cache adapter `AddAccount`
- implement sync cache database interface `add_account` and `load_account`
- introduces new tables `account` and `account_event` in PSQL schema
- implemented `FromRow` trait on `AccountEventModel` for correct transformation of Postgres item to native Rust struct
- added new `test_add_account` in `test_cache_database_postgres.rs` tests
- type change to owner `String` in impl `Deserialize for `Money` and `Currency`