### PR TITLE
Fix unsubscribing from order book deltas

### DIFF
--- a/nautilus_trader/common/component.pxd
+++ b/nautilus_trader/common/component.pxd
@@ -284,6 +284,7 @@ cdef class MessageBus:
     cpdef bint is_subscribed(self, str topic, handler)
     cpdef bint is_pending_request(self, UUID4 request_id)
     cpdef bint is_streaming_type(self, type cls)
+    cpdef int num_subscribers(self, str pattern=*)
 
     cpdef void dispose(self)
     cpdef void register(self, str endpoint, handler)

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -2135,7 +2135,7 @@ cdef class MessageBus:
 
         Returns
         -------
-        bool
+        int
 
         """
         return len(self.subscriptions(pattern))

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -2123,6 +2123,23 @@ cdef class MessageBus:
         """
         return len(self.subscriptions(pattern)) > 0
 
+    cpdef int num_subscribers(self, str pattern = None):
+        """
+        Return the number of subscribers for the give topic `pattern`.
+
+        Parameters
+        ----------
+        pattern : str, optional
+            The topic filter. May include wildcard characters `*` and `?`.
+            If ``None`` then query is for **all** topics.
+
+        Returns
+        -------
+        bool
+
+        """
+        return len(self.subscriptions(pattern))
+
     cpdef bint is_subscribed(self, str topic, handler: Callable[[Any], None]):
         """
         Return if topic and handler is subscribed to the message bus.

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1087,11 +1087,9 @@ cdef class DataEngine(Component):
 
         cdef int num_subscribers = self._msgbus.num_subscribers(pattern=topic)
         cdef bint is_internal_book_subscriber = self._msgbus.is_subscribed(topic=topic, handler=self._update_order_book)
-        self._log.debug(f"Number of subscribers: {num_subscribers}, is internal book subscriber: {is_internal_book_subscriber}")
 
         # Remove the subscription for the internal order book if it is the last subscription
         if num_subscribers == 1 and is_internal_book_subscriber:
-            self._log.debug(f"Unsubscribe from {topic} for internal order book")
             self._msgbus.unsubscribe(
                 topic=topic,
                 handler=self._update_order_book,

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1083,11 +1083,21 @@ cdef class DataEngine(Component):
             self._log.error("Cannot unsubscribe from synthetic instrument `OrderBookDelta` data")
             return
 
-        if not self._msgbus.has_subscribers(
-            f"data.book.deltas"
-            f".{instrument_id.venue}"
-            f".{instrument_id.symbol}",
-        ):
+        cdef str topic = f"data.book.deltas.{instrument_id.venue}.{instrument_id.symbol}"
+
+        cdef int num_subscribers = self._msgbus.num_subscribers(pattern=topic)
+        cdef bint is_internal_book_subscriber = self._msgbus.is_subscribed(topic=topic, handler=self._update_order_book)
+        self._log.debug(f"Number of subscribers: {num_subscribers}, is internal book subscriber: {is_internal_book_subscriber}")
+
+        # Remove the subscription for the internal order book if it is the last subscription
+        if num_subscribers == 1 and is_internal_book_subscriber:
+            self._log.debug(f"Unsubscribe from {topic} for internal order book")
+            self._msgbus.unsubscribe(
+                topic=topic,
+                handler=self._update_order_book,
+            )
+
+        if not self._msgbus.has_subscribers(topic):
             if instrument_id in client.subscribed_order_book_deltas():
                 client.unsubscribe_order_book_deltas(instrument_id)
 

--- a/tests/unit_tests/msgbus/test_bus.py
+++ b/tests/unit_tests/msgbus/test_bus.py
@@ -195,6 +195,19 @@ class TestMessageBus:
         assert self.msgbus.has_subscribers()
         assert self.msgbus.has_subscribers(pattern="system")
 
+    def test_num_subscribers(self):
+        # Arrange, Act
+        self.msgbus.subscribe(topic="*", handler=[].append)
+        self.msgbus.subscribe(topic="system", handler=[].append)
+
+        # Assert
+        assert self.msgbus.num_subscribers() == 2
+        assert self.msgbus.num_subscribers(pattern="system") == 1
+
+    def test_num_subscribers_without_subscribers_returns_zero(self):
+        # Assert
+        assert self.msgbus.num_subscribers() == 0
+
     def test_subscribe_when_handler_already_subscribed_does_not_add_subscription(self):
         # Arrange
         handler = [].append


### PR DESCRIPTION
# Pull Request

The order book subscription is kept alive forever instead of closed on request. The actor is subscribing to the order book deltas, but also the data engine which is maintaining it's own order book. So there are 2 subscribers. The DataEngine._setup_order_book  sets up the subscription, but doesn't unsubscribe from the subscription later.

The message bus exposes the number of subscriptions for a certain topic, and during the unsubscription process, the data engine checks if the internal order book subscription is the last one.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

During development of dYdX adapter. The unsubscribe_order_book_deltas() was not called by the DataEngine.
