### PR TITLE
Implement quote tick processing for SimulatedExchange

### DIFF
--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -28,6 +28,7 @@ use nautilus_model::{
     data::{
         bar::{Bar, BarType},
         delta::OrderBookDelta,
+        quote::QuoteTick,
     },
     enums::{
         AccountType, BookType, ContingencyType, LiquiditySide, MarketStatus, OmsType, OrderSide,
@@ -251,6 +252,16 @@ impl OrderMatchingEngine {
         log::debug!("Processing {delta}");
 
         self.book.apply_delta(delta);
+    }
+
+    pub fn process_quote_tick(&mut self, tick: &QuoteTick) {
+        log::debug!("Processing {tick}");
+
+        if self.book_type == BookType::L1_MBP {
+            self.book.update_quote_tick(tick).unwrap();
+        }
+
+        self.iterate(tick.ts_event);
     }
 
     // -- TRADING COMMANDS ------------------------------------------------------------------------

--- a/nautilus_core/core/src/correctness.rs
+++ b/nautilus_core/core/src/correctness.rs
@@ -26,7 +26,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::Hash,
 };
 
@@ -110,16 +110,14 @@ pub fn check_string_contains(s: &str, pat: &str, param: &str) -> anyhow::Result<
 }
 
 /// Checks the values are equal.
-pub fn check_equal<T: PartialEq + Debug>(
+pub fn check_equal<T: PartialEq + Debug + Display>(
     lhs: T,
     rhs: T,
     lhs_param: &str,
     rhs_param: &str,
 ) -> anyhow::Result<()> {
     if lhs != rhs {
-        anyhow::bail!(
-            "'{lhs_param}' value of {lhs:?} was not equal to '{rhs_param}' value of {rhs:?}",
-        );
+        anyhow::bail!("'{lhs_param}' value of {lhs} was not equal to '{rhs_param}' value of {rhs}",);
     }
     Ok(())
 }
@@ -403,6 +401,8 @@ where
 ////////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
+    use std::fmt::Display;
+
     use rstest::rstest;
 
     use super::*;
@@ -474,7 +474,7 @@ mod tests {
     #[case(10i32, 20i32, "left", "right", false)]
     #[case("hello", "hello", "left", "right", true)]
     #[case("hello", "world", "left", "right", false)]
-    fn test_check_equal<T: PartialEq + Debug>(
+    fn test_check_equal<T: PartialEq + Debug + Display>(
         #[case] lhs: T,
         #[case] rhs: T,
         #[case] lhs_param: &str,

--- a/nautilus_core/model/src/ffi/orderbook/book.rs
+++ b/nautilus_core/model/src/ffi/orderbook/book.rs
@@ -28,11 +28,7 @@ use crate::{
     },
     enums::{BookType, OrderSide},
     identifiers::InstrumentId,
-    orderbook::{
-        aggregation::{update_book_with_quote_tick, update_book_with_trade_tick},
-        analysis::book_check_integrity,
-        book::OrderBook,
-    },
+    orderbook::{analysis::book_check_integrity, book::OrderBook},
     types::{price::Price, quantity::Quantity},
 };
 
@@ -258,7 +254,7 @@ pub extern "C" fn orderbook_get_quantity_for_price(
 /// - If book type is not `L1_MBP`.
 #[no_mangle]
 pub extern "C" fn orderbook_update_quote_tick(book: &mut OrderBook_API, quote: &QuoteTick) {
-    update_book_with_quote_tick(book, quote).unwrap();
+    book.update_quote_tick(quote).unwrap();
 }
 
 /// Updates the order book with a trade tick.
@@ -269,7 +265,7 @@ pub extern "C" fn orderbook_update_quote_tick(book: &mut OrderBook_API, quote: &
 /// - If book type is not `L1_MBP`.
 #[no_mangle]
 pub extern "C" fn orderbook_update_trade_tick(book: &mut OrderBook_API, tick: &TradeTick) {
-    update_book_with_trade_tick(book, tick).unwrap();
+    book.update_trade_tick(tick).unwrap();
 }
 
 #[no_mangle]

--- a/nautilus_core/model/src/python/orderbook/book.rs
+++ b/nautilus_core/model/src/python/orderbook/book.rs
@@ -23,12 +23,7 @@ use crate::{
     },
     enums::{BookType, OrderSide},
     identifiers::InstrumentId,
-    orderbook::{
-        aggregation::{update_book_with_quote_tick, update_book_with_trade_tick},
-        analysis::book_check_integrity,
-        book::OrderBook,
-        level::Level,
-    },
+    orderbook::{analysis::book_check_integrity, book::OrderBook, level::Level},
     types::{price::Price, quantity::Quantity},
 };
 
@@ -217,11 +212,11 @@ impl OrderBook {
 #[pyfunction()]
 #[pyo3(name = "update_book_with_quote_tick")]
 pub fn py_update_book_with_quote_tick(book: &mut OrderBook, quote: &QuoteTick) -> PyResult<()> {
-    update_book_with_quote_tick(book, quote).map_err(to_pyvalue_err)
+    book.update_quote_tick(quote).map_err(to_pyvalue_err)
 }
 
 #[pyfunction()]
 #[pyo3(name = "update_book_with_trade_tick")]
 pub fn py_update_book_with_trade_tick(book: &mut OrderBook, trade: &TradeTick) -> PyResult<()> {
-    update_book_with_trade_tick(book, trade).map_err(to_pyvalue_err)
+    book.update_trade_tick(trade).map_err(to_pyvalue_err)
 }


### PR DESCRIPTION
# Pull Request

- implemented `best_bid_price` , `best_ask_price`  and `process_quote_tick` in `SimulatedExchange`
- implemented `process_quote_tick` in `OrderMatchingEngine`
- added tests `test_venue_mismatch_between_exchange_and_instrument`, `est_cash_account_trading_futures_or_perpetuals` and `test_exchange_process_quote_tick` 
- added `Display` trait bound in `check_equal` function
- pushed two orderbook aggr function `update_book_with_quote_tick` and `update_book_with_trade_tick`, `update_book_bid` and `update_book_ask` inside `Orderbook` struct 