### PR TITLE
Fix order handling for BEST_EFFORT_CANCELED messages of dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/common/enums.py
+++ b/nautilus_trader/adapters/dydx/common/enums.py
@@ -244,7 +244,7 @@ class DYDXEnumParser:
             DYDXOrderStatus.OPEN: OrderStatus.ACCEPTED,
             DYDXOrderStatus.FILLED: OrderStatus.FILLED,
             DYDXOrderStatus.CANCELED: OrderStatus.CANCELED,
-            DYDXOrderStatus.BEST_EFFORT_CANCELED: OrderStatus.CANCELED,
+            DYDXOrderStatus.BEST_EFFORT_CANCELED: OrderStatus.ACCEPTED,
             DYDXOrderStatus.BEST_EFFORT_OPENED: OrderStatus.ACCEPTED,
             DYDXOrderStatus.UNTRIGGERED: OrderStatus.ACCEPTED,
         }

--- a/nautilus_trader/adapters/dydx/common/enums.py
+++ b/nautilus_trader/adapters/dydx/common/enums.py
@@ -244,7 +244,7 @@ class DYDXEnumParser:
             DYDXOrderStatus.OPEN: OrderStatus.ACCEPTED,
             DYDXOrderStatus.FILLED: OrderStatus.FILLED,
             DYDXOrderStatus.CANCELED: OrderStatus.CANCELED,
-            DYDXOrderStatus.BEST_EFFORT_CANCELED: OrderStatus.ACCEPTED,
+            DYDXOrderStatus.BEST_EFFORT_CANCELED: OrderStatus.PENDING_CANCEL,
             DYDXOrderStatus.BEST_EFFORT_OPENED: OrderStatus.ACCEPTED,
             DYDXOrderStatus.UNTRIGGERED: OrderStatus.ACCEPTED,
         }

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1089,6 +1089,7 @@ class DYDXExecutionClient(LiveExecutionClient):
             OrderSide.SELL: DYDXOrder.Side.SIDE_SELL,
         }
         time_in_force_map = {
+            TimeInForce.GTC: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
             TimeInForce.GTD: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
             TimeInForce.IOC: DYDXOrder.TimeInForce.TIME_IN_FORCE_IOC,
             TimeInForce.FOK: DYDXOrder.TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -79,7 +79,6 @@ from nautilus_trader.live.retry import RetryManagerPool
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OrderSide
-from nautilus_trader.model.enums import OrderStatus
 from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.enums import PositionSide
 from nautilus_trader.model.enums import TimeInForce
@@ -885,19 +884,19 @@ class DYDXExecutionClient(LiveExecutionClient):
                 venue_order_id=report.venue_order_id,
                 ts_event=report.ts_last,
             )
-        elif order_msg.status in (DYDXOrderStatus.BEST_EFFORT_CANCELED, DYDXOrderStatus.CANCELED):
-            if order.status != OrderStatus.CANCELED:
-                self.generate_order_canceled(
-                    strategy_id=strategy_id,
-                    instrument_id=report.instrument_id,
-                    client_order_id=report.client_order_id,
-                    venue_order_id=report.venue_order_id,
-                    ts_event=report.ts_last,
-                )
-        elif order_msg.status == DYDXOrderStatus.FILLED:
-            # Skip order filled message. The _handle_fill_message generates
+        elif order_msg.status == DYDXOrderStatus.CANCELED:
+            self.generate_order_canceled(
+                strategy_id=strategy_id,
+                instrument_id=report.instrument_id,
+                client_order_id=report.client_order_id,
+                venue_order_id=report.venue_order_id,
+                ts_event=report.ts_last,
+            )
+        elif order_msg.status in (DYDXOrderStatus.FILLED, DYDXOrderStatus.BEST_EFFORT_CANCELED):
+            # Skip order filled message and best effort canceled message. The _handle_fill_message generates
             # a fill report.
-            self._log.debug(f"Skip order fill message: {order_msg}")
+            # Best effort canceled is not a terminal state. Hence, we keep the state at accepted.
+            self._log.debug(f"Skip order message: {order_msg}")
         else:
             message = f"Unknown order status `{order_msg.status}`"
             self._log.error(message)
@@ -1090,7 +1089,6 @@ class DYDXExecutionClient(LiveExecutionClient):
             OrderSide.SELL: DYDXOrder.Side.SIDE_SELL,
         }
         time_in_force_map = {
-            TimeInForce.GTC: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
             TimeInForce.GTD: DYDXOrder.TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
             TimeInForce.IOC: DYDXOrder.TimeInForce.TIME_IN_FORCE_IOC,
             TimeInForce.FOK: DYDXOrder.TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -144,7 +144,7 @@ def test_parse_nautilus_order_side(
         (DYDXOrderStatus.OPEN, OrderStatus.ACCEPTED),
         (DYDXOrderStatus.FILLED, OrderStatus.FILLED),
         (DYDXOrderStatus.CANCELED, OrderStatus.CANCELED),
-        (DYDXOrderStatus.BEST_EFFORT_CANCELED, OrderStatus.ACCEPTED),
+        (DYDXOrderStatus.BEST_EFFORT_CANCELED, OrderStatus.PENDING_CANCEL),
         (DYDXOrderStatus.BEST_EFFORT_OPENED, OrderStatus.ACCEPTED),
         (DYDXOrderStatus.UNTRIGGERED, OrderStatus.ACCEPTED),
     ],

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -144,8 +144,9 @@ def test_parse_nautilus_order_side(
         (DYDXOrderStatus.OPEN, OrderStatus.ACCEPTED),
         (DYDXOrderStatus.FILLED, OrderStatus.FILLED),
         (DYDXOrderStatus.CANCELED, OrderStatus.CANCELED),
-        (DYDXOrderStatus.BEST_EFFORT_CANCELED, OrderStatus.CANCELED),
+        (DYDXOrderStatus.BEST_EFFORT_CANCELED, OrderStatus.ACCEPTED),
         (DYDXOrderStatus.BEST_EFFORT_OPENED, OrderStatus.ACCEPTED),
+        (DYDXOrderStatus.UNTRIGGERED, OrderStatus.ACCEPTED),
     ],
 )
 def test_parse_order_status(

--- a/tests/integration_tests/adapters/dydx/test_websocket_schema.py
+++ b/tests/integration_tests/adapters/dydx/test_websocket_schema.py
@@ -698,7 +698,7 @@ def test_account_channel_data_order_best_effort_canceled() -> None:
         order_side=OrderSide.SELL,
         order_type=OrderType.LIMIT,
         time_in_force=TimeInForce.IOC,
-        order_status=OrderStatus.CANCELED,
+        order_status=OrderStatus.ACCEPTED,
         price=Price(2519.4, 4),
         quantity=Quantity(0.003, 5),
         filled_qty=Quantity(0, 5),

--- a/tests/integration_tests/adapters/dydx/test_websocket_schema.py
+++ b/tests/integration_tests/adapters/dydx/test_websocket_schema.py
@@ -698,7 +698,7 @@ def test_account_channel_data_order_best_effort_canceled() -> None:
         order_side=OrderSide.SELL,
         order_type=OrderType.LIMIT,
         time_in_force=TimeInForce.IOC,
-        order_status=OrderStatus.ACCEPTED,
+        order_status=OrderStatus.PENDING_CANCEL,
         price=Price(2519.4, 4),
         quantity=Quantity(0.003, 5),
         filled_qty=Quantity(0, 5),


### PR DESCRIPTION
# Pull Request

Fix order handling for BEST_EFFORT_CANCELED messages of dYdX

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example and unit tests