### PR TITLE
Fix _next_rotation_time update for multiple data types in StreamingFeatherWriter

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -736,13 +736,12 @@ class ParquetDataCatalog(BaseDataCatalog):
         # Non-instrument feather files
         for fn in self.fs.glob(f"{prefix}/*.feather"):
             cls_name = fn.replace(prefix + "/", "").replace(".feather", "")
-            cls_name = cls_name.split("_")[0]
+            cls_name = "_".join(cls_name.split("_")[:-1])
             yield FeatherFile(path=fn, class_name=cls_name)
 
         # Per-instrument feather files
         for ins_fn in self.fs.glob(f"{prefix}/**/*.feather"):
             ins_cls_name = pathlib.Path(ins_fn.replace(prefix + "/", "")).parent.name
-            ins_cls_name = ins_cls_name.split("_")[0]
             yield FeatherFile(path=ins_fn, class_name=ins_cls_name)
 
     def _read_feather_file(
@@ -766,10 +765,17 @@ class ParquetDataCatalog(BaseDataCatalog):
         **kwargs: Any,
     ) -> None:
         table_name = class_to_filename(data_cls)
-        feather_file = Path(self.path) / "backtest" / instance_id / f"{table_name}.feather"
+        feather_dir = Path(self.path) / "backtest" / instance_id
+        feather_files = sorted(feather_dir.glob(f"{table_name}_*.feather"))
 
-        feather_table = self._read_feather_file(feather_file)
-        custom_data_list = self._handle_table_nautilus(feather_table, data_cls)
+        all_data = []
+        for feather_file in feather_files:
+            feather_table = self._read_feather_file(str(feather_file))
+            if feather_table is not None:
+                custom_data_list = self._handle_table_nautilus(feather_table, data_cls)
+                all_data.extend(custom_data_list)
+
+        all_data.sort(key=lambda x: x.ts_init)
 
         used_catalog = self if other_catalog is None else other_catalog
-        used_catalog.write_data(custom_data_list, **kwargs)
+        used_catalog.write_data(all_data, **kwargs)

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -736,11 +736,13 @@ class ParquetDataCatalog(BaseDataCatalog):
         # Non-instrument feather files
         for fn in self.fs.glob(f"{prefix}/*.feather"):
             cls_name = fn.replace(prefix + "/", "").replace(".feather", "")
+            cls_name = cls_name.split("_")[0]
             yield FeatherFile(path=fn, class_name=cls_name)
 
         # Per-instrument feather files
         for ins_fn in self.fs.glob(f"{prefix}/**/*.feather"):
             ins_cls_name = pathlib.Path(ins_fn.replace(prefix + "/", "")).parent.name
+            ins_cls_name = ins_cls_name.split("_")[0]
             yield FeatherFile(path=ins_fn, class_name=ins_cls_name)
 
     def _read_feather_file(

--- a/nautilus_trader/persistence/config.py
+++ b/nautilus_trader/persistence/config.py
@@ -15,9 +15,13 @@
 
 from __future__ import annotations
 
+from datetime import time
+
 import fsspec
+import pandas as pd
 
 from nautilus_trader.common.config import NautilusConfig
+from nautilus_trader.persistence.writer import RotationMode
 
 
 class StreamingConfig(NautilusConfig, frozen=True):
@@ -39,6 +43,16 @@ class StreamingConfig(NautilusConfig, frozen=True):
     include_types : list[type], optional
         A list of Arrow serializable types to write.
         If this is specified then **only** the included types will be written.
+    rotation_mode : RotationMode, default RotationMode.NO_ROTATION
+        The mode for file rotation.
+    max_file_size : int, default 1GB
+        The maximum file size in bytes before rotation (for SIZE mode).
+    rotation_interval : pd.Timedelta, default 1 day
+        The time interval for file rotation (for INTERVAL mode and SCHEDULED_DATES mode).
+    rotation_time : time, default 00:00
+        The time of day for file rotation (for SCHEDULED_DATES mode).
+    rotation_timezone : str, default 'UTC'
+        The timezone for rotation calculations (for SCHEDULED_DATES mode).
 
     """
 
@@ -48,6 +62,11 @@ class StreamingConfig(NautilusConfig, frozen=True):
     flush_interval_ms: int | None = None
     replace_existing: bool = False
     include_types: list[type] | None = None
+    rotation_mode: RotationMode = RotationMode.NO_ROTATION
+    max_file_size: int = 1024 * 1024 * 1024  # 1GB
+    rotation_interval: pd.Timedelta = pd.Timedelta(days=1)
+    rotation_time: time = time(0, 0, 0, 0)
+    rotation_timezone: str = "UTC"
 
     @property
     def fs(self):

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -13,15 +13,21 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import datetime
+
+from datetime import time
+from enum import Enum
 from io import TextIOWrapper
 from typing import Any, BinaryIO
 
 import fsspec
+import pandas as pd
 import pyarrow as pa
+import pytz
 from fsspec.compression import AbstractBufferedFile
 from pyarrow import RecordBatchStreamWriter
 
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import Clock
 from nautilus_trader.common.component import Logger
 from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.data import Data
@@ -31,8 +37,6 @@ from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.persistence.funcs import class_to_filename
 from nautilus_trader.persistence.funcs import urisafe_instrument_id
 from nautilus_trader.serialization.arrow.serializer import ArrowSerializer
@@ -40,14 +44,26 @@ from nautilus_trader.serialization.arrow.serializer import list_schemas
 from nautilus_trader.serialization.arrow.serializer import register_arrow
 
 
+class RotationMode(Enum):
+    SIZE = "size"
+    INTERVAL = "interval"
+    SCHEDULED_DATES = "scheduled_dates"
+    NO_ROTATION = "no_rotation"
+
+
 class StreamingFeatherWriter:
     """
-    Provides a stream writer of Nautilus objects into feather files.
+    Provides a stream writer of Nautilus objects into feather files with rotation
+    capabilities.
 
     Parameters
     ----------
     path : str
         The path to persist the stream to.
+    cache : Cache
+        The cache for the query info.
+    clock : Clock
+        The clock to use for time-related operations.
     fs_protocol : str, default 'file'
         The `fsspec` file system protocol.
     flush_interval_ms : int, optional
@@ -57,18 +73,37 @@ class StreamingFeatherWriter:
     include_types : list[type], optional
         A list of Arrow serializable types to write.
         If this is specified then **only** the included types will be written.
+    rotation_mode : RotationMode, default RotationMode.NO_ROTATION
+        The mode for file rotation.
+    max_file_size : int, default 1GB
+        The maximum file size in bytes before rotation (for SIZE mode).
+    rotation_interval : pd.Timedelta, default 1 day
+        The time interval for file rotation (for INTERVAL mode and SCHEDULED_DATES mode).
+    rotation_time : time, default 00:00
+        The time of day for file rotation (for SCHEDULED_DATES mode).
+    rotation_timezone : str, default 'UTC'
+        The timezone for rotation calculations(for SCHEDULED_DATES mode).
 
     """
 
     def __init__(
         self,
         path: str,
+        cache: Cache,
+        clock: Clock,
         fs_protocol: str | None = "file",
         flush_interval_ms: int | None = None,
         replace: bool = False,
         include_types: list[type] | None = None,
+        rotation_mode: RotationMode = RotationMode.NO_ROTATION,
+        max_file_size: int = 1024 * 1024 * 1024,  # 1GB
+        rotation_interval: pd.Timedelta = pd.Timedelta(days=1),
+        rotation_time: time = time(0, 0, 0, 0),
+        rotation_timezone: str = "UTC",
     ) -> None:
         self.path = path
+        self.cache = cache
+        self.clock = clock
         self.fs: fsspec.AbstractFileSystem = fsspec.filesystem(fs_protocol)
         self.fs.makedirs(self.fs._parent(self.path), exist_ok=True)
 
@@ -85,32 +120,132 @@ class StreamingFeatherWriter:
 
         self._schemas = list_schemas()
         self.logger = Logger(type(self).__name__)
-        self._files: dict[object, TextIOWrapper | BinaryIO | AbstractBufferedFile] = {}
-        self._writers: dict[str, RecordBatchStreamWriter] = {}
+        self._files: dict[
+            str | tuple[str, str],
+            TextIOWrapper | BinaryIO | AbstractBufferedFile,
+        ] = {}
+        self._writers: dict[str | tuple[str, str], RecordBatchStreamWriter] = {}
         self._instrument_writers: dict[tuple[str, str], RecordBatchStreamWriter] = {}
         self._per_instrument_writers = {
             "order_book_delta",
             "quote_tick",
             "trade_tick",
         }
-        self._instruments: dict[InstrumentId, Instrument] = {}
-        self._create_writers()
+        self.rotation_mode = rotation_mode
+        self.max_file_size = max_file_size
+        self.rotation_interval = rotation_interval
+        self.rotation_time = rotation_time
+        self.rotation_timezone = pytz.timezone(rotation_timezone)
+        self._file_sizes: dict[str | tuple[str, str], int] = {}
+        self._file_creation_times: dict[str | tuple[str, str], pd.Timestamp] = {}
+        self._next_rotation_time: pd.Timestamp | None = None
 
-        self.flush_interval_ms = datetime.timedelta(milliseconds=flush_interval_ms or 1000)
-        self._last_flush = datetime.datetime(1970, 1, 1)  # Default value to begin
+        self._create_writers()
+        self._update_next_rotation_time()
+
+        self.flush_interval_ms = flush_interval_ms or 1000
+        self._last_flush = self.clock.utc_now()
         self.missing_writers: set[type] = set()
 
-    @property
-    def is_closed(self) -> bool:
+    def _update_next_rotation_time(self) -> None:
         """
-        Return whether all file streams are closed.
+        Update the next rotation time based on the current rotation mode and clock.
+        """
+        now = self.clock.utc_now()
+        if self.rotation_mode == RotationMode.INTERVAL:
+            self._next_rotation_time = now + self.rotation_interval
+        elif self.rotation_mode == RotationMode.SCHEDULED_DATES:
+            if self._next_rotation_time is None:
+                user_rotation_time = pd.Timestamp.combine(now.date(), self.rotation_time)
+                self._next_rotation_time = pd.Timestamp(
+                    user_rotation_time,
+                    tz=self.rotation_timezone,
+                ).tz_convert("UTC")
+                while self._next_rotation_time <= now:
+                    self._next_rotation_time += self.rotation_interval
+            else:
+                self._next_rotation_time = now + self.rotation_interval
+        elif self.rotation_mode in (RotationMode.SIZE, RotationMode.NO_ROTATION):
+            self._next_rotation_time = None
+
+    def _check_file_rotation(self, table_name: str) -> bool:
+        """
+        Check if file rotation is needed for the given table.
+
+        Parameters
+        ----------
+        table_name : str
+            The name of the table to check.
 
         Returns
         -------
         bool
+            True if rotation is needed, False otherwise.
 
         """
-        return all(self._files[table_name].closed for table_name in self._files)
+        if self.rotation_mode == RotationMode.NO_ROTATION:
+            return False
+        elif self.rotation_mode == RotationMode.SIZE:
+            return self._file_sizes.get(table_name, 0) >= self.max_file_size
+        elif self.rotation_mode in (RotationMode.INTERVAL, RotationMode.SCHEDULED_DATES):
+            now = self.clock.utc_now()
+            if self._next_rotation_time and now >= self._next_rotation_time:
+                self._update_next_rotation_time()
+                return True
+        return False
+
+    def _rotate_regular_file(self, table_name: str, cls: type) -> None:
+        """
+        Rotate the file for a regular table.
+
+        Parameters
+        ----------
+        table_name : str
+            The name of the table to rotate.
+        cls : type
+            The class type for the writer.
+
+        """
+        if table_name in self._writers:
+            self._files[table_name].flush()
+            self._writers[table_name].close()
+            self._files[table_name].close()
+            del self._writers[table_name]
+            del self._files[table_name]
+
+        self._create_writer(cls=cls, table_name=table_name)
+        self._file_sizes[table_name] = 0
+        self._file_creation_times[table_name] = self.clock.utc_now()
+        self.logger.info(f"Rotated regular file for table '{table_name}'")
+
+    def _rotate_per_instrument_file(self, cls: type, obj: Any) -> None:
+        """
+        Rotate the file for a per-instrument table.
+
+        Parameters
+        ----------
+        cls : type
+            The class type of the object.
+        obj : Any
+            The object containing instrument data.
+
+        """
+        table_name = class_to_filename(cls)
+        key = (table_name, obj.instrument_id.value)
+        if key in self._instrument_writers:
+            self._files[key].flush()
+            self._instrument_writers[key].close()
+            self._files[key].close()
+            del self._instrument_writers[key]
+            del self._files[key]
+
+        self._create_instrument_writer(cls=cls, obj=obj)
+
+        self._file_sizes[key] = 0
+        self._file_creation_times[key] = self.clock.utc_now()
+        self.logger.info(
+            f"Rotated instrument file for table '{table_name}' with instrument ID '{obj.instrument_id.value}'",
+        )
 
     def _create_writer(self, cls: type, table_name: str | None = None) -> None:
         # Check if an include types filter has been specified
@@ -125,12 +260,15 @@ class StreamingFeatherWriter:
             return
 
         schema = self._schemas[cls]
-        full_path = f"{self.path}/{table_name}.feather"
+        timestamp = self.clock.utc_now().strftime("%Y%m%d_%H%M%S")
+        full_path = f"{self.path}/{table_name}_{timestamp}.feather"
 
         self.fs.makedirs(self.fs._parent(full_path), exist_ok=True)
         f = self.fs.open(full_path, "wb")
         self._files[table_name] = f
         self._writers[table_name] = pa.ipc.new_stream(f, schema)
+        self._file_sizes[table_name] = 0
+        self._file_creation_times[table_name] = self.clock.utc_now()
 
         self.logger.info(f"Created writer for table '{table_name}'")
 
@@ -152,18 +290,21 @@ class StreamingFeatherWriter:
         key = (table_name, obj.instrument_id.value)
         self.fs.makedirs(folder, exist_ok=True)
 
-        full_path = f"{folder}/{urisafe_instrument_id(obj.instrument_id.value)}.feather"
+        timestamp = self.clock.utc_now().strftime("%Y%m%d_%H%M%S")
+        full_path = f"{folder}/{urisafe_instrument_id(obj.instrument_id.value)}_{timestamp}.feather"
+
         f = self.fs.open(full_path, "wb")
         self._files[key] = f
         self._instrument_writers[key] = pa.ipc.new_stream(f, schema)
-
+        self._file_sizes[table_name] = 0
+        self._file_creation_times[table_name] = self.clock.utc_now()
         self.logger.info(f"Created writer for table '{table_name}'")
 
     def _extract_obj_metadata(
         self,
         obj: TradeTick | QuoteTick | Bar | OrderBookDelta,
     ) -> dict[bytes, bytes]:
-        instrument = self._instruments[obj.instrument_id]
+        instrument = self.cache.instrument(obj.instrument_id)
         metadata = {b"instrument_id": obj.instrument_id.value.encode()}
         if (
             isinstance(obj, OrderBookDelta)
@@ -216,9 +357,6 @@ class StreamingFeatherWriter:
 
         if isinstance(obj, CustomData):
             cls = obj.data_type.type
-        elif isinstance(obj, Instrument):
-            if obj.id not in self._instruments:
-                self._instruments[obj.id] = obj
 
         table = class_to_filename(cls)
         if isinstance(obj, Bar):
@@ -233,7 +371,8 @@ class StreamingFeatherWriter:
                 self._create_writer(cls=cls, table_name=table)
             elif table in self._per_instrument_writers:
                 key = (table, obj.instrument_id.value)  # type: ignore
-                if key not in self._instrument_writers:
+                instrument = self.cache.instrument(obj.instrument_id)  # type: ignore
+                if key not in self._instrument_writers and instrument is not None:
                     self._create_instrument_writer(cls=cls, obj=obj)
             elif cls not in self.missing_writers:
                 self.logger.warning(f"Can't find writer for cls: {cls}")
@@ -243,7 +382,11 @@ class StreamingFeatherWriter:
                 return
 
         if table in self._per_instrument_writers:
-            writer: RecordBatchStreamWriter = self._instrument_writers[(table, obj.instrument_id.value)]  # type: ignore
+            key = (table, obj.instrument_id.value)  # type: ignore
+            if key in self._instrument_writers:
+                writer: RecordBatchStreamWriter = self._instrument_writers[key]
+            else:
+                return
         else:
             writer: RecordBatchStreamWriter = self._writers[table]  # type: ignore
 
@@ -253,7 +396,13 @@ class StreamingFeatherWriter:
 
         try:
             writer.write_table(serialized)
+            self._file_sizes[table] = self._file_sizes.get(table, 0) + serialized.nbytes
             self.check_flush()
+            if self._check_file_rotation(table):
+                if table in self._per_instrument_writers:
+                    self._rotate_per_instrument_file(cls=cls, obj=obj)
+                else:
+                    self._rotate_regular_file(table, cls)
         except Exception as e:
             self.logger.error(f"Failed to serialize {cls=}")
             self.logger.error(f"ERROR = `{e}`")
@@ -263,8 +412,8 @@ class StreamingFeatherWriter:
         """
         Flush all stream writers if current time greater than the next flush interval.
         """
-        now = datetime.datetime.now()
-        if now - self._last_flush > self.flush_interval_ms:
+        now = self.clock.utc_now()
+        if (now - self._last_flush).total_seconds() * 1000 > self.flush_interval_ms:
             self.flush()
             self._last_flush = now
 
@@ -286,6 +435,49 @@ class StreamingFeatherWriter:
             del self._writers[wcls]
         for fcls in self._files:
             self._files[fcls].close()
+
+    def get_current_file_info(self) -> dict[str | tuple[str, str], dict[str, Any]]:
+        """
+        Get information about the current files being written.
+
+        Returns
+        -------
+        dict[str | tuple[str, str], dict[str, Any]]
+            A dictionary containing file information for each table.
+
+        """
+        return {
+            table_name: {
+                "size": self._file_sizes.get(table_name, 0),
+                "creation_time": self._file_creation_times.get(table_name),
+            }
+            for table_name in self._writers
+        }
+
+    def get_next_rotation_time(self) -> pd.Timestamp | None:
+        """
+        Get the expected time for the next file rotation.
+
+        Returns
+        -------
+        pd.Timestamp | None
+            The next rotation time, or None if not applicable.
+
+        """
+        return self._next_rotation_time
+
+    @property
+    def is_closed(self) -> bool:
+        """
+        Return whether all file streams are closed.
+
+        Returns
+        -------
+        bool
+            True if all streams are closed, False otherwise.
+
+        """
+        return all(self._files[table_name].closed for table_name in self._files)
 
 
 def generate_signal_class(name: str, value_type: type) -> type:

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -260,8 +260,9 @@ class StreamingFeatherWriter:
             return
 
         schema = self._schemas[cls]
-        timestamp = self.clock.utc_now().strftime("%Y%m%d_%H%M%S")
+        timestamp = self.clock.timestamp_ns()
         full_path = f"{self.path}/{table_name}_{timestamp}.feather"
+        print(full_path)
 
         self.fs.makedirs(self.fs._parent(full_path), exist_ok=True)
         f = self.fs.open(full_path, "wb")
@@ -290,7 +291,7 @@ class StreamingFeatherWriter:
         key = (table_name, obj.instrument_id.value)
         self.fs.makedirs(folder, exist_ok=True)
 
-        timestamp = self.clock.utc_now().strftime("%Y%m%d_%H%M%S")
+        timestamp = self.clock.timestamp_ns()
         full_path = f"{folder}/{urisafe_instrument_id(obj.instrument_id.value)}_{timestamp}.feather"
 
         f = self.fs.open(full_path, "wb")
@@ -393,7 +394,6 @@ class StreamingFeatherWriter:
         serialized = ArrowSerializer.serialize_batch([obj], data_cls=cls)
         if not serialized:
             return
-
         try:
             writer.write_table(serialized)
             self._file_sizes[table] = self._file_sizes.get(table, 0) + serialized.nbytes

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -45,10 +45,10 @@ from nautilus_trader.serialization.arrow.serializer import register_arrow
 
 
 class RotationMode(Enum):
-    SIZE = "size"
-    INTERVAL = "interval"
-    SCHEDULED_DATES = "scheduled_dates"
-    NO_ROTATION = "no_rotation"
+    SIZE = 0
+    INTERVAL = 1
+    SCHEDULED_DATES = 2
+    NO_ROTATION = 3
 
 
 class StreamingFeatherWriter:

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -101,22 +101,24 @@ class StreamingFeatherWriter:
         rotation_time: time = time(0, 0, 0, 0),
         rotation_timezone: str = "UTC",
     ) -> None:
+        # Ensure the path is a directory or create it
         self.path = path
         self.cache = cache
         self.clock = clock
         self.fs: fsspec.AbstractFileSystem = fsspec.filesystem(fs_protocol)
         self.fs.makedirs(self.fs._parent(self.path), exist_ok=True)
 
-        if self.fs.exists(self.path) and not self.fs.isdir(self.path):
-            raise FileNotFoundError("Path must be directory or empty")
+        if self.fs.exists(self.path):
+            if not self.fs.isdir(self.path):
+                raise FileNotFoundError("Path must be directory or empty")
+        else:
+            self.fs.makedirs(self.path, exist_ok=True)  # Create directory if it doesn't exist
 
         self.include_types = include_types
         if self.fs.exists(self.path) and replace:
             for fn in self.fs.ls(self.path):
                 self.fs.rm(fn)
             self.fs.rmdir(self.path)
-
-        self.fs.makedirs(self.path, exist_ok=True)
 
         self._schemas = list_schemas()
         self.logger = Logger(type(self).__name__)
@@ -138,43 +140,47 @@ class StreamingFeatherWriter:
         self.rotation_timezone = pytz.timezone(rotation_timezone)
         self._file_sizes: dict[str | tuple[str, str], int] = {}
         self._file_creation_times: dict[str | tuple[str, str], pd.Timestamp] = {}
-        self._next_rotation_time: pd.Timestamp | None = None
+        self._next_rotation_times: dict[str | tuple[str, str], pd.Timestamp | None] = {}
 
         self._create_writers()
-        self._update_next_rotation_time()
 
         self.flush_interval_ms = flush_interval_ms or 1000
         self._last_flush = self.clock.utc_now()
         self.missing_writers: set[type] = set()
 
-    def _update_next_rotation_time(self) -> None:
+    def _update_next_rotation_time(self, table_name: str | tuple[str, str]) -> None:
         """
-        Update the next rotation time based on the current rotation mode and clock.
+        Update the next rotation time for a specific table based on the current rotation
+        mode and clock.
         """
         now = self.clock.utc_now()
         if self.rotation_mode == RotationMode.INTERVAL:
-            self._next_rotation_time = now + self.rotation_interval
+            self._next_rotation_times[table_name] = now + self.rotation_interval
         elif self.rotation_mode == RotationMode.SCHEDULED_DATES:
-            if self._next_rotation_time is None:
+            if (
+                table_name not in self._next_rotation_times
+                or self._next_rotation_times[table_name] is None
+            ):
                 user_rotation_time = pd.Timestamp.combine(now.date(), self.rotation_time)
-                self._next_rotation_time = pd.Timestamp(
+                next_rotation_time = pd.Timestamp(
                     user_rotation_time,
                     tz=self.rotation_timezone,
                 ).tz_convert("UTC")
-                while self._next_rotation_time <= now:
-                    self._next_rotation_time += self.rotation_interval
+                while next_rotation_time <= now:
+                    next_rotation_time += self.rotation_interval
+                self._next_rotation_times[table_name] = next_rotation_time
             else:
-                self._next_rotation_time = now + self.rotation_interval
+                self._next_rotation_times[table_name] = now + self.rotation_interval
         elif self.rotation_mode in (RotationMode.SIZE, RotationMode.NO_ROTATION):
-            self._next_rotation_time = None
+            self._next_rotation_times[table_name] = None
 
-    def _check_file_rotation(self, table_name: str) -> bool:
+    def _check_file_rotation(self, table_name: str | tuple[str, str]) -> bool:
         """
         Check if file rotation is needed for the given table.
 
         Parameters
         ----------
-        table_name : str
+        table_name : str | tuple[str, str]
             The name of the table to check.
 
         Returns
@@ -189,8 +195,12 @@ class StreamingFeatherWriter:
             return self._file_sizes.get(table_name, 0) >= self.max_file_size
         elif self.rotation_mode in (RotationMode.INTERVAL, RotationMode.SCHEDULED_DATES):
             now = self.clock.utc_now()
-            if self._next_rotation_time and now >= self._next_rotation_time:
-                self._update_next_rotation_time()
+            next_rotation_time = self._next_rotation_times.get(table_name)
+            if next_rotation_time is None:
+                self._update_next_rotation_time(table_name)
+                return False
+            elif now >= next_rotation_time:
+                self._update_next_rotation_time(table_name)
                 return True
         return False
 
@@ -297,8 +307,8 @@ class StreamingFeatherWriter:
         f = self.fs.open(full_path, "wb")
         self._files[key] = f
         self._instrument_writers[key] = pa.ipc.new_stream(f, schema)
-        self._file_sizes[table_name] = 0
-        self._file_creation_times[table_name] = self.clock.utc_now()
+        self._file_sizes[key] = 0
+        self._file_creation_times[key] = self.clock.utc_now()
         self.logger.info(f"Created writer for table '{table_name}'")
 
     def _extract_obj_metadata(
@@ -454,17 +464,25 @@ class StreamingFeatherWriter:
             for table_name in self._writers
         }
 
-    def get_next_rotation_time(self) -> pd.Timestamp | None:
+    def get_next_rotation_time(
+        self,
+        table_name: str | tuple[str, str],
+    ) -> pd.Timestamp | None:
         """
         Get the expected time for the next file rotation.
+
+        Parameters
+        ----------
+        table_name : str | tuple[str, str]
+            The specific table name to get the next rotation time for.
 
         Returns
         -------
         pd.Timestamp | None
-            The next rotation time, or None if not applicable.
+            The next rotation time for the specified table, or None if not set.
 
         """
-        return self._next_rotation_time
+        return self._next_rotation_times.get(table_name)
 
     @property
     def is_closed(self) -> bool:

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -515,9 +515,16 @@ class NautilusKernel:
         path = f"{config.catalog_path}/{self._environment.value}/{self.instance_id}"
         self._writer = StreamingFeatherWriter(
             path=path,
+            cache=self._cache,
+            clock=self._clock,
             fs_protocol=config.fs_protocol,
             flush_interval_ms=config.flush_interval_ms,
             include_types=config.include_types,
+            rotation_mode=config.rotation_mode,
+            max_file_size=config.max_file_size,
+            rotation_interval=config.rotation_interval,
+            rotation_time=config.rotation_time,
+            rotation_timezone=config.rotation_timezone,
         )
         self._trader.subscribe("*", self._writer.write)
         self._log.info(f"Writing data & events to {path}")

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("eec4a983b988d398cafeaf45e3eec4bf2ac12bbaa840442b8a1174da2ca0b9f5",),
+                ("789b190f1bbf143aebf018f49307f0107cf052b2def65179d5fb133b457b3da0",),
             ),
             (
                 TestConfigStubs.risk_engine_config,
@@ -303,7 +303,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.streaming_config,
                 ("catalog",),
                 {},
-                ("c287d8e433d931f014895daa4400171a67c30b8c61d94f51be60ad162bdef6cd",),
+                ("302b840b10cdd0cc2664ee5f3bb8623ada23d6a6c7ecb8f41117fddecc6bea9a",),
             ),
         ],
     )

--- a/tests/unit_tests/common/test_actor.py
+++ b/tests/unit_tests/common/test_actor.py
@@ -1893,6 +1893,8 @@ class TestActor:
 
         writer = StreamingFeatherWriter(
             path=catalog.path,
+            cache=self.cache,
+            clock=self.clock,
             fs_protocol=catalog.fs_protocol,
             replace=True,
         )

--- a/tests/unit_tests/common/test_actor.py
+++ b/tests/unit_tests/common/test_actor.py
@@ -1889,6 +1889,8 @@ class TestActor:
             cache=self.cache,
             clock=self.clock,
         )
+
+        self.clock.set_time(1704067205000000000)
         catalog = setup_catalog(protocol="memory", path="/catalog")
 
         writer = StreamingFeatherWriter(
@@ -1904,7 +1906,7 @@ class TestActor:
         actor.publish_signal(name="Test", value=5.0, ts_event=0)
 
         # Assert
-        assert catalog.fs.exists(f"{catalog.path}/custom_signal_test.feather")
+        assert catalog.fs.exists(f"{catalog.path}/custom_signal_test_1704067205000000000.feather")
 
     def test_subscribe_bars(self) -> None:
         # Arrange


### PR DESCRIPTION
# Pull Request

The pull is a supplement and improvement to issue https://github.com/nautechsystems/nautilus_trader/issues/1945 ，In the latest StreamingFeatherWriter, when recording multiple types or sets of data, the _next_rotation_time is used by one of them, preventing rotation for other types of data. To avoid this issue, _next_rotation_time has been modified to a dictionary format.

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Validated using two methodologies: live trading implementation and historical backtesting
