### PR TITLE
Fix check for OmsType in OrderMatchingEngine

### DIFF
--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -1996,7 +1996,7 @@ cdef class OrderMatchingEngine:
 
     cdef PositionId _get_position_id(self, Order order, bint generate=True):
         cdef PositionId position_id
-        if OmsType.HEDGING:
+        if self.oms_type == OmsType.HEDGING:
             position_id = self.cache.position_id(order.client_order_id)
             if position_id is not None:
                 return position_id


### PR DESCRIPTION
# Pull Request

- missing `self.oms_type` in oms type checking

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


