### PR TITLE
Improve Postgres testing

### DIFF
--- a/nautilus_core/infrastructure/src/sql/cache.rs
+++ b/nautilus_core/infrastructure/src/sql/cache.rs
@@ -41,10 +41,7 @@ use sqlx::{postgres::PgConnectOptions, PgPool};
 use ustr::Ustr;
 
 use crate::sql::{
-    pg::{
-        connect_pg, get_postgres_connect_options, PostgresConnectOptions,
-        PostgresConnectOptionsBuilder,
-    },
+    pg::{connect_pg, get_postgres_connect_options},
     queries::DatabaseQueries,
 };
 
@@ -137,19 +134,7 @@ impl PostgresCacheDatabase {
     }
 }
 
-pub async fn reset_pg_database(pg_options: Option<PostgresConnectOptions>) -> anyhow::Result<()> {
-    let pg_connect_options = pg_options.unwrap_or(
-        PostgresConnectOptionsBuilder::default()
-            .username(String::from("postgres"))
-            .build()?,
-    );
-    let pg_pool = connect_pg(pg_connect_options.into()).await?;
-    DatabaseQueries::truncate(&pg_pool).await?;
-    Ok(())
-}
-
 pub async fn get_pg_cache_database() -> anyhow::Result<PostgresCacheDatabase> {
-    reset_pg_database(None).await?;
     let connect_options = get_postgres_connect_options(None, None, None, None, None);
     Ok(PostgresCacheDatabase::connect(
         Some(connect_options.host),

--- a/nautilus_core/infrastructure/tests/test_cache_postgres.rs
+++ b/nautilus_core/infrastructure/tests/test_cache_postgres.rs
@@ -46,6 +46,7 @@ mod serial_tests {
     async fn test_cache_instruments() {
         let mut database = get_pg_cache_database().await.unwrap();
         let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+
         let eth = Currency::new("ETH", 2, 0, "ETH", CurrencyType::Crypto);
         let usdt = Currency::new("USDT", 2, 0, "USDT", CurrencyType::Crypto);
         let crypto_perpetual = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
@@ -70,6 +71,8 @@ mod serial_tests {
         assert_eq!(cached_instrument_ids, vec![&crypto_perpetual.id()]);
         let target_instrument = cache.instrument(&crypto_perpetual.id());
         assert_eq!(target_instrument.unwrap(), &crypto_perpetual);
+
+        database.flush().unwrap();
         database.close().unwrap();
     }
 
@@ -77,6 +80,7 @@ mod serial_tests {
     async fn test_cache_orders() {
         let mut database = get_pg_cache_database().await.unwrap();
         let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+
         let instrument = currency_pair_ethusdt();
         let market_order = OrderTestBuilder::new(OrderType::Market)
             .instrument_id(instrument.id())
@@ -111,6 +115,8 @@ mod serial_tests {
         assert_eq!(cached_order_ids.len(), 1);
         let target_order = cache.order(&market_order.client_order_id());
         assert_eq!(target_order.unwrap(), &market_order);
+
+        database.flush().unwrap();
         database.close().unwrap();
     }
 
@@ -118,6 +124,7 @@ mod serial_tests {
     async fn test_cache_accounts() {
         let mut database = get_pg_cache_database().await.unwrap();
         let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+
         let account = AccountAny::default();
         let last_event = account.last_event().unwrap();
         if last_event.base_currency.is_some() {
@@ -142,6 +149,8 @@ mod serial_tests {
         assert_eq!(cached_accounts.len(), 1);
         let target_account_for_venue = cache.account_for_venue(&account.id().get_issuer());
         assert_eq!(*target_account_for_venue.unwrap(), account);
+
+        database.flush().unwrap();
         database.close().unwrap();
     }
 }


### PR DESCRIPTION
# Pull Request

- removed `reset_pg_database` function as truncate/flush is doing the exact functionality
- clearing of db is removed from  `get_pg_cache_database` factory, so that users are responsible for cleaning it after usage
- as we have mutable and immutable function on `PostgresCacheDatabase` and there is no async drop in Rust currently, so we must properly clean and close the connection at the end of each test