### PR TITLE
Remove mutable reference in cache database trait in Rust

### DIFF
--- a/nautilus_core/common/src/cache/database.rs
+++ b/nautilus_core/common/src/cache/database.rs
@@ -46,7 +46,7 @@ pub trait CacheDatabaseAdapter {
 
     fn flush(&mut self) -> anyhow::Result<()>;
 
-    fn load(&mut self) -> anyhow::Result<HashMap<String, Bytes>>;
+    fn load(&self) -> anyhow::Result<HashMap<String, Bytes>>;
 
     fn load_currencies(&mut self) -> anyhow::Result<HashMap<Ustr, Currency>>;
 
@@ -60,98 +60,94 @@ pub trait CacheDatabaseAdapter {
 
     fn load_positions(&mut self) -> anyhow::Result<HashMap<PositionId, Position>>;
 
-    fn load_index_order_position(&mut self) -> anyhow::Result<HashMap<ClientOrderId, Position>>;
+    fn load_index_order_position(&self) -> anyhow::Result<HashMap<ClientOrderId, Position>>;
 
-    fn load_index_order_client(&mut self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>>;
+    fn load_index_order_client(&self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>>;
 
-    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Option<Currency>>;
+    fn load_currency(&self, code: &Ustr) -> anyhow::Result<Option<Currency>>;
 
     fn load_instrument(
-        &mut self,
+        &self,
         instrument_id: &InstrumentId,
     ) -> anyhow::Result<Option<InstrumentAny>>;
 
-    fn load_synthetic(
-        &mut self,
-        instrument_id: &InstrumentId,
-    ) -> anyhow::Result<SyntheticInstrument>;
+    fn load_synthetic(&self, instrument_id: &InstrumentId) -> anyhow::Result<SyntheticInstrument>;
 
-    fn load_account(&mut self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>>;
+    fn load_account(&self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>>;
 
-    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>>;
+    fn load_order(&self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>>;
 
-    fn load_position(&mut self, position_id: &PositionId) -> anyhow::Result<Position>;
+    fn load_position(&self, position_id: &PositionId) -> anyhow::Result<Position>;
 
-    fn load_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>>;
+    fn load_actor(&self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>>;
 
-    fn delete_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<()>;
+    fn delete_actor(&self, component_id: &ComponentId) -> anyhow::Result<()>;
 
-    fn load_strategy(&mut self, strategy_id: &StrategyId)
-        -> anyhow::Result<HashMap<String, Bytes>>;
+    fn load_strategy(&self, strategy_id: &StrategyId) -> anyhow::Result<HashMap<String, Bytes>>;
 
-    fn delete_strategy(&mut self, component_id: &StrategyId) -> anyhow::Result<()>;
+    fn delete_strategy(&self, component_id: &StrategyId) -> anyhow::Result<()>;
 
-    fn add(&mut self, key: String, value: Bytes) -> anyhow::Result<()>;
+    fn add(&self, key: String, value: Bytes) -> anyhow::Result<()>;
 
-    fn add_currency(&mut self, currency: &Currency) -> anyhow::Result<()>;
+    fn add_currency(&self, currency: &Currency) -> anyhow::Result<()>;
 
-    fn add_instrument(&mut self, instrument: &InstrumentAny) -> anyhow::Result<()>;
+    fn add_instrument(&self, instrument: &InstrumentAny) -> anyhow::Result<()>;
 
-    fn add_synthetic(&mut self, synthetic: &SyntheticInstrument) -> anyhow::Result<()>;
+    fn add_synthetic(&self, synthetic: &SyntheticInstrument) -> anyhow::Result<()>;
 
-    fn add_account(&mut self, account: &AccountAny) -> anyhow::Result<()>;
+    fn add_account(&self, account: &AccountAny) -> anyhow::Result<()>;
 
-    fn add_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()>;
+    fn add_order(&self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()>;
 
-    fn add_position(&mut self, position: &Position) -> anyhow::Result<()>;
+    fn add_position(&self, position: &Position) -> anyhow::Result<()>;
 
-    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()>;
+    fn add_order_book(&self, order_book: &OrderBook) -> anyhow::Result<()>;
 
-    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()>;
+    fn add_quote(&self, quote: &QuoteTick) -> anyhow::Result<()>;
 
-    fn load_quotes(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>>;
+    fn load_quotes(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>>;
 
-    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()>;
+    fn add_trade(&self, trade: &TradeTick) -> anyhow::Result<()>;
 
-    fn load_trades(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>>;
+    fn load_trades(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>>;
 
-    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()>;
+    fn add_bar(&self, bar: &Bar) -> anyhow::Result<()>;
 
-    fn load_bars(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>>;
+    fn load_bars(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>>;
 
-    fn add_signal(&mut self, signal: &Signal) -> anyhow::Result<()>;
+    fn add_signal(&self, signal: &Signal) -> anyhow::Result<()>;
 
-    fn load_signals(&mut self, name: &str) -> anyhow::Result<Vec<Signal>>;
+    fn load_signals(&self, name: &str) -> anyhow::Result<Vec<Signal>>;
 
-    fn add_custom_data(&mut self, data: &CustomData) -> anyhow::Result<()>;
+    fn add_custom_data(&self, data: &CustomData) -> anyhow::Result<()>;
 
-    fn load_custom_data(&mut self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>>;
+    fn load_custom_data(&self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>>;
 
     fn index_venue_order_id(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         venue_order_id: VenueOrderId,
     ) -> anyhow::Result<()>;
 
     fn index_order_position(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         position_id: PositionId,
     ) -> anyhow::Result<()>;
 
-    fn update_actor(&mut self) -> anyhow::Result<()>;
+    fn update_actor(&self) -> anyhow::Result<()>;
 
-    fn update_strategy(&mut self) -> anyhow::Result<()>;
+    fn update_strategy(&self) -> anyhow::Result<()>;
 
-    fn update_account(&mut self, account: &AccountAny) -> anyhow::Result<()>;
+    fn update_account(&self, account: &AccountAny) -> anyhow::Result<()>;
 
-    fn update_order(&mut self, order_event: &OrderEventAny) -> anyhow::Result<()>;
+    fn update_order(&self, order_event: &OrderEventAny) -> anyhow::Result<()>;
 
-    fn update_position(&mut self, position: &Position) -> anyhow::Result<()>;
+    fn update_position(&self, position: &Position) -> anyhow::Result<()>;
 
-    fn snapshot_order_state(&mut self, order: &OrderAny) -> anyhow::Result<()>;
+    fn snapshot_order_state(&self, order: &OrderAny) -> anyhow::Result<()>;
 
-    fn snapshot_position_state(&mut self, position: &Position) -> anyhow::Result<()>;
+    fn snapshot_position_state(&self, position: &Position) -> anyhow::Result<()>;
 
-    fn heartbeat(&mut self, timestamp: UnixNanos) -> anyhow::Result<()>;
+    fn heartbeat(&self, timestamp: UnixNanos) -> anyhow::Result<()>;
 }

--- a/nautilus_core/infrastructure/src/python/sql/cache.rs
+++ b/nautilus_core/infrastructure/src/python/sql/cache.rs
@@ -232,18 +232,18 @@ impl PostgresCacheDatabase {
     }
 
     #[pyo3(name = "add")]
-    fn py_add(mut slf: PyRefMut<'_, Self>, key: String, value: Vec<u8>) -> PyResult<()> {
+    fn py_add(slf: PyRefMut<'_, Self>, key: String, value: Vec<u8>) -> PyResult<()> {
         slf.add(key, Bytes::from(value)).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_currency")]
-    fn py_add_currency(mut slf: PyRefMut<'_, Self>, currency: Currency) -> PyResult<()> {
+    fn py_add_currency(slf: PyRefMut<'_, Self>, currency: Currency) -> PyResult<()> {
         slf.add_currency(&currency).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_instrument")]
     fn py_add_instrument(
-        mut slf: PyRefMut<'_, Self>,
+        slf: PyRefMut<'_, Self>,
         instrument: PyObject,
         py: Python<'_>,
     ) -> PyResult<()> {
@@ -254,7 +254,7 @@ impl PostgresCacheDatabase {
 
     #[pyo3(name = "add_order")]
     fn py_add_order(
-        mut slf: PyRefMut<'_, Self>,
+        slf: PyRefMut<'_, Self>,
         order: PyObject,
         client_id: Option<ClientId>,
         py: Python<'_>,
@@ -265,46 +265,42 @@ impl PostgresCacheDatabase {
     }
 
     #[pyo3(name = "add_account")]
-    fn py_add_account(
-        mut slf: PyRefMut<'_, Self>,
-        account: PyObject,
-        py: Python<'_>,
-    ) -> PyResult<()> {
+    fn py_add_account(slf: PyRefMut<'_, Self>, account: PyObject, py: Python<'_>) -> PyResult<()> {
         let account_any = convert_pyobject_to_account_any(py, account)?;
         slf.add_account(&account_any).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_quote")]
-    fn py_add_quote(mut slf: PyRefMut<'_, Self>, quote: PyObject, py: Python<'_>) -> PyResult<()> {
+    fn py_add_quote(slf: PyRefMut<'_, Self>, quote: PyObject, py: Python<'_>) -> PyResult<()> {
         let quote = quote.extract::<QuoteTick>(py)?;
         slf.add_quote(&quote).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_trade")]
-    fn py_add_trade(mut slf: PyRefMut<'_, Self>, trade: PyObject, py: Python<'_>) -> PyResult<()> {
+    fn py_add_trade(slf: PyRefMut<'_, Self>, trade: PyObject, py: Python<'_>) -> PyResult<()> {
         let trade = trade.extract::<TradeTick>(py)?;
         slf.add_trade(&trade).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_bar")]
-    fn py_add_bar(mut slf: PyRefMut<'_, Self>, bar: PyObject, py: Python<'_>) -> PyResult<()> {
+    fn py_add_bar(slf: PyRefMut<'_, Self>, bar: PyObject, py: Python<'_>) -> PyResult<()> {
         let bar = bar.extract::<Bar>(py)?;
         slf.add_bar(&bar).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_signal")]
-    fn py_add_signal(mut slf: PyRefMut<'_, Self>, signal: Signal) -> PyResult<()> {
+    fn py_add_signal(slf: PyRefMut<'_, Self>, signal: Signal) -> PyResult<()> {
         slf.add_signal(&signal).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "add_custom_data")]
-    fn py_add_custom_data(mut slf: PyRefMut<'_, Self>, data: CustomData) -> PyResult<()> {
+    fn py_add_custom_data(slf: PyRefMut<'_, Self>, data: CustomData) -> PyResult<()> {
         slf.add_custom_data(&data).map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "update_order")]
     fn py_update_order(
-        mut slf: PyRefMut<'_, Self>,
+        slf: PyRefMut<'_, Self>,
         order_event: PyObject,
         py: Python<'_>,
     ) -> PyResult<()> {
@@ -313,11 +309,7 @@ impl PostgresCacheDatabase {
     }
 
     #[pyo3(name = "update_account")]
-    fn py_update_account(
-        mut slf: PyRefMut<'_, Self>,
-        order: PyObject,
-        py: Python<'_>,
-    ) -> PyResult<()> {
+    fn py_update_account(slf: PyRefMut<'_, Self>, order: PyObject, py: Python<'_>) -> PyResult<()> {
         let order_any = convert_pyobject_to_account_any(py, order)?;
         slf.update_account(&order_any).map_err(to_pyruntime_err)
     }

--- a/nautilus_core/infrastructure/src/redis/cache.rs
+++ b/nautilus_core/infrastructure/src/redis/cache.rs
@@ -677,7 +677,7 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         Ok(())
     }
 
-    fn load(&mut self) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load(&self) -> anyhow::Result<HashMap<String, Bytes>> {
         // self.database.load()
         Ok(HashMap::new()) // TODO
     }
@@ -786,137 +786,131 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
         Ok(positions)
     }
 
-    fn load_index_order_position(&mut self) -> anyhow::Result<HashMap<ClientOrderId, Position>> {
+    fn load_index_order_position(&self) -> anyhow::Result<HashMap<ClientOrderId, Position>> {
         todo!()
     }
 
-    fn load_index_order_client(&mut self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>> {
+    fn load_index_order_client(&self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>> {
         todo!()
     }
 
-    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Option<Currency>> {
+    fn load_currency(&self, code: &Ustr) -> anyhow::Result<Option<Currency>> {
         todo!()
     }
 
     fn load_instrument(
-        &mut self,
+        &self,
         instrument_id: &InstrumentId,
     ) -> anyhow::Result<Option<InstrumentAny>> {
         todo!()
     }
 
-    fn load_synthetic(
-        &mut self,
-        instrument_id: &InstrumentId,
-    ) -> anyhow::Result<SyntheticInstrument> {
+    fn load_synthetic(&self, instrument_id: &InstrumentId) -> anyhow::Result<SyntheticInstrument> {
         todo!()
     }
 
-    fn load_account(&mut self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>> {
+    fn load_account(&self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>> {
         todo!()
     }
 
-    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>> {
+    fn load_order(&self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>> {
         todo!()
     }
 
-    fn load_position(&mut self, position_id: &PositionId) -> anyhow::Result<Position> {
+    fn load_position(&self, position_id: &PositionId) -> anyhow::Result<Position> {
         todo!()
     }
 
-    fn load_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load_actor(&self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>> {
         todo!()
     }
 
-    fn delete_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<()> {
+    fn delete_actor(&self, component_id: &ComponentId) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn load_strategy(
-        &mut self,
-        strategy_id: &StrategyId,
-    ) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load_strategy(&self, strategy_id: &StrategyId) -> anyhow::Result<HashMap<String, Bytes>> {
         todo!()
     }
 
-    fn delete_strategy(&mut self, component_id: &StrategyId) -> anyhow::Result<()> {
+    fn delete_strategy(&self, component_id: &StrategyId) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add(&mut self, key: String, value: Bytes) -> anyhow::Result<()> {
+    fn add(&self, key: String, value: Bytes) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_currency(&mut self, currency: &Currency) -> anyhow::Result<()> {
+    fn add_currency(&self, currency: &Currency) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_instrument(&mut self, instrument: &InstrumentAny) -> anyhow::Result<()> {
+    fn add_instrument(&self, instrument: &InstrumentAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_synthetic(&mut self, synthetic: &SyntheticInstrument) -> anyhow::Result<()> {
+    fn add_synthetic(&self, synthetic: &SyntheticInstrument) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_account(&mut self, account: &AccountAny) -> anyhow::Result<()> {
+    fn add_account(&self, account: &AccountAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
+    fn add_order(&self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_position(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn add_position(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
+    fn add_order_book(&self, order_book: &OrderBook) -> anyhow::Result<()> {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
-    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+    fn add_quote(&self, quote: &QuoteTick) -> anyhow::Result<()> {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
-    fn load_quotes(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>> {
+    fn load_quotes(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>> {
         anyhow::bail!("Loading quote data for Redis cache adapter not supported")
     }
 
-    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()> {
+    fn add_trade(&self, trade: &TradeTick) -> anyhow::Result<()> {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
-    fn load_trades(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>> {
+    fn load_trades(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>> {
         anyhow::bail!("Loading market data for Redis cache adapter not supported")
     }
 
-    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()> {
+    fn add_bar(&self, bar: &Bar) -> anyhow::Result<()> {
         anyhow::bail!("Saving market data for Redis cache adapter not supported")
     }
 
-    fn load_bars(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>> {
+    fn load_bars(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>> {
         anyhow::bail!("Loading market data for Redis cache adapter not supported")
     }
 
-    fn add_signal(&mut self, signal: &Signal) -> anyhow::Result<()> {
+    fn add_signal(&self, signal: &Signal) -> anyhow::Result<()> {
         anyhow::bail!("Saving signals for Redis cache adapter not supported")
     }
 
-    fn load_signals(&mut self, name: &str) -> anyhow::Result<Vec<Signal>> {
+    fn load_signals(&self, name: &str) -> anyhow::Result<Vec<Signal>> {
         anyhow::bail!("Loading signals from Redis cache adapter not supported")
     }
 
-    fn add_custom_data(&mut self, data: &CustomData) -> anyhow::Result<()> {
+    fn add_custom_data(&self, data: &CustomData) -> anyhow::Result<()> {
         anyhow::bail!("Saving custom data for Redis cache adapter not supported")
     }
 
-    fn load_custom_data(&mut self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>> {
+    fn load_custom_data(&self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>> {
         anyhow::bail!("Loading custom data from Redis cache adapter not supported")
     }
 
     fn index_venue_order_id(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         venue_order_id: VenueOrderId,
     ) -> anyhow::Result<()> {
@@ -924,42 +918,42 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
     }
 
     fn index_order_position(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         position_id: PositionId,
     ) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_actor(&mut self) -> anyhow::Result<()> {
+    fn update_actor(&self) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_strategy(&mut self) -> anyhow::Result<()> {
+    fn update_strategy(&self) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_account(&mut self, account: &AccountAny) -> anyhow::Result<()> {
+    fn update_account(&self, account: &AccountAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_order(&mut self, order_event: &OrderEventAny) -> anyhow::Result<()> {
+    fn update_order(&self, order_event: &OrderEventAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_position(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn update_position(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn snapshot_order_state(&mut self, order: &OrderAny) -> anyhow::Result<()> {
+    fn snapshot_order_state(&self, order: &OrderAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn snapshot_position_state(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn snapshot_position_state(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn heartbeat(&mut self, timestamp: UnixNanos) -> anyhow::Result<()> {
+    fn heartbeat(&self, timestamp: UnixNanos) -> anyhow::Result<()> {
         todo!()
     }
 }

--- a/nautilus_core/infrastructure/src/sql/cache.rs
+++ b/nautilus_core/infrastructure/src/sql/cache.rs
@@ -389,7 +389,7 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn load(&mut self) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load(&self) -> anyhow::Result<HashMap<String, Bytes>> {
         let pool = self.pool.clone();
         let (tx, rx) = std::sync::mpsc::channel();
         tokio::spawn(async move {
@@ -527,11 +527,11 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         todo!()
     }
 
-    fn load_index_order_position(&mut self) -> anyhow::Result<HashMap<ClientOrderId, Position>> {
+    fn load_index_order_position(&self) -> anyhow::Result<HashMap<ClientOrderId, Position>> {
         todo!()
     }
 
-    fn load_index_order_client(&mut self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>> {
+    fn load_index_order_client(&self) -> anyhow::Result<HashMap<ClientOrderId, ClientId>> {
         let pool = self.pool.clone();
         let (tx, rx) = std::sync::mpsc::channel();
         tokio::spawn(async move {
@@ -553,7 +553,7 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn load_currency(&mut self, code: &Ustr) -> anyhow::Result<Option<Currency>> {
+    fn load_currency(&self, code: &Ustr) -> anyhow::Result<Option<Currency>> {
         let pool = self.pool.clone();
         let code = code.to_owned(); // Clone the code
         let (tx, rx) = std::sync::mpsc::channel();
@@ -577,7 +577,7 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
     }
 
     fn load_instrument(
-        &mut self,
+        &self,
         instrument_id: &InstrumentId,
     ) -> anyhow::Result<Option<InstrumentAny>> {
         let pool = self.pool.clone();
@@ -602,14 +602,11 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn load_synthetic(
-        &mut self,
-        instrument_id: &InstrumentId,
-    ) -> anyhow::Result<SyntheticInstrument> {
+    fn load_synthetic(&self, instrument_id: &InstrumentId) -> anyhow::Result<SyntheticInstrument> {
         todo!()
     }
 
-    fn load_account(&mut self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>> {
+    fn load_account(&self, account_id: &AccountId) -> anyhow::Result<Option<AccountAny>> {
         let pool = self.pool.clone();
         let account_id = account_id.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -632,7 +629,7 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn load_order(&mut self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>> {
+    fn load_order(&self, client_order_id: &ClientOrderId) -> anyhow::Result<Option<OrderAny>> {
         let pool = self.pool.clone();
         let client_order_id = client_order_id.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -653,84 +650,81 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn load_position(&mut self, position_id: &PositionId) -> anyhow::Result<Position> {
+    fn load_position(&self, position_id: &PositionId) -> anyhow::Result<Position> {
         todo!()
     }
 
-    fn load_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load_actor(&self, component_id: &ComponentId) -> anyhow::Result<HashMap<String, Bytes>> {
         todo!()
     }
 
-    fn delete_actor(&mut self, component_id: &ComponentId) -> anyhow::Result<()> {
+    fn delete_actor(&self, component_id: &ComponentId) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn load_strategy(
-        &mut self,
-        strategy_id: &StrategyId,
-    ) -> anyhow::Result<HashMap<String, Bytes>> {
+    fn load_strategy(&self, strategy_id: &StrategyId) -> anyhow::Result<HashMap<String, Bytes>> {
         todo!()
     }
 
-    fn delete_strategy(&mut self, component_id: &StrategyId) -> anyhow::Result<()> {
+    fn delete_strategy(&self, component_id: &StrategyId) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add(&mut self, key: String, value: Bytes) -> anyhow::Result<()> {
+    fn add(&self, key: String, value: Bytes) -> anyhow::Result<()> {
         let query = DatabaseQuery::Add(key, value.into());
         self.tx
             .send(query)
             .map_err(|e| anyhow::anyhow!("Failed to send query to database message handler: {e}"))
     }
 
-    fn add_currency(&mut self, currency: &Currency) -> anyhow::Result<()> {
+    fn add_currency(&self, currency: &Currency) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddCurrency(*currency);
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to query add_currency to database message handler: {e}")
         })
     }
 
-    fn add_instrument(&mut self, instrument: &InstrumentAny) -> anyhow::Result<()> {
+    fn add_instrument(&self, instrument: &InstrumentAny) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddInstrument(instrument.clone());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_instrument to database message handler: {e}")
         })
     }
 
-    fn add_synthetic(&mut self, synthetic: &SyntheticInstrument) -> anyhow::Result<()> {
+    fn add_synthetic(&self, synthetic: &SyntheticInstrument) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_account(&mut self, account: &AccountAny) -> anyhow::Result<()> {
+    fn add_account(&self, account: &AccountAny) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddAccount(account.clone(), false);
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_account to database message handler: {e}")
         })
     }
 
-    fn add_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
+    fn add_order(&self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddOrder(order.clone(), client_id, false);
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_order to database message handler: {e}")
         })
     }
 
-    fn add_position(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn add_position(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_order_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
+    fn add_order_book(&self, order_book: &OrderBook) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn add_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+    fn add_quote(&self, quote: &QuoteTick) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddQuote(quote.to_owned());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_quote to database message handler: {e}")
         })
     }
 
-    fn load_quotes(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>> {
+    fn load_quotes(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<QuoteTick>> {
         let pool = self.pool.clone();
         let instrument_id = instrument_id.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -755,14 +749,14 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn add_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()> {
+    fn add_trade(&self, trade: &TradeTick) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddTrade(trade.to_owned());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_trade to database message handler: {e}")
         })
     }
 
-    fn load_trades(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>> {
+    fn load_trades(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<TradeTick>> {
         let pool = self.pool.clone();
         let instrument_id = instrument_id.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -787,14 +781,14 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn add_bar(&mut self, bar: &Bar) -> anyhow::Result<()> {
+    fn add_bar(&self, bar: &Bar) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddBar(bar.to_owned());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_bar to database message handler: {e}")
         })
     }
 
-    fn load_bars(&mut self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>> {
+    fn load_bars(&self, instrument_id: &InstrumentId) -> anyhow::Result<Vec<Bar>> {
         let pool = self.pool.clone();
         let instrument_id = instrument_id.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -819,14 +813,14 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn add_signal(&mut self, signal: &Signal) -> anyhow::Result<()> {
+    fn add_signal(&self, signal: &Signal) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddSignal(signal.to_owned());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_signal to database message handler: {e}")
         })
     }
 
-    fn load_signals(&mut self, name: &str) -> anyhow::Result<Vec<Signal>> {
+    fn load_signals(&self, name: &str) -> anyhow::Result<Vec<Signal>> {
         let pool = self.pool.clone();
         let name = name.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -849,14 +843,14 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         Ok(rx.recv()?)
     }
 
-    fn add_custom_data(&mut self, data: &CustomData) -> anyhow::Result<()> {
+    fn add_custom_data(&self, data: &CustomData) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddCustom(data.to_owned());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_signal to database message handler: {e}")
         })
     }
 
-    fn load_custom_data(&mut self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>> {
+    fn load_custom_data(&self, data_type: &DataType) -> anyhow::Result<Vec<CustomData>> {
         let pool = self.pool.clone();
         let data_type = data_type.to_owned();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -880,7 +874,7 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
     }
 
     fn index_venue_order_id(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         venue_order_id: VenueOrderId,
     ) -> anyhow::Result<()> {
@@ -888,48 +882,48 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
     }
 
     fn index_order_position(
-        &mut self,
+        &self,
         client_order_id: ClientOrderId,
         position_id: PositionId,
     ) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_actor(&mut self) -> anyhow::Result<()> {
+    fn update_actor(&self) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_strategy(&mut self) -> anyhow::Result<()> {
+    fn update_strategy(&self) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn update_account(&mut self, account: &AccountAny) -> anyhow::Result<()> {
+    fn update_account(&self, account: &AccountAny) -> anyhow::Result<()> {
         let query = DatabaseQuery::AddAccount(account.clone(), true);
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query add_account to database message handler: {e}")
         })
     }
 
-    fn update_order(&mut self, event: &OrderEventAny) -> anyhow::Result<()> {
+    fn update_order(&self, event: &OrderEventAny) -> anyhow::Result<()> {
         let query = DatabaseQuery::UpdateOrder(event.clone());
         self.tx.send(query).map_err(|e| {
             anyhow::anyhow!("Failed to send query update_order to database message handler: {e}")
         })
     }
 
-    fn update_position(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn update_position(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn snapshot_order_state(&mut self, order: &OrderAny) -> anyhow::Result<()> {
+    fn snapshot_order_state(&self, order: &OrderAny) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn snapshot_position_state(&mut self, position: &Position) -> anyhow::Result<()> {
+    fn snapshot_position_state(&self, position: &Position) -> anyhow::Result<()> {
         todo!()
     }
 
-    fn heartbeat(&mut self, timestamp: UnixNanos) -> anyhow::Result<()> {
+    fn heartbeat(&self, timestamp: UnixNanos) -> anyhow::Result<()> {
         todo!()
     }
 }

--- a/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_database_postgres.rs
@@ -61,7 +61,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_general_object_adds_to_cache() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         let test_id_value = Bytes::from("test_value");
         pg_cache
             .add(String::from("test_id"), test_id_value.clone())
@@ -261,7 +261,7 @@ mod serial_tests {
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-001-1");
         let client_order_id_2 = ClientOrderId::new("O-19700101-000000-001-001-2");
         let instrument = currency_pair_ethusdt();
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
 
         let market_order = OrderTestBuilder::new(OrderType::Market)
             .instrument_id(instrument.id())
@@ -335,7 +335,7 @@ mod serial_tests {
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-002-1");
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
         let account = account_id();
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // add foreign key dependencies: instrument and currencies
         pg_cache
             .add_currency(&instrument.base_currency().unwrap())
@@ -391,7 +391,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_and_update_account() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         let mut account = AccountAny::Cash(CashAccount::new(
             cash_account_state_million_usd("1000000 USD", "0 USD", "1000000 USD"),
             false,
@@ -427,7 +427,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_postgres_cache_database_add_trade_tick() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // add target instrument and currencies
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -455,7 +455,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_postgres_cache_database_add_quote_tick() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // add target instrument and currencies
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -483,7 +483,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_postgres_cache_database_add_bar() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // add target instrument and currencies
         let instrument = InstrumentAny::CurrencyPair(audusd_sim());
         pg_cache
@@ -539,7 +539,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_postgres_cache_database_add_signal() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // Add signal
         let name = Ustr::from("SignalExample");
         let value = "0.0".to_string();
@@ -558,7 +558,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_postgres_cache_database_add_custom_data() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_pg_cache_database().await.unwrap();
         // Add custom data
         let metadata =
             indexmap! {"a".to_string() => "1".to_string(), "b".to_string() => "2".to_string()};


### PR DESCRIPTION
# Pull Request

- in the trait `CacheDatabaseAdapter`, we have relaxed the signature of some functions to use immutable references. This change is possible because the `load_*` functions are read-only, and the `add_*` functions just are send data into the channel, so nothing is mutated from this function
- the exceptions are load_currencies and load_positions because the `con.keys` function from Redis requires a mutable reference.
