### PR TITLE
Implement stateful orders for dYdX

### DIFF
--- a/docs/integrations/dydx.md
+++ b/docs/integrations/dydx.md
@@ -57,6 +57,48 @@ dYdX offers a flexible combination of trigger types, enabling a broader range of
 However, the execution engine currently only supports submitting market and limit orders. Stop orders 
 and trailing stop orders can be implemented later.
 
+## Short-term and long-term orders
+
+dYdX makes a distinction between short-term orders and long-term orders (or stateful orders).
+Short-term orders are meant to be placed immediately and belongs in the same block the order was received.
+These orders stay in-memory up to 20 blocks, with only their fill amount and expiry block height being committed to state. Short-term orders are mainly intended for use by market makers with high throughput or for market orders.
+
+By default, all orders are sent as short-term orders. To construct long-term orders, you can attach a tag to
+an order like this:
+
+```python
+from nautilus_trader.adapters.dydx.common.common import DYDXOrderTags
+
+order: LimitOrder = self.order_factory.limit(
+    instrument_id=self.instrument_id,
+    order_side=OrderSide.BUY,
+    quantity=self.instrument.make_qty(self.trade_size),
+    price=self.instrument.make_price(price),
+    time_in_force=TimeInForce.GTD,
+    expire_time=self.clock.utc_now() + pd.Timedelta(minutes=10),
+    post_only=True,
+    emulation_trigger=self.emulation_trigger,
+    tags=[DYDXOrderTags(is_short_term_order=False).value],
+)
+```
+
+To specify the number of blocks that an order is active:
+```python
+from nautilus_trader.adapters.dydx.common.common import DYDXOrderTags
+
+order: LimitOrder = self.order_factory.limit(
+    instrument_id=self.instrument_id,
+    order_side=OrderSide.BUY,
+    quantity=self.instrument.make_qty(self.trade_size),
+    price=self.instrument.make_price(price),
+    time_in_force=TimeInForce.GTD,
+    expire_time=self.clock.utc_now() + pd.Timedelta(seconds=5),
+    post_only=True,
+    emulation_trigger=self.emulation_trigger,
+    tags=[DYDXOrderTags(is_short_term_order=True, num_blocks_open=5).value],
+)
+```
+
 ## Configuration
 
 The product types for each client must be specified in the configurations.

--- a/nautilus_trader/adapters/dydx/common/common.py
+++ b/nautilus_trader/adapters/dydx/common/common.py
@@ -1,0 +1,32 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.config import NautilusConfig
+
+
+class DYDXOrderTags(NautilusConfig, frozen=True, repr_omit_defaults=True):
+    """
+    Used to attach to Nautilus Order Tags for dYdX specific order parameters.
+    """
+
+    is_short_term_order: bool = True
+    num_blocks_open: int = 20
+
+    @property
+    def value(self) -> str:
+        return f"DYDXOrderTags:{self.json().decode()}"
+
+    def __str__(self) -> str:
+        return self.value

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1064,7 +1064,7 @@ class DYDXExecutionClient(LiveExecutionClient):
 
         if dydx_order_tags.is_short_term_order is False:
             order_flags = OrderFlags.LONG_TERM
-            good_til_block_time = nanos_to_secs(self._clock.timestamp_ns()) + 120
+            good_til_block_time = int(nanos_to_secs(self._clock.timestamp_ns())) + 120
 
         order_id = order_builder.create_order_id(
             address=self._wallet_address,

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1060,9 +1060,11 @@ class DYDXExecutionClient(LiveExecutionClient):
 
         dydx_order_tags = self._parse_order_tags(order=order)
         order_flags = OrderFlags.SHORT_TERM
+        good_til_block_time: int | None = None
 
         if dydx_order_tags.is_short_term_order is False:
             order_flags = OrderFlags.LONG_TERM
+            good_til_block_time = nanos_to_secs(self._clock.timestamp_ns()) + 120
 
         order_id = order_builder.create_order_id(
             address=self._wallet_address,
@@ -1080,6 +1082,7 @@ class DYDXExecutionClient(LiveExecutionClient):
             wallet=self._wallet,
             order_id=order_id,
             good_til_block=current_block + 10,
+            good_til_block_time=good_til_block_time,
         )
 
         if response.tx_response.code != 0:

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1058,11 +1058,17 @@ class DYDXExecutionClient(LiveExecutionClient):
             )
             return
 
+        dydx_order_tags = self._parse_order_tags(order=order)
+        order_flags = OrderFlags.SHORT_TERM
+
+        if dydx_order_tags.is_short_term_order is False:
+            order_flags = OrderFlags.LONG_TERM
+
         order_id = order_builder.create_order_id(
             address=self._wallet_address,
             subaccount_number=self._subaccount,
             client_id=client_order_id_int,
-            order_flags=OrderFlags.SHORT_TERM,
+            order_flags=order_flags,
         )
 
         if self._wallet is None:

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1083,4 +1083,4 @@ class DYDXExecutionClient(LiveExecutionClient):
         )
 
         if response.tx_response.code != 0:
-            self._log.error(f"Failed to cancel the order: {response.raw_log}")
+            self._log.error(f"Failed to cancel the order: {response}")

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -27,6 +27,7 @@ import pandas as pd
 from grpc.aio._call import AioRpcError
 from v4_proto.dydxprotocol.clob.order_pb2 import Order as DYDXOrder
 
+from nautilus_trader.adapters.dydx.common.common import DYDXOrderTags
 from nautilus_trader.adapters.dydx.common.constants import DYDX_VENUE
 from nautilus_trader.adapters.dydx.common.credentials import get_mnemonic
 from nautilus_trader.adapters.dydx.common.credentials import get_wallet_address
@@ -56,6 +57,7 @@ from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import MessageBus
 from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.datetime import dt_to_unix_nanos
+from nautilus_trader.core.datetime import nanos_to_secs
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import CancelOrder
@@ -825,6 +827,19 @@ class DYDXExecutionClient(LiveExecutionClient):
 
         return order_builder
 
+    def _parse_order_tags(self, order: Order) -> DYDXOrderTags:
+        """
+        Parse the order tags to submit short term and long term orders.
+        """
+        result = DYDXOrderTags()
+
+        if order.tags is not None:
+            for order_tag in order.tags:
+                if order_tag.startswith("DYDXOrderTags:"):
+                    result = DYDXOrderTags.parse(order_tag.replace("DYDXOrderTags:", ""))
+
+        return result
+
     async def _submit_order(self, command: SubmitOrder) -> None:
         order = command.order
 
@@ -861,11 +876,39 @@ class DYDXExecutionClient(LiveExecutionClient):
             client_order_id=order.client_order_id,
         )
 
+        dydx_order_tags = self._parse_order_tags(order=order)
+        order_flags = OrderFlags.SHORT_TERM
+        good_till_date_secs: int | None = None
+        good_til_block: int | None = None
+
+        if dydx_order_tags.is_short_term_order:
+            try:
+                latest_block = await self._grpc_account.latest_block_height()
+            except AioRpcError as e:
+                rejection_reason = f"Failed to submit the order while retrieve the latest block height: code {e.code} {e.details}"
+                self._log.error(rejection_reason)
+
+                self.generate_order_rejected(
+                    strategy_id=order.strategy_id,
+                    instrument_id=order.instrument_id,
+                    client_order_id=order.client_order_id,
+                    reason=rejection_reason,
+                    ts_event=self._clock.timestamp_ns(),
+                )
+                return
+
+            good_til_block = latest_block + dydx_order_tags.num_blocks_open
+        else:
+            order_flags = OrderFlags.LONG_TERM
+            good_till_date_secs = (
+                int(nanos_to_secs(order.expire_time_ns)) if order.expire_time_ns else None
+            )
+
         order_id = order_builder.create_order_id(
             address=self._wallet_address,
             subaccount_number=self._subaccount,
             client_id=client_order_id_int,
-            order_flags=OrderFlags.SHORT_TERM,
+            order_flags=order_flags,
         )
         order_type_map = {
             OrderType.LIMIT: DYDXGRPCOrderType.LIMIT,
@@ -882,21 +925,6 @@ class DYDXExecutionClient(LiveExecutionClient):
             TimeInForce.IOC: DYDXOrder.TimeInForce.TIME_IN_FORCE_IOC,
             TimeInForce.FOK: DYDXOrder.TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,
         }
-
-        try:
-            latest_block = await self._grpc_account.latest_block_height()
-        except AioRpcError as e:
-            rejection_reason = f"Failed to submit the order while retrieve the latest block height: code {e.code} {e.details}"
-            self._log.error(rejection_reason)
-
-            self.generate_order_rejected(
-                strategy_id=order.strategy_id,
-                instrument_id=order.instrument_id,
-                client_order_id=order.client_order_id,
-                reason=rejection_reason,
-                ts_event=self._clock.timestamp_ns(),
-            )
-            return
 
         price = 0
 
@@ -928,7 +956,8 @@ class DYDXExecutionClient(LiveExecutionClient):
             time_in_force=time_in_force_map[order.time_in_force],
             reduce_only=order.is_reduce_only,
             post_only=order.is_post_only,
-            good_til_block=latest_block + 20,
+            good_til_block=good_til_block,
+            good_til_block_time=good_till_date_secs,
         )
 
         if self._wallet is None:

--- a/nautilus_trader/adapters/dydx/grpc/order_builder.py
+++ b/nautilus_trader/adapters/dydx/grpc/order_builder.py
@@ -244,6 +244,35 @@ class OrderBuilder:
     ) -> Order:
         """
         Create a new Order instance.
+
+        order_id : OrderId
+            OrderId protobuf message.
+        order_type: DYDXGRPCOrderType
+            Order type enum: LIMIT, MARKET, STOP_LIMIT, TAKE_PROFIT_LIMIT,
+            STOP_MARKET or TAKE_PROFIT_MARKET.
+        side : Order.Side
+            The side of the order.
+        size : float
+            The size of the order.
+        price : float
+            The price of the limit order. Set to 0 for market orders.
+        time_in_force : Order.TimeInForce
+            Time in force setting for the order.
+            Options: GTT (Good-Til-Time), FOK (Fill-Or-Kill), IOC (Immediate-Or-Cancel)
+        post_only : bool, default False
+            Ensures that the order will only be added to the order book if it does
+            not immediately fill against an existing order in the order book.
+            In other words, a post-only limit order will only be placed if it can
+            be added as a maker order and not as a taker order.
+        good_til_block : int, optional
+            The block height when the order expires if it is not yet filled.
+        good_til_block_time : int, optional
+            The time in seconds since the epoch when the order expired if it is
+            not yet filled.
+        execution : OrderExecution, default OrderExecution.DEFAULT
+            OrderExecution enum: DEFAULT, IOC, FOK or POST_ONLY
+        conditional_order_trigger_subticks : int, default value is 0.
+
         """
         order_time_in_force = OrderHelper.calculate_time_in_force(
             order_type,


### PR DESCRIPTION
# Pull Request

Use a `DYDXOrderTags` dataclass to add additional order attributes following the `IBOrderTags` class.
dYdX makes a distinction between short-term orders and long-term orders (or stateful orders). 
Strategies can construct these 2 types of orders by attaching a tag to an order using `DYDXOrderTags`.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested?

Testing using the testnet for both short-term and longterm orders.
