### PR TITLE
Add sccache in CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -14,6 +14,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     name: build - Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -34,6 +40,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       RUST_BACKTRACE: 1
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"
@@ -196,6 +197,7 @@ jobs:
       RUST_BACKTRACE: 1
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
 
     steps:
       - name: Checkout repository
@@ -204,15 +206,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
 
-      - name: Set sccache-cache env vars (non-Windows)
-        if: runner.os != 'Windows'
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CC=sccache clang" >> $GITHUB_ENV
-          echo "CXX=sccache clang" >> $GITHUB_ENV
-
       - name: Set sccache-cache env vars (Windows)
-        if: runner.os == 'Windows'
         run: |
           echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
@@ -317,6 +311,7 @@ jobs:
       RUST_BACKTRACE: 1
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,9 +196,9 @@ jobs:
       RUST_BACKTRACE: 1
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
-      CMAKE_C_COMPILER_LAUNCHER: "sccache"
-      CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
+      RUSTC_WRAPPER: "${{ env.SCCACHE_PATH }}"
+      CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
+      CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,9 +196,6 @@ jobs:
       RUST_BACKTRACE: 1
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "${{ env.SCCACHE_PATH }}"
-      CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
-      CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
 
     steps:
       - name: Checkout repository
@@ -206,6 +203,20 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Set sccache-cache env vars (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CC=sccache clang" >> $GITHUB_ENV
+          echo "CXX=sccache clang" >> $GITHUB_ENV
+
+      - name: Set sccache-cache env vars (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
+          echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
+          echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
 
       - name: Free disk space (Windows)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,8 +197,8 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
-      CC: "sccache clang"
-      CXX: "sccache clang"
+      CMAKE_C_COMPILER_LAUNCHER: "sccache"
+      CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ jobs:
     env:
       BUILD_MODE: debug
       RUST_BACKTRACE: 1
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     services:
       redis:
@@ -59,6 +64,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |
@@ -186,10 +194,18 @@ jobs:
     env:
       BUILD_MODE: debug
       RUST_BACKTRACE: 1
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Free disk space (Windows)
         run: |
@@ -288,10 +304,18 @@ jobs:
     env:
       BUILD_MODE: debug
       RUST_BACKTRACE: 1
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Free disk space (macOS)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,12 @@ jobs:
         python-version: ["3.11"]
     name: build - Python ${{ matrix.python-version }} (${{ matrix.arch }} ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
     services:
       redis:
         image: redis
@@ -51,6 +57,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -57,12 +56,14 @@ jobs:
       - name: Set sccache-cache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "CC=sccache clang" >> $GITHUB_ENV
           echo "CXX=sccache clang" >> $GITHUB_ENV
 
       - name: Set sccache-cache env vars (Windows)
         if: runner.os == 'Windows'
         run: |
+          echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
 
@@ -308,8 +309,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       BUILD_MODE: release
+      # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -340,12 +341,14 @@ jobs:
       - name: Set sccache-cache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "CC=sccache clang" >> $GITHUB_ENV
           echo "CXX=sccache clang" >> $GITHUB_ENV
 
       - name: Set sccache-cache env vars (Windows)
         if: runner.os == 'Windows'
         run: |
+          echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Set sccache-cache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
@@ -66,9 +69,6 @@ jobs:
           echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |
@@ -338,6 +338,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Set sccache-cache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
@@ -351,9 +354,6 @@ jobs:
           echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
           echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         shell: bash
     name: test-pip-install - Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -49,6 +55,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |
@@ -81,6 +90,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
+    env:
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -102,6 +117,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |
@@ -173,6 +191,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COPY_TO_SOURCE: false # Do not copy built *.so files back into source tree
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -191,6 +214,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |
@@ -272,6 +298,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       BUILD_MODE: release
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -298,6 +328,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Set up Rust toolchain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
-      CC: "sccache clang"
-      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -55,6 +53,18 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set sccache-cache env vars (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          echo "CC=sccache clang" >> $GITHUB_ENV
+          echo "CXX=sccache clang" >> $GITHUB_ENV
+
+      - name: Set sccache-cache env vars (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
@@ -300,8 +310,6 @@ jobs:
       BUILD_MODE: release
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
-      CC: "sccache clang"
-      CXX: "sccache clang"
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -328,6 +336,18 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set sccache-cache env vars (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          echo "CC=sccache clang" >> $GITHUB_ENV
+          echo "CXX=sccache clang" >> $GITHUB_ENV
+
+      - name: Set sccache-cache env vars (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Set sccache-cache env vars (Windows)
         if: runner.os == 'Windows'
         run: |
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
+          echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
@@ -346,8 +346,8 @@ jobs:
       - name: Set sccache-cache env vars (Windows)
         if: runner.os == 'Windows'
         run: |
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
+          echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -104,6 +105,7 @@ jobs:
     env:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"
@@ -204,6 +206,7 @@ jobs:
       COPY_TO_SOURCE: false # Do not copy built *.so files back into source tree
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang"
@@ -311,6 +314,7 @@ jobs:
       BUILD_MODE: release
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
 
     steps:
       - name: Free disk space (Ubuntu)


### PR DESCRIPTION
# Pull Request

Use `sccache` to speedup CI

- https://github.com/mozilla/sccache

Execution stats in task `Post Run sccache-cache`.

# But

When using GitHub Actions cache as the storage for sccache, sccache frequently hits the service's rate limit, resulting in the following error: `Failed to restore: Cache service responded with 429`。