### PR TITLE
Add date field to custom data decorator for partitioning

### DIFF
--- a/nautilus_trader/model/custom.py
+++ b/nautilus_trader/model/custom.py
@@ -19,6 +19,7 @@ from typing import Any
 import msgspec
 import pyarrow as pa
 
+from nautilus_trader.core.datetime import unix_nanos_to_dt
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.serialization.arrow.serializer import register_arrow
 from nautilus_trader.serialization.base import register_serializable_type
@@ -73,6 +74,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
 
                 result["ts_event"] = self._ts_event
                 result["ts_init"] = self._ts_init
+                result["date"] = int(unix_nanos_to_dt(result["ts_event"]).strftime("%Y%m%d"))
 
                 return result
 
@@ -83,6 +85,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
             @classmethod
             def from_dict(cls, data: dict[str, Any]) -> cls:
                 data.pop("type", None)
+                data.pop("date", None)
 
                 if "instrument_id" in data:
                     data["instrument_id"] = InstrumentId.from_str(data["instrument_id"])
@@ -140,6 +143,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
                     "type": pa.string(),
                     "ts_event": pa.int64(),
                     "ts_init": pa.int64(),
+                    "date": pa.int32(),
                 },
             )
 

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -756,6 +756,7 @@ class ParquetDataCatalog(BaseDataCatalog):
         instance_id: UUID4,
         data_cls: type,
         other_catalog: ParquetDataCatalog | None = None,
+        **kwargs: Any,
     ) -> None:
         table_name = class_to_filename(data_cls)
         feather_file = Path(self.path) / "backtest" / instance_id / f"{table_name}.feather"
@@ -763,7 +764,5 @@ class ParquetDataCatalog(BaseDataCatalog):
         feather_table = self._read_feather_file(feather_file)
         custom_data_list = self._handle_table_nautilus(feather_table, data_cls)
 
-        if other_catalog is not None:
-            other_catalog.write_data(custom_data_list)
-        else:
-            self.write_data(custom_data_list)
+        used_catalog = self if other_catalog is None else other_catalog
+        used_catalog.write_data(custom_data_list, **kwargs)

--- a/tests/unit_tests/model/test_custom_data.py
+++ b/tests/unit_tests/model/test_custom_data.py
@@ -51,6 +51,7 @@ def test_customdata_decorator_dict() -> None:
         "delta": 0.0,
         "ts_event": 1,
         "ts_init": 2,
+        "date": 19700101,
     }
 
 


### PR DESCRIPTION
# Pull Request

Add date field to custom data decorator for partitioning

Also add **kwargs to convert_stream_to_data in order to be able to use catalog.write_data options for example `partitioning=['date'], existing_data_behavior='overwrite_or_ignore'`

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Own prototype and tests
