### PR TITLE
Move PSQL cache load function impl

### DIFF
--- a/nautilus_core/infrastructure/src/python/sql/cache_database.rs
+++ b/nautilus_core/infrastructure/src/python/sql/cache_database.rs
@@ -54,8 +54,9 @@ impl PostgresCacheDatabase {
 
     #[pyo3(name = "load")]
     fn py_load(slf: PyRef<'_, Self>) -> PyResult<HashMap<String, Vec<u8>>> {
-        let result = get_runtime().block_on(async { slf.load().await });
-        result.map_err(to_pyruntime_err)
+        get_runtime()
+            .block_on(async { DatabaseQueries::load(&slf.pool).await })
+            .map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "load_currency")]

--- a/nautilus_core/infrastructure/src/sql/cache_database.rs
+++ b/nautilus_core/infrastructure/src/sql/cache_database.rs
@@ -42,7 +42,6 @@ use tokio::{
 use ustr::Ustr;
 
 use crate::sql::{
-    models::general::GeneralRow,
     pg::{
         connect_pg, delete_nautilus_postgres_tables, get_postgres_connect_options,
         PostgresConnectOptions, PostgresConnectOptionsBuilder,
@@ -277,23 +276,6 @@ impl PostgresCacheDatabase {
             drain_buffer(&pool, &mut buffer).await;
         }
     }
-
-    pub async fn load(&self) -> Result<HashMap<String, Vec<u8>>, sqlx::Error> {
-        let query = sqlx::query_as::<_, GeneralRow>("SELECT * FROM general");
-        let result = query.fetch_all(&self.pool).await;
-        match result {
-            Ok(rows) => {
-                let mut cache: HashMap<String, Vec<u8>> = HashMap::new();
-                for row in rows {
-                    cache.insert(row.id, row.value);
-                }
-                Ok(cache)
-            }
-            Err(e) => {
-                panic!("Failed to load general table: {e}")
-            }
-        }
-    }
 }
 
 pub async fn reset_pg_database(pg_options: Option<PostgresConnectOptions>) -> anyhow::Result<()> {
@@ -336,7 +318,29 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
     }
 
     fn load(&mut self) -> anyhow::Result<HashMap<String, Bytes>> {
-        todo!()
+        let pool = self.pool.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        tokio::spawn(async move {
+            let result = DatabaseQueries::load(&pool).await;
+            match result {
+                Ok(items) => {
+                    let mapping = items
+                        .into_iter()
+                        .map(|(k, v)| (k, Bytes::from(v)))
+                        .collect();
+                    if let Err(e) = tx.send(mapping) {
+                        log::error!("Failed to send general items: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to load general items: {:?}", e);
+                    if let Err(e) = tx.send(HashMap::new()) {
+                        log::error!("Failed to send empty general items: {:?}", e);
+                    }
+                }
+            }
+        });
+        Ok(rx.recv()?)
     }
 
     fn load_currencies(&mut self) -> anyhow::Result<HashMap<Ustr, Currency>> {

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -19,10 +19,7 @@ mod serial_tests {
     use std::{collections::HashSet, time::Duration};
 
     use bytes::Bytes;
-    use nautilus_common::{
-        cache::database::CacheDatabaseAdapter,
-        testing::{wait_until, wait_until_async},
-    };
+    use nautilus_common::{cache::database::CacheDatabaseAdapter, testing::wait_until};
     use nautilus_infrastructure::sql::cache_database::get_pg_cache_database;
     use nautilus_model::{
         accounts::{any::AccountAny, cash::CashAccount},
@@ -61,15 +58,14 @@ mod serial_tests {
         pg_cache
             .add(String::from("test_id"), test_id_value.clone())
             .unwrap();
-        wait_until_async(
-            || async {
-                let result = pg_cache.load().await.unwrap();
+        wait_until(
+            || {
+                let result = pg_cache.load().unwrap();
                 result.keys().len() > 0
             },
             Duration::from_secs(2),
-        )
-        .await;
-        let result = pg_cache.load().await.unwrap();
+        );
+        let result = pg_cache.load().unwrap();
         assert_eq!(result.keys().len(), 1);
         assert_eq!(
             result.keys().cloned().collect::<Vec<String>>(),

--- a/nautilus_core/network/src/python/mod.rs
+++ b/nautilus_core/network/src/python/mod.rs
@@ -19,9 +19,12 @@ pub mod http;
 pub mod socket;
 pub mod websocket;
 
-use crate::python::http::{HttpError, HttpTimeoutError};
-use crate::python::websocket::WebSocketClientError;
 use pyo3::{prelude::*, PyTypeCheck, PyTypeInfo};
+
+use crate::python::{
+    http::{HttpError, HttpTimeoutError},
+    websocket::WebSocketClientError,
+};
 
 /// Loaded as nautilus_pyo3.network
 #[pymodule]


### PR DESCRIPTION
# Pull Request

- Move load PSQL cache function to trait with blocking implementation
- tests for `load` function already exist in Rust and Python