### PR TITLE
Allow chained internal bar aggregation

### DIFF
--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1400,7 +1400,7 @@ cdef class Actor(Component):
         Condition.true(self.trader_id is not None, "The actor has not been registered")
 
         self._msgbus.subscribe(
-            topic=f"data.bars.{bar_type}",
+            topic=f"data.bars.{bar_type.standard()}",
             handler=self.handle_bar,
         )
 

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -102,6 +102,7 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef bint _build_with_no_updates
     cdef bint _timestamp_on_close
     cdef bint _is_left_open
+    cdef bint _add_delay
 
     cdef readonly timedelta interval
     """The aggregators time interval.\n\n:returns: `timedelta`"""

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -610,7 +610,7 @@ cdef class TimeBarAggregator(BarAggregator):
     ):
         super().__init__(
             instrument=instrument,
-            bar_type=bar_type,
+            bar_type=bar_type.standard(),
             handler=handler,
         )
 
@@ -626,6 +626,7 @@ cdef class TimeBarAggregator(BarAggregator):
         self._cached_update = None
         self._build_with_no_updates = build_with_no_updates
         self._timestamp_on_close = timestamp_on_close
+        self._add_delay = bar_type.is_composite() and bar_type.composite().is_internally_aggregated()
 
         if interval_type == "left-open":
             self._is_left_open = True
@@ -701,6 +702,9 @@ cdef class TimeBarAggregator(BarAggregator):
                 f"Aggregation type not supported for time bars, "
                 f"was {bar_aggregation_to_str(self.bar_type.spec.aggregation)}",
             )
+
+        if self._add_delay:
+            start_time += timedelta(microseconds=10)
 
         return start_time
 
@@ -779,6 +783,7 @@ cdef class TimeBarAggregator(BarAggregator):
             self._stored_close_ns = 0
 
     cdef void _apply_update_bar(self, Bar bar):
+        #self._log.warning(str(bar))
         self._builder.update_bar(bar)
 
     cpdef void _build_bar(self, TimeEvent event):

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -783,7 +783,6 @@ cdef class TimeBarAggregator(BarAggregator):
             self._stored_close_ns = 0
 
     cdef void _apply_update_bar(self, Bar bar):
-        #self._log.warning(str(bar))
         self._builder.update_bar(bar)
 
     cpdef void _build_bar(self, TimeEvent event):

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -981,7 +981,7 @@ cdef class DataEngine(Component):
 
         if bar_type.is_internally_aggregated():
             # Internal aggregation
-            if bar_type not in self._bar_aggregators:
+            if bar_type.standard() not in self._bar_aggregators:
                 self._start_bar_aggregator(client, bar_type, await_partial)
         else:
             # External aggregation
@@ -1194,7 +1194,7 @@ cdef class DataEngine(Component):
 
         if bar_type.is_internally_aggregated():
             # Internal aggregation
-            if bar_type in self._bar_aggregators:
+            if bar_type.standard() in self._bar_aggregators:
                 self._stop_bar_aggregator(client, bar_type)
         else:
             # External aggregation
@@ -1730,7 +1730,7 @@ cdef class DataEngine(Component):
         aggregator.set_await_partial(await_partial)
 
         # Add aggregator
-        self._bar_aggregators[bar_type] = aggregator
+        self._bar_aggregators[bar_type.standard()] = aggregator
         self._log.debug(f"Added {aggregator} for {bar_type} bars")
 
         # Subscribe to required data
@@ -1762,7 +1762,7 @@ cdef class DataEngine(Component):
             self._handle_subscribe_quote_ticks(client, bar_type.instrument_id)
 
     cpdef void _stop_bar_aggregator(self, MarketDataClient client, BarType bar_type):
-        cdef aggregator = self._bar_aggregators.get(bar_type)
+        cdef aggregator = self._bar_aggregators.get(bar_type.standard())
         if aggregator is None:
             self._log.warning(
                 f"Cannot stop bar aggregator: "
@@ -1800,7 +1800,7 @@ cdef class DataEngine(Component):
             self._handle_unsubscribe_quote_ticks(client, bar_type.instrument_id)
 
         # Remove from aggregators
-        del self._bar_aggregators[bar_type]
+        del self._bar_aggregators[bar_type.standard()]
 
     cpdef void _update_synthetics_with_quote(self, list synthetics, QuoteTick update):
         cdef SyntheticInstrument synthetic

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -1439,7 +1439,7 @@ class TestTimeBarAggregator:
         # Assert
         bar = handler[0]
         assert len(handler) == 1
-        assert bar.bar_type == bar_type
+        assert bar.bar_type == bar_type.standard()
         assert bar.open == Price.from_str("1.00005")
         assert bar.high == Price.from_str("1.00020")
         assert bar.low == Price.from_str("1.00003")


### PR DESCRIPTION
# Pull Request

Allows aggregation of composite bars. For example:

```python
bar_type = BarType.from_str(f"ESU4-2-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
self.subscribe_bars(bar_type)

bar_type2 = BarType.from_str(f"ESU4-4-MINUTE-LAST-INTERNAL@2-MINUTE-INTERNAL")
self.subscribe_bars(bar_type2)
```

Also emitted bars from composite aggregations are now standard bars meaning without "@" only the left side is emitted as bar type.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How has this change been tested?

On personal prototype, don't know how to test this feature in a test yet as it involves various parts of the system (engine, time aggregator, actor, message bus).
