### PR TITLE
Use custom client order IDs for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -113,7 +113,10 @@ class ClientOrderIdHelper:
         """
         Generate a unique client order ID integer and save it in the Cache.
         """
-        client_order_id_int = secrets.randbelow(MAX_CLIENT_ID)
+        try:
+            client_order_id_int = int(client_order_id.value)
+        except ValueError:
+            client_order_id_int = secrets.randbelow(MAX_CLIENT_ID)
 
         # Store the generated client order ID integer in the cache for later lookup.
         # MAX_CLIENT_ID is 2**32 - 1 which can be represented by 32 bits, i.e. 4 bytes.
@@ -129,12 +132,17 @@ class ClientOrderIdHelper:
         """
         Retrieve the ClientOrderId integer from the cache.
         """
-        value = self._cache.get(client_order_id.value)
+        result = None
 
-        if value is not None:
-            return int.from_bytes(value, byteorder="big")
+        try:
+            result = int(client_order_id.value)
+        except ValueError:
+            value = self._cache.get(client_order_id.value)
 
-        return None
+            if value is not None:
+                result = int.from_bytes(value, byteorder="big")
+
+        return result
 
     def get_client_order_id(self, client_order_id_int: int) -> ClientOrderId:
         """

--- a/tests/integration_tests/adapters/dydx/conftest.py
+++ b/tests/integration_tests/adapters/dydx/conftest.py
@@ -18,10 +18,12 @@ Create fixtures for commonly used objects.
 
 import pytest
 
+from nautilus_trader.adapters.dydx.common.constants import DYDX_VENUE
 from nautilus_trader.adapters.dydx.common.symbol import DYDXSymbol
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 from nautilus_trader.common.component import LiveClock
 from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Venue
 
 
 @pytest.fixture
@@ -60,8 +62,11 @@ def http_client(live_clock: LiveClock) -> DYDXHttpClient:
 
 
 @pytest.fixture()
-def venue():
-    pass
+def venue() -> Venue:
+    """
+    Create a stub dYdX venue.
+    """
+    return DYDX_VENUE
 
 
 @pytest.fixture()

--- a/tests/integration_tests/adapters/dydx/test_execution.py
+++ b/tests/integration_tests/adapters/dydx/test_execution.py
@@ -1,0 +1,126 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------"""Unit tests for the execution engine of dYdX."""
+"""
+Unit tests for the dYdX execution engine.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from nautilus_trader.adapters.dydx.execution import ClientOrderIdHelper
+from nautilus_trader.model.identifiers import ClientOrderId
+
+
+@pytest.fixture
+def client_order_id_helper(cache):
+    """
+    Create a stub ClientOrderIdHelper.
+    """
+    return ClientOrderIdHelper(cache=cache)
+
+
+@pytest.mark.parametrize("order_string", [str(uuid4()), str(12345)])
+def test_generate_client_order_id_int_uuid(client_order_id_helper, order_string) -> None:
+    """
+    Test the generate_client_order_id_int method with a UUID4.
+    """
+    # Prepare
+    client_order_id = ClientOrderId(order_string)
+
+    # Act
+    result = client_order_id_helper.generate_client_order_id_int(client_order_id)
+
+    # Assert
+    assert isinstance(result, int)
+
+
+def test_generate_client_order_id_int_with_int(client_order_id_helper) -> None:
+    """
+    Test the generate_client_order_id_int method with an integer.
+    """
+    # Prepare
+    expected_result = 12345
+    client_order_id = ClientOrderId(str(expected_result))
+
+    # Act
+    result = client_order_id_helper.generate_client_order_id_int(client_order_id)
+
+    # Assert
+    assert result == expected_result
+
+
+def test_retrieve_from_cache(client_order_id_helper) -> None:
+    """
+    Test the generate_client_order_id_int method with an integer.
+    """
+    # Prepare
+    client_order_id_int = 12345
+    expected_result = ClientOrderId(str(client_order_id_int))
+    client_order_id_helper.generate_client_order_id_int(expected_result)
+
+    # Act
+    result = client_order_id_helper.get_client_order_id(client_order_id_int)
+
+    # Assert
+    assert result.value == expected_result.value
+    assert result == expected_result
+
+
+def test_retrieve_from_empty_cache(client_order_id_helper) -> None:
+    """
+    Test the generate_client_order_id_int method with an integer.
+    """
+    # Prepare
+    client_order_id_int = 12345
+    expected_result = ClientOrderId(str(client_order_id_int))
+
+    # Act
+    result = client_order_id_helper.get_client_order_id(client_order_id_int)
+
+    # Assert
+    assert result.value == expected_result.value
+    assert result == expected_result
+
+
+def test_retrieve_client_order_id_integer_from_cache(client_order_id_helper) -> None:
+    """
+    Test the generate_client_order_id_int method with an integer.
+    """
+    # Prepare
+    expected_result = 12345
+    client_order_id = ClientOrderId(str(expected_result))
+    client_order_id_helper.generate_client_order_id_int(client_order_id)
+
+    # Act
+    result = client_order_id_helper.get_client_order_id_int(client_order_id)
+
+    # Assert
+    assert result == expected_result
+
+
+def test_retrieve_client_order_id_integer_from_empty_cache(client_order_id_helper) -> None:
+    """
+    Test the generate_client_order_id_int method with an integer.
+    """
+    # Prepare
+    expected_result = 12345
+    client_order_id = ClientOrderId(str(expected_result))
+
+    # Act
+    result = client_order_id_helper.get_client_order_id_int(client_order_id)
+
+    # Assert
+    assert result == expected_result


### PR DESCRIPTION
# Pull Request

Use custom client order IDs set by the strategy and fallback to generating new integers for dYdX

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Unit test and live example with both custom and client order IDs generated by NT
