### PR TITLE
Update composite bars and refactor bar aggregation

### DIFF
--- a/nautilus_core/model/src/python/data/bar.rs
+++ b/nautilus_core/model/src/python/data/bar.rs
@@ -123,6 +123,52 @@ impl BarType {
     fn py_from_str(value: &str) -> PyResult<Self> {
         Self::from_str(value).map_err(to_pyvalue_err)
     }
+
+    #[staticmethod]
+    #[pyo3(name = "new_composite")]
+    fn py_new_composite(
+        instrument_id: InstrumentId,
+        spec: BarSpecification,
+        aggregation_source: AggregationSource,
+        composite_instrument_id: InstrumentId,
+        composite_spec: BarSpecification,
+        composite_aggregation_source: AggregationSource,
+    ) -> Self {
+        Self::new_composite(
+            instrument_id,
+            spec,
+            aggregation_source,
+            composite_instrument_id,
+            composite_spec,
+            composite_aggregation_source,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_bar_types")]
+    fn py_from_bar_types(standard: &Self, composite: &Self) -> Self {
+        Self::from_bar_types(standard, composite)
+    }
+
+    #[pyo3(name = "is_standard")]
+    fn py_is_standard(&self) -> bool {
+        self.is_standard()
+    }
+
+    #[pyo3(name = "is_composite")]
+    fn py_is_composite(&self) -> bool {
+        self.is_composite()
+    }
+
+    #[pyo3(name = "standard")]
+    fn py_standard(&self) -> Self {
+        self.standard()
+    }
+
+    #[pyo3(name = "composite")]
+    fn py_composite(&self) -> Self {
+        self.composite()
+    }
 }
 
 impl Bar {

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -51,8 +51,9 @@ cdef class BarBuilder:
     cdef Price _close
     cdef Quantity volume
 
-    cpdef void set_partial(self, Bar partial_bar, bint run_once=*)
+    cpdef void set_partial(self, Bar partial_bar)
     cpdef void update(self, Price price, Quantity size, uint64_t ts_event)
+    cpdef void update_bar(self, Bar bar)
     cpdef void reset(self)
     cpdef Bar build_now(self)
     cpdef Bar build(self, uint64_t ts_event, uint64_t ts_init)
@@ -70,8 +71,9 @@ cdef class BarAggregator:
     cpdef void handle_quote_tick(self, QuoteTick tick)
     cpdef void handle_trade_tick(self, TradeTick tick)
     cpdef void handle_bar(self, Bar bar)
-    cpdef void set_partial(self, Bar partial_bar, bint run_once=*)
+    cpdef void set_partial(self, Bar partial_bar)
     cdef void _apply_update(self, Price price, Quantity size, uint64_t ts_event)
+    cdef void _apply_update_bar(self, Bar bar)
     cdef void _build_now_and_send(self)
     cdef void _build_and_send(self, uint64_t ts_event, uint64_t ts_init)
 

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -152,48 +152,6 @@ class TestBarBuilder:
         assert bar.ts_init == 4_000_000_000
         assert builder.ts_last == 1_000_000_000
 
-    def test_set_partial_when_already_set_updates_with_run_once_false(self):
-        # Arrange
-        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
-        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
-
-        partial_bar1 = Bar(
-            bar_type=bar_type,
-            open=Price.from_str("1.00001"),
-            high=Price.from_str("1.00010"),
-            low=Price.from_str("1.00000"),
-            close=Price.from_str("1.00002"),
-            volume=Quantity.from_str("1"),
-            ts_event=1_000_000_000,
-            ts_init=1_000_000_000,
-        )
-
-        partial_bar2 = Bar(
-            bar_type=bar_type,
-            open=Price.from_str("2.00001"),
-            high=Price.from_str("2.00010"),
-            low=Price.from_str("2.00000"),
-            close=Price.from_str("2.00002"),
-            volume=Quantity.from_str("2"),
-            ts_event=1_000_000_000,
-            ts_init=3_000_000_000,
-        )
-
-        # Act
-        builder.set_partial(partial_bar1)
-        builder.set_partial(partial_bar2, run_once=False)
-
-        bar = builder.build(4_000_000_000, 4_000_000_000)
-
-        # Assert
-        assert bar.open == Price.from_str("1.00001")
-        assert bar.high == Price.from_str("2.00010")
-        assert bar.low == Price.from_str("1.00000")
-        assert bar.close == Price.from_str("2.00002")
-        assert bar.volume == Quantity.from_str("3")
-        assert bar.ts_init == 4_000_000_000
-        assert builder.ts_last == 3_000_000_000
-
     def test_single_update_results_in_expected_properties(self):
         # Arrange
         bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
@@ -1482,9 +1440,9 @@ class TestTimeBarAggregator:
         bar = handler[0]
         assert len(handler) == 1
         assert bar.bar_type == bar_type
-        assert Price.from_str("1.00005") == bar.open
-        assert Price.from_str("1.00020") == bar.high
-        assert Price.from_str("1.00003") == bar.low
-        assert Price.from_str("1.00008") == bar.close
-        assert Quantity.from_int(3) == bar.volume
+        assert bar.open == Price.from_str("1.00005")
+        assert bar.high == Price.from_str("1.00020")
+        assert bar.low == Price.from_str("1.00003")
+        assert bar.close == Price.from_str("1.00008")
+        assert bar.volume == Quantity.from_int(3)
         assert bar.ts_init == 3 * 60 * 1_000_000_000

--- a/tests/unit_tests/model/test_bar_pyo3.py
+++ b/tests/unit_tests/model/test_bar_pyo3.py
@@ -638,3 +638,40 @@ class TestBar:
 
         # Assert
         assert unpickled == bar
+
+    def test_bar_type_composite_parse_valid(self):
+        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+        bar_type = BarType.from_str(input_str)
+        standard = bar_type.standard()
+        composite = bar_type.composite()
+        composite_input = "BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+
+        assert bar_type.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert bar_type.spec == BarSpecification(
+            step=2,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert bar_type.aggregation_source == AggregationSource.INTERNAL
+        assert bar_type == BarType.from_str(input_str)
+        assert bar_type.is_composite()
+
+        assert standard.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert standard.spec == BarSpecification(
+            step=2,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert standard.aggregation_source == AggregationSource.INTERNAL
+        assert standard.is_standard()
+
+        assert composite.instrument_id == InstrumentId.from_str("BTCUSDT-PERP.BINANCE")
+        assert composite.spec == BarSpecification(
+            step=1,
+            aggregation=BarAggregation.MINUTE,
+            price_type=PriceType.LAST,
+        )
+        assert composite.aggregation_source == AggregationSource.EXTERNAL
+        assert composite == BarType.from_str(composite_input)
+        assert composite.is_standard()
+        assert bar_type == BarType.from_bar_types(standard, composite)


### PR DESCRIPTION
# Pull Request

Make recent addition of aggregation of bars into bars in line with existing implementation, which will facilitate the aggregation of bars using other Aggregators (based on volume for example).

Add new composite methods for BarType to PyO3 integration (which was super easy compared to with cython and FFI)

## Type of change

Delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Using tests
