### PR TITLE
Fix creation of instrumend_id folder when writing PyO3 bars in catalog

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -334,7 +334,7 @@ class ParquetDataCatalog(BaseDataCatalog):
                 name = type(obj).__name__
             if isinstance(obj, Instrument):
                 return name, obj.id.value
-            elif isinstance(obj, Bar):
+            elif hasattr(obj, "bar_type"):
                 return name, str(obj.bar_type)
             elif hasattr(obj, "instrument_id"):
                 return name, obj.instrument_id.value


### PR DESCRIPTION
# Pull Request

Fixed creation of instrumend_id folder when writing PyO3 bars in catalog.

Fixed by checking an object has a bar_type instead of checking it's a Bar, the new check emcompasses both types of bars (cython and pyo3).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Can be checked using the code in the linked issue:
https://github.com/nautechsystems/nautilus_trader/issues/1811
