### PR TITLE
Fix decoding fill HTTP messages for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/schemas/account/fills.py
+++ b/nautilus_trader/adapters/dydx/schemas/account/fills.py
@@ -62,6 +62,7 @@ class DYDXFillResponse(msgspec.Struct, forbid_unknown_fields=True):
     subaccountNumber: int
     orderId: str | None = None
     clientMetadata: str | None = None
+    affiliateRevShare: str | None = None
 
     def parse_to_fill_report(
         self,

--- a/tests/integration_tests/adapters/dydx/test_http_endpoints.py
+++ b/tests/integration_tests/adapters/dydx/test_http_endpoints.py
@@ -259,6 +259,22 @@ def test_fills(fills_response: DYDXFillsResponse) -> None:
     assert len(fills_response.fills) == expected_num_fills
 
 
+def test_fills_with_affiliate_rev_share() -> None:
+    """
+    Test parsing the fills message with the new affiliateRevShare field.
+    """
+    # Arrange
+    expected_num_fills = 1
+    decoder = msgspec.json.Decoder(DYDXFillsResponse)
+
+    # Act
+    with Path("tests/test_data/dydx/http/v4_fills.json").open() as file_reader:
+        fills_response = decoder.decode(file_reader.read())
+
+    # Assert
+    assert len(fills_response.fills) == expected_num_fills
+
+
 def test_parse_to_position_status_report(
     perpetual_positions_response: DYDXPerpetualPositionsResponse,
 ) -> None:

--- a/tests/test_data/dydx/http/v4_fills.json
+++ b/tests/test_data/dydx/http/v4_fills.json
@@ -1,0 +1,21 @@
+{
+    "fills": [
+        {
+            "affiliateRevShare": "0",
+            "clientMetadata": "0",
+            "createdAt": "2024-10-12T15:09:16.874Z",
+            "createdAtHeight": "22883718",
+            "fee": "0.000496",
+            "id": "ac2df5fb-b135-5bd6-bb5a-62487d9f67d3",
+            "liquidity": "MAKER",
+            "market": "ETH-USD",
+            "marketType": "PERPETUAL",
+            "orderId": "bdfa3018-6054-5a11-b4af-8873a0b3f801",
+            "price": "2477.6",
+            "side": "SELL",
+            "size": "0.002",
+            "subaccountNumber": 0,
+            "type": "LIMIT"
+        }
+    ]
+}


### PR DESCRIPTION
# Pull Request

The fills HTTP endpoint has introduced a new field called `affiliateRevShare`.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Add unit test and live example.
