### PR TITLE
Add option to saving market data in Rust cache

### DIFF
--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -24,11 +24,13 @@ use std::collections::HashMap;
 use nautilus_core::nanos::UnixNanos;
 use nautilus_model::{
     accounts::any::AccountAny,
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
     identifiers::{
         AccountId, ClientId, ClientOrderId, ComponentId, InstrumentId, PositionId, StrategyId,
         VenueOrderId,
     },
     instruments::{any::InstrumentAny, synthetic::SyntheticInstrument},
+    orderbook::book::OrderBook,
     orders::any::OrderAny,
     position::Position,
     types::currency::Currency,
@@ -103,6 +105,14 @@ pub trait CacheDatabaseAdapter {
     fn add_order(&mut self, order: &OrderAny) -> anyhow::Result<()>;
 
     fn add_position(&mut self, position: &Position) -> anyhow::Result<()>;
+
+    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()>;
+
+    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()>;
+
+    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()>;
+
+    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()>;
 
     fn index_venue_order_id(
         &mut self,

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -25,11 +25,13 @@ use nautilus_common::{cache::database::CacheDatabaseAdapter, enums::Serializatio
 use nautilus_core::{correctness::check_slice_not_empty, nanos::UnixNanos, uuid::UUID4};
 use nautilus_model::{
     accounts::any::AccountAny,
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
     identifiers::{
         AccountId, ClientId, ClientOrderId, ComponentId, InstrumentId, PositionId, StrategyId,
         TraderId, VenueOrderId,
     },
     instruments::{any::InstrumentAny, synthetic::SyntheticInstrument},
+    orderbook::book::OrderBook,
     orders::any::OrderAny,
     position::Position,
     types::currency::Currency,
@@ -885,6 +887,22 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
 
     fn add_position(&mut self, position: &Position) -> anyhow::Result<()> {
         todo!()
+    }
+
+    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
+        anyhow::bail!("Saving market data for Redis cache adapter not supported")
+    }
+
+    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+        anyhow::bail!("Saving market data for Redis cache adapter not supported")
+    }
+
+    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()> {
+        anyhow::bail!("Saving market data for Redis cache adapter not supported")
+    }
+
+    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()> {
+        anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
     fn index_venue_order_id(

--- a/nautilus_core/infrastructure/src/sql/cache_database.rs
+++ b/nautilus_core/infrastructure/src/sql/cache_database.rs
@@ -23,11 +23,13 @@ use nautilus_common::cache::database::CacheDatabaseAdapter;
 use nautilus_core::nanos::UnixNanos;
 use nautilus_model::{
     accounts::any::AccountAny,
+    data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
     identifiers::{
         AccountId, ClientId, ClientOrderId, ComponentId, InstrumentId, PositionId, StrategyId,
         VenueOrderId,
     },
     instruments::{any::InstrumentAny, synthetic::SyntheticInstrument},
+    orderbook::book::OrderBook,
     orders::any::OrderAny,
     position::Position,
     types::currency::Currency,
@@ -562,6 +564,22 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
     }
 
     fn add_position(&mut self, position: &Position) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()> {
         todo!()
     }
 


### PR DESCRIPTION
# Pull Request

- opens up the possibility of saving market data for future historical analysis to Postgres
- new parameter `save_market_data` was added to Cache config to signal desire also to save market data
- four new methods were added to trait `CacheDatabaseAdapter` and are:  `add_order_book` , `add_quote` , `add_trade` and`add_bar` 
- Postgres cache adapter waits for implementation
- saving market data to Redis is not supported ( we can also add this but don't know if it makes sense to save this high frequency data to redis cache, Postgres adapter is perfect for this)
