### PR TITLE
Add support for options on futures in Interactive Brokers adapter

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -126,6 +126,7 @@ def sec_type_to_asset_class(sec_type: str) -> AssetClass:
         "CASH": "FX",
         "BOND": "DEBT",
         "CMDTY": "COMMODITY",
+        "FUT": "INDEX",
     }
     return asset_class_from_str(mapping.get(sec_type, sec_type))
 
@@ -151,7 +152,7 @@ def parse_instrument(
         return parse_index_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type in ("FUT", "CONTFUT"):
         return parse_futures_contract(details=contract_details, instrument_id=instrument_id)
-    elif security_type == "OPT":
+    elif security_type in ("OPT", "FOP"):
         return parse_options_contract(details=contract_details, instrument_id=instrument_id)
     elif security_type == "CASH":
         return parse_forex_contract(details=contract_details, instrument_id=instrument_id)

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -229,7 +229,7 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         [option_details] = (
             await self._client.get_contract_details(
                 IBContract(
-                    secType="OPT",
+                    secType=("FOP" if underlying.secType == "FUT" else "OPT"),
                     symbol=underlying.symbol,
                     lastTradeDateOrContractMonth=last_trading_date,
                     exchange=exchange or "SMART",

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -136,7 +136,7 @@ class IBTestContractStubs:
         nextOptionType="",
         nextOptionPartial=False,
         notes="",
-    ) -> Contract:
+    ) -> ContractDetails:
         return set_attributes(ContractDetails(), locals())
 
     @staticmethod
@@ -272,6 +272,82 @@ class IBTestContractStubs:
             "secIdList": [],
             "realExpirationDate": "20231120",
             "lastTradeTime": "14:30:00",
+            "stockType": "",
+            "minSize": 1.0,
+            "sizeIncrement": 1.0,
+            "suggestedSizeIncrement": 1.0,
+            "cusip": "",
+            "ratings": "",
+            "descAppend": "",
+            "bondType": "",
+            "couponType": "",
+            "callable": False,
+            "putable": False,
+            "coupon": 0,
+            "convertible": False,
+            "maturity": "",
+            "issueDate": "",
+            "nextOptionDate": "",
+            "nextOptionType": "",
+            "nextOptionPartial": False,
+            "notes": "",
+        }
+        return IBTestContractStubs.create_contract_details(**params)
+
+    @staticmethod
+    def es_future_option_contract() -> Contract:
+        params = {
+            "secType": "FOP",
+            "conId": 715834345,
+            "symbol": "ES",
+            "lastTradeDateOrContractMonth": "20240722",
+            "strike": 5655.0,
+            "right": "C",
+            "multiplier": "50",
+            "exchange": "CME",
+            "primaryExchange": "",
+            "currency": "USD",
+            "localSymbol": "E4AN4 C5655",
+            "tradingClass": "E4A",
+            "includeExpired": False,
+            "secIdType": "",
+            "secId": "",
+            "description": "",
+            "issuerId": "",
+            "comboLegsDescrip": "",
+            "comboLegs": [],
+            "deltaNeutralContract": None,
+        }
+        return IBTestContractStubs.create_contract(**params)
+
+    @classmethod
+    def es_future_option_contract_details(cls) -> ContractDetails:
+        params = {
+            "contract": cls.es_future_option_contract(),
+            "marketName": "E4A",
+            "minTick": 0.05,
+            "orderTypes": "ACTIVETIM,AD,ADJUST,ALERT,ALLOC,AVGCOST,BASKET,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,LTH,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,VOLAT,WHATIF",  # noqa: E501
+            "validExchanges": "CME",
+            "priceMagnifier": 1,
+            "underConId": 568550526,
+            "longName": "E-mini S&P 500",
+            "contractMonth": "202407",
+            "industry": "",
+            "category": "",
+            "subcategory": "",
+            "timeZoneId": "US/Central",
+            "tradingHours": "20240720:CLOSED;20240721:1700-20240722:1500",
+            "liquidHours": "20240720:CLOSED;20240721:CLOSED;20240722:0830-20240722:1500",
+            "evRule": "",
+            "evMultiplier": 0,
+            "mdSizeMultiplier": 1,
+            "aggGroup": 2147483647,
+            "underSymbol": "ESU4",
+            "underSecType": "FUT",
+            "marketRuleIds": "3541",
+            "secIdList": [],
+            "realExpirationDate": "20240722",
+            "lastTradeTime": "23:00:00",
             "stockType": "",
             "minSize": 1.0,
             "sizeIncrement": 1.0,

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -21,6 +21,7 @@ import pytest
 
 # fmt: off
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
+from nautilus_trader.adapters.interactive_brokers.common import IBContractDetails
 from nautilus_trader.adapters.interactive_brokers.parsing.data import bar_spec_to_bar_size
 from nautilus_trader.adapters.interactive_brokers.parsing.data import timedelta_to_duration_str
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import RE_CASH
@@ -39,8 +40,11 @@ from nautilus_trader.adapters.interactive_brokers.parsing.instruments import _ti
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import expiry_timestring_to_datetime
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import ib_contract_to_instrument_id
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import instrument_id_to_ib_contract
+from nautilus_trader.adapters.interactive_brokers.parsing.instruments import parse_instrument
 from nautilus_trader.model.data import BarSpecification
 from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import OptionsContract
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
 
 
 # fmt: on
@@ -382,3 +386,17 @@ def test_expiry_timestring_to_datetime(expiry: str, expected: pd.Timestamp):
     result = expiry_timestring_to_datetime(expiry=expiry)
     # Act, Assert
     assert result == expected
+
+
+def test_parse_instrument_future_option():
+    # Arrange
+    contract_details = IBTestContractStubs.es_future_option_contract_details()
+    contract_details.contract = IBContract(**contract_details.contract.__dict__)
+    contract_details = IBContractDetails(**contract_details.__dict__)
+
+    # Act
+    instrument = parse_instrument(contract_details)
+
+    # Assert
+    assert instrument.id.value == "E4AN24C5655.CME"
+    assert isinstance(instrument, OptionsContract), "instrument is not a OptionContract"


### PR DESCRIPTION
# Pull Request

Fixes Future Options support in Interactive Brokers adapter.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Added test.
