### PR TITLE
Implement Binance TradeLite message support

### DIFF
--- a/nautilus_trader/adapters/binance/config.py
+++ b/nautilus_trader/adapters/binance/config.py
@@ -110,6 +110,9 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
         If Binance Futures hedging position IDs should be used.
         If False, then order event `position_id`(s) from the execution client will be `None`, which
         allows *virtual* positions with `OmsType.HEDGING`.
+    use_tradelite: bool, default False
+        If TRADE_LITE events should be used.
+        If True, commissions will be calculated based on the instrument's details.
     treat_expired_as_canceled : bool, default False
         If the `EXPIRED` execution type is semantically treated as `CANCELED`.
         Binance treats cancels with certain combinations of order type and time in force as expired
@@ -139,6 +142,7 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
     use_gtd: bool = True
     use_reduce_only: bool = True
     use_position_ids: bool = True
+    use_tradelite: bool = False
     treat_expired_as_canceled: bool = False
     recv_window_ms: PositiveInt = 5_000
     max_retries: PositiveInt | None = None

--- a/nautilus_trader/adapters/binance/config.py
+++ b/nautilus_trader/adapters/binance/config.py
@@ -110,7 +110,7 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
         If Binance Futures hedging position IDs should be used.
         If False, then order event `position_id`(s) from the execution client will be `None`, which
         allows *virtual* positions with `OmsType.HEDGING`.
-    use_tradelite: bool, default False
+    use_trade_lite: bool, default False
         If TRADE_LITE events should be used.
         If True, commissions will be calculated based on the instrument's details.
     treat_expired_as_canceled : bool, default False
@@ -142,7 +142,7 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
     use_gtd: bool = True
     use_reduce_only: bool = True
     use_position_ids: bool = True
-    use_tradelite: bool = False
+    use_trade_lite: bool = False
     treat_expired_as_canceled: bool = False
     recv_window_ms: PositiveInt = 5_000
     max_retries: PositiveInt | None = None

--- a/nautilus_trader/adapters/binance/futures/execution.py
+++ b/nautilus_trader/adapters/binance/futures/execution.py
@@ -21,6 +21,7 @@ import msgspec
 from nautilus_trader.accounting.accounts.margin import MarginAccount
 from nautilus_trader.adapters.binance.common.enums import BinanceAccountType
 from nautilus_trader.adapters.binance.common.enums import BinanceErrorCode
+from nautilus_trader.adapters.binance.common.enums import BinanceExecutionType
 from nautilus_trader.adapters.binance.config import BinanceExecClientConfig
 from nautilus_trader.adapters.binance.execution import BinanceCommonExecutionClient
 from nautilus_trader.adapters.binance.futures.enums import BinanceFuturesEnumParser
@@ -294,7 +295,8 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
 
     def _handle_order_trade_update(self, raw: bytes) -> None:
         order_update = self._decoder_futures_order_update_wrapper.decode(raw)
-        order_update.data.o.handle_order_trade_update(self)
+        if not (self._use_trade_lite and order_update.data.o.x == BinanceExecutionType.TRADE):
+            order_update.data.o.handle_order_trade_update(self)
 
     def _handle_margin_call(self, raw: bytes) -> None:
         self._log.warning("MARGIN CALL received")  # Implement

--- a/nautilus_trader/adapters/binance/futures/execution.py
+++ b/nautilus_trader/adapters/binance/futures/execution.py
@@ -137,7 +137,7 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
             BinanceFuturesEventType.TRADE_LITE: self._handle_trade_lite,
         }
 
-        if config.use_tradelite:
+        if config.use_trade_lite:
             self._log.info("TRADE_LITE events will be used", LogColor.BLUE)
 
         # WebSocket futures schema decoders
@@ -306,7 +306,7 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
 
     def _handle_trade_lite(self, raw: bytes) -> None:
         trade_lite = self._decoder_futures_trade_lite_wrapper.decode(raw)
-        if not self._config.use_tradelite:
+        if not self._config.use_trade_lite:
             self._log.debug(
                 "TradeLite event received but not enabled in config",
             )

--- a/nautilus_trader/adapters/binance/futures/execution.py
+++ b/nautilus_trader/adapters/binance/futures/execution.py
@@ -137,7 +137,8 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
             BinanceFuturesEventType.TRADE_LITE: self._handle_trade_lite,
         }
 
-        if config.use_trade_lite:
+        self._use_trade_lite = config.use_trade_lite
+        if self._use_trade_lite:
             self._log.info("TRADE_LITE events will be used", LogColor.BLUE)
 
         # WebSocket futures schema decoders
@@ -306,7 +307,7 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
 
     def _handle_trade_lite(self, raw: bytes) -> None:
         trade_lite = self._decoder_futures_trade_lite_wrapper.decode(raw)
-        if not self._config.use_trade_lite:
+        if not self._use_trade_lite:
             self._log.debug(
                 "TradeLite event received but not enabled in config",
             )

--- a/nautilus_trader/adapters/binance/futures/schemas/user.py
+++ b/nautilus_trader/adapters/binance/futures/schemas/user.py
@@ -322,13 +322,19 @@ class BinanceFuturesOrderData(msgspec.Struct, kw_only=True, frozen=True):
             )
         elif self.x == BinanceExecutionType.TRADE:
             # Determine commission
-            commission_asset: str | None = self.N
-            commission_amount: str | None = self.n
+            commission_asset: str | float | None = self.N
+            commission_amount: str | float | None = self.n
+
+            last_qty = Quantity(float(self.l), size_precision)
+            last_px = Price(float(self.L), price_precision)
+
             if commission_asset is not None:
                 commission = Money.from_str(f"{commission_amount} {commission_asset}")
             else:
-                # Commission in margin collateral currency
-                commission = Money(0, instrument.quote_currency)
+                fee = instrument.maker_fee if self.m else instrument.taker_fee
+                commission_asset = instrument.quote_currency
+                commission_amount = float(last_qty * last_px * fee)
+                commission = Money(commission_amount, commission_asset)
 
             venue_position_id: PositionId | None = None
             if exec_client.use_position_ids:
@@ -343,8 +349,8 @@ class BinanceFuturesOrderData(msgspec.Struct, kw_only=True, frozen=True):
                 trade_id=TradeId(str(self.t)),  # Trade ID
                 order_side=exec_client._enum_parser.parse_binance_order_side(self.S),
                 order_type=exec_client._enum_parser.parse_binance_order_type(self.o),
-                last_qty=Quantity(float(self.l), size_precision),
-                last_px=Price(float(self.L), price_precision),
+                last_qty=last_qty,
+                last_px=last_px,
                 quote_currency=instrument.quote_currency,
                 commission=commission,
                 liquidity_side=LiquiditySide.MAKER if self.m else LiquiditySide.TAKER,
@@ -442,6 +448,43 @@ class BinanceFuturesTradeLiteMsg(msgspec.Struct, frozen=True):
     L: str  # Last Filled Price
     t: int  # Trade ID
     m: bool  # Is trade the maker side
+
+    def to_order_data(self) -> BinanceFuturesOrderData:
+        """
+        Convert TradeLite message to OrderData format.
+        """
+        return BinanceFuturesOrderData(
+            s=self.s,
+            c=self.c,
+            S=self.S,
+            o=BinanceOrderType.LIMIT,
+            f=BinanceTimeInForce.GTC,
+            q=self.q,
+            p=self.p,
+            ap="0",
+            x=BinanceExecutionType.TRADE,
+            X=BinanceOrderStatus.FILLED,
+            i=self.i,
+            l=self.l,
+            z=self.l,
+            L=self.L,
+            N=None,
+            n=None,
+            T=self.T,
+            t=self.t,
+            b="0",
+            a="0",
+            m=self.m,
+            R=False,
+            wt=BinanceFuturesWorkingType.CONTRACT_PRICE,
+            ot=BinanceOrderType.LIMIT,
+            ps=BinanceFuturesPositionSide.BOTH,
+            rp="0",
+            gtd=0,
+            pP=False,
+            si=0,
+            ss=0,
+        )
 
 
 class BinanceFuturesTradeLiteWrapper(msgspec.Struct, frozen=True):

--- a/nautilus_trader/adapters/binance/futures/schemas/user.py
+++ b/nautilus_trader/adapters/binance/futures/schemas/user.py
@@ -322,7 +322,7 @@ class BinanceFuturesOrderData(msgspec.Struct, kw_only=True, frozen=True):
             )
         elif self.x == BinanceExecutionType.TRADE:
             # Determine commission
-            commission_asset: str | float | None = self.N
+            commission_asset: str | None = self.N
             commission_amount: str | float | None = self.n
 
             last_qty = Quantity(float(self.l), size_precision)


### PR DESCRIPTION
# Pull Request

1. Add `use_trade_lite` option to `BinanceExecClientConfig`
2. Add convert from `BinanceFuturesTradeLiteMsg` to `BinanceFuturesOrderData`
3. Add calc of commissions based on event info and cached instrument
## Type of change

- [x] New feature (non-breaking change which adds functionality)
