### PR TITLE
Add optional time origins for time bar aggregation

### DIFF
--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -30,11 +30,13 @@ from nautilus_trader.config import BacktestDataConfig
 from nautilus_trader.config import BacktestEngineConfig
 from nautilus_trader.config import BacktestRunConfig
 from nautilus_trader.config import BacktestVenueConfig
+from nautilus_trader.config import DataEngineConfig
 from nautilus_trader.config import ImportableStrategyConfig
 from nautilus_trader.config import LoggingConfig
 from nautilus_trader.config import StrategyConfig
 from nautilus_trader.core.datetime import unix_nanos_to_str
 from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarAggregation
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
@@ -246,10 +248,17 @@ catalog = DataCatalogConfig(
     path=catalog.path,
 )
 
+data_engine = DataEngineConfig(
+    time_bars_origins={
+        BarAggregation.MINUTE: pd.Timedelta(seconds=0),
+    },
+)
+
 engine_config = BacktestEngineConfig(
     strategies=strategies,
     logging=logging,
     catalog=catalog,
+    data_engine=data_engine,
 )
 
 # BacktestRunConfig

--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -244,9 +244,11 @@ logging = LoggingConfig(
     clear_log_file=True,
 )
 
-catalog = DataCatalogConfig(
-    path=catalog.path,
-)
+catalogs = [
+    DataCatalogConfig(
+        path=catalog.path,
+    ),
+]
 
 data_engine = DataEngineConfig(
     time_bars_origins={
@@ -257,7 +259,7 @@ data_engine = DataEngineConfig(
 engine_config = BacktestEngineConfig(
     strategies=strategies,
     logging=logging,
-    catalog=catalog,
+    catalogs=catalogs,
     data_engine=data_engine,
 )
 

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -108,6 +108,7 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef bint _add_delay
     cdef uint64_t _batch_open_ns
     cdef uint64_t _batch_next_close_ns
+    cdef object _time_bars_origin
 
     cdef readonly timedelta interval
     """The aggregators time interval.\n\n:returns: `timedelta`"""
@@ -116,7 +117,6 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef readonly uint64_t next_close_ns
     """The aggregators next closing time.\n\n:returns: `uint64_t`"""
 
-    cpdef datetime get_start_time(self, datetime now, bint enable_delay=*)
     cpdef void stop(self)
     cdef timedelta _get_interval(self)
     cdef uint64_t _get_interval_ns(self)

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -699,6 +699,7 @@ cdef class TimeBarAggregator(BarAggregator):
         bint build_with_no_updates = True,
         bint timestamp_on_close = True,
         str interval_type = "left-open",
+        object time_bars_origin=None, # pd.Timedelta or pd.DateOffset
         int composite_bar_build_delay=15, # in microsecond
     ):
         super().__init__(
@@ -724,6 +725,7 @@ cdef class TimeBarAggregator(BarAggregator):
         self._add_delay = bar_type.is_composite() and bar_type.composite().is_internally_aggregated()
         self._batch_open_ns = 0
         self._batch_next_close_ns = 0
+        self._time_bars_origin = time_bars_origin
 
         if interval_type == "left-open":
             self._is_left_open = True
@@ -737,7 +739,7 @@ cdef class TimeBarAggregator(BarAggregator):
     def __str__(self):
         return f"{type(self).__name__}(interval_ns={self.interval_ns}, next_close_ns={self.next_close_ns})"
 
-    cpdef datetime get_start_time(self, datetime now, bint enable_delay=True):
+    def get_start_time(self, now: datetime, enable_delay: bool = True) -> datetime:
         """
         Return the start time for the aggregators next bar.
 
@@ -747,53 +749,94 @@ cdef class TimeBarAggregator(BarAggregator):
             The timestamp (UTC).
 
         """
-        cdef int step = self.bar_type.spec.step
-        cdef datetime start_time
+        step = self.bar_type.spec.step
+        aggregation = self.bar_type.spec.aggregation
 
-        if self.bar_type.spec.aggregation == BarAggregation.MILLISECOND:
-            diff_microseconds = ((now.microsecond // 1000) % step) * 1000
-            diff_seconds = 0 if diff_microseconds == 0 else max(0, (step // 1000) - 1)
-            diff = timedelta(
-                seconds=diff_seconds,
-                microseconds=diff_microseconds,
-            )
-            start_time = (now - diff).floor(freq="ms")
-        elif self.bar_type.spec.aggregation == BarAggregation.SECOND:
-            diff_seconds = now.second % step
-            diff_minutes = 0 if diff_seconds == 0 else max(0, (step // 60) - 1)
-            diff = timedelta(
-                minutes=diff_minutes,
-                seconds=diff_seconds,
-            )
-            start_time = (now - diff).floor(freq="s")
-        elif self.bar_type.spec.aggregation == BarAggregation.MINUTE:
-            diff_minutes = now.minute % step
-            diff_hours = 0 if diff_minutes == 0 else max(0, (step // 60) - 1)
-            diff = timedelta(
-                hours=diff_hours,
-                minutes=diff_minutes,
-            )
-            start_time = (now - diff).floor(freq="min")
-        elif self.bar_type.spec.aggregation == BarAggregation.HOUR:
-            diff_hours = now.hour % step
-            diff_days = 0 if diff_hours == 0 else max(0, (step // 24) - 1)
-            diff = timedelta(
-                days=diff_days,
-                hours=diff_hours,
-            )
-            start_time = (now - diff).floor(freq="h")
-        elif self.bar_type.spec.aggregation == BarAggregation.DAY:
-            start_time = (now - timedelta(days=(now.day - 1))).floor(freq="d")
-        elif self.bar_type.spec.aggregation == BarAggregation.WEEK:
-            start_time = (now - timedelta(days=now.dayofweek)).floor(freq="d")
-        elif self.bar_type.spec.aggregation == BarAggregation.MONTH:
-            diff_months = (now.month - 1) % step
-            diff = pd.DateOffset(months=diff_months)
-            start_time = (now - timedelta(days=(now.day - 1)) - diff).floor(freq="d")
+        if aggregation == BarAggregation.MILLISECOND:
+            start_time = now.floor(freq="s")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(seconds=1)
+
+            while start_time <= now:
+                start_time += pd.Timedelta(milliseconds=step)
+
+            start_time -= pd.Timedelta(milliseconds=step)
+        elif aggregation == BarAggregation.SECOND:
+            start_time = now.floor(freq="min")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(minutes=1)
+
+            while start_time <= now:
+                start_time += pd.Timedelta(seconds=step)
+
+            start_time -= pd.Timedelta(seconds=step)
+        elif aggregation == BarAggregation.MINUTE:
+            start_time = now.floor(freq="h")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(hours=1)
+
+            while start_time <= now:
+                start_time += pd.Timedelta(minutes=step)
+
+            start_time -= pd.Timedelta(minutes=step)
+        elif aggregation == BarAggregation.HOUR:
+            start_time = now.floor(freq="d")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(days=1)
+
+            while start_time <= now:
+                start_time += pd.Timedelta(hours=step)
+
+            start_time -= pd.Timedelta(hours=step)
+        elif aggregation == BarAggregation.DAY:
+            start_time = now.floor(freq="d")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(days=1)
+        elif aggregation == BarAggregation.WEEK:
+            start_time = (now - pd.Timedelta(days=now.dayofweek)).floor(freq="d")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.Timedelta(weeks=1)
+        elif aggregation == BarAggregation.MONTH:
+            start_time = (now - pd.DateOffset(months=now.month - 1, days=now.day - 1)).floor(freq="d")
+
+            if self._time_bars_origin is not None:
+                start_time += self._time_bars_origin
+
+            if now < start_time:
+                start_time -= pd.DateOffset(years=1)
+
+            while start_time <= now:
+                start_time += pd.DateOffset(months=step)
+
+            start_time -= pd.DateOffset(months=step)
         else:  # pragma: no cover (design-time error)
             raise ValueError(
                 f"Aggregation type not supported for time bars, "
-                f"was {bar_aggregation_to_str(self.bar_type.spec.aggregation)}",
+                f"was {bar_aggregation_to_str(aggregation)}",
             )
 
         if self._add_delay and enable_delay:
@@ -872,7 +915,7 @@ cdef class TimeBarAggregator(BarAggregator):
                 callback=self._build_bar,
             )
         else:
-            # the monthly alert time is define iteratively at each alert time as there is no regular interval
+            # The monthly alert time is defined iteratively at each alert time as there is no regular interval
             alert_time = start_time + pd.DateOffset(months=step)
 
             self._clock.set_time_alert(
@@ -917,7 +960,7 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef void _batch_post_update(self, uint64_t time_ns):
         cdef int step = self.bar_type.spec.step
 
-        # update has already been done, resetting _batch_next_close_ns
+        # Update has already been done, resetting _batch_next_close_ns
         if not self._batch_mode and time_ns == self._batch_next_close_ns and time_ns > self._stored_open_ns:
             self._batch_next_close_ns = 0
             return

--- a/nautilus_trader/data/config.py
+++ b/nautilus_trader/data/config.py
@@ -34,6 +34,8 @@ class DataEngineConfig(NautilusConfig, frozen=True):
         Determines the type of interval used for time aggregation.
         - 'left-open': start time is excluded and end time is included (default).
         - 'right-open': start time is included and end time is excluded.
+    time_bars_origins : dict[BarAggregation, pd.Timedelta | pd.DateOffset], optional
+            A dictionary mapping time bar aggregations to their origin time offsets.
     validate_data_sequence : bool, default False
         If data objects timestamp sequencing will be validated and handled.
     buffer_deltas : bool, default False
@@ -49,6 +51,7 @@ class DataEngineConfig(NautilusConfig, frozen=True):
     time_bars_build_with_no_updates: bool = True
     time_bars_timestamp_on_close: bool = True
     time_bars_interval_type: str = "left-open"
+    time_bars_origins: dict | None = None
     validate_data_sequence: bool = False
     buffer_deltas: bool = False
     external_clients: list[ClientId] | None = None

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -15,6 +15,7 @@
 
 from libc.stdint cimport uint64_t
 
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
 from nautilus_trader.cache.cache cimport Cache
 from nautilus_trader.common.component cimport Component
 from nautilus_trader.common.component cimport TimeEvent
@@ -51,7 +52,7 @@ cdef class DataEngine(Component):
     cdef readonly Cache _cache
     cdef readonly DataClient _default_client
     cdef readonly set[ClientId] _external_clients
-    cdef readonly object _catalog
+    cdef readonly list[ParquetDataCatalog] _catalogs
 
     cdef readonly dict[ClientId, DataClient] _clients
     cdef readonly dict[Venue, DataClient] _routing_map

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -20,6 +20,7 @@ from nautilus_trader.common.component cimport Component
 from nautilus_trader.common.component cimport TimeEvent
 from nautilus_trader.core.data cimport Data
 from nautilus_trader.core.rust.model cimport BookType
+from nautilus_trader.data.aggregation cimport BarAggregator
 from nautilus_trader.data.client cimport DataClient
 from nautilus_trader.data.client cimport MarketDataClient
 from nautilus_trader.data.messages cimport DataCommand
@@ -28,6 +29,7 @@ from nautilus_trader.data.messages cimport DataResponse
 from nautilus_trader.data.messages cimport Subscribe
 from nautilus_trader.data.messages cimport Unsubscribe
 from nautilus_trader.model.data cimport Bar
+from nautilus_trader.model.data cimport BarAggregation
 from nautilus_trader.model.data cimport BarType
 from nautilus_trader.model.data cimport CustomData
 from nautilus_trader.model.data cimport DataType
@@ -38,12 +40,11 @@ from nautilus_trader.model.data cimport OrderBookDeltas
 from nautilus_trader.model.data cimport OrderBookDepth10
 from nautilus_trader.model.data cimport QuoteTick
 from nautilus_trader.model.data cimport TradeTick
+from nautilus_trader.model.identifiers cimport ClientId
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport Venue
 from nautilus_trader.model.instruments.base cimport Instrument
 from nautilus_trader.model.instruments.synthetic cimport SyntheticInstrument
-from nautilus_trader.model.objects cimport Price
-from nautilus_trader.model.objects cimport Quantity
 
 
 cdef class DataEngine(Component):
@@ -65,6 +66,7 @@ cdef class DataEngine(Component):
     cdef readonly bint _time_bars_build_with_no_updates
     cdef readonly bint _time_bars_timestamp_on_close
     cdef readonly str _time_bars_interval_type
+    cdef readonly dict[BarAggregation, object] _time_bars_origins # pd.Timedelta or pd.DateOffset
     cdef readonly bint _validate_data_sequence
     cdef readonly bint _buffer_deltas
 

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -148,6 +148,7 @@ cdef class DataEngine(Component):
         self._time_bars_build_with_no_updates = config.time_bars_build_with_no_updates
         self._time_bars_timestamp_on_close = config.time_bars_timestamp_on_close
         self._time_bars_interval_type = config.time_bars_interval_type
+        self._time_bars_origins = config.time_bars_origins or {}
         self._validate_data_sequence = config.validate_data_sequence
         self._buffer_deltas = config.buffer_deltas
 
@@ -1861,6 +1862,7 @@ cdef class DataEngine(Component):
                 build_with_no_updates=self._time_bars_build_with_no_updates,
                 timestamp_on_close=self._time_bars_timestamp_on_close,
                 interval_type=self._time_bars_interval_type,
+                time_bars_origin=self._time_bars_origins.get(bar_type.spec.aggregation),
             )
         elif bar_type.spec.aggregation == BarAggregation.TICK:
             aggregator = TickBarAggregator(

--- a/nautilus_trader/system/config.py
+++ b/nautilus_trader/system/config.py
@@ -59,8 +59,8 @@ class NautilusKernelConfig(NautilusConfig, frozen=True):
         The order emulator configuration.
     streaming : StreamingConfig, optional
         The configuration for streaming to feather files.
-    catalog : DataCatalogConfig, optional
-        The data catalog config.
+    catalogs : list[DataCatalogConfig], optional
+        The list of data catalog configs.
     actors : list[ImportableActorConfig]
         The actor configurations for the kernel.
     strategies : list[ImportableStrategyConfig]
@@ -100,7 +100,7 @@ class NautilusKernelConfig(NautilusConfig, frozen=True):
     exec_engine: ExecEngineConfig | None = None
     emulator: OrderEmulatorConfig | None = None
     streaming: StreamingConfig | None = None
-    catalog: DataCatalogConfig | None = None
+    catalogs: list[DataCatalogConfig] = []
     actors: list[ImportableActorConfig] = []
     strategies: list[ImportableStrategyConfig] = []
     exec_algorithms: list[ImportableExecAlgorithmConfig] = []

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -469,14 +469,16 @@ class NautilusKernel:
             self._setup_streaming(config=config.streaming)
 
         # Set up data catalog
-        self._catalog: ParquetDataCatalog | None = None
-        if config.catalog:
-            self._catalog = ParquetDataCatalog(
-                path=config.catalog.path,
-                fs_protocol=config.catalog.fs_protocol,
-                fs_storage_options=config.catalog.fs_storage_options,
-            )
-            self._data_engine.register_catalog(catalog=self._catalog)
+        self._catalogs: list[ParquetDataCatalog] = []
+        if config.catalogs:
+            for catalog_config in config.catalogs:
+                catalog = ParquetDataCatalog(
+                    path=catalog_config.path,
+                    fs_protocol=catalog_config.fs_protocol,
+                    fs_storage_options=catalog_config.fs_storage_options,
+                )
+                self._catalogs.append(catalog)
+                self._data_engine.register_catalog(catalog=catalog)
 
         # Create importable actors
         for actor_config in config.actors:
@@ -836,16 +838,16 @@ class NautilusKernel:
         return self._writer
 
     @property
-    def catalog(self) -> ParquetDataCatalog | None:
+    def catalogs(self) -> list[ParquetDataCatalog]:
         """
-        Return the kernels data catalog.
+        Return the kernel's list of data catalogs.
 
         Returns
         -------
-        ParquetDataCatalog or ``None``
+        list[ParquetDataCatalog]
 
         """
-        return self._catalog
+        return self._catalogs
 
     def get_log_guard(self) -> nautilus_pyo3.LogGuard | LogGuard | None:
         """

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("499a5c4420525f6ce807eaf53a0941570d20e33e259d7c033f9b6f9f49f86acb",),
+                ("4fadcd3b1ee12132fb725668c223e19aa195a220edbb36edaf9443b958550816",),
             ),
             (
                 TestConfigStubs.risk_engine_config,

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("6a44f23fd33a520d108a397dd5bcf688f189101d3433f79cb7a72f5939841da0",),
+                ("499a5c4420525f6ce807eaf53a0941570d20e33e259d7c033f9b6f9f49f86acb",),
             ),
             (
                 TestConfigStubs.risk_engine_config,

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -1960,6 +1960,84 @@ class TestTimeBarAggregator:
         assert bar.volume == Quantity.from_int(3)
         assert bar.ts_init == 3 * 60 * 1_000_000_000
 
+    def test_update_timer_with_test_clock_sends_single_bar_to_handler_with_bars_and_time_origin(
+        self,
+    ):
+        # Arrange
+        clock = TestClock()
+        clock.set_time(30 * 60 * 1_000_000_000)
+        handler = []
+        instrument_id = TestIdStubs.audusd_id()
+        bar_spec3 = BarSpecification(3, BarAggregation.MINUTE, PriceType.LAST)
+        bar_spec1 = BarSpecification(1, BarAggregation.MINUTE, PriceType.LAST)
+        bar_type = BarType.new_composite(
+            instrument_id,
+            bar_spec3,
+            AggregationSource.INTERNAL,
+            bar_spec1.step,
+            bar_spec1.aggregation,
+            AggregationSource.EXTERNAL,
+        )
+        aggregator = TimeBarAggregator(
+            AUDUSD_SIM,
+            bar_type,
+            handler.append,
+            clock,
+            time_bars_origin=pd.Timedelta(seconds=30),
+        )
+        composite_bar_type = bar_type.composite()
+
+        bar1 = Bar(
+            bar_type=composite_bar_type,
+            open=Price.from_str("1.00005"),
+            high=Price.from_str("1.00010"),
+            low=Price.from_str("1.00004"),
+            close=Price.from_str("1.00007"),
+            volume=Quantity.from_int(1),
+            ts_event=31 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+            ts_init=1 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+        )
+
+        bar2 = Bar(
+            bar_type=composite_bar_type,
+            open=Price.from_str("1.00007"),
+            high=Price.from_str("1.00020"),
+            low=Price.from_str("1.00003"),
+            close=Price.from_str("1.00015"),
+            volume=Quantity.from_int(1),
+            ts_event=32 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+            ts_init=2 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+        )
+
+        bar3 = Bar(
+            bar_type=composite_bar_type,
+            open=Price.from_str("1.00015"),
+            high=Price.from_str("1.00015"),
+            low=Price.from_str("1.00007"),
+            close=Price.from_str("1.00008"),
+            volume=Quantity.from_int(1),
+            ts_event=33 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+            ts_init=33 * 60 * 1_000_000_000,  # 1 minute in nanoseconds
+        )
+
+        # Act
+        aggregator.handle_bar(bar1)
+        aggregator.handle_bar(bar2)
+        aggregator.handle_bar(bar3)
+        events = clock.advance_time(bar3.ts_event)
+        events[0].handle()
+
+        # Assert
+        bar = handler[0]
+        assert len(handler) == 1
+        assert bar.bar_type == bar_type.standard()
+        assert bar.open == Price.from_str("1.00005")
+        assert bar.high == Price.from_str("1.00020")
+        assert bar.low == Price.from_str("1.00003")
+        assert bar.close == Price.from_str("1.00008")
+        assert bar.volume == Quantity.from_int(3)
+        assert bar.ts_init == 33 * 60 * 1_000_000_000
+
     def test_update_timer_with_test_clock_sends_single_monthly_bar_to_handler_with_bars(self):
         # Arrange
         clock = TestClock()


### PR DESCRIPTION
# Pull Request

+ Add optional time origins for aggregation of time bars. 
Also changed default behaviour of get_start_time when aggregation step exceeds the next time frame. Now get_start_time tries to start as closely as possible to now instead of as far as possible when now was not a multiple of step. This makes more sense to me, the logic is more predictable in terms of when a bar starts. Although aggregating with a number of steps exceeding the next time frame should be an edge case.

+ Allow several catalogs in data engine for queries

+ Refine time bar aggregation's logic: improved logic around _build_on_next_tick which is used to avoid race conditions between data update and the timer, ensure that the next bar effectively falls within previous interval. Avoid creating bar when no update has happened, like when markets are closed.

## Type of change

- New feature (non-breaking change which adds functionality

## How has this change been tested?

Added a test and an example in one test notebook (when changing the time_bars_origins dict we see bars finishing at a different time then exact minutes)
