### PR TITLE
Add adaptive_bar_ordering to BacktestVenueConfig

### DIFF
--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -225,6 +225,13 @@ class TestHistoricalAggStrategy(Strategy):
 
 # %%
 # BacktestEngineConfig
+tested_market_data = "bars"  # or "quotes" or "trades"
+
+historical_start_delay = 10 if tested_market_data == "bars" else 2
+historical_end_delay = 1 if tested_market_data == "bars" else 0
+
+backtest_start = "2024-07-01T23:55" if tested_market_data == "bars" else "2024-07-02T00:00"
+backtest_end = "2024-07-02T00:10" if tested_market_data == "bars" else "2024-07-02T00:02"
 
 strategies = [
     ImportableStrategyConfig(
@@ -232,12 +239,8 @@ strategies = [
         config_path=TestHistoricalAggConfig.fully_qualified_name(),
         config={
             "symbol_id": InstrumentId.from_str(f"{future_symbols[0]}.GLBX"),
-            # for bars
-            "historical_start_delay": 10,
-            "historical_end_delay": 1,
-            # for quotes
-            # "historical_start_delay": 2,
-            # "historical_end_delay": 0,
+            "historical_start_delay": historical_start_delay,
+            "historical_end_delay": historical_end_delay,
         },
     ),
 ]
@@ -248,7 +251,7 @@ logging = LoggingConfig(
     log_level="WARN",
     log_level_file="WARN",
     log_directory=".",
-    log_file_format=None,  # 'json' or None
+    log_file_format=None,  # "json" or None
     log_file_name="databento_option_greeks",
     clear_log_file=True,
 )
@@ -315,12 +318,8 @@ configs = [
         data=data,
         venues=venues,
         chunk_size=None,  # use None when loading custom data
-        # for bars
-        start="2024-07-01T23:55",
-        end="2024-07-02T00:10",
-        # for quotes or trades
-        # start="2024-07-02T00:00",
-        # end="2024-07-02T00:02",
+        start=backtest_start,
+        end=backtest_end,
     ),
 ]
 

--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -110,6 +110,11 @@ class BacktestVenueConfig(NautilusConfig, frozen=True):
         If all venue generated identifiers will be random UUID4's.
     use_reduce_only : bool, default True
         If the `reduce_only` execution instruction on orders will be honored.
+    adaptive_bar_ordering : bool, default False
+        If High or Low should be processed first depending on distance with Open when using bars with the order matching engine.
+        If False then the processing order is always Open, High, Low, Close.
+        If High is closer to Open than Low then the processing order is Open, High, Low, Close.
+        If Low is closer to Open than High then the processing order is Open, Low, High, Close.
 
     """
 
@@ -131,6 +136,7 @@ class BacktestVenueConfig(NautilusConfig, frozen=True):
     use_position_ids: bool = True
     use_random_ids: bool = False
     use_reduce_only: bool = True
+    adaptive_bar_ordering: bool = False
     # fill_model: FillModel | None = None  # TODO: Implement
     modules: list[ImportableActorConfig] | None = None
 

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -402,6 +402,7 @@ cdef class BacktestEngine:
         use_position_ids: bool = True,
         use_random_ids: bool = False,
         use_reduce_only: bool = True,
+        adaptive_bar_ordering: bool = False,
     ) -> None:
         """
         Add a `SimulatedExchange` with the given parameters to the backtest engine.
@@ -454,6 +455,11 @@ cdef class BacktestEngine:
             If all venue generated identifiers will be random UUID4's.
         use_reduce_only : bool, default True
             If the `reduce_only` execution instruction on orders will be honored.
+        adaptive_bar_ordering : bool, default False
+            If High or Low should be processed first depending on distance with Open when using bars with the order matching engine.
+            If False then the processing order is always Open, High, Low, Close.
+            If High is closer to Open than Low then the processing order is Open, High, Low, Close.
+            If Low is closer to Open than High then the processing order is Open, Low, High, Close.
 
         Raises
         ------
@@ -507,6 +513,7 @@ cdef class BacktestEngine:
             use_position_ids=use_position_ids,
             use_random_ids=use_random_ids,
             use_reduce_only=use_reduce_only,
+            adaptive_bar_ordering=adaptive_bar_ordering,
         )
 
         self._venues[venue] = exchange

--- a/nautilus_trader/backtest/exchange.pxd
+++ b/nautilus_trader/backtest/exchange.pxd
@@ -103,6 +103,8 @@ cdef class SimulatedExchange:
     """The simulation modules registered with the exchange.\n\n:returns: `list[SimulationModule]`"""
     cdef readonly dict instruments
     """The exchange instruments.\n\n:returns: `dict[InstrumentId, Instrument]`"""
+    cdef readonly bint adaptive_bar_ordering
+    """If High or Low should be processed first depending on distance with Open when using bars with the order matching engine.\n\n:returns: `bool`"""
 
     cdef dict _matching_engines
     cdef object _message_queue

--- a/nautilus_trader/backtest/exchange.pyx
+++ b/nautilus_trader/backtest/exchange.pyx
@@ -124,6 +124,11 @@ cdef class SimulatedExchange:
         they have initially arrived. Setting this to False would be appropriate for real-time
         sandbox environments, where we don't want to introduce additional latency of waiting for
         the next data event before processing the trading command.
+    adaptive_bar_ordering : bool, default False
+        If High or Low should be processed first depending on distance with Open when using bars with the order matching engine.
+        If False then the processing order is always Open, High, Low, Close.
+        If High is closer to Open than Low then the processing order is Open, High, Low, Close.
+        If Low is closer to Open than High then the processing order is Open, Low, High, Close.
 
     Raises
     ------
@@ -170,6 +175,7 @@ cdef class SimulatedExchange:
         bint use_random_ids = False,
         bint use_reduce_only = True,
         bint use_message_queue = True,
+        bint adaptive_bar_ordering = False,
     ) -> None:
         Condition.not_empty(starting_balances, "starting_balances")
         Condition.list_type(starting_balances, Money, "starting_balances")
@@ -212,6 +218,7 @@ cdef class SimulatedExchange:
         self.fill_model = fill_model
         self.fee_model = fee_model
         self.latency_model = latency_model
+        self.adaptive_bar_ordering = adaptive_bar_ordering
 
         # Load modules
         self.modules = []
@@ -356,6 +363,7 @@ cdef class SimulatedExchange:
             use_position_ids=self.use_position_ids,
             use_random_ids=self.use_random_ids,
             use_reduce_only=self.use_reduce_only,
+            adaptive_bar_ordering=self.adaptive_bar_ordering,
         )
 
         self._matching_engines[instrument.id] = matching_engine

--- a/nautilus_trader/backtest/matching_engine.pxd
+++ b/nautilus_trader/backtest/matching_engine.pxd
@@ -92,6 +92,7 @@ cdef class OrderMatchingEngine:
     cdef bint _use_position_ids
     cdef bint _use_random_ids
     cdef bint _use_reduce_only
+    cdef bint _adaptive_bar_ordering
     cdef dict _account_ids
     cdef dict _execution_bar_types
     cdef dict _execution_bar_deltas
@@ -152,7 +153,17 @@ cdef class OrderMatchingEngine:
     cpdef void process_auction_book(self, OrderBook book)
     cpdef void process_instrument_close(self, InstrumentClose close)
     cdef void _process_trade_ticks_from_bar(self, Bar bar)
+    cdef TradeTick _create_base_trade_tick(self, Bar bar, Quantity size)
+    cdef void _process_trade_bar_open(self, Bar bar, TradeTick tick)
+    cdef void _process_trade_bar_high(self, Bar bar, TradeTick tick)
+    cdef void _process_trade_bar_low(self, Bar bar, TradeTick tick)
+    cdef void _process_trade_bar_close(self, Bar bar, TradeTick tick)
     cdef void _process_quote_ticks_from_bar(self)
+    cdef QuoteTick _create_base_quote_tick(self, Quantity bid_size, Quantity ask_size)
+    cdef void _process_quote_bar_open(self, QuoteTick tick)
+    cdef void _process_quote_bar_high(self, QuoteTick tick)
+    cdef void _process_quote_bar_low(self, QuoteTick tick)
+    cdef void _process_quote_bar_close(self, QuoteTick tick)
 
 # -- TRADING COMMANDS -----------------------------------------------------------------------------
 

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -271,6 +271,7 @@ class BacktestNode:
                 use_position_ids=config.use_position_ids,
                 use_random_ids=config.use_random_ids,
                 use_reduce_only=config.use_reduce_only,
+                adaptive_bar_ordering=config.adaptive_bar_ordering,
             )
 
         # Add instruments

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -13,7 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-from cpython.datetime cimport datetime
 from cpython.datetime cimport timedelta
 from libc.stdint cimport uint8_t
 from libc.stdint cimport uint64_t

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -213,7 +213,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1094  # UNIX
+        assert result == 1134  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_run_config_parse_obj(self) -> None:
@@ -234,7 +234,7 @@ class TestBacktestConfigParsing:
         assert isinstance(config, BacktestRunConfig)
         node = BacktestNode(configs=[config])
         assert isinstance(node, BacktestNode)
-        assert len(raw) == 817  # UNIX
+        assert len(raw) == 847  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_data_config_to_dict(self) -> None:
@@ -255,7 +255,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1842
+        assert result == 1882
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_run_config_id(self) -> None:
@@ -263,7 +263,7 @@ class TestBacktestConfigParsing:
         print("token:", token)
         value: bytes = self.backtest_config.json()
         print("token_value:", value.decode())
-        assert token == "1c56872343b29fa693183a480e69f891240c7e99460909e584ff2ff65f72941f"
+        assert token == "5a59c616fc4860d1e64eef6c2eab22773af29d6795b988ffd298f44347922dce"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     @pytest.mark.parametrize(
@@ -273,7 +273,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.venue_config,
                 (),
                 {},
-                ("4b938c293e30fa63dbc4d27630cd66945dd52fa757b1a93f2ee8e4e47b0565f9",),
+                ("25172d184dd3512c40e299e028e22c5c64269ddcabc7c4b34d666ce8ff70196c",),
             ),
             (
                 TestConfigStubs.backtest_data_config,

--- a/tests/unit_tests/backtest/test_matching_engine.py
+++ b/tests/unit_tests/backtest/test_matching_engine.py
@@ -40,6 +40,17 @@ from nautilus_trader.test_kit.stubs.execution import TestExecStubs
 from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 
 
+# from nautilus_trader.model.data import Bar
+# from nautilus_trader.model.data import BarType
+# from nautilus_trader.model.events.order import OrderFilled
+# from nautilus_trader.model.identifiers import AccountId
+# from nautilus_trader.model.identifiers import ClientOrderId
+# from nautilus_trader.model.objects import Price
+# from nautilus_trader.model.objects import Quantity
+# from nautilus_trader.model.orders import MarketOrder
+# from nautilus_trader.core.uuid import UUID4
+
+
 _ETHUSDT_PERP_BINANCE = TestInstrumentProvider.ethusdt_perp_binance()
 
 
@@ -156,3 +167,84 @@ class TestOrderMatchingEngine:
         # Assert
         assert self.matching_engine.msgbus.sent_count == 1
         assert isinstance(messages[0], OrderFilled)
+
+    # @pytest.mark.parametrize("adaptive_ordering,bar_prices,expected_prices",
+    #     [
+    #         (   # Test case 1: Adaptive ordering, Low closer to Open
+    #             True,
+    #             {"open": "10.00", "high": "10.50", "low": "9.90", "close": "10.20"},
+    #             ["10.00", "9.90", "10.50", "10.20"]  # Open -> Low -> High -> Close
+    #         ),
+    #         (   # Test case 2: Adaptive ordering, High closer to Open
+    #             True,
+    #             {"open": "10.00", "high": "10.10", "low": "9.50", "close": "10.20"},
+    #             ["10.00", "10.10", "9.50", "10.20"]  # Open -> High -> Low -> Close
+    #         ),
+    #         (   # Test case 3: Non-adaptive ordering (always same sequence)
+    #             False,
+    #             {"open": "10.00", "high": "10.10", "low": "9.50", "close": "10.20"},
+    #             ["10.00", "10.10", "9.50", "10.20"]  # Always Open -> High -> Low -> Close
+    #         ),
+    #     ],
+    # )
+    # def test_adaptive_bar_ordering(
+    #         self,
+    #         adaptive_ordering: bool,
+    #         bar_prices: dict,
+    #         expected_prices: list,
+    # ):
+    #     # Arrange
+    #     engine = OrderMatchingEngine(
+    #         instrument=self.instrument,
+    #         raw_id=1,
+    #         fill_model=FillModel(),
+    #         fee_model=MakerTakerFeeModel(),
+    #         book_type=BookType.L1_MBP,
+    #         oms_type=OmsType.HEDGING,
+    #         account_type=AccountType.MARGIN,
+    #         msgbus=self.msgbus,
+    #         cache=self.cache,
+    #         clock=self.clock,
+    #         adaptive_bar_ordering=adaptive_ordering,
+    #     )
+    #
+    #     client_order = MarketOrder(
+    #         trader_id=TestIdStubs.trader_id(),
+    #         strategy_id=TestIdStubs.strategy_id(),
+    #         instrument_id=self.instrument_id,
+    #         client_order_id=ClientOrderId("O-123456"),
+    #         order_side=OrderSide.BUY,
+    #         quantity=Quantity.from_str("1.000"),
+    #         init_id=UUID4(),
+    #         ts_init=0,
+    #     )
+    #
+    #     self.cache.add_order(client_order)
+    #     engine.process_order(client_order, self.account_id)
+    #     # engine.process_status(MarketStatusAction.PRE_OPEN)
+    #
+    #     bar = Bar(
+    #         bar_type=BarType.from_str(f"{self.instrument_id.value}-1-MINUTE-LAST-EXTERNAL"),
+    #         open=Price.from_str(bar_prices["open"]),
+    #         high=Price.from_str(bar_prices["high"]),
+    #         low=Price.from_str(bar_prices["low"]),
+    #         close=Price.from_str(bar_prices["close"]),
+    #         volume=Quantity.from_str("100.0"),
+    #         ts_event=0,
+    #         ts_init=0,
+    #     )
+    #
+    #     received_messages = []
+    #     engine.msgbus.register("ExecEngine.process", received_messages.append)
+    #     self.matching_engine.process_status(MarketStatusAction.TRADING)
+    #
+    #     # Act
+    #     engine._core.set_last_raw(bar._mem.open.raw)
+    #     engine.process_order(client_order, AccountId("SIM-000"))
+    #     engine.process_bar(bar)
+    #
+    #     # Assert
+    #     assert len(received_messages) == 4
+    #     fill_events = [msg for msg in received_messages if isinstance(msg, OrderFilled)]
+    #     actual_prices = [str(event.last_px) for event in fill_events]
+    #     assert actual_prices == expected_prices

--- a/tests/unit_tests/trading/test_strategy.py
+++ b/tests/unit_tests/trading/test_strategy.py
@@ -1665,7 +1665,7 @@ class TestStrategy:
             ContingencyType.OUO,
         ],
     )
-    def test_managed_contingenies_when_canceled_entry_then_cancels_oto_orders(
+    def test_managed_contingencies_when_canceled_entry_then_cancels_oto_orders(
         self,
         contingency_type: ContingencyType,
     ) -> None:
@@ -1714,7 +1714,7 @@ class TestStrategy:
             ContingencyType.OUO,
         ],
     )
-    def test_managed_contingenies_when_canceled_bracket_then_cancels_contingent_order(
+    def test_managed_contingencies_when_canceled_bracket_then_cancels_contingent_order(
         self,
         contingency_type: ContingencyType,
     ) -> None:
@@ -1755,7 +1755,7 @@ class TestStrategy:
         assert bracket.orders[1].status == OrderStatus.CANCELED
         assert bracket.orders[2].status == OrderStatus.PENDING_CANCEL
 
-    def test_managed_contingenies_when_modify_bracket_then_modifies_ouo_order(
+    def test_managed_contingencies_when_modify_bracket_then_modifies_ouo_order(
         self,
     ) -> None:
         # Arrange
@@ -1804,7 +1804,7 @@ class TestStrategy:
             ContingencyType.OUO,
         ],
     )
-    def test_managed_contingenies_when_filled_sl_then_cancels_contingent_order(
+    def test_managed_contingencies_when_filled_sl_then_cancels_contingent_order(
         self,
         contingency_type: ContingencyType,
     ) -> None:
@@ -1859,7 +1859,7 @@ class TestStrategy:
             ContingencyType.OUO,
         ],
     )
-    def test_managed_contingenies_when_filled_tp_then_cancels_contingent_order(
+    def test_managed_contingencies_when_filled_tp_then_cancels_contingent_order(
         self,
         contingency_type: ContingencyType,
     ) -> None:


### PR DESCRIPTION
# Pull Request

Add adaptive_bar_ordering to BacktestVenueConfig

Executes Low before High if Low is closer to Open, and vice versa

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Attempted to add a test in test_matching_engine.py, left it as comment for further work
