### PR TITLE
Bootstrapping process_order for OrderMatchingEngine in Rust

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -2598,6 +2598,7 @@ version = "0.28.0"
 dependencies = [
  "anyhow",
  "cbindgen",
+ "chrono",
  "log",
  "nautilus-common",
  "nautilus-core",

--- a/nautilus_core/backtest/Cargo.toml
+++ b/nautilus_core/backtest/Cargo.toml
@@ -14,8 +14,9 @@ crate-type = ["rlib", "staticlib"]
 nautilus-common = { path = "../common" }
 nautilus-core = { path = "../core" }
 nautilus-execution = { path = "../execution" }
-nautilus-model = { path = "../model" }
+nautilus-model = { path = "../model" , features = ["stubs"]}
 anyhow = { workspace = true }
+chrono = { workspace = true }
 log = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 ustr = { workspace = true }

--- a/nautilus_core/common/src/msgbus/mod.rs
+++ b/nautilus_core/common/src/msgbus/mod.rs
@@ -484,6 +484,12 @@ pub fn is_matching(topic: &Ustr, pattern: &Ustr) -> bool {
     table[n][m]
 }
 
+impl Default for MessageBus {
+    fn default() -> Self {
+        Self::new(TraderId::from("TRADER-001"), UUID4::new(), None, None)
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -90,7 +90,7 @@ mod serial_tests {
         let crypto_perpetual = crypto_perpetual_ethusdt();
         let currency_pair = currency_pair_ethusdt();
         let equity = equity_aapl();
-        let futures_contract = futures_contract_es();
+        let futures_contract = futures_contract_es(None, None);
         let options_contract = options_contract_appl();
         // Insert all the instruments
         pg_cache

--- a/nautilus_core/model/src/events/order/any.rs
+++ b/nautilus_core/model/src/events/order/any.rs
@@ -16,6 +16,7 @@
 use nautilus_core::nanos::UnixNanos;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ustr::Ustr;
 
 use super::OrderEventType;
 use crate::{
@@ -140,6 +141,28 @@ impl OrderEventAny {
             Self::Updated(event) => event.ts_event,
             Self::PartiallyFilled(event) => event.ts_event,
             Self::Filled(event) => event.ts_event,
+        }
+    }
+
+    pub fn message(&self) -> Option<Ustr> {
+        match self {
+            Self::Initialized(_) => None,
+            Self::Denied(event) => Some(event.reason),
+            Self::Emulated(_) => None,
+            Self::Released(_) => None,
+            Self::Submitted(_) => None,
+            Self::Accepted(_) => None,
+            Self::Rejected(event) => Some(event.reason),
+            Self::Canceled(_) => None,
+            Self::Expired(_) => None,
+            Self::Triggered(_) => None,
+            Self::PendingUpdate(_) => None,
+            Self::PendingCancel(_) => None,
+            Self::ModifyRejected(event) => Some(event.reason),
+            Self::CancelRejected(event) => Some(event.reason),
+            Self::Updated(_) => None,
+            Self::PartiallyFilled(_) => None,
+            Self::Filled(_) => None,
         }
     }
 }

--- a/nautilus_core/model/src/instruments/any.rs
+++ b/nautilus_core/model/src/instruments/any.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use nautilus_core::nanos::UnixNanos;
 use rust_decimal::Decimal;
 
 use super::{
@@ -21,6 +22,7 @@ use super::{
     options_contract::OptionsContract, options_spread::OptionsSpread, Instrument,
 };
 use crate::{
+    enums::InstrumentClass,
     identifiers::InstrumentId,
     types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
 };
@@ -190,6 +192,48 @@ impl InstrumentAny {
             Self::FuturesSpread(inst) => inst.multiplier(),
             Self::OptionsContract(inst) => inst.multiplier(),
             Self::OptionsSpread(inst) => inst.multiplier(),
+        }
+    }
+
+    #[must_use]
+    pub fn instrument_class(&self) -> InstrumentClass {
+        match self {
+            Self::CryptoFuture(inst) => inst.instrument_class(),
+            Self::CryptoPerpetual(inst) => inst.instrument_class(),
+            Self::CurrencyPair(inst) => inst.instrument_class(),
+            Self::Equity(inst) => inst.instrument_class(),
+            Self::FuturesContract(inst) => inst.instrument_class(),
+            Self::FuturesSpread(inst) => inst.instrument_class(),
+            Self::OptionsContract(inst) => inst.instrument_class(),
+            Self::OptionsSpread(inst) => inst.instrument_class(),
+        }
+    }
+
+    #[must_use]
+    pub fn activation_ns(&self) -> Option<UnixNanos> {
+        match self {
+            Self::CryptoFuture(inst) => inst.activation_ns(),
+            Self::CryptoPerpetual(inst) => inst.activation_ns(),
+            Self::CurrencyPair(inst) => inst.activation_ns(),
+            Self::Equity(inst) => inst.activation_ns(),
+            Self::FuturesContract(inst) => inst.activation_ns(),
+            Self::FuturesSpread(inst) => inst.activation_ns(),
+            Self::OptionsContract(inst) => inst.activation_ns(),
+            Self::OptionsSpread(inst) => inst.activation_ns(),
+        }
+    }
+
+    #[must_use]
+    pub fn expiration_ns(&self) -> Option<UnixNanos> {
+        match self {
+            Self::CryptoFuture(inst) => inst.expiration_ns(),
+            Self::CryptoPerpetual(inst) => inst.expiration_ns(),
+            Self::CurrencyPair(inst) => inst.expiration_ns(),
+            Self::Equity(inst) => inst.expiration_ns(),
+            Self::FuturesContract(inst) => inst.expiration_ns(),
+            Self::FuturesSpread(inst) => inst.expiration_ns(),
+            Self::OptionsContract(inst) => inst.expiration_ns(),
+            Self::OptionsSpread(inst) => inst.expiration_ns(),
         }
     }
 

--- a/nautilus_core/model/src/instruments/futures_contract.rs
+++ b/nautilus_core/model/src/instruments/futures_contract.rs
@@ -269,11 +269,11 @@ impl Instrument for FuturesContract {
 mod tests {
     use rstest::rstest;
 
-    use crate::instruments::{futures_contract::FuturesContract, stubs::*};
+    use crate::instruments::stubs::*;
 
     #[rstest]
-    fn test_equality(futures_contract_es: FuturesContract) {
-        let cloned = futures_contract_es;
-        assert_eq!(futures_contract_es, cloned);
+    fn test_equality() {
+        let futures_contract = futures_contract_es(None, None);
+        assert_eq!(futures_contract, futures_contract.clone());
     }
 }

--- a/nautilus_core/model/src/instruments/mod.rs
+++ b/nautilus_core/model/src/instruments/mod.rs
@@ -143,3 +143,10 @@ pub trait Instrument: 'static + Send {
         Quantity::new(value, self.size_precision()).unwrap() // TODO: Handle error properly
     }
 }
+
+pub const EXPIRING_INSTRUMENT_TYPES: [InstrumentClass; 4] = [
+    InstrumentClass::Future,
+    InstrumentClass::FutureSpread,
+    InstrumentClass::Option,
+    InstrumentClass::OptionSpread,
+];

--- a/nautilus_core/model/src/instruments/stubs.rs
+++ b/nautilus_core/model/src/instruments/stubs.rs
@@ -323,18 +323,30 @@ pub fn equity_aapl() -> Equity {
 // FuturesContract
 ////////////////////////////////////////////////////////////////////////////////
 
-#[fixture]
-pub fn futures_contract_es() -> FuturesContract {
-    let activation = Utc.with_ymd_and_hms(2021, 4, 8, 0, 0, 0).unwrap();
-    let expiration = Utc.with_ymd_and_hms(2021, 7, 8, 0, 0, 0).unwrap();
+pub fn futures_contract_es(
+    activation: Option<UnixNanos>,
+    expiration: Option<UnixNanos>,
+) -> FuturesContract {
+    let activation = activation.unwrap_or(UnixNanos::from(
+        Utc.with_ymd_and_hms(2021, 4, 8, 0, 0, 0)
+            .unwrap()
+            .timestamp_nanos_opt()
+            .unwrap() as u64,
+    ));
+    let expiration = expiration.unwrap_or(UnixNanos::from(
+        Utc.with_ymd_and_hms(2021, 7, 8, 0, 0, 0)
+            .unwrap()
+            .timestamp_nanos_opt()
+            .unwrap() as u64,
+    ));
     FuturesContract::new(
         InstrumentId::from("ESZ1.GLBX"),
         Symbol::from("ESZ1"),
         AssetClass::Index,
         Some(Ustr::from("XCME")),
         Ustr::from("ES"),
-        UnixNanos::from(activation.timestamp_nanos_opt().unwrap() as u64),
-        UnixNanos::from(expiration.timestamp_nanos_opt().unwrap() as u64),
+        activation,
+        expiration,
         Currency::USD(),
         2,
         Price::from("0.01"),


### PR DESCRIPTION
# Pull Request

- changed even type in `generate_order_*` functions to `OrderEventAny`
- defined constant `EXPIRING_INSTRUMENT_TYPES`
- bootstrapping `process_order` trading command function with order exists check, activation and expiration check
- created test suite with stub `OrderMatchingEngine` in Rust with tests `test_order_matching_engine_instrument_already_expired` and `test_order_matching_engine_instrument_not_active`
- added generic message handler `MessageSavingHandler` which saves messages in list 