### PR TITLE
Refine sccache for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,20 @@ jobs:
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
+    env:
+      # > --------------------------------------------------
+      # > sccache
+      # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_DIRECT: "true"
+      SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
+      RUSTC_WRAPPER: "sccache"
+      CC: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Checkout repository
@@ -42,6 +56,17 @@ jobs:
       - name: Install build dependencies
         run: python -m pip install --upgrade pip setuptools wheel poetry-plugin-export pre-commit msgspec
 
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-pre-commit-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-pre-commit-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Cached pre-commit
         id: cached-pre-commit
         uses: actions/cache@v4
@@ -53,6 +78,7 @@ jobs:
         continue-on-error: true
         run: |
           pre-commit run --all-files
+          # sccache --show-stats
 
       - name: Add PR comment on failure
         if: failure() && github.event_name == 'pull_request'
@@ -69,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]  # TODO: Change to ubuntu-latest when GitHub stabilizes
+        os: [ubuntu-22.04, ubuntu-24.04] # TODO: Change to ubuntu-latest when GitHub stabilizes
         python-version: ["3.11", "3.12"]
     defaults:
       run:
@@ -80,12 +106,19 @@ jobs:
     env:
       BUILD_MODE: release
       RUST_BACKTRACE: 1
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     services:
       redis:
@@ -125,9 +158,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
       - name: Set up Rust toolchain
         run: |
           rustup toolchain add --profile minimal stable --component clippy,rustfmt
@@ -154,6 +184,17 @@ jobs:
 
       - name: Install build dependencies
         run: python -m pip install --upgrade pip setuptools wheel poetry-plugin-export pre-commit msgspec
+
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Cached cargo
         id: cached-cargo
@@ -189,6 +230,7 @@ jobs:
         run: |
           make install-cli
           nautilus database init --schema ${{ github.workspace }}/schema
+          # sccache --show-stats
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -202,7 +244,9 @@ jobs:
           tool: nextest
 
       - name: Run nautilus_core tests
-        run: make cargo-test
+        run: |
+          make cargo-test
+          # sccache --show-stats
 
       - name: Update version in pyproject.toml
         run: |
@@ -245,6 +289,7 @@ jobs:
         run: |
           poetry build --format wheel
           ls -lh dist/
+          # sccache --show-stats
 
       - name: Install Python wheel
         run: |
@@ -286,19 +331,23 @@ jobs:
     env:
       BUILD_MODE: release
       RUST_BACKTRACE: 1
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
 
       # - name: Free disk space  # Continue to monitor
       #   run: |
@@ -332,6 +381,17 @@ jobs:
 
       - name: Install build dependencies
         run: python -m pip install --upgrade pip setuptools wheel poetry-plugin-export pre-commit msgspec
+
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Cached cargo
         id: cached-cargo
@@ -452,26 +512,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [pre-commit]
     env:
-      BUILD_MODE: debug  # Not building wheels, so debug is fine
+      BUILD_MODE: debug # Not building wheels, so debug is fine
       RUST_BACKTRACE: 1
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIR: "C:\\.cache\\sccache"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
-      - name: Set sccache-cache env vars
-        run: |
-          echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-          echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-          echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-
-      # - name: Free disk space  # Continue to monitor
+      # - name: Free disk space # Continue to monitor
       #   run: |
       #     rm -rf "/c/Program Files/dotnet"
       #     rm -rf "/c/Program Files (x86)/Microsoft Visual Studio/2019"
@@ -502,6 +563,17 @@ jobs:
 
       - name: Install build dependencies
         run: python -m pip install --upgrade pip setuptools wheel pre-commit msgspec
+
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Cached cargo
         id: cached-cargo
@@ -562,7 +634,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist/
-          pattern: '*.whl'
+          pattern: "*.whl"
 
       - name: Configure AWS CLI for Cloudflare R2
         run: |
@@ -915,4 +987,3 @@ jobs:
           done
 
           echo "Artifact deletion process completed"
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: ${{ matrix.os }}-sccache-pre-commit-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
-          restore-keys: ${{ matrix.os }}-sccache-pre-commit-
+          key: ${{ runner.os }}-sccache-pre-commit-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-sccache-pre-commit-
 
       - name: Run sccache
         uses: mozilla-actions/sccache-action@v0.0.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"
@@ -111,7 +111,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"
@@ -336,7 +336,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
         continue-on-error: true
         run: |
           pre-commit run --all-files
-          # sccache --show-stats
 
       - name: Add PR comment on failure
         if: failure() && github.event_name == 'pull_request'
@@ -232,7 +231,6 @@ jobs:
         run: |
           make install-cli
           nautilus database init --schema ${{ github.workspace }}/schema
-          # sccache --show-stats
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -248,7 +246,6 @@ jobs:
       - name: Run nautilus_core tests
         run: |
           make cargo-test
-          # sccache --show-stats
 
       - name: Update version in pyproject.toml
         run: |
@@ -291,7 +288,6 @@ jobs:
         run: |
           poetry build --format wheel
           ls -lh dist/
-          # sccache --show-stats
 
       - name: Install Python wheel
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
@@ -109,6 +110,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
@@ -334,6 +336,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
@@ -518,6 +521,7 @@ jobs:
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIR: "C:\\.cache\\sccache"
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,12 +15,19 @@ jobs:
     name: build - python ${{ matrix.python-version }} (${{ matrix.arch }} ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
     services:
       redis:
         image: redis
@@ -59,9 +66,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
       - name: Set up Rust toolchain
         run: |
           rustup toolchain add --profile minimal stable --component clippy,rustfmt
@@ -88,6 +92,17 @@ jobs:
 
       - name: Install build dependencies
         run: python -m pip install --upgrade pip setuptools wheel pre-commit msgspec
+
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Set poetry cache-dir
         run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,12 +10,19 @@ jobs:
     env:
       BUILD_MODE: release
       RUST_BACKTRACE: 1
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     services:
       redis:
@@ -44,8 +51,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Set up Rust toolchain
         run: |
@@ -81,7 +96,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Run pre-commit  # Runs again here to check on Python 3.12
+      - name: Run pre-commit # Runs again here to check on Python 3.12
         run: |
           pre-commit run --all-files
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,6 +13,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,7 +15,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
@@ -140,7 +140,7 @@ jobs:
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
-      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
       CXX: "sccache clang++"
@@ -298,7 +298,7 @@ jobs:
       - name: Set sccache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
-          echo "SCCACHE_DIR=~/.cache/sccache" >> $GITHUB_ENV
+          echo "SCCACHE_DIR=${{ github.workspace }}/.cache/sccache" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "CC=sccache clang" >> $GITHUB_ENV
           echo "CXX=sccache clang++" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
@@ -138,6 +139,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
@@ -262,6 +264,7 @@ jobs:
       # > --------------------------------------------------
       # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       # Incrementally compiled crates cannot be cached by sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,19 @@ jobs:
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
     env:
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIR: ~/.cache/sccache
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -46,8 +53,16 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Set up Rust toolchain
         run: |
@@ -120,12 +135,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COPY_TO_SOURCE: false # Do not copy built *.so files back into source tree
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      SCCACHE_DIR: ~/.cache/sccache
       RUSTC_WRAPPER: "sccache"
       CC: "sccache clang"
-      CXX: "sccache clang"
+      CXX: "sccache clang++"
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -145,8 +167,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Set up Rust toolchain
         run: |
@@ -220,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]  # Change to ubuntu-latest when GitHub stabilizes
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest] # Change to ubuntu-latest when GitHub stabilizes
         python-version: ["3.11", "3.12"]
     defaults:
       run:
@@ -229,9 +259,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       BUILD_MODE: release
+      # > --------------------------------------------------
+      # > sccache
       # https://github.com/Mozilla-Actions/sccache-action
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_DIRECT: "true"
       SCCACHE_CACHE_MULTIARCH: 1
+      # Incrementally compiled crates cannot be cached by sccache
+      # https://github.com/mozilla/sccache#rust
+      CARGO_INCREMENTAL: 0
+      # > --------------------------------------------------
 
     steps:
       - name: Free disk space (Ubuntu)
@@ -259,22 +295,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
-      - name: Set sccache-cache env vars (non-Windows)
+      - name: Set sccache env vars (non-Windows)
         if: runner.os != 'Windows'
         run: |
+          echo "SCCACHE_DIR=~/.cache/sccache" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "CC=sccache clang" >> $GITHUB_ENV
-          echo "CXX=sccache clang" >> $GITHUB_ENV
+          echo "CXX=sccache clang++" >> $GITHUB_ENV
 
-      - name: Set sccache-cache env vars (Windows)
+      - name: Set sccache env vars (Windows)
         if: runner.os == 'Windows'
         run: |
-          echo RUSTC_WRAPPER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-          echo CMAKE_C_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
-          echo CMAKE_CXX_COMPILER_LAUNCHER="${{ env.SCCACHE_PATH }}" >> $GITHUB_ENV
+          echo SCCACHE_DIR="C:\.cache\sccache" >> $GITHUB_ENV
+          echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
+          echo CMAKE_C_COMPILER_LAUNCHER=sccache >> $GITHUB_ENV
+          echo CMAKE_CXX_COMPILER_LAUNCHER=sccache >> $GITHUB_ENV
+
+      - name: Cached sccache
+        id: cached-sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-sccache-build-
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Set up Rust toolchain
         run: |

--- a/build.py
+++ b/build.py
@@ -50,9 +50,12 @@ else:
 
 TARGET_DIR = Path.cwd() / "nautilus_core" / "target" / BUILD_MODE
 
+use_sccache = "sccache" in os.environ.get("CC", "") or "sccache" in os.environ.get("CXX", "")
+
 if platform.system() == "Linux":
     # Use clang as the default compiler
-    os.environ["CC"] = "clang"
+    os.environ["CC"] = "sccache clang" if use_sccache else "clang"
+    os.environ["CXX"] = "sccache clang++" if use_sccache else "clang++"
     os.environ["LDSHARED"] = "clang -shared"
 
 if platform.system() == "Darwin" and platform.machine() == "arm64":


### PR DESCRIPTION
# Pull Request

Refine sccache for CI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Detail

This update replaces the `GHA mode` in sccache with `local mode`, storing the entire cache generated by sccache in the GHA cache. This approach prevents frequent writes to the GHA cache, which could otherwise lead to 429 errors. However, it does come at the cost of using more GitHub Actions storage space.

If use `GHA mode` and the GHA cache doesn’t trigger 429 errors or if an S3-like service is used, the cache can be utilized to its full potential, resulting in a higher cache hit rate. However, the network I/O involved might increase the total execution time and incur higher monetary costs.

Given these trade-offs, storing the entire sccache cache in the GHA cache currently seems to be the most optimal solution.

## Total Run Time

`4h 46m 35s` -> `3h 40m 49s`

### Before:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/7495f869-e1a0-48a8-b2ee-50dadc461700" />

[link](https://github.com/nautechsystems/nautilus_trader/actions/runs/12613670666/usage)

### After:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/2c5e19c0-9bc0-4a21-978a-d47d8589003c" />

[link](https://github.com/nautechsystems/nautilus_trader/actions/runs/12619041642/usage)

## Known Issues

The current cache key is defined as:

`${{ matrix.os }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}`.

In certain cases, this may lead to reduced cache hit rates. The ideal solution would be to include the Python version in the cache key, such as:

`${{ matrix.os }}-py${{ matrix.python-version }}-sccache-build-${{ hashFiles('**/Cargo.lock', '**/poetry.lock') }}`

However, GitHub Actions has a total cache space limit of 10 GB. Including the Python version in the key would significantly increase space usage, potentially squeezing out other types of caches. Therefore, a compromise was made to balance cache efficiency and storage constraints.

## Tips

Can view sccache stats on the summary page.