### PR TITLE
Improve error handling by refactoring result type and unwraps

### DIFF
--- a/nautilus_core/adapters/src/databento/decode.rs
+++ b/nautilus_core/adapters/src/databento/decode.rs
@@ -557,7 +557,7 @@ pub fn decode_tbbo_msg(
         Quantity::from_raw(u64::from(top_level.ask_sz) * FIXED_SCALAR as u64, 0),
         msg.ts_recv.into(),
         ts_init,
-    )?;
+    );
 
     let trade = TradeTick::new(
         instrument_id,
@@ -588,7 +588,7 @@ pub fn decode_mbp1_msg(
         Quantity::from_raw(u64::from(top_level.ask_sz) * FIXED_SCALAR as u64, 0),
         msg.ts_recv.into(),
         ts_init,
-    )?;
+    );
 
     let maybe_trade = if include_trades && msg.action as u8 as char == 'T' {
         Some(TradeTick::new(

--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -1377,30 +1377,27 @@ mod tests {
         let stop_loss_client_order_id = ClientOrderId::from("O-19700101-000000-001-001-2");
 
         // Create entry market order
-        let mut entry_order = OrderAny::Market(
-            MarketOrder::new(
-                TraderId::default(),
-                StrategyId::default(),
-                instrument_es.id(),
-                entry_client_order_id,
-                OrderSide::Buy,
-                Quantity::from("1"),
-                TimeInForce::Gtc,
-                UUID4::new(),
-                UnixNanos::default(),
-                false,
-                false,
-                Some(ContingencyType::Oto), // <- set contingency type to OTO
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap(),
-        );
+        let mut entry_order = OrderAny::Market(MarketOrder::new(
+            TraderId::default(),
+            StrategyId::default(),
+            instrument_es.id(),
+            entry_client_order_id,
+            OrderSide::Buy,
+            Quantity::from("1"),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            UnixNanos::default(),
+            false,
+            false,
+            Some(ContingencyType::Oto), // <- set contingency type to OTO
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ));
         // Set entry order status to Rejected with proper event
         let rejected_event = OrderRejected::default();
         entry_order

--- a/nautilus_core/common/src/factories.rs
+++ b/nautilus_core/common/src/factories.rs
@@ -131,8 +131,7 @@ impl OrderFactory {
             exec_algorithm_params,
             exec_spawn_id,
             tags,
-        )
-        .unwrap();
+        );
         OrderAny::Market(order)
     }
 }

--- a/nautilus_core/infrastructure/src/sql/models/data.rs
+++ b/nautilus_core/infrastructure/src/sql/models/data.rs
@@ -102,8 +102,7 @@ impl<'r> FromRow<'r, PgRow> for QuoteTickModel {
             ask_size,
             ts_event,
             ts_init,
-        )
-        .unwrap();
+        );
         Ok(QuoteTickModel(quote))
     }
 }

--- a/nautilus_core/model/src/data/deltas.rs
+++ b/nautilus_core/model/src/data/deltas.rs
@@ -21,7 +21,10 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use nautilus_core::nanos::UnixNanos;
+use nautilus_core::{
+    correctness::{check_predicate_true, FAILED},
+    nanos::UnixNanos,
+};
 
 use super::{delta::OrderBookDelta, GetTsInit};
 use crate::identifiers::InstrumentId;
@@ -54,21 +57,33 @@ impl OrderBookDeltas {
     #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub fn new(instrument_id: InstrumentId, deltas: Vec<OrderBookDelta>) -> Self {
-        assert!(!deltas.is_empty(), "`deltas` cannot be empty");
+        Self::new_checked(instrument_id, deltas).expect(FAILED)
+    }
+
+    /// Creates a new [`OrderBookDeltas`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new_checked(
+        instrument_id: InstrumentId,
+        deltas: Vec<OrderBookDelta>,
+    ) -> anyhow::Result<Self> {
+        check_predicate_true(!deltas.is_empty(), "`deltas` cannot be empty")?;
         // SAFETY: We asserted `deltas` is not empty
         let last = deltas.last().unwrap();
         let flags = last.flags;
         let sequence = last.sequence;
         let ts_event = last.ts_event;
         let ts_init = last.ts_init;
-        Self {
+        Ok(Self {
             instrument_id,
             deltas,
             flags,
             sequence,
             ts_event,
             ts_init,
-        }
+        })
     }
 }
 

--- a/nautilus_core/model/src/data/deltas.rs
+++ b/nautilus_core/model/src/data/deltas.rs
@@ -64,7 +64,6 @@ impl OrderBookDeltas {
     ///
     /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
     #[allow(clippy::too_many_arguments)]
-    #[must_use]
     pub fn new_checked(
         instrument_id: InstrumentId,
         deltas: Vec<OrderBookDelta>,

--- a/nautilus_core/model/src/data/quote.rs
+++ b/nautilus_core/model/src/data/quote.rs
@@ -74,6 +74,30 @@ impl QuoteTick {
         ask_size: Quantity,
         ts_event: UnixNanos,
         ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            instrument_id,
+            bid_price,
+            ask_price,
+            bid_size,
+            ask_size,
+            ts_event,
+            ts_init,
+        )
+        .expect(FAILED)
+    }
+
+    /// Creates a new [`QuoteTick`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    pub fn new_checked(
+        instrument_id: InstrumentId,
+        bid_price: Price,
+        ask_price: Price,
+        bid_size: Quantity,
+        ask_size: Quantity,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
     ) -> anyhow::Result<Self> {
         check_equal_u8(
             bid_price.precision,

--- a/nautilus_core/model/src/ffi/data/quote.rs
+++ b/nautilus_core/model/src/ffi/data/quote.rs
@@ -50,7 +50,6 @@ pub extern "C" fn quote_tick_new(
         ts_event,
         ts_init,
     )
-    .unwrap()
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/ffi/instruments/synthetic.rs
+++ b/nautilus_core/model/src/ffi/instruments/synthetic.rs
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn synthetic_instrument_new(
         ts_init.into(),
     );
 
-    SyntheticInstrument_API(Box::new(synth.unwrap()))
+    SyntheticInstrument_API(Box::new(synth))
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/instruments/crypto_perpetual.rs
+++ b/nautilus_core/model/src/instruments/crypto_perpetual.rs
@@ -16,7 +16,7 @@
 use std::hash::{Hash, Hasher};
 
 use nautilus_core::{
-    correctness::{check_equal_u8, check_positive_i64, check_positive_u64, FAILED},
+    correctness::{check_equal_u8, check_positive_i64, check_positive_u64},
     nanos::UnixNanos,
 };
 use rust_decimal::Decimal;
@@ -65,7 +65,78 @@ pub struct CryptoPerpetual {
 }
 
 impl CryptoPerpetual {
-    /// Creates a new [`CryptoPerpetual`] instance.
+    /// Creates a new [`CryptoPerpetual`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        base_currency: Currency,
+        quote_currency: Currency,
+        settlement_currency: Currency,
+        is_inverse: bool,
+        price_precision: u8,
+        size_precision: u8,
+        price_increment: Price,
+        size_increment: Quantity,
+        maker_fee: Decimal,
+        taker_fee: Decimal,
+        margin_init: Decimal,
+        margin_maint: Decimal,
+        lot_size: Option<Quantity>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_notional: Option<Money>,
+        min_notional: Option<Money>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<Self> {
+        check_equal_u8(
+            price_precision,
+            price_increment.precision,
+            stringify!(price_precision),
+            stringify!(price_increment.precision),
+        )?;
+        check_equal_u8(
+            size_precision,
+            size_increment.precision,
+            stringify!(size_precision),
+            stringify!(size_increment.precision),
+        )?;
+        check_positive_i64(price_increment.raw, stringify!(price_increment.raw))?;
+        check_positive_u64(size_increment.raw, stringify!(size_increment.raw))?;
+
+        Ok(Self {
+            id,
+            raw_symbol,
+            base_currency,
+            quote_currency,
+            settlement_currency,
+            is_inverse,
+            price_precision,
+            size_precision,
+            price_increment,
+            size_increment,
+            maker_fee,
+            taker_fee,
+            margin_init,
+            margin_maint,
+            lot_size: lot_size.unwrap_or(Quantity::from(1)),
+            max_quantity,
+            min_quantity,
+            max_notional,
+            min_notional,
+            max_price,
+            min_price,
+            ts_event,
+            ts_init,
+        })
+    }
+
+    /// Creates a new [`CryptoPerpetual`] instance
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: InstrumentId,
@@ -92,24 +163,7 @@ impl CryptoPerpetual {
         ts_event: UnixNanos,
         ts_init: UnixNanos,
     ) -> Self {
-        check_equal_u8(
-            price_precision,
-            price_increment.precision,
-            stringify!(price_precision),
-            stringify!(price_increment.precision),
-        )
-        .expect(FAILED);
-        check_equal_u8(
-            size_precision,
-            size_increment.precision,
-            stringify!(size_precision),
-            stringify!(size_increment.precision),
-        )
-        .expect(FAILED);
-        check_positive_i64(price_increment.raw, stringify!(price_increment.raw)).expect(FAILED);
-        check_positive_u64(size_increment.raw, stringify!(size_increment.raw)).expect(FAILED);
-
-        Self {
+        Self::new_checked(
             id,
             raw_symbol,
             base_currency,
@@ -124,7 +178,7 @@ impl CryptoPerpetual {
             taker_fee,
             margin_init,
             margin_maint,
-            lot_size: lot_size.unwrap_or(Quantity::from(1)),
+            lot_size,
             max_quantity,
             min_quantity,
             max_notional,
@@ -133,7 +187,8 @@ impl CryptoPerpetual {
             min_price,
             ts_event,
             ts_init,
-        }
+        )
+        .expect("Failed to create CryptoPerpetual instance")
     }
 }
 

--- a/nautilus_core/model/src/instruments/currency_pair.rs
+++ b/nautilus_core/model/src/instruments/currency_pair.rs
@@ -16,7 +16,7 @@
 use std::hash::{Hash, Hasher};
 
 use nautilus_core::{
-    correctness::{check_equal_u8, check_positive_i64, check_positive_u64, FAILED},
+    correctness::{check_equal_u8, check_positive_i64, check_positive_u64},
     nanos::UnixNanos,
 };
 use rust_decimal::Decimal;
@@ -62,6 +62,73 @@ pub struct CurrencyPair {
 }
 
 impl CurrencyPair {
+    /// Creates a new [`CurrencyPair`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        base_currency: Currency,
+        quote_currency: Currency,
+        price_precision: u8,
+        size_precision: u8,
+        price_increment: Price,
+        size_increment: Quantity,
+        taker_fee: Decimal,
+        maker_fee: Decimal,
+        margin_init: Decimal,
+        margin_maint: Decimal,
+        lot_size: Option<Quantity>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_notional: Option<Money>,
+        min_notional: Option<Money>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<Self> {
+        check_equal_u8(
+            price_precision,
+            price_increment.precision,
+            stringify!(price_precision),
+            stringify!(price_increment.precision),
+        )?;
+        check_equal_u8(
+            size_precision,
+            size_increment.precision,
+            stringify!(size_precision),
+            stringify!(size_increment.precision),
+        )?;
+        check_positive_i64(price_increment.raw, stringify!(price_increment.raw))?;
+        check_positive_u64(size_increment.raw, stringify!(size_increment.raw))?;
+
+        Ok(Self {
+            id,
+            raw_symbol,
+            base_currency,
+            quote_currency,
+            price_precision,
+            size_precision,
+            price_increment,
+            size_increment,
+            maker_fee,
+            taker_fee,
+            margin_init,
+            margin_maint,
+            lot_size,
+            max_quantity,
+            min_quantity,
+            max_notional,
+            min_notional,
+            max_price,
+            min_price,
+            ts_event,
+            ts_init,
+        })
+    }
+
     /// Creates a new [`CurrencyPair`] instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -87,24 +154,7 @@ impl CurrencyPair {
         ts_event: UnixNanos,
         ts_init: UnixNanos,
     ) -> Self {
-        check_equal_u8(
-            price_precision,
-            price_increment.precision,
-            stringify!(price_precision),
-            stringify!(price_increment.precision),
-        )
-        .expect(FAILED);
-        check_equal_u8(
-            size_precision,
-            size_increment.precision,
-            stringify!(size_precision),
-            stringify!(size_increment.precision),
-        )
-        .expect(FAILED);
-        check_positive_i64(price_increment.raw, stringify!(price_increment.raw)).expect(FAILED);
-        check_positive_u64(size_increment.raw, stringify!(size_increment.raw)).expect(FAILED);
-
-        Self {
+        Self::new_checked(
             id,
             raw_symbol,
             base_currency,
@@ -113,8 +163,8 @@ impl CurrencyPair {
             size_precision,
             price_increment,
             size_increment,
-            maker_fee,
             taker_fee,
+            maker_fee,
             margin_init,
             margin_maint,
             lot_size,
@@ -126,7 +176,8 @@ impl CurrencyPair {
             min_price,
             ts_event,
             ts_init,
-        }
+        )
+        .expect("Failed to create CurrencyPair instance")
     }
 }
 

--- a/nautilus_core/model/src/instruments/futures_spread.rs
+++ b/nautilus_core/model/src/instruments/futures_spread.rs
@@ -17,7 +17,7 @@ use std::hash::{Hash, Hasher};
 
 use nautilus_core::{
     correctness::{
-        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional, FAILED,
+        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional,
     },
     nanos::UnixNanos,
 };
@@ -67,6 +67,70 @@ pub struct FuturesSpread {
 }
 
 impl FuturesSpread {
+    /// Creates a new [`FuturesSpread`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        asset_class: AssetClass,
+        exchange: Option<Ustr>,
+        underlying: Ustr,
+        strategy_type: Ustr,
+        activation_ns: UnixNanos,
+        expiration_ns: UnixNanos,
+        currency: Currency,
+        price_precision: u8,
+        price_increment: Price,
+        multiplier: Quantity,
+        lot_size: Quantity,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+        margin_init: Option<Decimal>,
+        margin_maint: Option<Decimal>,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<Self> {
+        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin))?;
+        check_valid_string(underlying.as_str(), stringify!(underlying))?;
+        check_valid_string(strategy_type.as_str(), stringify!(strategy_type))?;
+        check_equal_u8(
+            price_precision,
+            price_increment.precision,
+            stringify!(price_precision),
+            stringify!(price_increment.precision),
+        )?;
+        check_positive_i64(price_increment.raw, stringify!(price_increment.raw))?;
+        Ok(Self {
+            id,
+            raw_symbol,
+            asset_class,
+            exchange,
+            underlying,
+            strategy_type,
+            activation_ns,
+            expiration_ns,
+            currency,
+            price_precision,
+            price_increment,
+            size_precision: 0,
+            size_increment: Quantity::from("1"),
+            multiplier,
+            lot_size,
+            margin_init: margin_init.unwrap_or(0.into()),
+            margin_maint: margin_maint.unwrap_or(0.into()),
+            max_quantity,
+            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            max_price,
+            min_price,
+            ts_event,
+            ts_init,
+        })
+    }
+
     /// Creates a new [`FuturesSpread`] instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -92,18 +156,7 @@ impl FuturesSpread {
         ts_event: UnixNanos,
         ts_init: UnixNanos,
     ) -> Self {
-        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin)).expect(FAILED);
-        check_valid_string(underlying.as_str(), stringify!(underlying)).expect(FAILED);
-        check_valid_string(strategy_type.as_str(), stringify!(strategy_type)).expect(FAILED);
-        check_equal_u8(
-            price_precision,
-            price_increment.precision,
-            stringify!(price_precision),
-            stringify!(price_increment.precision),
-        )
-        .expect(FAILED);
-        check_positive_i64(price_increment.raw, stringify!(price_increment.raw)).expect(FAILED);
-        Self {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -115,19 +168,18 @@ impl FuturesSpread {
             currency,
             price_precision,
             price_increment,
-            size_precision: 0,
-            size_increment: Quantity::from("1"),
             multiplier,
             lot_size,
-            margin_init: margin_init.unwrap_or(0.into()),
-            margin_maint: margin_maint.unwrap_or(0.into()),
             max_quantity,
-            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            min_quantity,
             max_price,
             min_price,
+            margin_init,
+            margin_maint,
             ts_event,
             ts_init,
-        }
+        )
+        .expect("Failed to create new FuturesSpread instance")
     }
 }
 

--- a/nautilus_core/model/src/instruments/options_contract.rs
+++ b/nautilus_core/model/src/instruments/options_contract.rs
@@ -17,7 +17,7 @@ use std::hash::{Hash, Hasher};
 
 use nautilus_core::{
     correctness::{
-        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional, FAILED,
+        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional,
     },
     nanos::UnixNanos,
 };
@@ -68,6 +68,72 @@ pub struct OptionsContract {
 }
 
 impl OptionsContract {
+    /// Creates a new [`OptionsContract`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        asset_class: AssetClass,
+        exchange: Option<Ustr>,
+        underlying: Ustr,
+        option_kind: OptionKind,
+        strike_price: Price,
+        currency: Currency,
+        activation_ns: UnixNanos,
+        expiration_ns: UnixNanos,
+        price_precision: u8,
+        price_increment: Price,
+        multiplier: Quantity,
+        lot_size: Quantity,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+        margin_init: Option<Decimal>,
+        margin_maint: Option<Decimal>,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<Self> {
+        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin))?;
+        check_valid_string(underlying.as_str(), stringify!(underlying))?;
+        check_equal_u8(
+            price_precision,
+            price_increment.precision,
+            stringify!(price_precision),
+            stringify!(price_increment.precision),
+        )?;
+        check_positive_i64(price_increment.raw, stringify!(price_increment.raw))?;
+
+        Ok(Self {
+            id,
+            raw_symbol,
+            asset_class,
+            exchange,
+            underlying,
+            option_kind,
+            activation_ns,
+            expiration_ns,
+            strike_price,
+            currency,
+            price_precision,
+            price_increment,
+            size_precision: 0,
+            size_increment: Quantity::from("1"),
+            multiplier,
+            lot_size,
+            max_quantity,
+            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            max_price,
+            min_price,
+            margin_init: margin_init.unwrap_or(0.into()),
+            margin_maint: margin_maint.unwrap_or(0.into()),
+            ts_event,
+            ts_init,
+        })
+    }
+
     /// Creates a new [`OptionsContract`] instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -94,43 +160,31 @@ impl OptionsContract {
         ts_event: UnixNanos,
         ts_init: UnixNanos,
     ) -> Self {
-        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin)).expect(FAILED);
-        check_valid_string(underlying.as_str(), stringify!(underlying)).expect(FAILED);
-        check_equal_u8(
-            price_precision,
-            price_increment.precision,
-            stringify!(price_precision),
-            stringify!(price_increment.precision),
-        )
-        .expect(FAILED);
-        check_positive_i64(price_increment.raw, stringify!(price_increment.raw)).expect(FAILED);
-
-        Self {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
             exchange,
             underlying,
             option_kind,
-            activation_ns,
-            expiration_ns,
             strike_price,
             currency,
+            activation_ns,
+            expiration_ns,
             price_precision,
             price_increment,
-            size_precision: 0,
-            size_increment: Quantity::from("1"),
             multiplier,
             lot_size,
             max_quantity,
-            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            min_quantity,
             max_price,
             min_price,
-            margin_init: margin_init.unwrap_or(0.into()),
-            margin_maint: margin_maint.unwrap_or(0.into()),
+            margin_init,
+            margin_maint,
             ts_event,
             ts_init,
-        }
+        )
+        .expect("Failed to create OptionsContract instance")
     }
 }
 

--- a/nautilus_core/model/src/instruments/options_spread.rs
+++ b/nautilus_core/model/src/instruments/options_spread.rs
@@ -17,7 +17,7 @@ use std::hash::{Hash, Hasher};
 
 use nautilus_core::{
     correctness::{
-        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional, FAILED,
+        check_equal_u8, check_positive_i64, check_valid_string, check_valid_string_optional,
     },
     nanos::UnixNanos,
 };
@@ -67,6 +67,70 @@ pub struct OptionsSpread {
 }
 
 impl OptionsSpread {
+    /// Creates a new [`OptionsSpread`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        id: InstrumentId,
+        raw_symbol: Symbol,
+        asset_class: AssetClass,
+        exchange: Option<Ustr>,
+        underlying: Ustr,
+        strategy_type: Ustr,
+        activation_ns: UnixNanos,
+        expiration_ns: UnixNanos,
+        currency: Currency,
+        price_precision: u8,
+        price_increment: Price,
+        multiplier: Quantity,
+        lot_size: Quantity,
+        margin_init: Option<Decimal>,
+        margin_maint: Option<Decimal>,
+        max_quantity: Option<Quantity>,
+        min_quantity: Option<Quantity>,
+        max_price: Option<Price>,
+        min_price: Option<Price>,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<Self> {
+        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin))?;
+        check_valid_string(underlying.as_str(), stringify!(underlying))?;
+        check_valid_string(strategy_type.as_str(), stringify!(strategy_type))?;
+        check_equal_u8(
+            price_precision,
+            price_increment.precision,
+            stringify!(price_precision),
+            stringify!(price_increment.precision),
+        )?;
+        check_positive_i64(price_increment.raw, stringify!(price_increment.raw))?;
+        Ok(Self {
+            id,
+            raw_symbol,
+            asset_class,
+            exchange,
+            underlying,
+            strategy_type,
+            activation_ns,
+            expiration_ns,
+            currency,
+            price_precision,
+            price_increment,
+            size_precision: 0,
+            size_increment: Quantity::from("1"),
+            multiplier,
+            lot_size,
+            margin_init: margin_init.unwrap_or(0.into()),
+            margin_maint: margin_maint.unwrap_or(0.into()),
+            max_quantity,
+            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            max_price,
+            min_price,
+            ts_event,
+            ts_init,
+        })
+    }
+
     /// Creates a new [`OptionsSpread`] instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -92,18 +156,7 @@ impl OptionsSpread {
         ts_event: UnixNanos,
         ts_init: UnixNanos,
     ) -> Self {
-        check_valid_string_optional(exchange.map(|u| u.as_str()), stringify!(isin)).expect(FAILED);
-        check_valid_string(underlying.as_str(), stringify!(underlying)).expect(FAILED);
-        check_valid_string(strategy_type.as_str(), stringify!(strategy_type)).expect(FAILED);
-        check_equal_u8(
-            price_precision,
-            price_increment.precision,
-            stringify!(price_precision),
-            stringify!(price_increment.precision),
-        )
-        .expect(FAILED);
-        check_positive_i64(price_increment.raw, stringify!(price_increment.raw)).expect(FAILED);
-        Self {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -115,19 +168,18 @@ impl OptionsSpread {
             currency,
             price_precision,
             price_increment,
-            size_precision: 0,
-            size_increment: Quantity::from("1"),
             multiplier,
             lot_size,
-            margin_init: margin_init.unwrap_or(0.into()),
-            margin_maint: margin_maint.unwrap_or(0.into()),
+            margin_init,
+            margin_maint,
             max_quantity,
-            min_quantity: Some(min_quantity.unwrap_or(1.into())),
+            min_quantity,
             max_price,
             min_price,
             ts_event,
             ts_init,
-        }
+        )
+        .expect("Failed to create OptionsSpread instance")
     }
 }
 

--- a/nautilus_core/model/src/instruments/stubs.rs
+++ b/nautilus_core/model/src/instruments/stubs.rs
@@ -47,7 +47,6 @@ impl Default for SyntheticInstrument {
             0.into(),
             0.into(),
         )
-        .unwrap()
     }
 }
 

--- a/nautilus_core/model/src/instruments/synthetic.rs
+++ b/nautilus_core/model/src/instruments/synthetic.rs
@@ -48,8 +48,10 @@ pub struct SyntheticInstrument {
 }
 
 impl SyntheticInstrument {
-    /// Creates a new [`SyntheticInstrument`] instance.
-    pub fn new(
+    /// Creates a new [`SyntheticInstrument`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    pub fn new_checked(
         symbol: Symbol,
         price_precision: u8,
         components: Vec<InstrumentId>,
@@ -79,6 +81,26 @@ impl SyntheticInstrument {
             ts_event,
             ts_init,
         })
+    }
+
+    /// Creates a new [`SyntheticInstrument`] instance
+    pub fn new(
+        symbol: Symbol,
+        price_precision: u8,
+        components: Vec<InstrumentId>,
+        formula: String,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            symbol,
+            price_precision,
+            components,
+            formula,
+            ts_event,
+            ts_init,
+        )
+        .expect("Failed to create synthetic instrument")
     }
 
     #[must_use]

--- a/nautilus_core/model/src/orderbook/book.rs
+++ b/nautilus_core/model/src/orderbook/book.rs
@@ -572,8 +572,7 @@ mod tests {
             Quantity::from("99.00000000"),
             0.into(),
             0.into(),
-        )
-        .unwrap();
+        );
 
         update_book_with_quote_tick(&mut book, &quote).unwrap();
 

--- a/nautilus_core/model/src/orders/default.rs
+++ b/nautilus_core/model/src/orders/default.rs
@@ -120,7 +120,6 @@ impl Default for MarketOrder {
             None,
             None,
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }
 
@@ -154,7 +153,6 @@ impl Default for MarketIfTouchedOrder {
             UUID4::default(),
             UnixNanos::default(),
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }
 
@@ -185,7 +183,6 @@ impl Default for MarketToLimitOrder {
             UUID4::default(),
             UnixNanos::default(),
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }
 
@@ -221,7 +218,6 @@ impl Default for StopLimitOrder {
             UUID4::default(),
             UnixNanos::default(),
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }
 
@@ -255,7 +251,6 @@ impl Default for StopMarketOrder {
             UUID4::default(),
             UnixNanos::default(),
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }
 
@@ -329,6 +324,5 @@ impl Default for TrailingStopMarketOrder {
             UUID4::default(),
             UnixNanos::default(),
         )
-        .unwrap() // SAFETY: Valid default values are used
     }
 }

--- a/nautilus_core/model/src/orders/market.rs
+++ b/nautilus_core/model/src/orders/market.rs
@@ -19,7 +19,11 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use nautilus_core::{nanos::UnixNanos, uuid::UUID4};
+use nautilus_core::{
+    correctness::{check_predicate_false, FAILED},
+    nanos::UnixNanos,
+    uuid::UUID4,
+};
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
@@ -76,11 +80,59 @@ impl MarketOrder {
         exec_algorithm_params: Option<HashMap<Ustr, Ustr>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<Ustr>>,
+    ) -> Self {
+        Self::new_checked(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            time_in_force,
+            init_id,
+            ts_init,
+            reduce_only,
+            quote_quantity,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags,
+        )
+        .expect(FAILED)
+    }
+
+    /// Creates a new [`MarketOrder`] instance.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_checked(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        time_in_force: TimeInForce,
+        init_id: UUID4,
+        ts_init: UnixNanos,
+        reduce_only: bool,
+        quote_quantity: bool,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<HashMap<Ustr, Ustr>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<Vec<Ustr>>,
     ) -> anyhow::Result<Self> {
         check_quantity_positive(quantity)?;
-        if time_in_force == TimeInForce::Gtd {
-            anyhow::bail!("GTD not supported for Market orders");
-        }
+        check_predicate_false(
+            time_in_force == TimeInForce::Gtd,
+            "GTD not supported for Market orders",
+        )?;
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -435,7 +487,6 @@ impl From<OrderInitialized> for MarketOrder {
             event.exec_spawn_id,
             event.tags,
         )
-        .unwrap() // SAFETY: From can panic
     }
 }
 

--- a/nautilus_core/model/src/orders/market_if_touched.rs
+++ b/nautilus_core/model/src/orders/market_if_touched.rs
@@ -84,7 +84,7 @@ impl MarketIfTouchedOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -120,7 +120,7 @@ impl MarketIfTouchedOrder {
             exec_spawn_id,
             tags,
         );
-        Ok(Self {
+        Self {
             core: OrderCore::new(init_order),
             trigger_price,
             trigger_type,
@@ -129,7 +129,7 @@ impl MarketIfTouchedOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        })
+        }
     }
 }
 
@@ -416,6 +416,6 @@ impl From<OrderInitialized> for MarketIfTouchedOrder {
             event.tags,
             event.event_id,
             event.ts_event,
-        ).unwrap() // SAFETY: From can panic
+        )
     }
 }

--- a/nautilus_core/model/src/orders/market_to_limit.rs
+++ b/nautilus_core/model/src/orders/market_to_limit.rs
@@ -79,7 +79,7 @@ impl MarketToLimitOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -115,13 +115,13 @@ impl MarketToLimitOrder {
             exec_spawn_id,
             tags,
         );
-        Ok(Self {
+        Self {
             core: OrderCore::new(init_order),
             price: None, // Price will be determined on fill
             expire_time,
             is_post_only: post_only,
             display_qty,
-        })
+        }
     }
 }
 
@@ -389,6 +389,5 @@ impl From<OrderInitialized> for MarketToLimitOrder {
             event.event_id,
             event.ts_event,
         )
-        .unwrap() // SAFETY: From can panic
     }
 }

--- a/nautilus_core/model/src/orders/stop_limit.rs
+++ b/nautilus_core/model/src/orders/stop_limit.rs
@@ -89,7 +89,7 @@ impl StopLimitOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -125,7 +125,7 @@ impl StopLimitOrder {
             exec_spawn_id,
             tags,
         );
-        Ok(Self {
+        Self {
             core: OrderCore::new(init_order),
             price,
             trigger_price,
@@ -136,7 +136,7 @@ impl StopLimitOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        })
+        }
     }
 }
 
@@ -436,7 +436,6 @@ impl From<OrderInitialized> for StopLimitOrder {
             event.event_id,
             event.ts_event,
         )
-        .unwrap() // SAFETY: From can panic
     }
 }
 

--- a/nautilus_core/model/src/orders/stop_market.rs
+++ b/nautilus_core/model/src/orders/stop_market.rs
@@ -85,7 +85,7 @@ impl StopMarketOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -121,7 +121,7 @@ impl StopMarketOrder {
             exec_spawn_id,
             tags,
         );
-        Ok(Self {
+        Self {
             core: OrderCore::new(init_order),
             trigger_price,
             trigger_type,
@@ -130,7 +130,7 @@ impl StopMarketOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        })
+        }
     }
 }
 
@@ -403,6 +403,5 @@ impl From<OrderInitialized> for StopMarketOrder {
             event.event_id,
             event.ts_event,
         )
-        .unwrap() // SAFETY: From can panic
     }
 }

--- a/nautilus_core/model/src/orders/stubs.rs
+++ b/nautilus_core/model/src/orders/stubs.rs
@@ -152,8 +152,7 @@ impl TestOrderStubs {
             None,
             None,
             None,
-        )
-        .unwrap();
+        );
         OrderAny::Market(order)
     }
 
@@ -185,8 +184,7 @@ impl TestOrderStubs {
             None,
             None,
             None,
-        )
-        .unwrap();
+        );
         OrderAny::Market(order)
     }
 
@@ -271,8 +269,7 @@ impl TestOrderStubs {
             None,
             UUID4::new(),
             UnixNanos::default(),
-        )
-        .unwrap();
+        );
         OrderAny::StopMarket(order)
     }
 
@@ -289,36 +286,33 @@ impl TestOrderStubs {
         time_in_force: Option<TimeInForce>,
         linked_order_ids: Option<Vec<ClientOrderId>>,
     ) -> OrderAny {
-        OrderAny::MarketIfTouched(
-            MarketIfTouchedOrder::new(
-                TraderId::default(),
-                StrategyId::default(),
-                instrument_id,
-                client_order_id.unwrap_or_default(),
-                order_side,
-                quantity,
-                trigger_price,
-                trigger_type.unwrap_or(TriggerType::BidAsk),
-                time_in_force.unwrap_or(TimeInForce::Gtc),
-                None,
-                false,
-                false,
-                None,
-                None,
-                None,
-                contingency_type,
-                None,
-                linked_order_ids,
-                None,
-                None,
-                None,
-                None,
-                None,
-                UUID4::new(),
-                UnixNanos::default(),
-            )
-            .unwrap(),
-        )
+        OrderAny::MarketIfTouched(MarketIfTouchedOrder::new(
+            TraderId::default(),
+            StrategyId::default(),
+            instrument_id,
+            client_order_id.unwrap_or_default(),
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type.unwrap_or(TriggerType::BidAsk),
+            time_in_force.unwrap_or(TimeInForce::Gtc),
+            None,
+            false,
+            false,
+            None,
+            None,
+            None,
+            contingency_type,
+            None,
+            linked_order_ids,
+            None,
+            None,
+            None,
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+        ))
     }
 
     pub fn make_accepted_order(order: &OrderAny) -> OrderAny {

--- a/nautilus_core/model/src/orders/trailing_stop_market.rs
+++ b/nautilus_core/model/src/orders/trailing_stop_market.rs
@@ -89,7 +89,7 @@ impl TrailingStopMarketOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Self> {
+    ) -> Self {
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -125,7 +125,7 @@ impl TrailingStopMarketOrder {
             exec_spawn_id,
             tags,
         );
-        Ok(Self {
+        Self {
             core: OrderCore::new(init_order),
             trigger_price,
             trigger_type,
@@ -136,7 +136,7 @@ impl TrailingStopMarketOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        })
+        }
     }
 }
 
@@ -425,6 +425,6 @@ impl From<OrderInitialized> for TrailingStopMarketOrder {
             event.tags,
             event.event_id,
             event.ts_event,
-        ).unwrap() // SAFETY: From can panic
+        )
     }
 }

--- a/nautilus_core/model/src/python/data/deltas.rs
+++ b/nautilus_core/model/src/python/data/deltas.rs
@@ -19,6 +19,7 @@ use std::{
     ops::Deref,
 };
 
+use nautilus_core::python::to_pyvalue_err;
 use pyo3::{prelude::*, pyclass::CompareOp, types::PyCapsule};
 
 use super::data_to_pycapsule;
@@ -35,8 +36,8 @@ use crate::{
 #[pymethods]
 impl OrderBookDeltas {
     #[new]
-    fn py_new(instrument_id: InstrumentId, deltas: Vec<OrderBookDelta>) -> Self {
-        Self::new(instrument_id, deltas)
+    fn py_new(instrument_id: InstrumentId, deltas: Vec<OrderBookDelta>) -> PyResult<Self> {
+        Self::new_checked(instrument_id, deltas).map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/data/quote.rs
+++ b/nautilus_core/model/src/python/data/quote.rs
@@ -69,7 +69,7 @@ impl QuoteTick {
         let ts_event: u64 = obj.getattr("ts_event")?.extract()?;
         let ts_init: u64 = obj.getattr("ts_init")?.extract()?;
 
-        Self::new(
+        Self::new_checked(
             instrument_id,
             bid_price,
             ask_price,
@@ -94,7 +94,7 @@ impl QuoteTick {
         ts_event: u64,
         ts_init: u64,
     ) -> PyResult<Self> {
-        Self::new(
+        Self::new_checked(
             instrument_id,
             bid_price,
             ask_price,
@@ -169,7 +169,7 @@ impl QuoteTick {
 
     #[staticmethod]
     fn _safe_constructor() -> PyResult<Self> {
-        Ok(Self::new(
+        Self::new_checked(
             InstrumentId::from("NULL.NULL"),
             Price::zero(0),
             Price::zero(0),
@@ -178,7 +178,7 @@ impl QuoteTick {
             UnixNanos::default(),
             UnixNanos::default(),
         )
-        .unwrap()) // Safe default
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
@@ -293,7 +293,7 @@ impl QuoteTick {
         ts_event: u64,
         ts_init: u64,
     ) -> PyResult<Self> {
-        Self::new(
+        Self::new_checked(
             instrument_id,
             Price::from_raw(bid_price_raw, bid_price_prec),
             Price::from_raw(ask_price_raw, ask_price_prec),

--- a/nautilus_core/model/src/python/data/status.rs
+++ b/nautilus_core/model/src/python/data/status.rs
@@ -100,8 +100,8 @@ impl InstrumentStatus {
         is_trading: Option<bool>,
         is_quoting: Option<bool>,
         is_short_sell_restricted: Option<bool>,
-    ) -> PyResult<Self> {
-        Ok(Self::new(
+    ) -> Self {
+        Self::new(
             instrument_id,
             action,
             ts_event.into(),
@@ -111,7 +111,7 @@ impl InstrumentStatus {
             is_trading,
             is_quoting,
             is_short_sell_restricted,
-        ))
+        )
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/data/trade.rs
+++ b/nautilus_core/model/src/python/data/trade.rs
@@ -157,8 +157,8 @@ impl TradeTick {
     }
 
     #[staticmethod]
-    fn _safe_constructor() -> PyResult<Self> {
-        Ok(Self::new(
+    fn _safe_constructor() -> Self {
+        Self::new(
             InstrumentId::from("NULL.NULL"),
             Price::zero(0),
             Quantity::zero(0),
@@ -166,9 +166,9 @@ impl TradeTick {
             TradeId::from("NULL"),
             UnixNanos::default(),
             UnixNanos::default(),
-        ))
-        // Safe default
+        )
     }
+
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
         match op {
             CompareOp::Eq => self.eq(other).into_py(py),

--- a/nautilus_core/model/src/python/events/order/cancel_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/cancel_rejected.rs
@@ -43,9 +43,9 @@ impl OrderCancelRejected {
         reconciliation: bool,
         venue_order_id: Option<VenueOrderId>,
         account_id: Option<AccountId>,
-    ) -> Self {
-        let reason = Ustr::from_str(reason).unwrap();
-        Self::new(
+    ) -> PyResult<Self> {
+        let reason = Ustr::from_str(reason).map_err(to_pyvalue_err)?;
+        Ok(Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -57,7 +57,7 @@ impl OrderCancelRejected {
             reconciliation,
             venue_order_id,
             account_id,
-        )
+        ))
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/events/order/denied.rs
+++ b/nautilus_core/model/src/python/events/order/denied.rs
@@ -40,9 +40,9 @@ impl OrderDenied {
         event_id: UUID4,
         ts_event: u64,
         ts_init: u64,
-    ) -> Self {
-        let reason = Ustr::from_str(reason).unwrap();
-        Self::new(
+    ) -> PyResult<Self> {
+        let reason = Ustr::from_str(reason).map_err(to_pyvalue_err)?;
+        Ok(Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -51,7 +51,7 @@ impl OrderDenied {
             event_id,
             ts_event.into(),
             ts_init.into(),
-        )
+        ))
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/events/order/modify_rejected.rs
+++ b/nautilus_core/model/src/python/events/order/modify_rejected.rs
@@ -43,9 +43,9 @@ impl OrderModifyRejected {
         reconciliation: bool,
         venue_order_id: Option<VenueOrderId>,
         account_id: Option<AccountId>,
-    ) -> Self {
-        let reason = Ustr::from_str(reason).unwrap();
-        Self::new(
+    ) -> PyResult<Self> {
+        let reason = Ustr::from_str(reason).map_err(to_pyvalue_err)?;
+        Ok(Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -57,7 +57,7 @@ impl OrderModifyRejected {
             reconciliation,
             venue_order_id,
             account_id,
-        )
+        ))
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/events/order/rejected.rs
+++ b/nautilus_core/model/src/python/events/order/rejected.rs
@@ -41,9 +41,9 @@ impl OrderRejected {
         ts_event: u64,
         ts_init: u64,
         reconciliation: bool,
-    ) -> Self {
-        let reason = Ustr::from_str(reason).unwrap();
-        Self::new(
+    ) -> PyResult<Self> {
+        let reason = Ustr::from_str(reason).map_err(to_pyvalue_err)?;
+        Ok(Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -54,7 +54,7 @@ impl OrderRejected {
             ts_event.into(),
             ts_init.into(),
             reconciliation,
-        )
+        ))
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/crypto_future.rs
+++ b/nautilus_core/model/src/python/instruments/crypto_future.rs
@@ -58,8 +58,8 @@ impl CryptoFuture {
         min_notional: Option<Money>,
         max_price: Option<Price>,
         min_price: Option<Price>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             underlying,
@@ -86,6 +86,7 @@ impl CryptoFuture {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __hash__(&self) -> isize {

--- a/nautilus_core/model/src/python/instruments/crypto_perpetual.rs
+++ b/nautilus_core/model/src/python/instruments/crypto_perpetual.rs
@@ -56,8 +56,8 @@ impl CryptoPerpetual {
         min_notional: Option<Money>,
         max_price: Option<Price>,
         min_price: Option<Price>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             base_currency,
@@ -82,6 +82,7 @@ impl CryptoPerpetual {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/currency_pair.rs
+++ b/nautilus_core/model/src/python/instruments/currency_pair.rs
@@ -54,8 +54,8 @@ impl CurrencyPair {
         min_notional: Option<Money>,
         max_price: Option<Price>,
         min_price: Option<Price>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             base_currency,
@@ -78,6 +78,7 @@ impl CurrencyPair {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/equity.rs
+++ b/nautilus_core/model/src/python/instruments/equity.rs
@@ -51,8 +51,8 @@ impl Equity {
         min_quantity: Option<Quantity>,
         max_price: Option<Price>,
         min_price: Option<Price>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             isin.map(|x| Ustr::from(&x)),
@@ -71,6 +71,7 @@ impl Equity {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/futures_contract.rs
+++ b/nautilus_core/model/src/python/instruments/futures_contract.rs
@@ -55,8 +55,8 @@ impl FuturesContract {
         max_price: Option<Price>,
         min_price: Option<Price>,
         exchange: Option<String>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -78,6 +78,7 @@ impl FuturesContract {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/futures_spread.rs
+++ b/nautilus_core/model/src/python/instruments/futures_spread.rs
@@ -56,8 +56,8 @@ impl FuturesSpread {
         max_price: Option<Price>,
         min_price: Option<Price>,
         exchange: Option<String>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -80,6 +80,7 @@ impl FuturesSpread {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/options_contract.rs
+++ b/nautilus_core/model/src/python/instruments/options_contract.rs
@@ -57,8 +57,8 @@ impl OptionsContract {
         max_price: Option<Price>,
         min_price: Option<Price>,
         exchange: Option<String>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -82,6 +82,7 @@ impl OptionsContract {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/instruments/options_spread.rs
+++ b/nautilus_core/model/src/python/instruments/options_spread.rs
@@ -56,8 +56,8 @@ impl OptionsSpread {
         max_price: Option<Price>,
         min_price: Option<Price>,
         exchange: Option<String>,
-    ) -> Self {
-        Self::new(
+    ) -> PyResult<Self> {
+        Self::new_checked(
             id,
             raw_symbol,
             asset_class,
@@ -80,6 +80,7 @@ impl OptionsSpread {
             ts_event.into(),
             ts_init.into(),
         )
+        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {

--- a/nautilus_core/model/src/python/orders/market.rs
+++ b/nautilus_core/model/src/python/orders/market.rs
@@ -71,7 +71,7 @@ impl MarketOrder {
         tags: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Self::new(
+        Self::new_checked(
             trader_id,
             strategy_id,
             instrument_id,
@@ -520,7 +520,7 @@ impl MarketOrder {
                 }
             })
         })?;
-        let market_order = Self::new(
+        Self::new_checked(
             trader_id,
             strategy_id,
             instrument_id,
@@ -541,8 +541,7 @@ impl MarketOrder {
             exec_spawn_id,
             tags,
         )
-        .unwrap();
-        Ok(market_order)
+        .map_err(to_pyvalue_err)
     }
 
     #[pyo3(name = "apply")]

--- a/nautilus_core/model/src/python/orders/market_if_touched.rs
+++ b/nautilus_core/model/src/python/orders/market_if_touched.rs
@@ -63,9 +63,9 @@ impl MarketIfTouchedOrder {
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<String>>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Ok(Self::new(
+        Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -92,7 +92,6 @@ impl MarketIfTouchedOrder {
             init_id,
             ts_init.into(),
         )
-        .unwrap())
     }
 
     #[getter]

--- a/nautilus_core/model/src/python/orders/market_to_limit.rs
+++ b/nautilus_core/model/src/python/orders/market_to_limit.rs
@@ -60,9 +60,9 @@ impl MarketToLimitOrder {
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<String>>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Ok(Self::new(
+        Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -86,7 +86,6 @@ impl MarketToLimitOrder {
             init_id,
             ts_init.into(),
         )
-        .unwrap())
     }
 
     #[getter]

--- a/nautilus_core/model/src/python/orders/stop_limit.rs
+++ b/nautilus_core/model/src/python/orders/stop_limit.rs
@@ -72,7 +72,7 @@ impl StopLimitOrder {
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<String>>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
         Self::new(
             trader_id,
@@ -103,7 +103,6 @@ impl StopLimitOrder {
             init_id,
             ts_init.into(),
         )
-        .map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
@@ -667,8 +666,7 @@ impl StopLimitOrder {
             tags,
             init_id,
             ts_init.into(),
-        )
-        .unwrap();
+        );
         Ok(stop_limit_order)
     }
 

--- a/nautilus_core/model/src/python/orders/stop_market.rs
+++ b/nautilus_core/model/src/python/orders/stop_market.rs
@@ -63,9 +63,9 @@ impl StopMarketOrder {
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<String>>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Ok(Self::new(
+        Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -92,7 +92,6 @@ impl StopMarketOrder {
             init_id,
             ts_init.into(),
         )
-        .unwrap())
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/python/orders/trailing_stop_market.rs
+++ b/nautilus_core/model/src/python/orders/trailing_stop_market.rs
@@ -65,9 +65,9 @@ impl TrailingStopMarketOrder {
         exec_algorithm_params: Option<HashMap<String, String>>,
         exec_spawn_id: Option<ClientOrderId>,
         tags: Option<Vec<String>>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let exec_algorithm_params = exec_algorithm_params.map(str_hashmap_to_ustr);
-        Ok(Self::new(
+        Self::new(
             trader_id,
             strategy_id,
             instrument_id,
@@ -96,7 +96,6 @@ impl TrailingStopMarketOrder {
             init_id,
             ts_init.into(),
         )
-        .unwrap())
     }
 
     #[getter]

--- a/nautilus_core/model/src/python/types/balance.rs
+++ b/nautilus_core/model/src/python/types/balance.rs
@@ -31,7 +31,7 @@ use crate::{
 impl AccountBalance {
     #[new]
     fn py_new(total: Money, locked: Money, free: Money) -> PyResult<Self> {
-        Ok(Self::new(total, locked, free))
+        Self::new_checked(total, locked, free).map_err(to_pyvalue_err)
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
@@ -62,12 +62,12 @@ impl AccountBalance {
         let locked_str: &str = dict.get_item("locked")?.unwrap().extract()?;
         let locked: f64 = locked_str.parse::<f64>().unwrap();
         let currency = Currency::from_str(currency).map_err(to_pyvalue_err)?;
-        let account_balance = Self::new(
+        Self::new_checked(
             Money::new(total, currency),
             Money::new(locked, currency),
             Money::new(free, currency),
-        );
-        Ok(account_balance)
+        )
+        .map_err(to_pyvalue_err)
     }
 
     #[pyo3(name = "to_dict")]

--- a/nautilus_core/model/src/python/types/currency.rs
+++ b/nautilus_core/model/src/python/types/currency.rs
@@ -42,10 +42,7 @@ impl Currency {
         name: &str,
         currency_type: CurrencyType,
     ) -> PyResult<Self> {
-        check_valid_string(code, "code").map_err(to_pyvalue_err)?;
-        check_valid_string(name, "name").map_err(to_pyvalue_err)?;
-        check_fixed_precision(precision).map_err(to_pyvalue_err)?;
-        Ok(Self::new(code, precision, iso4217, name, currency_type))
+        Self::new_checked(code, precision, iso4217, name, currency_type).map_err(to_pyvalue_err)
     }
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
@@ -158,7 +155,8 @@ impl Currency {
                 if strict {
                     Err(to_pyvalue_err(e))
                 } else {
-                    Ok(Self::new(value, 8, 0, value, CurrencyType::Crypto))
+                    Self::new_checked(value, 8, 0, value, CurrencyType::Crypto)
+                        .map_err(to_pyvalue_err)
                 }
             }
         }

--- a/nautilus_core/model/src/python/types/money.rs
+++ b/nautilus_core/model/src/python/types/money.rs
@@ -41,9 +41,7 @@ use crate::types::{
 impl Money {
     #[new]
     fn py_new(amount: f64, currency: Currency) -> PyResult<Self> {
-        check_in_range_inclusive_f64(amount, MONEY_MIN, MONEY_MAX, "amount")
-            .map_err(to_pyvalue_err)?;
-        Ok(Self::new(amount, currency))
+        Self::new_checked(amount, currency).map_err(to_pyvalue_err)
     }
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {

--- a/nautilus_core/model/src/python/types/price.rs
+++ b/nautilus_core/model/src/python/types/price.rs
@@ -41,10 +41,7 @@ use crate::types::{
 impl Price {
     #[new]
     fn py_new(value: f64, precision: u8) -> PyResult<Self> {
-        check_in_range_inclusive_f64(value, PRICE_MIN, PRICE_MAX, "value")
-            .map_err(to_pyvalue_err)?;
-        check_fixed_precision(precision).map_err(to_pyvalue_err)?;
-        Ok(Self::new(value, precision))
+        Self::new_checked(value, precision).map_err(to_pyvalue_err)
     }
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
@@ -348,14 +345,14 @@ impl Price {
     #[staticmethod]
     #[pyo3(name = "zero")]
     #[pyo3(signature = (precision = 0))]
-    fn py_zero(precision: u8) -> Self {
-        Self::new(0.0, precision)
+    fn py_zero(precision: u8) -> PyResult<Self> {
+        Self::new_checked(0.0, precision).map_err(to_pyvalue_err)
     }
 
     #[staticmethod]
     #[pyo3(name = "from_int")]
-    fn py_from_int(value: u64) -> Self {
-        Self::new(value as f64, 0)
+    fn py_from_int(value: u64) -> PyResult<Self> {
+        Self::new_checked(value as f64, 0).map_err(to_pyvalue_err)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/python/types/quantity.rs
+++ b/nautilus_core/model/src/python/types/quantity.rs
@@ -41,10 +41,7 @@ use crate::types::{
 impl Quantity {
     #[new]
     fn py_new(value: f64, precision: u8) -> PyResult<Self> {
-        check_in_range_inclusive_f64(value, QUANTITY_MIN, QUANTITY_MAX, "value")
-            .map_err(to_pyvalue_err)?;
-        check_fixed_precision(precision).map_err(to_pyvalue_err)?;
-        Ok(Self::new(value, precision))
+        Self::new_checked(value, precision).map_err(to_pyvalue_err)
     }
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
@@ -348,14 +345,14 @@ impl Quantity {
     #[staticmethod]
     #[pyo3(name = "zero")]
     #[pyo3(signature = (precision = 0))]
-    fn py_zero(precision: u8) -> Self {
-        Self::new(0.0, precision)
+    fn py_zero(precision: u8) -> PyResult<Self> {
+        Self::new_checked(0.0, precision).map_err(to_pyvalue_err)
     }
 
     #[staticmethod]
     #[pyo3(name = "from_int")]
-    fn py_from_int(value: u64) -> Self {
-        Self::new(value as f64, 0)
+    fn py_from_int(value: u64) -> PyResult<Self> {
+        Self::new_checked(value as f64, 0).map_err(to_pyvalue_err)
     }
 
     #[staticmethod]

--- a/nautilus_core/model/src/types/money.rs
+++ b/nautilus_core/model/src/types/money.rs
@@ -21,7 +21,7 @@ use std::{
     str::FromStr,
 };
 
-use nautilus_core::correctness::{check_in_range_inclusive_f64, FAILED};
+use nautilus_core::correctness::check_in_range_inclusive_f64;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Deserializer, Serialize};
 use thousands::Separable;
@@ -50,14 +50,21 @@ pub struct Money {
 }
 
 impl Money {
-    /// Creates a new [`Money`] instance.
-    pub fn new(amount: f64, currency: Currency) -> Self {
-        check_in_range_inclusive_f64(amount, MONEY_MIN, MONEY_MAX, "amount").expect(FAILED);
+    /// Creates a new [`Money`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    pub fn new_checked(amount: f64, currency: Currency) -> anyhow::Result<Self> {
+        check_in_range_inclusive_f64(amount, MONEY_MIN, MONEY_MAX, "amount")?;
 
-        Self {
+        Ok(Self {
             raw: f64_to_fixed_i64(amount, currency.precision),
             currency,
-        }
+        })
+    }
+
+    /// Creates a new [`Money`] instance.
+    pub fn new(amount: f64, currency: Currency) -> Self {
+        Self::new_checked(amount, currency).expect("Failed to create Money instance")
     }
 
     #[must_use]

--- a/nautilus_core/model/src/types/price.rs
+++ b/nautilus_core/model/src/types/price.rs
@@ -62,13 +62,18 @@ pub struct Price {
 }
 
 impl Price {
-    pub fn new(value: f64, precision: u8) -> Self {
-        check_in_range_inclusive_f64(value, PRICE_MIN, PRICE_MAX, "value").expect(FAILED);
-        check_fixed_precision(precision).expect(FAILED);
-        Self {
+    pub fn new_checked(value: f64, precision: u8) -> anyhow::Result<Self> {
+        check_in_range_inclusive_f64(value, PRICE_MIN, PRICE_MAX, "value")?;
+        check_fixed_precision(precision)?;
+
+        Ok(Self {
             raw: f64_to_fixed_i64(value, precision),
             precision,
-        }
+        })
+    }
+
+    pub fn new(value: f64, precision: u8) -> Self {
+        Self::new_checked(value, precision).expect("Failed to create new Price instance")
     }
 
     pub fn from_raw(raw: i64, precision: u8) -> Self {

--- a/nautilus_core/model/src/types/quantity.rs
+++ b/nautilus_core/model/src/types/quantity.rs
@@ -53,14 +53,22 @@ pub struct Quantity {
 }
 
 impl Quantity {
-    /// Creates a new [`Quantity`] instance.
-    pub fn new(value: f64, precision: u8) -> Self {
-        check_in_range_inclusive_f64(value, QUANTITY_MIN, QUANTITY_MAX, "value").expect(FAILED);
-        check_fixed_precision(precision).expect(FAILED);
-        Self {
+    /// Creates a new [`Quantity`] instance with correctness checking.
+    ///
+    /// Note: PyO3 requires a Result type that stacktrace can be printed for errors.
+    pub fn new_checked(value: f64, precision: u8) -> anyhow::Result<Self> {
+        check_in_range_inclusive_f64(value, QUANTITY_MIN, QUANTITY_MAX, "value")?;
+        check_fixed_precision(precision)?;
+
+        Ok(Self {
             raw: f64_to_fixed_u64(value, precision),
             precision,
-        }
+        })
+    }
+
+    /// Creates a new [`Quantity`] instance.
+    pub fn new(value: f64, precision: u8) -> Self {
+        Self::new_checked(value, precision).expect("Valid input for `Quantity`")
     }
 
     pub fn from_raw(raw: u64, precision: u8) -> Self {


### PR DESCRIPTION
# Pull Request

Improve error handling by refactoring result type and unwraps. Sanitize PyO3 apis using a `new_checked` variation that returns Result type.

## Type of change

- [x] Refactor

## How has this change been tested?

Module tests were run
