### PR TITLE
Implement and test Rust cache_accounts

### DIFF
--- a/nautilus_core/model/src/accounts/any.rs
+++ b/nautilus_core/model/src/accounts/any.rs
@@ -74,3 +74,15 @@ impl From<AccountState> for AccountAny {
         }
     }
 }
+
+impl Default for AccountAny {
+    fn default() -> Self {
+        AccountAny::Cash(CashAccount::default())
+    }
+}
+
+impl PartialEq for AccountAny {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}

--- a/nautilus_core/model/src/accounts/cash.rs
+++ b/nautilus_core/model/src/accounts/cash.rs
@@ -25,7 +25,10 @@ use crate::{
     accounts::base::{Account, BaseAccount},
     enums::{AccountType, LiquiditySide, OrderSide},
     events::{account::state::AccountState, order::filled::OrderFilled},
-    identifiers::AccountId,
+    identifiers::{
+        stubs::{account_id, uuid4},
+        AccountId,
+    },
     instruments::any::InstrumentAny,
     position::Position,
     types::{
@@ -214,6 +217,30 @@ impl Display for CashAccount {
                 |base_currency| format!("{}", base_currency.code)
             ),
         )
+    }
+}
+
+impl Default for CashAccount {
+    fn default() -> Self {
+        // million dollar account
+        let init_event = AccountState::new(
+            account_id(),
+            AccountType::Cash,
+            vec![AccountBalance::new(
+                Money::from("1000000 USD"),
+                Money::from("0 USD"),
+                Money::from("1000000 USD"),
+            )
+            .unwrap()],
+            vec![],
+            true,
+            uuid4(),
+            0.into(),
+            0.into(),
+            Some(Currency::USD()),
+        )
+        .unwrap();
+        Self::new(init_event, false).unwrap()
     }
 }
 


### PR DESCRIPTION
# Pull Request

- cache `add_*` method should also register correct indexes what is missing in current Rust Cache implementation, see https://github.com/nautechsystems/nautilus_trader/blob/dddfd4cef8b592554e654be242dcb4545d7f173c/nautilus_trader/cache/cache.pyx#L1403
- added few unit Rust cache tests around accounts
- implemented sync `load_accounts`
- added `test_cache_accounts` to `test_cache_postgres.rs` 