### PR TITLE
Refactor composite BarType removing unattainable states

### DIFF
--- a/nautilus_core/model/src/ffi/data/bar.rs
+++ b/nautilus_core/model/src/ffi/data/bar.rs
@@ -108,23 +108,18 @@ pub extern "C" fn bar_type_new_composite(
     spec: BarSpecification,
     aggregation_source: AggregationSource,
 
-    composite_instrument_id: InstrumentId,
-    composite_spec: BarSpecification,
+    composite_step: usize,
+    composite_aggregation: BarAggregation,
     composite_aggregation_source: AggregationSource,
 ) -> BarType {
     BarType::new_composite(
         instrument_id,
         spec,
         aggregation_source,
-        composite_instrument_id,
-        composite_spec,
+        composite_step,
+        composite_aggregation,
         composite_aggregation_source,
     )
-}
-
-#[no_mangle]
-pub extern "C" fn bar_type_from_bar_types(standard: &BarType, composite: &BarType) -> BarType {
-    BarType::from_bar_types(standard, composite)
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/python/data/bar.rs
+++ b/nautilus_core/model/src/python/data/bar.rs
@@ -130,24 +130,18 @@ impl BarType {
         instrument_id: InstrumentId,
         spec: BarSpecification,
         aggregation_source: AggregationSource,
-        composite_instrument_id: InstrumentId,
-        composite_spec: BarSpecification,
+        composite_step: usize,
+        composite_aggregation: BarAggregation,
         composite_aggregation_source: AggregationSource,
     ) -> Self {
         Self::new_composite(
             instrument_id,
             spec,
             aggregation_source,
-            composite_instrument_id,
-            composite_spec,
+            composite_step,
+            composite_aggregation,
             composite_aggregation_source,
         )
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "from_bar_types")]
-    fn py_from_bar_types(standard: &Self, composite: &Self) -> Self {
-        Self::from_bar_types(standard, composite)
     }
 
     #[pyo3(name = "is_standard")]

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -1151,13 +1151,13 @@ typedef struct Composite_Body {
      */
     enum AggregationSource aggregation_source;
     /**
-     * The composite bar types instrument ID.
+     * The composite step for binning samples for bar aggregation.
      */
-    struct InstrumentId_t composite_instrument_id;
+    uintptr_t composite_step;
     /**
-     * The composite bar types specification.
+     * The composite type of bar aggregation.
      */
-    struct BarSpecification_t composite_spec;
+    uint8_t composite_aggregation;
     /**
      * The composite bar types aggregation source.
      */
@@ -1521,12 +1521,9 @@ struct BarType_t bar_type_new(struct InstrumentId_t instrument_id,
 struct BarType_t bar_type_new_composite(struct InstrumentId_t instrument_id,
                                         struct BarSpecification_t spec,
                                         enum AggregationSource aggregation_source,
-                                        struct InstrumentId_t composite_instrument_id,
-                                        struct BarSpecification_t composite_spec,
+                                        uintptr_t composite_step,
+                                        uint8_t composite_aggregation,
                                         enum AggregationSource composite_aggregation_source);
-
-struct BarType_t bar_type_from_bar_types(const struct BarType_t *standard,
-                                         const struct BarType_t *composite);
 
 uint8_t bar_type_is_standard(const struct BarType_t *bar_type);
 

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -632,10 +632,10 @@ cdef extern from "../includes/model.h":
         BarSpecification_t spec;
         # The bar types aggregation source.
         AggregationSource aggregation_source;
-        # The composite bar types instrument ID.
-        InstrumentId_t composite_instrument_id;
-        # The composite bar types specification.
-        BarSpecification_t composite_spec;
+        # The composite step for binning samples for bar aggregation.
+        uintptr_t composite_step;
+        # The composite type of bar aggregation.
+        uint8_t composite_aggregation;
         # The composite bar types aggregation source.
         AggregationSource composite_aggregation_source;
 
@@ -882,11 +882,9 @@ cdef extern from "../includes/model.h":
     BarType_t bar_type_new_composite(InstrumentId_t instrument_id,
                                      BarSpecification_t spec,
                                      AggregationSource aggregation_source,
-                                     InstrumentId_t composite_instrument_id,
-                                     BarSpecification_t composite_spec,
+                                     uintptr_t composite_step,
+                                     uint8_t composite_aggregation,
                                      AggregationSource composite_aggregation_source);
-
-    BarType_t bar_type_from_bar_types(const BarType_t *standard, const BarType_t *composite);
 
     uint8_t bar_type_is_standard(const BarType_t *bar_type);
 

--- a/nautilus_trader/model/data.pyx
+++ b/nautilus_trader/model/data.pyx
@@ -63,7 +63,6 @@ from nautilus_trader.core.rust.model cimport bar_type_aggregation_source
 from nautilus_trader.core.rust.model cimport bar_type_check_parsing
 from nautilus_trader.core.rust.model cimport bar_type_composite
 from nautilus_trader.core.rust.model cimport bar_type_eq
-from nautilus_trader.core.rust.model cimport bar_type_from_bar_types
 from nautilus_trader.core.rust.model cimport bar_type_from_cstr
 from nautilus_trader.core.rust.model cimport bar_type_ge
 from nautilus_trader.core.rust.model cimport bar_type_gt
@@ -680,10 +679,8 @@ cdef class BarType:
                 spec.price_type,
                 self.aggregation_source,
 
-                composite.instrument_id.value,
                 spec_composite.step,
                 spec_composite.aggregation,
-                spec_composite.price_type,
                 composite.aggregation_source
             )
 
@@ -713,13 +710,9 @@ cdef class BarType:
                 ),
                 state[4],
 
-                composite_instrument_id._mem,
-                bar_specification_new(
-                    state[6],
-                    state[7],
-                    state[8]
-                ),
-                state[9],
+                state[5],
+                state[6],
+                state[7],
             )
 
     cdef str to_str(self):
@@ -853,8 +846,8 @@ cdef class BarType:
         BarSpecification bar_spec,
         AggregationSource aggregation_source,
 
-        InstrumentId composite_instrument_id,
-        BarSpecification composite_bar_spec,
+        int composite_step,
+        BarAggregation composite_aggregation,
         AggregationSource composite_aggregation_source,
     ) -> BarType:
         return BarType.from_mem_c(
@@ -863,15 +856,11 @@ cdef class BarType:
                 bar_spec._mem,
                 aggregation_source,
 
-                composite_instrument_id._mem,
-                composite_bar_spec._mem,
+                composite_step,
+                composite_aggregation,
                 composite_aggregation_source,
             )
         )
-
-    @staticmethod
-    def from_bar_types(BarType standard, BarType composite) -> BarType:
-        return BarType.from_mem_c(bar_type_from_bar_types(&standard._mem, &composite._mem))
 
     cpdef bint is_standard(self):
         """
@@ -1014,7 +1003,6 @@ cdef class Bar(Data):
             )
         else:
             instrument_id = InstrumentId.from_str_c(state[0])
-            composite_instrument_id = InstrumentId.from_str_c(state[5])
 
             self._mem = bar_new_from_raw(
                 bar_type_new_composite(
@@ -1026,14 +1014,12 @@ cdef class Bar(Data):
                     ),
                     state[4],
 
-                    composite_instrument_id._mem,
-                    bar_specification_new(
-                        state[6],
-                        state[7],
-                        state[8]
-                    ),
-                    state[9],
+                    state[5],
+                    state[6],
+                    state[7]
                 ),
+                state[8],
+                state[9],
                 state[10],
                 state[11],
                 state[12],
@@ -1041,8 +1027,6 @@ cdef class Bar(Data):
                 state[14],
                 state[15],
                 state[16],
-                state[17],
-                state[18],
             )
 
     def __eq__(self, Bar other) -> bool:

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -1384,8 +1384,8 @@ class TestTimeBarAggregator:
             instrument_id,
             bar_spec3,
             AggregationSource.INTERNAL,
-            instrument_id,
-            bar_spec1,
+            bar_spec1.step,
+            bar_spec1.aggregation,
             AggregationSource.EXTERNAL,
         )
         aggregator = TimeBarAggregator(

--- a/tests/unit_tests/model/test_bar.py
+++ b/tests/unit_tests/model/test_bar.py
@@ -721,7 +721,7 @@ class TestBar:
         assert unpickled == bar
 
     def test_bar_type_composite_parse_valid(self):
-        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"
         bar_type = BarType.from_str(input_str)
         standard = bar_type.standard()
         composite = bar_type.composite()
@@ -755,4 +755,3 @@ class TestBar:
         assert composite.aggregation_source == AggregationSource.EXTERNAL
         assert composite == BarType.from_str(composite_input)
         assert composite.is_standard()
-        assert bar_type == BarType.from_bar_types(standard, composite)

--- a/tests/unit_tests/model/test_bar_pyo3.py
+++ b/tests/unit_tests/model/test_bar_pyo3.py
@@ -640,7 +640,7 @@ class TestBar:
         assert unpickled == bar
 
     def test_bar_type_composite_parse_valid(self):
-        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL"
+        input_str = "BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"
         bar_type = BarType.from_str(input_str)
         standard = bar_type.standard()
         composite = bar_type.composite()
@@ -674,4 +674,3 @@ class TestBar:
         assert composite.aggregation_source == AggregationSource.EXTERNAL
         assert composite == BarType.from_str(composite_input)
         assert composite.is_standard()
-        assert bar_type == BarType.from_bar_types(standard, composite)


### PR DESCRIPTION
# Pull Request

The new BarType has a string representation of:

`"BTCUSDT-PERP.BINANCE-2-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"`

Removed BarType.from_bar_types function as it could cause invalid states, or require more error management.

Tested with tests
