### PR TITLE
Fix backtest start and end time validation assertion

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -1080,7 +1080,7 @@ cdef class BacktestEngine:
         else:
             end = pd.to_datetime(end, utc=True)
             end_ns = end.value
-        Condition.is_true(start_ns < end_ns, "start was >= end")
+        Condition.is_true(start_ns <= end_ns, "start was > end")
         Condition.not_empty(self._data, "data")
 
         # Set clocks


### PR DESCRIPTION
# Pull Request

Fix backtest start and end time validation assertion

When running a backtest with a streaming catalog, it can happen that the last batch of data contains just 2 ticks. If these 2 ticks have the same ts_init, then the validation fails.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Running a backtest