### PR TITLE
Implement PSQL Rust cache database updating accounts

### DIFF
--- a/nautilus_core/model/src/accounts/any.rs
+++ b/nautilus_core/model/src/accounts/any.rs
@@ -44,6 +44,13 @@ impl AccountAny {
         }
     }
 
+    pub fn events(&self) -> Vec<AccountState> {
+        match self {
+            AccountAny::Margin(margin) => margin.events(),
+            AccountAny::Cash(cash) => cash.events(),
+        }
+    }
+
     pub fn apply(&mut self, event: AccountState) {
         match self {
             AccountAny::Margin(margin) => margin.apply(event),

--- a/nautilus_core/model/src/accounts/stubs.rs
+++ b/nautilus_core/model/src/accounts/stubs.rs
@@ -53,7 +53,7 @@ pub fn calculate_commission(
     let account_state = if Some(Currency::USDT()) == currency {
         cash_account_state_million_usdt()
     } else {
-        cash_account_state_million_usd()
+        cash_account_state_million_usd("1000000 USD", "0 USD", "1000000 USD")
     };
     let account = cash_account_million_usd(account_state);
     account

--- a/nautilus_core/model/src/events/account/stubs.rs
+++ b/nautilus_core/model/src/events/account/stubs.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use nautilus_core::uuid::UUID4;
 use rstest::fixture;
 
 use crate::{
@@ -44,19 +45,21 @@ pub fn cash_account_state() -> AccountState {
 }
 
 #[fixture]
-pub fn cash_account_state_million_usd() -> AccountState {
+pub fn cash_account_state_million_usd(
+    #[default("1000000 USD")] total: &str,
+    #[default("0 USD")] locked: &str,
+    #[default("1000000 USD")] free: &str,
+) -> AccountState {
     AccountState::new(
         account_id(),
         AccountType::Cash,
-        vec![AccountBalance::new(
-            Money::from("1000000 USD"),
-            Money::from("0 USD"),
-            Money::from("1000000 USD"),
-        )
-        .unwrap()],
+        vec![
+            AccountBalance::new(Money::from(total), Money::from(locked), Money::from(free))
+                .unwrap(),
+        ],
         vec![],
         true,
-        uuid4(),
+        UUID4::new(),
         0.into(),
         0.into(),
         Some(Currency::USD()),


### PR DESCRIPTION
# Pull Request

- added bool `updated` to `AddAccount` query command to signal that command should also check if initial record in `account_event` exists
- tested in Rust E2E if works
- some changes in cash account fixture
