### PR TITLE
Add conversion function of streamed data to backtest data

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -44,6 +44,7 @@ from nautilus_trader.core.inspect import is_nautilus_class
 from nautilus_trader.core.message import Event
 from nautilus_trader.core.nautilus_pyo3 import DataBackendSession
 from nautilus_trader.core.nautilus_pyo3 import NautilusDataType
+from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model import NautilusRustDataType
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import CustomData
@@ -749,3 +750,20 @@ class ParquetDataCatalog(BaseDataCatalog):
                 return reader.read_all()
         except (pa.ArrowInvalid, OSError):
             return None
+
+    def convert_stream_to_data(
+        self,
+        instance_id: UUID4,
+        data_cls: type,
+        other_catalog: ParquetDataCatalog | None = None,
+    ) -> None:
+        table_name = class_to_filename(data_cls)
+        feather_file = Path(self.path) / "backtest" / instance_id / f"{table_name}.feather"
+
+        feather_table = self._read_feather_file(feather_file)
+        custom_data_list = self._handle_table_nautilus(feather_table, data_cls)
+
+        if other_catalog is not None:
+            other_catalog.write_data(custom_data_list)
+        else:
+            self.write_data(custom_data_list)

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -140,8 +140,8 @@ class TestPersistenceStreaming:
         assert result["NewsEventData"] == 86985  # type: ignore
 
     def test_feather_writer_include_types(
-        self,
-        catalog_betfair: ParquetDataCatalog,
+            self,
+            catalog_betfair: ParquetDataCatalog,
     ) -> None:
         # Arrange
         self.catalog = catalog_betfair
@@ -190,6 +190,62 @@ class TestPersistenceStreaming:
         result = Counter([r.__class__.__name__ for r in result])  # type: ignore
         assert result["NewsEventData"] == 86985  # type: ignore
         assert len(result) == 1
+
+    def test_feather_writer_stream_to_data(
+            self,
+            catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        self.catalog = catalog_betfair
+        TestPersistenceStubs.setup_news_event_persistence()
+
+        # Load news events into catalog
+        news_events = TestPersistenceStubs.news_events()
+        self.catalog.write_data(news_events)
+
+        data_config = BacktestDataConfig(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+            data_cls=NewsEventData.fully_qualified_name(),
+            client_id="NewsClient",
+        )
+
+        # Add some arbitrary instrument data to appease BacktestEngine
+        instrument_data_config = BacktestDataConfig(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+            data_cls=InstrumentStatus.fully_qualified_name(),
+        )
+
+        streaming = BetfairTestStubs.streaming_config(
+            catalog_path=self.catalog.path,
+            catalog_fs_protocol="file",
+        )
+
+        run_config = BacktestRunConfig(
+            engine=BacktestEngineConfig(streaming=streaming),
+            data=[data_config, instrument_data_config],
+            venues=[BetfairTestStubs.betfair_venue_config(book_type="L1_MBP")],
+        )
+
+        node = BacktestNode(configs=[run_config])
+        r = node.run()
+
+        # Act
+        # NewsEventData is overridden here with data from the stream, but it should be the same data
+        self.catalog.convert_stream_to_data(r[0].instance_id, NewsEventData)
+
+        node2 = BacktestNode(configs=[run_config])
+        r2 = node2.run()
+
+        # Assert
+        result = self.catalog.read_backtest(
+            instance_id=r2[0].instance_id,
+            raise_on_failed_deserialize=True,
+        )
+
+        result = Counter([r.__class__.__name__ for r in result])  # type: ignore
+        assert result["NewsEventData"] == 86985  # type: ignore
 
     def test_feather_writer_signal_data(
         self,

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -140,8 +140,8 @@ class TestPersistenceStreaming:
         assert result["NewsEventData"] == 86985  # type: ignore
 
     def test_feather_writer_include_types(
-            self,
-            catalog_betfair: ParquetDataCatalog,
+        self,
+        catalog_betfair: ParquetDataCatalog,
     ) -> None:
         # Arrange
         self.catalog = catalog_betfair
@@ -192,8 +192,8 @@ class TestPersistenceStreaming:
         assert len(result) == 1
 
     def test_feather_writer_stream_to_data(
-            self,
-            catalog_betfair: ParquetDataCatalog,
+        self,
+        catalog_betfair: ParquetDataCatalog,
     ) -> None:
         # Arrange
         self.catalog = catalog_betfair


### PR DESCRIPTION
# Pull Request

Added the function convert_stream_to_data in ParquetDataCatalog that allows to convert some streamed data to backtest data. This is useful when custom data is produced by an actor for example so it can be reused in other backtests.

Related to this issue https://github.com/nautechsystems/nautilus_trader/issues/1796

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested on my own code as well as added a new test
