### PR TITLE
Refine test data getters in Rust

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "log",
  "nautilus-core",
  "nautilus-model",
+ "nautilus-test-kit",
  "procfs",
  "pyo3",
  "quickcheck",

--- a/nautilus_core/model/tests/test_order_book.rs
+++ b/nautilus_core/model/tests/test_order_book.rs
@@ -13,11 +13,13 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::path::Path;
+
 use nautilus_adapters::databento::loader::DatabentoDataLoader;
 use nautilus_model::{enums::BookType, identifiers::InstrumentId, orderbook::book::OrderBook};
 use nautilus_test_kit::{
     common::{
-        get_test_data_large_checksums_filepath, get_test_data_large_path, get_workspace_root_path,
+        get_test_data_file_path, get_test_data_large_checksums_filepath, get_workspace_root_path,
     },
     files::ensure_file_exists_or_download_http,
 };
@@ -25,12 +27,12 @@ use rstest::*;
 
 #[rstest]
 pub fn test_order_book_databento_mbo_nasdaq() {
-    let testdata = get_test_data_large_path();
     let checksums = get_test_data_large_checksums_filepath();
     let filename = "databento_mbo_xnas_itch.csv";
-    let filepath = testdata.join("large").join(filename);
+    let file_path = get_test_data_file_path(format!("large/{}", filename).as_str());
     let url = "https://hist.databento.com/v0/dataset/sample/download/xnas.itch/mbo";
-    ensure_file_exists_or_download_http(&filepath, url, Some(&checksums)).unwrap();
+    ensure_file_exists_or_download_http(Path::new(file_path.as_str()), url, Some(&checksums))
+        .unwrap();
 
     let instrument_id = InstrumentId::from("AAPL.XNAS");
     let mut _book = OrderBook::new(instrument_id, BookType::L3_MBO);

--- a/nautilus_core/persistence/Cargo.toml
+++ b/nautilus_core/persistence/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 nautilus-core = { path = "../core" }
 nautilus-model = { path = "../model", features = ["stubs"] }
+nautilus-test-kit = { path = "../test_kit" }
 anyhow = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/nautilus_core/persistence/Cargo.toml
+++ b/nautilus_core/persistence/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 nautilus-core = { path = "../core" }
 nautilus-model = { path = "../model", features = ["stubs"] }
-nautilus-test-kit = { path = "../test_kit" }
 anyhow = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
@@ -27,6 +26,7 @@ datafusion = { version = "41.0.0", default-features = false, features = ["compre
 dotenv = "0.15.0"
 
 [dev-dependencies]
+nautilus-test-kit = { path = "../test_kit" }
 criterion = { workspace = true }
 rstest = { workspace = true }
 quickcheck = "1"

--- a/nautilus_core/test_kit/src/common.rs
+++ b/nautilus_core/test_kit/src/common.rs
@@ -34,20 +34,33 @@ pub fn get_project_root_path() -> PathBuf {
 }
 
 #[must_use]
-pub fn get_test_data_large_path() -> PathBuf {
-    get_project_root_path().join("tests").join("test_data")
+pub fn get_test_data_path() -> PathBuf {
+    if let Ok(test_data_root_path) = std::env::var("TEST_DATA_ROOT_PATH") {
+        get_project_root_path()
+            .join(test_data_root_path)
+            .join("test_data")
+    } else {
+        get_project_root_path().join("tests").join("test_data")
+    }
+}
+
+#[must_use]
+pub fn get_test_data_file_path(path: &str) -> String {
+    get_test_data_path()
+        .join(path)
+        .to_str()
+        .unwrap()
+        .to_string()
 }
 
 #[must_use]
 pub fn get_test_data_large_checksums_filepath() -> PathBuf {
-    get_test_data_large_path()
-        .join("large")
-        .join("checksums.json")
+    get_test_data_path().join("large").join("checksums.json")
 }
 
 #[must_use]
 pub fn ensure_test_data_exists(filename: &str, url: &str) -> PathBuf {
-    let filepath = get_test_data_large_path().join("large").join(filename);
+    let filepath = get_test_data_path().join("large").join(filename);
     let checksums_filepath = get_test_data_large_checksums_filepath();
     ensure_file_exists_or_download_http(&filepath, url, Some(&checksums_filepath)).unwrap();
     filepath


### PR DESCRIPTION
# Pull Request

- refined test data getters path to use unified get test data function
- added possibility of optional `TEST_DATA_ROOT_PATH` env which can be put in `.cargo/config.toml` if test data is located somewhere else

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Describe how this code was/is tested.

- Run `make cargo-test` and they are working and correctly mapping the test data dir