### PR TITLE
Add time_bars_skip_first_non_full_bar to DataEngineConfig

### DIFF
--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -110,6 +110,7 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef uint64_t _batch_open_ns
     cdef uint64_t _batch_next_close_ns
     cdef object _time_bars_origin
+    cdef bint _skip_first_non_full_bar
 
     cdef readonly timedelta interval
     """The aggregators time interval.\n\n:returns: `timedelta`"""

--- a/nautilus_trader/data/config.py
+++ b/nautilus_trader/data/config.py
@@ -52,6 +52,7 @@ class DataEngineConfig(NautilusConfig, frozen=True):
     time_bars_timestamp_on_close: bool = True
     time_bars_interval_type: str = "left-open"
     time_bars_origins: dict | None = None
+    time_bars_skip_first_non_full_bar: bool = False
     validate_data_sequence: bool = False
     buffer_deltas: bool = False
     external_clients: list[ClientId] | None = None

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -74,6 +74,7 @@ cdef class DataEngine(Component):
     cdef readonly bint _time_bars_timestamp_on_close
     cdef readonly str _time_bars_interval_type
     cdef readonly dict[BarAggregation, object] _time_bars_origins # pd.Timedelta or pd.DateOffset
+    cdef bint _time_bars_skip_first_non_full_bar
     cdef readonly bint _validate_data_sequence
     cdef readonly bint _buffer_deltas
 

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -151,6 +151,7 @@ cdef class DataEngine(Component):
         self._time_bars_timestamp_on_close = config.time_bars_timestamp_on_close
         self._time_bars_interval_type = config.time_bars_interval_type
         self._time_bars_origins = config.time_bars_origins or {}
+        self._time_bars_skip_first_non_full_bar = config.time_bars_skip_first_non_full_bar
         self._validate_data_sequence = config.validate_data_sequence
         self._buffer_deltas = config.buffer_deltas
 
@@ -2245,6 +2246,7 @@ cdef class DataEngine(Component):
                 timestamp_on_close=self._time_bars_timestamp_on_close,
                 interval_type=self._time_bars_interval_type,
                 time_bars_origin=self._time_bars_origins.get(bar_type.spec.aggregation),
+                skip_first_non_full_bar=self._time_bars_skip_first_non_full_bar,
             )
         elif bar_type.spec.aggregation == BarAggregation.TICK:
             aggregator = TickBarAggregator(

--- a/tests/test_data/large/checksums.json
+++ b/tests/test_data/large/checksums.json
@@ -1,8 +1,1 @@
-{
-  "databento_mbo_xnas_itch.csv": "sha256:5481466e7776659f7f093b1ca8b05c7e88b8d586036692089cca5decc7965099",
-  "tardis_binance-futures_book_snapshot_25_2020-09-01_BTCUSDT.csv.gz": "sha256:c9ce8ae07da3fe22ed2b8bca00290c8875f9234cbe9e7734ff3ef662eb4d4712",
-  "tardis_binance-futures_book_snapshot_5_2020-09-01_BTCUSDT.csv.gz": "sha256:d62035442308aa139b7771bb22c8cdb3be989cfc88693507a306c35b98b630de",
-  "tardis_bitmex_trades_2020-03-01_XBTUSD.csv.gz": "sha256:bafdeba528965322baeb0a01b8c3d6bac73891c5a929713b6a6a2f75361200ab",
-  "tardis_deribit_incremental_book_L2_2020-04-01_BTC-PERPETUAL.csv.gz": "sha256:a15aa5d6c52adbdc2e3c5593b487106e1a3fc78f151f939b4d86dbcb5f116876",
-  "tardis_huobi-dm-swap_quotes_2020-05-01_BTC-USD.csv.gz": "sha256:edd2d2f4491c21dd604c98389f2f94779b05104d684d97f4b3ec148f43cfcd67"
-}
+{"databento_mbo_xnas_itch.csv":"sha256:5481466e7776659f7f093b1ca8b05c7e88b8d586036692089cca5decc7965099","tardis_binance-futures_book_snapshot_25_2020-09-01_BTCUSDT.csv.gz":"sha256:df7a4313f582e07b49be2d062fa7db654163801fd5aa9814344c0e210a6fd37d","tardis_binance-futures_book_snapshot_5_2020-09-01_BTCUSDT.csv.gz":"sha256:d62035442308aa139b7771bb22c8cdb3be989cfc88693507a306c35b98b630de","tardis_bitmex_trades_2020-03-01_XBTUSD.csv.gz":"sha256:bafdeba528965322baeb0a01b8c3d6bac73891c5a929713b6a6a2f75361200ab","tardis_deribit_incremental_book_L2_2020-04-01_BTC-PERPETUAL.csv.gz":"sha256:b921a645c9dd163cab0f6e8129aaa0e91a59e5959504237e10a774955c6a2df2","tardis_huobi-dm-swap_quotes_2020-05-01_BTC-USD.csv.gz":"sha256:edd2d2f4491c21dd604c98389f2f94779b05104d684d97f4b3ec148f43cfcd67"}

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("4fadcd3b1ee12132fb725668c223e19aa195a220edbb36edaf9443b958550816",),
+                ("beaf1858d1c3dd01eac2edbf44e0244f217e30c57daac7d1707ab086a3977262",),
             ),
             (
                 TestConfigStubs.risk_engine_config,


### PR DESCRIPTION
# Pull Request

Add time_bars_skip_first_non_full_bar to DataEngineConfig config

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added test
