### PR TITLE
Add `max_ws_reconnection_tries` to exec client config for Bybit

### DIFF
--- a/nautilus_trader/adapters/bybit/config.py
+++ b/nautilus_trader/adapters/bybit/config.py
@@ -43,7 +43,7 @@ class BybitDataClientConfig(LiveDataClientConfig, frozen=True):
         If the client is connecting to the Bybit testnet API.
     update_instruments_interval_mins: PositiveInt or None, default 60
         The interval (minutes) between reloading instruments from the venue.
-    max_reconnection_tries: int, default 3
+    max_ws_reconnection_tries: int, default 3
         The number of retries to reconnect the websocket connection if the
         connection is broken.
 
@@ -89,6 +89,9 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
         The maximum number of times a submit, cancel or modify order request will be retried.
     retry_delay : PositiveFloat, optional
         The delay (seconds) between retries. Short delays with frequent retries may result in account bans.
+    max_ws_reconnection_tries: int, default 3
+        The number of retries to reconnect the websocket connection if the
+        connection is broken.
 
     Warnings
     --------
@@ -106,3 +109,4 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     use_gtd: bool = False  # Not supported on Bybit
     max_retries: PositiveInt | None = None
     retry_delay: PositiveFloat | None = None
+    max_ws_reconnection_tries: int | None = 3

--- a/nautilus_trader/adapters/bybit/execution.py
+++ b/nautilus_trader/adapters/bybit/execution.py
@@ -181,6 +181,7 @@ class BybitExecutionClient(LiveExecutionClient):
             api_key=config.api_key or get_api_key(config.demo, config.testnet),
             api_secret=config.api_secret or get_api_secret(config.demo, config.testnet),
             loop=loop,
+            max_reconnection_tries=config.max_ws_reconnection_tries,
         )
 
         # HTTP API

--- a/nautilus_trader/adapters/dydx/config.py
+++ b/nautilus_trader/adapters/dydx/config.py
@@ -36,7 +36,7 @@ class DYDXDataClientConfig(LiveDataClientConfig, frozen=True):
         If the client is connecting to the dYdX testnet API.
     update_instruments_interval_mins: PositiveInt or None, default 60
         The interval (minutes) between reloading instruments from the venue.
-    max_reconnection_tries: int, default 3
+    max_ws_reconnection_tries: int, default 3
         The number of retries to reconnect the websocket connection if the
         connection is broken.
 


### PR DESCRIPTION
# Pull Request

Add `max_ws_reconnection_tries` to exec client config for Bybit.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
