### PR TITLE
Add mode option to ParquetDataCatalog.write_data

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -5,6 +5,7 @@
 # Note: Use the python extension jupytext to be able to open this python file in jupyter as a notebook
 
 # %%
+# from nautilus_trader.adapters.databento.data_utils import init_databento_client
 import nautilus_trader.adapters.databento.data_utils as db_data_utils
 from nautilus_trader import PACKAGE_ROOT
 from nautilus_trader.adapters.databento.data_utils import data_path
@@ -175,8 +176,8 @@ class OptionStrategy(Strategy):
 # %%
 # BacktestEngineConfig
 
-load_greeks = False
-stream_data = False
+# for saving and loading custom data greeks, use False, True then True, False below
+load_greeks, stream_data = False, False
 
 actors = [
     ImportableActorConfig(
@@ -273,7 +274,7 @@ configs = [
         engine=engine_config,
         data=data,
         venues=venues,
-        chunk_size=10_000,  # use None when using load_greeks ?
+        chunk_size=None,  # use None when loading custom data
     ),
 ]
 

--- a/nautilus_trader/adapters/databento/data_utils.py
+++ b/nautilus_trader/adapters/databento/data_utils.py
@@ -64,16 +64,25 @@ def databento_cost(symbols, start_time, end_time, schema, dataset="GLBX.MDP3", *
     Calculate the cost of retrieving data from the Databento API for the given
     parameters.
 
-    Args:
-        symbols (list[str]): The symbols to retrieve data for.
-        start_time (str): The start time of the data in ISO 8601 format.
-        end_time (str): The end time of the data in ISO 8601 format.
-        schema (str): The data schema to retrieve.
-        dataset (str, optional): The Databento dataset to use, defaults to "GLBX.MDP3".
-        **kwargs: Additional keyword arguments to pass to the Databento API.
+    Parameters
+    ----------
+    symbols : list of str
+        The symbols to retrieve data for.
+    start_time : str
+        The start time of the data in ISO 8601 format.
+    end_time : str
+        The end time of the data in ISO 8601 format.
+    schema : str
+        The data schema to retrieve.
+    dataset : str, optional
+        The Databento dataset to use, defaults to "GLBX.MDP3".
+    **kwargs
+        Additional keyword arguments to pass to the Databento API.
 
-    Returns:
-        float: The estimated cost of retrieving the data.
+    Returns
+    -------
+    float
+        The estimated cost of retrieving the data.
 
     """
     definition_start_date, definition_end_date = databento_definition_dates(start_time)
@@ -98,29 +107,46 @@ def databento_data(
     dataset="GLBX.MDP3",
     to_catalog=True,
     base_path=None,
+    write_data_mode="overwrite",
     **kwargs,
 ):
     """
     Download and save Databento data and definition files, and optionally save the data
     to a catalog.
 
-    Args:
-        symbols (list[str]): The symbols to retrieve data for.
-        start_time (str): The start time of the data in ISO 8601 format.
-        end_time (str): The end time of the data in ISO 8601 format.
-        schema (str): The data schema to retrieve, either "definition" or another valid schema.
-        file_prefix (str): The prefix to use for the downloaded data files.
-        *folders (str): Additional folders to create in the data path.
-        dataset (str, optional): The Databento dataset to use, defaults to "GLBX.MDP3".
-        to_catalog (bool, optional): Whether to save the data to a catalog, defaults to True.
-        base_path (str, optional): The base path to use for the data folder, defaults to None.
-        **kwargs: Additional keyword arguments to pass to the Databento API.
+    Parameters
+    ----------
+    symbols : list of str
+        The symbols to retrieve data for.
+    start_time : str
+        The start time of the data in ISO 8601 format.
+    end_time : str
+        The end time of the data in ISO 8601 format.
+    schema : str
+        The data schema to retrieve, either "definition" or another valid schema.
+    file_prefix : str
+        The prefix to use for the downloaded data files.
+    *folders : str
+        Additional folders to create in the data path.
+    dataset : str, optional
+        The Databento dataset to use, defaults to "GLBX.MDP3".
+    to_catalog : bool, optional
+        Whether to save the data to a catalog, defaults to True.
+    base_path : str, optional
+        The base path to use for the data folder, defaults to None.
+    write_data_mode : str, optional
+        Whether to "append", "prepend" or "overwrite" data to an existing catalog, defaults to "overwrite".
+    **kwargs
+        Additional keyword arguments to pass to the Databento API.
 
-    Returns:
-        dict: A dictionary containing the downloaded data and metadata.
+    Returns
+    -------
+    dict
+        A dictionary containing the downloaded data and metadata.
 
-    Note:
-        If schema is equal to 'definition' then no data is downloaded or saved to the catalog.
+    Notes
+    -----
+    If schema is equal to 'definition' then no data is downloaded or saved to the catalog.
 
     """
     used_path = create_data_folder(*folders, "databento", base_path=base_path)
@@ -185,13 +211,20 @@ def databento_data(
             data_file,
             *folders,
             base_path=base_path,
+            write_data_mode=write_data_mode,
         )
         result.update(catalog_data)
 
     return result
 
 
-def save_data_to_catalog(definition_file, data_file, *folders, base_path=None):
+def save_data_to_catalog(
+    definition_file,
+    data_file,
+    *folders,
+    base_path=None,
+    write_data_mode="overwrite",
+):
     catalog = load_catalog(*folders, base_path=base_path)
 
     loader = DatabentoDataLoader()
@@ -199,7 +232,7 @@ def save_data_to_catalog(definition_file, data_file, *folders, base_path=None):
     nautilus_data = loader.from_dbn_file(data_file, as_legacy_cython=False)
 
     catalog.write_data(nautilus_definition)
-    catalog.write_data(nautilus_data)
+    catalog.write_data(nautilus_data, mode=write_data_mode)
 
     return {
         "catalog": catalog,

--- a/nautilus_trader/risk/greeks.py
+++ b/nautilus_trader/risk/greeks.py
@@ -38,12 +38,18 @@ class GreeksCalculatorConfig(ActorConfig, frozen=True):
     """
     Configuration settings for the GreeksCalculator actor.
 
-    Attributes:
-        load_greeks (bool): Flag to determine whether to load pre-calculated Greeks.
-        underlying (str): The underlying asset symbol.
-        bar_spec (str): The bar specification for data subscription.
-        curve_name (str): The name of the interest rate curve.
-        interest_rate (float): The interest rate used for calculations.
+    Parameters
+    ----------
+    load_greeks : bool, default False
+        Flag to determine whether to load pre-calculated Greeks.
+    underlying : str, default "ES"
+        The underlying asset symbol.
+    bar_spec : str, default "1-MINUTE-LAST"
+        The bar specification for data subscription.
+    curve_name : str, default "USD_ShortTerm"
+        The name of the interest rate curve.
+    interest_rate : float, default 0.05
+        The interest rate used for calculations.
 
     """
 
@@ -61,19 +67,34 @@ class GreeksCalculator(Actor):
     This calculator works specifically for European options on futures with no dividends.
     It computes the Greeks for all options of a given underlying when a bar of the future is received.
 
-    Attributes:
-        load_greeks (bool): Flag to determine whether to load pre-calculated Greeks.
-        underlying (str): The underlying asset symbol.
-        bar_spec (str): The bar specification for data subscription.
-        curve_name (str): The name of the interest rate curve.
-        interest_rate (InterestRateData or InterestRateCurveData): The interest rate data used for calculations.
+    Parameters
+    ----------
+    config : GreeksCalculatorConfig
+        The configuration settings for the GreeksCalculator.
 
-    Methods:
-        on_start(): Initializes data subscriptions when the actor starts.
-        on_data(data): Handles incoming data updates (GreeksData, InterestRateData or InterestRateCurveData).
-        on_bar(bar: Bar): Processes incoming bar data and triggers Greek calculations.
-        compute_greeks(instrument_id: InstrumentId, future_price: float, ts_event: int):
-            Computes Greeks for options based on the future price.
+    Attributes
+    ----------
+    load_greeks : bool
+        Flag to determine whether to load pre-calculated Greeks.
+    underlying : str
+        The underlying asset symbol.
+    bar_spec : str
+        The bar specification for data subscription.
+    curve_name : str
+        The name of the interest rate curve.
+    interest_rate : float
+        The interest rate used for calculations.
+
+    Methods
+    -------
+    on_start()
+        Initializes data subscriptions when the actor starts.
+    on_data(data)
+        Handles incoming data updates (GreeksData, InterestRateData or InterestRateCurveData).
+    on_bar(bar: Bar)
+        Processes incoming bar data and triggers Greek calculations.
+    compute_greeks(instrument_id: InstrumentId, future_price: float, ts_event: int)
+        Computes Greeks for options based on the future price.
 
     """
 
@@ -192,9 +213,12 @@ class InterestRateProviderConfig(ActorConfig, frozen=True):
     """
     Configuration for the InterestRateProvider actor.
 
-    Attributes:
-        interest_rates_file (str): Path to the file containing interest rate data.
-        curve_name (str): Name of the interest rate curve, defaulting to "USD_ShortTerm".
+    Parameters
+    ----------
+    interest_rates_file : str
+        Path to the file containing interest rate data.
+    curve_name : str, default "USD_ShortTerm"
+        Name of the interest rate curve. Default is "USD_ShortTerm".
 
     """
 
@@ -210,14 +234,19 @@ class InterestRateProvider(Actor):
     updating the current interest rate, and publishing interest rate data
     on the message bus.
 
-    Attributes:
-        interest_rates_file (str): Path to the file containing interest rate data.
-        curve_name (str): Name of the interest rate curve.
-        interest_rates_df (pandas.DataFrame): DataFrame containing imported interest rate data.
+    Parameters
+    ----------
+    interest_rates_file : str
+        Path to the file containing interest rate data.
+    curve_name : str
+        Name of the interest rate curve.
 
-    Methods:
-        on_start(): Initializes the interest rate data on actor start.
-        update_interest_rate(alert=None): Updates and publishes the current interest rate.
+    Methods
+    -------
+    on_start()
+        Initializes the interest rate data on actor start.
+    update_interest_rate(alert=None)
+        Updates and publishes the current interest rate.
 
     """
 

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -266,6 +266,26 @@ def test_catalog_bars_querying_by_bar_type(catalog: ParquetDataCatalog) -> None:
     assert len(bars) == len(stub_bars) == 10
 
 
+def test_catalog_append_data(catalog: ParquetDataCatalog) -> None:
+    # Arrange
+    bar_type = TestDataStubs.bartype_adabtc_binance_1min_last()
+    instrument = TestInstrumentProvider.adabtc_binance()
+    stub_bars = TestDataStubs.binance_bars_from_csv(
+        "ADABTC-1m-2021-11-27.csv",
+        bar_type,
+        instrument,
+    )
+    catalog.write_data(stub_bars)
+
+    # Act
+    catalog.write_data(stub_bars, mode="append")
+
+    # Assert
+    bars = catalog.bars(bar_types=[str(bar_type)])
+    all_bars = catalog.bars()
+    assert len(bars) == len(all_bars) == 20
+
+
 def test_catalog_bars_querying_by_instrument_id(catalog: ParquetDataCatalog) -> None:
     # Arrange
     bar_type = TestDataStubs.bartype_adabtc_binance_1min_last()


### PR DESCRIPTION
# Pull Request

Add mode option to ParquetDataCatalog.write_data. This allows for example to download new historical data and append or prepend it to an existing catalog. The existing file will be loaded in memory, then written again followed or preceded by the new data. The default write_data_mode is the same behaviour as before, called "overwrite".

## Type of change

- New feature (non-breaking change which adds functionality

## How has this change been tested?

on prototype, add write_data_mode="append" here https://github.com/nautechsystems/nautilus_trader/blob/develop/examples/backtest/databento_option_greeks.py#L60 
Added test
