### PR TITLE
Handle directory and live streams to catalog

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -918,11 +918,16 @@ class ParquetDataCatalog(BaseDataCatalog):
         instance_id: str,
         data_cls: type,
         other_catalog: ParquetDataCatalog | None = None,
+        subdirectory: str = "backtest",
         **kwargs: Any,
     ) -> None:
         table_name = class_to_filename(data_cls)
-        feather_dir = Path(self.path) / "backtest" / instance_id
-        feather_files = sorted(feather_dir.glob(f"{table_name}_*.feather"))
+        feather_dir = Path(self.path) / subdirectory / instance_id
+
+        if (feather_dir / table_name).is_dir():
+            feather_files = sorted((feather_dir / table_name).glob("*.feather"))
+        else:
+            feather_files = sorted(feather_dir.glob(f"{table_name}_*.feather"))
 
         all_data = []
         for feather_file in feather_files:

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -166,7 +166,7 @@ def test_catalog_with_databento_instruments(catalog: ParquetDataCatalog) -> None
 
 
 @pytest.mark.skip(reason="Not yet partitioning")
-def test_partioning_min_rows_per_group(
+def test_partitioning_min_rows_per_group(
     catalog_betfair: ParquetDataCatalog,
 ) -> None:
     # Arrange

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -258,12 +258,20 @@ class TestPersistenceStreaming:
         assert result["NewsEventData"] == 86_985  # type: ignore
 
     def test_stream_to_data_directory(self, catalog_betfair: ParquetDataCatalog):
+        # Arrange - run backtest then delete data so we can test against it
         [backtest_result] = self._run_default_backtest(catalog_betfair)
+        catalog_betfair.fs.rm(f"{catalog_betfair.path}/data", recursive=True)
+        assert not catalog_betfair.list_data_types()
+
+        # Act
         catalog_betfair.convert_stream_to_data(
             backtest_result.instance_id,
             subdirectory="backtest",
             data_cls=TradeTick,
         )
+
+        # Assert
+        assert catalog_betfair.list_data_types() == ["trade_tick"]
 
     def test_feather_writer_signal_data(
         self,

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -257,6 +257,14 @@ class TestPersistenceStreaming:
         result = Counter([r.__class__.__name__ for r in result])  # type: ignore
         assert result["NewsEventData"] == 86_985  # type: ignore
 
+    def test_stream_to_data_directory(self, catalog_betfair: ParquetDataCatalog):
+        [backtest_result] = self._run_default_backtest(catalog_betfair)
+        catalog_betfair.convert_stream_to_data(
+            backtest_result.instance_id,
+            subdirectory="backtest",
+            data_cls=TradeTick,
+        )
+
     def test_feather_writer_signal_data(
         self,
         catalog_betfair: ParquetDataCatalog,


### PR DESCRIPTION
# Pull Request

Update `convert_stream_to_data` to allow converting `live` data and dir structure data types (`trade_tick`, `orderbook_deltas`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Test added.