### PR TITLE
Improve indicators by reducing Result return type

### DIFF
--- a/nautilus_core/common/src/clock.rs
+++ b/nautilus_core/common/src/clock.rs
@@ -69,7 +69,7 @@ pub trait Clock {
         name: &str,
         alert_time_ns: UnixNanos,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()>;
+    );
 
     /// Set a `Timer` to start alerting at every interval
     /// between start and stop time. Optional callback gets
@@ -81,7 +81,7 @@ pub trait Clock {
         start_time_ns: UnixNanos,
         stop_time_ns: Option<UnixNanos>,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()>;
+    );
 
     fn next_time_ns(&self, name: &str) -> UnixNanos;
     fn cancel_timer(&mut self, name: &str);
@@ -227,7 +227,7 @@ impl Clock for TestClock {
         name: &str,
         alert_time_ns: UnixNanos,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()> {
+    ) {
         check_valid_string(name, stringify!(name)).expect(FAILED);
         check_predicate_true(
             callback.is_some() | self.default_callback.is_some(),
@@ -247,9 +247,8 @@ impl Clock for TestClock {
             (alert_time_ns - time_ns).into(),
             time_ns,
             Some(alert_time_ns),
-        )?;
+        );
         self.timers.insert(name_ustr, timer);
-        Ok(())
     }
 
     fn set_timer_ns(
@@ -259,7 +258,7 @@ impl Clock for TestClock {
         start_time_ns: UnixNanos,
         stop_time_ns: Option<UnixNanos>,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()> {
+    ) {
         check_valid_string(name, "name").expect(FAILED);
         check_positive_u64(interval_ns, stringify!(interval_ns)).expect(FAILED);
         check_predicate_true(
@@ -274,9 +273,8 @@ impl Clock for TestClock {
             None => None,
         };
 
-        let timer = TestTimer::new(name, interval_ns, start_time_ns, stop_time_ns)?;
+        let timer = TestTimer::new(name, interval_ns, start_time_ns, stop_time_ns);
         self.timers.insert(name_ustr, timer);
-        Ok(())
     }
 
     fn next_time_ns(&self, name: &str) -> UnixNanos {
@@ -385,7 +383,7 @@ impl Clock for LiveClock {
         name: &str,
         mut alert_time_ns: UnixNanos,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()> {
+    ) {
         check_valid_string(name, stringify!(name)).expect(FAILED);
         assert!(
             callback.is_some() | self.default_callback.is_some(),
@@ -400,11 +398,10 @@ impl Clock for LiveClock {
         let ts_now = self.get_time_ns();
         alert_time_ns = std::cmp::max(alert_time_ns, ts_now);
         let interval_ns = (alert_time_ns - ts_now).into();
-        let mut timer = LiveTimer::new(name, interval_ns, ts_now, Some(alert_time_ns), callback)?;
+        let mut timer = LiveTimer::new(name, interval_ns, ts_now, Some(alert_time_ns), callback);
 
         timer.start();
         self.timers.insert(Ustr::from(name), timer);
-        Ok(())
     }
 
     fn set_timer_ns(
@@ -414,7 +411,7 @@ impl Clock for LiveClock {
         start_time_ns: UnixNanos,
         stop_time_ns: Option<UnixNanos>,
         callback: Option<EventHandler>,
-    ) -> anyhow::Result<()> {
+    ) {
         check_valid_string(name, stringify!(name)).expect(FAILED);
         check_positive_u64(interval_ns, stringify!(interval_ns)).expect(FAILED);
         check_predicate_true(
@@ -428,10 +425,9 @@ impl Clock for LiveClock {
             None => self.default_callback.clone().unwrap(),
         };
 
-        let mut timer = LiveTimer::new(name, interval_ns, start_time_ns, stop_time_ns, callback)?;
+        let mut timer = LiveTimer::new(name, interval_ns, start_time_ns, stop_time_ns, callback);
         timer.start();
         self.timers.insert(Ustr::from(name), timer);
-        Ok(())
     }
 
     fn next_time_ns(&self, name: &str) -> UnixNanos {

--- a/nautilus_core/common/src/ffi/clock.rs
+++ b/nautilus_core/common/src/ffi/clock.rs
@@ -152,9 +152,7 @@ pub unsafe extern "C" fn test_clock_set_time_alert(
         }
     };
 
-    clock
-        .set_time_alert_ns(name, alert_time_ns, handler)
-        .unwrap();
+    clock.set_time_alert_ns(name, alert_time_ns, handler);
 }
 
 /// # Safety
@@ -185,9 +183,7 @@ pub unsafe extern "C" fn test_clock_set_timer(
         }
     };
 
-    clock
-        .set_timer_ns(name, interval_ns, start_time_ns, stop_time_ns, handler)
-        .unwrap();
+    clock.set_timer_ns(name, interval_ns, start_time_ns, stop_time_ns, handler);
 }
 
 /// # Safety
@@ -362,9 +358,7 @@ pub unsafe extern "C" fn live_clock_set_time_alert(
         }
     };
 
-    clock
-        .set_time_alert_ns(name, alert_time_ns, handler)
-        .unwrap();
+    clock.set_time_alert_ns(name, alert_time_ns, handler);
 }
 
 /// # Safety
@@ -401,9 +395,7 @@ pub unsafe extern "C" fn live_clock_set_timer(
         }
     };
 
-    clock
-        .set_timer_ns(name, interval_ns, start_time_ns, stop_time_ns, handler)
-        .unwrap();
+    clock.set_timer_ns(name, interval_ns, start_time_ns, stop_time_ns, handler);
 }
 
 /// # Safety

--- a/nautilus_core/common/src/python/clock.rs
+++ b/nautilus_core/common/src/python/clock.rs
@@ -44,9 +44,7 @@ mod tests {
             test_clock.register_default_handler(handler);
 
             let timer_name = "TEST_TIME1";
-            test_clock
-                .set_timer_ns(timer_name, 10, 0.into(), None, None)
-                .unwrap();
+            test_clock.set_timer_ns(timer_name, 10, 0.into(), None, None);
 
             assert_eq!(test_clock.timer_names(), [timer_name]);
             assert_eq!(test_clock.timer_count(), 1);
@@ -64,9 +62,7 @@ mod tests {
             test_clock.register_default_handler(handler);
 
             let timer_name = "TEST_TIME1";
-            test_clock
-                .set_timer_ns(timer_name, 10, 0.into(), None, None)
-                .unwrap();
+            test_clock.set_timer_ns(timer_name, 10, 0.into(), None, None);
             test_clock.cancel_timer(timer_name);
 
             assert!(test_clock.timer_names().is_empty());
@@ -85,9 +81,7 @@ mod tests {
             test_clock.register_default_handler(handler);
 
             let timer_name = "TEST_TIME1";
-            test_clock
-                .set_timer_ns(timer_name, 10, 0.into(), None, None)
-                .unwrap();
+            test_clock.set_timer_ns(timer_name, 10, 0.into(), None, None);
             test_clock.cancel_timers();
 
             assert!(test_clock.timer_names().is_empty());
@@ -106,9 +100,7 @@ mod tests {
             test_clock.register_default_handler(handler);
 
             let timer_name = "TEST_TIME1";
-            test_clock
-                .set_timer_ns(timer_name, 1, 1.into(), Some(UnixNanos::from(3)), None)
-                .unwrap();
+            test_clock.set_timer_ns(timer_name, 1, 1.into(), Some(UnixNanos::from(3)), None);
             test_clock.advance_time(2.into(), true);
 
             assert_eq!(test_clock.timer_names(), [timer_name]);
@@ -126,9 +118,7 @@ mod tests {
             let handler = EventHandler::new(py_append);
             test_clock.register_default_handler(handler);
 
-            test_clock
-                .set_timer_ns("TEST_TIME1", 2, 0.into(), Some(UnixNanos::from(3)), None)
-                .unwrap();
+            test_clock.set_timer_ns("TEST_TIME1", 2, 0.into(), Some(UnixNanos::from(3)), None);
             test_clock.advance_time(3.into(), true);
 
             assert_eq!(test_clock.timer_names().len(), 1);
@@ -147,9 +137,7 @@ mod tests {
             let handler = EventHandler::new(py_append);
             test_clock.register_default_handler(handler);
 
-            test_clock
-                .set_timer_ns("TEST_TIME1", 2, 0.into(), Some(UnixNanos::from(3)), None)
-                .unwrap();
+            test_clock.set_timer_ns("TEST_TIME1", 2, 0.into(), Some(UnixNanos::from(3)), None);
             test_clock.advance_time(3.into(), false);
 
             assert_eq!(test_clock.timer_names().len(), 1);

--- a/nautilus_core/common/src/timer.rs
+++ b/nautilus_core/common/src/timer.rs
@@ -140,19 +140,19 @@ impl TestTimer {
         interval_ns: u64,
         start_time_ns: UnixNanos,
         stop_time_ns: Option<UnixNanos>,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         check_valid_string(name, stringify!(name)).expect(FAILED);
         // SAFETY: Guaranteed to be non-zero
         let interval_ns = NonZeroU64::new(std::cmp::max(interval_ns, 1)).unwrap();
 
-        Ok(Self {
+        Self {
             name: Ustr::from(name),
             interval_ns,
             start_time_ns,
             stop_time_ns,
             next_time_ns: start_time_ns + interval_ns.get(),
             is_expired: false,
-        })
+        }
     }
 
     /// Returns the next time in UNIX nanoseconds when the timer will fire.
@@ -244,13 +244,13 @@ impl LiveTimer {
         start_time_ns: UnixNanos,
         stop_time_ns: Option<UnixNanos>,
         callback: EventHandler,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         check_valid_string(name, stringify!(name)).expect(FAILED);
         // SAFETY: Guaranteed to be non-zero
         let interval_ns = NonZeroU64::new(std::cmp::max(interval_ns, 1)).unwrap();
 
         log::debug!("Creating timer '{}'", name);
-        Ok(Self {
+        Self {
             name: Ustr::from(name),
             interval_ns,
             start_time_ns,
@@ -259,7 +259,7 @@ impl LiveTimer {
             is_expired: Arc::new(AtomicBool::new(false)),
             callback,
             canceler: None,
-        })
+        }
     }
 
     /// Returns the next time in UNIX nanoseconds when the timer will fire.
@@ -406,7 +406,7 @@ mod tests {
 
     #[rstest]
     fn test_test_timer_pop_event() {
-        let mut timer = TestTimer::new("test_timer", 1, UnixNanos::from(1), None).unwrap();
+        let mut timer = TestTimer::new("test_timer", 1, UnixNanos::from(1), None);
 
         assert!(timer.next().is_some());
         assert!(timer.next().is_some());
@@ -416,7 +416,7 @@ mod tests {
 
     #[rstest]
     fn test_test_timer_advance_within_next_time_ns() {
-        let mut timer = TestTimer::new("test_timer", 5, UnixNanos::default(), None).unwrap();
+        let mut timer = TestTimer::new("test_timer", 5, UnixNanos::default(), None);
         let _: Vec<TimeEvent> = timer.advance(UnixNanos::from(1)).collect();
         let _: Vec<TimeEvent> = timer.advance(UnixNanos::from(2)).collect();
         let _: Vec<TimeEvent> = timer.advance(UnixNanos::from(3)).collect();
@@ -427,7 +427,7 @@ mod tests {
 
     #[rstest]
     fn test_test_timer_advance_up_to_next_time_ns() {
-        let mut timer = TestTimer::new("test_timer", 1, UnixNanos::default(), None).unwrap();
+        let mut timer = TestTimer::new("test_timer", 1, UnixNanos::default(), None);
         assert_eq!(timer.advance(UnixNanos::from(1)).count(), 1);
         assert!(!timer.is_expired);
     }
@@ -439,8 +439,7 @@ mod tests {
             1,
             UnixNanos::default(),
             Some(UnixNanos::from(2)),
-        )
-        .unwrap();
+        );
         assert_eq!(timer.advance(UnixNanos::from(2)).count(), 2);
         assert!(timer.is_expired);
     }
@@ -452,8 +451,7 @@ mod tests {
             1,
             UnixNanos::default(),
             Some(UnixNanos::from(5)),
-        )
-        .unwrap();
+        );
         assert_eq!(timer.advance(UnixNanos::from(5)).count(), 5);
         assert!(timer.is_expired);
     }
@@ -465,8 +463,7 @@ mod tests {
             1,
             UnixNanos::default(),
             Some(UnixNanos::from(5)),
-        )
-        .unwrap();
+        );
         assert_eq!(timer.advance(UnixNanos::from(10)).count(), 5);
         assert!(timer.is_expired);
     }
@@ -484,8 +481,7 @@ mod tests {
         let clock = get_atomic_clock_realtime();
         let start_time = clock.get_time_ns();
         let interval_ns = 100 * NANOSECONDS_IN_MILLISECOND;
-        let mut timer =
-            LiveTimer::new("TEST_TIMER", interval_ns, start_time, None, handler).unwrap();
+        let mut timer = LiveTimer::new("TEST_TIMER", interval_ns, start_time, None, handler);
         let next_time_ns = timer.next_time_ns();
         timer.start();
 
@@ -517,8 +513,7 @@ mod tests {
             start_time,
             Some(stop_time),
             handler,
-        )
-        .unwrap();
+        );
         let next_time_ns = timer.next_time_ns();
         timer.start();
 
@@ -549,8 +544,7 @@ mod tests {
             start_time,
             Some(stop_time),
             handler,
-        )
-        .unwrap();
+        );
         timer.start();
 
         wait_until(|| timer.is_expired(), Duration::from_secs(2));

--- a/nautilus_core/data/src/aggregation.rs
+++ b/nautilus_core/data/src/aggregation.rs
@@ -509,7 +509,7 @@ where
             start_time_ns,
             None,
             None, // TODO: Implement Rust callback handlers properly (see above commented code)
-        )?;
+        );
 
         log::debug!("Started timer {}", self.timer_name);
         Ok(())

--- a/nautilus_core/indicators/src/average/ama.rs
+++ b/nautilus_core/indicators/src/average/ama.rs
@@ -110,10 +110,8 @@ impl AdaptiveMovingAverage {
         period_fast: usize,
         period_slow: usize,
         price_type: Option<PriceType>,
-    ) -> anyhow::Result<Self> {
-        // Inputs don't require validation, however we return a `Result`
-        // to standardize with other indicators which do need validation.
-        Ok(Self {
+    ) -> Self {
+        Self {
             period_efficiency_ratio,
             period_fast,
             period_slow,
@@ -126,7 +124,7 @@ impl AdaptiveMovingAverage {
             has_inputs: false,
             initialized: false,
             efficiency_ratio: EfficiencyRatio::new(period_efficiency_ratio, price_type)?,
-        })
+        }
     }
 
     #[must_use]
@@ -171,6 +169,7 @@ impl MovingAverage for AdaptiveMovingAverage {
             .powi(2);
 
         // Calculate the AMA
+        // TODO: Remove unwraps
         self.value = smoothing_constant
             .mul_add(value - self.prior_value.unwrap(), self.prior_value.unwrap());
         if self.efficiency_ratio.initialized() {

--- a/nautilus_core/indicators/src/average/ama.rs
+++ b/nautilus_core/indicators/src/average/ama.rs
@@ -123,7 +123,7 @@ impl AdaptiveMovingAverage {
             prior_value: None,
             has_inputs: false,
             initialized: false,
-            efficiency_ratio: EfficiencyRatio::new(period_efficiency_ratio, price_type)?,
+            efficiency_ratio: EfficiencyRatio::new(period_efficiency_ratio, price_type),
         }
     }
 

--- a/nautilus_core/indicators/src/average/dema.rs
+++ b/nautilus_core/indicators/src/average/dema.rs
@@ -88,8 +88,8 @@ impl Indicator for DoubleExponentialMovingAverage {
 
 impl DoubleExponentialMovingAverage {
     /// Creates a new [`DoubleExponentialMovingAverage`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             value: 0.0,
@@ -98,7 +98,7 @@ impl DoubleExponentialMovingAverage {
             initialized: false,
             ema1: ExponentialMovingAverage::new(period, price_type)?,
             ema2: ExponentialMovingAverage::new(period, price_type)?,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/dema.rs
+++ b/nautilus_core/indicators/src/average/dema.rs
@@ -96,8 +96,8 @@ impl DoubleExponentialMovingAverage {
             count: 0,
             has_inputs: false,
             initialized: false,
-            ema1: ExponentialMovingAverage::new(period, price_type)?,
-            ema2: ExponentialMovingAverage::new(period, price_type)?,
+            ema1: ExponentialMovingAverage::new(period, price_type),
+            ema2: ExponentialMovingAverage::new(period, price_type),
         }
     }
 }

--- a/nautilus_core/indicators/src/average/ema.rs
+++ b/nautilus_core/indicators/src/average/ema.rs
@@ -79,10 +79,8 @@ impl Indicator for ExponentialMovingAverage {
 
 impl ExponentialMovingAverage {
     /// Creates a new [`ExponentialMovingAverage`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
-        // Inputs don't require validation, however we return a `Result`
-        // to standardize with other indicators which do need validation.
-        Ok(Self {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             alpha: 2.0 / (period as f64 + 1.0),
@@ -90,7 +88,7 @@ impl ExponentialMovingAverage {
             count: 0,
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/hma.rs
+++ b/nautilus_core/indicators/src/average/hma.rs
@@ -97,7 +97,7 @@ fn _get_weights(size: usize) -> Vec<f64> {
 
 impl HullMovingAverage {
     /// Creates a new [`HullMovingAverage`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
         let period_halved = period / 2;
         let period_sqrt = (period as f64).sqrt() as usize;
 
@@ -105,11 +105,11 @@ impl HullMovingAverage {
         let w2 = _get_weights(period);
         let w3 = _get_weights(period_sqrt);
 
-        let ma1 = WeightedMovingAverage::new(period_halved, w1, price_type)?;
-        let ma2 = WeightedMovingAverage::new(period, w2, price_type)?;
-        let ma3 = WeightedMovingAverage::new(period_sqrt, w3, price_type)?;
+        let ma1 = WeightedMovingAverage::new(period_halved, w1, price_type);
+        let ma2 = WeightedMovingAverage::new(period, w2, price_type);
+        let ma3 = WeightedMovingAverage::new(period_sqrt, w3, price_type);
 
-        Ok(Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             value: 0.0,
@@ -119,7 +119,7 @@ impl HullMovingAverage {
             ma1,
             ma2,
             ma3,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/lr.rs
+++ b/nautilus_core/indicators/src/average/lr.rs
@@ -76,8 +76,8 @@ impl Indicator for LinearRegression {
 
 impl LinearRegression {
     /// Creates a new [`LinearRegression`] instance.
-    pub fn new(period: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize) -> Self {
+        Self {
             period,
             slope: 0.0,
             intercept: 0.0,
@@ -88,7 +88,7 @@ impl LinearRegression {
             inputs: Vec::with_capacity(period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {

--- a/nautilus_core/indicators/src/average/mod.rs
+++ b/nautilus_core/indicators/src/average/mod.rs
@@ -78,21 +78,15 @@ impl MovingAverageFactory {
         let price_type = Some(PriceType::Last);
 
         match moving_average_type {
-            MovingAverageType::Simple => {
-                Box::new(SimpleMovingAverage::new(period, price_type).unwrap())
-            }
+            MovingAverageType::Simple => Box::new(SimpleMovingAverage::new(period, price_type)),
             MovingAverageType::Exponential => {
-                Box::new(ExponentialMovingAverage::new(period, price_type).unwrap())
+                Box::new(ExponentialMovingAverage::new(period, price_type))
             }
             MovingAverageType::DoubleExponential => {
-                Box::new(DoubleExponentialMovingAverage::new(period, price_type).unwrap())
+                Box::new(DoubleExponentialMovingAverage::new(period, price_type))
             }
-            MovingAverageType::Wilder => {
-                Box::new(WilderMovingAverage::new(period, price_type).unwrap())
-            }
-            MovingAverageType::Hull => {
-                Box::new(HullMovingAverage::new(period, price_type).unwrap())
-            }
+            MovingAverageType::Wilder => Box::new(WilderMovingAverage::new(period, price_type)),
+            MovingAverageType::Hull => Box::new(HullMovingAverage::new(period, price_type)),
         }
     }
 }

--- a/nautilus_core/indicators/src/average/rma.rs
+++ b/nautilus_core/indicators/src/average/rma.rs
@@ -79,13 +79,11 @@ impl Indicator for WilderMovingAverage {
 
 impl WilderMovingAverage {
     /// Creates a new [`WilderMovingAverage`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
-        // Inputs don't require validation, however we return a `Result`
-        // to standardize with other indicators which do need validation.
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
         // The Wilder Moving Average is The Wilder's Moving Average is simply
         // an Exponential Moving Average (EMA) with a modified alpha.
         // alpha = 1 / period
-        Ok(Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             alpha: 1.0 / (period as f64),
@@ -93,7 +91,7 @@ impl WilderMovingAverage {
             count: 0,
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/sma.rs
+++ b/nautilus_core/indicators/src/average/sma.rs
@@ -78,17 +78,15 @@ impl Indicator for SimpleMovingAverage {
 
 impl SimpleMovingAverage {
     /// Creates a new [`SimpleMovingAverage`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
-        // Inputs don't require validation, however we return a `Result`
-        // to standardize with other indicators which do need validation.
-        Ok(Self {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             value: 0.0,
             count: 0,
             inputs: Vec::with_capacity(period),
             initialized: false,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/vidya.rs
+++ b/nautilus_core/indicators/src/average/vidya.rs
@@ -91,8 +91,8 @@ impl VariableIndexDynamicAverage {
         period: usize,
         price_type: Option<PriceType>,
         cmo_ma_type: Option<MovingAverageType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             value: 0.0,
@@ -100,9 +100,9 @@ impl VariableIndexDynamicAverage {
             has_inputs: false,
             initialized: false,
             alpha: 2.0 / (period as f64 + 1.0),
-            cmo: ChandeMomentumOscillator::new(period, cmo_ma_type)?,
+            cmo: ChandeMomentumOscillator::new(period, cmo_ma_type),
             cmo_pct: 0.0,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/average/vwap.rs
+++ b/nautilus_core/indicators/src/average/vwap.rs
@@ -20,7 +20,7 @@ use nautilus_model::data::bar::Bar;
 use crate::indicator::Indicator;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")

--- a/nautilus_core/indicators/src/average/vwap.rs
+++ b/nautilus_core/indicators/src/average/vwap.rs
@@ -72,15 +72,15 @@ impl Indicator for VolumeWeightedAveragePrice {
 
 impl VolumeWeightedAveragePrice {
     /// Creates a new [`VolumeWeightedAveragePrice`] instance.
-    pub const fn new() -> anyhow::Result<Self> {
-        Ok(Self {
+    pub const fn new() -> Self {
+        Self {
             value: 0.0,
             has_inputs: false,
             initialized: false,
             price_volume: 0.0,
             volume_total: 0.0,
             day: 0.0,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, price: f64, volume: f64, timestamp: f64) {

--- a/nautilus_core/indicators/src/average/wma.rs
+++ b/nautilus_core/indicators/src/average/wma.rs
@@ -53,15 +53,13 @@ impl Display for WeightedMovingAverage {
 
 impl WeightedMovingAverage {
     /// Creates a new [`WeightedMovingAverage`] instance.
-    pub fn new(
-        period: usize,
-        weights: Vec<f64>,
-        price_type: Option<PriceType>,
-    ) -> anyhow::Result<Self> {
-        if weights.len() != period {
-            return Err(anyhow::anyhow!("Weights length must be equal to period"));
-        }
-        Ok(Self {
+    pub fn new(period: usize, weights: Vec<f64>, price_type: Option<PriceType>) -> Self {
+        assert_eq!(
+            weights.len(),
+            period,
+            "Weights length must be equal to period"
+        );
+        Self {
             period,
             weights,
             price_type: price_type.unwrap_or(PriceType::Last),
@@ -69,7 +67,7 @@ impl WeightedMovingAverage {
             inputs: Vec::with_capacity(period),
             initialized: false,
             has_inputs: false,
-        })
+        }
     }
 
     fn weighted_average(&self) -> f64 {
@@ -182,7 +180,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_two_inputs_equal_weights() {
-        let mut wma = WeightedMovingAverage::new(2, vec![0.5, 0.5], None).unwrap();
+        let mut wma = WeightedMovingAverage::new(2, vec![0.5, 0.5], None);
         wma.update_raw(1.0);
         wma.update_raw(2.0);
         assert_eq!(wma.value, 1.5);
@@ -190,7 +188,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_four_inputs_equal_weights() {
-        let mut wma = WeightedMovingAverage::new(4, vec![0.25, 0.25, 0.25, 0.25], None).unwrap();
+        let mut wma = WeightedMovingAverage::new(4, vec![0.25, 0.25, 0.25, 0.25], None);
         wma.update_raw(1.0);
         wma.update_raw(2.0);
         wma.update_raw(3.0);

--- a/nautilus_core/indicators/src/average/wma.rs
+++ b/nautilus_core/indicators/src/average/wma.rs
@@ -167,9 +167,9 @@ mod tests {
     }
 
     #[rstest]
+    #[should_panic]
     fn test_different_weights_len_and_period_error() {
-        let wma = WeightedMovingAverage::new(10, vec![0.5, 0.5, 0.5], None);
-        assert!(wma.is_err());
+        WeightedMovingAverage::new(10, vec![0.5, 0.5, 0.5], None);
     }
 
     #[rstest]

--- a/nautilus_core/indicators/src/book/imbalance.rs
+++ b/nautilus_core/indicators/src/book/imbalance.rs
@@ -20,7 +20,7 @@ use nautilus_model::{orderbook::book::OrderBook, types::quantity::Quantity};
 use crate::indicator::Indicator;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")

--- a/nautilus_core/indicators/src/book/imbalance.rs
+++ b/nautilus_core/indicators/src/book/imbalance.rs
@@ -65,15 +65,13 @@ impl Indicator for BookImbalanceRatio {
 
 impl BookImbalanceRatio {
     /// Creates a new [`BookImbalanceRatio`] instance.
-    pub const fn new() -> anyhow::Result<Self> {
-        // Inputs don't require validation, however we return a `Result`
-        // to standardize with other indicators which do need validation.
-        Ok(Self {
+    pub const fn new() -> Self {
+        Self {
             value: 0.0,
             count: 0,
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update(&mut self, best_bid: Option<Quantity>, best_ask: Option<Quantity>) {
@@ -108,7 +106,7 @@ mod tests {
 
     #[rstest]
     fn test_initialized() {
-        let imbalance = BookImbalanceRatio::new().unwrap();
+        let imbalance = BookImbalanceRatio::new();
         let display_str = format!("{imbalance}");
         assert_eq!(display_str, "BookImbalanceRatio()");
         assert_eq!(imbalance.value, 0.0);
@@ -119,7 +117,7 @@ mod tests {
 
     #[rstest]
     fn test_one_value_input_balanced() {
-        let mut imbalance = BookImbalanceRatio::new().unwrap();
+        let mut imbalance = BookImbalanceRatio::new();
         let book = stub_order_book_mbp_appl_xnas();
         imbalance.handle_book(&book);
 
@@ -131,7 +129,7 @@ mod tests {
 
     #[rstest]
     fn test_reset() {
-        let mut imbalance = BookImbalanceRatio::new().unwrap();
+        let mut imbalance = BookImbalanceRatio::new();
         let book = stub_order_book_mbp_appl_xnas();
         imbalance.handle_book(&book);
         imbalance.reset();
@@ -144,7 +142,7 @@ mod tests {
 
     #[rstest]
     fn test_one_value_input_with_bid_imbalance() {
-        let mut imbalance = BookImbalanceRatio::new().unwrap();
+        let mut imbalance = BookImbalanceRatio::new();
         let book = stub_order_book_mbp(
             InstrumentId::from("AAPL.XNAS"),
             101.0,
@@ -167,7 +165,7 @@ mod tests {
 
     #[rstest]
     fn test_one_value_input_with_ask_imbalance() {
-        let mut imbalance = BookImbalanceRatio::new().unwrap();
+        let mut imbalance = BookImbalanceRatio::new();
         let book = stub_order_book_mbp(
             InstrumentId::from("AAPL.XNAS"),
             101.0,
@@ -190,7 +188,7 @@ mod tests {
 
     #[rstest]
     fn test_one_value_input_with_bid_imbalance_multiple_inputs() {
-        let mut imbalance = BookImbalanceRatio::new().unwrap();
+        let mut imbalance = BookImbalanceRatio::new();
         let book = stub_order_book_mbp(
             InstrumentId::from("AAPL.XNAS"),
             101.0,

--- a/nautilus_core/indicators/src/momentum/amat.rs
+++ b/nautilus_core/indicators/src/momentum/amat.rs
@@ -96,8 +96,8 @@ impl ArcherMovingAveragesTrends {
         slow_period: usize,
         signal_period: usize,
         ma_type: Option<MovingAverageType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             fast_period,
             slow_period,
             signal_period,
@@ -116,7 +116,7 @@ impl ArcherMovingAveragesTrends {
             slow_ma_price: VecDeque::with_capacity(signal_period + 1),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {
@@ -127,6 +127,7 @@ impl ArcherMovingAveragesTrends {
             self.fast_ma_price.push_back(self.fast_ma.value());
             self.slow_ma_price.push_back(self.slow_ma.value());
 
+            // TODO: Remove unwraps
             self.long_run = self.fast_ma_price.back().unwrap()
                 - self.fast_ma_price.front().unwrap()
                 > 0.0

--- a/nautilus_core/indicators/src/momentum/aroon.rs
+++ b/nautilus_core/indicators/src/momentum/aroon.rs
@@ -92,8 +92,8 @@ impl Indicator for AroonOscillator {
 
 impl AroonOscillator {
     /// Creates a new [`AroonOscillator`] instance.
-    pub fn new(period: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize) -> Self {
+        Self {
             period,
             high_inputs: VecDeque::with_capacity(period),
             low_inputs: VecDeque::with_capacity(period),
@@ -103,7 +103,7 @@ impl AroonOscillator {
             count: 0,
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64) {
@@ -180,25 +180,25 @@ mod tests {
 
     #[rstest]
     fn test_name_returns_expected_string() {
-        let aroon = AroonOscillator::new(10).unwrap();
+        let aroon = AroonOscillator::new(10);
         assert_eq!(aroon.name(), "AroonOscillator");
     }
 
     #[rstest]
     fn test_period() {
-        let aroon = AroonOscillator::new(10).unwrap();
+        let aroon = AroonOscillator::new(10);
         assert_eq!(aroon.period, 10);
     }
 
     #[rstest]
     fn test_initialized_without_inputs_returns_false() {
-        let aroon = AroonOscillator::new(10).unwrap();
+        let aroon = AroonOscillator::new(10);
         assert!(!aroon.initialized());
     }
 
     #[rstest]
     fn test_initialized_with_required_inputs_returns_true() {
-        let mut aroon = AroonOscillator::new(10).unwrap();
+        let mut aroon = AroonOscillator::new(10);
         for _ in 0..20 {
             aroon.update_raw(110.08, 109.61);
         }
@@ -207,7 +207,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_one_input() {
-        let mut aroon = AroonOscillator::new(1).unwrap();
+        let mut aroon = AroonOscillator::new(1);
         aroon.update_raw(110.08, 109.61);
         assert_eq!(aroon.aroon_up, 100.0);
         assert_eq!(aroon.aroon_down, 100.0);
@@ -216,7 +216,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_twenty_inputs() {
-        let mut aroon = AroonOscillator::new(20).unwrap();
+        let mut aroon = AroonOscillator::new(20);
         let inputs = [
             (110.08, 109.61),
             (110.15, 109.91),
@@ -249,7 +249,7 @@ mod tests {
 
     #[rstest]
     fn test_reset_successfully_returns_indicator_to_fresh_state() {
-        let mut aroon = AroonOscillator::new(10).unwrap();
+        let mut aroon = AroonOscillator::new(10);
         for _ in 0..1000 {
             aroon.update_raw(110.08, 109.61);
         }

--- a/nautilus_core/indicators/src/momentum/bb.rs
+++ b/nautilus_core/indicators/src/momentum/bb.rs
@@ -99,8 +99,8 @@ impl Indicator for BollingerBands {
 
 impl BollingerBands {
     /// Creates a new [`BollingerBands`] instance.
-    pub fn new(period: usize, k: f64, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, k: f64, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             k,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -111,7 +111,7 @@ impl BollingerBands {
             lower: 0.0,
             ma: MovingAverageFactory::create(ma_type.unwrap_or(MovingAverageType::Simple), period),
             prices: VecDeque::with_capacity(period),
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/momentum/bias.rs
+++ b/nautilus_core/indicators/src/momentum/bias.rs
@@ -73,8 +73,8 @@ impl Indicator for Bias {
 
 impl Bias {
     /// Creates a new [`Bias`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             value: 0.0,
@@ -83,7 +83,7 @@ impl Bias {
             ma: MovingAverageFactory::create(ma_type.unwrap_or(MovingAverageType::Simple), period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {
@@ -114,7 +114,7 @@ mod tests {
 
     #[fixture]
     fn bias() -> Bias {
-        Bias::new(10, None).unwrap()
+        Bias::new(10, None)
     }
 
     #[rstest]

--- a/nautilus_core/indicators/src/momentum/cci.rs
+++ b/nautilus_core/indicators/src/momentum/cci.rs
@@ -82,8 +82,8 @@ impl CommodityChannelIndex {
         period: usize,
         scalar: f64,
         ma_type: Option<MovingAverageType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             scalar,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -93,7 +93,7 @@ impl CommodityChannelIndex {
             has_inputs: false,
             initialized: false,
             mad: 0.0,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/momentum/cci.rs
+++ b/nautilus_core/indicators/src/momentum/cci.rs
@@ -78,11 +78,7 @@ impl Indicator for CommodityChannelIndex {
 
 impl CommodityChannelIndex {
     /// Creates a new [`CommodityChannelIndex`] instance.
-    pub fn new(
-        period: usize,
-        scalar: f64,
-        ma_type: Option<MovingAverageType>,
-    ) -> Self {
+    pub fn new(period: usize, scalar: f64, ma_type: Option<MovingAverageType>) -> Self {
         Self {
             period,
             scalar,

--- a/nautilus_core/indicators/src/momentum/cmo.rs
+++ b/nautilus_core/indicators/src/momentum/cmo.rs
@@ -82,8 +82,8 @@ impl Indicator for ChandeMomentumOscillator {
 
 impl ChandeMomentumOscillator {
     /// Creates a new [`ChandeMomentumOscillator`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Wilder),
             average_gain: MovingAverageFactory::create(MovingAverageType::Wilder, period),
@@ -93,7 +93,7 @@ impl ChandeMomentumOscillator {
             count: 0,
             initialized: false,
             has_inputs: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {

--- a/nautilus_core/indicators/src/momentum/dm.rs
+++ b/nautilus_core/indicators/src/momentum/dm.rs
@@ -78,8 +78,8 @@ impl Indicator for DirectionalMovement {
 
 impl DirectionalMovement {
     /// Creates a new [`DirectionalMovement`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             pos: 0.0,
@@ -96,7 +96,7 @@ impl DirectionalMovement {
             ),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64) {

--- a/nautilus_core/indicators/src/momentum/kvo.rs
+++ b/nautilus_core/indicators/src/momentum/kvo.rs
@@ -98,8 +98,8 @@ impl KlingerVolumeOscillator {
         slow_period: usize,
         signal_period: usize,
         ma_type: Option<MovingAverageType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             fast_period,
             slow_period,
             signal_period,
@@ -121,7 +121,7 @@ impl KlingerVolumeOscillator {
             hlc3: 0.0,
             previous_hlc3: 0.0,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64, volume: f64) {

--- a/nautilus_core/indicators/src/momentum/macd.rs
+++ b/nautilus_core/indicators/src/momentum/macd.rs
@@ -99,8 +99,8 @@ impl MovingAverageConvergenceDivergence {
         slow_period: usize,
         ma_type: Option<MovingAverageType>,
         price_type: Option<PriceType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             fast_period,
             slow_period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -117,7 +117,7 @@ impl MovingAverageConvergenceDivergence {
                 ma_type.unwrap_or(MovingAverageType::Simple),
                 slow_period,
             ),
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/momentum/obv.rs
+++ b/nautilus_core/indicators/src/momentum/obv.rs
@@ -73,14 +73,14 @@ impl Indicator for OnBalanceVolume {
 
 impl OnBalanceVolume {
     /// Creates a new [`OnBalanceVolume`] instance.
-    pub fn new(period: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize) -> Self {
+        Self {
             period,
             value: 0.0,
             obv: VecDeque::with_capacity(period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, open: f64, close: f64, volume: f64) {

--- a/nautilus_core/indicators/src/momentum/pressure.rs
+++ b/nautilus_core/indicators/src/momentum/pressure.rs
@@ -81,11 +81,7 @@ impl Indicator for Pressure {
 
 impl Pressure {
     /// Creates a new [`Pressure`] instance.
-    pub fn new(
-        period: usize,
-        ma_type: Option<MovingAverageType>,
-        atr_floor: Option<f64>,
-    ) -> Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>, atr_floor: Option<f64>) -> Self {
         Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -97,7 +93,7 @@ impl Pressure {
                 Some(MovingAverageType::Exponential),
                 Some(false),
                 atr_floor,
-            )?,
+            ),
             average_volume: MovingAverageFactory::create(
                 ma_type.unwrap_or(MovingAverageType::Simple),
                 period,

--- a/nautilus_core/indicators/src/momentum/pressure.rs
+++ b/nautilus_core/indicators/src/momentum/pressure.rs
@@ -85,8 +85,8 @@ impl Pressure {
         period: usize,
         ma_type: Option<MovingAverageType>,
         atr_floor: Option<f64>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             atr_floor: atr_floor.unwrap_or(0.0),
@@ -104,7 +104,7 @@ impl Pressure {
             ),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64, volume: f64) {

--- a/nautilus_core/indicators/src/momentum/psl.rs
+++ b/nautilus_core/indicators/src/momentum/psl.rs
@@ -74,8 +74,8 @@ impl Indicator for PsychologicalLine {
 
 impl PsychologicalLine {
     /// Creates a new [`PsychologicalLine`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             value: 0.0,
@@ -84,7 +84,7 @@ impl PsychologicalLine {
             has_inputs: false,
             initialized: false,
             diff: 0.0,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {

--- a/nautilus_core/indicators/src/momentum/roc.rs
+++ b/nautilus_core/indicators/src/momentum/roc.rs
@@ -70,15 +70,15 @@ impl Indicator for RateOfChange {
 
 impl RateOfChange {
     /// Creates a new [`RateOfChange`] instance.
-    pub fn new(period: usize, use_log: Option<bool>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, use_log: Option<bool>) -> Self {
+        Self {
             period,
             use_log: use_log.unwrap_or(false),
             value: 0.0,
             prices: VecDeque::with_capacity(period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, price: f64) {

--- a/nautilus_core/indicators/src/momentum/rsi.rs
+++ b/nautilus_core/indicators/src/momentum/rsi.rs
@@ -87,8 +87,8 @@ impl Indicator for RelativeStrengthIndex {
 
 impl RelativeStrengthIndex {
     /// Creates a new [`RelativeStrengthIndex`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Exponential),
             value: 0.0,
@@ -100,7 +100,7 @@ impl RelativeStrengthIndex {
             average_loss: MovingAverageFactory::create(MovingAverageType::Exponential, period),
             rsi_max: 1.0,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, value: f64) {

--- a/nautilus_core/indicators/src/momentum/stochastics.rs
+++ b/nautilus_core/indicators/src/momentum/stochastics.rs
@@ -78,8 +78,8 @@ impl Indicator for Stochastics {
 
 impl Stochastics {
     /// Creates a new [`Stochastics`] instance.
-    pub fn new(period_k: usize, period_d: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period_k: usize, period_d: usize) -> Self {
+        Self {
             period_k,
             period_d,
             has_inputs: false,
@@ -90,7 +90,7 @@ impl Stochastics {
             lows: VecDeque::with_capacity(period_k),
             h_sub_l: VecDeque::with_capacity(period_d),
             c_sub_1: VecDeque::with_capacity(period_d),
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/momentum/swings.rs
+++ b/nautilus_core/indicators/src/momentum/swings.rs
@@ -89,8 +89,8 @@ impl Indicator for Swings {
 
 impl Swings {
     /// Creates a new [`Swings`] instance.
-    pub fn new(period: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize) -> Self {
+        Self {
             period,
             high_inputs: VecDeque::with_capacity(period + 1),
             low_inputs: VecDeque::with_capacity(period + 1),
@@ -106,7 +106,7 @@ impl Swings {
             duration: 0,
             since_high: 0,
             since_low: 0,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, timestamp: f64) {

--- a/nautilus_core/indicators/src/momentum/vhf.rs
+++ b/nautilus_core/indicators/src/momentum/vhf.rs
@@ -77,8 +77,8 @@ impl Indicator for VerticalHorizontalFilter {
 
 impl VerticalHorizontalFilter {
     /// Creates a new [`VerticalHorizontalFilter`] instance.
-    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             value: 0.0,
@@ -87,7 +87,7 @@ impl VerticalHorizontalFilter {
             has_inputs: false,
             initialized: false,
             prices: VecDeque::with_capacity(period),
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {

--- a/nautilus_core/indicators/src/python/average/ama.rs
+++ b/nautilus_core/indicators/src/python/average/ama.rs
@@ -33,14 +33,13 @@ impl AdaptiveMovingAverage {
         period_fast: usize,
         period_slow: usize,
         price_type: Option<PriceType>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         Self::new(
             period_efficiency_ratio,
             period_fast,
             period_slow,
             price_type,
         )
-        .map_err(to_pyvalue_err)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/dema.rs
+++ b/nautilus_core/indicators/src/python/average/dema.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl DoubleExponentialMovingAverage {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/ema.rs
+++ b/nautilus_core/indicators/src/python/average/ema.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl ExponentialMovingAverage {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/hma.rs
+++ b/nautilus_core/indicators/src/python/average/hma.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl HullMovingAverage {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/lr.rs
+++ b/nautilus_core/indicators/src/python/average/lr.rs
@@ -25,8 +25,8 @@ use crate::{
 #[pymethods]
 impl LinearRegression {
     #[new]
-    pub fn py_new(period: usize) -> PyResult<Self> {
-        Self::new(period).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize) -> Self {
+        Self::new(period)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/rma.rs
+++ b/nautilus_core/indicators/src/python/average/rma.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl WilderMovingAverage {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/sma.rs
+++ b/nautilus_core/indicators/src/python/average/sma.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl SimpleMovingAverage {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/vidya.rs
+++ b/nautilus_core/indicators/src/python/average/vidya.rs
@@ -32,8 +32,8 @@ impl VariableIndexDynamicAverage {
         period: usize,
         price_type: Option<PriceType>,
         cmo_ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
-        Self::new(period, price_type, cmo_ma_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, price_type, cmo_ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/vwap.rs
+++ b/nautilus_core/indicators/src/python/average/vwap.rs
@@ -28,8 +28,8 @@ use crate::{
 #[pymethods]
 impl VolumeWeightedAveragePrice {
     #[new]
-    pub fn py_new() -> PyResult<Self> {
-        Self::new().map_err(to_pyvalue_err)
+    pub fn py_new() -> Self {
+        Self::new()
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/average/wma.rs
+++ b/nautilus_core/indicators/src/python/average/wma.rs
@@ -28,11 +28,7 @@ use crate::{
 #[pymethods]
 impl WeightedMovingAverage {
     #[new]
-    pub fn py_new(
-        period: usize,
-        weights: Vec<f64>,
-        price_type: Option<PriceType>,
-    ) -> Self {
+    pub fn py_new(period: usize, weights: Vec<f64>, price_type: Option<PriceType>) -> Self {
         Self::new(period, weights, price_type)
     }
 

--- a/nautilus_core/indicators/src/python/average/wma.rs
+++ b/nautilus_core/indicators/src/python/average/wma.rs
@@ -32,8 +32,8 @@ impl WeightedMovingAverage {
         period: usize,
         weights: Vec<f64>,
         price_type: Option<PriceType>,
-    ) -> PyResult<Self> {
-        Self::new(period, weights, price_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, weights, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/book/imbalance.rs
+++ b/nautilus_core/indicators/src/python/book/imbalance.rs
@@ -22,8 +22,8 @@ use crate::{book::imbalance::BookImbalanceRatio, indicator::Indicator};
 #[pymethods]
 impl BookImbalanceRatio {
     #[new]
-    fn py_new() -> PyResult<Self> {
-        Self::new().map_err(to_pyvalue_err)
+    fn py_new() -> Self {
+        Self::new()
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/amat.rs
+++ b/nautilus_core/indicators/src/python/momentum/amat.rs
@@ -29,8 +29,8 @@ impl ArcherMovingAveragesTrends {
         slow_period: usize,
         signal_period: usize,
         ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
-        Self::new(fast_period, slow_period, signal_period, ma_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(fast_period, slow_period, signal_period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/aroon.rs
+++ b/nautilus_core/indicators/src/python/momentum/aroon.rs
@@ -22,8 +22,8 @@ use crate::{indicator::Indicator, momentum::aroon::AroonOscillator};
 #[pymethods]
 impl AroonOscillator {
     #[new]
-    pub fn py_new(period: usize) -> PyResult<Self> {
-        Self::new(period).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize) -> Self {
+        Self::new(period)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/bb.rs
+++ b/nautilus_core/indicators/src/python/momentum/bb.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::bb::Boll
 #[pymethods]
 impl BollingerBands {
     #[new]
-    pub fn py_new(period: usize, k: f64, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, k, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, k: f64, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, k, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/bias.rs
+++ b/nautilus_core/indicators/src/python/momentum/bias.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::bias::Bi
 #[pymethods]
 impl Bias {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/cci.rs
+++ b/nautilus_core/indicators/src/python/momentum/cci.rs
@@ -24,11 +24,7 @@ use crate::{
 #[pymethods]
 impl CommodityChannelIndex {
     #[new]
-    pub fn py_new(
-        period: usize,
-        scalar: f64,
-        ma_type: Option<MovingAverageType>,
-    ) -> Self {
+    pub fn py_new(period: usize, scalar: f64, ma_type: Option<MovingAverageType>) -> Self {
         Self::new(period, scalar, ma_type)
     }
 

--- a/nautilus_core/indicators/src/python/momentum/cci.rs
+++ b/nautilus_core/indicators/src/python/momentum/cci.rs
@@ -28,8 +28,8 @@ impl CommodityChannelIndex {
         period: usize,
         scalar: f64,
         ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
-        Self::new(period, scalar, ma_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, scalar, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/cmo.rs
+++ b/nautilus_core/indicators/src/python/momentum/cmo.rs
@@ -24,8 +24,8 @@ use crate::{
 #[pymethods]
 impl ChandeMomentumOscillator {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     #[getter]

--- a/nautilus_core/indicators/src/python/momentum/dm.rs
+++ b/nautilus_core/indicators/src/python/momentum/dm.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::dm::Dire
 #[pymethods]
 impl DirectionalMovement {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/kvo.rs
+++ b/nautilus_core/indicators/src/python/momentum/kvo.rs
@@ -29,8 +29,8 @@ impl KlingerVolumeOscillator {
         slow_period: usize,
         signal_period: usize,
         ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
-        Self::new(fast_period, slow_period, signal_period, ma_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(fast_period, slow_period, signal_period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/macd.rs
+++ b/nautilus_core/indicators/src/python/momentum/macd.rs
@@ -34,8 +34,8 @@ impl MovingAverageConvergenceDivergence {
         slow_period: usize,
         ma_type: Option<MovingAverageType>,
         price_type: Option<PriceType>,
-    ) -> PyResult<Self> {
-        Self::new(fast_period, slow_period, ma_type, price_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(fast_period, slow_period, ma_type, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/obv.rs
+++ b/nautilus_core/indicators/src/python/momentum/obv.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::obv::OnB
 #[pymethods]
 impl OnBalanceVolume {
     #[new]
-    pub fn py_new(period: usize) -> PyResult<Self> {
-        Self::new(period).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize) -> Self {
+        Self::new(period)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/pressure.rs
+++ b/nautilus_core/indicators/src/python/momentum/pressure.rs
@@ -26,8 +26,8 @@ impl Pressure {
         period: usize,
         ma_type: Option<MovingAverageType>,
         atr_floor: Option<f64>,
-    ) -> PyResult<Self> {
-        Self::new(period, ma_type, atr_floor).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, ma_type, atr_floor)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/psl.rs
+++ b/nautilus_core/indicators/src/python/momentum/psl.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::psl::Psy
 #[pymethods]
 impl PsychologicalLine {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/roc.rs
+++ b/nautilus_core/indicators/src/python/momentum/roc.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::roc::Rat
 #[pymethods]
 impl RateOfChange {
     #[new]
-    pub fn py_new(period: usize, use_log: Option<bool>) -> PyResult<Self> {
-        Self::new(period, use_log).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, use_log: Option<bool>) -> Self {
+        Self::new(period, use_log)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/rsi.rs
+++ b/nautilus_core/indicators/src/python/momentum/rsi.rs
@@ -27,8 +27,8 @@ use crate::{
 #[pymethods]
 impl RelativeStrengthIndex {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/stochastics.rs
+++ b/nautilus_core/indicators/src/python/momentum/stochastics.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::stochast
 #[pymethods]
 impl Stochastics {
     #[new]
-    pub fn py_new(period_k: usize, period_d: usize) -> PyResult<Self> {
-        Self::new(period_k, period_d).map_err(to_pyvalue_err)
+    pub fn py_new(period_k: usize, period_d: usize) -> Self {
+        Self::new(period_k, period_d)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/swings.rs
+++ b/nautilus_core/indicators/src/python/momentum/swings.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, momentum::swings::
 #[pymethods]
 impl Swings {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/momentum/vhf.rs
+++ b/nautilus_core/indicators/src/python/momentum/vhf.rs
@@ -24,8 +24,8 @@ use crate::{
 #[pymethods]
 impl VerticalHorizontalFilter {
     #[new]
-    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> PyResult<Self> {
-        Self::new(period, ma_type).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize, ma_type: Option<MovingAverageType>) -> Self {
+        Self::new(period, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/ratio/efficiency_ratio.rs
+++ b/nautilus_core/indicators/src/python/ratio/efficiency_ratio.rs
@@ -22,8 +22,8 @@ use crate::{indicator::Indicator, ratio::efficiency_ratio::EfficiencyRatio};
 #[pymethods]
 impl EfficiencyRatio {
     #[new]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
-        Self::new(period, price_type).map_err(to_pyvalue_err)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self::new(period, price_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/ratio/spread_analyzer.rs
+++ b/nautilus_core/indicators/src/python/ratio/spread_analyzer.rs
@@ -25,8 +25,8 @@ use crate::{indicator::Indicator, ratio::spread_analyzer::SpreadAnalyzer};
 #[pymethods]
 impl SpreadAnalyzer {
     #[new]
-    fn py_new(instrument_id: InstrumentId, capacity: usize) -> PyResult<Self> {
-        Self::new(capacity, instrument_id).map_err(to_pyvalue_err)
+    fn py_new(instrument_id: InstrumentId, capacity: usize) -> Self {
+        Self::new(capacity, instrument_id)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/atr.rs
+++ b/nautilus_core/indicators/src/python/volatility/atr.rs
@@ -27,8 +27,8 @@ impl AverageTrueRange {
         ma_type: Option<MovingAverageType>,
         use_previous: Option<bool>,
         value_floor: Option<f64>,
-    ) -> PyResult<Self> {
-        Self::new(period, ma_type, use_previous, value_floor).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, ma_type, use_previous, value_floor)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/dc.rs
+++ b/nautilus_core/indicators/src/python/volatility/dc.rs
@@ -22,8 +22,8 @@ use crate::{average::MovingAverageType, indicator::Indicator, volatility::dc::Do
 #[pymethods]
 impl DonchianChannel {
     #[new]
-    pub fn py_new(period: usize) -> PyResult<Self> {
-        Self::new(period).map_err(to_pyvalue_err)
+    pub fn py_new(period: usize) -> Self {
+        Self::new(period)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/fuzzy.rs
+++ b/nautilus_core/indicators/src/python/volatility/fuzzy.rs
@@ -34,9 +34,9 @@ impl FuzzyCandle {
         body_size: CandleBodySize,
         upper_wick_size: CandleWickSize,
         lower_wick_size: CandleWickSize,
-    ) -> PyResult<Self> {
+    ) -> Self {
         Self::new(direction, size, body_size, upper_wick_size, lower_wick_size)
-            .map_err(to_pyvalue_err)
+            
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/fuzzy.rs
+++ b/nautilus_core/indicators/src/python/volatility/fuzzy.rs
@@ -36,7 +36,6 @@ impl FuzzyCandle {
         lower_wick_size: CandleWickSize,
     ) -> Self {
         Self::new(direction, size, body_size, upper_wick_size, lower_wick_size)
-            
     }
 
     fn __repr__(&self) -> String {
@@ -86,8 +85,8 @@ impl FuzzyCandlesticks {
         threshold2: f64,
         threshold3: f64,
         threshold4: f64,
-    ) -> PyResult<Self> {
-        Self::new(period, threshold1, threshold2, threshold3, threshold4).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, threshold1, threshold2, threshold3, threshold4)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/kc.rs
+++ b/nautilus_core/indicators/src/python/volatility/kc.rs
@@ -39,7 +39,6 @@ impl KeltnerChannel {
             use_previous,
             atr_floor,
         )
-        
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/kc.rs
+++ b/nautilus_core/indicators/src/python/volatility/kc.rs
@@ -30,7 +30,7 @@ impl KeltnerChannel {
         ma_type_atr: Option<MovingAverageType>,
         use_previous: Option<bool>,
         atr_floor: Option<f64>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         Self::new(
             period,
             k_multiplier,
@@ -39,7 +39,7 @@ impl KeltnerChannel {
             use_previous,
             atr_floor,
         )
-        .map_err(to_pyvalue_err)
+        
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/kp.rs
+++ b/nautilus_core/indicators/src/python/volatility/kp.rs
@@ -30,7 +30,7 @@ impl KeltnerPosition {
         ma_type_atr: Option<MovingAverageType>,
         use_previous: Option<bool>,
         atr_floor: Option<f64>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         Self::new(
             period,
             k_multiplier,
@@ -39,7 +39,7 @@ impl KeltnerPosition {
             use_previous,
             atr_floor,
         )
-        .map_err(to_pyvalue_err)
+        
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/kp.rs
+++ b/nautilus_core/indicators/src/python/volatility/kp.rs
@@ -39,7 +39,6 @@ impl KeltnerPosition {
             use_previous,
             atr_floor,
         )
-        
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/rvi.rs
+++ b/nautilus_core/indicators/src/python/volatility/rvi.rs
@@ -24,11 +24,7 @@ use crate::{
 #[pymethods]
 impl RelativeVolatilityIndex {
     #[new]
-    pub fn py_new(
-        period: usize,
-        scalar: Option<f64>,
-        ma_type: Option<MovingAverageType>,
-    ) -> Self {
+    pub fn py_new(period: usize, scalar: Option<f64>, ma_type: Option<MovingAverageType>) -> Self {
         Self::new(period, scalar, ma_type)
     }
 

--- a/nautilus_core/indicators/src/python/volatility/rvi.rs
+++ b/nautilus_core/indicators/src/python/volatility/rvi.rs
@@ -28,8 +28,8 @@ impl RelativeVolatilityIndex {
         period: usize,
         scalar: Option<f64>,
         ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
-        Self::new(period, scalar, ma_type).map_err(to_pyvalue_err)
+    ) -> Self {
+        Self::new(period, scalar, ma_type)
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/vr.rs
+++ b/nautilus_core/indicators/src/python/volatility/vr.rs
@@ -28,9 +28,9 @@ impl VolatilityRatio {
         use_previous: Option<bool>,
         value_floor: Option<f64>,
         ma_type: Option<MovingAverageType>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         Self::new(fast_period, slow_period, ma_type, use_previous, value_floor)
-            .map_err(to_pyvalue_err)
+            
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/python/volatility/vr.rs
+++ b/nautilus_core/indicators/src/python/volatility/vr.rs
@@ -30,7 +30,6 @@ impl VolatilityRatio {
         ma_type: Option<MovingAverageType>,
     ) -> Self {
         Self::new(fast_period, slow_period, ma_type, use_previous, value_floor)
-            
     }
 
     fn __repr__(&self) -> String {

--- a/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
+++ b/nautilus_core/indicators/src/ratio/efficiency_ratio.rs
@@ -80,15 +80,15 @@ impl Indicator for EfficiencyRatio {
 
 impl EfficiencyRatio {
     /// Creates a new [`EfficiencyRatio`] instance.
-    pub fn new(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
+        Self {
             period,
             price_type: price_type.unwrap_or(PriceType::Last),
             value: 0.0,
             inputs: Vec::with_capacity(period),
             deltas: Vec::with_capacity(period),
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, value: f64) {

--- a/nautilus_core/indicators/src/ratio/spread_analyzer.rs
+++ b/nautilus_core/indicators/src/ratio/spread_analyzer.rs
@@ -98,8 +98,8 @@ impl Indicator for SpreadAnalyzer {
 
 impl SpreadAnalyzer {
     /// Creates a new [`SpreadAnalyzer`] instance.
-    pub fn new(capacity: usize, instrument_id: InstrumentId) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(capacity: usize, instrument_id: InstrumentId) -> Self {
+        Self {
             capacity,
             instrument_id,
             current: 0.0,
@@ -107,7 +107,7 @@ impl SpreadAnalyzer {
             initialized: false,
             has_inputs: false,
             spreads: Vec::with_capacity(capacity),
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -114,54 +114,53 @@ pub fn bar_ethusdt_binance_minute_bid(#[default("1522")] close_price: &str) -> B
 ////////////////////////////////////////////////////////////////////////////////
 #[fixture]
 pub fn indicator_ama_10() -> AdaptiveMovingAverage {
-    AdaptiveMovingAverage::new(10, 2, 30, Some(PriceType::Mid)).unwrap()
+    AdaptiveMovingAverage::new(10, 2, 30, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_sma_10() -> SimpleMovingAverage {
-    SimpleMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+    SimpleMovingAverage::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_ema_10() -> ExponentialMovingAverage {
-    ExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+    ExponentialMovingAverage::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_hma_10() -> HullMovingAverage {
-    HullMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+    HullMovingAverage::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_rma_10() -> WilderMovingAverage {
-    WilderMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+    WilderMovingAverage::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_dema_10() -> DoubleExponentialMovingAverage {
-    DoubleExponentialMovingAverage::new(10, Some(PriceType::Mid)).unwrap()
+    DoubleExponentialMovingAverage::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_vidya_10() -> VariableIndexDynamicAverage {
     VariableIndexDynamicAverage::new(10, Some(PriceType::Mid), Some(MovingAverageType::Wilder))
-        .unwrap()
 }
 
 #[fixture]
 pub fn indicator_vwap() -> VolumeWeightedAveragePrice {
-    VolumeWeightedAveragePrice::new().unwrap()
+    VolumeWeightedAveragePrice::new()
 }
 
 #[fixture]
 pub fn indicator_wma_10() -> WeightedMovingAverage {
     let weights = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
-    WeightedMovingAverage::new(10, weights, Some(PriceType::Mid)).unwrap()
+    WeightedMovingAverage::new(10, weights, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn indicator_lr_10() -> LinearRegression {
-    LinearRegression::new(10).unwrap()
+    LinearRegression::new(10)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -169,12 +168,12 @@ pub fn indicator_lr_10() -> LinearRegression {
 ////////////////////////////////////////////////////////////////////////////////
 #[fixture]
 pub fn efficiency_ratio_10() -> EfficiencyRatio {
-    EfficiencyRatio::new(10, Some(PriceType::Mid)).unwrap()
+    EfficiencyRatio::new(10, Some(PriceType::Mid))
 }
 
 #[fixture]
 pub fn spread_analyzer_10() -> SpreadAnalyzer {
-    SpreadAnalyzer::new(10, InstrumentId::from("ETHUSDT-PERP.BINANCE")).unwrap()
+    SpreadAnalyzer::new(10, InstrumentId::from("ETHUSDT-PERP.BINANCE"))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -182,67 +181,67 @@ pub fn spread_analyzer_10() -> SpreadAnalyzer {
 ////////////////////////////////////////////////////////////////////////////////
 #[fixture]
 pub fn rsi_10() -> RelativeStrengthIndex {
-    RelativeStrengthIndex::new(10, Some(MovingAverageType::Exponential)).unwrap()
+    RelativeStrengthIndex::new(10, Some(MovingAverageType::Exponential))
 }
 
 #[fixture]
 pub fn cmo_10() -> ChandeMomentumOscillator {
-    ChandeMomentumOscillator::new(10, Some(MovingAverageType::Wilder)).unwrap()
+    ChandeMomentumOscillator::new(10, Some(MovingAverageType::Wilder))
 }
 
 #[fixture]
 pub fn bias_10() -> Bias {
-    Bias::new(10, Some(MovingAverageType::Wilder)).unwrap()
+    Bias::new(10, Some(MovingAverageType::Wilder))
 }
 
 #[fixture]
 pub fn vhf_10() -> VerticalHorizontalFilter {
-    VerticalHorizontalFilter::new(10, Some(MovingAverageType::Simple)).unwrap()
+    VerticalHorizontalFilter::new(10, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn kvo_345() -> KlingerVolumeOscillator {
-    KlingerVolumeOscillator::new(3, 4, 5, Some(MovingAverageType::Simple)).unwrap()
+    KlingerVolumeOscillator::new(3, 4, 5, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn dm_10() -> DirectionalMovement {
-    DirectionalMovement::new(10, Some(MovingAverageType::Simple)).unwrap()
+    DirectionalMovement::new(10, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn amat_345() -> ArcherMovingAveragesTrends {
-    ArcherMovingAveragesTrends::new(3, 4, 5, Some(MovingAverageType::Simple)).unwrap()
+    ArcherMovingAveragesTrends::new(3, 4, 5, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn swings_10() -> Swings {
-    Swings::new(10).unwrap()
+    Swings::new(10)
 }
 
 #[fixture]
 pub fn bb_10() -> BollingerBands {
-    BollingerBands::new(10, 0.1, Some(MovingAverageType::Simple)).unwrap()
+    BollingerBands::new(10, 0.1, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn stochastics_10() -> Stochastics {
-    Stochastics::new(10, 10).unwrap()
+    Stochastics::new(10, 10)
 }
 
 #[fixture]
 pub fn psl_10() -> PsychologicalLine {
-    PsychologicalLine::new(10, Some(MovingAverageType::Simple)).unwrap()
+    PsychologicalLine::new(10, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
 pub fn pressure_10() -> Pressure {
-    Pressure::new(10, Some(MovingAverageType::Simple), Some(1.0)).unwrap()
+    Pressure::new(10, Some(MovingAverageType::Simple), Some(1.0))
 }
 
 #[fixture]
 pub fn cci_10() -> CommodityChannelIndex {
-    CommodityChannelIndex::new(10, 2.0, Some(MovingAverageType::Simple)).unwrap()
+    CommodityChannelIndex::new(10, 2.0, Some(MovingAverageType::Simple))
 }
 
 #[fixture]
@@ -253,12 +252,11 @@ pub fn macd_10() -> MovingAverageConvergenceDivergence {
         Some(MovingAverageType::Simple),
         Some(PriceType::Bid),
     )
-    .unwrap()
 }
 
 #[fixture]
 pub fn obv_10() -> OnBalanceVolume {
-    OnBalanceVolume::new(10).unwrap()
+    OnBalanceVolume::new(10)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -273,17 +271,16 @@ pub fn vr_10() -> VolatilityRatio {
         Some(false),
         Some(10.0),
     )
-    .unwrap()
 }
 
 #[fixture]
 pub fn dc_10() -> DonchianChannel {
-    DonchianChannel::new(10).unwrap()
+    DonchianChannel::new(10)
 }
 
 #[fixture]
 pub fn rvi_10() -> RelativeVolatilityIndex {
-    RelativeVolatilityIndex::new(10, Some(10.0), Some(MovingAverageType::Simple)).unwrap()
+    RelativeVolatilityIndex::new(10, Some(10.0), Some(MovingAverageType::Simple))
 }
 
 #[fixture]
@@ -296,7 +293,6 @@ pub fn kc_10() -> KeltnerChannel {
         Some(true),
         Some(0.0),
     )
-    .unwrap()
 }
 
 #[fixture]
@@ -309,15 +305,14 @@ pub fn kp_10() -> KeltnerPosition {
         Some(true),
         Some(0.0),
     )
-    .unwrap()
 }
 
 #[fixture]
 pub fn roc_10() -> RateOfChange {
-    RateOfChange::new(10, Some(true)).unwrap()
+    RateOfChange::new(10, Some(true))
 }
 
 #[fixture]
 pub fn fuzzy_candlesticks_10() -> FuzzyCandlesticks {
-    FuzzyCandlesticks::new(10, 0.1, 0.15, 0.2, 0.3).unwrap()
+    FuzzyCandlesticks::new(10, 0.1, 0.15, 0.2, 0.3)
 }

--- a/nautilus_core/indicators/src/testing.rs
+++ b/nautilus_core/indicators/src/testing.rs
@@ -29,6 +29,8 @@
 /// # Example
 ///
 /// ```
+/// use nautilus_indicators::testing::approx_equal;
+///
 /// let a = 0.1 + 0.2;
 /// let b = 0.3;
 /// assert!(approx_equal(a, b));

--- a/nautilus_core/indicators/src/volatility/atr.rs
+++ b/nautilus_core/indicators/src/volatility/atr.rs
@@ -154,33 +154,31 @@ mod tests {
 
     #[rstest]
     fn test_name_returns_expected_string() {
-        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         assert_eq!(atr.name(), "AverageTrueRange");
     }
 
     #[rstest]
     fn test_str_repr_returns_expected_string() {
-        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), Some(true), Some(0.0))
-            .unwrap();
+        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), Some(true), Some(0.0));
         assert_eq!(format!("{atr}"), "AverageTrueRange(10,SIMPLE,true,0)");
     }
 
     #[rstest]
     fn test_period() {
-        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         assert_eq!(atr.period, 10);
     }
 
     #[rstest]
     fn test_initialized_without_inputs_returns_false() {
-        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         assert!(!atr.initialized());
     }
 
     #[rstest]
     fn test_initialized_with_required_inputs_returns_true() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         for _ in 0..10 {
             atr.update_raw(1.0, 1.0, 1.0);
         }
@@ -189,14 +187,13 @@ mod tests {
 
     #[rstest]
     fn test_value_with_no_inputs_returns_zero() {
-        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         assert_eq!(atr.value, 0.0);
     }
 
     #[rstest]
     fn test_value_with_epsilon_input() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         let epsilon = std::f64::EPSILON;
         atr.update_raw(epsilon, epsilon, epsilon);
         assert_eq!(atr.value, 0.0);
@@ -204,24 +201,21 @@ mod tests {
 
     #[rstest]
     fn test_value_with_one_ones_input() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         atr.update_raw(1.0, 1.0, 1.0);
         assert_eq!(atr.value, 0.0);
     }
 
     #[rstest]
     fn test_value_with_one_input() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         atr.update_raw(1.00020, 1.0, 1.00010);
         assert!(approx_equal(atr.value, 0.0002));
     }
 
     #[rstest]
     fn test_value_with_three_inputs() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         atr.update_raw(1.00020, 1.0, 1.00010);
         atr.update_raw(1.00020, 1.0, 1.00010);
         atr.update_raw(1.00020, 1.0, 1.00010);
@@ -230,8 +224,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_close_on_high() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         let mut high = 1.00010;
         let mut low = 1.0;
         for _ in 0..1000 {
@@ -245,8 +238,7 @@ mod tests {
 
     #[rstest]
     fn test_value_with_close_on_low() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         let mut high = 1.00010;
         let mut low = 1.0;
         for _ in 0..1000 {
@@ -262,7 +254,7 @@ mod tests {
     fn test_floor_with_ten_ones_inputs() {
         let floor = 0.00005;
         let mut floored_atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, Some(floor)).unwrap();
+            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, Some(floor));
         for _ in 0..20 {
             floored_atr.update_raw(1.0, 1.0, 1.0);
         }
@@ -273,7 +265,7 @@ mod tests {
     fn test_floor_with_exponentially_decreasing_high_inputs() {
         let floor = 0.00005;
         let mut floored_atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, Some(floor)).unwrap();
+            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, Some(floor));
         let mut high = 1.00020;
         let low = 1.0;
         let close = 1.0;
@@ -286,8 +278,7 @@ mod tests {
 
     #[rstest]
     fn test_reset_successfully_returns_indicator_to_fresh_state() {
-        let mut atr =
-            AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None).unwrap();
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
         for _ in 0..1000 {
             atr.update_raw(1.00010, 1.0, 1.00005);
         }

--- a/nautilus_core/indicators/src/volatility/atr.rs
+++ b/nautilus_core/indicators/src/volatility/atr.rs
@@ -89,8 +89,8 @@ impl AverageTrueRange {
         ma_type: Option<MovingAverageType>,
         use_previous: Option<bool>,
         value_floor: Option<f64>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
             use_previous: use_previous.unwrap_or(true),
@@ -101,7 +101,7 @@ impl AverageTrueRange {
             ma: MovingAverageFactory::create(MovingAverageType::Simple, period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/volatility/dc.rs
+++ b/nautilus_core/indicators/src/volatility/dc.rs
@@ -75,8 +75,8 @@ impl Indicator for DonchianChannel {
 
 impl DonchianChannel {
     /// Creates a new [`DonchianChannel`] instance.
-    pub fn new(period: usize) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new(period: usize) -> Self {
+        Self {
             period,
             upper: 0.0,
             middle: 0.0,
@@ -85,7 +85,7 @@ impl DonchianChannel {
             lower_prices: VecDeque::with_capacity(period),
             has_inputs: false,
             initialized: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64) {

--- a/nautilus_core/indicators/src/volatility/fuzzy.rs
+++ b/nautilus_core/indicators/src/volatility/fuzzy.rs
@@ -117,14 +117,14 @@ impl FuzzyCandle {
         body_size: CandleBodySize,
         upper_wick_size: CandleWickSize,
         lower_wick_size: CandleWickSize,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             direction,
             size,
             body_size,
             upper_wick_size,
             lower_wick_size,
-        })
+        }
     }
 }
 

--- a/nautilus_core/indicators/src/volatility/fuzzy.rs
+++ b/nautilus_core/indicators/src/volatility/fuzzy.rs
@@ -218,8 +218,8 @@ impl FuzzyCandlesticks {
         threshold2: f64,
         threshold3: f64,
         threshold4: f64,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             threshold1,
             threshold2,
@@ -232,8 +232,7 @@ impl FuzzyCandlesticks {
                 CandleBodySize::None,
                 CandleWickSize::None,
                 CandleWickSize::None,
-            )
-            .unwrap(),
+            ),
             has_inputs: false,
             initialized: false,
             lengths: VecDeque::with_capacity(period),
@@ -244,7 +243,7 @@ impl FuzzyCandlesticks {
             last_high: 0.0,
             last_low: 0.0,
             last_close: 0.0,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, open: f64, high: f64, low: f64, close: f64) {
@@ -308,8 +307,7 @@ impl FuzzyCandlesticks {
                 mean_lower_wick_percent,
                 sd_lower_wick_percent,
             ),
-        )
-        .unwrap();
+        );
 
         self.vector = vec![
             self.value.direction as i32,
@@ -331,8 +329,7 @@ impl FuzzyCandlesticks {
             CandleBodySize::None,
             CandleWickSize::None,
             CandleWickSize::None,
-        )
-        .unwrap();
+        );
         self.vector = Vec::new();
         self.last_open = 0.0;
         self.last_high = 0.0;

--- a/nautilus_core/indicators/src/volatility/kc.rs
+++ b/nautilus_core/indicators/src/volatility/kc.rs
@@ -88,8 +88,8 @@ impl KeltnerChannel {
         ma_type_atr: Option<MovingAverageType>,
         use_previous: Option<bool>,
         atr_floor: Option<f64>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             k_multiplier,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -103,7 +103,7 @@ impl KeltnerChannel {
             initialized: false,
             ma: MovingAverageFactory::create(ma_type.unwrap_or(MovingAverageType::Simple), period),
             atr: AverageTrueRange::new(period, ma_type_atr, use_previous, atr_floor)?,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/volatility/kc.rs
+++ b/nautilus_core/indicators/src/volatility/kc.rs
@@ -102,7 +102,7 @@ impl KeltnerChannel {
             has_inputs: false,
             initialized: false,
             ma: MovingAverageFactory::create(ma_type.unwrap_or(MovingAverageType::Simple), period),
-            atr: AverageTrueRange::new(period, ma_type_atr, use_previous, atr_floor)?,
+            atr: AverageTrueRange::new(period, ma_type_atr, use_previous, atr_floor),
         }
     }
 

--- a/nautilus_core/indicators/src/volatility/kp.rs
+++ b/nautilus_core/indicators/src/volatility/kp.rs
@@ -106,7 +106,7 @@ impl KeltnerPosition {
                 ma_type_atr,
                 use_previous,
                 atr_floor,
-            )
+            ),
         }
     }
 

--- a/nautilus_core/indicators/src/volatility/kp.rs
+++ b/nautilus_core/indicators/src/volatility/kp.rs
@@ -88,8 +88,8 @@ impl KeltnerPosition {
         ma_type_atr: Option<MovingAverageType>,
         use_previous: Option<bool>,
         atr_floor: Option<f64>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             k_multiplier,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -107,8 +107,7 @@ impl KeltnerPosition {
                 use_previous,
                 atr_floor,
             )
-            .unwrap(),
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {

--- a/nautilus_core/indicators/src/volatility/rvi.rs
+++ b/nautilus_core/indicators/src/volatility/rvi.rs
@@ -97,8 +97,8 @@ impl RelativeVolatilityIndex {
         period: usize,
         scalar: Option<f64>,
         ma_type: Option<MovingAverageType>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             period,
             scalar: scalar.unwrap_or(100.0),
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -117,7 +117,7 @@ impl RelativeVolatilityIndex {
             previous_close: 0.0,
             std: 0.0,
             has_inputs: false,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, close: f64) {

--- a/nautilus_core/indicators/src/volatility/rvi.rs
+++ b/nautilus_core/indicators/src/volatility/rvi.rs
@@ -93,11 +93,7 @@ impl Indicator for RelativeVolatilityIndex {
 
 impl RelativeVolatilityIndex {
     /// Creates a new [`RelativeVolatilityIndex`] instance.
-    pub fn new(
-        period: usize,
-        scalar: Option<f64>,
-        ma_type: Option<MovingAverageType>,
-    ) -> Self {
+    pub fn new(period: usize, scalar: Option<f64>, ma_type: Option<MovingAverageType>) -> Self {
         Self {
             period,
             scalar: scalar.unwrap_or(100.0),

--- a/nautilus_core/indicators/src/volatility/vr.rs
+++ b/nautilus_core/indicators/src/volatility/vr.rs
@@ -95,8 +95,8 @@ impl VolatilityRatio {
             value: 0.0,
             has_inputs: false,
             initialized: false,
-            atr_fast: AverageTrueRange::new(fast_period, ma_type, use_previous, value_floor)?,
-            atr_slow: AverageTrueRange::new(slow_period, ma_type, use_previous, value_floor)?,
+            atr_fast: AverageTrueRange::new(fast_period, ma_type, use_previous, value_floor),
+            atr_slow: AverageTrueRange::new(slow_period, ma_type, use_previous, value_floor),
         }
     }
 

--- a/nautilus_core/indicators/src/volatility/vr.rs
+++ b/nautilus_core/indicators/src/volatility/vr.rs
@@ -85,8 +85,8 @@ impl VolatilityRatio {
         ma_type: Option<MovingAverageType>,
         use_previous: Option<bool>,
         value_floor: Option<f64>,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             fast_period,
             slow_period,
             ma_type: ma_type.unwrap_or(MovingAverageType::Simple),
@@ -97,7 +97,7 @@ impl VolatilityRatio {
             initialized: false,
             atr_fast: AverageTrueRange::new(fast_period, ma_type, use_previous, value_floor)?,
             atr_slow: AverageTrueRange::new(slow_period, ma_type, use_previous, value_floor)?,
-        })
+        }
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {


### PR DESCRIPTION
# Pull Request

Only VWAP indicator requires assertion. Because of it all other indicators return result type. The VWAP condition check as been made an assertion and all Results have been removed.

Related #1848 

## Type of change

- [x] Refactor

## How has this change been tested?

All indicator tests passing.
