### PR TITLE
Implement load_index_order_client in Postgres cache database 

### DIFF
--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -98,7 +98,7 @@ pub trait CacheDatabaseAdapter {
 
     fn add_account(&mut self, account: &AccountAny) -> anyhow::Result<()>;
 
-    fn add_order(&mut self, order: &OrderAny) -> anyhow::Result<()>;
+    fn add_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()>;
 
     fn add_position(&mut self, position: &Position) -> anyhow::Result<()>;
 

--- a/nautilus_core/common/src/cache/mod.rs
+++ b/nautilus_core/common/src/cache/mod.rs
@@ -1390,7 +1390,7 @@ impl Cache {
         }
 
         if let Some(database) = &mut self.database {
-            database.add_order(&order)?;
+            database.add_order(&order, client_id)?;
             // TODO: Implement
             // if self.config.snapshot_orders {
             //     database.snapshot_order_state(order)?;

--- a/nautilus_core/infrastructure/src/python/sql/cache_database.rs
+++ b/nautilus_core/infrastructure/src/python/sql/cache_database.rs
@@ -20,7 +20,7 @@ use nautilus_common::{cache::database::CacheDatabaseAdapter, runtime::get_runtim
 use nautilus_core::python::to_pyruntime_err;
 use nautilus_model::{
     data::{bar::Bar, quote::QuoteTick, trade::TradeTick},
-    identifiers::{AccountId, ClientOrderId, InstrumentId},
+    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId},
     python::{
         account::{convert_account_any_to_pyobject, convert_pyobject_to_account_any},
         instruments::{instrument_any_to_pyobject, pyobject_to_instrument_any},
@@ -127,9 +127,15 @@ impl PostgresCacheDatabase {
     }
 
     #[pyo3(name = "add_order")]
-    fn py_add_order(mut slf: PyRefMut<'_, Self>, order: PyObject, py: Python<'_>) -> PyResult<()> {
+    fn py_add_order(
+        mut slf: PyRefMut<'_, Self>,
+        order: PyObject,
+        client_id: Option<ClientId>,
+        py: Python<'_>,
+    ) -> PyResult<()> {
         let order_any = convert_pyobject_to_order_any(py, order)?;
-        slf.add_order(&order_any).map_err(to_pyruntime_err)
+        slf.add_order(&order_any, client_id)
+            .map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "update_order")]

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -847,7 +847,7 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         todo!()
     }
 
-    fn add_order(&mut self, order: &OrderAny) -> anyhow::Result<()> {
+    fn add_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
         todo!()
     }
 

--- a/nautilus_core/infrastructure/src/sql/models/general.rs
+++ b/nautilus_core/infrastructure/src/sql/models/general.rs
@@ -13,8 +13,34 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use nautilus_model::identifiers::{ClientId, ClientOrderId};
+use sqlx::{postgres::PgRow, Error, FromRow, Row};
+
 #[derive(Debug, sqlx::FromRow)]
 pub struct GeneralRow {
     pub id: String,
     pub value: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct OrderEventOrderClientIdCombination {
+    pub order_id: ClientOrderId,
+    pub client_id: ClientId,
+}
+
+impl<'r> FromRow<'r, PgRow> for OrderEventOrderClientIdCombination {
+    fn from_row(row: &'r PgRow) -> Result<Self, Error> {
+        let order_id = row
+            .try_get::<&str, _>("order_id")
+            .map(ClientOrderId::from)
+            .unwrap();
+        let client_id = row
+            .try_get::<&str, _>("client_id")
+            .map(ClientId::from)
+            .unwrap();
+        Ok(OrderEventOrderClientIdCombination {
+            order_id,
+            client_id,
+        })
+    }
 }

--- a/nautilus_core/infrastructure/tests/test_cache_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_postgres.rs
@@ -93,7 +93,7 @@ mod serial_tests {
             .add_instrument(&InstrumentAny::CurrencyPair(instrument))
             .unwrap();
         // insert into database and wait
-        database.add_order(&market_order).unwrap();
+        database.add_order(&market_order, None).unwrap();
         wait_until(
             || {
                 let order = database

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -27,6 +27,10 @@ CREATE TABLE IF NOT EXISTS "account" (
   id TEXT PRIMARY KEY NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS "client" (
+    id TEXT PRIMARY KEY NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS "strategy" (
   id TEXT PRIMARY KEY NOT NULL,
   order_id_tag TEXT,
@@ -105,6 +109,7 @@ CREATE TABLE IF NOT EXISTS "order_event" (
     strategy_id TEXT NOT NULL,
     instrument_id TEXT REFERENCES instrument(id) ON DELETE CASCADE,
     order_id TEXT DEFAULT NULL,
+    client_id TEXT REFERENCES client(id) ON DELETE CASCADE,
     trade_id TEXT,
     currency TEXT REFERENCES currency(id),
     order_type TEXT,


### PR DESCRIPTION
# Pull Request

- changed signature of `add_order` in trait `CacheDatabaseAdapter` to accept optional `client_id`
- implemented `load_index_order_client` function of cache database
- added `OrderEventOrderClientIdCombination` struct to help with parsing distinct order client ids query
- created new PSQL table `client` and put and foreign key column `client_id` in table `order_event`