### PR TITLE
Add in the money probability field to GreeksData

### DIFF
--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -4124,7 +4124,8 @@ class GreeksData(Data):
     gamma: float
     vega: float
     theta: float
-    quantity: int
+    quantity: float
+    itm_prob: float
 
     def __init__(
         self,
@@ -4143,7 +4144,8 @@ class GreeksData(Data):
         gamma: float = 0.0,
         vega: float = 0.0,
         theta: float = 0.0,
-        quantity: int = 1,
+        quantity: float = 0.0,
+        itm_prob: float = 0.0,
     ): ...
 
     @classmethod

--- a/nautilus_trader/model/greeks.py
+++ b/nautilus_trader/model/greeks.py
@@ -43,19 +43,22 @@ class GreeksData(Data):
     vega: float = 0.0
     theta: float = 0.0
 
-    quantity: int = 1
+    quantity: float = 0.0
+    # in the money probability, P(phi * S_T > phi * K), phi = 1 if is_call else -1
+    itm_prob: float = 0.0
 
     def __repr__(self):
         return (
             f"GreeksData(instrument_id={self.instrument_id}, "
-            f"expiry={self.expiry}, vol={self.vol * 100:.2f}%, price={self.price:.2f}, delta={self.delta:.2f}, "
+            f"expiry={self.expiry}, itm_prob={self.itm_prob * 100:.2f}%, "
+            f"vol={self.vol * 100:.2f}%, price={self.price:.2f}, delta={self.delta:.2f}, "
             f"gamma={self.gamma:.2f}, vega={self.vega:.2f}, theta={self.theta:.2f}, quantity={self.quantity}, "
             f"ts_event={unix_nanos_to_str(self.ts_event)}, ts_init={unix_nanos_to_str(self.ts_init)})"
         )
 
     @classmethod
     def from_delta(cls, instrument_id: InstrumentId, delta: float):
-        return GreeksData(instrument_id=instrument_id, delta=delta)
+        return GreeksData(instrument_id=instrument_id, delta=delta, quantity=1.0)
 
     def __rmul__(self, quantity):  # quantity * greeks
         return GreeksData(
@@ -75,6 +78,7 @@ class GreeksData(Data):
             quantity * self.vega,
             quantity * self.theta,
             quantity * self.quantity,
+            self.itm_prob,
         )
 
 

--- a/nautilus_trader/risk/greeks.py
+++ b/nautilus_trader/risk/greeks.py
@@ -194,6 +194,8 @@ class GreeksCalculator(Actor):
                 greeks.gamma,
                 greeks.vega,
                 greeks.theta,
+                1.0,
+                abs(greeks.delta / multiplier),
             )
 
             # write greeks to the cache


### PR DESCRIPTION
# Pull Request

Add in the money probability field to GreeksData

This is a useful common information for knowing the relative position of the spot of the underlying of a vanilla option (call or put) with respect to the strike of an option.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Local test on prototype databento_option_greeks.py in examples/backtest
