### PR TITLE
Implement process_market_order in OrderMatchingEngine

### DIFF
--- a/nautilus_core/execution/src/matching_core.rs
+++ b/nautilus_core/execution/src/matching_core.rs
@@ -42,6 +42,8 @@ pub struct OrderMatchingCore {
     pub ask: Option<Price>,
     /// The last price for the matching core.
     pub last: Option<Price>,
+    pub is_bid_initialized: bool,
+    pub is_ask_initialized: bool,
     orders_bid: Vec<PassiveOrderAny>,
     orders_ask: Vec<PassiveOrderAny>,
     trigger_stop_order: Option<fn(&StopOrderAny)>,
@@ -65,6 +67,8 @@ impl OrderMatchingCore {
             bid: None,
             ask: None,
             last: None,
+            is_bid_initialized: false,
+            is_ask_initialized: false,
             orders_bid: Vec::new(),
             orders_ask: Vec::new(),
             trigger_stop_order,


### PR DESCRIPTION
# Pull Request

- finished `process_market_order` with checks if the market is initialized 
- bootstrapped others missing methods
- tested in `test_process_market_order_no_market_rejected`
