### PR TITLE
Fix interest rate curve custom data and interpolation

### DIFF
--- a/nautilus_trader/common/math.pyx
+++ b/nautilus_trader/common/math.pyx
@@ -25,7 +25,8 @@ cdef inline double linear_weighting(double y1, double y2, double x1_diff):
     return y1 + x1_diff * (y2 - y1)
 
 cdef inline int pos_search(double x, np.ndarray xs):
-    cdef int pos = max(min(int(np.searchsorted(xs, x, side='right'))) - 1, 0)
+    cdef int n_elem = xs.shape[0]
+    cdef int pos = max(min(int(np.searchsorted(xs, x, side='right')), n_elem - 1) - 1, 0)
     return pos
 
 cdef inline double quad_polynomial(double x, double x0, double x1, double x2, double y0, double y1, double y2):

--- a/nautilus_trader/model/greeks.py
+++ b/nautilus_trader/model/greeks.py
@@ -183,11 +183,12 @@ class InterestRateCurveData(Data):
 
         return result
 
-    def from_dict(self, data):
+    @classmethod
+    def from_dict(cls, data):
         data.pop("type", None)
         data.pop("date", None)
 
         data["tenors"] = np.frombuffer(data["tenors"])
-        data["interst_rates"] = np.frombuffer(data["interest_rates"])
+        data["interest_rates"] = np.frombuffer(data["interest_rates"])
 
         return InterestRateCurveData(**data)

--- a/tests/unit_tests/common/test_math.py
+++ b/tests/unit_tests/common/test_math.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from nautilus_trader.common.math import quadratic_interpolation
+
+
+class TestQuadraticInterpolation:
+    @pytest.fixture
+    def xs(self):
+        return np.array(
+            [
+                0.08333333,
+                0.16666667,
+                0.25,
+                0.33333333,
+                0.5,
+                1.0,
+                2.0,
+                3.0,
+                5.0,
+                7.0,
+                10.0,
+                20.0,
+                30.0,
+            ],
+        )
+
+    @pytest.fixture
+    def ys(self):
+        return np.array(
+            [
+                0.0459,
+                0.0453,
+                0.0446,
+                0.0446,
+                0.0438,
+                0.0423,
+                0.0415,
+                0.041,
+                0.0407,
+                0.0412,
+                0.0417,
+                0.0443,
+                0.0433,
+            ],
+        )
+
+    def test_below(self, xs, ys):
+        assert quadratic_interpolation(0.01, xs, ys) == pytest.approx(0.0459)
+
+    def test_above(self, xs, ys):
+        assert quadratic_interpolation(40.0, xs, ys) == pytest.approx(0.0433)
+
+    def test_at_point(self, xs, ys):
+        assert quadratic_interpolation(10.0, xs, ys) == pytest.approx(0.0417)
+
+    def test_interpolation(self, xs, ys):
+        assert quadratic_interpolation(0.75, xs, ys) == pytest.approx(0.0429, abs=1e-4)


### PR DESCRIPTION
# Pull Request

- Adds missing decorator and fixes typo InterestRateCurveData
- Fixes binary search helper function used for interest rate curve interpolation 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- Added unit tests for `quadratic_interpolation`
- Tested visually

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/938f5239-2887-4eff-bd20-3ca6a0dc8df4">

