### PR TITLE
Implement orderbook delta processing for SimulatedExchange

### DIFF
--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -262,7 +262,11 @@ impl OrderMatchingEngine {
     pub fn process_order_book_delta(&mut self, delta: &OrderBookDelta) {
         log::debug!("Processing {delta}");
 
-        self.book.apply_delta(delta);
+        if self.book_type == BookType::L2_MBP || self.book_type == BookType::L3_MBO {
+            self.book.apply_delta(delta);
+        }
+
+        self.iterate(delta.ts_event);
     }
 
     pub fn process_quote_tick(&mut self, tick: &QuoteTick) {


### PR DESCRIPTION
# Pull Request

Implemented orderbook delta processing in Rust `SimulatedExchange` object

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added new test `test_exchange_process_orderbook_delta` in Simulated exchange Rust file

