### PR TITLE
Add date field with customdataclass only when using to_arrow

### DIFF
--- a/nautilus_trader/model/custom.py
+++ b/nautilus_trader/model/custom.py
@@ -64,7 +64,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
 
         if "to_dict" not in cls.__dict__:
 
-            def to_dict(self) -> dict[str, Any]:
+            def to_dict(self, to_arrow=False) -> dict[str, Any]:
                 result = {attr: getattr(self, attr) for attr in self.__annotations__}
 
                 result["type"] = str(cls.__name__)
@@ -74,7 +74,9 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
 
                 result["ts_event"] = self._ts_event
                 result["ts_init"] = self._ts_init
-                result["date"] = int(unix_nanos_to_dt(result["ts_event"]).strftime("%Y%m%d"))
+
+                if to_arrow:
+                    result["date"] = int(unix_nanos_to_dt(result["ts_event"]).strftime("%Y%m%d"))
 
                 return result
 
@@ -112,7 +114,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
         if "to_arrow" not in cls.__dict__:
 
             def to_arrow(self) -> pa.RecordBatch:
-                return pa.RecordBatch.from_pylist([self.to_dict()], schema=cls._schema)
+                return pa.RecordBatch.from_pylist([self.to_dict(to_arrow=True)], schema=cls._schema)
 
             cls.to_arrow = to_arrow
 

--- a/tests/unit_tests/model/test_custom_data.py
+++ b/tests/unit_tests/model/test_custom_data.py
@@ -43,9 +43,17 @@ def test_customdata_decorator_dict() -> None:
 
     # Act
     data_dict = data.to_dict()
+    data_dict_to_arrow = data.to_dict(to_arrow=True)
 
     # Assert
     assert data_dict == {
+        "type": "GreeksTestData",
+        "instrument_id": "ES.GLBX",
+        "delta": 0.0,
+        "ts_event": 1,
+        "ts_init": 2,
+    }
+    assert data_dict_to_arrow == {
         "type": "GreeksTestData",
         "instrument_id": "ES.GLBX",
         "delta": 0.0,


### PR DESCRIPTION
# Pull Request

Adds an extra date field only for to_arrow serialisation used for catalogs.
Space impact of extra field is minimal with parquet as columns are compressed.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Improved an existing test
