### PR TITLE
Implement trade tick schema with PSQL cache database in Rust

### DIFF
--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -108,6 +108,8 @@ pub trait CacheDatabaseAdapter {
 
     fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()>;
 
+    fn load_trades(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>>;
+
     fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()>;
 
     fn index_venue_order_id(

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -876,6 +876,10 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
+    fn load_trades(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>> {
+        anyhow::bail!("Loading market data for Redis cache adapter not supported")
+    }
+
     fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()> {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }

--- a/nautilus_core/infrastructure/src/sql/mod.rs
+++ b/nautilus_core/infrastructure/src/sql/mod.rs
@@ -14,8 +14,9 @@
 // -------------------------------------------------------------------------------------------------
 
 // Be careful about ordering and foreign key constraints when deleting data.
-pub const NAUTILUS_TABLES: [&str; 6] = [
+pub const NAUTILUS_TABLES: [&str; 7] = [
     "general",
+    "trade",
     "instrument",
     "account_event",
     "order_event",

--- a/nautilus_core/infrastructure/src/sql/models/data.rs
+++ b/nautilus_core/infrastructure/src/sql/models/data.rs
@@ -1,0 +1,64 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::str::FromStr;
+
+use nautilus_core::nanos::UnixNanos;
+use nautilus_model::{
+    data::trade::TradeTick,
+    identifiers::{InstrumentId, TradeId},
+    types::{price::Price, quantity::Quantity},
+};
+use sqlx::{postgres::PgRow, Error, FromRow, Row};
+
+use crate::sql::models::enums::AggressorSideModel;
+
+pub struct TradeTickModel(pub TradeTick);
+
+impl<'r> FromRow<'r, PgRow> for TradeTickModel {
+    fn from_row(row: &'r PgRow) -> Result<Self, Error> {
+        let instrument_id = row
+            .try_get::<&str, _>("instrument_id")
+            .map(|x| InstrumentId::from_str(x).unwrap())?;
+        let price = row
+            .try_get::<&str, _>("price")
+            .map(|x| Price::from_str(x).unwrap())?;
+        let size = row
+            .try_get::<&str, _>("quantity")
+            .map(|x| Quantity::from_str(x).unwrap())?;
+        let aggressor_side = row
+            .try_get::<AggressorSideModel, _>("aggressor_side")
+            .map(|x| x.0)?;
+        let trade_id = row
+            .try_get::<&str, _>("venue_trade_id")
+            .map(|x| TradeId::from_str(x).unwrap())?;
+        let ts_event = row
+            .try_get::<String, _>("ts_event")
+            .map(|res| UnixNanos::from(res.as_str()))?;
+        let ts_init = row
+            .try_get::<String, _>("ts_init")
+            .map(|res| UnixNanos::from(res.as_str()))?;
+        let trade = TradeTick::new(
+            instrument_id,
+            price,
+            size,
+            aggressor_side,
+            trade_id,
+            ts_event,
+            ts_init,
+        );
+        Ok(TradeTickModel(trade))
+    }
+}

--- a/nautilus_core/infrastructure/src/sql/models/mod.rs
+++ b/nautilus_core/infrastructure/src/sql/models/mod.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 pub mod accounts;
+pub mod data;
 pub mod enums;
 pub mod general;
 pub mod instruments;

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -27,6 +27,7 @@ mod serial_tests {
     use nautilus_infrastructure::sql::cache_database::get_pg_cache_database;
     use nautilus_model::{
         accounts::{any::AccountAny, cash::CashAccount},
+        data::stubs::stub_trade_tick_ethusdt_buyer,
         enums::{CurrencyType, OrderSide, OrderStatus},
         events::account::stubs::cash_account_state_million_usd,
         identifiers::{
@@ -350,5 +351,33 @@ mod serial_tests {
         );
         let account_result = pg_cache.load_account(&account.id()).unwrap();
         entirely_equal(account_result.unwrap(), account);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_postgres_cache_database_add_trade_tick() {
+        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        // add target instrument and currencies
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        pg_cache
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
+        pg_cache.add_currency(&instrument.quote_currency()).unwrap();
+        pg_cache.add_instrument(&instrument).unwrap();
+        // add trade tick
+        let trade_tick = stub_trade_tick_ethusdt_buyer();
+        pg_cache.add_trade(&trade_tick).unwrap();
+        wait_until(
+            || {
+                pg_cache
+                    .load_instrument(&instrument.id())
+                    .unwrap()
+                    .is_some()
+                    && !pg_cache.load_trades(&instrument.id()).unwrap().is_empty()
+            },
+            Duration::from_secs(2),
+        );
+        let trades = pg_cache.load_trades(&instrument.id()).unwrap();
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0], trade_tick);
     }
 }

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -2,7 +2,7 @@
 
 CREATE TYPE ACCOUNT_TYPE AS ENUM ('Cash', 'Margin', 'Betting');
 CREATE TYPE AGGREGATION_SOURCE AS ENUM ('External', 'Internal');
-CREATE TYPE AGGRESSOR_SIDE AS ENUM ('NoAggressor', 'Buyer', 'Seller');
+CREATE TYPE AGGRESSOR_SIDE AS ENUM ('NO_AGGRESSOR','BUYER','SELLER');
 CREATE TYPE ASSET_CLASS AS ENUM ('FX', 'EQUITY', 'COMMODITY', 'DEBT', 'INDEX', 'CRYPTOCURRENCY', 'ALTERNATIVE');
 CREATE TYPE INSTRUMENT_CLASS AS ENUM ('Spot', 'Swap', 'Future', 'FutureSpread', 'Forward', 'Cfg', 'Bond', 'Option', 'OptionSpread', 'Warrant', 'SportsBetting');
 CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volume', 'VolumeImbalance', 'VolumeRuns', 'Value', 'ValueImbalance', 'ValueRuns', 'Millisecond', 'Second', 'Minute', 'Hour', 'Day', 'Week', 'Month');
@@ -154,6 +154,19 @@ CREATE TABLE IF NOT EXISTS "account_event"(
     balances JSONB,
     margins JSONB,
     is_reported BOOLEAN DEFAULT FALSE,
+    ts_event TEXT NOT NULL,
+    ts_init TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "trade" (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    instrument_id TEXT REFERENCES instrument(id) ON DELETE CASCADE,
+    price TEXT NOT NULL,
+    quantity TEXT NOT NULL,
+    aggressor_side AGGRESSOR_SIDE,
+    venue_trade_id TEXT,
     ts_event TEXT NOT NULL,
     ts_init TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# Pull Request

- added new function `load_trades` in `CacheDatabaseAdapter ` trait
- added new variant `AddTrade` in `DatabaseQuery` enum
- implemented `add_trade` and `load_trades` for `PostgresCacheAdapter`
- tested in `test_cache_database_postgres.rs`