### PR TITLE
Make trader_id foreign key in order_events table

### DIFF
--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS "general" (
 
 CREATE TABLE IF NOT EXISTS "trader" (
     id TEXT PRIMARY KEY NOT NULL,
-    instance_id UUID NOT NULL
+    instance_id UUID
 );
 
 CREATE TABLE IF NOT EXISTS "account" (
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS "order" (
 CREATE TABLE IF NOT EXISTS "order_event" (
     id TEXT PRIMARY KEY NOT NULL,
     kind TEXT NOT NULL,
-    trader_id TEXT NOT NULL,
+    trader_id TEXT REFERENCES trader(id) ON DELETE CASCADE,
     strategy_id TEXT NOT NULL,
     instrument_id TEXT NOT NULL,
     order_id TEXT DEFAULT NULL,


### PR DESCRIPTION
# Pull Request

- added an idempotent query to create potential records in `trader` table if it doesn't exist
- make `trader_id` column reference/foreign key in `order_event` table
- it helps strengthen the referential integrity of PSQL schema and adds the possibility of cascade delete on account events
- later these two new transactions which were added to check if both `trader` and `account` exist in add functions can be dropped and substituted with ids creation at node startup (so we don't have to try to create them at every account or order event save)