### PR TITLE
Check short selling Equity without MarginAccount in OrderMatchingEngine

### DIFF
--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -29,7 +29,7 @@ use nautilus_model::{
         bar::{Bar, BarType},
         delta::OrderBookDelta,
     },
-    enums::{AccountType, BookType, LiquiditySide, MarketStatus, OmsType},
+    enums::{AccountType, BookType, LiquiditySide, MarketStatus, OmsType, OrderSide, OrderType},
     events::order::{
         OrderAccepted, OrderCancelRejected, OrderCanceled, OrderEventAny, OrderExpired,
         OrderFilled, OrderModifyRejected, OrderRejected, OrderTriggered, OrderUpdated,
@@ -45,6 +45,7 @@ use nautilus_model::{
         trailing_stop_limit::TrailingStopLimitOrder,
         trailing_stop_market::TrailingStopMarketOrder,
     },
+    position::Position,
     types::{currency::Currency, money::Money, price::Price, quantity::Quantity},
 };
 use ustr::Ustr;
@@ -311,6 +312,89 @@ impl OrderMatchingEngine {
                 return;
             }
         }
+
+        // Get position if exists
+        let position: Option<&Position> = self
+            .cache
+            .position_for_order(&order.client_order_id())
+            .or_else(|| {
+                if self.oms_type == OmsType::Netting {
+                    let position_id = PositionId::new(
+                        format!("{}-{}", order.instrument_id(), order.strategy_id()).as_str(),
+                    )
+                    .unwrap();
+                    self.cache.position(&position_id)
+                } else {
+                    None
+                }
+            });
+
+        // Check not shorting an equity without a MARGIN account
+        if order.order_side() == OrderSide::Sell
+            && self.account_type != AccountType::Margin
+            && matches!(self.instrument, InstrumentAny::Equity(_))
+            && (position.is_none()
+                || !order.would_reduce_only(position.unwrap().side, position.unwrap().quantity))
+        {
+            let position_string = position.map_or("None".to_string(), |pos| pos.id.to_string());
+            self.generate_order_rejected(
+                order,
+                format!(
+                    "Short selling not permitted on a CASH account with position {} and order {}",
+                    position_string, order,
+                )
+                .into(),
+            );
+            return;
+        }
+
+        match order.order_type() {
+            OrderType::Market => self.process_market_order(order),
+            OrderType::Limit => self.process_limit_order(order),
+            OrderType::MarketToLimit => self.process_market_to_limit_order(order),
+            OrderType::StopMarket => self.process_stop_market_order(order),
+            OrderType::StopLimit => self.process_stop_limit_order(order),
+            OrderType::MarketIfTouched => self.process_market_if_touched_order(order),
+            OrderType::LimitIfTouched => self.process_limit_if_touched_order(order),
+            OrderType::TrailingStopMarket => self.process_trailing_stop_market_order(order),
+            OrderType::TrailingStopLimit => self.process_trailing_stop_limit_order(order),
+        }
+    }
+
+    fn process_market_order(&mut self, order: &OrderAny) {
+        todo!("process_market_order")
+    }
+
+    fn process_limit_order(&mut self, order: &OrderAny) {
+        todo!("process_limit_order")
+    }
+
+    fn process_market_to_limit_order(&mut self, order: &OrderAny) {
+        todo!("process_market_to_limit_order")
+    }
+
+    fn process_stop_market_order(&mut self, order: &OrderAny) {
+        todo!("process_stop_market_order")
+    }
+
+    fn process_stop_limit_order(&mut self, order: &OrderAny) {
+        todo!("process_stop_limit_order")
+    }
+
+    fn process_market_if_touched_order(&mut self, order: &OrderAny) {
+        todo!("process_market_if_touched_order")
+    }
+
+    fn process_limit_if_touched_order(&mut self, order: &OrderAny) {
+        todo!("process_limit_if_touched_order")
+    }
+
+    fn process_trailing_stop_market_order(&mut self, order: &OrderAny) {
+        todo!("process_trailing_stop_market_order")
+    }
+
+    fn process_trailing_stop_limit_order(&mut self, order: &OrderAny) {
+        todo!("process_trailing_stop_limit_order")
     }
 
     // -- ORDER PROCESSING ----------------------------------------------------
@@ -684,7 +768,11 @@ mod tests {
         enums::{AccountType, BookType, OmsType, OrderSide},
         events::order::{OrderEventAny, OrderEventType},
         identifiers::AccountId,
-        instruments::{any::InstrumentAny, stubs::futures_contract_es},
+        instruments::{
+            any::InstrumentAny,
+            equity::Equity,
+            stubs::{futures_contract_es, *},
+        },
         orders::stubs::TestOrderStubs,
         types::{price::Price, quantity::Quantity},
     };
@@ -740,6 +828,7 @@ mod tests {
     fn get_order_matching_engine(
         instrument: InstrumentAny,
         msgbus: Rc<MessageBus>,
+        account_type: Option<AccountType>,
     ) -> OrderMatchingEngine {
         let cache = Rc::new(Cache::default());
         let config = OrderMatchingEngineConfig::default();
@@ -748,7 +837,7 @@ mod tests {
             1,
             BookType::L1_MBP,
             OmsType::Netting,
-            AccountType::Cash,
+            account_type.unwrap_or(AccountType::Cash),
             &ATOMIC_TIME,
             msgbus,
             cache,
@@ -785,7 +874,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus));
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
         let order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Buy,
@@ -835,7 +924,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus));
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
         let order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Buy,
@@ -871,7 +960,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus));
+        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
         let order = TestOrderStubs::market_order(
             instrument_es.id(),
             OrderSide::Buy,
@@ -907,7 +996,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus));
+        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
         let limit_order = TestOrderStubs::limit_order(
             instrument_es.id(),
             OrderSide::Sell,
@@ -945,7 +1034,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus));
+        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
         let stop_order = TestOrderStubs::stop_market_order(
             instrument_es.id(),
             OrderSide::Sell,
@@ -966,6 +1055,48 @@ mod tests {
         assert_eq!(
             first_message.message().unwrap(),
             Ustr::from("Invalid order trigger price precision for order O-19700101-000000-001-001-1, was 5 when ESZ1.GLBX price precision is 2")
+        );
+    }
+
+    #[rstest]
+    fn test_order_matching_engine_error_shorting_equity_without_margin_account(
+        mut msgbus: MessageBus,
+        order_event_handler: ShareableMessageHandler,
+        account_id: AccountId,
+        time: AtomicTime,
+        equity_aapl: Equity,
+    ) {
+        let instrument = InstrumentAny::Equity(equity_aapl);
+        // Register saving message handler to exec engine endpoint
+        msgbus.register(
+            msgbus.switchboard.exec_engine_process.as_str(),
+            order_event_handler.clone(),
+        );
+
+        // Create engine and process order
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
+        let order = TestOrderStubs::market_order(
+            instrument.id(),
+            OrderSide::Sell,
+            Quantity::from("1"),
+            None,
+            None,
+        );
+
+        engine.process_order(&order, account_id);
+
+        // Get messages and test
+        let saved_messages = get_order_event_handler_messages(order_event_handler);
+        assert_eq!(saved_messages.len(), 1);
+        let first_message = saved_messages.first().unwrap();
+        assert_eq!(first_message.event_type(), OrderEventType::Rejected);
+        assert_eq!(
+            first_message.message().unwrap(),
+            Ustr::from(
+                "Short selling not permitted on a CASH account with position None and order \
+                MarketOrder(SELL 1 AAPL.XNAS @ MARKET GTC, status=INITIALIZED, client_order_id=O-19700101-000000-001-001-1, \
+                 venue_order_id=None, position_id=None, exec_algorithm_id=None, \
+                 exec_spawn_id=None, tags=None)")
         );
     }
 }

--- a/nautilus_core/model/src/orders/any.rs
+++ b/nautilus_core/model/src/orders/any.rs
@@ -31,7 +31,10 @@ use super::{
     trailing_stop_market::TrailingStopMarketOrder,
 };
 use crate::{
-    enums::{LiquiditySide, OrderSide, OrderSideSpecified, OrderStatus, OrderType, TriggerType},
+    enums::{
+        LiquiditySide, OrderSide, OrderSideSpecified, OrderStatus, OrderType, PositionSide,
+        TriggerType,
+    },
     events::order::OrderEventAny,
     identifiers::{
         AccountId, ClientOrderId, ExecAlgorithmId, InstrumentId, PositionId, StrategyId, TraderId,
@@ -480,6 +483,21 @@ impl OrderAny {
             Self::StopMarket(order) => Some(order.trigger_price),
             Self::TrailingStopLimit(order) => Some(order.trigger_price),
             Self::TrailingStopMarket(order) => Some(order.trigger_price),
+        }
+    }
+
+    #[must_use]
+    pub fn would_reduce_only(&self, side: PositionSide, position_qty: Quantity) -> bool {
+        match self {
+            Self::Limit(order) => order.would_reduce_only(side, position_qty),
+            Self::Market(order) => order.would_reduce_only(side, position_qty),
+            Self::MarketToLimit(order) => order.would_reduce_only(side, position_qty),
+            Self::LimitIfTouched(order) => order.would_reduce_only(side, position_qty),
+            Self::MarketIfTouched(order) => order.would_reduce_only(side, position_qty),
+            Self::StopLimit(order) => order.would_reduce_only(side, position_qty),
+            Self::StopMarket(order) => order.would_reduce_only(side, position_qty),
+            Self::TrailingStopLimit(order) => order.would_reduce_only(side, position_qty),
+            Self::TrailingStopMarket(order) => order.would_reduce_only(side, position_qty),
         }
     }
 }


### PR DESCRIPTION
# Pull Request

- added position initialization if it exists in `process_order`
- added a check for not shorting an equity without a MARGIN account and generating corresponding `OrderRejected` event
- test `test_order_matching_engine_error_shorting_equity_without_margin_account`
- bootstrapped target order processing functions