### PR TITLE
Use an alias for Order in the dYdX adapter

### DIFF
--- a/docs/integrations/dydx.md
+++ b/docs/integrations/dydx.md
@@ -69,7 +69,7 @@ config = TradingNodeConfig(
     exec_clients={
         "DYDX": {
             "wallet_address": "YOUR_DYDX_WALLET_ADDRESS",
-            "subaccount": "YOUR_DYDYX_SUBACCOUNT_NUMBER"
+            "subaccount": "YOUR_DYDX_SUBACCOUNT_NUMBER"
             "mnemonic": "YOUR_MNEMONIC",
             "is_testnet": False,
         },
@@ -128,7 +128,7 @@ config = TradingNodeConfig(
     exec_clients={
         "DYDX": {
             "wallet_address": "YOUR_DYDX_WALLET_ADDRESS",
-            "subaccount": "YOUR_DYDYX_SUBACCOUNT_NUMBER"
+            "subaccount": "YOUR_DYDX_SUBACCOUNT_NUMBER"
             "mnemonic": "YOUR_MNEMONIC",
             "is_testnet": True,
         },

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 import msgspec
 import pandas as pd
 from grpc.aio._call import AioRpcError
-from v4_proto.dydxprotocol.clob.order_pb2 import Order
+from v4_proto.dydxprotocol.clob.order_pb2 import Order as DYDXOrder
 
 from nautilus_trader.adapters.dydx.common.constants import DYDX_VENUE
 from nautilus_trader.adapters.dydx.common.credentials import get_mnemonic
@@ -81,6 +81,7 @@ from nautilus_trader.model.objects import MarginBalance
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import Order
 
 
 if TYPE_CHECKING:
@@ -871,15 +872,15 @@ class DYDXExecutionClient(LiveExecutionClient):
             OrderType.MARKET: DYDXGRPCOrderType.MARKET,
         }
         order_side_map = {
-            OrderSide.NO_ORDER_SIDE: Order.Side.SIDE_UNSPECIFIED,
-            OrderSide.BUY: Order.Side.SIDE_BUY,
-            OrderSide.SELL: Order.Side.SIDE_SELL,
+            OrderSide.NO_ORDER_SIDE: DYDXOrder.Side.SIDE_UNSPECIFIED,
+            OrderSide.BUY: DYDXOrder.Side.SIDE_BUY,
+            OrderSide.SELL: DYDXOrder.Side.SIDE_SELL,
         }
         time_in_force_map = {
-            TimeInForce.GTC: Order.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
-            TimeInForce.GTD: Order.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
-            TimeInForce.IOC: Order.TimeInForce.TIME_IN_FORCE_IOC,
-            TimeInForce.FOK: Order.TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,
+            TimeInForce.GTC: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
+            TimeInForce.GTD: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
+            TimeInForce.IOC: DYDXOrder.TimeInForce.TIME_IN_FORCE_IOC,
+            TimeInForce.FOK: DYDXOrder.TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,
         }
 
         try:


### PR DESCRIPTION
# Pull Request

- Use an alias for the gRPC `Order` and import the Nautilus `Order` class for type-checking which was causing a naming conflict.
- Typo in the documentation

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Unit tests and running a live example on the testnet.
