### PR TITLE
Add fee model to OrderMatchingEngine in Rust

### DIFF
--- a/nautilus_core/backtest/src/exchange.rs
+++ b/nautilus_core/backtest/src/exchange.rs
@@ -200,6 +200,7 @@ impl SimulatedExchange {
             instrument,
             self.instruments.len() as u32,
             self.fill_model.clone(),
+            self.fee_model.clone(),
             self.book_type,
             self.oms_type,
             self.account_type,

--- a/nautilus_core/backtest/src/matching_engine/mod.rs
+++ b/nautilus_core/backtest/src/matching_engine/mod.rs
@@ -54,7 +54,10 @@ use nautilus_model::{
 use ustr::Ustr;
 use uuid::Uuid;
 
-use crate::{matching_engine::config::OrderMatchingEngineConfig, models::fill::FillModel};
+use crate::{
+    matching_engine::config::OrderMatchingEngineConfig,
+    models::{fee::FeeModelAny, fill::FillModel},
+};
 
 /// An order matching engine for a single market.
 pub struct OrderMatchingEngine {
@@ -80,6 +83,7 @@ pub struct OrderMatchingEngine {
     book: OrderBook,
     core: OrderMatchingCore,
     fill_model: FillModel,
+    fee_model: FeeModelAny,
     target_bid: Option<Price>,
     target_ask: Option<Price>,
     target_last: Option<Price>,
@@ -100,6 +104,7 @@ impl OrderMatchingEngine {
         instrument: InstrumentAny,
         raw_id: u32,
         fill_model: FillModel,
+        fee_model: FeeModelAny,
         book_type: BookType,
         oms_type: OmsType,
         account_type: AccountType,
@@ -121,6 +126,7 @@ impl OrderMatchingEngine {
             instrument,
             raw_id,
             fill_model,
+            fee_model,
             book_type,
             oms_type,
             account_type,

--- a/nautilus_core/backtest/src/matching_engine/tests.rs
+++ b/nautilus_core/backtest/src/matching_engine/tests.rs
@@ -51,7 +51,7 @@ use ustr::Ustr;
 
 use crate::{
     matching_engine::{config::OrderMatchingEngineConfig, OrderMatchingEngine},
-    models::fill::FillModel,
+    models::{fee::FeeModelAny, fill::FillModel},
 };
 
 static ATOMIC_TIME: LazyLock<AtomicTime> =
@@ -176,6 +176,7 @@ fn get_order_matching_engine(
         instrument,
         1,
         FillModel::default(),
+        FeeModelAny::default(),
         BookType::L1_MBP,
         OmsType::Netting,
         account_type.unwrap_or(AccountType::Cash),
@@ -199,6 +200,7 @@ fn get_order_matching_engine_l2(
         instrument,
         1,
         FillModel::default(),
+        FeeModelAny::default(),
         BookType::L2_MBP,
         OmsType::Netting,
         account_type.unwrap_or(AccountType::Cash),
@@ -801,6 +803,7 @@ fn test_get_position_id_hedging_with_existing_position(
         instrument_eth_usdt.clone(),
         1,
         FillModel::default(),
+        FeeModelAny::default(),
         BookType::L1_MBP,
         OmsType::Hedging,
         AccountType::Cash,
@@ -841,6 +844,7 @@ fn test_get_position_id_hedging_with_generated_position(
         instrument_eth_usdt,
         1,
         FillModel::default(),
+        FeeModelAny::default(),
         BookType::L1_MBP,
         OmsType::Hedging,
         AccountType::Cash,
@@ -868,6 +872,7 @@ fn test_get_position_id_netting(
         instrument_eth_usdt.clone(),
         1,
         FillModel::default(),
+        FeeModelAny::default(),
         BookType::L1_MBP,
         OmsType::Netting,
         AccountType::Cash,

--- a/nautilus_core/backtest/src/models/fee.rs
+++ b/nautilus_core/backtest/src/models/fee.rs
@@ -37,6 +37,29 @@ pub enum FeeModelAny {
     MakerTaker(MakerTakerFeeModel),
 }
 
+impl FeeModel for FeeModelAny {
+    fn get_commission(
+        &self,
+        order: &OrderAny,
+        fill_quantity: Quantity,
+        fill_px: Price,
+        instrument: &InstrumentAny,
+    ) -> anyhow::Result<Money> {
+        match self {
+            Self::Fixed(model) => model.get_commission(order, fill_quantity, fill_px, instrument),
+            Self::MakerTaker(model) => {
+                model.get_commission(order, fill_quantity, fill_px, instrument)
+            }
+        }
+    }
+}
+
+impl Default for FeeModelAny {
+    fn default() -> Self {
+        Self::MakerTaker(MakerTakerFeeModel)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FixedFeeModel {
     commission: Money,


### PR DESCRIPTION
# Pull Request

- `FeeModel` was missing in the order matching engine, so adding it to the struct with the default variant of `MakerTakerFeeModel` in tests
