### PR TITLE
Refactor BarType for aggregating bars into other bars 

### DIFF
--- a/nautilus_core/common/src/cache/mod.rs
+++ b/nautilus_core/common/src/cache/mod.rs
@@ -2574,15 +2574,15 @@ impl Cache {
         let mut bar_types = self
             .bars
             .keys()
-            .filter(|bar_type| bar_type.aggregation_source == aggregation_source)
+            .filter(|bar_type| bar_type.aggregation_source() == aggregation_source)
             .collect::<Vec<&BarType>>();
 
         if let Some(instrument_id) = instrument_id {
-            bar_types.retain(|bar_type| &bar_type.instrument_id == instrument_id);
+            bar_types.retain(|bar_type| bar_type.instrument_id() == *instrument_id);
         }
 
         if let Some(price_type) = price_type {
-            bar_types.retain(|bar_type| &bar_type.spec.price_type == price_type);
+            bar_types.retain(|bar_type| &bar_type.spec().price_type == price_type);
         }
 
         bar_types

--- a/nautilus_core/data/src/aggregation.rs
+++ b/nautilus_core/data/src/aggregation.rs
@@ -46,8 +46,8 @@ pub trait BarAggregator {
     /// Updates the aggregator with the given quote.
     fn handle_quote_tick(&mut self, quote: QuoteTick) {
         self.update(
-            quote.extract_price(self.bar_type().spec.price_type),
-            quote.extract_size(self.bar_type().spec.price_type),
+            quote.extract_price(self.bar_type().spec().price_type),
+            quote.extract_size(self.bar_type().spec().price_type),
             quote.ts_event,
         );
     }
@@ -84,13 +84,13 @@ impl BarBuilder {
     pub fn new(instrument: &InstrumentAny, bar_type: BarType) -> Self {
         correctness::check_equal(
             instrument.id(),
-            bar_type.instrument_id,
+            bar_type.instrument_id(),
             "instrument.id",
             "bar_type.instrument_id",
         )
         .expect(FAILED);
         correctness::check_equal(
-            bar_type.aggregation_source,
+            bar_type.aggregation_source(),
             AggregationSource::Internal,
             "bar_type.aggregation_source",
             "AggregationSource::Internal",
@@ -302,7 +302,7 @@ impl BarAggregator for TickBarAggregator {
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos) {
         self.core.apply_update(price, size, ts_event);
 
-        if self.core.builder.count >= self.core.bar_type.spec.step {
+        if self.core.builder.count >= self.core.bar_type.spec().step {
             self.core.build_now_and_send();
         }
     }
@@ -341,7 +341,7 @@ impl BarAggregator for VolumeBarAggregator {
     #[allow(unused_assignments)] // Temp for development
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos) {
         let mut raw_size_update = size.raw;
-        let raw_step = (self.core.bar_type.spec.step as f64 * FIXED_SCALAR) as u64;
+        let raw_step = (self.core.bar_type.spec().step as f64 * FIXED_SCALAR) as u64;
         let mut raw_size_diff = 0;
 
         while raw_size_update > 0 {
@@ -413,14 +413,14 @@ impl BarAggregator for ValueBarAggregator {
 
         while size_update > 0.0 {
             let value_update = price.as_f64() * size_update;
-            if self.cum_value + value_update < self.core.bar_type.spec.step as f64 {
+            if self.cum_value + value_update < self.core.bar_type.spec().step as f64 {
                 self.cum_value += value_update;
                 self.core
                     .apply_update(price, Quantity::new(size_update, size.precision), ts_event);
                 break;
             }
 
-            let value_diff = self.core.bar_type.spec.step as f64 - self.cum_value;
+            let value_diff = self.core.bar_type.spec().step as f64 - self.cum_value;
             let size_diff = size_update * (value_diff / value_update);
             self.core
                 .apply_update(price, Quantity::new(size_diff, size.precision), ts_event);

--- a/nautilus_core/data/src/aggregation.rs
+++ b/nautilus_core/data/src/aggregation.rs
@@ -45,9 +45,11 @@ pub trait BarAggregator {
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos);
     /// Updates the aggregator with the given quote.
     fn handle_quote_tick(&mut self, quote: QuoteTick) {
+        let spec = self.bar_type().spec();
+
         self.update(
-            quote.extract_price(self.bar_type().spec().price_type),
-            quote.extract_size(self.bar_type().spec().price_type),
+            quote.extract_price(spec.price_type),
+            quote.extract_size(spec.price_type),
             quote.ts_event,
         );
     }
@@ -301,8 +303,9 @@ impl BarAggregator for TickBarAggregator {
     /// Apply the given update to the aggregator.
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos) {
         self.core.apply_update(price, size, ts_event);
+        let spec = self.core.bar_type.spec();
 
-        if self.core.builder.count >= self.core.bar_type.spec().step {
+        if self.core.builder.count >= spec.step {
             self.core.build_now_and_send();
         }
     }
@@ -341,7 +344,8 @@ impl BarAggregator for VolumeBarAggregator {
     #[allow(unused_assignments)] // Temp for development
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos) {
         let mut raw_size_update = size.raw;
-        let raw_step = (self.core.bar_type.spec().step as f64 * FIXED_SCALAR) as u64;
+        let spec = self.core.bar_type.spec();
+        let raw_step = (spec.step as f64 * FIXED_SCALAR) as u64;
         let mut raw_size_diff = 0;
 
         while raw_size_update > 0 {
@@ -410,17 +414,18 @@ impl BarAggregator for ValueBarAggregator {
     /// Apply the given update to the aggregator.
     fn update(&mut self, price: Price, size: Quantity, ts_event: UnixNanos) {
         let mut size_update = size.as_f64();
+        let spec = self.core.bar_type.spec();
 
         while size_update > 0.0 {
             let value_update = price.as_f64() * size_update;
-            if self.cum_value + value_update < self.core.bar_type.spec().step as f64 {
+            if self.cum_value + value_update < spec.step as f64 {
                 self.cum_value += value_update;
                 self.core
                     .apply_update(price, Quantity::new(size_update, size.precision), ts_event);
                 break;
             }
 
-            let value_diff = self.core.bar_type.spec().step as f64 - self.cum_value;
+            let value_diff = spec.step as f64 - self.cum_value;
             let size_diff = size_update * (value_diff / value_update);
             self.core
                 .apply_update(price, Quantity::new(size_diff, size.precision), ts_event);

--- a/nautilus_core/data/src/client.rs
+++ b/nautilus_core/data/src/client.rs
@@ -639,7 +639,7 @@ impl DataClientAdapter {
         DataResponse::new(
             correlation_id,
             self.client_id,
-            bar_type.instrument_id.venue,
+            bar_type.instrument_id().venue,
             data_type,
             data,
             self.clock.timestamp_ns(),

--- a/nautilus_core/data/src/engine/mod.rs
+++ b/nautilus_core/data/src/engine/mod.rs
@@ -532,7 +532,7 @@ impl DataEngine {
             .cache
             .as_ref()
             .borrow_mut()
-            .order_book(data.instrument_id())
+            .order_book(&data.instrument_id())
         {
             match data {
                 Data::Delta(delta) => book.apply_delta(delta),

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -92,7 +92,7 @@ pub fn bar_ethusdt_binance_minute_bid(#[default("1522")] close_price: &str) -> B
         aggregation: BarAggregation::Minute,
         price_type: PriceType::Bid,
     };
-    let bar_type = BarType {
+    let bar_type = BarType::StandardBar {
         instrument_id,
         spec: bar_spec,
         aggregation_source: AggregationSource::External,

--- a/nautilus_core/indicators/src/stubs.rs
+++ b/nautilus_core/indicators/src/stubs.rs
@@ -92,7 +92,7 @@ pub fn bar_ethusdt_binance_minute_bid(#[default("1522")] close_price: &str) -> B
         aggregation: BarAggregation::Minute,
         price_type: PriceType::Bid,
     };
-    let bar_type = BarType::StandardBar {
+    let bar_type = BarType::Standard {
         instrument_id,
         spec: bar_spec,
         aggregation_source: AggregationSource::External,

--- a/nautilus_core/infrastructure/src/sql/queries.rs
+++ b/nautilus_core/infrastructure/src/sql/queries.rs
@@ -680,11 +680,11 @@ impl DatabaseQueries {
                 instrument_id = $1, step = $2, bar_aggregation = $3::bar_aggregation, price_type = $4::price_type, aggregation_source = $5::aggregation_source,
                 open = $6, high = $7, low = $8, close = $9, volume = $10, ts_event = $11, ts_init = $12, updated_at = CURRENT_TIMESTAMP
         "#)
-            .bind(bar.bar_type.instrument_id.to_string())
-            .bind(bar.bar_type.spec.step as i32)
-            .bind(BarAggregationModel(bar.bar_type.spec.aggregation))
-            .bind(PriceTypeModel(bar.bar_type.spec.price_type))
-            .bind(AggregationSourceModel(bar.bar_type.aggregation_source))
+            .bind(bar.bar_type.instrument_id().to_string())
+            .bind(bar.bar_type.spec().step as i32)
+            .bind(BarAggregationModel(bar.bar_type.spec().aggregation))
+            .bind(PriceTypeModel(bar.bar_type.spec().price_type))
+            .bind(AggregationSourceModel(bar.bar_type.aggregation_source()))
             .bind(bar.open.to_string())
             .bind(bar.high.to_string())
             .bind(bar.low.to_string())

--- a/nautilus_core/model/src/data/bar.rs
+++ b/nautilus_core/model/src/data/bar.rs
@@ -41,12 +41,14 @@ use crate::{
 ///
 /// Panics if the aggregation method of the given `bar_type` is not time based.
 pub fn get_bar_interval(bar_type: &BarType) -> TimeDelta {
-    match bar_type.spec.aggregation {
-        BarAggregation::Millisecond => TimeDelta::milliseconds(bar_type.spec.step as i64),
-        BarAggregation::Second => TimeDelta::seconds(bar_type.spec.step as i64),
-        BarAggregation::Minute => TimeDelta::minutes(bar_type.spec.step as i64),
-        BarAggregation::Hour => TimeDelta::hours(bar_type.spec.step as i64),
-        BarAggregation::Day => TimeDelta::days(bar_type.spec.step as i64),
+    let spec = bar_type.spec();
+
+    match spec.aggregation {
+        BarAggregation::Millisecond => TimeDelta::milliseconds(spec.step as i64),
+        BarAggregation::Second => TimeDelta::seconds(spec.step as i64),
+        BarAggregation::Minute => TimeDelta::minutes(spec.step as i64),
+        BarAggregation::Hour => TimeDelta::hours(spec.step as i64),
+        BarAggregation::Day => TimeDelta::days(spec.step as i64),
         _ => panic!("Aggregation not time based"),
     }
 }
@@ -65,9 +67,10 @@ pub fn get_bar_interval_ns(bar_type: &BarType) -> UnixNanos {
 
 /// Returns the time bar start as a timezone-aware `DateTime<Utc>`.
 pub fn get_time_bar_start(now: DateTime<Utc>, bar_type: &BarType) -> DateTime<Utc> {
-    let step = bar_type.spec.step;
+    let spec = bar_type.spec();
+    let step = spec.step;
 
-    match bar_type.spec.aggregation {
+    match spec.aggregation {
         BarAggregation::Millisecond => {
             let diff_milliseconds = now.timestamp_subsec_millis() as usize % step;
             now - TimeDelta::milliseconds(diff_milliseconds as i64)
@@ -97,7 +100,7 @@ pub fn get_time_bar_start(now: DateTime<Utc>, bar_type: &BarType) -> DateTime<Ut
         }
         _ => panic!(
             "Aggregation type {} not supported for time bars",
-            bar_type.spec.aggregation
+            spec.aggregation
         ),
     }
 }
@@ -146,13 +149,30 @@ impl Display for BarSpecification {
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")
 )]
-pub struct BarType {
-    /// The bar types instrument ID.
-    pub instrument_id: InstrumentId,
-    /// The bar types specification.
-    pub spec: BarSpecification,
-    /// The bar types aggregation source.
-    pub aggregation_source: AggregationSource,
+pub enum BarType {
+    StandardBar {
+        /// The bar types instrument ID.
+        instrument_id: InstrumentId,
+        /// The bar types specification.
+        spec: BarSpecification,
+        /// The bar types aggregation source.
+        aggregation_source: AggregationSource,
+    },
+    CompositeBar {
+        /// The bar types instrument ID.
+        instrument_id: InstrumentId,
+        /// The bar types specification.
+        spec: BarSpecification,
+        /// The bar types aggregation source.
+        aggregation_source: AggregationSource,
+
+        /// The composite bar types instrument ID.
+        composite_instrument_id: InstrumentId,
+        /// The composite bar types specification.
+        composite_spec: BarSpecification,
+        /// The composite bar types aggregation source.
+        composite_aggregation_source: AggregationSource,
+    },
 }
 
 impl BarType {
@@ -163,10 +183,114 @@ impl BarType {
         spec: BarSpecification,
         aggregation_source: AggregationSource,
     ) -> Self {
-        Self {
+        Self::StandardBar {
             instrument_id,
             spec,
             aggregation_source,
+        }
+    }
+
+    pub fn new_composite(
+        instrument_id: InstrumentId,
+        spec: BarSpecification,
+        aggregation_source: AggregationSource,
+
+        composite_instrument_id: InstrumentId,
+        composite_spec: BarSpecification,
+        composite_aggregation_source: AggregationSource,
+    ) -> Self {
+        Self::CompositeBar {
+            instrument_id,
+            spec,
+            aggregation_source,
+
+            composite_instrument_id,
+            composite_spec,
+            composite_aggregation_source,
+        }
+    }
+
+    pub fn from_bar_types(standard_bar: &Self, composite_bar: &Self) -> Self {
+        Self::CompositeBar {
+            instrument_id: standard_bar.instrument_id(),
+            spec: standard_bar.spec(),
+            aggregation_source: standard_bar.aggregation_source(),
+
+            composite_instrument_id: composite_bar.instrument_id(),
+            composite_spec: composite_bar.spec(),
+            composite_aggregation_source: composite_bar.aggregation_source(),
+        }
+    }
+
+    pub fn is_standard(&self) -> bool {
+        match &self {
+            BarType::StandardBar { .. } => true,
+            BarType::CompositeBar { .. } => false,
+        }
+    }
+
+    pub fn is_composite(&self) -> bool {
+        match &self {
+            BarType::StandardBar { .. } => false,
+            BarType::CompositeBar { .. } => true,
+        }
+    }
+
+    pub fn standard(&self) -> Self {
+        match &self {
+            &&b @ BarType::StandardBar { .. } => b,
+            BarType::CompositeBar {
+                instrument_id,
+                spec,
+                aggregation_source,
+
+                composite_instrument_id: _,
+                composite_spec: _,
+                composite_aggregation_source: _,
+            } => Self::new(*instrument_id, *spec, *aggregation_source),
+        }
+    }
+
+    pub fn composite(&self) -> Self {
+        match &self {
+            &&b @ BarType::StandardBar { .. } => b, // case shouldn't be used if is_composite is called before
+            BarType::CompositeBar {
+                instrument_id: _,
+                spec: _,
+                aggregation_source: _,
+
+                composite_instrument_id,
+                composite_spec,
+                composite_aggregation_source,
+            } => Self::new(
+                *composite_instrument_id,
+                *composite_spec,
+                *composite_aggregation_source,
+            ),
+        }
+    }
+
+    pub fn instrument_id(&self) -> InstrumentId {
+        match &self {
+            BarType::StandardBar { instrument_id, .. }
+            | BarType::CompositeBar { instrument_id, .. } => *instrument_id,
+        }
+    }
+
+    pub fn spec(&self) -> BarSpecification {
+        match &self {
+            BarType::StandardBar { spec, .. } | BarType::CompositeBar { spec, .. } => *spec,
+        }
+    }
+
+    pub fn aggregation_source(&self) -> AggregationSource {
+        match &self {
+            BarType::StandardBar {
+                aggregation_source, ..
+            }
+            | BarType::CompositeBar {
+                aggregation_source, ..
+            } => *aggregation_source,
         }
     }
 }
@@ -183,7 +307,11 @@ impl FromStr for BarType {
     type Err = BarTypeParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pieces: Vec<&str> = s.rsplitn(5, '-').collect();
+        let parts: Vec<&str> = s.split('@').collect();
+        let bar_type_str = parts[0];
+        let composite_bar_type_str = parts.get(1);
+
+        let pieces: Vec<&str> = bar_type_str.rsplitn(5, '-').collect();
         let rev_pieces: Vec<&str> = pieces.into_iter().rev().collect();
         if rev_pieces.len() != 5 {
             return Err(BarTypeParseError {
@@ -223,15 +351,81 @@ impl FromStr for BarType {
                 position: 4,
             })?;
 
-        Ok(Self {
-            instrument_id,
-            spec: BarSpecification {
-                step,
-                aggregation,
-                price_type,
-            },
-            aggregation_source,
-        })
+        if let Some(composite_str) = composite_bar_type_str {
+            let composite_pieces: Vec<&str> = composite_str.rsplitn(5, '-').collect();
+            let rev_composite_pieces: Vec<&str> = composite_pieces.into_iter().rev().collect();
+            if rev_composite_pieces.len() != 5 {
+                return Err(BarTypeParseError {
+                    input: s.to_string(),
+                    token: String::new(),
+                    position: 5,
+                });
+            }
+
+            let composite_instrument_id =
+                InstrumentId::from_str(rev_composite_pieces[0]).map_err(|_| BarTypeParseError {
+                    input: s.to_string(),
+                    token: rev_composite_pieces[0].to_string(),
+                    position: 5,
+                })?;
+
+            let composite_step =
+                rev_composite_pieces[1]
+                    .parse()
+                    .map_err(|_| BarTypeParseError {
+                        input: s.to_string(),
+                        token: rev_composite_pieces[1].to_string(),
+                        position: 6,
+                    })?;
+            let composite_aggregation =
+                BarAggregation::from_str(rev_composite_pieces[2]).map_err(|_| {
+                    BarTypeParseError {
+                        input: s.to_string(),
+                        token: rev_composite_pieces[2].to_string(),
+                        position: 7,
+                    }
+                })?;
+            let composite_price_type =
+                PriceType::from_str(rev_composite_pieces[3]).map_err(|_| BarTypeParseError {
+                    input: s.to_string(),
+                    token: rev_composite_pieces[3].to_string(),
+                    position: 8,
+                })?;
+            let composite_aggregation_source = AggregationSource::from_str(rev_composite_pieces[4])
+                .map_err(|_| BarTypeParseError {
+                    input: s.to_string(),
+                    token: rev_composite_pieces[4].to_string(),
+                    position: 9,
+                })?;
+
+            Ok(Self::CompositeBar {
+                instrument_id,
+                spec: BarSpecification {
+                    step,
+                    aggregation,
+                    price_type,
+                },
+                aggregation_source,
+
+                composite_instrument_id,
+                composite_spec: BarSpecification {
+                    step: composite_step,
+                    aggregation: composite_aggregation,
+                    price_type: composite_price_type,
+                },
+                composite_aggregation_source,
+            })
+        } else {
+            Ok(Self::StandardBar {
+                instrument_id,
+                spec: BarSpecification {
+                    step,
+                    aggregation,
+                    price_type,
+                },
+                aggregation_source,
+            })
+        }
     }
 }
 
@@ -240,13 +434,37 @@ impl From<&str> for BarType {
         Self::from_str(value).expect(FAILED)
     }
 }
+
 impl Display for BarType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}-{}-{}",
-            self.instrument_id, self.spec, self.aggregation_source
-        )
+        match &self {
+            BarType::StandardBar {
+                instrument_id,
+                spec,
+                aggregation_source,
+            } => {
+                write!(f, "{}-{}-{}", instrument_id, spec, aggregation_source)
+            }
+            BarType::CompositeBar {
+                instrument_id,
+                spec,
+                aggregation_source,
+                composite_instrument_id,
+                composite_spec,
+                composite_aggregation_source,
+            } => {
+                write!(
+                    f,
+                    "{}-{}-{}@{}-{}-{}",
+                    instrument_id,
+                    spec,
+                    aggregation_source,
+                    composite_instrument_id,
+                    composite_spec,
+                    composite_aggregation_source
+                )
+            }
+        }
     }
 }
 
@@ -329,7 +547,7 @@ impl Bar {
         size_precision: u8,
     ) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
-        let instrument_id = bar_type.instrument_id;
+        let instrument_id = bar_type.instrument_id();
         metadata.insert("bar_type".to_string(), bar_type.to_string());
         metadata.insert("instrument_id".to_string(), instrument_id.to_string());
         metadata.insert("price_precision".to_string(), price_precision.to_string());
@@ -379,10 +597,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::{
-        enums::BarAggregation,
-        identifiers::{Symbol, Venue},
-    };
+    use crate::identifiers::{Symbol, Venue};
 
     #[rstest]
     #[case(BarAggregation::Millisecond, 1, TimeDelta::milliseconds(1))]
@@ -402,7 +617,7 @@ mod tests {
         #[case] step: usize,
         #[case] expected: TimeDelta,
     ) {
-        let bar_type = BarType {
+        let bar_type = BarType::StandardBar {
             instrument_id: InstrumentId::from("BTCUSDT-PERP.BINANCE"),
             spec: BarSpecification {
                 step,
@@ -434,7 +649,7 @@ mod tests {
         #[case] step: usize,
         #[case] expected: UnixNanos,
     ) {
-        let bar_type = BarType {
+        let bar_type = BarType::StandardBar {
             instrument_id: InstrumentId::from("BTCUSDT-PERP.BINANCE"),
             spec: BarSpecification {
                 step,
@@ -454,81 +669,81 @@ mod tests {
     BarAggregation::Millisecond,
     1,
     Utc.timestamp_opt(1658349296, 123_000_000).unwrap(),  // 2024-07-21 12:34:56.123 UTC
-)]
+    )]
     #[rstest]
     #[case::millisecond(
     Utc.timestamp_opt(1658349296, 123_000_000).unwrap(), // 2024-07-21 12:34:56.123 UTC
     BarAggregation::Millisecond,
     10,
     Utc.timestamp_opt(1658349296, 120_000_000).unwrap(),  // 2024-07-21 12:34:56.120 UTC
-)]
+    )]
     #[case::second(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Millisecond,
     1000,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap()
-)]
+    )]
     #[case::second(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Second,
     1,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap()
-)]
+    )]
     #[case::second(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Second,
     5,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 55).unwrap()
-)]
+    )]
     #[case::second(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Second,
     60,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 0).unwrap()
-)]
+    )]
     #[case::minute(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Minute,
     1,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 0).unwrap()
-)]
+    )]
     #[case::minute(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Minute,
     5,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 30, 0).unwrap()
-)]
+    )]
     #[case::minute(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Minute,
     60,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 0, 0).unwrap()
-)]
+    )]
     #[case::hour(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Hour,
     1,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 0, 0).unwrap()
-)]
+    )]
     #[case::hour(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Hour,
     2,
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 0, 0).unwrap()
-)]
+    )]
     #[case::day(
     Utc.with_ymd_and_hms(2024, 7, 21, 12, 34, 56).unwrap(),
     BarAggregation::Day,
     1,
     Utc.with_ymd_and_hms(2024, 7, 21, 0, 0, 0).unwrap()
-)]
+    )]
     fn test_get_time_bar_start(
         #[case] now: DateTime<Utc>,
         #[case] aggregation: BarAggregation,
         #[case] step: usize,
         #[case] expected: DateTime<Utc>,
     ) {
-        let bar_type = BarType {
+        let bar_type = BarType::StandardBar {
             instrument_id: InstrumentId::from("BTCUSDT-PERP.BINANCE"),
             spec: BarSpecification {
                 step,
@@ -559,19 +774,89 @@ mod tests {
         let bar_type = BarType::from(input);
 
         assert_eq!(
-            bar_type.instrument_id,
+            bar_type.instrument_id(),
             InstrumentId::from("BTCUSDT-PERP.BINANCE")
         );
         assert_eq!(
-            bar_type.spec,
+            bar_type.spec(),
             BarSpecification {
                 step: 1,
                 aggregation: BarAggregation::Minute,
                 price_type: PriceType::Last,
             }
         );
-        assert_eq!(bar_type.aggregation_source, AggregationSource::External);
+        assert_eq!(bar_type.aggregation_source(), AggregationSource::External);
         assert_eq!(bar_type, BarType::from(input));
+    }
+
+    #[rstest]
+    fn test_bar_type_composite_parse_valid() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL";
+        let bar_type = BarType::from(input);
+
+        assert_eq!(
+            bar_type.instrument_id(),
+            InstrumentId::from("BTCUSDT-PERP.BINANCE")
+        );
+        assert_eq!(
+            bar_type.spec(),
+            BarSpecification {
+                step: 2,
+                aggregation: BarAggregation::Minute,
+                price_type: PriceType::Last,
+            }
+        );
+        assert_eq!(bar_type.aggregation_source(), AggregationSource::Internal);
+        assert_eq!(bar_type, BarType::from(input));
+        assert!(bar_type.is_composite());
+
+        assert_eq!(
+            bar_type.standard().instrument_id(),
+            InstrumentId::from("BTCUSDT-PERP.BINANCE")
+        );
+        assert_eq!(
+            bar_type.standard().spec(),
+            BarSpecification {
+                step: 2,
+                aggregation: BarAggregation::Minute,
+                price_type: PriceType::Last,
+            }
+        );
+        assert_eq!(
+            bar_type.standard().aggregation_source(),
+            AggregationSource::Internal
+        );
+        assert!(bar_type.standard().is_standard());
+
+        let composite_bar_type = bar_type.composite();
+        let composite_input = "BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL";
+
+        assert_eq!(
+            composite_bar_type.instrument_id(),
+            InstrumentId::from("BTCUSDT-PERP.BINANCE")
+        );
+        assert_eq!(
+            composite_bar_type.spec(),
+            BarSpecification {
+                step: 1,
+                aggregation: BarAggregation::Minute,
+                price_type: PriceType::Last,
+            }
+        );
+        assert_eq!(
+            composite_bar_type.aggregation_source(),
+            AggregationSource::External
+        );
+        assert_eq!(composite_bar_type, BarType::from(composite_input));
+        assert!(composite_bar_type.is_standard());
+    }
+
+    #[rstest]
+    fn test_bar_type_is_composite() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL";
+        let bar_type = BarType::from(input);
+
+        assert!(bar_type.is_composite());
     }
 
     #[rstest]
@@ -639,6 +924,76 @@ mod tests {
     }
 
     #[rstest]
+    fn test_bar_type_parse_invalid_token_pos_5() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@INVALID-1-MINUTE-LAST-EXTERNAL";
+        let result = BarType::from_str(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Error parsing `BarType` from '{input}', invalid token: 'INVALID' at position 5"
+            )
+        );
+    }
+
+    #[rstest]
+    fn test_bar_type_parse_invalid_token_pos_6() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-INVALID-MINUTE-LAST-EXTERNAL";
+        let result = BarType::from_str(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Error parsing `BarType` from '{input}', invalid token: 'INVALID' at position 6"
+            )
+        );
+    }
+
+    #[rstest]
+    fn test_bar_type_parse_invalid_token_pos_7() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-INVALID-LAST-EXTERNAL";
+        let result = BarType::from_str(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Error parsing `BarType` from '{input}', invalid token: 'INVALID' at position 7"
+            )
+        );
+    }
+
+    #[rstest]
+    fn test_bar_type_parse_invalid_token_pos_8() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-INVALID-EXTERNAL";
+        let result = BarType::from_str(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Error parsing `BarType` from '{input}', invalid token: 'INVALID' at position 8"
+            )
+        );
+    }
+
+    #[rstest]
+    fn test_bar_type_parse_invalid_token_pos_9() {
+        let input = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-INVALID";
+        let result = BarType::from_str(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Error parsing `BarType` from '{input}', invalid token: 'INVALID' at position 9"
+            )
+        );
+    }
+
+    #[rstest]
     fn test_bar_type_equality() {
         let instrument_id1 = InstrumentId {
             symbol: Symbol::new("AUD/USD"),
@@ -653,17 +1008,17 @@ mod tests {
             aggregation: BarAggregation::Minute,
             price_type: PriceType::Bid,
         };
-        let bar_type1 = BarType {
+        let bar_type1 = BarType::StandardBar {
             instrument_id: instrument_id1,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
         };
-        let bar_type2 = BarType {
+        let bar_type2 = BarType::StandardBar {
             instrument_id: instrument_id1,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
         };
-        let bar_type3 = BarType {
+        let bar_type3 = BarType::StandardBar {
             instrument_id: instrument_id2,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
@@ -689,26 +1044,41 @@ mod tests {
             aggregation: BarAggregation::Minute,
             price_type: PriceType::Bid,
         };
-        let bar_type1 = BarType {
+        let bar_spec2 = BarSpecification {
+            step: 2,
+            aggregation: BarAggregation::Minute,
+            price_type: PriceType::Bid,
+        };
+        let bar_type1 = BarType::StandardBar {
             instrument_id: instrument_id1,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
         };
-        let bar_type2 = BarType {
+        let bar_type2 = BarType::StandardBar {
             instrument_id: instrument_id1,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
         };
-        let bar_type3 = BarType {
+        let bar_type3 = BarType::StandardBar {
             instrument_id: instrument_id2,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,
+        };
+        let bar_type4 = BarType::CompositeBar {
+            instrument_id: instrument_id2,
+            spec: bar_spec2,
+            aggregation_source: AggregationSource::Internal,
+
+            composite_instrument_id: instrument_id2,
+            composite_spec: bar_spec,
+            composite_aggregation_source: AggregationSource::External,
         };
 
         assert!(bar_type1 <= bar_type2);
         assert!(bar_type1 < bar_type3);
         assert!(bar_type3 > bar_type1);
         assert!(bar_type3 >= bar_type1);
+        assert!(bar_type4 >= bar_type1);
     }
 
     #[rstest]
@@ -722,7 +1092,7 @@ mod tests {
             aggregation: BarAggregation::Minute,
             price_type: PriceType::Bid,
         };
-        let bar_type = BarType {
+        let bar_type = BarType::StandardBar {
             instrument_id,
             spec: bar_spec,
             aggregation_source: AggregationSource::External,

--- a/nautilus_core/model/src/data/mod.rs
+++ b/nautilus_core/model/src/data/mod.rs
@@ -63,14 +63,14 @@ pub enum Data {
 
 impl Data {
     /// Returns the instrument ID for the data.
-    pub fn instrument_id(&self) -> &InstrumentId {
+    pub fn instrument_id(&self) -> InstrumentId {
         match self {
-            Self::Delta(delta) => &delta.instrument_id,
-            Self::Deltas(deltas) => &deltas.instrument_id,
-            Self::Depth10(depth) => &depth.instrument_id,
-            Self::Quote(quote) => &quote.instrument_id,
-            Self::Trade(trade) => &trade.instrument_id,
-            Self::Bar(bar) => &bar.bar_type.instrument_id,
+            Self::Delta(delta) => delta.instrument_id,
+            Self::Deltas(deltas) => deltas.instrument_id,
+            Self::Depth10(depth) => depth.instrument_id,
+            Self::Quote(quote) => quote.instrument_id,
+            Self::Trade(trade) => trade.instrument_id,
+            Self::Bar(bar) => bar.bar_type.instrument_id(),
         }
     }
 

--- a/nautilus_core/model/src/data/stubs.rs
+++ b/nautilus_core/model/src/data/stubs.rs
@@ -333,7 +333,7 @@ pub fn stub_bar() -> Bar {
         aggregation: BarAggregation::Minute,
         price_type: PriceType::Bid,
     };
-    let bar_type = BarType {
+    let bar_type = BarType::StandardBar {
         instrument_id,
         spec: bar_spec,
         aggregation_source: AggregationSource::External,

--- a/nautilus_core/model/src/data/stubs.rs
+++ b/nautilus_core/model/src/data/stubs.rs
@@ -333,7 +333,7 @@ pub fn stub_bar() -> Bar {
         aggregation: BarAggregation::Minute,
         price_type: PriceType::Bid,
     };
-    let bar_type = BarType::StandardBar {
+    let bar_type = BarType::Standard {
         instrument_id,
         spec: bar_spec,
         aggregation_source: AggregationSource::External,

--- a/nautilus_core/model/src/ffi/data/bar.rs
+++ b/nautilus_core/model/src/ffi/data/bar.rs
@@ -94,11 +94,75 @@ pub extern "C" fn bar_type_new(
 ) -> BarType {
     let aggregation_source = AggregationSource::from_repr(aggregation_source as usize)
         .expect("Error converting enum from integer");
-    BarType {
+
+    BarType::StandardBar {
         instrument_id,
         spec,
         aggregation_source,
     }
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_new_composite(
+    instrument_id: InstrumentId,
+    spec: BarSpecification,
+    aggregation_source: AggregationSource,
+
+    composite_instrument_id: InstrumentId,
+    composite_spec: BarSpecification,
+    composite_aggregation_source: AggregationSource,
+) -> BarType {
+    BarType::new_composite(
+        instrument_id,
+        spec,
+        aggregation_source,
+        composite_instrument_id,
+        composite_spec,
+        composite_aggregation_source,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_from_bar_types(
+    standard_bar: &BarType,
+    composite_bar: &BarType,
+) -> BarType {
+    BarType::from_bar_types(standard_bar, composite_bar)
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_is_standard(bar_type: &BarType) -> u8 {
+    bar_type.is_standard() as u8
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_is_composite(bar_type: &BarType) -> u8 {
+    bar_type.is_composite() as u8
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_standard(bar_type: &BarType) -> BarType {
+    bar_type.standard()
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_composite(bar_type: &BarType) -> BarType {
+    bar_type.composite()
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_instrument_id(bar_type: &BarType) -> InstrumentId {
+    bar_type.instrument_id()
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_spec(bar_type: &BarType) -> BarSpecification {
+    bar_type.spec()
+}
+
+#[no_mangle]
+pub extern "C" fn bar_type_aggregation_source(bar_type: &BarType) -> AggregationSource {
+    bar_type.aggregation_source()
 }
 
 /// Returns any [`BarType`] parsing error from the provided C string pointer.

--- a/nautilus_core/model/src/ffi/data/bar.rs
+++ b/nautilus_core/model/src/ffi/data/bar.rs
@@ -95,7 +95,7 @@ pub extern "C" fn bar_type_new(
     let aggregation_source = AggregationSource::from_repr(aggregation_source as usize)
         .expect("Error converting enum from integer");
 
-    BarType::StandardBar {
+    BarType::Standard {
         instrument_id,
         spec,
         aggregation_source,
@@ -123,11 +123,8 @@ pub extern "C" fn bar_type_new_composite(
 }
 
 #[no_mangle]
-pub extern "C" fn bar_type_from_bar_types(
-    standard_bar: &BarType,
-    composite_bar: &BarType,
-) -> BarType {
-    BarType::from_bar_types(standard_bar, composite_bar)
+pub extern "C" fn bar_type_from_bar_types(standard: &BarType, composite: &BarType) -> BarType {
+    BarType::from_bar_types(standard, composite)
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/python/data/bar.rs
+++ b/nautilus_core/model/src/python/data/bar.rs
@@ -80,17 +80,14 @@ impl BarSpecification {
 #[pymethods]
 impl BarType {
     #[new]
-    #[pyo3(signature = (instrument_id, spec, aggregation_source = AggregationSource::External))]
+    #[pyo3(signature = (instrument_id, spec, aggregation_source = AggregationSource::External)
+    )]
     fn py_new(
         instrument_id: InstrumentId,
         spec: BarSpecification,
         aggregation_source: AggregationSource,
     ) -> Self {
-        Self {
-            instrument_id,
-            spec,
-            aggregation_source,
-        }
+        Self::new(instrument_id, spec, aggregation_source)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/persistence/tests/test_catalog.rs
+++ b/nautilus_core/persistence/tests/test_catalog.rs
@@ -293,7 +293,7 @@ fn test_bar_query() {
     let ticks: Vec<Data> = query_result.collect();
 
     if let Data::Bar(b) = &ticks[0] {
-        assert_eq!("ADABTC.BINANCE", b.bar_type.instrument_id.to_string());
+        assert_eq!("ADABTC.BINANCE", b.bar_type.instrument_id().to_string());
     } else {
         panic!("Invalid test");
     }

--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -484,7 +484,7 @@ cdef class OrderMatchingEngine:
             return  # Can only process an L1 book with bars
 
         cdef BarType bar_type = bar.bar_type
-        if bar_type._mem.aggregation_source == AggregationSource.INTERNAL:
+        if bar_type.aggregation_source == AggregationSource.INTERNAL:
             return  # Do not process internally aggregated bars
 
         cdef InstrumentId instrument_id = bar_type.instrument_id

--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -1188,7 +1188,7 @@ cdef class Cache(CacheFacade):
 
         bars.appendleft(bar)
 
-        cdef PriceType price_type = <PriceType>bar._mem.bar_type.spec.price_type
+        cdef PriceType price_type = bar.bar_type.spec.price_type
         if price_type == PriceType.BID:
             self._bars_bid[bar.bar_type.instrument_id] = bar
         elif price_type == PriceType.ASK:
@@ -1306,7 +1306,7 @@ cdef class Cache(CacheFacade):
             cached_bars.appendleft(bar)
 
         bar = bars[-1]
-        cdef PriceType price_type = <PriceType>bar._mem.bar_type.spec.price_type
+        cdef PriceType price_type = bar.bar_type.spec.price_type
         if price_type == PriceType.BID:
             self._bars_bid[bar.bar_type.instrument_id] = bar
         elif price_type == PriceType.ASK:

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -1073,7 +1073,12 @@ typedef struct BarSpecification_t {
  * Represents a bar type including the instrument ID, bar specification and
  * aggregation source.
  */
-typedef struct BarType_t {
+typedef enum BarType_t_Tag {
+    STANDARD_BAR,
+    COMPOSITE_BAR,
+} BarType_t_Tag;
+
+typedef struct StandardBar_Body {
     /**
      * The bar types instrument ID.
      */
@@ -1086,6 +1091,41 @@ typedef struct BarType_t {
      * The bar types aggregation source.
      */
     enum AggregationSource aggregation_source;
+} StandardBar_Body;
+
+typedef struct CompositeBar_Body {
+    /**
+     * The bar types instrument ID.
+     */
+    struct InstrumentId_t instrument_id;
+    /**
+     * The bar types specification.
+     */
+    struct BarSpecification_t spec;
+    /**
+     * The bar types aggregation source.
+     */
+    enum AggregationSource aggregation_source;
+    /**
+     * The composite bar types instrument ID.
+     */
+    struct InstrumentId_t composite_instrument_id;
+    /**
+     * The composite bar types specification.
+     */
+    struct BarSpecification_t composite_spec;
+    /**
+     * The composite bar types aggregation source.
+     */
+    enum AggregationSource composite_aggregation_source;
+} CompositeBar_Body;
+
+typedef struct BarType_t {
+    BarType_t_Tag tag;
+    union {
+        StandardBar_Body STANDARD_BAR;
+        CompositeBar_Body COMPOSITE_BAR;
+    };
 } BarType_t;
 
 /**
@@ -1400,6 +1440,30 @@ uint8_t bar_specification_ge(const struct BarSpecification_t *lhs,
 struct BarType_t bar_type_new(struct InstrumentId_t instrument_id,
                               struct BarSpecification_t spec,
                               uint8_t aggregation_source);
+
+struct BarType_t bar_type_new_composite(struct InstrumentId_t instrument_id,
+                                        struct BarSpecification_t spec,
+                                        enum AggregationSource aggregation_source,
+                                        struct InstrumentId_t composite_instrument_id,
+                                        struct BarSpecification_t composite_spec,
+                                        enum AggregationSource composite_aggregation_source);
+
+struct BarType_t bar_type_from_bar_types(const struct BarType_t *standard_bar,
+                                         const struct BarType_t *composite_bar);
+
+uint8_t bar_type_is_standard(const struct BarType_t *bar_type);
+
+uint8_t bar_type_is_composite(const struct BarType_t *bar_type);
+
+struct BarType_t bar_type_standard(const struct BarType_t *bar_type);
+
+struct BarType_t bar_type_composite(const struct BarType_t *bar_type);
+
+struct InstrumentId_t bar_type_instrument_id(const struct BarType_t *bar_type);
+
+struct BarSpecification_t bar_type_spec(const struct BarType_t *bar_type);
+
+enum AggregationSource bar_type_aggregation_source(const struct BarType_t *bar_type);
 
 /**
  * Returns any [`BarType`] parsing error from the provided C string pointer.

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -1074,11 +1074,11 @@ typedef struct BarSpecification_t {
  * aggregation source.
  */
 typedef enum BarType_t_Tag {
-    STANDARD_BAR,
-    COMPOSITE_BAR,
+    STANDARD,
+    COMPOSITE,
 } BarType_t_Tag;
 
-typedef struct StandardBar_Body {
+typedef struct Standard_Body {
     /**
      * The bar types instrument ID.
      */
@@ -1091,9 +1091,9 @@ typedef struct StandardBar_Body {
      * The bar types aggregation source.
      */
     enum AggregationSource aggregation_source;
-} StandardBar_Body;
+} Standard_Body;
 
-typedef struct CompositeBar_Body {
+typedef struct Composite_Body {
     /**
      * The bar types instrument ID.
      */
@@ -1118,13 +1118,13 @@ typedef struct CompositeBar_Body {
      * The composite bar types aggregation source.
      */
     enum AggregationSource composite_aggregation_source;
-} CompositeBar_Body;
+} Composite_Body;
 
 typedef struct BarType_t {
     BarType_t_Tag tag;
     union {
-        StandardBar_Body STANDARD_BAR;
-        CompositeBar_Body COMPOSITE_BAR;
+        Standard_Body STANDARD;
+        Composite_Body COMPOSITE;
     };
 } BarType_t;
 
@@ -1448,8 +1448,8 @@ struct BarType_t bar_type_new_composite(struct InstrumentId_t instrument_id,
                                         struct BarSpecification_t composite_spec,
                                         enum AggregationSource composite_aggregation_source);
 
-struct BarType_t bar_type_from_bar_types(const struct BarType_t *standard_bar,
-                                         const struct BarType_t *composite_bar);
+struct BarType_t bar_type_from_bar_types(const struct BarType_t *standard,
+                                         const struct BarType_t *composite);
 
 uint8_t bar_type_is_standard(const struct BarType_t *bar_type);
 

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -585,13 +585,36 @@ cdef extern from "../includes/model.h":
 
     # Represents a bar type including the instrument ID, bar specification and
     # aggregation source.
-    cdef struct BarType_t:
+    cpdef enum BarType_t_Tag:
+        STANDARD_BAR,
+        COMPOSITE_BAR,
+
+    cdef struct StandardBar_Body:
         # The bar types instrument ID.
         InstrumentId_t instrument_id;
         # The bar types specification.
         BarSpecification_t spec;
         # The bar types aggregation source.
         AggregationSource aggregation_source;
+
+    cdef struct CompositeBar_Body:
+        # The bar types instrument ID.
+        InstrumentId_t instrument_id;
+        # The bar types specification.
+        BarSpecification_t spec;
+        # The bar types aggregation source.
+        AggregationSource aggregation_source;
+        # The composite bar types instrument ID.
+        InstrumentId_t composite_instrument_id;
+        # The composite bar types specification.
+        BarSpecification_t composite_spec;
+        # The composite bar types aggregation source.
+        AggregationSource composite_aggregation_source;
+
+    cdef struct BarType_t:
+        BarType_t_Tag tag;
+        StandardBar_Body STANDARD_BAR;
+        CompositeBar_Body COMPOSITE_BAR;
 
     # Represents an aggregated bar.
     cdef struct Bar_t:
@@ -812,6 +835,30 @@ cdef extern from "../includes/model.h":
     BarType_t bar_type_new(InstrumentId_t instrument_id,
                            BarSpecification_t spec,
                            uint8_t aggregation_source);
+
+    BarType_t bar_type_new_composite(InstrumentId_t instrument_id,
+                                     BarSpecification_t spec,
+                                     AggregationSource aggregation_source,
+                                     InstrumentId_t composite_instrument_id,
+                                     BarSpecification_t composite_spec,
+                                     AggregationSource composite_aggregation_source);
+
+    BarType_t bar_type_from_bar_types(const BarType_t *standard_bar,
+                                      const BarType_t *composite_bar);
+
+    uint8_t bar_type_is_standard(const BarType_t *bar_type);
+
+    uint8_t bar_type_is_composite(const BarType_t *bar_type);
+
+    BarType_t bar_type_standard(const BarType_t *bar_type);
+
+    BarType_t bar_type_composite(const BarType_t *bar_type);
+
+    InstrumentId_t bar_type_instrument_id(const BarType_t *bar_type);
+
+    BarSpecification_t bar_type_spec(const BarType_t *bar_type);
+
+    AggregationSource bar_type_aggregation_source(const BarType_t *bar_type);
 
     # Returns any [`BarType`] parsing error from the provided C string pointer.
     #

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -586,10 +586,10 @@ cdef extern from "../includes/model.h":
     # Represents a bar type including the instrument ID, bar specification and
     # aggregation source.
     cpdef enum BarType_t_Tag:
-        STANDARD_BAR,
-        COMPOSITE_BAR,
+        STANDARD,
+        COMPOSITE,
 
-    cdef struct StandardBar_Body:
+    cdef struct Standard_Body:
         # The bar types instrument ID.
         InstrumentId_t instrument_id;
         # The bar types specification.
@@ -597,7 +597,7 @@ cdef extern from "../includes/model.h":
         # The bar types aggregation source.
         AggregationSource aggregation_source;
 
-    cdef struct CompositeBar_Body:
+    cdef struct Composite_Body:
         # The bar types instrument ID.
         InstrumentId_t instrument_id;
         # The bar types specification.
@@ -613,8 +613,8 @@ cdef extern from "../includes/model.h":
 
     cdef struct BarType_t:
         BarType_t_Tag tag;
-        StandardBar_Body STANDARD_BAR;
-        CompositeBar_Body COMPOSITE_BAR;
+        Standard_Body STANDARD;
+        Composite_Body COMPOSITE;
 
     # Represents an aggregated bar.
     cdef struct Bar_t:
@@ -843,8 +843,7 @@ cdef extern from "../includes/model.h":
                                      BarSpecification_t composite_spec,
                                      AggregationSource composite_aggregation_source);
 
-    BarType_t bar_type_from_bar_types(const BarType_t *standard_bar,
-                                      const BarType_t *composite_bar);
+    BarType_t bar_type_from_bar_types(const BarType_t *standard, const BarType_t *composite);
 
     uint8_t bar_type_is_standard(const BarType_t *bar_type);
 

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -51,7 +51,7 @@ cdef class BarBuilder:
     cdef Price _close
     cdef Quantity volume
 
-    cpdef void set_partial(self, Bar partial_bar)
+    cpdef void set_partial(self, Bar partial_bar, bint run_once=*)
     cpdef void update(self, Price price, Quantity size, uint64_t ts_event)
     cpdef void reset(self)
     cpdef Bar build_now(self)
@@ -69,7 +69,8 @@ cdef class BarAggregator:
 
     cpdef void handle_quote_tick(self, QuoteTick tick)
     cpdef void handle_trade_tick(self, TradeTick tick)
-    cpdef void set_partial(self, Bar partial_bar)
+    cpdef void handle_bar(self, Bar bar)
+    cpdef void set_partial(self, Bar partial_bar, bint run_once=*)
     cdef void _apply_update(self, Price price, Quantity size, uint64_t ts_event)
     cdef void _build_now_and_send(self)
     cdef void _build_and_send(self, uint64_t ts_event, uint64_t ts_init)

--- a/nautilus_trader/model/data.pxd
+++ b/nautilus_trader/model/data.pxd
@@ -21,6 +21,7 @@ from libc.stdint cimport uint64_t
 
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.rust.core cimport CVec
+from nautilus_trader.core.rust.model cimport AggregationSource
 from nautilus_trader.core.rust.model cimport AggressorSide
 from nautilus_trader.core.rust.model cimport Bar_t
 from nautilus_trader.core.rust.model cimport BarSpecification_t
@@ -142,6 +143,11 @@ cdef class BarType:
 
     cpdef bint is_externally_aggregated(self)
     cpdef bint is_internally_aggregated(self)
+
+    cpdef bint is_standard(self)
+    cpdef bint is_composite(self)
+    cpdef BarType standard(self)
+    cpdef BarType composite(self)
 
 
 cdef class Bar(Data):

--- a/nautilus_trader/model/data.pyx
+++ b/nautilus_trader/model/data.pyx
@@ -669,9 +669,9 @@ cdef class BarType:
                 self.aggregation_source,
             )
         else:
-            composite_bar_type = self.composite()
+            composite = self.composite()
             spec = self.spec
-            spec_composite = composite_bar_type.spec
+            spec_composite = composite.spec
 
             return (
                 self.instrument_id.value,
@@ -680,11 +680,11 @@ cdef class BarType:
                 spec.price_type,
                 self.aggregation_source,
 
-                composite_bar_type.instrument_id.value,
+                composite.instrument_id.value,
                 spec_composite.step,
                 spec_composite.aggregation,
                 spec_composite.price_type,
-                composite_bar_type.aggregation_source
+                composite.aggregation_source
             )
 
     def __setstate__(self, state):
@@ -870,12 +870,12 @@ cdef class BarType:
         )
 
     @staticmethod
-    def from_bar_types(BarType standard_bar, BarType composite_bar) -> BarType:
-        return BarType.from_mem_c(bar_type_from_bar_types(&standard_bar._mem, &composite_bar._mem))
+    def from_bar_types(BarType standard, BarType composite) -> BarType:
+        return BarType.from_mem_c(bar_type_from_bar_types(&standard._mem, &composite._mem))
 
     cpdef bint is_standard(self):
         """
-        Return a value indicating whether the bar type corresponds to BarType::StandardBar in rust.
+        Return a value indicating whether the bar type corresponds to BarType::Standard in rust.
 
         Returns
         -------
@@ -886,7 +886,7 @@ cdef class BarType:
 
     cpdef bint is_composite(self):
         """
-        Return a value indicating whether the bar type corresponds to BarType::CompositeBar in rust.
+        Return a value indicating whether the bar type corresponds to BarType::Composite in rust.
 
         Returns
         -------

--- a/nautilus_trader/model/data.pyx
+++ b/nautilus_trader/model/data.pyx
@@ -59,15 +59,24 @@ from nautilus_trader.core.rust.model cimport bar_specification_lt
 from nautilus_trader.core.rust.model cimport bar_specification_new
 from nautilus_trader.core.rust.model cimport bar_specification_to_cstr
 from nautilus_trader.core.rust.model cimport bar_to_cstr
+from nautilus_trader.core.rust.model cimport bar_type_aggregation_source
 from nautilus_trader.core.rust.model cimport bar_type_check_parsing
+from nautilus_trader.core.rust.model cimport bar_type_composite
 from nautilus_trader.core.rust.model cimport bar_type_eq
+from nautilus_trader.core.rust.model cimport bar_type_from_bar_types
 from nautilus_trader.core.rust.model cimport bar_type_from_cstr
 from nautilus_trader.core.rust.model cimport bar_type_ge
 from nautilus_trader.core.rust.model cimport bar_type_gt
 from nautilus_trader.core.rust.model cimport bar_type_hash
+from nautilus_trader.core.rust.model cimport bar_type_instrument_id
+from nautilus_trader.core.rust.model cimport bar_type_is_composite
+from nautilus_trader.core.rust.model cimport bar_type_is_standard
 from nautilus_trader.core.rust.model cimport bar_type_le
 from nautilus_trader.core.rust.model cimport bar_type_lt
 from nautilus_trader.core.rust.model cimport bar_type_new
+from nautilus_trader.core.rust.model cimport bar_type_new_composite
+from nautilus_trader.core.rust.model cimport bar_type_spec
+from nautilus_trader.core.rust.model cimport bar_type_standard
 from nautilus_trader.core.rust.model cimport bar_type_to_cstr
 from nautilus_trader.core.rust.model cimport book_order_debug_to_cstr
 from nautilus_trader.core.rust.model cimport book_order_eq
@@ -649,25 +658,69 @@ cdef class BarType:
         )
 
     def __getstate__(self):
-        return (
-            self.instrument_id.value,
-            self._mem.spec.step,
-            self._mem.spec.aggregation,
-            self._mem.spec.price_type,
-            self._mem.aggregation_source
-        )
+        if self.is_standard():
+            spec = self.spec
+
+            return (
+                self.instrument_id.value,
+                spec.step,
+                spec.aggregation,
+                spec.price_type,
+                self.aggregation_source,
+            )
+        else:
+            composite_bar_type = self.composite()
+            spec = self.spec
+            spec_composite = composite_bar_type.spec
+
+            return (
+                self.instrument_id.value,
+                spec.step,
+                spec.aggregation,
+                spec.price_type,
+                self.aggregation_source,
+
+                composite_bar_type.instrument_id.value,
+                spec_composite.step,
+                spec_composite.aggregation,
+                spec_composite.price_type,
+                composite_bar_type.aggregation_source
+            )
 
     def __setstate__(self, state):
-        cdef InstrumentId instrument_id = InstrumentId.from_str_c(state[0])
-        self._mem = bar_type_new(
-            instrument_id._mem,
-            bar_specification_new(
-                state[1],
-                state[2],
-                state[3]
-            ),
-            state[4],
-        )
+        if len(state) == 5:
+            instrument_id = InstrumentId.from_str_c(state[0])
+
+            self._mem = bar_type_new(
+                instrument_id._mem,
+                bar_specification_new(
+                    state[1],
+                    state[2],
+                    state[3]
+                ),
+                state[4],
+            )
+        else:
+            instrument_id = InstrumentId.from_str_c(state[0])
+            composite_instrument_id = InstrumentId.from_str_c(state[5])
+
+            self._mem = bar_type_new_composite(
+                instrument_id._mem,
+                bar_specification_new(
+                    state[1],
+                    state[2],
+                    state[3]
+                ),
+                state[4],
+
+                composite_instrument_id._mem,
+                bar_specification_new(
+                    state[6],
+                    state[7],
+                    state[8]
+                ),
+                state[9],
+            )
 
     cdef str to_str(self):
         return cstr_to_pystr(bar_type_to_cstr(&self._mem))
@@ -706,7 +759,7 @@ cdef class BarType:
         InstrumentId
 
         """
-        return InstrumentId.from_mem_c(self._mem.instrument_id)
+        return InstrumentId.from_mem_c(bar_type_instrument_id(&self._mem))
 
     @property
     def spec(self) -> BarSpecification:
@@ -718,7 +771,7 @@ cdef class BarType:
         BarSpecification
 
         """
-        return BarSpecification.from_mem_c(self._mem.spec)
+        return BarSpecification.from_mem_c(bar_type_spec(&self._mem))
 
     @property
     def aggregation_source(self) -> AggregationSource:
@@ -730,7 +783,7 @@ cdef class BarType:
         AggregationSource
 
         """
-        return self._mem.aggregation_source
+        return bar_type_aggregation_source(&self._mem)
 
     @staticmethod
     cdef BarType from_mem_c(BarType_t mem):
@@ -793,6 +846,64 @@ cdef class BarType:
 
         """
         return self.aggregation_source == AggregationSource.INTERNAL
+
+    @staticmethod
+    def new_composite(
+        InstrumentId instrument_id,
+        BarSpecification bar_spec,
+        AggregationSource aggregation_source,
+
+        InstrumentId composite_instrument_id,
+        BarSpecification composite_bar_spec,
+        AggregationSource composite_aggregation_source,
+    ) -> BarType:
+        return BarType.from_mem_c(
+            bar_type_new_composite(
+                instrument_id._mem,
+                bar_spec._mem,
+                aggregation_source,
+
+                composite_instrument_id._mem,
+                composite_bar_spec._mem,
+                composite_aggregation_source,
+            )
+        )
+
+    @staticmethod
+    def from_bar_types(BarType standard_bar, BarType composite_bar) -> BarType:
+        return BarType.from_mem_c(bar_type_from_bar_types(&standard_bar._mem, &composite_bar._mem))
+
+    cpdef bint is_standard(self):
+        """
+        Return a value indicating whether the bar type corresponds to BarType::StandardBar in rust.
+
+        Returns
+        -------
+        bool
+
+        """
+        return bar_type_is_standard(&self._mem)
+
+    cpdef bint is_composite(self):
+        """
+        Return a value indicating whether the bar type corresponds to BarType::CompositeBar in rust.
+
+        Returns
+        -------
+        bool
+
+        """
+        return bar_type_is_composite(&self._mem)
+
+    cpdef BarType standard(self):
+        cdef BarType bar_type = BarType.__new__(BarType)
+        bar_type._mem = bar_type_standard(&self._mem)
+        return bar_type
+
+    cpdef BarType  composite(self):
+        cdef BarType bar_type = BarType.__new__(BarType)
+        bar_type._mem = bar_type_composite(&self._mem)
+        return bar_type
 
 
 cdef class Bar(Data):
@@ -862,12 +973,10 @@ cdef class Bar(Data):
         self.is_revision = is_revision
 
     def __getstate__(self):
-        return (
-            self.bar_type.instrument_id.value,
-            self._mem.bar_type.spec.step,
-            self._mem.bar_type.spec.aggregation,
-            self._mem.bar_type.spec.price_type,
-            self._mem.bar_type.aggregation_source,
+        bar_type = BarType.from_mem_c(self._mem.bar_type)
+        bart_type_state = bar_type.__getstate__()
+
+        return bart_type_state + (
             self._mem.open.raw,
             self._mem.high.raw,
             self._mem.low.raw,
@@ -880,27 +989,61 @@ cdef class Bar(Data):
         )
 
     def __setstate__(self, state):
-        cdef InstrumentId instrument_id = InstrumentId.from_str_c(state[0])
-        self._mem = bar_new_from_raw(
-            bar_type_new(
-                instrument_id._mem,
-                bar_specification_new(
-                    state[1],
-                    state[2],
-                    state[3],
+        if len(state) == 14:
+            instrument_id = InstrumentId.from_str_c(state[0])
+
+            self._mem = bar_new_from_raw(
+                bar_type_new(
+                    instrument_id._mem,
+                    bar_specification_new(
+                        state[1],
+                        state[2],
+                        state[3],
+                    ),
+                    state[4],
                 ),
-                state[4],
-            ),
-            state[5],
-            state[6],
-            state[7],
-            state[8],
-            state[9],
-            state[10],
-            state[11],
-            state[12],
-            state[13],
-        )
+                state[5],
+                state[6],
+                state[7],
+                state[8],
+                state[9],
+                state[10],
+                state[11],
+                state[12],
+                state[13],
+            )
+        else:
+            instrument_id = InstrumentId.from_str_c(state[0])
+            composite_instrument_id = InstrumentId.from_str_c(state[5])
+
+            self._mem = bar_new_from_raw(
+                bar_type_new_composite(
+                    instrument_id._mem,
+                    bar_specification_new(
+                        state[1],
+                        state[2],
+                        state[3]
+                    ),
+                    state[4],
+
+                    composite_instrument_id._mem,
+                    bar_specification_new(
+                        state[6],
+                        state[7],
+                        state[8]
+                    ),
+                    state[9],
+                ),
+                state[10],
+                state[11],
+                state[12],
+                state[13],
+                state[14],
+                state[15],
+                state[16],
+                state[17],
+                state[18],
+            )
 
     def __eq__(self, Bar other) -> bool:
         return self.to_str() == other.to_str()

--- a/tests/unit_tests/model/test_bar.py
+++ b/tests/unit_tests/model/test_bar.py
@@ -723,8 +723,8 @@ class TestBar:
     def test_bar_type_composite_parse_valid(self):
         input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
         bar_type = BarType.from_str(input_str)
-        standard_bar_type = bar_type.standard()
-        composite_bar_type = bar_type.composite()
+        standard = bar_type.standard()
+        composite = bar_type.composite()
         composite_input = "BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
 
         assert bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
@@ -737,22 +737,22 @@ class TestBar:
         assert bar_type == BarType.from_str(input_str)
         assert bar_type.is_composite()
 
-        assert standard_bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
-        assert standard_bar_type.spec == BarSpecification(
+        assert standard.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert standard.spec == BarSpecification(
             step=2,
             aggregation=BarAggregation.MINUTE,
             price_type=PriceType.LAST,
         )
-        assert standard_bar_type.aggregation_source == AggregationSource.INTERNAL
-        assert standard_bar_type.is_standard()
+        assert standard.aggregation_source == AggregationSource.INTERNAL
+        assert standard.is_standard()
 
-        assert composite_bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
-        assert composite_bar_type.spec == BarSpecification(
+        assert composite.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert composite.spec == BarSpecification(
             step=1,
             aggregation=BarAggregation.MINUTE,
             price_type=PriceType.LAST,
         )
-        assert composite_bar_type.aggregation_source == AggregationSource.EXTERNAL
-        assert composite_bar_type == BarType.from_str(composite_input)
-        assert composite_bar_type.is_standard()
-        assert bar_type == BarType.from_bar_types(standard_bar_type, composite_bar_type)
+        assert composite.aggregation_source == AggregationSource.EXTERNAL
+        assert composite == BarType.from_str(composite_input)
+        assert composite.is_standard()
+        assert bar_type == BarType.from_bar_types(standard, composite)

--- a/tests/unit_tests/model/test_bar.py
+++ b/tests/unit_tests/model/test_bar.py
@@ -719,3 +719,40 @@ class TestBar:
 
         # Assert
         assert unpickled == bar
+
+    def test_bar_type_composite_parse_valid(self):
+        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+        bar_type = BarType.from_str(input_str)
+        standard_bar_type = bar_type.standard()
+        composite_bar_type = bar_type.composite()
+        composite_input = "BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+
+        assert bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert bar_type.spec == BarSpecification(
+            step=2,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert bar_type.aggregation_source == AggregationSource.INTERNAL
+        assert bar_type == BarType.from_str(input_str)
+        assert bar_type.is_composite()
+
+        assert standard_bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert standard_bar_type.spec == BarSpecification(
+            step=2,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert standard_bar_type.aggregation_source == AggregationSource.INTERNAL
+        assert standard_bar_type.is_standard()
+
+        assert composite_bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert composite_bar_type.spec == BarSpecification(
+            step=1,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert composite_bar_type.aggregation_source == AggregationSource.EXTERNAL
+        assert composite_bar_type == BarType.from_str(composite_input)
+        assert composite_bar_type.is_standard()
+        assert bar_type == BarType.from_bar_types(standard_bar_type, composite_bar_type)


### PR DESCRIPTION
# Pull Request

Refactor BarType for aggregating bars into other bars

A usage example is 

```python
bar_type = BarType.from_str(f"ESU4-2-MINUTE-LAST-INTERNAL@ESU4-1-MINUTE-LAST-EXTERNAL")  
self.subscribe_bars(bar_type)
```
## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How has this change been tested?

My own code and tests

I haven't updated the doc yet
