### PR TITLE
Implement orderbook deltas processing for SimulatedExchange

### DIFF
--- a/nautilus_core/backtest/src/matching_engine.rs
+++ b/nautilus_core/backtest/src/matching_engine.rs
@@ -29,6 +29,7 @@ use nautilus_model::{
     data::{
         bar::{Bar, BarType},
         delta::OrderBookDelta,
+        deltas::OrderBookDeltas,
         quote::QuoteTick,
         trade::TradeTick,
     },
@@ -267,6 +268,16 @@ impl OrderMatchingEngine {
         }
 
         self.iterate(delta.ts_event);
+    }
+
+    pub fn process_order_book_deltas(&mut self, deltas: &OrderBookDeltas) {
+        log::debug!("Processing {deltas}");
+
+        if self.book_type == BookType::L2_MBP || self.book_type == BookType::L3_MBO {
+            self.book.apply_deltas(deltas);
+        }
+
+        self.iterate(deltas.ts_event);
     }
 
     pub fn process_quote_tick(&mut self, quote: &QuoteTick) {


### PR DESCRIPTION
# Pull Request

Implemented orderbook delta processing in Rust `SimulatedExchange` struct

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added new test `test_exchange_process_orderbook_deltas` in Simulated exchange Rust file 