### PR TITLE
Fix docstring typo for fill_order function in OrderMatchingEngine

### DIFF
--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -1896,7 +1896,7 @@ cdef class OrderMatchingEngine:
             The order to fill.
         last_px : Price
             The fill price for the order.
-        last_qty : Price
+        last_qty : Quantity
             The fill quantity for the order.
         liquidity_side : LiquiditySide
             The liquidity side for the fill.


### PR DESCRIPTION
# Pull Request

- fixes small typo in docs of function `fill_order` parameter in Cythons OrderMatchingEngine
