### PR TITLE
Update bid and ask in matching engine iteration

### DIFF
--- a/nautilus_core/execution/src/matching_core.rs
+++ b/nautilus_core/execution/src/matching_core.rs
@@ -114,6 +114,16 @@ impl OrderMatchingCore {
         self.is_last_initialized = true;
     }
 
+    pub fn set_bid_raw(&mut self, bid: Price) {
+        self.bid = Some(bid);
+        self.is_bid_initialized = true;
+    }
+
+    pub fn set_ask_raw(&mut self, ask: Price) {
+        self.ask = Some(ask);
+        self.is_ask_initialized = true;
+    }
+
     pub fn reset(&mut self) {
         self.bid = None;
         self.ask = None;


### PR DESCRIPTION
# Pull Request

In `iterate` function of `OrderMatchingEngine` we must also update `bid` and `ask` values in `OrderMatchingCore`.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added test `test_matching_core_bid_ask_initialized`  which checks that after bid and ask orderbook delta processing, we set the correct values of bid and ask in order matching core