### PR TITLE
Implement native PSQL enum mapping on AssetClass

### DIFF
--- a/nautilus_core/infrastructure/src/sql/models/instruments.rs
+++ b/nautilus_core/infrastructure/src/sql/models/instruments.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use nautilus_core::nanos::UnixNanos;
 use nautilus_model::{
-    enums::{AssetClass, OptionKind},
+    enums::OptionKind,
     identifiers::{InstrumentId, Symbol},
     instruments::{
         any::InstrumentAny, crypto_future::CryptoFuture, crypto_perpetual::CryptoPerpetual,
@@ -34,6 +34,8 @@ use nautilus_model::{
 use rust_decimal::Decimal;
 use sqlx::{postgres::PgRow, FromRow, Row};
 use ustr::Ustr;
+
+use crate::sql::models::enums::AssetClassModel;
 
 pub struct InstrumentAnyModel(pub InstrumentAny);
 pub struct CryptoFutureModel(pub CryptoFuture);
@@ -485,8 +487,8 @@ impl<'r> FromRow<'r, PgRow> for FuturesContractModel {
             .try_get::<String, _>("raw_symbol")
             .map(|res| Symbol::new(res.as_str()).unwrap())?;
         let asset_class = row
-            .try_get::<String, _>("asset_class")
-            .map(|res| AssetClass::from_str(res.as_str()).unwrap())?;
+            .try_get::<AssetClassModel, _>("asset_class")
+            .map(|res| res.0)?;
         let exchange = row
             .try_get::<Option<String>, _>("exchange")
             .map(|res| res.map(|s| Ustr::from(s.as_str())))?;
@@ -583,8 +585,8 @@ impl<'r> FromRow<'r, PgRow> for OptionsContractModel {
             .try_get::<String, _>("raw_symbol")
             .map(|res| Symbol::new(res.as_str()).unwrap())?;
         let asset_class = row
-            .try_get::<String, _>("asset_class")
-            .map(|res| AssetClass::from_str(res.as_str()).unwrap())?;
+            .try_get::<AssetClassModel, _>("asset_class")
+            .map(|res| res.0)?;
         let exchange = row
             .try_get::<Option<String>, _>("exchange")
             .map(|res| res.map(|s| Ustr::from(s.as_str())))?;

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -32,8 +32,12 @@ use nautilus_model::{
 use sqlx::{PgPool, Row};
 
 use crate::sql::models::{
-    accounts::AccountEventModel, enums::CurrencyTypeModel, general::GeneralRow,
-    instruments::InstrumentAnyModel, orders::OrderEventAnyModel, types::CurrencyModel,
+    accounts::AccountEventModel,
+    enums::{AssetClassModel, CurrencyTypeModel},
+    general::GeneralRow,
+    instruments::InstrumentAnyModel,
+    orders::OrderEventAnyModel,
+    types::CurrencyModel,
 };
 
 pub struct DatabaseQueries;
@@ -114,7 +118,7 @@ impl DatabaseQueries {
                 multiplier, option_kind, is_inverse, strike_price, activation_ns, expiration_ns, price_precision, size_precision,
                 price_increment, size_increment, maker_fee, taker_fee, margin_init, margin_maint, lot_size, max_quantity, min_quantity, max_notional,
                 min_notional, max_price, min_price, ts_init, ts_event, created_at, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::asset_class, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             ON CONFLICT (id)
             DO UPDATE
             SET
@@ -131,7 +135,7 @@ impl DatabaseQueries {
             .bind(instrument.quote_currency().code.as_str())
             .bind(instrument.settlement_currency().code.as_str())
             .bind(instrument.isin().map(|x| x.to_string()))
-            .bind(instrument.asset_class().to_string())
+            .bind(AssetClassModel(instrument.asset_class()))
             .bind(instrument.exchange().map(|x| x.to_string()))
             .bind(instrument.multiplier().to_string())
             .bind(instrument.option_kind().map(|x| x.to_string()))

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -3,7 +3,7 @@
 CREATE TYPE ACCOUNT_TYPE AS ENUM ('Cash', 'Margin', 'Betting');
 CREATE TYPE AGGREGATION_SOURCE AS ENUM ('External', 'Internal');
 CREATE TYPE AGGRESSOR_SIDE AS ENUM ('NoAggressor', 'Buyer', 'Seller');
-CREATE TYPE ASSET_CLASS AS ENUM ('Fx', 'Equity', 'Commodity', 'Debt', 'Index', 'Cryptocurrency', 'Alternative');
+CREATE TYPE ASSET_CLASS AS ENUM ('FX', 'EQUITY', 'COMMODITY', 'DEBT', 'INDEX', 'CRYPTOCURRENCY', 'ALTERNATIVE');
 CREATE TYPE INSTRUMENT_CLASS AS ENUM ('Spot', 'Swap', 'Future', 'FutureSpread', 'Forward', 'Cfg', 'Bond', 'Option', 'OptionSpread', 'Warrant', 'SportsBetting');
 CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volume', 'VolumeImbalance', 'VolumeRuns', 'Value', 'ValueImbalance', 'ValueRuns', 'Millisecond', 'Second', 'Minute', 'Hour', 'Day', 'Week', 'Month');
 CREATE TYPE BOOK_ACTION AS ENUM ('Add', 'Update', 'Delete','Clear');
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS "instrument" (
     quote_currency TEXT REFERENCES currency(id),
     settlement_currency TEXT REFERENCES currency(id),
     isin TEXT,
-    asset_class TEXT,
+    asset_class ASSET_CLASS,
     exchange TEXT,
     multiplier TEXT,
     option_kind TEXT,


### PR DESCRIPTION
# Pull Request

- refactored the `AssetClass` enum definition in PSQL schema to screaming snake case notation
- created a wrapper `AssetClassModel` on the enum `AssetClass` and implemented sqlx traits `Decode`, `Encode` and `Type`
- added target enum casting in INSERT enum query
