### PR TITLE
Add data types for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/common/types.py
+++ b/nautilus_trader/adapters/dydx/common/types.py
@@ -13,9 +13,16 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pyarrow as pa
 
 from nautilus_trader.core import Data
 from nautilus_trader.model.custom import customdataclass
+from nautilus_trader.model.identifiers import InstrumentId
 
 
 @customdataclass
@@ -25,3 +32,71 @@ class DYDXInternalError(Data):
     """
 
     error_msg: str
+
+    _schema = pa.schema(
+        {
+            "error_msg": pa.string(),
+            "ts_event": pa.int64(),
+            "ts_init": pa.int64(),
+        },
+        metadata={"type": "DYDXInternalError"},
+    )
+
+
+@customdataclass
+class DYDXOraclePrice(Data):
+    """
+    Represents an oracle price.
+    """
+
+    instrument_id: InstrumentId
+    price: Decimal
+
+    _schema = pa.schema(
+        {
+            "instrument_id": pa.string(),
+            "price": pa.string(),
+            "ts_event": pa.int64(),
+            "ts_init": pa.int64(),
+        },
+        metadata={"type": "DYDXOraclePrice"},
+    )
+
+    @staticmethod
+    def to_dict(obj: DYDXOraclePrice) -> dict[str, Any]:
+        """
+        Return a dictionary representation of this object.
+
+        Returns
+        -------
+        dict[str, Any]
+
+        """
+        return {
+            "instrument_id": obj.instrument_id.value,
+            "price": str(obj.price),
+            "ts_event": obj.ts_event,
+            "ts_init": obj.ts_init,
+        }
+
+    @staticmethod
+    def from_dict(values: dict[str, Any]) -> DYDXOraclePrice:
+        """
+        Return a DYDXOraclePrice parsed from the given values.
+
+        Parameters
+        ----------
+        values : dict[str, Any]
+            The values for initialization.
+
+        Returns
+        -------
+        DYDXOraclePrice
+
+        """
+        return DYDXOraclePrice(
+            instrument_id=InstrumentId.from_str(values["instrument_id"]),
+            price=Decimal(values["price"]),
+            ts_event=values["ts_event"],
+            ts_init=values["ts_init"],
+        )

--- a/nautilus_trader/adapters/dydx/common/types.py
+++ b/nautilus_trader/adapters/dydx/common/types.py
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2024 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+
+from nautilus_trader.core import Data
+from nautilus_trader.model.custom import customdataclass
+
+
+@customdataclass
+class DYDXInternalError(Data):
+    """
+    Represents an internal error of the indexer.
+    """
+
+    error_msg: str

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -26,6 +26,7 @@ from nautilus_trader.adapters.dydx.common.constants import DYDX_VENUE
 from nautilus_trader.adapters.dydx.common.enums import DYDXEnumParser
 from nautilus_trader.adapters.dydx.common.parsing import get_interval_from_bar_type
 from nautilus_trader.adapters.dydx.common.symbol import DYDXSymbol
+from nautilus_trader.adapters.dydx.common.types import DYDXInternalError
 from nautilus_trader.adapters.dydx.config import DYDXDataClientConfig
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 from nautilus_trader.adapters.dydx.http.market import DYDXMarketHttpAPI
@@ -259,6 +260,13 @@ class DYDXDataClient(LiveMarketDataClient):
                 self._log.info("Websocket connected")
             elif ws_message.type == "error":
                 self._log.error(f"Websocket error: {ws_message.message}")
+                ts_init = self._clock.timestamp_ns()
+                dydx_internal_error = DYDXInternalError(
+                    error_msg=ws_message.message,
+                    ts_event=ts_init,
+                    ts_init=ts_init,
+                )
+                self._handle_data(dydx_internal_error)
             else:
                 self._log.error(
                     f"Unknown message `{ws_message.channel}` `{ws_message.type}`: {raw.decode()}",

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -45,6 +45,7 @@ from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.live.data_client import LiveMarketDataClient
+from nautilus_trader.model import DataType
 from nautilus_trader.model.book import OrderBook
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import BarType
@@ -266,7 +267,8 @@ class DYDXDataClient(LiveMarketDataClient):
                     ts_event=ts_init,
                     ts_init=ts_init,
                 )
-                self._handle_data(dydx_internal_error)
+                data_type = DataType(DYDXInternalError)
+                self._msgbus.publish(topic=f"data.{data_type.topic}", msg=dydx_internal_error)
             else:
                 self._log.error(
                     f"Unknown message `{ws_message.channel}` `{ws_message.type}`: {raw.decode()}",

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -259,7 +259,7 @@ class DYDXDataClient(LiveMarketDataClient):
             elif ws_message.type == "connected":
                 self._log.info("Websocket connected")
             elif ws_message.type == "error":
-                self._log.error(f"Websocket error: {ws_message.message}")
+                self._log.warning(f"Websocket error: {ws_message.message}")
                 ts_init = self._clock.timestamp_ns()
                 dydx_internal_error = DYDXInternalError(
                     error_msg=ws_message.message,


### PR DESCRIPTION
# Pull Request

- Add DYDXInternalError data type for dYdX. The data indexer regularly throws internal errors resulting in incorrect order books.
This gives the strategy the opportunity to halt trading and wait until a new snapshot arrives.
- Add a custom DYDXOraclePrice data type for dYdX. The oracle price is used to determine funding rates.

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?

Live example
