### PR TITLE
Implement subscribe SignalData for Actor

### DIFF
--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -171,6 +171,8 @@ cdef class Actor(Component):
     cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, ClientId client_id=*)
     cpdef void publish_data(self, DataType data_type, Data data)
     cpdef void publish_signal(self, str name, value, uint64_t ts_event=*)
+    cpdef void subscribe_signal(self, str name=*)
+    cpdef bint is_signal(self, Data data, str name=*)
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -172,7 +172,6 @@ cdef class Actor(Component):
     cpdef void publish_data(self, DataType data_type, Data data)
     cpdef void publish_signal(self, str name, value, uint64_t ts_event=*)
     cpdef void subscribe_signal(self, str name=*)
-    cpdef bint is_signal(self, Data data, str name=*)
 
 # -- REQUESTS -------------------------------------------------------------------------------------
 

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1841,6 +1841,24 @@ cdef class Actor(Component):
         )
         self.publish_data(data_type=DataType(cls), data=data)
 
+    cpdef void subscribe_signal(self, str name = ""):
+        Condition.not_none(name, "name")
+
+        topic = f"Signal{name.title()}*"
+
+        self._msgbus.subscribe(
+            topic=f"data.{topic}",
+            handler=self.handle_data,
+        )
+
+    cpdef bint is_signal(self, Data data, str name = ""):
+        Condition.not_none(data, "data")
+
+        if name == "":
+            return data.__class__.__name__.startswith("Signal")
+
+        return data.__class__.__name__ == f"Signal{name.title()}"
+
 # -- REQUESTS -------------------------------------------------------------------------------------
 
     cpdef UUID4 request_data(

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1851,14 +1851,6 @@ cdef class Actor(Component):
             handler=self.handle_data,
         )
 
-    cpdef bint is_signal(self, Data data, str name = ""):
-        Condition.not_none(data, "data")
-
-        if name == "":
-            return data.__class__.__name__.startswith("Signal")
-
-        return data.__class__.__name__ == f"Signal{name.title()}"
-
 # -- REQUESTS -------------------------------------------------------------------------------------
 
     cpdef UUID4 request_data(

--- a/nautilus_trader/core/data.pyx
+++ b/nautilus_trader/core/data.pyx
@@ -65,3 +65,10 @@ cdef class Data:
 
         """
         return cls.__module__ + ':' + cls.__qualname__
+
+    @classmethod
+    def is_signal(cls, str name = "") -> bool:
+        if name == "":
+            return cls.__name__.startswith("Signal")
+
+        return cls.__name__ == f"Signal{name.title()}"

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -361,7 +361,13 @@ def generate_signal_class(name: str, value_type: type) -> type:
         {
             "ts_event": pa.uint64(),
             "ts_init": pa.uint64(),
-            "value": {int: pa.int64(), float: pa.float64(), str: pa.string()}[value_type],
+            "value": {
+                int: pa.int64(),
+                float: pa.float64(),
+                str: pa.string(),
+                bool: pa.bool_(),
+                bytes: pa.binary(),
+            }[value_type],
         },
     )
     register_arrow(

--- a/tests/unit_tests/common/test_actor.py
+++ b/tests/unit_tests/common/test_actor.py
@@ -1840,8 +1840,8 @@ class TestActor:
         # Assert
         msg = handler[0]
         assert isinstance(msg, Data)
-        assert actor.is_signal(msg)
-        assert actor.is_signal(msg, "test")
+        assert msg.is_signal()
+        assert msg.is_signal("test")
         assert msg.ts_event == 0
         assert msg.ts_init == 0
         assert msg.value == value

--- a/tests/unit_tests/common/test_actor.py
+++ b/tests/unit_tests/common/test_actor.py
@@ -1840,9 +1840,45 @@ class TestActor:
         # Assert
         msg = handler[0]
         assert isinstance(msg, Data)
+        assert actor.is_signal(msg)
+        assert actor.is_signal(msg, "test")
         assert msg.ts_event == 0
         assert msg.ts_init == 0
         assert msg.value == value
+
+    def test_subscribe_signal(self) -> None:
+        # Arrange
+        actor = MockActor()
+        actor.register_base(
+            portfolio=self.portfolio,
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+
+        # Act
+        actor.subscribe_signal("test")
+
+        # Assert
+        assert self.data_engine.command_count == 0
+        assert actor.msgbus.subscriptions()[4].topic == "data.SignalTest*"
+
+    def test_subscribe_all_signals(self) -> None:
+        # Arrange
+        actor = MockActor()
+        actor.register_base(
+            portfolio=self.portfolio,
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+
+        # Act
+        actor.subscribe_signal()
+
+        # Assert
+        assert self.data_engine.command_count == 0
+        assert actor.msgbus.subscriptions()[4].topic == "data.Signal*"
 
     def test_publish_data_persist(self) -> None:
         # Arrange


### PR DESCRIPTION
# Pull Request

Added functionalities to be able to use Signals in actors. Subscribe signal allows to subcribe to all or one signal of a given name which will be received by the on_data callback in an actor. is_signal is a method of Data to check that a received data in on_data is a signal or a signal of a give name.

Also added more possible basic value types to SignalData.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality

## How has this change been tested?

Tested on my own code and added tests