### PR TITLE
Add optional timeout for HTTP requests in Rust

### DIFF
--- a/nautilus_core/network/src/python/http.rs
+++ b/nautilus_core/network/src/python/http.rs
@@ -112,6 +112,7 @@ impl HttpClient {
         headers: Option<HashMap<String, String>>,
         body: Option<&'py PyBytes>,
         keys: Option<Vec<String>>,
+        timeout_sec: Option<u64>,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let headers = headers.unwrap_or_default();
@@ -128,7 +129,10 @@ impl HttpClient {
                     key.await;
                 })
                 .await;
-            match client.send_request(method, url, headers, body_vec).await {
+            match client
+                .send_request(method, url, headers, body_vec, timeout_sec)
+                .await
+            {
                 Ok(res) => Ok(res),
                 Err(e) => Err(PyErr::new::<PyException, _>(format!(
                     "Error handling response: {e}"


### PR DESCRIPTION
# Pull Request

Set an optional timeout for HTTP requests instead of using no timeout. 
When an HTTP server does not respond, a live execution cannot be stopped by pressing CTRL-C. With a timeout, the request times out, and the live execution exits as expected. This also gives the possibility to retry requests from the adapter side.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

By calling HTTP endpoints of dYdX. The testnet is very slow and sometimes never responds.
