### PR TITLE
Implement native PSQL enum mapping on TrailingOffsetType

### DIFF
--- a/nautilus_core/infrastructure/src/sql/models/orders.rs
+++ b/nautilus_core/infrastructure/src/sql/models/orders.rs
@@ -17,10 +17,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
 use nautilus_model::{
-    enums::{
-        ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TrailingOffsetType,
-        TriggerType,
-    },
+    enums::{ContingencyType, LiquiditySide, OrderSide, OrderType, TimeInForce, TriggerType},
     events::order::{
         OrderAccepted, OrderCancelRejected, OrderCanceled, OrderDenied, OrderEmulated,
         OrderEventAny, OrderExpired, OrderFilled, OrderInitialized, OrderModifyRejected,
@@ -35,6 +32,8 @@ use nautilus_model::{
 };
 use sqlx::{postgres::PgRow, FromRow, Row};
 use ustr::Ustr;
+
+use crate::sql::models::enums::TrailingOffsetTypeModel;
 
 pub struct OrderEventAnyModel(pub OrderEventAny);
 pub struct OrderAcceptedModel(pub OrderAccepted);
@@ -168,9 +167,9 @@ impl<'r> FromRow<'r, PgRow> for OrderInitializedModel {
             .ok()
             .and_then(|x| x.map(Price::from));
         let trailing_offset_type = row
-            .try_get::<Option<&str>, _>("trailing_offset_type")
+            .try_get::<Option<TrailingOffsetTypeModel>, _>("trailing_offset_type")
             .ok()
-            .and_then(|x| x.map(|x| TrailingOffsetType::from_str(x).unwrap()));
+            .and_then(|x| x.map(|x| x.0));
         let expire_time = row
             .try_get::<Option<&str>, _>("expire_time")
             .ok()

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -33,7 +33,7 @@ use sqlx::{PgPool, Row};
 
 use crate::sql::models::{
     accounts::AccountEventModel,
-    enums::{AssetClassModel, CurrencyTypeModel},
+    enums::{AssetClassModel, CurrencyTypeModel, TrailingOffsetTypeModel},
     general::GeneralRow,
     instruments::InstrumentAnyModel,
     orders::OrderEventAnyModel,
@@ -317,7 +317,7 @@ impl DatabaseQueries {
                 exec_algorithm_id, exec_spawn_id, venue_order_id, account_id, position_id, commission, ts_event, ts_init, created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-                $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                $21, $22, $23, $24::trailing_offset_type, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
             ON CONFLICT (id)
             DO UPDATE
@@ -355,7 +355,7 @@ impl DatabaseQueries {
             .bind(order_event.trigger_type().map(|x| x.to_string()))
             .bind(order_event.limit_offset().map(|x| x.to_string()))
             .bind(order_event.trailing_offset().map(|x| x.to_string()))
-            .bind(order_event.trailing_offset_type().map(|x| format!("{:?}", x)))
+            .bind(order_event.trailing_offset_type().map(TrailingOffsetTypeModel))
             .bind(order_event.expire_time().map(|x| x.to_string()))
             .bind(order_event.display_qty().map(|x| x.to_string()))
             .bind(order_event.emulation_trigger().map(|x| x.to_string()))

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -9,6 +9,7 @@ CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volum
 CREATE TYPE BOOK_ACTION AS ENUM ('Add', 'Update', 'Delete','Clear');
 CREATE TYPE ORDER_STATUS AS ENUM ('Initialized', 'Denied', 'Emulated', 'Released', 'Submitted', 'Accepted', 'Rejected', 'Canceled', 'Expired', 'Triggered', 'PendingUpdate', 'PendingCancel', 'PartiallyFilled', 'Filled');
 CREATE TYPE CURRENCY_TYPE AS ENUM('CRYPTO', 'FIAT', 'COMMODITY_BACKED');
+CREATE TYPE TRAILING_OFFSET_TYPE AS ENUM('NO_TRAILING_OFFSET', 'PRICE', 'BASIS_POINTS', 'TICKS', 'PRICE_TIER');
 
 ------------------- TABLES -------------------
 
@@ -122,7 +123,7 @@ CREATE TABLE IF NOT EXISTS "order_event" (
     trigger_type TEXT,
     limit_offset TEXT,
     trailing_offset TEXT,
-    trailing_offset_type TEXT,
+    trailing_offset_type TRAILING_OFFSET_TYPE,
     expire_time TEXT,
     display_qty TEXT,
     emulation_trigger TEXT,


### PR DESCRIPTION
# Pull Request

- added the `TrailingOffsetType` enum definition in PSQL schema
- created a wrapper `TrailingOffsetTypeModel` on the enum `TrailingOffsetType` and implemented sqlx traits `Decode`, `Encode`, and `Type`
- added target enum casting in INSERT query
