### PR TITLE
Add max_reconnection_tries to data client config for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/config.py
+++ b/nautilus_trader/adapters/dydx/config.py
@@ -36,12 +36,16 @@ class DYDXDataClientConfig(LiveDataClientConfig, frozen=True):
         If the client is connecting to the dYdX testnet API.
     update_instruments_interval_mins: PositiveInt or None, default 60
         The interval (minutes) between reloading instruments from the venue.
+    max_reconnection_tries: int, default 3
+        The number of retries to reconnect the websocket connection if the
+        connection is broken.
 
     """
 
     wallet_address: str | None = None
     is_testnet: bool = False
     update_instruments_interval_mins: PositiveInt | None = 60
+    max_ws_reconnection_tries: int | None = 3
 
 
 class DYDXExecClientConfig(LiveExecClientConfig, frozen=True):

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -133,6 +133,7 @@ class DYDXDataClient(LiveMarketDataClient):
             handler_reconnect=None,
             base_url=ws_base_url,
             loop=loop,
+            max_reconnection_tries=config.max_ws_reconnection_tries,
         )
 
         # HTTP API

--- a/nautilus_trader/adapters/dydx/grpc/order_builder.py
+++ b/nautilus_trader/adapters/dydx/grpc/order_builder.py
@@ -240,7 +240,7 @@ class OrderBuilder:
         good_til_block: int | None = None,
         good_til_block_time: int | None = None,
         execution: OrderExecution = OrderExecution.DEFAULT,
-        conditional_order_trigger_subticks: int = 0,
+        trigger_price: float | None = None,
     ) -> Order:
         """
         Create a new Order instance.
@@ -271,7 +271,9 @@ class OrderBuilder:
             not yet filled.
         execution : OrderExecution, default OrderExecution.DEFAULT
             OrderExecution enum: DEFAULT, IOC, FOK or POST_ONLY
-        conditional_order_trigger_subticks : int, default value is 0.
+        trigger_price : float, optional.
+            The price of the conditional limit order. Only applicable to STOP_LIMIT,
+            STOP_MARKET, TAKE_PROFIT_MARKET or TAKE_PROFIT_LIMIT orders.
 
         """
         order_time_in_force = OrderHelper.calculate_time_in_force(
@@ -282,6 +284,10 @@ class OrderBuilder:
         )
         client_metadata = OrderHelper.calculate_client_metadata(order_type)
         condition_type = OrderHelper.calculate_condition_type(order_type)
+        conditional_order_trigger_subticks = 0
+
+        if trigger_price is not None:
+            conditional_order_trigger_subticks = self.calculate_subticks(trigger_price)
 
         return Order(
             order_id=order_id,

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -2770,6 +2770,7 @@ class WebSocketConfig:
         heartbeat: int | None = None,
         heartbeat_msg: str | None = None,
         ping_handler: Callable[..., Any] | None = None,
+        max_reconnection_tries: int | None = None,
     ) -> None: ...
 
 class WebSocketClient:


### PR DESCRIPTION
… stop limit and stop market orders

# Pull Request

Add max_reconnection_tries to data client config for dYdX and implement stop limit and stop market orders.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Live example. Submitting limit stop orders and market stop orders needs more testing. Therefore, not updating the documentation yet.
