### PR TITLE
Make instrument_id foreign key in order_events table

### DIFF
--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -232,6 +232,15 @@ mod serial_tests {
             Some(client_order_id_2),
             None,
         );
+        // add foreign key dependencies: instrument and currencies
+        pg_cache
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
+        pg_cache.add_currency(&instrument.quote_currency()).unwrap();
+        pg_cache
+            .add_instrument(&InstrumentAny::CurrencyPair(instrument))
+            .unwrap();
+        // add orders
         pg_cache.add_order(&market_order).unwrap();
         pg_cache.add_order(&limit_order).unwrap();
         wait_until(
@@ -261,8 +270,12 @@ mod serial_tests {
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
         let account = account_id();
         let mut pg_cache = get_pg_cache_database().await.unwrap();
-        // Add the target currency of order
+        // add foreign key dependencies: instrument and currencies
+        pg_cache
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
         pg_cache.add_currency(&instrument.quote_currency()).unwrap();
+        pg_cache.add_instrument(&instrument).unwrap();
         // 1. Create the order
         let mut market_order = TestOrderStubs::market_order(
             instrument.id(),

--- a/nautilus_core/infrastructure/tests/test_cache_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_postgres.rs
@@ -84,6 +84,14 @@ mod serial_tests {
             Some(ClientOrderId::new("O-19700101-0000-001-001-1").unwrap()),
             None,
         );
+        // add foreign key dependencies: instrument and currencies
+        database
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
+        database.add_currency(&instrument.quote_currency()).unwrap();
+        database
+            .add_instrument(&InstrumentAny::CurrencyPair(instrument))
+            .unwrap();
         // insert into database and wait
         database.add_order(&market_order).unwrap();
         wait_until(

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS "order_event" (
     kind TEXT NOT NULL,
     trader_id TEXT REFERENCES trader(id) ON DELETE CASCADE,
     strategy_id TEXT NOT NULL,
-    instrument_id TEXT NOT NULL,
+    instrument_id TEXT REFERENCES instrument(id) ON DELETE CASCADE,
     order_id TEXT DEFAULT NULL,
     trade_id TEXT,
     currency TEXT REFERENCES currency(id),

--- a/tests/integration_tests/infrastructure/test_cache_database_postgres.py
+++ b/tests/integration_tests/infrastructure/test_cache_database_postgres.py
@@ -355,6 +355,10 @@ class TestCachePostgresAdapter:
             OrderSide.BUY,
             Quantity.from_int(100_000),
         )
+        # Add foreign key dependencies: instrument and currencies
+        self.database.add_currency(_AUDUSD_SIM.base_currency)
+        self.database.add_currency(_AUDUSD_SIM.quote_currency)
+        self.database.add_instrument(_AUDUSD_SIM)
 
         # Act
         self.database.add_order(order)
@@ -376,6 +380,10 @@ class TestCachePostgresAdapter:
             OrderSide.BUY,
             Quantity.from_int(100_000),
         )
+        # Add foreign key dependencies: instrument and currencies
+        self.database.add_currency(_AUDUSD_SIM.base_currency)
+        self.database.add_currency(_AUDUSD_SIM.quote_currency)
+        self.database.add_instrument(_AUDUSD_SIM)
 
         self.database.add_order(order)
 
@@ -412,6 +420,10 @@ class TestCachePostgresAdapter:
             Quantity.from_int(100_000),
             Price.from_str("1.00000"),
         )
+        # Add foreign key dependencies: instrument and currencies
+        self.database.add_currency(_AUDUSD_SIM.base_currency)
+        self.database.add_currency(_AUDUSD_SIM.quote_currency)
+        self.database.add_instrument(_AUDUSD_SIM)
 
         self.database.add_order(order)
         # Allow MPSC thread to insert


### PR DESCRIPTION
# Pull Request

- make column  `instrument_id` in `order_events` table reference to `instrument` table
- fix psql cache tests as instrument now needs to be inserted before order events