### PR TITLE
Implement position getter for netting Oms in OrderMatchingEngine

### DIFF
--- a/nautilus_core/backtest/src/matching_engine/mod.rs
+++ b/nautilus_core/backtest/src/matching_engine/mod.rs
@@ -880,7 +880,15 @@ impl OrderMatchingEngine {
                 panic!("Position id should be generated. Hedging Oms type order matching engine doesnt exists in cache.")
             }
         } else {
-            todo!("Netting OMS position getter")
+            // Netting OMS (position id will be derived from instrument and strategy)
+            let cache = self.cache.as_ref().borrow();
+            let positions_open =
+                cache.positions_open(None, Some(&order.instrument_id()), None, None);
+            if !positions_open.is_empty() {
+                Some(positions_open[0].id.to_owned())
+            } else {
+                None
+            }
         }
     }
 


### PR DESCRIPTION
# Pull Request

- finish `get_position_id` for `OrderMatchingEngine` in Rust for netting OMS engine type calculation
- tested in `test_get_position_id_netting`
