### PR TITLE
Introduce PSQL functions to Postgres schema and Nautilus CLI

### DIFF
--- a/schema/functions.sql
+++ b/schema/functions.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION get_all_tables ()
+    RETURNS TEXT[] AS $$
+DECLARE
+    result TEXT[];
+BEGIN
+    SELECT
+        array_agg(t.table_name) INTO result
+    FROM information_schema.tables t
+    LEFT JOIN pg_class pc ON t.table_name = pc.relname
+    WHERE table_schema = current_schema();
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Pull Request

- added `functions.sql` which will store Postgres functions written in procedural `plpgsql` language. These functions can be later used by the Postgres related Rust code and the other queries
- refactor `init_postgres` function to also account for these functions when splitting with the target delimiter 
- changed logging from `tracing` to `log`