### PR TITLE
Implement bar processing for SimulatedExchange

### DIFF
--- a/nautilus_core/execution/src/matching_core.rs
+++ b/nautilus_core/execution/src/matching_core.rs
@@ -44,6 +44,7 @@ pub struct OrderMatchingCore {
     pub last: Option<Price>,
     pub is_bid_initialized: bool,
     pub is_ask_initialized: bool,
+    pub is_last_initialized: bool,
     orders_bid: Vec<PassiveOrderAny>,
     orders_ask: Vec<PassiveOrderAny>,
     trigger_stop_order: Option<fn(&StopOrderAny)>,
@@ -69,6 +70,7 @@ impl OrderMatchingCore {
             last: None,
             is_bid_initialized: false,
             is_ask_initialized: false,
+            is_last_initialized: false,
             orders_bid: Vec::new(),
             orders_ask: Vec::new(),
             trigger_stop_order,
@@ -109,6 +111,7 @@ impl OrderMatchingCore {
 
     pub fn set_last_raw(&mut self, last: Price) {
         self.last = Some(last);
+        self.is_last_initialized = true;
     }
 
     pub fn reset(&mut self) {

--- a/nautilus_core/model/src/data/bar.rs
+++ b/nautilus_core/model/src/data/bar.rs
@@ -22,7 +22,7 @@ use std::{
     str::FromStr,
 };
 
-use chrono::{DateTime, Datelike, TimeDelta, Timelike, Utc};
+use chrono::{DateTime, Datelike, Duration, TimeDelta, Timelike, Utc};
 use derive_builder::Builder;
 use indexmap::IndexMap;
 use nautilus_core::{correctness::FAILED, nanos::UnixNanos, serialization::Serializable};
@@ -133,6 +133,20 @@ impl BarSpecification {
             step,
             aggregation,
             price_type,
+        }
+    }
+
+    pub fn timedelta(&self) -> TimeDelta {
+        match self.aggregation {
+            BarAggregation::Millisecond => Duration::milliseconds(self.step as i64),
+            BarAggregation::Second => Duration::seconds(self.step as i64),
+            BarAggregation::Minute => Duration::minutes(self.step as i64),
+            BarAggregation::Hour => Duration::hours(self.step as i64),
+            BarAggregation::Day => Duration::days(self.step as i64),
+            _ => panic!(
+                "Timedelta not supported for aggregation type: {:?}",
+                self.aggregation
+            ),
         }
     }
 }
@@ -516,6 +530,10 @@ impl Bar {
             ts_event,
             ts_init,
         })
+    }
+
+    pub fn instrument_id(&self) -> InstrumentId {
+        self.bar_type.instrument_id()
     }
 
     /// Returns the metadata for the type, for use with serialization formats.


### PR DESCRIPTION
# Pull Request

- implements `process_bar` function of `SimulatedExchange' and same function in `OrderMatchingEngine`
- added test `test_exchange_process_bar_last_bar_spec` with the last price aggregated bar testing and test `test_exchange_process_bar_bid_ask_bar_spec` with bid/ask aggregated bars