### PR TITLE
Filter orders for dYdX OrderStatusReports

### DIFF
--- a/nautilus_trader/adapters/dydx/common/enums.py
+++ b/nautilus_trader/adapters/dydx/common/enums.py
@@ -227,9 +227,17 @@ class DYDXEnumParser:
             DYDXOrderType.STOP_MARKET: OrderType.STOP_MARKET,
         }
 
+        self.nautilus_to_dydx_order_type = {
+            value: key for key, value in self.dydx_to_nautilus_order_type.items()
+        }
+
         self.dydx_to_nautilus_order_side = {
             DYDXOrderSide.BUY: OrderSide.BUY,
             DYDXOrderSide.SELL: OrderSide.SELL,
+        }
+
+        self.nautilus_to_dydx_order_side = {
+            value: key for key, value in self.dydx_to_nautilus_order_side.items()
         }
 
         self.dydx_to_nautilus_order_status = {
@@ -275,6 +283,12 @@ class DYDXEnumParser:
         """
         return self.dydx_to_nautilus_order_type[order_type]
 
+    def parse_nautilus_order_type(self, order_type: OrderType) -> DYDXOrderType:
+        """
+        Convert a Nautilus order type to a DYDX order type.
+        """
+        return self.nautilus_to_dydx_order_type[order_type]
+
     def parse_dydx_order_side(self, order_side: DYDXOrderSide | None) -> OrderSide:
         """
         Convert a DYDX order side to a Nautilus order side.
@@ -283,6 +297,15 @@ class DYDXEnumParser:
             return OrderSide.NO_ORDER_SIDE
 
         return self.dydx_to_nautilus_order_side[order_side]
+
+    def parse_nautilus_order_side(self, order_side: OrderSide) -> DYDXOrderSide | None:
+        """
+        Convert a Nautilus order side to a DYDX order side.
+        """
+        if order_side == OrderSide.NO_ORDER_SIDE:
+            return None
+
+        return self.nautilus_to_dydx_order_side[order_side]
 
     def parse_dydx_order_status(self, order_status: DYDXOrderStatus) -> OrderStatus:
         """

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -310,6 +310,8 @@ class DYDXExecutionClient(LiveExecutionClient):
         instrument_id: InstrumentId,
         client_order_id: ClientOrderId | None = None,
         venue_order_id: VenueOrderId | None = None,
+        order_side: OrderSide | None = None,
+        order_type: OrderType | None = None,
     ) -> OrderStatusReport | None:
         PyCondition.false(
             client_order_id is None and venue_order_id is None,
@@ -330,6 +332,8 @@ class DYDXExecutionClient(LiveExecutionClient):
                 address=self._wallet_address,
                 subaccount_number=self._subaccount,
                 symbol=instrument_id.symbol.value.removesuffix("-PERP"),
+                order_side=self._enum_parser.parse_nautilus_order_side(order_side),
+                order_type=self._enum_parser.parse_nautilus_order_type(order_type),
                 return_latest_orders=True,
             )
 
@@ -422,6 +426,8 @@ class DYDXExecutionClient(LiveExecutionClient):
                 instrument_id=instrument_id,
                 client_order_id=client_order_id,
                 venue_order_id=venue_order_id,
+                order_side=order.side,
+                order_type=order.order_type,
             )
 
         except DYDXError as e:

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -69,6 +69,30 @@ def test_parse_order_type(
 
 
 @pytest.mark.parametrize(
+    ("order_type", "expected_result"),
+    [
+        (OrderType.LIMIT, DYDXOrderType.LIMIT),
+        (OrderType.MARKET, DYDXOrderType.MARKET),
+        (OrderType.STOP_LIMIT, DYDXOrderType.STOP_LIMIT),
+        (OrderType.STOP_MARKET, DYDXOrderType.STOP_MARKET),
+    ],
+)
+def test_parse_nautilus_order_type(
+    order_type: OrderType,
+    expected_result: DYDXOrderType,
+    enum_parser: DYDXEnumParser,
+) -> None:
+    """
+    Test converting the Nautilus order types to dYdX order types.
+    """
+    # Act
+    result = enum_parser.parse_nautilus_order_type(order_type)
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
     ("dydx_order_side", "expected_result"),
     [
         (DYDXOrderSide.BUY, OrderSide.BUY),
@@ -85,6 +109,28 @@ def test_parse_order_side(
     """
     # Act
     result = enum_parser.parse_dydx_order_side(dydx_order_side)
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("order_side", "expected_result"),
+    [
+        (OrderSide.BUY, DYDXOrderSide.BUY),
+        (OrderSide.SELL, DYDXOrderSide.SELL),
+    ],
+)
+def test_parse_nautilus_order_side(
+    order_side: OrderSide,
+    expected_result: DYDXOrderSide,
+    enum_parser: DYDXEnumParser,
+) -> None:
+    """
+    Test converting the Nautilus order side to dYdX order side.
+    """
+    # Act
+    result = enum_parser.parse_nautilus_order_side(order_side)
 
     # Assert
     assert result == expected_result

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -97,10 +97,11 @@ def test_parse_nautilus_order_type(
     [
         (DYDXOrderSide.BUY, OrderSide.BUY),
         (DYDXOrderSide.SELL, OrderSide.SELL),
+        (None, OrderSide.NO_ORDER_SIDE),
     ],
 )
 def test_parse_order_side(
-    dydx_order_side: DYDXOrderSide,
+    dydx_order_side: DYDXOrderSide | None,
     expected_result: OrderSide,
     enum_parser: DYDXEnumParser,
 ) -> None:
@@ -119,11 +120,12 @@ def test_parse_order_side(
     [
         (OrderSide.BUY, DYDXOrderSide.BUY),
         (OrderSide.SELL, DYDXOrderSide.SELL),
+        (OrderSide.NO_ORDER_SIDE, None),
     ],
 )
 def test_parse_nautilus_order_side(
     order_side: OrderSide,
-    expected_result: DYDXOrderSide,
+    expected_result: DYDXOrderSide | None,
     enum_parser: DYDXEnumParser,
 ) -> None:
     """


### PR DESCRIPTION
# Pull Request

Filter the orders by order type and side when creating a OrderStatusReport dYdX

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Unit tests and live example