### PR TITLE
Catch AioRpcError connection errors in dYdX instrument provider

### DIFF
--- a/nautilus_trader/adapters/dydx/http/client.py
+++ b/nautilus_trader/adapters/dydx/http/client.py
@@ -163,8 +163,8 @@ class DYDXHttpClient:
                     else:
                         self._log.error(f"Failed to perform HTTP request: {e}")
                         raise
-                except HttpError:
-                    self._log.error("Failed to perform HTTP request: {e}")
+                except HttpError as e:
+                    self._log.error(f"Failed to perform HTTP request: {e}")
                     raise
 
         if BAD_REQUEST_ERROR_CODE <= response.status < INTERNAL_SERVER_ERROR_CODE:

--- a/nautilus_trader/adapters/dydx/providers.py
+++ b/nautilus_trader/adapters/dydx/providers.py
@@ -110,7 +110,7 @@ class DYDXInstrumentProvider(InstrumentProvider):
         try:
             fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
         except AioRpcError as e:
-            self._log.error(f"Failed to get the user fee tier: code {e.code} {e.details}")
+            self._log.error(f"Failed to get the user fee tier: {e}")
             return
 
         for instrument_id in instrument_ids:
@@ -142,7 +142,7 @@ class DYDXInstrumentProvider(InstrumentProvider):
             try:
                 fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
             except AioRpcError as e:
-                self._log.error(f"Failed to get the user fee tier: code {e.code} {e.details}")
+                self._log.error(f"Failed to get the user fee tier: {e}")
                 return
 
         maker_fee = Decimal(fee_tier.tier.maker_fee_ppm) / FEE_SCALING

--- a/nautilus_trader/adapters/dydx/providers.py
+++ b/nautilus_trader/adapters/dydx/providers.py
@@ -18,6 +18,7 @@ Instrument provider for the dYdX venue.
 
 from decimal import Decimal
 
+from grpc.aio._call import AioRpcError
 from v4_proto.dydxprotocol.feetiers import query_pb2 as fee_tier_query
 
 from nautilus_trader.adapters.dydx.common.constants import DYDX_VENUE
@@ -106,7 +107,11 @@ class DYDXInstrumentProvider(InstrumentProvider):
         filters_str = "..." if not filters else f" with filters {filters}..."
         self._log.info(f"Loading instruments {instrument_ids}{filters_str}.")
 
-        fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
+        try:
+            fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
+        except AioRpcError as e:
+            self._log.error(f"Failed to get the user fee tier: code {e.code} {e.details}")
+            return
 
         for instrument_id in instrument_ids:
             await self._load_instruments(
@@ -134,7 +139,11 @@ class DYDXInstrumentProvider(InstrumentProvider):
         markets = await self._http_market.fetch_instruments(symbol=symbol)
 
         if fee_tier is None:
-            fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
+            try:
+                fee_tier = await self._grpc_account.get_user_fee_tier(address=self._wallet_address)
+            except AioRpcError as e:
+                self._log.error(f"Failed to get the user fee tier: code {e.code} {e.details}")
+                return
 
         maker_fee = Decimal(fee_tier.tier.maker_fee_ppm) / FEE_SCALING
         taker_fee = Decimal(fee_tier.tier.taker_fee_ppm) / FEE_SCALING


### PR DESCRIPTION
# Pull Request

- Catch AioRpcError connection errors in the instrument provider. These errors sometimes occur when the DataEngine request an update of the instruments (which runs every hour).
- Fix exception message when a HttpError occurs
- Add assertions to unit test for parsing deltas

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Using the live example