### PR TITLE
Allow bar aggregators to persist after request_aggregated_bars 

### DIFF
--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -133,17 +133,21 @@ class TestHistoricalAggStrategy(Strategy):
             f"{self.config.symbol_id}-5-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL",
         )
 
-        self.subscribe_bars(bar_type_1)
-        self.subscribe_bars(bar_type_2)
-        self.subscribe_bars(bar_type_3)
-
         self.request_aggregated_bars(
             [bar_type_1, bar_type_2, bar_type_3],
             start=start_historical_bars,
             end=end_historical_bars,
-            update_existing_subscriptions=True,
+            update_subscriptions=True,
             include_external_data=False,
         )
+
+        self.user_log("request_aggregated_bars done")
+
+        self.subscribe_bars(bar_type_1)
+        self.subscribe_bars(bar_type_2)
+        self.subscribe_bars(bar_type_3)
+
+        self.user_log("subscribe_bars done")
 
         #### for testing indicators with bars
         # self.register_indicator_for_bars(external_bar_type, self.external_sma)
@@ -161,16 +165,16 @@ class TestHistoricalAggStrategy(Strategy):
         # bar_type_1 = BarType.from_str(f"{self.config.symbol_id}-1-MINUTE-BID-INTERNAL")
         # bar_type_2 = BarType.from_str(f"{self.config.symbol_id}-2-MINUTE-BID-INTERNAL@1-MINUTE-INTERNAL")
 
-        # self.subscribe_bars(bar_type_1)
-        # self.subscribe_bars(bar_type_2)
-
         # self.request_aggregated_bars(
         #     [bar_type_1, bar_type_2],
         #     start=start_historical_bars,
         #     end=end_historical_bars,
-        #     update_existing_subscriptions=True,
+        #     update_subscriptions=True,
         #     include_external_data=False,
         # )
+
+        # self.subscribe_bars(bar_type_1)
+        # self.subscribe_bars(bar_type_2)
 
         ######### for testing trades
         # utc_now = self._clock.utc_now()
@@ -184,27 +188,29 @@ class TestHistoricalAggStrategy(Strategy):
         # bar_type_1 = BarType.from_str(f"{self.config.symbol_id}-1-MINUTE-LAST-INTERNAL")
         # bar_type_2 = BarType.from_str(f"{self.config.symbol_id}-2-MINUTE-LAST-INTERNAL@1-MINUTE-INTERNAL")
 
-        # self.subscribe_bars(bar_type_1)
-        # self.subscribe_bars(bar_type_2)
-
         # self.request_aggregated_bars(
         #     [bar_type_1, bar_type_2],
         #     start=start_historical_bars,
         #     end=end_historical_bars,
-        #     update_existing_subscriptions=True,
+        #     update_subscriptions=True,
         #     include_external_data=False,
         # )
 
+        # self.subscribe_bars(bar_type_1)
+        # self.subscribe_bars(bar_type_2)
+
     def on_historical_data(self, data):
         if type(data) is Bar:
-            self.user_log(f"historical bar ts_init = {unix_nanos_to_str(data.ts_init)}")
+            self.user_log(
+                f"historical bar ts_init = {unix_nanos_to_str(data.ts_init)}, {data.ts_init}",
+            )
             self.user_log(data)
 
             # self.user_log(f"{self.external_sma.value=}, {self.external_sma.initialized=}")
             # self.user_log(f"{self.composite_sma.value=}, {self.composite_sma.initialized=}")
 
     def on_bar(self, bar):
-        self.user_log(f"bar ts_init = {unix_nanos_to_str(bar.ts_init)}")
+        self.user_log(f"bar ts_init = {unix_nanos_to_str(bar.ts_init)}, {bar.ts_init}")
         self.user_log(bar)
 
         # self.user_log(f"{self.external_sma.value=}, {self.external_sma.initialized=}")

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -252,7 +252,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint include_external_data=*,
-        bint update_existing_subscriptions=*,
+        bint update_subscriptions=*,
         bint update_catalog=*,
         dict[str, object] params=*,
     )

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -2598,7 +2598,7 @@ cdef class Actor(Component):
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
         bint include_external_data = False,
-        bint update_existing_subscriptions = False,
+        bint update_subscriptions = False,
         bint update_catalog = False,
         dict[str, object] params = None,
     ):
@@ -2629,8 +2629,8 @@ cdef class Actor(Component):
             completed processing.
         include_external_data : bool, default False
             If True, includes the queried external data in the response.
-        update_existing_subscriptions : bool, default False
-            If True, updates the aggregators of any existing subscription with the queried external data.
+        update_subscriptions : bool, default False
+            If True, updates the aggregators of any existing or future subscription with the queried external data.
         update_catalog : bool, default False
             If True then updates the catalog with new data received from a client.
         params : dict[str, Any], optional
@@ -2687,7 +2687,7 @@ cdef class Actor(Component):
 
         params = params if params else {}
         params["include_external_data"] = include_external_data
-        params["update_existing_subscriptions"] = update_existing_subscriptions
+        params["update_subscriptions"] = update_subscriptions
         params["update_catalog"] = update_catalog
 
         cdef UUID4 request_id = UUID4()

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -66,6 +66,7 @@ cdef class BarAggregator:
     cdef object _handler_backup
     cdef bint _await_partial
     cdef bint _batch_mode
+    cdef public bint is_running
 
     cdef readonly BarType bar_type
     """The aggregators bar type.\n\n:returns: `BarType`"""

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -299,6 +299,7 @@ cdef class BarAggregator:
             bar_type=self.bar_type,
         )
         self._batch_mode = False
+        self.is_running = False # is_running means that an aggregator receives data from the message bus
 
     def start_batch_update(self, handler: Callable[[Bar], None], uint64_t time_ns) -> None:
         self._batch_mode = True

--- a/nautilus_trader/data/client.pyx
+++ b/nautilus_trader/data/client.pyx
@@ -361,6 +361,8 @@ cdef class MarketDataClient(DataClient):
         ----------
         data_type : DataType
             The data type for the subscription.
+        params : dict[str, Any], optional
+            Additional params for the subscription.
 
         """
         self._log.error(
@@ -543,6 +545,8 @@ cdef class MarketDataClient(DataClient):
         ----------
         data_type : DataType
             The data type for the subscription.
+        params : dict[str, Any], optional
+            Additional params for the subscription.
 
         """
         self._log.error(

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -198,6 +198,7 @@ cdef class DataEngine(Component):
     cpdef void _update_order_book(self, Data data)
     cpdef void _snapshot_order_book(self, TimeEvent snap_event)
     cpdef void _publish_order_book(self, InstrumentId instrument_id, str topic)
+    cpdef object _create_bar_aggregator(self, Instrument instrument, BarType bar_type)
     cpdef void _start_bar_aggregator(self, MarketDataClient client, BarType bar_type, bint await_partial, dict params)
     cpdef void _stop_bar_aggregator(self, MarketDataClient client, BarType bar_type, dict params)
     cpdef void _update_synthetics_with_quote(self, list synthetics, QuoteTick update)

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -2779,7 +2779,7 @@ class TestDataEngine:
         handler = []
         params = {}
         params["include_external_data"] = True
-        params["update_existing_subscriptions"] = False
+        params["update_subscriptions"] = False
         params["update_catalog"] = False
 
         request_id = UUID4()
@@ -2900,7 +2900,7 @@ class TestDataEngine:
         handler = []
         params = {}
         params["include_external_data"] = False
-        params["update_existing_subscriptions"] = False
+        params["update_subscriptions"] = False
         params["update_catalog"] = False
 
         request_id = UUID4()
@@ -2997,7 +2997,7 @@ class TestDataEngine:
         handler = []
         params = {}
         params["include_external_data"] = False
-        params["update_existing_subscriptions"] = False
+        params["update_subscriptions"] = False
         params["update_catalog"] = False
 
         request_id = UUID4()


### PR DESCRIPTION
# Pull Request

Allow bar aggregators to persist after request_aggregated_bars for future subscriptions

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change: change of argument name from update_existing_subscriptions to update_subscriptions

## How has this change been tested?

Existing tests
