### PR TITLE
Add reduce only checks in OrderMatchingEngine

### DIFF
--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -348,6 +348,29 @@ impl OrderMatchingEngine {
             return;
         }
 
+        // Check reduce-only instruction
+        if self.config.use_reduce_only
+            && order.is_reduce_only()
+            && !order.is_closed()
+            && position.map_or(true, |pos| {
+                pos.is_closed()
+                    || (order.is_buy() && pos.is_long())
+                    || (order.is_sell() && pos.is_short())
+            })
+        {
+            self.generate_order_rejected(
+                order,
+                format!(
+                    "Reduce-only order {} ({}-{}) would have increased position",
+                    order.client_order_id(),
+                    order.order_type().to_string().to_uppercase(),
+                    order.order_side().to_string().to_uppercase()
+                )
+                .into(),
+            );
+            return;
+        }
+
         match order.order_type() {
             OrderType::Market => self.process_market_order(order),
             OrderType::Limit => self.process_limit_order(order),
@@ -829,9 +852,10 @@ mod tests {
         instrument: InstrumentAny,
         msgbus: Rc<MessageBus>,
         account_type: Option<AccountType>,
+        config: Option<OrderMatchingEngineConfig>,
     ) -> OrderMatchingEngine {
         let cache = Rc::new(Cache::default());
-        let config = OrderMatchingEngineConfig::default();
+        let config = config.unwrap_or_default();
         OrderMatchingEngine::new(
             instrument,
             1,
@@ -874,7 +898,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None, None);
         let order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Buy,
@@ -924,7 +948,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None, None);
         let order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Buy,
@@ -960,7 +984,8 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
+        let mut engine =
+            get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None, None);
         let order = TestOrderStubs::market_order(
             instrument_es.id(),
             OrderSide::Buy,
@@ -996,7 +1021,8 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
+        let mut engine =
+            get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None, None);
         let limit_order = TestOrderStubs::limit_order(
             instrument_es.id(),
             OrderSide::Sell,
@@ -1034,7 +1060,8 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None);
+        let mut engine =
+            get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None, None);
         let stop_order = TestOrderStubs::stop_market_order(
             instrument_es.id(),
             OrderSide::Sell,
@@ -1074,7 +1101,7 @@ mod tests {
         );
 
         // Create engine and process order
-        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None);
+        let mut engine = get_order_matching_engine(instrument.clone(), Rc::new(msgbus), None, None);
         let order = TestOrderStubs::market_order(
             instrument.id(),
             OrderSide::Sell,
@@ -1097,6 +1124,53 @@ mod tests {
                 MarketOrder(SELL 1 AAPL.XNAS @ MARKET GTC, status=INITIALIZED, client_order_id=O-19700101-000000-001-001-1, \
                  venue_order_id=None, position_id=None, exec_algorithm_id=None, \
                  exec_spawn_id=None, tags=None)")
+        );
+    }
+
+    #[rstest]
+    fn test_order_matching_engine_reduce_only_error(
+        mut msgbus: MessageBus,
+        order_event_handler: ShareableMessageHandler,
+        account_id: AccountId,
+        time: AtomicTime,
+        instrument_es: InstrumentAny,
+    ) {
+        // Register saving message handler to exec engine endpoint
+        msgbus.register(
+            msgbus.switchboard.exec_engine_process.as_str(),
+            order_event_handler.clone(),
+        );
+
+        // Create engine (with reduce_only option) and process order
+        let config = OrderMatchingEngineConfig {
+            use_reduce_only: true,
+            bar_execution: false,
+            reject_stop_orders: false,
+            support_gtd_orders: false,
+            support_contingent_orders: false,
+            use_position_ids: false,
+            use_random_ids: false,
+        };
+        let mut engine =
+            get_order_matching_engine(instrument_es.clone(), Rc::new(msgbus), None, Some(config));
+        let market_order = TestOrderStubs::market_order_reduce(
+            instrument_es.id(),
+            OrderSide::Buy,
+            Quantity::from("1"),
+            None,
+            None,
+        );
+
+        engine.process_order(&market_order, account_id);
+
+        // Get messages and test
+        let saved_messages = get_order_event_handler_messages(order_event_handler);
+        assert_eq!(saved_messages.len(), 1);
+        let first_message = saved_messages.first().unwrap();
+        assert_eq!(first_message.event_type(), OrderEventType::Rejected);
+        assert_eq!(
+            first_message.message().unwrap(),
+            Ustr::from("Reduce-only order O-19700101-000000-001-001-1 (MARKET-BUY) would have increased position")
         );
     }
 }

--- a/nautilus_core/model/src/orders/any.rs
+++ b/nautilus_core/model/src/orders/any.rs
@@ -500,6 +500,51 @@ impl OrderAny {
             Self::TrailingStopMarket(order) => order.would_reduce_only(side, position_qty),
         }
     }
+
+    #[must_use]
+    pub fn is_reduce_only(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_reduce_only(),
+            Self::Market(order) => order.is_reduce_only(),
+            Self::MarketToLimit(order) => order.is_reduce_only(),
+            Self::LimitIfTouched(order) => order.is_reduce_only(),
+            Self::MarketIfTouched(order) => order.is_reduce_only(),
+            Self::StopLimit(order) => order.is_reduce_only(),
+            Self::StopMarket(order) => order.is_reduce_only(),
+            Self::TrailingStopLimit(order) => order.is_reduce_only(),
+            Self::TrailingStopMarket(order) => order.is_reduce_only(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_buy(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_buy(),
+            Self::LimitIfTouched(order) => order.is_buy(),
+            Self::Market(order) => order.is_buy(),
+            Self::MarketIfTouched(order) => order.is_buy(),
+            Self::MarketToLimit(order) => order.is_buy(),
+            Self::StopLimit(order) => order.is_buy(),
+            Self::StopMarket(order) => order.is_buy(),
+            Self::TrailingStopLimit(order) => order.is_buy(),
+            Self::TrailingStopMarket(order) => order.is_buy(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_sell(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_sell(),
+            Self::LimitIfTouched(order) => order.is_sell(),
+            Self::Market(order) => order.is_sell(),
+            Self::MarketIfTouched(order) => order.is_sell(),
+            Self::MarketToLimit(order) => order.is_sell(),
+            Self::StopLimit(order) => order.is_sell(),
+            Self::StopMarket(order) => order.is_sell(),
+            Self::TrailingStopLimit(order) => order.is_sell(),
+            Self::TrailingStopMarket(order) => order.is_sell(),
+        }
+    }
 }
 
 impl PartialEq for OrderAny {

--- a/nautilus_core/model/src/orders/stubs.rs
+++ b/nautilus_core/model/src/orders/stubs.rs
@@ -161,6 +161,39 @@ impl TestOrderStubs {
     }
 
     #[must_use]
+    pub fn market_order_reduce(
+        instrument_id: InstrumentId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        client_order_id: Option<ClientOrderId>,
+        time_in_force: Option<TimeInForce>,
+    ) -> OrderAny {
+        let order = MarketOrder::new(
+            TraderId::default(),
+            StrategyId::default(),
+            instrument_id,
+            client_order_id.unwrap_or_default(),
+            order_side,
+            quantity,
+            time_in_force.unwrap_or(TimeInForce::Gtc),
+            UUID4::new(),
+            UnixNanos::default(),
+            true, // reduce only
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        OrderAny::Market(order)
+    }
+
+    #[must_use]
     pub fn limit_order(
         instrument_id: InstrumentId,
         order_side: OrderSide,


### PR DESCRIPTION
# Pull Request

- added new util function `market_order_reduce` in `TestOrderStubs` for market reduce orders, 
- implemented `is_reduce_only` , `is_buy` and `is_sell` in `OrderAny`
- added reduce only checks in `process_order` for order matching engine
- tested in `test_order_matching_engine_reduce_only_error`