### PR TITLE
Added timeout from env variable to IB client requests

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import functools
+import os
 from collections.abc import Callable
 from decimal import Decimal
 from inspect import iscoroutinefunction
@@ -109,7 +110,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         """
         if not (subscription := self._subscriptions.get(name=name)):
             self._log.info(
-                f"Creating and registering a new Subscription instance for {subscription}",
+                f"Creating and registering a new Subscription instance for {name}",
             )
             req_id = self._next_req_id()
             if subscription_method == self.subscribe_historical_bars:
@@ -390,7 +391,8 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
                 return []
             self._log.debug(f"reqHistoricalData: {request.req_id=}, {contract=}")
             request.handle()
-            return await self._await_request(request, timeout, default_value=[])
+            ib_timeout = int(os.environ.get("IB_REQUEST_TIMEOUT", timeout))
+            return await self._await_request(request, ib_timeout, default_value=[])
         else:
             self._log.info(f"Request already exist for {request}")
             return []


### PR DESCRIPTION
# Pull Request

This very small PR include two changes:
1. It fixes a bug in IB data client logger, which always printed None instead of the instrument name
2. For some requests to IB, instead of using a default timeout of 60, the timeout can be set with an environment variable, which if does not exist, will default to 60.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

The code was tested locally by building nautilus and using it as a dependency in a project.
