### PR TITLE
Fix no log in backtest run if log not initialized

### DIFF
--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -25,6 +25,7 @@ from nautilus_trader.backtest.engine import BacktestEngineConfig
 from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.common.component import Logger
 from nautilus_trader.common.component import LogGuard
+from nautilus_trader.common.component import init_logging
 from nautilus_trader.common.config import ActorFactory
 from nautilus_trader.common.config import InvalidConfiguration
 from nautilus_trader.core import nautilus_pyo3
@@ -161,6 +162,11 @@ class BacktestNode:
             except Exception as e:
                 # Broad catch all prevents a single backtest run from halting
                 # the execution of the other backtests (such as a zero balance exception).
+                try:
+                    init_logging()
+                except Exception:
+                    Logger(type(self).__name__).info("LogGuard already exists")
+
                 Logger(type(self).__name__).error(f"Error running backtest: {e}")
                 Logger(type(self).__name__).info(f"Config: {config}")
 

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -26,6 +26,7 @@ from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.common.component import Logger
 from nautilus_trader.common.component import LogGuard
 from nautilus_trader.common.component import init_logging
+from nautilus_trader.common.component import is_logging_initialized
 from nautilus_trader.common.config import ActorFactory
 from nautilus_trader.common.config import InvalidConfiguration
 from nautilus_trader.core import nautilus_pyo3
@@ -162,10 +163,8 @@ class BacktestNode:
             except Exception as e:
                 # Broad catch all prevents a single backtest run from halting
                 # the execution of the other backtests (such as a zero balance exception).
-                try:
+                if not is_logging_initialized():
                     init_logging()
-                except Exception:
-                    Logger(type(self).__name__).info("LogGuard already exists")
 
                 Logger(type(self).__name__).error(f"Error running backtest: {e}")
                 Logger(type(self).__name__).info(f"Config: {config}")


### PR DESCRIPTION
# Pull Request

Allow some log messages to stdout in an edge case where the kernel of a backtest fails before the logging is initialized

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

The issue can be reproduced for example by not passing a correct type to a strategy config in cython (the type mismatch creates an error and if the logger is not initialized, then the backtestnode's call to Logger does nothing.)
