### PR TITLE
Update average price in ValueBarAggregator when using bars

### DIFF
--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -607,7 +607,7 @@ cdef class ValueBarAggregator(BarAggregator):
 
     cdef void _apply_update_bar(self, Bar bar, Quantity volume, uint64_t ts_init):
         volume_update = volume
-        average_price = (bar.open + bar.high + bar.low + bar.close) * Decimal(0.25)
+        average_price = Quantity((bar.high + bar.low + bar.close) / Decimal(3.0), precision=self._builder.price_precision)
 
         while volume_update > 0:  # While there is value to apply
             value_update = average_price * volume_update  # Calculated value in quote currency

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 from datetime import timedelta
+from decimal import ROUND_HALF_UP
 from decimal import Decimal
 
 import pandas as pd
@@ -1507,7 +1508,8 @@ class TestTestValueBarAggregator:
         assert handler[1].low == Price.from_str("20.00000")
         assert handler[1].close == Price.from_str("20.00000")
         assert handler[1].volume == Quantity.from_str("5000.00")
-        assert aggregator.get_cumulative_value() == Decimal("40000.11000")
+        expected = Decimal("40000.11")
+        assert aggregator.get_cumulative_value().quantize(expected, ROUND_HALF_UP) == expected
 
     def test_handle_bar_when_value_beyond_threshold_sends_bars_to_handler(self):
         # Arrange
@@ -1571,7 +1573,10 @@ class TestTestValueBarAggregator:
         assert handler[1].low == Price.from_str("20.00000")
         assert handler[1].close == Price.from_str("20.00015")
         assert handler[1].volume == Quantity.from_str("5000.00")
-        assert aggregator.get_cumulative_value() == Decimal("40001.02500")
+        expected = Decimal("40001.11")
+        assert (
+            aggregator.get_cumulative_value().quantize(expected, rounding=ROUND_HALF_UP) == expected
+        )
 
     def test_run_quote_ticks_through_aggregator_results_in_expected_bars(self):
         # Arrange


### PR DESCRIPTION
# Pull Request

Modified price value to average of high low close instead of open high low close in the ValueBarAggregator when using bars as source data.
This is to avoid having the close value being used a second time in the next open value, also similarly to the VWAP price.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tests have been updated to reflect the new formula.

Such syntax needed to be used in order to compare decimal numbers because of dividing by 3.

```
expected = Decimal("40001.11")
assert (
   aggregator.get_cumulative_value().quantize(expected, rounding=ROUND_HALF_UP) == expected
)
```
