### PR TITLE
Catch HttpError and HttpTimeoutError exception when performing HTTP requests for the dYdX adapter 

### DIFF
--- a/nautilus_trader/adapters/dydx/http/client.py
+++ b/nautilus_trader/adapters/dydx/http/client.py
@@ -146,7 +146,7 @@ class DYDXHttpClient:
                         headers=self._headers,
                         body=msgspec.json.encode(payload) if payload else None,
                         keys=ratelimiter_keys,
-                        timeout_secs=1,
+                        timeout_secs=timeout_secs,
                     )
                     done = True
                 except HttpTimeoutError as e:

--- a/nautilus_trader/adapters/dydx/http/client.py
+++ b/nautilus_trader/adapters/dydx/http/client.py
@@ -29,8 +29,10 @@ from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import Logger
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.core.nautilus_pyo3 import HttpClient
+from nautilus_trader.core.nautilus_pyo3 import HttpError
 from nautilus_trader.core.nautilus_pyo3 import HttpMethod
 from nautilus_trader.core.nautilus_pyo3 import HttpResponse
+from nautilus_trader.core.nautilus_pyo3 import HttpTimeoutError
 from nautilus_trader.core.nautilus_pyo3 import Quota
 
 
@@ -144,11 +146,10 @@ class DYDXHttpClient:
                         headers=self._headers,
                         body=msgspec.json.encode(payload) if payload else None,
                         keys=ratelimiter_keys,
-                        timeout_secs=timeout_secs,
+                        timeout_secs=1,
                     )
                     done = True
-                except Exception as e:
-                    # Exception thrown by Rust code. Most probably caused by a timeout.
+                except HttpTimeoutError as e:
                     if retry_counter < max_tries - 1:
                         sleep_duration_ms = randint(  # noqa: S311
                             initial_sleep_duration_ms,
@@ -162,6 +163,9 @@ class DYDXHttpClient:
                     else:
                         self._log.error(f"Failed to perform HTTP request: {e}")
                         raise
+                except HttpError:
+                    self._log.error("Failed to perform HTTP request: {e}")
+                    raise
 
         if BAD_REQUEST_ERROR_CODE <= response.status < INTERNAL_SERVER_ERROR_CODE:
             raise DYDXError(


### PR DESCRIPTION
# Pull Request

Catch HttpError and HttpTimeoutError exception when performing HTTP requests for the dYdX adapter instead of a catch-all exception.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Using the live example.
