### PR TITLE
Fix Bybit parsing of trade and quote ticks for websocket messages

### DIFF
--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -68,6 +68,7 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
 
 
 class BybitDataClient(LiveMarketDataClient):
@@ -672,10 +673,10 @@ class BybitDataClient(LiveMarketDataClient):
                 ask_price = Price(float(msg.data.ask1Price), instrument.price_precision)
 
             if msg.data.bid1Size is not None:
-                bid_size = Price(float(msg.data.bid1Size), instrument.size_precision)
+                bid_size = Quantity(float(msg.data.bid1Size), instrument.size_precision)
 
             if msg.data.ask1Size is not None:
-                ask_size = Price(float(msg.data.ask1Size), instrument.size_precision)
+                ask_size = Quantity(float(msg.data.ask1Size), instrument.size_precision)
 
             quote = QuoteTick(
                 instrument_id=instrument_id,

--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -68,7 +68,6 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.model.objects import Price
-from nautilus_trader.model.objects import Quantity
 
 
 class BybitDataClient(LiveMarketDataClient):
@@ -647,30 +646,43 @@ class BybitDataClient(LiveMarketDataClient):
         try:
             symbol = msg.data.symbol + f"-{product_type.value.upper()}"
             instrument_id: InstrumentId = self._get_cached_instrument_id(symbol)
+            instrument = self._cache.instrument(instrument_id)
+
+            if instrument is None:
+                self._log.error(f"Cannot parse trade data: no instrument for {instrument_id}")
+                return
+
             last_quote = self._last_quotes.get(instrument_id)
+
+            bid_price = None
+            ask_price = None
+            bid_size = None
+            ask_size = None
+
+            if last_quote is not None:
+                bid_price = last_quote.bid_price
+                ask_price = last_quote.ask_price
+                bid_size = last_quote.bid_size
+                ask_size = last_quote.ask_size
+
+            if msg.data.bid1Price is not None:
+                bid_price = Price(float(msg.data.bid1Price), instrument.price_precision)
+
+            if msg.data.ask1Price is not None:
+                ask_price = Price(float(msg.data.ask1Price), instrument.price_precision)
+
+            if msg.data.bid1Size is not None:
+                bid_size = Price(float(msg.data.bid1Size), instrument.size_precision)
+
+            if msg.data.ask1Size is not None:
+                ask_size = Price(float(msg.data.ask1Size), instrument.size_precision)
 
             quote = QuoteTick(
                 instrument_id=instrument_id,
-                bid_price=(
-                    Price.from_str(msg.data.bid1Price)
-                    if msg.data.bid1Price or last_quote is None
-                    else last_quote.bid_price
-                ),
-                ask_price=(
-                    Price.from_str(msg.data.ask1Price)
-                    if msg.data.ask1Price or last_quote is None
-                    else last_quote.ask_price
-                ),
-                bid_size=(
-                    Quantity.from_str(msg.data.bid1Size)
-                    if msg.data.bid1Size or last_quote is None
-                    else last_quote.bid_size
-                ),
-                ask_size=(
-                    Quantity.from_str(msg.data.ask1Size)
-                    if msg.data.ask1Size or last_quote is None
-                    else last_quote.ask_size
-                ),
+                bid_price=bid_price,
+                ask_price=ask_price,
+                bid_size=bid_size,
+                ask_size=ask_size,
                 ts_event=millis_to_nanos(msg.ts),
                 ts_init=self._clock.timestamp_ns(),
             )
@@ -686,9 +698,17 @@ class BybitDataClient(LiveMarketDataClient):
             for data in msg.data:
                 symbol = data.s + f"-{product_type.value.upper()}"
                 instrument_id: InstrumentId = self._get_cached_instrument_id(symbol)
+                instrument = self._cache.instrument(instrument_id)
+
+                if instrument is None:
+                    self._log.error(f"Cannot parse trade data: no instrument for {instrument_id}")
+                    return
+
                 trade: TradeTick = data.parse_to_trade_tick(
                     instrument_id,
-                    self._clock.timestamp_ns(),
+                    price_precision=instrument.price_precision,
+                    size_precision=instrument.size_precision,
+                    ts_init=self._clock.timestamp_ns(),
                 )
                 self._handle_data(trade)
         except Exception as e:

--- a/nautilus_trader/adapters/bybit/schemas/ws.py
+++ b/nautilus_trader/adapters/bybit/schemas/ws.py
@@ -553,12 +553,14 @@ class BybitWsTrade(msgspec.Struct):
     def parse_to_trade_tick(
         self,
         instrument_id: InstrumentId,
+        price_precision: int,
+        size_precision: int,
         ts_init: int,
     ) -> TradeTick:
         return TradeTick(
             instrument_id=instrument_id,
-            price=Price.from_str(self.p),
-            size=Quantity.from_str(self.v),
+            price=Price(float(self.p), price_precision),
+            size=Quantity(float(self.v), size_precision),
             aggressor_side=AggressorSide.SELLER if self.S == "Sell" else AggressorSide.BUYER,
             trade_id=TradeId(str(self.i)),
             ts_event=millis_to_nanos(self.T),

--- a/nautilus_trader/adapters/bybit/schemas/ws.py
+++ b/nautilus_trader/adapters/bybit/schemas/ws.py
@@ -490,38 +490,6 @@ class BybitWsTickerOptionMsg(msgspec.Struct):
 ################################################################################
 
 
-class BybitWsTradeSpot(msgspec.Struct):
-    # The timestamp (ms) that the order is filled
-    T: int
-    # Symbol name
-    s: str
-    # Side of taker. Buy,Sell
-    S: str
-    # Trade size
-    v: str
-    # Trade price
-    p: str
-    # Trade id
-    i: str
-    # Whether is a block trade or not
-    BT: bool
-
-    def parse_to_trade_tick(
-        self,
-        instrument_id: InstrumentId,
-        ts_init: int,
-    ) -> TradeTick:
-        return TradeTick(
-            instrument_id=instrument_id,
-            price=Price.from_str(self.p),
-            size=Quantity.from_str(self.v),
-            aggressor_side=AggressorSide.SELLER if self.S == "Sell" else AggressorSide.BUYER,
-            trade_id=TradeId(str(self.i)),
-            ts_event=millis_to_nanos(self.T),
-            ts_init=ts_init,
-        )
-
-
 class BybitWsTrade(msgspec.Struct):
     # The timestamp (ms) that the order is filled
     T: int


### PR DESCRIPTION
# Pull Request

Explicitly set the quote price, quote size, trade price and trade size precisions for the Bybit venue.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Subscribing to live trade data for the bybit venue. Asserting in strategy that the correct prize and size precision are used for all ticks and adding a unit test.
