### PR TITLE
Port limit order filling for OrderMatchingEngine in Rust

### DIFF
--- a/nautilus_core/backtest/src/matching_engine/mod.rs
+++ b/nautilus_core/backtest/src/matching_engine/mod.rs
@@ -1439,7 +1439,7 @@ impl OrderMatchingEngine {
         msgbus.send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
     }
 
-    fn generate_order_accepted(&self, order: &OrderAny, venue_order_id: VenueOrderId) {
+    fn generate_order_accepted(&self, order: &mut OrderAny, venue_order_id: VenueOrderId) {
         let ts_now = self.clock.get_time_ns();
         let account_id = order
             .account_id()
@@ -1458,6 +1458,8 @@ impl OrderMatchingEngine {
         ));
         let msgbus = self.msgbus.as_ref().borrow();
         msgbus.send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+
+        order.apply(event).expect("Failed to apply order event");
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/nautilus_core/backtest/src/matching_engine/mod.rs
+++ b/nautilus_core/backtest/src/matching_engine/mod.rs
@@ -54,7 +54,8 @@ use nautilus_model::{
     instruments::{InstrumentAny, EXPIRING_INSTRUMENT_TYPES},
     orderbook::OrderBook,
     orders::{
-        OrderAny, PassiveOrderAny, StopOrderAny, TrailingStopLimitOrder, TrailingStopMarketOrder,
+        LimitOrderAny, OrderAny, PassiveOrderAny, StopOrderAny, TrailingStopLimitOrder,
+        TrailingStopMarketOrder,
     },
     position::Position,
     types::{
@@ -618,8 +619,8 @@ impl OrderMatchingEngine {
                         )
                             .into(),
                     );
+                    return;
                 }
-                return;
             }
 
             // Check for valid order trigger price precision
@@ -737,8 +738,53 @@ impl OrderMatchingEngine {
         self.fill_market_order(order);
     }
 
-    fn process_limit_order(&mut self, order: &OrderAny) {
-        todo!("process_limit_order")
+    fn process_limit_order(&mut self, order: &mut OrderAny) {
+        if order.is_post_only()
+            && self
+                .core
+                .is_limit_matched(&LimitOrderAny::from(order.to_owned()))
+        {
+            self.generate_order_rejected(
+                order,
+                format!(
+                    "POST_ONLY {} {} order limit px of {} would have been a TAKER: bid={}, ask={}",
+                    order.order_type(),
+                    order.order_side(),
+                    order.price().unwrap(),
+                    self.core
+                        .bid
+                        .map(|p| p.to_string())
+                        .unwrap_or_else(|| "None".to_string()),
+                    self.core
+                        .ask
+                        .map(|p| p.to_string())
+                        .unwrap_or_else(|| "None".to_string())
+                )
+                .into(),
+            );
+            return;
+        }
+
+        // Order is valid and accepted
+        self.accept_order(order);
+
+        // Check for immediate fill
+        if self
+            .core
+            .is_limit_matched(&LimitOrderAny::from(order.to_owned()))
+        {
+            // Filling as liquidity taker
+            if order.liquidity_side().is_some()
+                && order.liquidity_side().unwrap() == LiquiditySide::NoLiquiditySide
+            {
+                order.set_liquidity_side(LiquiditySide::Taker)
+            }
+            self.fill_limit_order(order);
+        } else if order.time_in_force() == TimeInForce::Fok
+            || order.time_in_force() == TimeInForce::Ioc
+        {
+            self.cancel_order(order, None);
+        }
     }
 
     fn process_market_to_limit_order(&mut self, order: &OrderAny) {
@@ -822,9 +868,18 @@ impl OrderMatchingEngine {
             }
 
             // Move market back to targets
-            self.core.bid = self.target_bid;
-            self.core.ask = self.target_ask;
-            self.core.last = self.target_last;
+            if let Some(target_bid) = self.target_bid {
+                self.core.bid = Some(target_bid);
+                self.target_bid = None;
+            }
+            if let Some(target_ask) = self.target_ask {
+                self.core.ask = Some(target_ask);
+                self.target_ask = None;
+            }
+            if let Some(target_last) = self.target_last {
+                self.core.last = Some(target_last);
+                self.target_last = None;
+            }
         }
 
         // Reset any targets after iteration
@@ -833,8 +888,107 @@ impl OrderMatchingEngine {
         self.target_last = None;
     }
 
-    fn determine_limit_price_and_volume(&self, order: &OrderAny) {
-        todo!("determine_limit_price_and_volume")
+    fn determine_limit_price_and_volume(&mut self, order: &OrderAny) -> Vec<(Price, Quantity)> {
+        match order.price() {
+            Some(order_price) => {
+                // construct book order with price as passive with limit order price
+                let book_order =
+                    BookOrder::new(order.order_side(), order_price, order.quantity(), 1);
+
+                let mut fills = self.book.simulate_fills(&book_order);
+
+                // return immediately if no fills
+                if fills.is_empty() {
+                    return fills;
+                }
+
+                // check if trigger price exists
+                if let Some(triggered_price) = order.trigger_price() {
+                    // Filling as TAKER from trigger
+                    if order
+                        .liquidity_side()
+                        .is_some_and(|liquidity_side| liquidity_side == LiquiditySide::Taker)
+                    {
+                        if order.order_side() == OrderSide::Sell && order_price > triggered_price {
+                            // manually change the fills index 0
+                            let first_fill = fills.first().unwrap();
+                            let triggered_qty = first_fill.1;
+                            fills[0] = (triggered_price, triggered_qty);
+                            self.target_bid = self.core.bid;
+                            self.target_ask = self.core.ask;
+                            self.target_last = self.core.last;
+                            self.core.set_ask_raw(order_price);
+                            self.core.set_last_raw(order_price);
+                        } else if order.order_side() == OrderSide::Buy
+                            && order_price < triggered_price
+                        {
+                            // manually change the fills index 0
+                            let first_fill = fills.first().unwrap();
+                            let triggered_qty = first_fill.1;
+                            fills[0] = (triggered_price, triggered_qty);
+                            self.target_bid = self.core.bid;
+                            self.target_ask = self.core.ask;
+                            self.target_last = self.core.last;
+                            self.core.set_bid_raw(order_price);
+                            self.core.set_last_raw(order_price);
+                        }
+                    }
+                }
+
+                // Filling as MAKER from trigger
+                if order
+                    .liquidity_side()
+                    .is_some_and(|liquidity_side| liquidity_side == LiquiditySide::Maker)
+                {
+                    if order.order_side() == OrderSide::Buy {
+                        let target_price = if order
+                            .trigger_price()
+                            .is_some_and(|trigger_price| order_price > trigger_price)
+                        {
+                            order.trigger_price().unwrap()
+                        } else {
+                            order_price
+                        };
+                        for fill in &fills {
+                            let last_px = fill.0;
+                            if last_px < order_price {
+                                // Marketable SELL would have filled at limit
+                                self.target_bid = self.core.bid;
+                                self.target_ask = self.core.ask;
+                                self.target_last = self.core.last;
+                                self.core.set_ask_raw(target_price);
+                                self.core.set_last_raw(target_price);
+                            }
+                        }
+                    } else if order.order_side() == OrderSide::Sell {
+                        let target_price = if order
+                            .trigger_price()
+                            .is_some_and(|trigger_price| order_price < trigger_price)
+                        {
+                            order.trigger_price().unwrap()
+                        } else {
+                            order_price
+                        };
+                        for fill in &fills {
+                            let last_px = fill.0;
+                            if last_px > order_price {
+                                // Marketable BUY would have filled at limit
+                                self.target_bid = self.core.bid;
+                                self.target_ask = self.core.ask;
+                                self.target_last = self.core.last;
+                                self.core.set_bid_raw(target_price);
+                                self.core.set_last_raw(target_price);
+                            }
+                        }
+                    } else {
+                        panic!("Invalid order side {}", order.order_side());
+                    }
+                }
+
+                fills
+            }
+            None => panic!("Limit order must have a price"),
+        }
     }
 
     fn determine_market_price_and_volume(&self, order: &OrderAny) -> Vec<(Price, Quantity)> {
@@ -892,7 +1046,69 @@ impl OrderMatchingEngine {
     }
 
     fn fill_limit_order(&mut self, order: &OrderAny) {
-        todo!("fill_limit_order")
+        match order.price() {
+            Some(order_price) => {
+                let cached_filled_qty = self.cached_filled_qty.get(&order.client_order_id());
+                if cached_filled_qty.is_some() && *cached_filled_qty.unwrap() >= order.quantity() {
+                    log::debug!(
+                        "Ignoring fill as already filled pending pending application of events: {}, {}, {}, {}",
+                        cached_filled_qty.unwrap(),
+                        order.quantity(),
+                        order.filled_qty(),
+                        order.leaves_qty(),
+                    );
+                    return;
+                }
+
+                if order
+                    .liquidity_side()
+                    .is_some_and(|liquidity_side| liquidity_side == LiquiditySide::Maker)
+                {
+                    if order.order_side() == OrderSide::Buy
+                        && self.core.bid.is_some_and(|bid| bid == order_price)
+                        && !self.fill_model.is_limit_filled()
+                    {
+                        // no filled
+                        return;
+                    }
+                    if order.order_side() == OrderSide::Sell
+                        && self.core.ask.is_some_and(|ask| ask == order_price)
+                        && !self.fill_model.is_limit_filled()
+                    {
+                        // no filled
+                        return;
+                    }
+                }
+
+                let venue_position_id = self.ids_generator.get_position_id(order, None);
+                let position = if let Some(venue_position_id) = venue_position_id {
+                    let cache = self.cache.as_ref().borrow();
+                    cache.position(&venue_position_id).cloned()
+                } else {
+                    None
+                };
+
+                if self.config.use_reduce_only && order.is_reduce_only() && position.is_none() {
+                    log::warn!(
+                        "Canceling REDUCE_ONLY {} as would increase position",
+                        order.order_type()
+                    );
+                    self.cancel_order(order, None);
+                    return;
+                }
+
+                let fills = self.determine_limit_price_and_volume(order);
+
+                self.apply_fills(
+                    order,
+                    fills,
+                    order.liquidity_side().unwrap(),
+                    venue_position_id,
+                    position,
+                );
+            }
+            None => panic!("Limit order must have a price"),
+        }
     }
 
     fn apply_fills(

--- a/nautilus_core/backtest/src/matching_engine/tests.rs
+++ b/nautilus_core/backtest/src/matching_engine/tests.rs
@@ -892,3 +892,137 @@ fn test_matching_engine_valid_market_buy(
     assert_eq!(order_filled_second.last_px, Price::from("1510.00"));
     assert_eq!(order_filled_second.last_qty, Quantity::from("1.000"));
 }
+
+#[rstest]
+fn test_process_limit_post_only_order_that_would_be_a_taker(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+    time: AtomicTime,
+) {
+    // Register saving message handler to exec engine endpoint
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // add liquidity to the orderbook
+    let orderbook_delta_sell = OrderBookDelta::new(
+        instrument_eth_usdt.id(),
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ),
+        0,
+        1,
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    );
+    // Create a post-only limit buy order with price above 1500.00
+    // that would match the existing sell order and be a taker
+    let mut post_only_limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1501.00"))
+        .quantity(Quantity::from("1.000"))
+        .post_only(true)
+        .client_order_id(ClientOrderId::from("O-19700101-000000-001-001-1"))
+        .build();
+
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+    engine_l2.process_order(&mut post_only_limit_order, account_id);
+
+    // test that one Order rejected event was generated
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 1);
+    let first_message = saved_messages.first().unwrap();
+    assert_eq!(first_message.event_type(), OrderEventType::Rejected);
+    let order_rejected = match first_message {
+        OrderEventAny::Rejected(order_rejected) => order_rejected,
+        _ => panic!("Expected OrderRejected event in first message"),
+    };
+    assert_eq!(
+        order_rejected.reason,
+        Ustr::from("POST_ONLY LIMIT BUY order limit px of 1501.00 would have been a TAKER: bid=None, ask=1500.00")
+    );
+}
+
+#[rstest]
+fn test_process_limit_order_matched_immediate_fill(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+    time: AtomicTime,
+) {
+    // Register saving message handler to exec engine endpoint
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // add liquidity to the orderbook
+    let orderbook_delta_sell = OrderBookDelta::new(
+        instrument_eth_usdt.id(),
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ),
+        0,
+        1,
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    );
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1501.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(client_order_id)
+        .build();
+
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    // check we have received first OrderAccepted and then OrderFilled event
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 2);
+    let order_event_first = saved_messages.first().unwrap();
+    let order_accepted = match order_event_first {
+        OrderEventAny::Accepted(order_accepted) => order_accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    assert_eq!(order_accepted.client_order_id, client_order_id);
+    let order_event_second = saved_messages.get(1).unwrap();
+    let order_filled = match order_event_second {
+        OrderEventAny::Filled(order_filled) => order_filled,
+        _ => panic!("Expected OrderFilled event in second message"),
+    };
+    assert_eq!(order_filled.client_order_id, client_order_id);
+    assert_eq!(order_filled.last_px, Price::from("1500.00"));
+    assert_eq!(order_filled.last_qty, Quantity::from("1.000"));
+}

--- a/nautilus_core/backtest/src/matching_engine/tests.rs
+++ b/nautilus_core/backtest/src/matching_engine/tests.rs
@@ -960,6 +960,75 @@ fn test_process_limit_post_only_order_that_would_be_a_taker(
 }
 
 #[rstest]
+fn test_process_limit_order_not_matched_and_canceled_fok_order(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+    time: AtomicTime,
+) {
+    // Register saving message handler to exec engine endpoint
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // add liquidity to the orderbook
+    let orderbook_delta_sell = OrderBookDelta::new(
+        instrument_eth_usdt.id(),
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ),
+        0,
+        1,
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    );
+
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    // create limit order which is bellow currently supplied liquidity and ask
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1495.00"))
+        .quantity(Quantity::from("1.000"))
+        .time_in_force(TimeInForce::Fok)
+        .client_order_id(client_order_id)
+        .build();
+
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    // check we have received OrderAccepted and then OrderCanceled event
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 2);
+    let order_event_first = saved_messages.first().unwrap();
+    let order_accepted = match order_event_first {
+        OrderEventAny::Accepted(order_accepted) => order_accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    assert_eq!(order_accepted.client_order_id, client_order_id);
+    let order_event_second = saved_messages.get(1).unwrap();
+    let order_rejected = match order_event_second {
+        OrderEventAny::Canceled(order_canceled) => order_canceled,
+        _ => panic!("Expected OrderCanceled event in second message"),
+    };
+    assert_eq!(order_rejected.client_order_id, client_order_id);
+}
+
+#[rstest]
 fn test_process_limit_order_matched_immediate_fill(
     instrument_eth_usdt: InstrumentAny,
     mut msgbus: MessageBus,


### PR DESCRIPTION
# Pull Request

- porting limit order flow in `OrderMatchingEngine`
