### PR TITLE
Add `enable_event_logging` for `StrategyConfig`

### DIFF
--- a/nautilus_trader/trading/config.py
+++ b/nautilus_trader/trading/config.py
@@ -60,6 +60,7 @@ class StrategyConfig(NautilusConfig, kw_only=True, frozen=True):
     external_order_claims: list[InstrumentId] | None = None
     manage_contingent_orders: bool = False
     manage_gtd_expiry: bool = False
+    enable_event_logging: bool = True
 
 
 class ImportableStrategyConfig(NautilusConfig, frozen=True):

--- a/nautilus_trader/trading/strategy.pxd
+++ b/nautilus_trader/trading/strategy.pxd
@@ -81,6 +81,8 @@ cdef class Strategy(Actor):
     """If contingent orders should be managed automatically by the strategy.\n\n:returns: `bool`"""
     cdef readonly bint manage_gtd_expiry
     """If all order GTD time in force expirations should be managed automatically by the strategy.\n\n:returns: `bool`"""
+    cdef readonly bint enable_event_logging
+    """If event logging should be enabled for the strategy.\n\n:returns: `bool`"""
 
 # -- REGISTRATION ---------------------------------------------------------------------------------
 

--- a/nautilus_trader/trading/strategy.pyx
+++ b/nautilus_trader/trading/strategy.pyx
@@ -152,6 +152,7 @@ cdef class Strategy(Actor):
         self.external_order_claims = self._parse_external_order_claims(config.external_order_claims)
         self.manage_contingent_orders = config.manage_contingent_orders
         self.manage_gtd_expiry = config.manage_gtd_expiry
+        self.enable_event_logging = config.enable_event_logging
 
         # Public components
         self.clock = self._clock
@@ -1529,7 +1530,7 @@ cdef class Strategy(Actor):
 
         if type(event) in self._warning_events:
             self.log.warning(f"{RECV}{EVT} {event}")
-        else:
+        elif self.enable_event_logging:
             self.log.info(f"{RECV}{EVT} {event}")
 
         cdef Order order

--- a/tests/unit_tests/trading/test_strategy.py
+++ b/tests/unit_tests/trading/test_strategy.py
@@ -188,22 +188,24 @@ class TestStrategy:
         assert result.strategy_path == "nautilus_trader.trading.strategy:Strategy"
         assert result.config_path == "nautilus_trader.trading.config:StrategyConfig"
         assert result.config == {
-            "oms_type": None,
-            "order_id_tag": None,
             "strategy_id": None,
+            "order_id_tag": None,
+            "oms_type": None,
             "external_order_claims": None,
             "manage_contingent_orders": False,
             "manage_gtd_expiry": False,
+            "enable_event_logging": True,
         }
 
     def test_strategy_to_importable_config(self) -> None:
         # Arrange
         config = StrategyConfig(
-            order_id_tag="001",
             strategy_id="ALPHA-01",
+            order_id_tag="001",
             external_order_claims=["ETHUSDT-PERP.DYDX"],
             manage_contingent_orders=True,
             manage_gtd_expiry=True,
+            enable_event_logging=False,
         )
 
         strategy = Strategy(config=config)
@@ -222,6 +224,7 @@ class TestStrategy:
             "external_order_claims": ["ETHUSDT-PERP.DYDX"],
             "manage_contingent_orders": True,
             "manage_gtd_expiry": True,
+            "enable_event_logging": False,
         }
 
     def test_strategy_equality(self) -> None:


### PR DESCRIPTION
# Pull Request

Add `enable_event_logging` for `StrategyConfig`.

In high-frequency trading strategies, `<--[EVT]` type events can be particularly noisy. To address this, a toggle switch has been added for better control.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
