### PR TITLE
Make `BybitResponse.time` field optional

### DIFF
--- a/nautilus_trader/adapters/bybit/http/client.py
+++ b/nautilus_trader/adapters/bybit/http/client.py
@@ -33,7 +33,7 @@ class BybitResponse(msgspec.Struct, frozen=True):
     retCode: int
     retMsg: str
     result: dict[str, Any]
-    time: int
+    time: int | None = None
     retExtInfo: dict[str, Any] | None = None
 
 


### PR DESCRIPTION
# Pull Request

Some responses that do not have `time` field.

Such as:
- https://bybit-exchange.github.io/docs/v5/account/account-info

## Type of change

Delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)