### PR TITLE
Improve customdataclass constructor to use positional arguments 

### DIFF
--- a/tests/unit_tests/model/test_custom_data.py
+++ b/tests/unit_tests/model/test_custom_data.py
@@ -39,7 +39,7 @@ def test_customdata_decorator_properties() -> None:
 
 def test_customdata_decorator_dict() -> None:
     # Arrange
-    data = GreeksTestData(1, 2)
+    data = GreeksTestData(1, 2, InstrumentId.from_str("ES.GLBX"), 0.0)
 
     # Act
     data_dict = data.to_dict()


### PR DESCRIPTION
# Pull Request

Improved customdataclass constructor to be able to use positional arguments after ts_event and ts_init

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Modified one test to check it's working as expected. Checked on my own code as well.
