### PR TITLE
Implement position getter for hedging Oms in OrderMatchingEngine

### DIFF
--- a/nautilus_core/common/src/cache/mod.rs
+++ b/nautilus_core/common/src/cache/mod.rs
@@ -1343,7 +1343,7 @@ impl Cache {
     }
 
     /// Indexes the given `position_id` with the other given IDs.
-    pub fn add_position_id(
+    fn add_position_id(
         &mut self,
         position_id: &PositionId,
         venue: &Venue,


### PR DESCRIPTION
# Pull Request

- implement `get_position_id` for `OrderMatchingEngine` in Rust for Hedgin Oms type

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

- test `test_get_position_id_hedging_with_existing_position` checks that engine correctly returns the position id which is already present in the cache
- test `test_get_position_id_hedging_with_generated_position` checks that engine correctly regenerates position id