### PR TITLE
Fix reconcile open orders and account websocket message for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/endpoints/account/perpetual_positions.py
+++ b/nautilus_trader/adapters/dydx/endpoints/account/perpetual_positions.py
@@ -39,7 +39,7 @@ class DYDXGetPerpetualPositionsGetParams(msgspec.Struct, omit_defaults=True, fro
 
     address: str
     subaccountNumber: int
-    status: DYDXPerpetualPositionStatus | None = None
+    status: list[DYDXPerpetualPositionStatus] | None = None
     limit: int | None = None
     createdBeforeOrAtHeight: int | None = None
     createdBeforeOrAt: datetime.datetime | None = None

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -487,7 +487,9 @@ class DYDXExecutionClient(LiveExecutionClient):
             address=self._wallet_address,
             subaccount_number=self._subaccount,
             symbol=symbol,
-            order_status=[DYDXOrderStatus.OPEN] if open_only else None,
+            order_status=(
+                [DYDXOrderStatus.OPEN, DYDXOrderStatus.BEST_EFFORT_OPENED] if open_only else None
+            ),
         )
 
         if dydx_orders is not None:

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -628,7 +628,7 @@ class DYDXExecutionClient(LiveExecutionClient):
         dydx_positions = await self._http_account.get_perpetual_positions(
             address=self._wallet_address,
             subaccount_number=self._subaccount,
-            status=DYDXPerpetualPositionStatus.OPEN,
+            status=[DYDXPerpetualPositionStatus.OPEN],
         )
 
         if dydx_positions is not None:

--- a/nautilus_trader/adapters/dydx/http/account.py
+++ b/nautilus_trader/adapters/dydx/http/account.py
@@ -120,7 +120,7 @@ class DYDXAccountHttpAPI:
         self,
         address: str,
         subaccount_number: int,
-        status: DYDXPerpetualPositionStatus | None = None,
+        status: list[DYDXPerpetualPositionStatus] | None = None,
         limit: int | None = None,
         created_before_or_at: datetime.datetime | None = None,
     ) -> DYDXPerpetualPositionsResponse | None:

--- a/nautilus_trader/adapters/dydx/http/client.py
+++ b/nautilus_trader/adapters/dydx/http/client.py
@@ -101,10 +101,23 @@ class DYDXHttpClient:
 
     def _urlencode(self, payload: dict[str, Any]) -> str:
         # Booleans are capitalized (True/False) when directly passed to `urlencode`
-        payload_list = [
-            (key, str(values).lower() if isinstance(values, bool) else values)
-            for key, values in payload.items()
-        ]
+        payload_list = []
+
+        for key, values in payload.items():
+            if isinstance(values, bool):
+                payload_list.append((key, str(values).lower()))
+            elif isinstance(values, list):
+                value = ""
+                num_values = len(values)
+                for item_id, list_item in enumerate(values):
+                    if item_id < num_values - 1:
+                        value += f"{list_item},"
+                    else:
+                        value += str(list_item)
+
+                payload_list.append((key, value))
+            else:
+                payload_list.append((key, values))
 
         return urllib.parse.urlencode(payload_list)
 

--- a/nautilus_trader/adapters/dydx/schemas/ws.py
+++ b/nautilus_trader/adapters/dydx/schemas/ws.py
@@ -655,6 +655,7 @@ class DYDXWsFillSubaccountMessageContents(msgspec.Struct, forbid_unknown_fields=
     orderId: str | None = None
     clientMetadata: str | None = None
     fee: str | None = None
+    affiliateRevShare: str | None = None
 
 
 class DYDXWsOrderSubaccountMessageContents(msgspec.Struct, forbid_unknown_fields=True):

--- a/tests/integration_tests/adapters/dydx/test_http_client.py
+++ b/tests/integration_tests/adapters/dydx/test_http_client.py
@@ -16,7 +16,6 @@
 Unit tests for the HTTP client.
 """
 
-from nautilus_trader.adapters.dydx.common.enums import DYDXOrderStatus
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 
 
@@ -40,8 +39,8 @@ def test_payload_urlencode_with_list(http_client: DYDXHttpClient) -> None:
     Test encoding the payload sent by the client when sending a list.
     """
     # Prepare
-    payload = {"status": [DYDXOrderStatus.BEST_EFFORT_OPENED, DYDXOrderStatus.OPEN]}
-    expected_result = "status=DYDXOrderStatus.BEST_EFFORT_OPENED%2CDYDXOrderStatus.OPEN"
+    payload = {"status": ["BEST_EFFORT_OPENED", "OPEN"]}
+    expected_result = "status=BEST_EFFORT_OPENED%2COPEN"
 
     # Act
     result = http_client._urlencode(payload)

--- a/tests/integration_tests/adapters/dydx/test_http_client.py
+++ b/tests/integration_tests/adapters/dydx/test_http_client.py
@@ -16,6 +16,7 @@
 Unit tests for the HTTP client.
 """
 
+from nautilus_trader.adapters.dydx.common.enums import DYDXOrderStatus
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 
 
@@ -26,6 +27,21 @@ def test_payload_urlencode(http_client: DYDXHttpClient) -> None:
     # Prepare
     payload = {"returnLatestOrders": True, "subaccountNumber": 0}
     expected_result = "returnLatestOrders=true&subaccountNumber=0"
+
+    # Act
+    result = http_client._urlencode(payload)
+
+    # Assert
+    assert result == expected_result
+
+
+def test_payload_urlencode_with_list(http_client: DYDXHttpClient) -> None:
+    """
+    Test encoding the payload sent by the client when sending a list.
+    """
+    # Prepare
+    payload = {"status": [DYDXOrderStatus.BEST_EFFORT_OPENED, DYDXOrderStatus.OPEN]}
+    expected_result = "status=DYDXOrderStatus.BEST_EFFORT_OPENED%2CDYDXOrderStatus.OPEN"
 
     # Act
     result = http_client._urlencode(payload)

--- a/tests/integration_tests/adapters/dydx/test_http_client.py
+++ b/tests/integration_tests/adapters/dydx/test_http_client.py
@@ -16,32 +16,41 @@
 Unit tests for the HTTP client.
 """
 
+from typing import Any
+
+import pytest
+
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 
 
-def test_payload_urlencode(http_client: DYDXHttpClient) -> None:
+@pytest.mark.parametrize(
+    ("payload", "expected_result"),
+    [
+        (
+            {"returnLatestOrders": True, "subaccountNumber": 0},
+            "returnLatestOrders=true&subaccountNumber=0",
+        ),
+        ({"status": ["BEST_EFFORT_OPENED", "OPEN"]}, "status=BEST_EFFORT_OPENED%2COPEN"),
+        ({"status": ["BEST_EFFORT_OPENED"]}, "status=BEST_EFFORT_OPENED"),
+        ({"limit": 100}, "limit=100"),
+        (
+            {
+                "status": ["BEST_EFFORT_OPENED", "OPEN"],
+                "returnLatestOrders": True,
+                "subaccountNumber": 0,
+            },
+            "status=BEST_EFFORT_OPENED%2COPEN&returnLatestOrders=true&subaccountNumber=0",
+        ),
+    ],
+)
+def test_payload_urlencode(
+    http_client: DYDXHttpClient,
+    payload: dict[str, Any],
+    expected_result: str,
+) -> None:
     """
     Test encoding the payload sent by the client.
     """
-    # Prepare
-    payload = {"returnLatestOrders": True, "subaccountNumber": 0}
-    expected_result = "returnLatestOrders=true&subaccountNumber=0"
-
-    # Act
-    result = http_client._urlencode(payload)
-
-    # Assert
-    assert result == expected_result
-
-
-def test_payload_urlencode_with_list(http_client: DYDXHttpClient) -> None:
-    """
-    Test encoding the payload sent by the client when sending a list.
-    """
-    # Prepare
-    payload = {"status": ["BEST_EFFORT_OPENED", "OPEN"]}
-    expected_result = "status=BEST_EFFORT_OPENED%2COPEN"
-
     # Act
     result = http_client._urlencode(payload)
 

--- a/tests/integration_tests/adapters/dydx/test_websocket_schema.py
+++ b/tests/integration_tests/adapters/dydx/test_websocket_schema.py
@@ -328,6 +328,29 @@ def test_account_channel_data_msg() -> None:
     assert len(msg.contents.orders) == 1
 
 
+def test_account_channel_data_msg_affiliate_rev_share_fill() -> None:
+    """
+    Test parsing the account channel data.
+    """
+    # Prepare
+    decoder = msgspec.json.Decoder(DYDXWsSubaccountsChannelData)
+
+    # Act
+    with Path(
+        "tests/test_data/dydx/websocket/v4_accounts_channel_data_affiliate_rev_share.json",
+    ).open() as file_reader:
+        msg = decoder.decode(file_reader.read())
+
+    # Assert
+    assert msg.channel == "v4_subaccounts"
+    assert msg.contents.orders is not None
+    assert msg.contents.fills is not None
+    assert msg.contents.perpetualPositions is not None
+    assert len(msg.contents.orders) == 1
+    assert len(msg.contents.fills) == 1
+    assert len(msg.contents.perpetualPositions) == 1
+
+
 def test_account_channel_data_msg_order_expired() -> None:
     """
     Test parsing the account channel data.

--- a/tests/test_data/dydx/websocket/v4_accounts_channel_data_affiliate_rev_share.json
+++ b/tests/test_data/dydx/websocket/v4_accounts_channel_data_affiliate_rev_share.json
@@ -1,0 +1,78 @@
+{
+    "type": "channel_data",
+    "connection_id": "72a02287-d522-4485-961d-74d420c52ca3",
+    "message_id": 5,
+    "id": "dydx1kzsvkf2ghjqlysuffdkhcdctknl4rsvcx5hkm5/0",
+    "channel": "v4_subaccounts",
+    "version": "3.0.0",
+    "contents": {
+      "fills": [
+        {
+          "id": "c01a0746-47fe-5773-b0e9-e9e3d3592e78",
+          "fee": "0.001219",
+          "side": "SELL",
+          "size": "0.001",
+          "type": "LIMIT",
+          "price": "2437",
+          "eventId": "01757f260000000200000005",
+          "orderId": "af5ca4ec-98ea-54ff-a43c-3555fbc031c2",
+          "createdAt": "2024-11-03T16:09:38.395Z",
+          "liquidity": "TAKER",
+          "clobPairId": "1",
+          "quoteAmount": "2.437",
+          "subaccountId": "4484a830-fa43-5b04-ba00-3621a33ef89d",
+          "clientMetadata": "1",
+          "createdAtHeight": "24477478",
+          "transactionHash": "446C1C91B86CE3544500A2395F8BE61923F742A759135B8B7F917BA3879D6E19",
+          "affiliateRevShare": "0",
+          "ticker": "ETH-USD"
+        }
+      ],
+      "perpetualPositions": [
+        {
+          "address": "dydx1kzsvkf2ghjqlysuffdkhcdctknl4rsvcx5hkm5",
+          "subaccountNumber": 0,
+          "positionId": "0a7ba1d8-dde9-5390-994f-dd5590ef91d0",
+          "market": "ETH-USD",
+          "side": "LONG",
+          "status": "OPEN",
+          "size": "0.013",
+          "maxSize": "0.014",
+          "netFunding": "0",
+          "entryPrice": "1885.328125",
+          "exitPrice": "2433.73333333333333333333",
+          "sumOpen": "0.02",
+          "sumClose": "0.003",
+          "realizedPnl": "1.64521562499999999999999",
+          "unrealizedPnl": "7.3268871"
+        }
+      ],
+      "blockHeight": "24477478",
+      "orders": [
+        {
+          "id": "af5ca4ec-98ea-54ff-a43c-3555fbc031c2",
+          "side": "SELL",
+          "size": "0.001",
+          "type": "LIMIT",
+          "price": "0.1",
+          "status": "FILLED",
+          "clientId": "1943906971",
+          "updatedAt": "2024-11-03T16:09:38.395Z",
+          "clobPairId": "1",
+          "orderFlags": "0",
+          "reduceOnly": true,
+          "timeInForce": "IOC",
+          "totalFilled": "0.001",
+          "goodTilBlock": "24477478",
+          "subaccountId": "4484a830-fa43-5b04-ba00-3621a33ef89d",
+          "triggerPrice": null,
+          "clientMetadata": "1",
+          "createdAtHeight": "24477478",
+          "updatedAtHeight": "24477478",
+          "goodTilBlockTime": null,
+          "postOnly": false,
+          "ticker": "ETH-USD"
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
# Pull Request

- Fix reconcile open orders for dYdX
- Fix the get_perpetual_positions status type
- Fix parsing account websocket messages

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## How has this change been tested?

Live example and unit tests