### PR TITLE
Fix handling include_types option in StreamingFeatherWriter

### DIFF
--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -209,6 +209,11 @@ class StreamingFeatherWriter:
         PyCondition.not_none(obj, "obj")
 
         cls = obj.__class__
+
+        # Check if an include types filter has been specified
+        if self.include_types is not None and cls not in self.include_types:
+            return
+
         if isinstance(obj, CustomData):
             cls = obj.data_type.type
         elif isinstance(obj, Instrument):

--- a/tests/integration_tests/adapters/betfair/test_kit.py
+++ b/tests/integration_tests/adapters/betfair/test_kit.py
@@ -206,11 +206,13 @@ class BetfairTestStubs:
         catalog_path: str,
         catalog_fs_protocol: str = "memory",
         flush_interval_ms: int | None = None,
+        include_types: list[type] | None = None,
     ) -> StreamingConfig:
         return StreamingConfig(
             catalog_path=catalog_path,
             fs_protocol=catalog_fs_protocol,
             flush_interval_ms=flush_interval_ms,
+            include_types=include_types,
         )
 
     @staticmethod

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -139,6 +139,58 @@ class TestPersistenceStreaming:
         result = Counter([r.__class__.__name__ for r in result])  # type: ignore
         assert result["NewsEventData"] == 86985  # type: ignore
 
+    def test_feather_writer_include_types(
+        self,
+        catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        self.catalog = catalog_betfair
+        TestPersistenceStubs.setup_news_event_persistence()
+
+        # Load news events into catalog
+        news_events = TestPersistenceStubs.news_events()
+        self.catalog.write_data(news_events)
+
+        data_config = BacktestDataConfig(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+            data_cls=NewsEventData.fully_qualified_name(),
+            client_id="NewsClient",
+        )
+
+        # Add some arbitrary instrument data to appease BacktestEngine
+        instrument_data_config = BacktestDataConfig(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+            data_cls=InstrumentStatus.fully_qualified_name(),
+        )
+
+        streaming = BetfairTestStubs.streaming_config(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+            include_types=[NewsEventData],
+        )
+
+        run_config = BacktestRunConfig(
+            engine=BacktestEngineConfig(streaming=streaming),
+            data=[data_config, instrument_data_config],
+            venues=[BetfairTestStubs.betfair_venue_config(book_type="L1_MBP")],
+        )
+
+        # Act
+        node = BacktestNode(configs=[run_config])
+        r = node.run()
+
+        # Assert
+        result = self.catalog.read_backtest(
+            instance_id=r[0].instance_id,
+            raise_on_failed_deserialize=True,
+        )
+
+        result = Counter([r.__class__.__name__ for r in result])  # type: ignore
+        assert result["NewsEventData"] == 86985  # type: ignore
+        assert len(result) == 1
+
     def test_feather_writer_signal_data(
         self,
         catalog_betfair: ParquetDataCatalog,


### PR DESCRIPTION
# Pull Request

As described in this issue below errors could happen in a backtest with the high-level API when using StreamingFeatherWriter with only one custom data type. 
https://github.com/nautechsystems/nautilus_trader/issues/1804

This was because the writer was still trying to write every types at run time, because a check now added was missing.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested on my own code and added a new test.
