### PR TITLE
Refine message handling for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -130,6 +130,7 @@ class DYDXDataClient(LiveMarketDataClient):
         self._ws_client = DYDXWebsocketClient(
             clock=clock,
             handler=self._handle_ws_message,
+            handler_reconnect=None,
             base_url=ws_base_url,
             loop=loop,
         )
@@ -147,7 +148,7 @@ class DYDXDataClient(LiveMarketDataClient):
         self._last_quotes: dict[InstrumentId, QuoteTick] = {}
         self._orderbook_subscriptions: set[str] = set()
         self._resubscribe_orderbook_lock = asyncio.Lock()
-        self._message_id: int | None = None
+        self._message_ids: dict[str, int] = {}
 
         # Hot caches
         self._bars: dict[BarType, Bar] = {}
@@ -239,13 +240,16 @@ class DYDXDataClient(LiveMarketDataClient):
         }
         try:
             ws_message = self._decoder_ws_msg_general.decode(raw)
+            stream_id = f"{ws_message.connection_id}-{ws_message.channel}-{ws_message.id}"
+            previous_message_id = self._message_ids.get(stream_id, -1)
 
-            if self._message_id is not None and ws_message.message_id != self._message_id + 1:
+            if ws_message.message_id is not None and ws_message.message_id <= previous_message_id:
                 self._log.error(
-                    f"Inconsistent message IDs. {self._message_id=} {ws_message.message_id=}",
+                    f"Inconsistent message IDs. {previous_message_id=} {ws_message.message_id=} {stream_id=} {ws_message=}",
                 )
 
-            self._message_id = ws_message.message_id
+            if ws_message.message_id is not None:
+                self._message_ids[stream_id] = ws_message.message_id
 
             key = (ws_message.channel, ws_message.type)
 

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -216,7 +216,7 @@ class DYDXDataClient(LiveMarketDataClient):
         """
         async with self._resubscribe_orderbook_lock:
             for symbol in self._orderbook_subscriptions:
-                await self._ws_client.unsubscribe_order_book(symbol)
+                await self._ws_client.unsubscribe_order_book(symbol, remove_subscription=False)
                 await self._ws_client.subscribe_order_book(symbol)
 
     def _send_all_instruments_to_data_engine(self) -> None:

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -231,6 +231,7 @@ class DYDXExecutionClient(LiveExecutionClient):
         self._ws_client = DYDXWebsocketClient(
             clock=clock,
             handler=self._handle_ws_message,
+            handler_reconnect=None,
             base_url=base_url_ws,
             loop=loop,
         )

--- a/nautilus_trader/adapters/dydx/websocket/client.py
+++ b/nautilus_trader/adapters/dydx/websocket/client.py
@@ -166,6 +166,9 @@ class DYDXWebsocketClient:
                 if self._ping_timestamp is not None and time_since_previous_ping > pd.Timedelta(
                     seconds=self._ping_interval_secs,
                 ):
+                    self._log.error(
+                        f"Time since previous received ping message is {time_since_previous_ping}",
+                    )
                     try:
                         await self.disconnect()
                         await self.connect()

--- a/nautilus_trader/adapters/dydx/websocket/client.py
+++ b/nautilus_trader/adapters/dydx/websocket/client.py
@@ -299,7 +299,7 @@ class DYDXWebsocketClient:
         msg = {"type": "unsubscribe", "channel": "v4_trades", "id": symbol}
         await self._send(msg)
 
-    async def unsubscribe_order_book(self, symbol: str) -> None:
+    async def unsubscribe_order_book(self, symbol: str, remove_subscription: bool = True) -> None:
         """
         Unsubscribe to trades messages.
         """
@@ -312,7 +312,9 @@ class DYDXWebsocketClient:
             self._log.warning(f"Cannot unsubscribe '{subscription}': not subscribed")
             return
 
-        self._subscriptions.remove(subscription)
+        if remove_subscription:
+            self._subscriptions.remove(subscription)
+
         msg = {"type": "unsubscribe", "channel": "v4_orderbook", "id": symbol}
         await self._send(msg)
 

--- a/nautilus_trader/adapters/dydx/websocket/client.py
+++ b/nautilus_trader/adapters/dydx/websocket/client.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from typing import Any
 
 import msgspec
+import pandas as pd
 
 from nautilus_trader.adapters.dydx.common.enums import DYDXCandlesResolution
 from nautilus_trader.common.component import LiveClock
@@ -69,6 +70,13 @@ class DYDXWebsocketClient:
         self._client: WebSocketClient | None = None
         self._is_running = False
         self._subscriptions: set[tuple[str, str]] = set()
+
+        # Every 30 seconds, the dYdX websocket API will send a heartbeat ping control
+        # frame to the connected client. If a pong event is not received within 10
+        # seconds back, the websocket API will disconnect.
+        self._ping_timestamp: pd.Timestamp | None = None
+        self._ping_interval_secs: int = 40
+        self._reconnect_task: asyncio.Task | None = None
 
     def is_connected(self) -> bool:
         """
@@ -125,7 +133,11 @@ class DYDXWebsocketClient:
         self._client = client
         self._log.info(f"Connected to {self._base_url}", LogColor.BLUE)
 
+        if self._reconnect_task is None:
+            self._reconnect_task = self._loop.create_task(self._reconnect_ping())
+
     def _handle_ping(self, raw: bytes) -> None:
+        self._ping_timestamp = self._clock.utc_now()
         self._loop.create_task(self.send_pong(raw))
 
     async def send_pong(self, raw: bytes) -> None:
@@ -136,6 +148,34 @@ class DYDXWebsocketClient:
             return
 
         await self._client.send_pong(raw)
+
+    async def _reconnect_ping(self) -> None:
+        """
+        Reconnect the websocket client when a ping message has not been received.
+        """
+        try:
+            while True:
+                self._log.debug(
+                    f"Scheduled `reconnect_ping` to run in {self._ping_interval_secs}s",
+                )
+                await asyncio.sleep(self._ping_interval_secs)
+
+                now_timestamp = self._clock.utc_now()
+                time_since_previous_ping = now_timestamp - self._ping_timestamp
+
+                if self._ping_timestamp is not None and time_since_previous_ping > pd.Timedelta(
+                    seconds=self._ping_interval_secs,
+                ):
+                    try:
+                        await self.disconnect()
+                        await self.connect()
+                        self.reconnect()
+                    except Exception as e:
+                        self._log.error(f"Failed to connect the websocket: {e}")
+                        self._client = None
+
+        except asyncio.CancelledError:
+            self._log.debug("Canceled `reconnect_ping` task")
 
     def reconnect(self) -> None:
         """


### PR DESCRIPTION
# Pull Request

- Log error when the message_id is not increasing for dYdX
- The `message_id` is not strictly monotonically increased when subscribing to multiple instruments or multiple data streams (deltas/trade ticks). However, it must be strictly increasing for the same instrument and data type.
- Add `handler_reconnect` (not yet in use)
- Add `is_connected` and `is_disconnected` public methods to websocket client
- Do not remove the deltas symbol from the internal list of subscriptions when resubscribing to the order book
- Reconnect the websocket client when a ping frame has not been received for at least 40 seconds

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example