### PR TITLE
Implemented native PSQL enum mapping with Rust on CurrencyType

### DIFF
--- a/nautilus_core/infrastructure/src/sql/models/enums.rs
+++ b/nautilus_core/infrastructure/src/sql/models/enums.rs
@@ -1,0 +1,59 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::str::FromStr;
+
+use nautilus_model::enums::CurrencyType;
+use sqlx::{
+    database::{HasArguments, HasValueRef},
+    encode::IsNull,
+    error::BoxDynError,
+    postgres::PgTypeInfo,
+    types::Type,
+    Decode, Postgres,
+};
+
+pub struct CurrencyTypeModel(pub CurrencyType);
+
+impl sqlx::Encode<'_, sqlx::Postgres> for CurrencyTypeModel {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let currency_type_str = match self.0 {
+            CurrencyType::Crypto => "CRYPTO",
+            CurrencyType::Fiat => "FIAT",
+            CurrencyType::CommodityBacked => "COMMODITY_BACKED",
+        };
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(currency_type_str, buf)
+    }
+}
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for CurrencyTypeModel {
+    fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        let currency_type_str: &str = <&str as Decode<sqlx::Postgres>>::decode(value)?;
+        let currency_type = CurrencyType::from_str(currency_type_str).map_err(|_| {
+            sqlx::Error::Decode(format!("Invalid currency type: {}", currency_type_str).into())
+        })?;
+        Ok(CurrencyTypeModel(currency_type))
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for CurrencyTypeModel {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        PgTypeInfo::with_name("currency_type")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        *ty == Self::type_info() || <&str as Type<sqlx::Postgres>>::compatible(ty)
+    }
+}

--- a/nautilus_core/infrastructure/src/sql/models/mod.rs
+++ b/nautilus_core/infrastructure/src/sql/models/mod.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod accounts;
+pub mod enums;
 pub mod general;
 pub mod instruments;
 pub mod orders;

--- a/nautilus_core/infrastructure/src/sql/models/types.rs
+++ b/nautilus_core/infrastructure/src/sql/models/types.rs
@@ -13,10 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::str::FromStr;
-
-use nautilus_model::{enums::CurrencyType, types::currency::Currency};
+use nautilus_model::types::currency::Currency;
 use sqlx::{postgres::PgRow, FromRow, Row};
+
+use crate::sql::models::enums::CurrencyTypeModel;
 
 pub struct CurrencyModel(pub Currency);
 
@@ -26,16 +26,13 @@ impl<'r> FromRow<'r, PgRow> for CurrencyModel {
         let precision = row.try_get::<i32, _>("precision")?;
         let iso4217 = row.try_get::<i32, _>("iso4217")?;
         let name = row.try_get::<String, _>("name")?;
-        let currency_type = row
-            .try_get::<String, _>("currency_type")
-            .map(|res| CurrencyType::from_str(res.as_str()).unwrap())?;
-
+        let currency_type_model = row.try_get::<CurrencyTypeModel, _>("currency_type")?;
         let currency = Currency::new(
             id.as_str(),
             precision as u8,
             iso4217 as u16,
             name.as_str(),
-            currency_type,
+            currency_type_model.0,
         )
         .unwrap();
         Ok(CurrencyModel(currency))

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -32,8 +32,8 @@ use nautilus_model::{
 use sqlx::{PgPool, Row};
 
 use crate::sql::models::{
-    accounts::AccountEventModel, general::GeneralRow, instruments::InstrumentAnyModel,
-    orders::OrderEventAnyModel, types::CurrencyModel,
+    accounts::AccountEventModel, enums::CurrencyTypeModel, general::GeneralRow,
+    instruments::InstrumentAnyModel, orders::OrderEventAnyModel, types::CurrencyModel,
 };
 
 pub struct DatabaseQueries;
@@ -65,13 +65,13 @@ impl DatabaseQueries {
 
     pub async fn add_currency(pool: &PgPool, currency: Currency) -> anyhow::Result<()> {
         sqlx::query(
-            "INSERT INTO currency (id, precision, iso4217, name, currency_type) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (id) DO NOTHING"
+            "INSERT INTO currency (id, precision, iso4217, name, currency_type) VALUES ($1, $2, $3, $4, $5::currency_type) ON CONFLICT (id) DO NOTHING"
         )
             .bind(currency.code.as_str())
             .bind(currency.precision as i32)
             .bind(currency.iso4217 as i32)
             .bind(currency.name.as_str())
-            .bind(currency.currency_type.to_string())
+            .bind(CurrencyTypeModel(currency.currency_type))
             .execute(pool)
             .await
             .map(|_| ())

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -8,7 +8,7 @@ CREATE TYPE INSTRUMENT_CLASS AS ENUM ('Spot', 'Swap', 'Future', 'FutureSpread', 
 CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volume', 'VolumeImbalance', 'VolumeRuns', 'Value', 'ValueImbalance', 'ValueRuns', 'Millisecond', 'Second', 'Minute', 'Hour', 'Day', 'Week', 'Month');
 CREATE TYPE BOOK_ACTION AS ENUM ('Add', 'Update', 'Delete','Clear');
 CREATE TYPE ORDER_STATUS AS ENUM ('Initialized', 'Denied', 'Emulated', 'Released', 'Submitted', 'Accepted', 'Rejected', 'Canceled', 'Expired', 'Triggered', 'PendingUpdate', 'PendingCancel', 'PartiallyFilled', 'Filled');
-
+CREATE TYPE CURRENCY_TYPE AS ENUM('CRYPTO', 'FIAT', 'COMMODITY_BACKED');
 
 ------------------- TABLES -------------------
 
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS "currency" (
     precision INTEGER,
     iso4217 INTEGER,
     name TEXT,
-    currency_type TEXT
+    currency_type CURRENCY_TYPE
 );
 
 CREATE TABLE IF NOT EXISTS "instrument" (


### PR DESCRIPTION
# Pull Request

Currently, our native Rust enums are represented as TEXT columns in the PSQL schema.
We want to map native Postgres enums to native Rust types we have. One way to solve this is to create a model wrapper on an enum and implement target sqlx traits.

- refactored the `CurrencyType` enum definition in PSQL schema to screaming snake case notation
- created a wrapper `CurrencyTypeModel` on the enum `CurrencyType` and implemented sqlx traits `Decode`, `Encode` and `Type`
- added target enum casting in INSERT currency query