### PR TITLE
Improve message bus topic matching performance

### DIFF
--- a/nautilus_core/common/src/msgbus/mod.rs
+++ b/nautilus_core/common/src/msgbus/mod.rs
@@ -638,6 +638,14 @@ mod tests {
     #[case("data.quotes.BINANCE", "data.*.BINANCE", true)]
     #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.*", true)]
     #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ETH*", true)]
+    #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ETH???", false)]
+    #[case("data.trades.BINANCE.ETHUSD", "data.*.BINANCE.ETH???", true)]
+    // We don't support [seq] style pattern
+    #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[HC]USDT", false)]
+    // We don't support [!seq] style pattern
+    #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[!ABC]USDT", false)]
+    // We don't support [^seq] style pattern
+    #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[^ABC]USDT", false)]
     fn test_is_matching(#[case] topic: &str, #[case] pattern: &str, #[case] expected: bool) {
         assert_eq!(
             is_matching(&Ustr::from(topic), &Ustr::from(pattern)),

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -2596,7 +2596,17 @@ cdef class MessageBus:
         return subs_array
 
 
+cdef inline bint contains_wildcard(str topic_or_pattern):
+    return '?' in topic_or_pattern or '*' in topic_or_pattern
+
+
 cdef inline bint is_matching(str topic, str pattern):
+    topic_contains_wildcard = contains_wildcard(topic)
+    pattern_contains_wildcard = contains_wildcard(pattern)
+
+    if not topic_contains_wildcard and not pattern_contains_wildcard:
+        return topic == pattern
+
     # Get length of string and wildcard pattern
     cdef int n = len(topic)
     cdef int m = len(pattern)

--- a/tests/unit_tests/msgbus/test_bus.py
+++ b/tests/unit_tests/msgbus/test_bus.py
@@ -469,6 +469,14 @@ class TestMessageBus:
         ["data.quotes.BINANCE", "data.*.BINANCE", True],
         ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.*", True],
         ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ETH*", True],
+        ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ETH???", False],
+        ["data.trades.BINANCE.ETHUSD", "data.*.BINANCE.ETH???", True],
+        # We don't support [seq] style pattern
+        ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[HC]USDT", False],
+        # We don't support [!seq] style pattern
+        ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[!ABC]USDT", False],
+        # We don't support [^seq] style pattern
+        ["data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[^ABC]USDT", False],
     ],
 )
 def test_is_matching_given_various_topic_pattern_combos(topic, pattern, expected):


### PR DESCRIPTION
# Pull Request

Improve `nautilus_trader.common.component.is_matching` exact match performance as suggested in #2150.

Also adds some more test cases.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Existing tests are almost sufficient.

For completeness, I have also added some more tests for
1. `?` pattern which we do support
2. `[seq]` and `[!seq]` pattern which do NOT support

