### PR TITLE
Improve message handler invoked testing

### DIFF
--- a/nautilus_core/common/src/msgbus/stubs.rs
+++ b/nautilus_core/common/src/msgbus/stubs.rs
@@ -1,0 +1,102 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{
+    any::Any,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use nautilus_core::message::Message;
+use nautilus_model::data::Data;
+use ustr::Ustr;
+
+use crate::{
+    messages::data::DataResponse,
+    msgbus::{MessageHandler, ShareableMessageHandler},
+};
+
+// Stub message handler which logs the data it receives
+pub struct StubMessageHandler {
+    id: Ustr,
+    callback: Arc<dyn Fn(Message) + Send>,
+}
+
+impl MessageHandler for StubMessageHandler {
+    fn id(&self) -> Ustr {
+        self.id
+    }
+
+    fn handle(&self, message: &dyn Any) {
+        (self.callback)(message.downcast_ref::<Message>().unwrap().clone());
+    }
+
+    fn handle_response(&self, _resp: DataResponse) {}
+
+    fn handle_data(&self, _resp: &Data) {}
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub fn get_stub_shareable_handler(id: Ustr) -> ShareableMessageHandler {
+    ShareableMessageHandler(Rc::new(StubMessageHandler {
+        id,
+        callback: Arc::new(|m: Message| {
+            format!("{m:?}");
+        }),
+    }))
+}
+
+// Stub message handler which checks if handle was called
+pub struct CallCheckMessageHandler {
+    id: Ustr,
+    called: Arc<AtomicBool>,
+}
+
+impl CallCheckMessageHandler {
+    pub fn was_called(&self) -> bool {
+        self.called.load(Ordering::SeqCst)
+    }
+}
+
+impl MessageHandler for CallCheckMessageHandler {
+    fn id(&self) -> Ustr {
+        self.id
+    }
+
+    fn handle(&self, _message: &dyn Any) {
+        self.called.store(true, Ordering::SeqCst);
+    }
+
+    fn handle_response(&self, _resp: DataResponse) {}
+
+    fn handle_data(&self, _resp: &Data) {}
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub fn get_call_check_shareable_handler(id: Ustr) -> ShareableMessageHandler {
+    ShareableMessageHandler(Rc::new(CallCheckMessageHandler {
+        id,
+        called: Arc::new(AtomicBool::new(false)),
+    }))
+}

--- a/nautilus_core/common/src/python/handler.rs
+++ b/nautilus_core/common/src/python/handler.rs
@@ -74,4 +74,8 @@ impl MessageHandler for PythonMessageHandler {
             eprintln!("Error calling handle method: {:?}", err);
         }
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }


### PR DESCRIPTION
# Pull Request

The idea was to test if an appropriate message handler was called with generic `&dyn Any` message object, for example in 
 the messagebus `send` method.  To do that custom `CallCheckMessageHandler` was defined which sets the flag to true if the handler is invoked. The most problem I faced was into downcasting to `Any`

- created the `stub` file which will contain these testing message handlers which will be used by other components across codebase
-  modified `MessageHandler` so that it inherits from `Any` trait,  which allows for type casting using `Any`'s methods like `downcast_ref`
- with that change, we better support type casting through `Any` and provide an `as_any` method for easier type casting.