### PR TITLE
Cleanup websocket tasks on disconnect if it is not alive

### DIFF
--- a/nautilus_core/network/src/websocket.rs
+++ b/nautilus_core/network/src/websocket.rs
@@ -444,7 +444,12 @@ impl WebSocketClient {
                         }
                         break;
                     }
-                    (true, false) => break,
+                    // Close the heartbeat task on disconnect if the connection is already closed
+                    (true, false) => {
+                        tracing::debug!("Inner client is disconnected");
+                        tracing::debug!("Shutting down inner client to clean up running tasks");
+                        inner.shutdown().await
+                    }
                     _ => (),
                 }
             }


### PR DESCRIPTION
# Pull Request

Cleanup websocket running tasks (hearbeat) on disconnect command even if inner client is not alive. Closes #1980 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Needs verification