### PR TITLE
Implement bar schema with PSQL cache database in Rust

### DIFF
--- a/nautilus_core/adapters/src/databento/decode.rs
+++ b/nautilus_core/adapters/src/databento/decode.rs
@@ -738,7 +738,7 @@ pub fn decode_ohlcv_msg(
         Quantity::from_raw(msg.volume * FIXED_SCALAR as u64, 0)?,
         ts_event,
         ts_init,
-    );
+    )?;
 
     Ok(bar)
 }

--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -114,6 +114,8 @@ pub trait CacheDatabaseAdapter {
 
     fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()>;
 
+    fn load_bars(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>>;
+
     fn index_venue_order_id(
         &mut self,
         client_order_id: ClientOrderId,

--- a/nautilus_core/data/src/aggregation.rs
+++ b/nautilus_core/data/src/aggregation.rs
@@ -199,7 +199,8 @@ impl BarBuilder {
             self.volume,
             ts_event,
             ts_init,
-        );
+        )
+        .unwrap();
 
         self.last_close = self.close;
         self.reset();
@@ -628,7 +629,8 @@ mod tests {
             Quantity::new(1.0, 0).unwrap(),
             UnixNanos::from(1_000_000_000),
             UnixNanos::from(2_000_000_000),
-        );
+        )
+        .unwrap();
 
         builder.set_partial(partial_bar);
         let bar = builder.build_now();
@@ -661,7 +663,8 @@ mod tests {
             Quantity::new(1.0, 0).unwrap(),
             UnixNanos::from(1_000_000_000),
             UnixNanos::from(1_000_000_000),
-        );
+        )
+        .unwrap();
 
         let partial_bar2 = Bar::new(
             bar_type,
@@ -672,7 +675,8 @@ mod tests {
             Quantity::new(2.0, 0).unwrap(),
             UnixNanos::from(3_000_000_000),
             UnixNanos::from(3_000_000_000),
-        );
+        )
+        .unwrap();
 
         builder.set_partial(partial_bar1);
         builder.set_partial(partial_bar2);

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -880,6 +880,10 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
+    fn load_bars(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>> {
+        anyhow::bail!("Loading market data for Redis cache adapter not supported")
+    }
+
     fn index_venue_order_id(
         &mut self,
         client_order_id: ClientOrderId,

--- a/nautilus_core/infrastructure/src/sql/models/enums.rs
+++ b/nautilus_core/infrastructure/src/sql/models/enums.rs
@@ -15,7 +15,10 @@
 
 use std::str::FromStr;
 
-use nautilus_model::enums::{AggressorSide, AssetClass, CurrencyType, TrailingOffsetType};
+use nautilus_model::enums::{
+    AggregationSource, AggressorSide, AssetClass, BarAggregation, CurrencyType, PriceType,
+    TrailingOffsetType,
+};
 use sqlx::{
     database::{HasArguments, HasValueRef},
     encode::IsNull,
@@ -159,6 +162,121 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for AggressorSideModel {
 impl sqlx::Type<sqlx::Postgres> for AggressorSideModel {
     fn type_info() -> sqlx::postgres::PgTypeInfo {
         PgTypeInfo::with_name("aggressor_side")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        *ty == Self::type_info() || <&str as Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+pub struct AggregationSourceModel(pub AggregationSource);
+
+impl sqlx::Encode<'_, sqlx::Postgres> for AggregationSourceModel {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let aggregation_source_str = match self.0 {
+            AggregationSource::Internal => "INTERNAL",
+            AggregationSource::External => "EXTERNAL",
+        };
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(aggregation_source_str, buf)
+    }
+}
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for AggregationSourceModel {
+    fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        let aggregation_source_str: &str = <&str as Decode<sqlx::Postgres>>::decode(value)?;
+        let aggregation_source =
+            AggregationSource::from_str(aggregation_source_str).map_err(|_| {
+                sqlx::Error::Decode(
+                    format!("Invalid aggregation source: {}", aggregation_source_str).into(),
+                )
+            })?;
+        Ok(AggregationSourceModel(aggregation_source))
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for AggregationSourceModel {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        PgTypeInfo::with_name("aggregation_source")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        *ty == Self::type_info() || <&str as Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+pub struct BarAggregationModel(pub BarAggregation);
+
+impl sqlx::Encode<'_, sqlx::Postgres> for BarAggregationModel {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let bar_aggregation_str = match self.0 {
+            BarAggregation::Tick => "TICK",
+            BarAggregation::TickImbalance => "TICK_IMBALANCE",
+            BarAggregation::TickRuns => "TICK_RUNS",
+            BarAggregation::Volume => "VOLUME",
+            BarAggregation::VolumeImbalance => "VOLUME_IMBALANCE",
+            BarAggregation::VolumeRuns => "VOLUME_RUNS",
+            BarAggregation::Value => "VALUE",
+            BarAggregation::ValueImbalance => "VALUE_IMBALANCE",
+            BarAggregation::ValueRuns => "VALUE_RUNS",
+            BarAggregation::Millisecond => "TIME",
+            BarAggregation::Second => "SECOND",
+            BarAggregation::Minute => "MINUTE",
+            BarAggregation::Hour => "HOUR",
+            BarAggregation::Day => "DAY",
+            BarAggregation::Week => "WEEK",
+            BarAggregation::Month => "MONTH",
+        };
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(bar_aggregation_str, buf)
+    }
+}
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for BarAggregationModel {
+    fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        let bar_aggregation_str: &str = <&str as Decode<sqlx::Postgres>>::decode(value)?;
+        let bar_aggregation = BarAggregation::from_str(bar_aggregation_str).map_err(|_| {
+            sqlx::Error::Decode(format!("Invalid bar aggregation: {}", bar_aggregation_str).into())
+        })?;
+        Ok(BarAggregationModel(bar_aggregation))
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for BarAggregationModel {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        PgTypeInfo::with_name("bar_aggregation")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        *ty == Self::type_info() || <&str as Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+pub struct PriceTypeModel(pub PriceType);
+
+impl sqlx::Encode<'_, sqlx::Postgres> for PriceTypeModel {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let price_type_str = match self.0 {
+            PriceType::Bid => "BID",
+            PriceType::Ask => "ASK",
+            PriceType::Mid => "MID",
+            PriceType::Last => "LAST",
+        };
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(price_type_str, buf)
+    }
+}
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PriceTypeModel {
+    fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        let price_type_str: &str = <&str as Decode<sqlx::Postgres>>::decode(value)?;
+        let price_type = PriceType::from_str(price_type_str).map_err(|_| {
+            sqlx::Error::Decode(format!("Invalid price type: {}", price_type_str).into())
+        })?;
+        Ok(PriceTypeModel(price_type))
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for PriceTypeModel {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        PgTypeInfo::with_name("price_type")
     }
 
     fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {

--- a/nautilus_core/model/src/data/bar.rs
+++ b/nautilus_core/model/src/data/bar.rs
@@ -299,7 +299,6 @@ pub struct Bar {
 
 impl Bar {
     /// Creates a new [`Bar`] instance.
-    #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         bar_type: BarType,
@@ -310,8 +309,8 @@ impl Bar {
         volume: Quantity,
         ts_event: UnixNanos,
         ts_init: UnixNanos,
-    ) -> Self {
-        Self {
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
             bar_type,
             open,
             high,
@@ -320,7 +319,7 @@ impl Bar {
             volume,
             ts_event,
             ts_init,
-        }
+        })
     }
 
     /// Returns the metadata for the type, for use with serialization formats.

--- a/nautilus_core/model/src/data/stubs.rs
+++ b/nautilus_core/model/src/data/stubs.rs
@@ -325,7 +325,7 @@ pub fn stub_trade_tick_ethusdt_buyer() -> TradeTick {
 #[fixture]
 pub fn stub_bar() -> Bar {
     let instrument_id = InstrumentId {
-        symbol: Symbol::new("AUDUSD").unwrap(),
+        symbol: Symbol::new("AUD/USD").unwrap(),
         venue: Venue::new("SIM").unwrap(),
     };
     let bar_spec = BarSpecification {

--- a/nautilus_core/model/src/python/data/bar.rs
+++ b/nautilus_core/model/src/python/data/bar.rs
@@ -170,7 +170,8 @@ impl Bar {
             volume,
             ts_event.into(),
             ts_init.into(),
-        ))
+        )
+        .unwrap())
     }
 }
 
@@ -187,8 +188,8 @@ impl Bar {
         volume: Quantity,
         ts_event: u64,
         ts_init: u64,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Ok(Self::new(
             bar_type,
             open,
             high,
@@ -198,6 +199,7 @@ impl Bar {
             ts_event.into(),
             ts_init.into(),
         )
+        .unwrap())
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/persistence/src/arrow/bar.rs
+++ b/nautilus_core/persistence/src/arrow/bar.rs
@@ -230,7 +230,8 @@ mod tests {
             Quantity::from(1100),
             1.into(),
             3.into(),
-        );
+        )
+        .unwrap();
         let bar2 = Bar::new(
             bar_type,
             Price::from("100.00"),
@@ -240,7 +241,8 @@ mod tests {
             Quantity::from(1110),
             2.into(),
             4.into(),
-        );
+        )
+        .unwrap();
 
         let data = vec![bar1, bar2];
         let record_batch = Bar::encode_batch(&metadata, &data).unwrap();

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -1,16 +1,16 @@
 ------------------- ENUMS -------------------
 
 CREATE TYPE ACCOUNT_TYPE AS ENUM ('Cash', 'Margin', 'Betting');
-CREATE TYPE AGGREGATION_SOURCE AS ENUM ('External', 'Internal');
+CREATE TYPE AGGREGATION_SOURCE AS ENUM ('EXTERNAL', 'INTERNAL');
 CREATE TYPE AGGRESSOR_SIDE AS ENUM ('NO_AGGRESSOR','BUYER','SELLER');
 CREATE TYPE ASSET_CLASS AS ENUM ('FX', 'EQUITY', 'COMMODITY', 'DEBT', 'INDEX', 'CRYPTOCURRENCY', 'ALTERNATIVE');
 CREATE TYPE INSTRUMENT_CLASS AS ENUM ('Spot', 'Swap', 'Future', 'FutureSpread', 'Forward', 'Cfg', 'Bond', 'Option', 'OptionSpread', 'Warrant', 'SportsBetting');
-CREATE TYPE BAR_AGGREGATION AS ENUM ('Tick', 'TickImbalance', 'TickRuns', 'Volume', 'VolumeImbalance', 'VolumeRuns', 'Value', 'ValueImbalance', 'ValueRuns', 'Millisecond', 'Second', 'Minute', 'Hour', 'Day', 'Week', 'Month');
+CREATE TYPE BAR_AGGREGATION AS ENUM ('TICK', 'TICK_IMBALANCE', 'TICK_RUNS', 'VOLUME', 'VOLUME_IMBALANCE', 'VOLUME_RUNS', 'VALUE', 'VALUE_IMBALANCE', 'VALUE_RUNS', 'MILLISECOND', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH');
 CREATE TYPE BOOK_ACTION AS ENUM ('Add', 'Update', 'Delete','Clear');
 CREATE TYPE ORDER_STATUS AS ENUM ('Initialized', 'Denied', 'Emulated', 'Released', 'Submitted', 'Accepted', 'Rejected', 'Canceled', 'Expired', 'Triggered', 'PendingUpdate', 'PendingCancel', 'PartiallyFilled', 'Filled');
 CREATE TYPE CURRENCY_TYPE AS ENUM('CRYPTO', 'FIAT', 'COMMODITY_BACKED');
 CREATE TYPE TRAILING_OFFSET_TYPE AS ENUM('NO_TRAILING_OFFSET', 'PRICE', 'BASIS_POINTS', 'TICKS', 'PRICE_TIER');
-
+CREATE TYPE PRICE_TYPE AS ENUM('BID','ASK','MID','LAST');
 ------------------- TABLES -------------------
 
 CREATE TABLE IF NOT EXISTS "general" (
@@ -180,6 +180,24 @@ CREATE TABLE IF NOT EXISTS "quote" (
     ask_price TEXT NOT NULL,
     bid_size TEXT NOT NULL,
     ask_size TEXT NOT NULL,
+    ts_event TEXT NOT NULL,
+    ts_init TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "bar" (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    instrument_id TEXT REFERENCES instrument(id) ON DELETE CASCADE,
+    step INTEGER NOT NULL,
+    bar_aggregation BAR_AGGREGATION NOT NULL,
+    price_type PRICE_TYPE NOT NULL,
+    aggregation_source AGGREGATION_SOURCE NOT NULL,
+    open TEXT NOT NULL,
+    high TEXT NOT NULL,
+    low TEXT NOT NULL,
+    close TEXT NOT NULL,
+    volume TEXT NOT NULL,
     ts_event TEXT NOT NULL,
     ts_init TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# Pull Request

- added new function `load_bars` in `CacheDatabaseAdapter ` trait
- added new variant `AddBar` in `DatabaseQuery` enum
- implemented `add_bar` and `load_bars` for `PostgresCacheAdapter`
- new enums in PSQL schema related to bar aggregation and price type
- tested in `test_cache_database_postgres.rs`

