### PR TITLE
Add specific params for data subscriptions and requests

### DIFF
--- a/examples/live/databento/databento_historical_data.py
+++ b/examples/live/databento/databento_historical_data.py
@@ -13,8 +13,6 @@
 #     name: python3
 # ---
 
-# %%
-
 # %% [markdown]
 # ## imports
 
@@ -22,51 +20,20 @@
 # Note: Use the python extension jupytext to be able to open this python file in jupyter as a notebook
 
 # %%
-# from nautilus_trader.backtest.node import BacktestNode
-# from nautilus_trader.common.enums import LogColor
-# from nautilus_trader.config import BacktestDataConfig
-# from nautilus_trader.config import BacktestEngineConfig
-# from nautilus_trader.config import BacktestRunConfig
-# from nautilus_trader.config import BacktestVenueConfig
-# from nautilus_trader.config import ImportableActorConfig
-# from nautilus_trader.config import ImportableStrategyConfig
-# from nautilus_trader.config import LoggingConfig
-# from nautilus_trader.config import StrategyConfig
-# from nautilus_trader.config import StreamingConfig
-# from nautilus_trader.core.datetime import unix_nanos_to_str
-# from nautilus_trader.model.data import Bar
-# from nautilus_trader.model.data import BarType
-# from nautilus_trader.model.data import QuoteTick
-# from nautilus_trader.model.enums import OrderSide
-# from nautilus_trader.model.greeks import GreeksData
-# from nautilus_trader.model.identifiers import InstrumentId
-# from nautilus_trader.model.identifiers import Venue
-# from nautilus_trader.model.objects import Price
-# from nautilus_trader.model.objects import Quantity
-# from nautilus_trader.risk.greeks import GreeksCalculator
-# from nautilus_trader.risk.greeks import GreeksCalculatorConfig
-# from nautilus_trader.risk.greeks import InterestRateProvider
-# from nautilus_trader.risk.greeks import InterestRateProviderConfig
-# from nautilus_trader.trading.strategy import Strategy
-from typing import Any
-
 from nautilus_trader.adapters.databento import DATABENTO
-from nautilus_trader.adapters.databento import DATABENTO_CLIENT_ID
 from nautilus_trader.adapters.databento import DatabentoDataClientConfig
 from nautilus_trader.adapters.databento import DatabentoLiveDataClientFactory
 from nautilus_trader.adapters.databento.data_utils import databento_data
 from nautilus_trader.adapters.databento.data_utils import load_catalog
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecEngineConfig
 from nautilus_trader.config import LoggingConfig
 from nautilus_trader.config import StrategyConfig
 from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.core.datetime import time_object_to_dt
 from nautilus_trader.live.node import TradingNode
-from nautilus_trader.model.book import OrderBook
-from nautilus_trader.model.data import OrderBookDeltas
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import TraderId
 from nautilus_trader.trading.strategy import Strategy
@@ -119,30 +86,10 @@ options_data = databento_data(
 
 # %%
 class DataSubscriberConfig(StrategyConfig, frozen=True):
-    """
-    Configuration for ``DataSubscriber`` instances.
-
-    Parameters
-    ----------
-    instrument_ids : list[InstrumentId]
-        The instrument IDs to subscribe to.
-
-    """
-
-    instrument_ids: list[InstrumentId]
+    instrument_ids: list[InstrumentId] | None = None
 
 
 class DataSubscriber(Strategy):
-    """
-    An example strategy which subscribes to live data.
-
-    Parameters
-    ----------
-    config : DataSubscriberConfig
-        The configuration for the instance.
-
-    """
-
     def __init__(self, config: DataSubscriberConfig) -> None:
         super().__init__(config)
 
@@ -150,122 +97,92 @@ class DataSubscriber(Strategy):
         self.instrument_ids = config.instrument_ids
 
     def on_start(self) -> None:
-        """
-        Actions to be performed when the strategy is started.
+        start_time = time_object_to_dt("2024-05-09T10:00")
+        end_time = time_object_to_dt("2024-05-09T10:05")
+        self.request_quote_ticks(
+            InstrumentId.from_str("ESM4.GLBX"),
+            start_time,
+            end_time,
+            params={"schema": "bbo-1m"},
+        )
 
-        Here we specify the 'DATABENTO' client_id for subscriptions.
+        # for instrument_id in self.instrument_ids:
+        # from nautilus_trader.model.enums import BookType
 
-        """
-        for instrument_id in self.instrument_ids:
-            # from nautilus_trader.model.enums import BookType
+        # self.subscribe_order_book_deltas(
+        #     instrument_id=instrument_id,
+        #     book_type=BookType.L3_MBO,
+        #     client_id=DATABENTO_CLIENT_ID,
+        # )
+        # self.subscribe_order_book_at_interval(
+        #     instrument_id=instrument_id,
+        #     book_type=BookType.L2_MBP,
+        #     depth=10,
+        #     client_id=DATABENTO_CLIENT_ID,
+        #     interval_ms=1000,
+        # )
 
-            # self.subscribe_order_book_deltas(
-            #     instrument_id=instrument_id,
-            #     book_type=BookType.L3_MBO,
-            #     client_id=DATABENTO_CLIENT_ID,
-            # )
-            # self.subscribe_order_book_at_interval(
-            #     instrument_id=instrument_id,
-            #     book_type=BookType.L2_MBP,
-            #     depth=10,
-            #     client_id=DATABENTO_CLIENT_ID,
-            #     interval_ms=1000,
-            # )
+        # self.subscribe_quote_ticks(instrument_id, client_id=DATABENTO_CLIENT_ID)
+        # self.subscribe_trade_ticks(instrument_id, client_id=DATABENTO_CLIENT_ID)
+        # self.subscribe_instrument_status(instrument_id, client_id=DATABENTO_CLIENT_ID)
+        # self.request_quote_ticks(instrument_id)
+        # self.request_trade_ticks(instrument_id)
 
-            self.subscribe_quote_ticks(instrument_id, client_id=DATABENTO_CLIENT_ID)
-            self.subscribe_trade_ticks(instrument_id, client_id=DATABENTO_CLIENT_ID)
-            # self.subscribe_instrument_status(instrument_id, client_id=DATABENTO_CLIENT_ID)
-            # self.request_quote_ticks(instrument_id)
-            # self.request_trade_ticks(instrument_id)
+        # from nautilus_trader.model.data import DataType
+        # from nautilus_trader.model.data import InstrumentStatus
+        #
+        # status_data_type = DataType(
+        #     type=InstrumentStatus,
+        #     metadata={"instrument_id": instrument_id},
+        # )
+        # self.request_data(status_data_type, client_id=DATABENTO_CLIENT_ID)
 
-            # from nautilus_trader.model.data import DataType
-            # from nautilus_trader.model.data import InstrumentStatus
-            #
-            # status_data_type = DataType(
-            #     type=InstrumentStatus,
-            #     metadata={"instrument_id": instrument_id},
-            # )
-            # self.request_data(status_data_type, client_id=DATABENTO_CLIENT_ID)
+        # from nautilus_trader.model.data import BarType
+        # self.request_bars(BarType.from_str(f"{instrument_id}-1-MINUTE-LAST-EXTERNAL"))
 
-            # from nautilus_trader.model.data import BarType
-            # self.request_bars(BarType.from_str(f"{instrument_id}-1-MINUTE-LAST-EXTERNAL"))
+        # # Imbalance
+        # from nautilus_trader.adapters.databento import DatabentoImbalance
+        #
+        # metadata = {"instrument_id": instrument_id}
+        # self.request_data(
+        #     data_type=DataType(type=DatabentoImbalance, metadata=metadata),
+        #     client_id=DATABENTO_CLIENT_ID,
+        # )
 
-            # # Imbalance
-            # from nautilus_trader.adapters.databento import DatabentoImbalance
-            #
-            # metadata = {"instrument_id": instrument_id}
-            # self.request_data(
-            #     data_type=DataType(type=DatabentoImbalance, metadata=metadata),
-            #     client_id=DATABENTO_CLIENT_ID,
-            # )
-
-            # # Statistics
-            # from nautilus_trader.adapters.databento import DatabentoStatistics
-            #
-            # metadata = {"instrument_id": instrument_id}
-            # self.subscribe_data(
-            #     data_type=DataType(type=DatabentoStatistics, metadata=metadata),
-            #     client_id=DATABENTO_CLIENT_ID,
-            # )
-            # self.request_data(
-            #     data_type=DataType(type=DatabentoStatistics, metadata=metadata),
-            #     client_id=DATABENTO_CLIENT_ID,
-            # )
+        # # Statistics
+        # from nautilus_trader.adapters.databento import DatabentoStatistics
+        #
+        # metadata = {"instrument_id": instrument_id}
+        # self.subscribe_data(
+        #     data_type=DataType(type=DatabentoStatistics, metadata=metadata),
+        #     client_id=DATABENTO_CLIENT_ID,
+        # )
+        # self.request_data(
+        #     data_type=DataType(type=DatabentoStatistics, metadata=metadata),
+        #     client_id=DATABENTO_CLIENT_ID,
+        # )
 
         # self.request_instruments(venue=Venue("GLBX"), client_id=DATABENTO_CLIENT_ID)
         # self.request_instruments(venue=Venue("XCHI"), client_id=DATABENTO_CLIENT_ID)
         # self.request_instruments(venue=Venue("XNAS"), client_id=DATABENTO_CLIENT_ID)
 
     def on_stop(self) -> None:
-        """
-        Actions to be performed when the strategy is stopped.
-        """
         # Databento does not support live data unsubscribing
+        pass
 
-    def on_historical_data(self, data: Any) -> None:
+    def on_historical_data(self, data) -> None:
         self.log.info(repr(data), LogColor.CYAN)
 
-    def on_order_book_deltas(self, deltas: OrderBookDeltas) -> None:
-        """
-        Actions to be performed when the strategy is running and receives order book
-        deltas.
-
-        Parameters
-        ----------
-        deltas : OrderBookDeltas
-            The order book deltas received.
-
-        """
+    def on_order_book_deltas(self, deltas) -> None:
         self.log.info(repr(deltas), LogColor.CYAN)
 
-    def on_order_book(self, order_book: OrderBook) -> None:
-        """
-        Actions to be performed when an order book update is received.
-        """
+    def on_order_book(self, order_book) -> None:
         self.log.info(f"\n{order_book.instrument_id}\n{order_book.pprint(10)}", LogColor.CYAN)
 
-    def on_quote_tick(self, tick: QuoteTick) -> None:
-        """
-        Actions to be performed when the strategy is running and receives a quote tick.
-
-        Parameters
-        ----------
-        tick : QuoteTick
-            The tick received.
-
-        """
+    def on_quote_tick(self, tick) -> None:
         self.log.info(repr(tick), LogColor.CYAN)
 
-    def on_trade_tick(self, tick: TradeTick) -> None:
-        """
-        Actions to be performed when the strategy is running and receives a trade tick.
-
-        Parameters
-        ----------
-        tick : TradeTick
-            The tick received.
-
-        """
+    def on_trade_tick(self, tick) -> None:
         self.log.info(repr(tick), LogColor.CYAN)
 
 
@@ -275,36 +192,49 @@ class DataSubscriber(Strategy):
 # %%
 # For correct subscription operation, you must specify all instruments to be immediately
 # subscribed for as part of the data client configuration
-instrument_ids = [
-    InstrumentId.from_str("ES.c.0.GLBX"),
-    # InstrumentId.from_str("ES.FUT.GLBX"),
-    # InstrumentId.from_str("CL.FUT.GLBX"),
-    # InstrumentId.from_str("LO.OPT.GLBX"),
-    # InstrumentId.from_str("AAPL.XNAS"),
-]
+instrument_ids = None
+# [
+# InstrumentId.from_str("ES.c.0.GLBX"),
+# InstrumentId.from_str("ES.FUT.GLBX"),
+# InstrumentId.from_str("CL.FUT.GLBX"),
+# InstrumentId.from_str("LO.OPT.GLBX"),
+# InstrumentId.from_str("AAPL.XNAS"),
+# ]
 
 # %%
+strat_config = DataSubscriberConfig(instrument_ids=instrument_ids)
+strategy = DataSubscriber(config=strat_config)
+
+exec_engine = LiveExecEngineConfig(
+    reconciliation=False,  # Not applicable
+    inflight_check_interval_ms=0,  # Not applicable
+    # snapshot_orders=True,
+    # snapshot_positions=True,
+    # snapshot_positions_interval_secs=5.0,
+)
+
+logging = LoggingConfig(
+    log_level="INFO",
+    use_pyo3=True,
+)
+
+data_clients: dict[str, LiveDataClientConfig] = {
+    DATABENTO: DatabentoDataClientConfig(
+        api_key=None,  # 'DATABENTO_API_KEY' env var
+        http_gateway=None,
+        instrument_provider=InstrumentProviderConfig(load_all=True),
+        instrument_ids=instrument_ids,
+        parent_symbols={"GLBX.MDP3": {"ES.FUT"}},
+        mbo_subscriptions_delay=10.0,
+    ),
+}
+
 # Configure the trading node
 config_node = TradingNodeConfig(
     trader_id=TraderId("TESTER-001"),
-    logging=LoggingConfig(log_level="INFO", use_pyo3=True),
-    exec_engine=LiveExecEngineConfig(
-        reconciliation=False,  # Not applicable
-        inflight_check_interval_ms=0,  # Not applicable
-        # snapshot_orders=True,
-        # snapshot_positions=True,
-        # snapshot_positions_interval_secs=5.0,
-    ),
-    data_clients={
-        DATABENTO: DatabentoDataClientConfig(
-            api_key=None,  # 'DATABENTO_API_KEY' env var
-            http_gateway=None,
-            instrument_provider=InstrumentProviderConfig(load_all=True),
-            instrument_ids=instrument_ids,
-            parent_symbols={"GLBX.MDP3": {"ES.FUT"}},
-            mbo_subscriptions_delay=10.0,
-        ),
-    },
+    logging=logging,
+    exec_engine=exec_engine,
+    data_clients=data_clients,
     timeout_connection=20.0,
     timeout_reconciliation=10.0,  # Not applicable
     timeout_portfolio=10.0,
@@ -316,18 +246,19 @@ config_node = TradingNodeConfig(
 # Instantiate the node with a configuration
 node = TradingNode(config=config_node)
 
-strat_config = DataSubscriberConfig(instrument_ids=instrument_ids)
-strategy = DataSubscriber(config=strat_config)
-
 # Add your strategies and modules
 node.trader.add_strategy(strategy)
 
 # Register your client factories with the node (can take user-defined factories)
 node.add_data_client_factory(DATABENTO, DatabentoLiveDataClientFactory)
+
 node.build()
 
 # %%
 node.run()
+
+# %%
+node.stop()
 
 # %%
 node.dispose()

--- a/nautilus_trader/adapters/_template/data.py
+++ b/nautilus_trader/adapters/_template/data.py
@@ -172,12 +172,16 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
             "method `_subscribe` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_instruments(self) -> None:
+    async def _subscribe_instruments(self, metadata: dict | None = None) -> None:
         raise NotImplementedError(
             "method `_subscribe_instruments` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_subscribe_instrument` must be implemented in the subclass",
         )  # pragma: no cover
@@ -187,7 +191,7 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(
             "method `_subscribe_order_book_deltas` must be implemented in the subclass",
@@ -198,33 +202,49 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(
             "method `_subscribe_order_book_snapshots` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_subscribe_quote_ticks` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_subscribe_trade_ticks` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         raise NotImplementedError(
             "method `_subscribe_bars` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_subscribe_instrument_status` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_subscribe_instrument_close` must be implemented in the subclass",
         )  # pragma: no cover
@@ -234,47 +254,75 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
             "method `_unsubscribe` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_instruments(self) -> None:
+    async def _unsubscribe_instruments(self, metadata: dict | None = None) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_instruments` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_instrument` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_order_book_deltas` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_order_book_snapshots` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_quote_tick` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_trade_ticks` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_bars` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        params: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_instrument_status` must be implemented in the subclass",
         )  # pragma: no cover
 
-    async def _unsubscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(
             "method `_unsubscribe_instrument_close` must be implemented in the subclass",
         )  # pragma: no cover
@@ -319,6 +367,7 @@ class TemplateLiveMarketDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         limit: int,
         correlation_id: UUID4,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(
             "method `_request_quote_tick` must be implemented in the subclass",

--- a/nautilus_trader/adapters/betfair/data.py
+++ b/nautilus_trader/adapters/betfair/data.py
@@ -191,7 +191,7 @@ class BetfairDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         PyCondition.not_none(instrument_id, "instrument_id")
 
@@ -232,43 +232,83 @@ class BetfairDataClient(LiveMarketDataClient):
         await self._stream.send_subscription_message(market_ids=list(self._subscribed_market_ids))
         self._log.info(f"Added market_ids {self._subscribed_market_ids} for <OrderBook> data")
 
-    async def _subscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping subscribe_instrument, Betfair subscribes as part of orderbook")
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping subscribe_quote_ticks, Betfair subscribes as part of orderbook")
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping subscribe_trade_ticks, Betfair subscribes as part of orderbook")
 
-    async def _subscribe_instruments(self) -> None:
+    async def _subscribe_instruments(self, metadata: dict | None = None) -> None:
         for instrument in self._instrument_provider.list_all():
             self._handle_data(instrument)
 
-    async def _subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
-    async def _subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         # TODO - this could be done by removing the market from self.__subscribed_market_ids and resending the
         #  subscription message - when we have a use case
 
         self._log.warning("Betfair does not support unsubscribing from instruments")
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         # TODO - this could be done by removing the market from self.__subscribed_market_ids and resending the
         #  subscription message - when we have a use case
         self._log.warning("Betfair does not support unsubscribing from instruments")
 
-    async def _unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping unsubscribe_instrument, not applicable for Betfair")
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping unsubscribe_quote_ticks, not applicable for Betfair")
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.info("Skipping unsubscribe_trade_ticks, not applicable for Betfair")
 
     # -- STREAMS ----------------------------------------------------------------------------------

--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -257,7 +257,7 @@ class BybitDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type == BookType.L3_MBO:
             self._log.error(
@@ -314,7 +314,11 @@ class BybitDataClient(LiveMarketDataClient):
         ws_client = self._ws_clients[bybit_symbol.product_type]
         await ws_client.subscribe_order_book(bybit_symbol.raw_symbol, depth=depth)
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
 
@@ -329,12 +333,16 @@ class BybitDataClient(LiveMarketDataClient):
         else:
             await ws_client.subscribe_tickers(bybit_symbol.raw_symbol)
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         await ws_client.subscribe_trades(bybit_symbol.raw_symbol)
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         bybit_symbol = BybitSymbol(bar_type.instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         interval_str = get_interval_from_bar_type(bar_type)
@@ -342,19 +350,31 @@ class BybitDataClient(LiveMarketDataClient):
         self._topic_bar_type[topic] = bar_type
         await ws_client.subscribe_klines(bybit_symbol.raw_symbol, interval_str)
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         depth = self._depths.get(instrument_id, 1)
         await ws_client.unsubscribe_order_book(bybit_symbol.raw_symbol, depth=depth)
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         depth = self._depths.get(instrument_id, 1)
         await ws_client.unsubscribe_order_book(bybit_symbol.raw_symbol, depth=depth)
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         if instrument_id in self._tob_quotes:
@@ -362,12 +382,16 @@ class BybitDataClient(LiveMarketDataClient):
         else:
             await ws_client.unsubscribe_tickers(bybit_symbol.raw_symbol)
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         await ws_client.unsubscribe_trades(bybit_symbol.raw_symbol)
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         bybit_symbol = BybitSymbol(bar_type.instrument_id.symbol.value)
         ws_client = self._ws_clients[bybit_symbol.product_type]
         interval_str = get_interval_from_bar_type(bar_type)

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -17,7 +17,7 @@ Provide a data client for the dYdX decentralized cypto exchange.
 """
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import msgspec
 import pandas as pd
@@ -683,7 +683,11 @@ class DYDXDataClient(LiveMarketDataClient):
         except Exception as e:
             self._log.error(f"Failed to parse market channel data: {raw.decode()} with error {e}")
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         dydx_symbol = DYDXSymbol(instrument_id.symbol.value)
         await self._ws_client.subscribe_trades(dydx_symbol.raw_symbol)
 
@@ -692,7 +696,7 @@ class DYDXDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type in (BookType.L1_MBP, BookType.L3_MBO):
             self._log.error(
@@ -712,7 +716,11 @@ class DYDXDataClient(LiveMarketDataClient):
         if not self._ws_client.has_subscription(subscription):
             await self._ws_client.subscribe_order_book(dydx_symbol.raw_symbol)
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.debug(
             f"Subscribing deltas {instrument_id} (quotes are not available)",
             LogColor.MAGENTA,
@@ -729,7 +737,7 @@ class DYDXDataClient(LiveMarketDataClient):
                 book_type=book_type,
             )
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         self._log.info(f"Subscribe to {bar_type} bars")
         dydx_symbol = DYDXSymbol(bar_type.instrument_id.symbol.value)
         candles_resolution = get_interval_from_bar_type(bar_type)
@@ -737,11 +745,19 @@ class DYDXDataClient(LiveMarketDataClient):
         self._topic_bar_type[topic] = bar_type
         await self._ws_client.subscribe_klines(dydx_symbol.raw_symbol, candles_resolution)
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         dydx_symbol = DYDXSymbol(instrument_id.symbol.value)
         await self._ws_client.unsubscribe_trades(dydx_symbol.raw_symbol)
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         dydx_symbol = DYDXSymbol(instrument_id.symbol.value)
 
         # Check if the websocket client is subscribed.
@@ -753,7 +769,11 @@ class DYDXDataClient(LiveMarketDataClient):
         if self._ws_client.has_subscription(subscription):
             await self._ws_client.unsubscribe_order_book(dydx_symbol.raw_symbol)
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         dydx_symbol = DYDXSymbol(instrument_id.symbol.value)
 
         # Check if the websocket client is subscribed.
@@ -762,7 +782,7 @@ class DYDXDataClient(LiveMarketDataClient):
         if self._ws_client.has_subscription(subscription):
             await self._unsubscribe_order_book_deltas(instrument_id=instrument_id)
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         dydx_symbol = DYDXSymbol(bar_type.instrument_id.symbol.value)
         candles_resolution = get_interval_from_bar_type(bar_type)
         await self._ws_client.unsubscribe_klines(dydx_symbol.raw_symbol, candles_resolution)

--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -15,7 +15,6 @@
 
 import asyncio
 from operator import attrgetter
-from typing import Any
 
 import pandas as pd
 
@@ -133,12 +132,16 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             "implement the `_subscribe` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instruments(self) -> None:
+    async def _subscribe_instruments(self, metadata: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instruments` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instrument` coroutine",  # pragma: no cover
         )
@@ -148,7 +151,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_order_book_deltas` coroutine",  # pragma: no cover
@@ -159,13 +162,17 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_order_book_snapshots` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         if not (instrument := self._cache.instrument(instrument_id)):
             self._log.error(
                 f"Cannot subscribe to quotes for {instrument_id}: instrument not found",
@@ -179,7 +186,11 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             ignore_size=self._ignore_quote_tick_size_updates,
         )
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         if not (instrument := self._cache.instrument(instrument_id)):
             self._log.error(
                 f"Cannot subscribe to trades for {instrument_id}: instrument not found",
@@ -199,7 +210,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             ignore_size=self._ignore_quote_tick_size_updates,
         )
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         if not (instrument := self._cache.instrument(bar_type.instrument_id)):
             self._log.error(f"Cannot subscribe to {bar_type} bars: instrument not found")
             return
@@ -218,10 +229,18 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
                 handle_revised_bars=self._handle_revised_bars,
             )
 
-    async def _subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
-    async def _subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
     async def _unsubscribe(self, data_type: DataType) -> None:
@@ -229,42 +248,70 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             "implement the `_unsubscribe` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instruments(self) -> None:
+    async def _unsubscribe_instruments(self, metadata: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instruments` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instrument` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_order_book_deltas` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_order_book_snapshots` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         await self._client.unsubscribe_ticks(instrument_id, "BidAsk")
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         await self._client.unsubscribe_ticks(instrument_id, "AllLast")
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         if bar_type.spec.timedelta == 5:
             await self._client.unsubscribe_realtime_bars(bar_type)
         else:
             await self._client.unsubscribe_historical_bars(bar_type)
 
-    async def _unsubscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
-    async def _unsubscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         pass  # Subscribed as part of orderbook
 
     async def _request(self, data_type: DataType, correlation_id: UUID4) -> None:

--- a/nautilus_trader/adapters/okx/data.py
+++ b/nautilus_trader/adapters/okx/data.py
@@ -244,7 +244,7 @@ class OKXDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type == BookType.L3_MBO:
             self._log.error(
@@ -300,7 +300,11 @@ class OKXDataClient(LiveMarketDataClient):
     # Copy subscribe method for book deltas to book snapshots (same logic)
     _subscribe_order_book_snapshots = _subscribe_order_book_deltas
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         if instrument_id in self._tob_client_map:
             self._log.warning(
                 f"Already subscribed to {instrument_id} top-of-book (quotes)",
@@ -318,7 +322,11 @@ class OKXDataClient(LiveMarketDataClient):
         self._tob_client_map[instrument_id] = ws_client
         await ws_client.subscribe_order_book(okx_symbol.raw_symbol, 1)
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         if instrument_id in self._trades_client_map:
             self._log.warning(
                 f"Already subscribed to {instrument_id} trades",
@@ -330,14 +338,18 @@ class OKXDataClient(LiveMarketDataClient):
         self._trades_client_map[instrument_id] = ws_client
         await ws_client.subscribe_trades(okx_symbol.raw_symbol)
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         PyCondition.is_true(
             bar_type.is_externally_aggregated(),
             "aggregation_source is not EXTERNAL",
         )
         self._log.error("OKX bar subscriptions are not yet implemented")
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.debug(
             f"Unsubscribing {instrument_id} from order book deltas/snapshots",
             LogColor.MAGENTA,
@@ -353,7 +365,11 @@ class OKXDataClient(LiveMarketDataClient):
     # Copy unsubscribe method for book deltas to book snapshots (same logic)
     _unsubscribe_order_book_snapshots = _unsubscribe_order_book_deltas
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.debug(
             f"Unsubscribing {instrument_id} from quotes (top-of-book)",
             LogColor.MAGENTA,
@@ -366,7 +382,11 @@ class OKXDataClient(LiveMarketDataClient):
                 break
         self._tob_client_map.pop(instrument_id, None)
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.debug(f"Unsubscribing {instrument_id} from trades", LogColor.MAGENTA)
         okx_symbol = OKXSymbol(instrument_id.symbol.value)
 
@@ -376,7 +396,7 @@ class OKXDataClient(LiveMarketDataClient):
                 break
         self._tob_client_map.pop(instrument_id, None)
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         self._log.error("OKX bar subscriptions are not yet implemented")
         return
 

--- a/nautilus_trader/adapters/polymarket/data.py
+++ b/nautilus_trader/adapters/polymarket/data.py
@@ -224,7 +224,7 @@ class PolymarketDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type == BookType.L3_MBO:
             self._log.error(
@@ -240,38 +240,62 @@ class PolymarketDataClient(LiveMarketDataClient):
 
         await self._subscribe_asset_book(instrument_id)
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         await self._subscribe_asset_book(instrument_id)
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         await self._subscribe_asset_book(instrument_id)
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         self._log.error(
             f"Cannot subscribe to {bar_type} bars: not implemented for Polymarket",
         )
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.error(
             f"Cannot unsubscribe from {instrument_id} order book deltas: unsubscribing not supported by Polymarket",
         )
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.error(
             f"Cannot unsubscribe from {instrument_id} order book snapshots: unsubscribing not supported by Polymarket",
         )
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.error(
             f"Cannot unsubscribe from {instrument_id} quotes: unsubscribing not supported by Polymarket",
         )
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._log.error(
             f"Cannot unsubscribe from {instrument_id} trades: unsubscribing not supported by Polymarket",
         )
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         self._log.error(
             f"Cannot unsubscribe from {bar_type} bars: not implemented for Polymarket",
         )

--- a/nautilus_trader/adapters/tardis/data.py
+++ b/nautilus_trader/adapters/tardis/data.py
@@ -251,7 +251,7 @@ class TardisDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type == BookType.L3_MBO:
             self._log.error(
@@ -269,7 +269,7 @@ class TardisDataClient(LiveMarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict | None = None,
+        metadata: dict | None = None,
     ) -> None:
         if book_type == BookType.L3_MBO:
             self._log.error(
@@ -283,39 +283,63 @@ class TardisDataClient(LiveMarketDataClient):
         tardis_data_type = f"{tardis_data_type}_{depth}_0ms"
         self._subscribe_stream(instrument_id, tardis_data_type, "order book snapshots")
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(QuoteTick)
         self._subscribe_stream(instrument_id, tardis_data_type, "quotes")
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(TradeTick)
         self._subscribe_stream(instrument_id, tardis_data_type, "trades")
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         tardis_data_type = convert_nautilus_bar_type_to_tardis_data_type(bar_type)
         self._subscribe_stream(bar_type.instrument_id, tardis_data_type, "bars")
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(OrderBookDelta)
         ws_client_key = get_ws_client_key(instrument_id, tardis_data_type)
         self._dispose_websocket_client_by_key(ws_client_key)
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(OrderBookDepth10)
         ws_client_key = get_ws_client_key(instrument_id, tardis_data_type)
         self._dispose_websocket_client_by_key(ws_client_key)
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(QuoteTick)
         ws_client_key = get_ws_client_key(instrument_id, tardis_data_type)
         self._dispose_websocket_client_by_key(ws_client_key)
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         tardis_data_type = convert_nautilus_data_type_to_tardis_data_type(TradeTick)
         ws_client_key = get_ws_client_key(instrument_id, tardis_data_type)
         self._dispose_websocket_client_by_key(ws_client_key)
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         tardis_data_type = convert_nautilus_bar_type_to_tardis_data_type(bar_type)
         ws_client_key = get_ws_client_key(bar_type.instrument_id, tardis_data_type)
         self._dispose_websocket_client_by_key(ws_client_key)

--- a/nautilus_trader/backtest/data_client.pyx
+++ b/nautilus_trader/backtest/data_client.pyx
@@ -150,13 +150,13 @@ cdef class BacktestMarketDataClient(MarketDataClient):
 
 # -- SUBSCRIPTIONS --------------------------------------------------------------------------------
 
-    cpdef void subscribe_instruments(self):
+    cpdef void subscribe_instruments(self, dict metadata = None):
         cdef Instrument instrument
         for instrument in self._cache.instruments(Venue(self.id.value)):
             self.subscribe_instrument(instrument.id)
         # Do nothing else for backtest
 
-    cpdef void subscribe_instrument(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         if not self._cache.instrument(instrument_id):
@@ -173,7 +173,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         InstrumentId instrument_id,
         BookType book_type,
         int depth = 0,
-        dict kwargs = None,
+        dict metadata = None,
     ):
         Condition.not_none(instrument_id, "instrument_id")
 
@@ -192,7 +192,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         InstrumentId instrument_id,
         BookType book_type,
         int depth = 0,
-        dict kwargs = None,
+        dict metadata = None,
     ):
         Condition.not_none(instrument_id, "instrument_id")
 
@@ -206,7 +206,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         self._add_subscription_order_book_snapshots(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id):
+    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         if not self._cache.instrument(instrument_id):
@@ -219,7 +219,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         self._add_subscription_quote_ticks(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id):
+    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         if not self._cache.instrument(instrument_id):
@@ -232,7 +232,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         self._add_subscription_trade_ticks(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void subscribe_bars(self, BarType bar_type):
+    cpdef void subscribe_bars(self, BarType bar_type, dict metadata = None):
         Condition.not_none(bar_type, "bar_type")
 
         if not self._cache.instrument(bar_type.instrument_id):
@@ -245,65 +245,65 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         self._add_subscription_bars(bar_type)
         # Do nothing else for backtest
 
-    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._add_subscription_instrument_status(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._add_subscription_instrument_close(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_instruments(self):
+    cpdef void unsubscribe_instruments(self, dict metadata = None):
         self._subscriptions_instrument.clear()
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_instrument(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_order_book_deltas(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_order_book_snapshots(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_quote_ticks(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_trade_ticks(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_bars(self, BarType bar_type):
+    cpdef void unsubscribe_bars(self, BarType bar_type, dict metadata = None):
         Condition.not_none(bar_type, "bar_type")
 
         self._remove_subscription_bars(bar_type)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_instrument_status(instrument_id)
         # Do nothing else for backtest
 
-    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id, dict metadata = None):
         Condition.not_none(instrument_id, "instrument_id")
 
         self._remove_subscription_instrument_close(instrument_id)
@@ -356,6 +356,7 @@ cdef class BacktestMarketDataClient(MarketDataClient):
         InstrumentId instrument_id,
         int limit,
         UUID4 correlation_id,
+        dict metadata = None,
     ):
         Condition.not_none(instrument_id, "instrument_id")
         Condition.not_none(correlation_id, "correlation_id")

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -136,17 +136,18 @@ cdef class Actor(Component):
 # -- SUBSCRIPTIONS --------------------------------------------------------------------------------
 
     cpdef void subscribe_data(self, DataType data_type, ClientId client_id=*)
-    cpdef void subscribe_instruments(self, Venue venue, ClientId client_id=*)
-    cpdef void subscribe_instrument(self, InstrumentId instrument_id, ClientId client_id=*)
+    cpdef bytes encode_params(self, dict params)
+    cpdef void subscribe_instruments(self, Venue venue, ClientId client_id=*, dict params=*)
+    cpdef void subscribe_instrument(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
     cpdef void subscribe_order_book_deltas(
         self,
         InstrumentId instrument_id,
         BookType book_type=*,
         int depth=*,
-        dict kwargs=*,
         ClientId client_id=*,
         bint managed=*,
         bint pyo3_conversion=*,
+        dict params=*,
     )
     cpdef void subscribe_order_book_at_interval(
         self,
@@ -154,24 +155,24 @@ cdef class Actor(Component):
         BookType book_type=*,
         int depth=*,
         int interval_ms=*,
-        dict kwargs=*,
         ClientId client_id=*,
         bint managed=*,
+        dict params=*,
     )
-    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void subscribe_bars(self, BarType bar_type, ClientId client_id=*, bint await_partial=*)
-    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id, ClientId client_id=*)
+    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void subscribe_bars(self, BarType bar_type, ClientId client_id=*, bint await_partial=*, dict params=*)
+    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
     cpdef void unsubscribe_data(self, DataType data_type, ClientId client_id=*)
-    cpdef void unsubscribe_instruments(self, Venue venue, ClientId client_id=*)
-    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void unsubscribe_order_book_at_interval(self, InstrumentId instrument_id, int interval_ms=*, ClientId client_id=*)
-    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*)
-    cpdef void unsubscribe_bars(self, BarType bar_type, ClientId client_id=*)
-    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, ClientId client_id=*)
+    cpdef void unsubscribe_instruments(self, Venue venue, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_order_book_at_interval(self, InstrumentId instrument_id, int interval_ms=*, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_bars(self, BarType bar_type, ClientId client_id=*, dict params=*)
+    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, ClientId client_id=*, dict params=*)
     cpdef void publish_data(self, DataType data_type, Data data)
     cpdef void publish_signal(self, str name, value, uint64_t ts_event=*)
     cpdef void subscribe_signal(self, str name=*)
@@ -192,6 +193,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef UUID4 request_instruments(
         self,
@@ -201,6 +203,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef UUID4 request_order_book_snapshot(
         self,
@@ -208,6 +211,7 @@ cdef class Actor(Component):
         int limit,
         ClientId client_id=*,
         callback=*,
+        dict params=*,
     )
     cpdef UUID4 request_quote_ticks(
         self,
@@ -216,8 +220,8 @@ cdef class Actor(Component):
         datetime end=*,
         ClientId client_id=*,
         callback=*,
-        str quote_type=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef UUID4 request_trade_ticks(
         self,
@@ -227,6 +231,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef UUID4 request_bars(
         self,
@@ -236,6 +241,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef UUID4 request_aggregated_bars(
         self,
@@ -247,6 +253,7 @@ cdef class Actor(Component):
         bint include_external_data=*,
         bint update_existing_subscriptions=*,
         bint update_catalog=*,
+        dict params=*,
     )
     cpdef bint is_pending_request(self, UUID4 request_id)
     cpdef bint has_pending_requests(self)

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -4019,6 +4019,8 @@ class DatabentoHistoricalClient:
         start: int,
         end: int | None = None,
         limit: int | None = None,
+        price_precision: int | None = None,
+        schema: str | None = None,
     ) -> list[QuoteTick]: ...
     async def get_range_trades(
         self,

--- a/nautilus_trader/data/client.pxd
+++ b/nautilus_trader/data/client.pxd
@@ -82,24 +82,24 @@ cdef class MarketDataClient(DataClient):
     cpdef list subscribed_instrument_status(self)
     cpdef list subscribed_instrument_close(self)
 
-    cpdef void subscribe_instruments(self)
-    cpdef void subscribe_instrument(self, InstrumentId instrument_id)
-    cpdef void subscribe_order_book_deltas(self, InstrumentId instrument_id, BookType book_type, int depth=*, dict kwargs=*)
-    cpdef void subscribe_order_book_snapshots(self, InstrumentId instrument_id, BookType book_type, int depth=*, dict kwargs=*)
-    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id)
-    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id)
-    cpdef void subscribe_bars(self, BarType bar_type)
-    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id)
-    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_instruments(self)
-    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_bars(self, BarType bar_type)
-    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id)
-    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id)
+    cpdef void subscribe_instruments(self, dict metadata=*)
+    cpdef void subscribe_instrument(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void subscribe_order_book_deltas(self, InstrumentId instrument_id, BookType book_type, int depth=*, dict metadata=*)
+    cpdef void subscribe_order_book_snapshots(self, InstrumentId instrument_id, BookType book_type, int depth=*, dict metadata=*)
+    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void subscribe_bars(self, BarType bar_type, dict metadata=*)
+    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_instruments(self, dict metadata=*)
+    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_bars(self, BarType bar_type, dict metadata=*)
+    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, dict metadata=*)
+    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id, dict metadata=*)
 
     cpdef void _add_subscription_instrument(self, InstrumentId instrument_id)
     cpdef void _add_subscription_order_book_deltas(self, InstrumentId instrument_id)
@@ -140,7 +140,8 @@ cdef class MarketDataClient(DataClient):
         self,
         InstrumentId instrument_id,
         int limit,
-        UUID4 correlation_id
+        UUID4 correlation_id,
+        dict metadata=*,
     )
     cpdef void request_quote_ticks(
         self,

--- a/nautilus_trader/data/client.pyx
+++ b/nautilus_trader/data/client.pyx
@@ -368,7 +368,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe` must be implemented in the subclass")
 
-    cpdef void subscribe_instruments(self):
+    cpdef void subscribe_instruments(self, dict metadata = None):
         """
         Subscribe to all `Instrument` data.
 
@@ -379,7 +379,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_instruments` must be implemented in the subclass")
 
-    cpdef void subscribe_instrument(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument(self, InstrumentId instrument_id, dict metadata = None):
         """
         Subscribe to the `Instrument` with the given instrument ID.
 
@@ -390,7 +390,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_instrument` must be implemented in the subclass")
 
-    cpdef void subscribe_order_book_deltas(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict kwargs = None):
+    cpdef void subscribe_order_book_deltas(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict metadata = None):
         """
         Subscribe to `OrderBookDeltas` data for the given instrument ID.
 
@@ -412,7 +412,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_order_book_deltas` must be implemented in the subclass")
 
-    cpdef void subscribe_order_book_snapshots(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict kwargs = None):
+    cpdef void subscribe_order_book_snapshots(self, InstrumentId instrument_id, BookType book_type, int depth = 0, dict metadata = None):
         """
         Subscribe to `OrderBook` snapshots data for the given instrument ID.
 
@@ -434,7 +434,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_order_book_snapshots` must be implemented in the subclass")
 
-    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id):
+    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata = None):
         """
         Subscribe to `QuoteTick` data for the given instrument ID.
 
@@ -450,7 +450,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_quote_ticks` must be implemented in the subclass")
 
-    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id):
+    cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata = None):
         """
         Subscribe to `TradeTick` data for the given instrument ID.
 
@@ -466,7 +466,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_trade_ticks` must be implemented in the subclass")
 
-    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument_status(self, InstrumentId instrument_id, dict metadata = None):
         """
         Subscribe to `InstrumentStatus` data for the given instrument ID.
 
@@ -482,7 +482,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_instrument_status` must be implemented in the subclass")
 
-    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id):
+    cpdef void subscribe_instrument_close(self, InstrumentId instrument_id, dict metadata = None):
         """
         Subscribe to `InstrumentClose` updates for the given instrument ID.
 
@@ -498,7 +498,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `subscribe_instrument_close` must be implemented in the subclass")
 
-    cpdef void subscribe_bars(self, BarType bar_type):
+    cpdef void subscribe_bars(self, BarType bar_type, dict metadata = None):
         """
         Subscribe to `Bar` data for the given bar type.
 
@@ -529,7 +529,7 @@ cdef class MarketDataClient(DataClient):
             f"You can implement by overriding the `unsubscribe` method for this client",
         )
 
-    cpdef void unsubscribe_instruments(self):
+    cpdef void unsubscribe_instruments(self, dict metadata = None):
         """
         Unsubscribe from all `Instrument` data.
 
@@ -540,7 +540,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_instruments` must be implemented in the subclass")
 
-    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `Instrument` data for the given instrument ID.
 
@@ -556,7 +556,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_instrument` must be implemented in the subclass")
 
-    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `OrderBookDeltas` data for the given instrument ID.
 
@@ -572,7 +572,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_order_book_deltas` must be implemented in the subclass")
 
-    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_order_book_snapshots(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `OrderBook` snapshots data for the given instrument ID.
 
@@ -588,7 +588,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_order_book_snapshots` must be implemented in the subclass")
 
-    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `QuoteTick` data for the given instrument ID.
 
@@ -604,7 +604,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_quote_ticks` must be implemented in the subclass")
 
-    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `TradeTick` data for the given instrument ID.
 
@@ -620,7 +620,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_trade_ticks` must be implemented in the subclass")
 
-    cpdef void unsubscribe_bars(self, BarType bar_type):
+    cpdef void unsubscribe_bars(self, BarType bar_type, dict metadata = None):
         """
         Unsubscribe from `Bar` data for the given bar type.
 
@@ -636,7 +636,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_bars` must be implemented in the subclass")
 
-    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument_status(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `InstrumentStatus` data for the given instrument ID.
 
@@ -652,7 +652,7 @@ cdef class MarketDataClient(DataClient):
         )
         raise NotImplementedError("method `unsubscribe_instrument_status` must be implemented in the subclass")
 
-    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id):
+    cpdef void unsubscribe_instrument_close(self, InstrumentId instrument_id, dict metadata = None):
         """
         Unsubscribe from `InstrumentClose` data for the given instrument ID.
 
@@ -826,6 +826,7 @@ cdef class MarketDataClient(DataClient):
         InstrumentId instrument_id,
         int limit,
         UUID4 correlation_id,
+        dict metadata = None,
     ):
         """
         Request order book snapshot data.

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -13,9 +13,11 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
 
 from nautilus_trader.persistence.catalog import ParquetDataCatalog
+
 from nautilus_trader.cache.cache cimport Cache
 from nautilus_trader.common.component cimport Component
 from nautilus_trader.common.component cimport TimeEvent
@@ -128,27 +130,34 @@ cdef class DataEngine(Component):
     cpdef void _execute_command(self, DataCommand command)
     cpdef void _handle_subscribe(self, DataClient client, Subscribe command)
     cpdef void _handle_unsubscribe(self, DataClient client, Unsubscribe command)
-    cpdef void _handle_subscribe_instrument(self, MarketDataClient client, InstrumentId instrument_id)
+    cpdef void _handle_subscribe_instrument(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
     cpdef void _handle_subscribe_order_book_deltas(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)  # noqa
     cpdef void _handle_subscribe_order_book(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)  # noqa
-    cpdef void _setup_order_book(self, MarketDataClient client, InstrumentId instrument_id, dict metadata, bint only_deltas, bint managed)  # noqa
+    cpdef void _setup_order_book(self, MarketDataClient client, InstrumentId instrument_id, bint only_deltas, bint managed, dict metadata)  # noqa
     cpdef void _create_new_book(self, Instrument instrument, BookType book_type)
-    cpdef void _handle_subscribe_quote_ticks(self, MarketDataClient client, InstrumentId instrument_id)
+    cpdef void _handle_subscribe_quote_ticks(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
     cpdef void _handle_subscribe_synthetic_quote_ticks(self, InstrumentId instrument_id)
-    cpdef void _handle_subscribe_trade_ticks(self, MarketDataClient client, InstrumentId instrument_id)
+    cpdef void _handle_subscribe_trade_ticks(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
     cpdef void _handle_subscribe_synthetic_trade_ticks(self, InstrumentId instrument_id)
-    cpdef void _handle_subscribe_bars(self, MarketDataClient client, BarType bar_type, bint await_partial)
+    cpdef void _handle_subscribe_bars(self, MarketDataClient client, BarType bar_type, bint await_partial, dict metadata)
     cpdef void _handle_subscribe_data(self, DataClient client, DataType data_type)
-    cpdef void _handle_subscribe_instrument_status(self, MarketDataClient client, InstrumentId instrument_id)
-    cpdef void _handle_subscribe_instrument_close(self, MarketDataClient client, InstrumentId instrument_id)
-    cpdef void _handle_unsubscribe_instrument(self, MarketDataClient client, InstrumentId instrument_id)
+    cpdef void _handle_subscribe_instrument_status(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
+    cpdef void _handle_subscribe_instrument_close(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
+    cpdef void _handle_unsubscribe_instrument(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
     cpdef void _handle_unsubscribe_order_book_deltas(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)  # noqa
     cpdef void _handle_unsubscribe_order_book(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)  # noqa
-    cpdef void _handle_unsubscribe_quote_ticks(self, MarketDataClient client, InstrumentId instrument_id)
-    cpdef void _handle_unsubscribe_trade_ticks(self, MarketDataClient client, InstrumentId instrument_id)
-    cpdef void _handle_unsubscribe_bars(self, MarketDataClient client, BarType bar_type)
+    cpdef void _handle_unsubscribe_quote_ticks(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
+    cpdef void _handle_unsubscribe_trade_ticks(self, MarketDataClient client, InstrumentId instrument_id, dict metadata)
+    cpdef void _handle_unsubscribe_bars(self, MarketDataClient client, BarType bar_type, dict metadata)
     cpdef void _handle_unsubscribe_data(self, DataClient client, DataType data_type)
     cpdef void _handle_request(self, DataRequest request)
+    cpdef void _handle_request_instruments(self, DataRequest request, DataClient client, datetime start, datetime end, dict metadata)
+    cpdef void _handle_request_instrument(self, DataRequest request, DataClient client, InstrumentId instrument_id, datetime start, datetime end, dict metadata)
+    cpdef void _handle_request_order_book_deltas(self, DataRequest request, DataClient client, dict metadata)
+    cpdef void _handle_request_quote_ticks(self, DataRequest request, DataClient client, datetime start, datetime end, datetime now, dict metadata)
+    cpdef void _handle_request_trade_ticks(self, DataRequest request, DataClient client, datetime start, datetime end, datetime now, dict metadata)
+    cpdef void _handle_request_bars(self, DataRequest request, DataClient client, datetime start, datetime end, datetime now, dict metadata)
+    cpdef void _handle_request_data(self, DataRequest request, DataClient client, datetime start, datetime end, datetime now)
     cpdef void _query_catalog(self, DataRequest request)
 
 # -- DATA HANDLERS --------------------------------------------------------------------------------
@@ -185,8 +194,8 @@ cdef class DataEngine(Component):
     cpdef void _update_order_book(self, Data data)
     cpdef void _snapshot_order_book(self, TimeEvent snap_event)
     cpdef void _publish_order_book(self, InstrumentId instrument_id, str topic)
-    cpdef void _start_bar_aggregator(self, MarketDataClient client, BarType bar_type, bint await_partial)
-    cpdef void _stop_bar_aggregator(self, MarketDataClient client, BarType bar_type)
+    cpdef void _start_bar_aggregator(self, MarketDataClient client, BarType bar_type, bint await_partial, dict metadata)
+    cpdef void _stop_bar_aggregator(self, MarketDataClient client, BarType bar_type, dict metadata)
     cpdef void _update_synthetics_with_quote(self, list synthetics, QuoteTick update)
     cpdef void _update_synthetic_with_quote(self, SyntheticInstrument synthetic, QuoteTick update)
     cpdef void _update_synthetics_with_trade(self, list synthetics, TradeTick update)

--- a/nautilus_trader/live/data_client.py
+++ b/nautilus_trader/live/data_client.py
@@ -26,7 +26,6 @@ import traceback
 from asyncio import Task
 from collections.abc import Callable
 from collections.abc import Coroutine
-from typing import Any
 
 import pandas as pd
 
@@ -450,20 +449,24 @@ class LiveMarketDataClient(MarketDataClient):
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_instruments(self) -> None:
+    def subscribe_instruments(self, metadata: dict | None = None) -> None:
         instrument_ids = list(self._instrument_provider.get_all().keys())
         [self._add_subscription_instrument(i) for i in instrument_ids]
         self.create_task(
-            self._subscribe_instruments(),
+            self._subscribe_instruments(metadata),
             log_msg=f"subscribe: instruments {self.venue}",
             success_msg=f"Subscribed {self.venue} instruments",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    def subscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._add_subscription_instrument(instrument_id)
         self.create_task(
-            self._subscribe_instrument(instrument_id),
+            self._subscribe_instrument(instrument_id, metadata),
             log_msg=f"subscribe: instrument {instrument_id}",
             success_msg=f"Subscribed {instrument_id} instrument",
             success_color=LogColor.BLUE,
@@ -474,7 +477,7 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         self._add_subscription_order_book_deltas(instrument_id)
         self.create_task(
@@ -482,7 +485,7 @@ class LiveMarketDataClient(MarketDataClient):
                 instrument_id=instrument_id,
                 book_type=book_type,
                 depth=depth,
-                kwargs=kwargs,
+                metadata=metadata,
             ),
             log_msg=f"subscribe: order_book_deltas {instrument_id}",
             success_msg=f"Subscribed {instrument_id} order book deltas depth={depth}",
@@ -494,7 +497,7 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         self._add_subscription_order_book_snapshots(instrument_id)
         self.create_task(
@@ -502,32 +505,40 @@ class LiveMarketDataClient(MarketDataClient):
                 instrument_id=instrument_id,
                 book_type=book_type,
                 depth=depth,
-                kwargs=kwargs,
+                metadata=metadata,
             ),
             log_msg=f"subscribe: order_book_snapshots {instrument_id}",
             success_msg=f"Subscribed {instrument_id} order book snapshots depth={depth}",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    def subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._add_subscription_quote_ticks(instrument_id)
         self.create_task(
-            self._subscribe_quote_ticks(instrument_id),
+            self._subscribe_quote_ticks(instrument_id, metadata),
             log_msg=f"subscribe: quote_ticks {instrument_id}",
             success_msg=f"Subscribed {instrument_id} quotes",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    def subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._add_subscription_trade_ticks(instrument_id)
         self.create_task(
-            self._subscribe_trade_ticks(instrument_id),
+            self._subscribe_trade_ticks(instrument_id, metadata),
             log_msg=f"subscribe: trade_ticks {instrument_id}",
             success_msg=f"Subscribed {instrument_id} trades",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_bars(self, bar_type: BarType) -> None:
+    def subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         PyCondition.is_true(
             bar_type.is_externally_aggregated(),
             "aggregation_source is not EXTERNAL",
@@ -535,25 +546,33 @@ class LiveMarketDataClient(MarketDataClient):
 
         self._add_subscription_bars(bar_type)
         self.create_task(
-            self._subscribe_bars(bar_type),
+            self._subscribe_bars(bar_type, metadata),
             log_msg=f"subscribe: bars {bar_type}",
             success_msg=f"Subscribed {bar_type} bars",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    def subscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._add_subscription_instrument_status(instrument_id)
         self.create_task(
-            self._subscribe_instrument_status(instrument_id),
+            self._subscribe_instrument_status(instrument_id, metadata),
             log_msg=f"subscribe: instrument_status {instrument_id}",
             success_msg=f"Subscribed {instrument_id} instrument status ",
             success_color=LogColor.BLUE,
         )
 
-    def subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    def subscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._add_subscription_instrument_close(instrument_id)
         self.create_task(
-            self._subscribe_instrument_close(instrument_id),
+            self._subscribe_instrument_close(instrument_id, metadata),
             log_msg=f"subscribe: instrument_close {instrument_id}",
             success_msg=f"Subscribed {instrument_id} instrument close",
             success_color=LogColor.BLUE,
@@ -568,83 +587,111 @@ class LiveMarketDataClient(MarketDataClient):
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_instruments(self) -> None:
+    def unsubscribe_instruments(self, metadata: dict | None = None) -> None:
         instrument_ids = list(self._instrument_provider.get_all().keys())
         [self._remove_subscription_instrument(i) for i in instrument_ids]
         self.create_task(
-            self._unsubscribe_instruments(),
+            self._unsubscribe_instruments(metadata),
             log_msg=f"unsubscribe: instruments {self.venue}",
             success_msg=f"Unsubscribed {self.venue} instruments",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_instrument(instrument_id)
         self.create_task(
-            self._unsubscribe_instrument(instrument_id),
+            self._unsubscribe_instrument(instrument_id, metadata),
             log_msg=f"unsubscribe: instrument {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} instrument",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_order_book_deltas(instrument_id)
         self.create_task(
-            self._unsubscribe_order_book_deltas(instrument_id),
+            self._unsubscribe_order_book_deltas(instrument_id, metadata),
             log_msg=f"unsubscribe: order_book_deltas {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} order book deltas",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_order_book_snapshots(instrument_id)
         self.create_task(
-            self._unsubscribe_order_book_snapshots(instrument_id),
+            self._unsubscribe_order_book_snapshots(instrument_id, metadata),
             log_msg=f"unsubscribe: order_book_snapshots {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} order book snapshots",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_quote_ticks(instrument_id)
         self.create_task(
-            self._unsubscribe_quote_ticks(instrument_id),
+            self._unsubscribe_quote_ticks(instrument_id, metadata),
             log_msg=f"unsubscribe: quote_ticks {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} quotes",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_trade_ticks(instrument_id)
         self.create_task(
-            self._unsubscribe_trade_ticks(instrument_id),
+            self._unsubscribe_trade_ticks(instrument_id, metadata),
             log_msg=f"unsubscribe: trade_ticks {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} trades",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_bars(self, bar_type: BarType) -> None:
+    def unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         self._remove_subscription_bars(bar_type)
         self.create_task(
-            self._unsubscribe_bars(bar_type),
+            self._unsubscribe_bars(bar_type, metadata),
             log_msg=f"unsubscribe: bars {bar_type}",
             success_msg=f"Unsubscribed {bar_type} bars",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_instrument_status(instrument_id)
         self.create_task(
-            self._unsubscribe_instrument_status(instrument_id),
+            self._unsubscribe_instrument_status(instrument_id, metadata),
             log_msg=f"unsubscribe: instrument_status {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} instrument status",
             success_color=LogColor.BLUE,
         )
 
-    def unsubscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    def unsubscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         self._remove_subscription_instrument_close(instrument_id)
         self.create_task(
-            self._unsubscribe_instrument_close(instrument_id),
+            self._unsubscribe_instrument_close(instrument_id, metadata),
             log_msg=f"unsubscribe: instrument_close {instrument_id}",
             success_msg=f"Unsubscribed {instrument_id} instrument close",
             success_color=LogColor.BLUE,
@@ -781,6 +828,7 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         limit: int,
         correlation_id: UUID4,
+        metadata: dict | None = None,
     ) -> None:
         limit_str = f" limit={limit}" if limit else ""
         self._log.info(f"Request {instrument_id} order_book_snapshot{limit_str}", LogColor.BLUE)
@@ -789,6 +837,7 @@ class LiveMarketDataClient(MarketDataClient):
                 instrument_id=instrument_id,
                 limit=limit,
                 correlation_id=correlation_id,
+                metadata=metadata,
             ),
             log_msg=f"request: order_book_snapshot {instrument_id}",
         )
@@ -811,12 +860,16 @@ class LiveMarketDataClient(MarketDataClient):
             "implement the `_subscribe` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instruments(self) -> None:
+    async def _subscribe_instruments(self, metadata: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instruments` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instrument` coroutine",  # pragma: no cover
         )
@@ -826,7 +879,7 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_order_book_deltas` coroutine",  # pragma: no cover
@@ -837,33 +890,49 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         book_type: BookType,
         depth: int | None = None,
-        kwargs: dict[str, Any] | None = None,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_order_book_snapshots` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_quote_ticks` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_trade_ticks` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_bars(self, bar_type: BarType) -> None:
+    async def _subscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_bars` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instrument_status` coroutine",  # pragma: no cover
         )
 
-    async def _subscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _subscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_subscribe_instrument_close` coroutine",  # pragma: no cover
         )
@@ -873,47 +942,75 @@ class LiveMarketDataClient(MarketDataClient):
             "implement the `_unsubscribe` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instruments(self) -> None:
+    async def _unsubscribe_instruments(self, params: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instruments` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instrument(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instrument` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_order_book_deltas(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_deltas(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_order_book_deltas` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_order_book_snapshots(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_order_book_snapshots(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_order_book_snapshots` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_quote_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_quote_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_quote_ticks` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_trade_ticks(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_trade_ticks(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_trade_ticks` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_bars(self, bar_type: BarType) -> None:
+    async def _unsubscribe_bars(self, bar_type: BarType, metadata: dict | None = None) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_bars` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instrument_status(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_status(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instrument_status` coroutine",  # pragma: no cover
         )
 
-    async def _unsubscribe_instrument_close(self, instrument_id: InstrumentId) -> None:
+    async def _unsubscribe_instrument_close(
+        self,
+        instrument_id: InstrumentId,
+        metadata: dict | None = None,
+    ) -> None:
         raise NotImplementedError(  # pragma: no cover
             "implement the `_unsubscribe_instrument_close` coroutine",  # pragma: no cover
         )
@@ -991,6 +1088,7 @@ class LiveMarketDataClient(MarketDataClient):
         instrument_id: InstrumentId,
         limit: int,
         correlation_id: UUID4,
+        metadata: dict | None = None,
     ) -> None:
         raise NotImplementedError(
             "implement the `_request_order_book_snapshot` coroutine",  # pragma: no cover


### PR DESCRIPTION
# Pull Request

Add ability to request and subscribe to databento bbo-1m and bbo-1s quotes

Also refactor of request, subscribe and unsubscribe functions to include metadata information containing a params dictionary for extra parameters in the implementation of some client methods

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added notebook example for requests. Not tested for subscribe, although here it uses a function that already is used for various schemas.
