### PR TITLE
Improve Postgres config

### DIFF
--- a/nautilus_core/cli/src/database/postgres.rs
+++ b/nautilus_core/cli/src/database/postgres.rs
@@ -30,9 +30,12 @@ pub async fn run_database_command(opt: DatabaseOpt) -> anyhow::Result<()> {
                 config.username,
                 config.password,
                 config.database,
-            )
-            .unwrap();
+            );
             let pg = connect_pg(pg_connect_options.clone().into()).await?;
+            log::info!(
+                "Connected with Postgres on url: {}",
+                pg_connect_options.connection_string()
+            );
             init_postgres(
                 &pg,
                 pg_connect_options.database,
@@ -48,9 +51,12 @@ pub async fn run_database_command(opt: DatabaseOpt) -> anyhow::Result<()> {
                 config.username,
                 config.password,
                 config.database,
-            )
-            .unwrap();
+            );
             let pg = connect_pg(pg_connect_options.clone().into()).await?;
+            log::info!(
+                "Connected with Postgres on url: {}",
+                pg_connect_options.connection_string()
+            );
             drop_postgres(&pg, pg_connect_options.database).await?;
         }
     }

--- a/nautilus_core/infrastructure/src/sql/cache.rs
+++ b/nautilus_core/infrastructure/src/sql/cache.rs
@@ -266,7 +266,7 @@ impl PostgresCacheDatabase {
         database: Option<String>,
     ) -> Result<Self, sqlx::Error> {
         let pg_connect_options =
-            get_postgres_connect_options(host, port, username, password, database).unwrap();
+            get_postgres_connect_options(host, port, username, password, database);
         let pool = connect_pg(pg_connect_options.clone().into()).await.unwrap();
         let (tx, rx) = unbounded_channel::<DatabaseQuery>();
 
@@ -326,10 +326,7 @@ pub async fn reset_pg_database(pg_options: Option<PostgresConnectOptions>) -> an
 
 pub async fn get_pg_cache_database() -> anyhow::Result<PostgresCacheDatabase> {
     reset_pg_database(None).await?;
-    // run tests as nautilus user
-    let connect_options = PostgresConnectOptionsBuilder::default()
-        .username(String::from("nautilus"))
-        .build()?;
+    let connect_options = get_postgres_connect_options(None, None, None, None, None);
     Ok(PostgresCacheDatabase::connect(
         Some(connect_options.host),
         Some(connect_options.port),


### PR DESCRIPTION
# Pull Request

- motivation was that `nautilus` cli should also be run without `.env` file (now it fails if file doesn't exists as envs will be null)
- we should use default development values which are hardcoded everywhere
- added logs of the Postgres connection URL used in CLI to see which database is running on
- changed the signature of `get_postgres_connect_options` if defaults are supplied, no need to return Result, as config will always exist without errors
- add `default_administrator` with root `postgres` user value, nautilus CLI will get the default values from there if no envs are found in environment