### PR TITLE
Add WebSocket API trading support for Bybit

### DIFF
--- a/examples/live/bybit/bybit_ema_cross.py
+++ b/examples/live/bybit/bybit_ema_cross.py
@@ -80,7 +80,7 @@ config_node = TradingNodeConfig(
             api_key=None,  # 'BYBIT_API_KEY' env var
             api_secret=None,  # 'BYBIT_API_SECRET' env var
             base_url_http=None,  # Override with custom endpoint
-            base_url_ws=None,  # Override with custom endpoint
+            base_url_ws_private=None,  # Override with custom endpoint
             instrument_provider=InstrumentProviderConfig(load_all=True),
             product_types=[product_type],
             testnet=False,  # If client uses the testnet

--- a/examples/live/bybit/bybit_ema_cross_bracket_algo.py
+++ b/examples/live/bybit/bybit_ema_cross_bracket_algo.py
@@ -83,7 +83,7 @@ config_node = TradingNodeConfig(
             api_key=None,  # 'BYBIT_API_KEY' env var
             api_secret=None,  # 'BYBIT_API_SECRET' env var
             base_url_http=None,  # Override with custom endpoint
-            base_url_ws=None,  # Override with custom endpoint
+            base_url_ws_private=None,  # Override with custom endpoint
             instrument_provider=InstrumentProviderConfig(load_all=True),
             product_types=[product_type],
             testnet=False,  # If client uses the testnet

--- a/examples/live/bybit/bybit_ema_cross_stop_entry.py
+++ b/examples/live/bybit/bybit_ema_cross_stop_entry.py
@@ -69,7 +69,7 @@ config_node = TradingNodeConfig(
             api_key=None,  # 'BYBIT_API_KEY' env var
             api_secret=None,  # 'BYBIT_API_SECRET' env var
             base_url_http=None,  # Override with custom endpoint
-            base_url_ws=None,  # Override with custom endpoint
+            base_url_ws_private=None,  # Override with custom endpoint
             instrument_provider=InstrumentProviderConfig(load_all=True),
             product_types=[product_type],
             testnet=False,  # If client uses the testnet

--- a/examples/live/bybit/bybit_ema_cross_with_trailing_stop.py
+++ b/examples/live/bybit/bybit_ema_cross_with_trailing_stop.py
@@ -69,7 +69,7 @@ config_node = TradingNodeConfig(
             api_key=None,  # 'BYBIT_API_KEY' env var
             api_secret=None,  # 'BYBIT_API_SECRET' env var
             base_url_http=None,  # Override with custom endpoint
-            base_url_ws=None,  # Override with custom endpoint
+            base_url_ws_private=None,  # Override with custom endpoint
             instrument_provider=InstrumentProviderConfig(load_all=True),
             product_types=[product_type],
             testnet=False,  # If client uses the testnet

--- a/examples/live/bybit/bybit_market_maker.py
+++ b/examples/live/bybit/bybit_market_maker.py
@@ -95,7 +95,7 @@ config_node = TradingNodeConfig(
             api_key=None,  # 'BYBIT_API_KEY' env var
             api_secret=None,  # 'BYBIT_API_SECRET' env var
             base_url_http=None,  # Override with custom endpoint
-            base_url_ws=None,  # Override with custom endpoint
+            base_url_ws_private=None,  # Override with custom endpoint
             instrument_provider=InstrumentProviderConfig(load_all=True),
             product_types=[product_type],
             demo=False,  # If client uses the demo API

--- a/nautilus_trader/adapters/bybit/common/constants.py
+++ b/nautilus_trader/adapters/bybit/common/constants.py
@@ -32,6 +32,12 @@ BYBIT_ALL_PRODUCTS: Final[list[BybitProductType]] = [
 # Set of Bybit error codes for which Nautilus will attempt retries,
 # potentially temporary conditions where a retry might make sense.
 BYBIT_RETRY_ERRORS_UTA: Final[set[int]] = {
+    # > ------------------------------------------------------------
+    # > Self defined error codes
+    -10_408,  # Client request timed out
+    # > ------------------------------------------------------------
+    # > Bybit defined error codes
+    # > https://bybit-exchange.github.io/docs/v5/error
     10_000,  # Server Timeout
     10_002,  # The request time exceeds the time window range
     10_006,  # Too many visits. Exceeded the API Rate Limit

--- a/nautilus_trader/adapters/bybit/common/enums.py
+++ b/nautilus_trader/adapters/bybit/common/enums.py
@@ -117,6 +117,13 @@ class BybitPositionSide(Enum):
 
 
 @unique
+class BybitWsOrderRequestMsgOP(Enum):
+    CREATE = "order.create"
+    AMEND = "order.amend"
+    CANCEL = "order.cancel"
+
+
+@unique
 class BybitKlineInterval(Enum):
     MINUTE_1 = "1"
     MINUTE_3 = "3"
@@ -149,6 +156,7 @@ class BybitOrderStatus(Enum):
 
 @unique
 class BybitOrderSide(Enum):
+    UNKNOWN = ""  # It will be an empty string in some cases
     BUY = "Buy"
     SELL = "Sell"
 

--- a/nautilus_trader/adapters/bybit/common/urls.py
+++ b/nautilus_trader/adapters/bybit/common/urls.py
@@ -62,3 +62,10 @@ def get_ws_base_url_private(is_testnet: bool) -> str:
         return "wss://stream-testnet.bybit.com/v5/private"
     else:
         return "wss://stream.bybit.com/v5/private"
+
+
+def get_ws_base_url_trade(is_testnet: bool) -> str:
+    if is_testnet:
+        return "wss://stream-testnet.bybit.com/v5/trade"
+    else:
+        return "wss://stream.bybit.com/v5/trade"

--- a/nautilus_trader/adapters/bybit/config.py
+++ b/nautilus_trader/adapters/bybit/config.py
@@ -91,7 +91,7 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
         (this is useful if managing GTD orders locally).
     use_ws_trade_api : bool, default False
         If the client is using websocket to send order requests.
-    use_http_batch_api: bool, default False
+    use_http_batch_api : bool, default False
         If the client is using http api to send batch order requests.
         Effective only when `use_ws_trade_api` is set to `True`.
     max_retries : PositiveInt, optional

--- a/nautilus_trader/adapters/bybit/config.py
+++ b/nautilus_trader/adapters/bybit/config.py
@@ -101,7 +101,7 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     max_ws_reconnection_tries: int, default 3
         The number of retries to reconnect the websocket connection if the
         connection is broken.
-    ws_trade_timeout_secs: float, default 5.0
+    ws_trade_timeout_secs : float, default 5.0
         The timeout for trade websocket messages.
 
     Warnings

--- a/nautilus_trader/adapters/bybit/config.py
+++ b/nautilus_trader/adapters/bybit/config.py
@@ -78,6 +78,10 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
         If None then will default to 'SPOT', you also cannot mix 'SPOT' with
         any other product type for execution, and it will use a `CASH` account
         type, vs `MARGIN` for the other derivative products.
+    base_url_ws_private : str, optional
+        The base URL for the `private` WebSocket client.
+    base_url_ws_trade : str, optional
+        The base URL for the `trade` WebSocket client.
     demo : bool, default False
         If the client is connecting to the Bybit demo API.
     testnet : bool, default False
@@ -85,6 +89,11 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     use_gtd : bool, default False
         If False, then GTD time in force will be remapped to GTC
         (this is useful if managing GTD orders locally).
+    use_ws_trade_api : bool, default False
+        If the client is using websocket to send order requests.
+    use_http_batch_api: bool, default False
+        If the client is using http api to send batch order requests.
+        Effective only when `use_ws_trade_api` is set to `True`.
     max_retries : PositiveInt, optional
         The maximum number of times a submit, cancel or modify order request will be retried.
     retry_delay : PositiveFloat, optional
@@ -92,6 +101,8 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     max_ws_reconnection_tries: int, default 3
         The number of retries to reconnect the websocket connection if the
         connection is broken.
+    ws_trade_timeout_secs: float, default 5.0
+        The timeout for trade websocket messages.
 
     Warnings
     --------
@@ -103,10 +114,14 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     api_secret: str | None = None
     product_types: list[BybitProductType] | None = None
     base_url_http: str | None = None
-    base_url_ws: str | None = None
+    base_url_ws_private: str | None = None
+    base_url_ws_trade: str | None = None
     demo: bool = False
     testnet: bool = False
     use_gtd: bool = False  # Not supported on Bybit
+    use_ws_trade_api: bool = False
+    use_http_batch_api: bool = False
     max_retries: PositiveInt | None = None
     retry_delay: PositiveFloat | None = None
     max_ws_reconnection_tries: int | None = 3
+    ws_trade_timeout_secs: float | None = 5.0

--- a/nautilus_trader/adapters/bybit/factories.py
+++ b/nautilus_trader/adapters/bybit/factories.py
@@ -23,6 +23,7 @@ from nautilus_trader.adapters.bybit.common.enums import BybitProductType
 from nautilus_trader.adapters.bybit.common.urls import get_http_base_url
 from nautilus_trader.adapters.bybit.common.urls import get_ws_base_url_private
 from nautilus_trader.adapters.bybit.common.urls import get_ws_base_url_public
+from nautilus_trader.adapters.bybit.common.urls import get_ws_base_url_trade
 from nautilus_trader.adapters.bybit.config import BybitDataClientConfig
 from nautilus_trader.adapters.bybit.config import BybitExecClientConfig
 from nautilus_trader.adapters.bybit.data import BybitDataClient
@@ -255,7 +256,10 @@ class BybitLiveExecClientFactory(LiveExecClientFactory):
             product_types=frozenset(config.product_types or BYBIT_ALL_PRODUCTS),
             config=config.instrument_provider,
         )
-        base_url_ws: str = get_ws_base_url_private(config.testnet)
+
+        base_url_ws_private: str = get_ws_base_url_private(config.testnet)
+        base_url_ws_trade: str = get_ws_base_url_trade(config.testnet)
+
         return BybitExecutionClient(
             loop=loop,
             client=client,
@@ -264,7 +268,8 @@ class BybitLiveExecClientFactory(LiveExecClientFactory):
             clock=clock,
             instrument_provider=provider,
             product_types=config.product_types or [BybitProductType.SPOT],
-            base_url_ws=config.base_url_ws or base_url_ws,
+            base_url_ws_private=config.base_url_ws_private or base_url_ws_private,
+            base_url_ws_trade=config.base_url_ws_trade or base_url_ws_trade,
             config=config,
             name=name,
         )

--- a/nautilus_trader/adapters/bybit/http/account.py
+++ b/nautilus_trader/adapters/bybit/http/account.py
@@ -79,7 +79,6 @@ from nautilus_trader.core.correctness import PyCondition
 
 if TYPE_CHECKING:
     from nautilus_trader.adapters.bybit.common.enums import BybitMarginMode
-    from nautilus_trader.adapters.bybit.common.enums import BybitProductType
     from nautilus_trader.adapters.bybit.http.client import BybitHttpClient
     from nautilus_trader.adapters.bybit.schemas.account.info import BybitAccountInfo
     from nautilus_trader.adapters.bybit.schemas.account.set_leverage import BybitSetLeverageResponse

--- a/nautilus_trader/adapters/bybit/websocket/client.py
+++ b/nautilus_trader/adapters/bybit/websocket/client.py
@@ -13,14 +13,32 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import asyncio
-from collections.abc import Awaitable
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING
 
-import msgspec
+from msgspec import json as msgspec_json
 
-from nautilus_trader.adapters.bybit.schemas.ws import BybitWsSubscriptionMsg
+from nautilus_trader.adapters.bybit.common.enums import BybitOrderSide
+from nautilus_trader.adapters.bybit.common.enums import BybitOrderType
+from nautilus_trader.adapters.bybit.common.enums import BybitProductType
+from nautilus_trader.adapters.bybit.common.enums import BybitTimeInForce
+from nautilus_trader.adapters.bybit.common.enums import BybitTpSlMode
+from nautilus_trader.adapters.bybit.common.enums import BybitTriggerDirection
+from nautilus_trader.adapters.bybit.common.enums import BybitTriggerType
+from nautilus_trader.adapters.bybit.common.enums import BybitWsOrderRequestMsgOP
+
+# fmt: off
+from nautilus_trader.adapters.bybit.endpoints.trade.amend_order import BybitAmendOrderPostParams
+from nautilus_trader.adapters.bybit.endpoints.trade.cancel_order import BybitCancelOrderPostParams
+from nautilus_trader.adapters.bybit.endpoints.trade.place_order import BybitPlaceOrderPostParams
+from nautilus_trader.adapters.bybit.http.errors import BybitError
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsMessageGeneral
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsOrderRequestMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsOrderResponseMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsPrivateChannelAuthMsg
+from nautilus_trader.adapters.bybit.schemas.ws import BybitWsTradeAuthMsg
 from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import Logger
 from nautilus_trader.common.enums import LogColor
@@ -28,9 +46,23 @@ from nautilus_trader.core.nautilus_pyo3 import WebSocketClient
 from nautilus_trader.core.nautilus_pyo3 import WebSocketClientError
 from nautilus_trader.core.nautilus_pyo3 import WebSocketConfig
 from nautilus_trader.core.nautilus_pyo3 import hmac_signature
+from nautilus_trader.core.uuid import UUID4
 
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from collections.abc import Callable
+    from collections.abc import Coroutine
+    from typing import Any
+
+    from nautilus_trader.adapters.bybit.endpoints.trade.batch_cancel_order import BybitBatchCancelOrder
+    from nautilus_trader.adapters.bybit.endpoints.trade.batch_place_order import BybitBatchPlaceOrder
+
+# fmt: on
 
 MAX_ARGS_PER_SUBSCRIPTION_REQUEST = 10
+
+WsOrderResponseFuture = asyncio.Future[BybitWsOrderResponseMsg]
 
 
 class BybitWebSocketClient:
@@ -47,9 +79,15 @@ class BybitWebSocketClient:
         The callback handler for message events.
     handler_reconnect : Callable[..., Awaitable[None]], optional
         The callback handler to be called on reconnect.
+    is_private : bool, optional
+        Whether the client is a private channel.
+    is_trade : bool, optional
+        Whether the client is a trade channel.
     max_reconnection_tries: int, default 3
         The number of retries to reconnect the websocket connection if the
         connection is broken.
+    ws_trade_timeout_secs: float, default 5.0
+        The timeout for trade websocket messages.
 
     """
 
@@ -63,7 +101,9 @@ class BybitWebSocketClient:
         api_secret: str,
         loop: asyncio.AbstractEventLoop,
         is_private: bool | None = False,
+        is_trade: bool | None = False,
         max_reconnection_tries: int | None = 3,
+        ws_trade_timeout_secs: float | None = 5.0,
     ) -> None:
         self._clock = clock
         self._log: Logger = Logger(name=type(self).__name__)
@@ -73,17 +113,30 @@ class BybitWebSocketClient:
         self._handler_reconnect: Callable[..., Awaitable[None]] | None = handler_reconnect
         self._loop = loop
         self._max_reconnection_tries = max_reconnection_tries
+        self._ws_trade_timeout_secs = ws_trade_timeout_secs
 
         self._client: WebSocketClient | None = None
         self._api_key = api_key
         self._api_secret = api_secret
-        self._is_private = is_private
         self._is_running = False
+        self._reconnecting = False
 
         self._subscriptions: list[str] = []
 
+        self._is_private = is_private
+        self._is_trade = is_trade
+        self._auth_required = is_private or is_trade
         self._is_authenticated = False
-        self._decoder_ws_subscription = msgspec.json.Decoder(BybitWsSubscriptionMsg)
+
+        self._decoder_ws_message_general = msgspec_json.Decoder(BybitWsMessageGeneral)
+        self._decoder_ws_private_channel_auth = msgspec_json.Decoder(BybitWsPrivateChannelAuthMsg)
+        self._decoder_ws_trade_auth = msgspec_json.Decoder(BybitWsTradeAuthMsg)
+        self._decoder_ws_order_response = msgspec_json.Decoder(BybitWsOrderResponseMsg)
+
+        self._pending_order_requests: dict[str, WsOrderResponseFuture] = {}
+
+        if self._is_private and self._is_trade:
+            raise ValueError("`is_private` and `is_trade` cannot both be True")
 
     @property
     def subscriptions(self) -> list[str]:
@@ -92,6 +145,15 @@ class BybitWebSocketClient:
     def has_subscription(self, item: str) -> bool:
         return item in self._subscriptions
 
+    @property
+    def channel_type(self) -> str:
+        if self._is_private:
+            return "Private"
+        elif self._is_trade:
+            return "Trade"
+        else:
+            return "Public"
+
     async def connect(self) -> None:
         self._is_running = True
         self._log.debug(f"Connecting to {self._base_url} websocket stream")
@@ -99,7 +161,7 @@ class BybitWebSocketClient:
             url=self._base_url,
             handler=self._msg_handler,
             heartbeat=20,
-            heartbeat_msg=msgspec.json.encode({"op": "ping"}).decode(),
+            heartbeat_msg=msgspec_json.encode({"op": "ping"}).decode(),
             headers=[],
             max_reconnection_tries=self._max_reconnection_tries,
         )
@@ -111,34 +173,42 @@ class BybitWebSocketClient:
         self._log.info(f"Connected to {self._base_url}", LogColor.BLUE)
 
         # Authenticate
-        if self._is_private:
+        if self._auth_required:
             await self._authenticate()
 
     def reconnect(self) -> None:
         """
         Reconnect the client to the server and resubscribe to all streams.
         """
-        if not self._is_running:
+        if not self._is_running or self._reconnecting:
             return
 
         self._log.warning(f"Trying to reconnect to {self._base_url}")
+        self._reconnecting = True
         self._loop.create_task(self._reconnect_wrapper())
 
     async def _reconnect_wrapper(self) -> None:
-        # Authenticate
-        if self._is_private:
-            await self._authenticate()
+        try:
+            # Authenticate
+            if self._auth_required:
+                await self._authenticate()
 
-        # Re-subscribe to all streams
-        await self._subscribe_all()
+            if self._is_private:
+                # Re-subscribe to all streams
+                await self._subscribe_all()
 
-        if self._handler_reconnect:
-            await self._handler_reconnect()
+            if self._handler_reconnect:
+                await self._handler_reconnect()
 
-        self._log.warning(f"Reconnected to {self._base_url}")
+            self._log.warning(f"Reconnected to {self._base_url}")
+        except Exception as e:
+            self._log.error(f"Reconnection failed: {e}")
+        finally:
+            self._reconnecting = False
 
     async def disconnect(self) -> None:
         self._is_running = False
+        self._reconnecting = False
 
         if self._client is None:
             self._log.warning("Cannot disconnect: not connected.")
@@ -163,16 +233,35 @@ class BybitWebSocketClient:
             The received message in bytes.
 
         """
-        if self._is_private and not self._is_authenticated:
-            msg = self._decoder_ws_subscription.decode(raw)
-            if msg.op == "auth":
-                if msg.success is True:
-                    self._is_authenticated = True
-                    self._log.info("Private channel authenticated")
-                else:
-                    raise RuntimeError(f"Private channel authentication failed: {msg}")
+        # TODO: better way to improve performance with high message volume?
+
+        msg = self._decoder_ws_message_general.decode(raw)
+        op = msg.op
+
+        if self._auth_required and not self._is_authenticated and op == "auth":
+            self._check_auth_success(raw)
+            return
+
+        if self._is_trade and op and "order." in op:
+            self._handle_order_ack(raw)
 
         self._handler(raw)
+
+    def _check_auth_success(self, raw: bytes) -> None:
+        msg: BybitWsPrivateChannelAuthMsg | BybitWsTradeAuthMsg
+
+        if self._is_private:
+            msg = self._decoder_ws_private_channel_auth.decode(raw)
+        elif self._is_trade:
+            msg = self._decoder_ws_trade_auth.decode(raw)
+        else:
+            raise RuntimeError("Invalid channel type")
+
+        if msg.is_auth_success():
+            self._is_authenticated = True
+            self._log.info(f"{self.channel_type} channel authenticated", LogColor.GREEN)
+        else:
+            raise RuntimeError(f"{self.channel_type} channel authentication failed: {msg}")
 
     async def _authenticate(self) -> None:
         self._is_authenticated = False
@@ -180,10 +269,11 @@ class BybitWebSocketClient:
         await self._send(signature)
 
         while not self._is_authenticated:
-            self._log.debug("Waiting for private channel authentication")
+            self._log.debug(f"Waiting for {self.channel_type} channel authentication")
             await asyncio.sleep(0.1)
 
     async def _subscribe(self, subscription: str) -> None:
+        self._log.debug(f"Subscribing to {subscription}")
         if subscription in self._subscriptions:
             self._log.warning(f"Cannot subscribe '{subscription}': already subscribed")
             return
@@ -200,6 +290,38 @@ class BybitWebSocketClient:
         self._subscriptions.remove(subscription)
         msg = {"op": "unsubscribe", "args": [subscription]}
         await self._send(msg)
+
+    async def _subscribe_all(self) -> None:
+        if self._client is None:
+            self._log.error("Cannot subscribe all: not connected")
+            return
+
+        self._log.info("Resubscribe to all data streams")
+
+        # You can input up to 10 args for each subscription request sent to one connection
+        subscription_lists = [
+            self._subscriptions[i : i + MAX_ARGS_PER_SUBSCRIPTION_REQUEST]
+            for i in range(0, len(self._subscriptions), MAX_ARGS_PER_SUBSCRIPTION_REQUEST)
+        ]
+
+        for subscriptions in subscription_lists:
+            msg = {"op": "subscribe", "args": subscriptions}
+            await self._send(msg)
+
+    async def _send(self, msg: dict[str, Any]) -> None:
+        await self._send_text(msgspec_json.encode(msg))
+
+    async def _send_text(self, msg: bytes) -> None:
+        if self._client is None:
+            self._log.error(f"Cannot send message {msg!r}: not connected")
+            return
+
+        self._log.debug(f"SENDING: {msg!r}")
+
+        try:
+            await self._client.send_text(msg)
+        except WebSocketClientError as e:
+            self._log.error(str(e))
 
     ################################################################################
     # Public
@@ -270,31 +392,235 @@ class BybitWebSocketClient:
             "args": [self._api_key, expires, signature],
         }
 
-    async def _subscribe_all(self) -> None:
-        if self._client is None:
-            self._log.error("Cannot subscribe all: not connected")
+    ################################################################################
+    # Trade
+    ################################################################################
+
+    def _handle_order_ack(self, raw: bytes) -> None:
+        try:
+            msg = self._decoder_ws_order_response.decode(raw)
+        except Exception as e:
+            self._log.error(f"Failed to decode order ack response {raw!r}: {e}")
             return
 
-        self._log.info("Resubscribe to all data streams")
+        req_id = msg.reqId
+        if not req_id:
+            self._log.debug(f"No `reqId` in order ack response: {msg}")
+            return
 
-        # You can input up to 10 args for each subscription request sent to one connection
-        subscription_lists = [
-            self._subscriptions[i : i + MAX_ARGS_PER_SUBSCRIPTION_REQUEST]
-            for i in range(0, len(self._subscriptions), MAX_ARGS_PER_SUBSCRIPTION_REQUEST)
+        ret_code = msg.retCode
+        future = self._pending_order_requests.pop(req_id, None)
+        if future is not None:
+            if ret_code == 0:
+                future.set_result(msg)
+            else:
+                future.set_exception(BybitError(code=ret_code, message=msg.retMsg))
+        else:
+            self._log.warning(f"Received ack for `unknown/timeout` reqId={req_id}, msg={msg}")
+            return
+
+    async def _order(
+        self,
+        op: BybitWsOrderRequestMsgOP,
+        args: list[
+            BybitPlaceOrderPostParams | BybitAmendOrderPostParams | BybitCancelOrderPostParams
+        ],
+        timeout_secs: float | None,
+    ) -> BybitWsOrderResponseMsg:
+        req_id = UUID4().value
+
+        future: WsOrderResponseFuture = self._loop.create_future()
+        self._pending_order_requests[req_id] = future
+
+        # Build request
+        request = BybitWsOrderRequestMsg(
+            reqId=req_id,
+            header={
+                "X-BAPI-TIMESTAMP": str(self._clock.timestamp_ms()),
+            },
+            op=op,
+            args=args,  # Args array, support one item only for now
+        )
+
+        # Send request
+        await self._send_text(msgspec_json.encode(request))
+
+        # Wait for response or timeout
+        try:
+            ack_resp = await asyncio.wait_for(future, timeout_secs)
+        except TimeoutError as e:
+            self._log.error(f"Order request `{req_id}` timed out. op={op}, args={args}")
+            future.cancel()
+            self._pending_order_requests.pop(req_id, None)
+            raise BybitError(code=-10_000, message="Request timed out") from e
+
+        return ack_resp
+
+    async def _batch_orders(
+        self,
+        tasks: list[Coroutine[Any, Any, BybitWsOrderResponseMsg]],
+    ) -> list[BybitWsOrderResponseMsg]:
+        futures = await asyncio.gather(*tasks, return_exceptions=True)
+
+        results: list[BybitWsOrderResponseMsg] = []
+        for result in futures:
+            if isinstance(result, BybitWsOrderResponseMsg):
+                results.append(result)
+            else:
+                self._log.error(f"Batch orders error: {result}")
+        return results
+
+    async def place_order(
+        self,
+        product_type: BybitProductType,
+        symbol: str,
+        side: BybitOrderSide,
+        quantity: str,
+        quote_quantity: bool,
+        order_type: BybitOrderType,
+        price: str | None = None,
+        time_in_force: BybitTimeInForce | None = None,
+        client_order_id: str | None = None,
+        reduce_only: bool | None = None,
+        tpsl_mode: BybitTpSlMode | None = None,
+        close_on_trigger: bool | None = None,
+        tp_order_type: BybitOrderType | None = None,
+        sl_order_type: BybitOrderType | None = None,
+        trigger_direction: BybitTriggerDirection | None = None,
+        trigger_type: BybitTriggerType | None = None,
+        trigger_price: str | None = None,
+        sl_trigger_price: str | None = None,
+        tp_trigger_price: str | None = None,
+        tp_limit_price: str | None = None,
+        sl_limit_price: str | None = None,
+    ) -> BybitWsOrderResponseMsg:
+        return await self._order(
+            timeout_secs=self._ws_trade_timeout_secs,
+            op=BybitWsOrderRequestMsgOP.CREATE,
+            args=[
+                BybitPlaceOrderPostParams(
+                    category=product_type,
+                    symbol=symbol,
+                    side=side,
+                    orderType=order_type,
+                    qty=quantity,
+                    marketUnit="baseCoin" if not quote_quantity else "quoteCoin",
+                    price=price,
+                    timeInForce=time_in_force,
+                    orderLinkId=client_order_id,
+                    reduceOnly=reduce_only,
+                    closeOnTrigger=close_on_trigger,
+                    tpslMode=tpsl_mode if product_type != BybitProductType.SPOT else None,
+                    triggerPrice=trigger_price,
+                    triggerDirection=trigger_direction,
+                    triggerBy=trigger_type,
+                    takeProfit=tp_trigger_price if product_type == BybitProductType.SPOT else None,
+                    stopLoss=sl_trigger_price if product_type == BybitProductType.SPOT else None,
+                    slTriggerBy=trigger_type if product_type != BybitProductType.SPOT else None,
+                    tpTriggerBy=trigger_type if product_type != BybitProductType.SPOT else None,
+                    tpLimitPrice=tp_limit_price if product_type != BybitProductType.SPOT else None,
+                    slLimitPrice=sl_limit_price if product_type != BybitProductType.SPOT else None,
+                    tpOrderType=tp_order_type,
+                    slOrderType=sl_order_type,
+                ),
+            ],
+        )
+
+    async def amend_order(
+        self,
+        product_type: BybitProductType,
+        symbol: str,
+        client_order_id: str | None = None,
+        venue_order_id: str | None = None,
+        trigger_price: str | None = None,
+        quantity: str | None = None,
+        price: str | None = None,
+    ) -> BybitWsOrderResponseMsg:
+        return await self._order(
+            timeout_secs=self._ws_trade_timeout_secs,
+            op=BybitWsOrderRequestMsgOP.AMEND,
+            args=[
+                BybitAmendOrderPostParams(
+                    category=product_type,
+                    symbol=symbol,
+                    orderId=venue_order_id,
+                    orderLinkId=client_order_id,
+                    triggerPrice=trigger_price,
+                    qty=quantity,
+                    price=price,
+                ),
+            ],
+        )
+
+    async def cancel_order(
+        self,
+        product_type: BybitProductType,
+        symbol: str,
+        client_order_id: str | None = None,
+        venue_order_id: str | None = None,
+        order_filter: str | None = None,
+    ) -> BybitWsOrderResponseMsg:
+        return await self._order(
+            timeout_secs=self._ws_trade_timeout_secs,
+            op=BybitWsOrderRequestMsgOP.CANCEL,
+            args=[
+                BybitCancelOrderPostParams(
+                    category=product_type,
+                    symbol=symbol,
+                    orderId=venue_order_id,
+                    orderLinkId=client_order_id,
+                    orderFilter=order_filter,
+                ),
+            ],
+        )
+
+    async def batch_place_orders(
+        self,
+        product_type: BybitProductType,
+        submit_orders: list[BybitBatchPlaceOrder],
+    ) -> list[BybitWsOrderResponseMsg]:
+        tasks = [
+            self.place_order(
+                product_type=product_type,
+                symbol=order.symbol,
+                side=order.side,
+                order_type=order.orderType,
+                quantity=order.qty,
+                quote_quantity=order.marketUnit == "quoteCoin",
+                price=order.price,
+                time_in_force=order.timeInForce,
+                client_order_id=order.orderLinkId,
+                reduce_only=order.reduceOnly,
+                close_on_trigger=order.closeOnTrigger,
+                trigger_price=order.triggerPrice,
+                trigger_direction=order.triggerDirection,
+                tp_order_type=order.tpOrderType,
+                sl_order_type=order.slOrderType,
+                tpsl_mode=order.tpslMode,
+                tp_trigger_price=order.takeProfit,
+                sl_trigger_price=order.stopLoss,
+                trigger_type=order.triggerBy,
+                tp_limit_price=order.tpLimitPrice,
+                sl_limit_price=order.slLimitPrice,
+            )
+            for order in submit_orders
         ]
 
-        for subscriptions in subscription_lists:
-            msg = {"op": "subscribe", "args": subscriptions}
-            await self._send(msg)
+        return await self._batch_orders(tasks)
 
-    async def _send(self, msg: dict[str, Any]) -> None:
-        if self._client is None:
-            self._log.error(f"Cannot send message {msg}: not connected")
-            return
+    async def batch_cancel_orders(
+        self,
+        product_type: BybitProductType,
+        cancel_orders: list[BybitBatchCancelOrder],
+    ) -> list[BybitWsOrderResponseMsg]:
+        tasks = [
+            self.cancel_order(
+                product_type=product_type,
+                symbol=order.symbol,
+                client_order_id=order.orderLinkId,
+                venue_order_id=order.orderId,
+            )
+            for order in cancel_orders
+        ]
 
-        self._log.debug(f"SENDING: {msg}")
-
-        try:
-            await self._client.send_text(msgspec.json.encode(msg))
-        except WebSocketClientError as e:
-            self._log.error(str(e))
+        return await self._batch_orders(tasks)

--- a/tests/integration_tests/adapters/bybit/resources/ws_messages/private/ws_position.json
+++ b/tests/integration_tests/adapters/bybit/resources/ws_messages/private/ws_position.json
@@ -21,6 +21,7 @@
             "takeProfit": "0",
             "stopLoss": "0",
             "trailingStop": "0",
+            "sessionAvgPrice": "0",
             "unrealisedPnl": "-1.8075",
             "cumRealisedPnl": "0.64782276",
             "createdTime": "1672121182216",
@@ -31,6 +32,10 @@
             "category": "linear",
             "positionStatus": "Normal",
             "adlRankIndicator": 2,
+            "autoAddMargin": 0,
+            "leverageSysUpdatedTime": "",
+            "mmrSysUpdatedTime": "",
+            "isReduceOnly": false,
             "seq": 4688002127
         }
     ]

--- a/tests/integration_tests/adapters/bybit/test_ws_decoders.py
+++ b/tests/integration_tests/adapters/bybit/test_ws_decoders.py
@@ -583,7 +583,7 @@ class TestBybitWsDecoders:
             tpslMode="Full",
             liqPrice="",
             bustPrice="",
-            category="linear",
+            category=BybitProductType.LINEAR,
             positionStatus="Normal",
             adlRankIndicator=2,
             autoAddMargin=0,

--- a/tests/integration_tests/adapters/bybit/test_ws_decoders.py
+++ b/tests/integration_tests/adapters/bybit/test_ws_decoders.py
@@ -575,6 +575,7 @@ class TestBybitWsDecoders:
             takeProfit="0",
             stopLoss="0",
             trailingStop="0",
+            sessionAvgPrice="0",
             unrealisedPnl="-1.8075",
             cumRealisedPnl="0.64782276",
             createdTime="1672121182216",
@@ -585,6 +586,10 @@ class TestBybitWsDecoders:
             category="linear",
             positionStatus="Normal",
             adlRankIndicator=2,
+            autoAddMargin=0,
+            leverageSysUpdatedTime="",
+            mmrSysUpdatedTime="",
+            isReduceOnly=False,
             seq=4688002127,
         )
         assert result.data == [target_data]


### PR DESCRIPTION
# Pull Request

This PR introduces the ability to trade on Bybit using the [WebSocket API](https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline).
The implementation is controlled by the following parameters in `BybitExecClientConfig`:

- `use_ws_trade_api` : bool, default False
	- Enable or disable the use of the WebSocket API for trading. Use WS API if `True` else HTTP API.
- `use_http_batch_api` : bool, default False
	- Bybit's WebSocket trading API currently does not support batch operations, only single-order handling. This parameter provides a toggle to use the HTTP batch API for order batch operations instead of the WebSocket API.
- `ws_trade_timeout_secs` : float, default 5.0
	- Specifies the timeout in seconds to wait for `ACK` message from the WebSocket trading API.
- `base_url_ws_private` : str, optional
	- Customizable WebSocket URL for private channel.
- `base_url_ws_trade` : str, optional
	- Customizable WebSocket URL for trading channel.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this change been tested?

I replaced `nautilus_trader.adapters.bybit` and all its submodules with the local `monkey_patch.adapters.bybit` using `monkey patching`.
This setup has been running in my production strategy environment for about a week without any issues observed so far.