### PR TITLE
Continue OrderEmulator

### DIFF
--- a/nautilus_core/adapters/databento/src/python/live.rs
+++ b/nautilus_core/adapters/databento/src/python/live.rs
@@ -73,24 +73,24 @@ impl DatabentoLiveClient {
             match msg {
                 LiveMessage::Data(data) => Python::with_gil(|py| {
                     let py_obj = data_to_pycapsule(py, data);
-                    call_python(py, &callback, py_obj)
+                    call_python(py, &callback, py_obj);
                 }),
                 LiveMessage::Instrument(data) => Python::with_gil(|py| {
                     let py_obj =
                         instrument_any_to_pyobject(py, data).expect("Failed creating instrument");
-                    call_python(py, &callback, py_obj)
+                    call_python(py, &callback, py_obj);
                 }),
                 LiveMessage::Status(data) => Python::with_gil(|py| {
                     let py_obj = data.into_py(py);
-                    call_python(py, &callback_pyo3, py_obj)
+                    call_python(py, &callback_pyo3, py_obj);
                 }),
                 LiveMessage::Imbalance(data) => Python::with_gil(|py| {
                     let py_obj = data.into_py(py);
-                    call_python(py, &callback_pyo3, py_obj)
+                    call_python(py, &callback_pyo3, py_obj);
                 }),
                 LiveMessage::Statistics(data) => Python::with_gil(|py| {
                     let py_obj = data.into_py(py);
-                    call_python(py, &callback_pyo3, py_obj)
+                    call_python(py, &callback_pyo3, py_obj);
                 }),
                 LiveMessage::Close => {
                     // Graceful close

--- a/nautilus_core/backtest/src/matching_engine/mod.rs
+++ b/nautilus_core/backtest/src/matching_engine/mod.rs
@@ -888,7 +888,7 @@ impl OrderMatchingEngine {
         // set order side as taker
         order.set_liquidity_side(LiquiditySide::Taker);
         let fills = self.determine_market_price_and_volume(order);
-        self.apply_fills(order, fills, LiquiditySide::Taker, None, position)
+        self.apply_fills(order, fills, LiquiditySide::Taker, None, position);
     }
 
     fn fill_limit_order(&mut self, order: &OrderAny) {
@@ -929,7 +929,7 @@ impl OrderMatchingEngine {
                 self.generate_order_rejected(
                     order,
                     format!("No market for {}", order.instrument_id()).into(),
-                )
+                );
             } else {
                 log::error!("Cannot fill order: no fills from book when fills were expected (check size in data)");
                 return;
@@ -943,28 +943,23 @@ impl OrderMatchingEngine {
         let mut initial_market_to_limit_fill = false;
         for (mut fill_px, fill_qty) in &fills {
             // Validate price precision
-            if fill_px.precision != self.instrument.price_precision() {
-                panic!(
-                    "Invalid price precision for fill price {} when instrument price precision is {}.\
+            assert!(
+                (fill_px.precision == self.instrument.price_precision()),
+                "Invalid price precision for fill price {} when instrument price precision is {}.\
                      Check that the data price precision matches the {} instrument",
-                    fill_px.precision,
-                    self.instrument.price_precision(),
-                    self.instrument.id()
-
-
-                );
-            }
+                fill_px.precision,
+                self.instrument.price_precision(),
+                self.instrument.id()
+            );
 
             // Validate quantity precision
-            if fill_qty.precision != self.instrument.size_precision() {
-                panic!(
+            assert!((fill_qty.precision == self.instrument.size_precision()),
                     "Invalid quantity precision for fill quantity {} when instrument size precision is {}.\
                      Check that the data quantity precision matches the {} instrument",
                     fill_qty.precision,
                     self.instrument.size_precision(),
                     self.instrument.id()
                 );
-            }
 
             if order.filled_qty() == Quantity::zero(order.filled_qty().precision)
                 && order.order_type() == OrderType::MarketToLimit
@@ -975,9 +970,9 @@ impl OrderMatchingEngine {
 
             if self.book_type == BookType::L1_MBP && self.fill_model.is_slipped() {
                 if order.order_side() == OrderSide::Buy {
-                    fill_px = fill_px.add(self.instrument.price_increment())
+                    fill_px = fill_px.add(self.instrument.price_increment());
                 } else if order.order_side() == OrderSide::Sell {
-                    fill_px = fill_px.sub(self.instrument.price_increment())
+                    fill_px = fill_px.sub(self.instrument.price_increment());
                 } else {
                     panic!("Invalid order side {}", order.order_side())
                 }
@@ -996,7 +991,7 @@ impl OrderMatchingEngine {
                         let adjusted_fill_qty =
                             Quantity::from_raw(position.quantity.raw, fill_qty.precision);
 
-                        self.generate_order_updated(order, adjusted_fill_qty, None, None)
+                        self.generate_order_updated(order, adjusted_fill_qty, None, None);
                     }
                 }
             }

--- a/nautilus_core/execution/src/emulator.rs
+++ b/nautilus_core/execution/src/emulator.rs
@@ -18,6 +18,7 @@
 #![allow(unused_variables)]
 
 use std::{
+    any::Any,
     cell::RefCell,
     collections::{HashMap, HashSet},
     rc::Rc,
@@ -28,17 +29,22 @@ use nautilus_common::{
     cache::Cache,
     clock::Clock,
     logging::{CMD, EVT, RECV},
-    msgbus::MessageBus,
+    messages::data::DataResponse,
+    msgbus::{
+        handler::{MessageHandler, ShareableMessageHandler},
+        MessageBus,
+    },
 };
 use nautilus_core::uuid::UUID4;
 use nautilus_model::{
-    data::{OrderBookDeltas, QuoteTick, TradeTick},
+    data::{Data, OrderBookDeltas, QuoteTick, TradeTick},
     enums::{ContingencyType, OrderSide, OrderStatus, OrderType, TriggerType},
     events::{OrderCanceled, OrderEmulated, OrderEventAny, OrderUpdated},
     identifiers::{ClientOrderId, InstrumentId, PositionId, StrategyId},
     orders::{OrderAny, PassiveOrderAny},
     types::{Price, Quantity},
 };
+use ustr::Ustr;
 
 use crate::{
     manager::OrderManager,
@@ -52,12 +58,28 @@ pub struct OrderEmulator {
     clock: Rc<RefCell<dyn Clock>>,
     cache: Rc<RefCell<Cache>>,
     msgbus: Rc<RefCell<MessageBus>>,
-    manager: OrderManager,
-    matching_cores: HashMap<InstrumentId, OrderMatchingCore>,
-    subscribed_quotes: HashSet<InstrumentId>,
-    subscribed_trades: HashSet<InstrumentId>,
-    subscribed_strategies: HashSet<StrategyId>,
-    monitored_positions: HashSet<PositionId>,
+    manager: Rc<RefCell<OrderManager>>,
+    state: Rc<RefCell<OrderEmulatorState>>,
+}
+
+struct OrderEmulatorExecuteHandler {
+    id: Ustr,
+    callback: Box<dyn Fn(&TradingCommand)>,
+}
+
+impl MessageHandler for OrderEmulatorExecuteHandler {
+    fn id(&self) -> Ustr {
+        self.id
+    }
+
+    fn handle(&self, msg: &dyn Any) {
+        (self.callback)(msg.downcast_ref::<&TradingCommand>().unwrap());
+    }
+    fn handle_response(&self, _resp: DataResponse) {}
+    fn handle_data(&self, _data: Data) {}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl OrderEmulator {
@@ -65,45 +87,89 @@ impl OrderEmulator {
         clock: Rc<RefCell<dyn Clock>>,
         cache: Rc<RefCell<Cache>>,
         msgbus: Rc<RefCell<MessageBus>>,
-        manager: OrderManager,
         debug: bool,
     ) -> Self {
-        // todo: at last
+        // TODO: Impl Actor Trait
+        // self.register_base(portfolio, msgbus, cache, clock);
+
+        let active_local = true;
+        let manager = Rc::new(RefCell::new(OrderManager::new(
+            clock.clone(),
+            msgbus.clone(),
+            cache.clone(),
+            active_local,
+            None,
+            None,
+            None,
+        )));
+        let state = Rc::new(RefCell::new(OrderEmulatorState::new(
+            clock.clone(),
+            cache.clone(),
+            msgbus.clone(),
+            manager.clone(),
+        )));
+
+        let handler = {
+            let state = state.clone();
+            ShareableMessageHandler(Rc::new(OrderEmulatorExecuteHandler {
+                id: Ustr::from(&UUID4::new().to_string()),
+                callback: Box::new(move |command: &TradingCommand| {
+                    state.borrow_mut().execute(command.clone());
+                }),
+            }))
+        };
+
+        msgbus
+            .borrow_mut()
+            .register("OrderEmulator.execute", handler);
+
         Self {
             clock,
             cache,
             msgbus,
             manager,
-            matching_cores: HashMap::new(),
-            subscribed_quotes: HashSet::new(),
-            subscribed_trades: HashSet::new(),
-            subscribed_strategies: HashSet::new(),
-            monitored_positions: HashSet::new(),
+            state,
         }
     }
 
     #[must_use]
     pub fn subscribed_quotes(&self) -> Vec<InstrumentId> {
-        let mut quotes: Vec<_> = self.subscribed_quotes.iter().copied().collect();
+        let mut quotes: Vec<InstrumentId> = self
+            .state
+            .borrow()
+            .subscribed_quotes
+            .iter()
+            .copied()
+            .collect();
         quotes.sort();
         quotes
     }
 
     #[must_use]
     pub fn subscribed_trades(&self) -> Vec<InstrumentId> {
-        let mut trades: Vec<_> = self.subscribed_trades.iter().copied().collect();
+        let mut trades: Vec<_> = self
+            .state
+            .borrow()
+            .subscribed_trades
+            .iter()
+            .copied()
+            .collect();
         trades.sort();
         trades
     }
 
     #[must_use]
     pub fn get_submit_order_commands(&self) -> HashMap<ClientOrderId, SubmitOrder> {
-        self.manager.get_submit_order_commands()
+        self.manager.borrow().get_submit_order_commands()
     }
 
     #[must_use]
-    pub fn get_matching_core(&self, instrument_id: &InstrumentId) -> Option<&OrderMatchingCore> {
-        self.matching_cores.get(instrument_id)
+    pub fn get_matching_core(&self, instrument_id: &InstrumentId) -> Option<OrderMatchingCore> {
+        self.state
+            .borrow()
+            .matching_cores
+            .get(instrument_id)
+            .cloned()
     }
 
     // Action Implementations
@@ -117,7 +183,7 @@ impl OrderEmulator {
             .collect();
 
         if emulated_orders.is_empty() {
-            log::info!("No emulated orders to reactivate");
+            log::error!("No emulated orders to reactivate");
             return Ok(());
         }
 
@@ -130,21 +196,19 @@ impl OrderEmulator {
             }
 
             if let Some(parent_order_id) = &order.parent_order_id() {
-                let cache = self.cache.borrow();
-                let parent_order = cache.order(parent_order_id).ok_or_else(|| {
-                    anyhow::anyhow!("Cannot handle order: parent {parent_order_id} not found")
-                })?;
+                let parent_order = if let Some(order) = self.cache.borrow().order(parent_order_id) {
+                    order.clone()
+                } else {
+                    log::error!("Cannot handle order: parent {parent_order_id} not found");
+                    continue;
+                };
 
-                let position_id = parent_order.position_id();
-
-                if parent_order.is_closed()
-                    && (position_id.is_none()
-                        || self
-                            .cache
-                            .borrow()
-                            .is_position_closed(&position_id.unwrap()))
-                {
-                    self.manager.cancel_order(order.clone());
+                let is_position_closed = parent_order
+                    .position_id()
+                    .is_some_and(|id| self.cache.borrow().is_position_closed(&id));
+                if parent_order.is_closed() && is_position_closed {
+                    // TODO: fix
+                    // self.manager_cancel_order(order.clone());
                     continue; // Parent already closed
                 }
 
@@ -167,7 +231,7 @@ impl OrderEmulator {
                 .client_id(&order.client_order_id())
                 .copied();
 
-            // fix unwraps
+            // TODO: fix unwraps
             let command = SubmitOrder::new(
                 order.trader_id(),
                 client_id.unwrap(),
@@ -182,8 +246,8 @@ impl OrderEmulator {
                 self.clock.borrow().timestamp_ns(),
             )?;
 
-            // todo: complete this
-            self.handle_submit_order(command);
+            // TODO: complete this
+            // self.handle_submit_order(command);
         }
 
         Ok(())
@@ -192,459 +256,37 @@ impl OrderEmulator {
     pub fn on_event(&mut self, event: OrderEventAny) {
         log::info!("{RECV}{EVT} {event}");
 
-        self.manager.handle_event(event.clone());
+        self.manager.borrow_mut().handle_event(event.clone());
 
-        let order = match self.cache.borrow().order(&event.client_order_id()) {
-            Some(order) => order.clone(),
-            None => return, // Order not in cache yet
-        };
-
-        if order.is_closed() {
-            if let Some(matching_core) = self.matching_cores.get_mut(&order.instrument_id()) {
-                if let Err(e) = matching_core.delete_order(&PassiveOrderAny::from(order)) {
-                    log::error!("Error deleting order: {}", e);
+        if let Some(order) = self.cache.borrow().order(&event.client_order_id()) {
+            if order.is_closed() {
+                if let Some(matching_core) = self
+                    .state
+                    .borrow_mut()
+                    .matching_cores
+                    .get_mut(&order.instrument_id())
+                {
+                    if let Err(e) =
+                        matching_core.delete_order(&PassiveOrderAny::from(order.clone()))
+                    {
+                        log::error!("Error deleting order: {}", e);
+                    }
                 }
             }
+        } else { // Order not in cache yet
         }
     }
 
     pub const fn on_stop(&self) {}
 
     pub fn on_reset(&mut self) {
-        self.manager.reset();
-        self.matching_cores.clear();
+        self.manager.borrow_mut().reset();
+        self.state.borrow_mut().matching_cores.clear();
     }
 
     pub const fn on_dispose(&self) {}
 
     // --------------------------------------------------------------------------------------------
-
-    pub fn execute(&mut self, command: TradingCommand) {
-        log::info!("{RECV}{CMD} {command}");
-
-        match command {
-            TradingCommand::SubmitOrder(command) => self.handle_submit_order(command),
-            TradingCommand::SubmitOrderList(command) => {
-                self.handle_submit_order_list(command).unwrap();
-            }
-            TradingCommand::ModifyOrder(command) => self.handle_modify_order(command).unwrap(),
-            TradingCommand::CancelOrder(command) => self.handle_cancel_order(command).unwrap(),
-            TradingCommand::CancelAllOrders(command) => {
-                self.handle_cancel_all_orders(command).unwrap();
-            }
-            _ => {
-                log::error!("Cannot handle command: unrecognized {:?}", command);
-            }
-        }
-    }
-
-    // keep it in Outer
-    pub fn create_matching_core(
-        &mut self,
-        instrument_id: InstrumentId,
-        price_increment: Price,
-    ) -> OrderMatchingCore {
-        // let matching_core = OrderMatchingCore::new(
-        //     instrument_id,
-        //     price_increment,
-        //     s,
-        //     fill_market_order,
-        //     fill_limit_order,
-        // );
-        // self.matching_cores.insert(instrument_id, matching_core);
-        log::info!("Creating matching core for {:?}", instrument_id);
-        // matching_core
-        todo!()
-    }
-
-    fn handle_submit_order(&mut self, command: SubmitOrder) {
-        let mut order = command.order.clone();
-        let emulation_trigger = order.emulation_trigger();
-
-        // Condition.not_equal(emulation_trigger, TriggerType.NO_TRIGGER, "command.order.emulation_trigger", "TriggerType.NO_TRIGGER")
-        // Condition.not_in(command.order.client_order_id, self._manager.get_submit_order_commands(), "command.order.client_order_id", "manager.submit_order_commands")
-
-        if !matches!(
-            emulation_trigger,
-            Some(TriggerType::Default | TriggerType::BidAsk | TriggerType::LastPrice)
-        ) {
-            log::error!(
-                "Cannot emulate order: `TriggerType` {:?} not supported",
-                emulation_trigger
-            );
-            self.manager.cancel_order(order.clone());
-            return;
-        }
-        // todo: fix unwrap
-        self.check_monitoring(command.strategy_id, command.position_id.unwrap());
-
-        // Get or create matching core
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or_else(|| order.instrument_id());
-
-        let mut matching_core = if let Some(core) = self.matching_cores.get(&trigger_instrument_id)
-        {
-            core.clone()
-        } else {
-            // Handle synthetic instruments
-            if trigger_instrument_id.is_synthetic() {
-                let synthetic = self
-                    .cache
-                    .borrow()
-                    .synthetic(&trigger_instrument_id)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Cannot emulate order: no synthetic instrument {} for trigger",
-                            trigger_instrument_id
-                        )
-                    })
-                    .unwrap()
-                    .clone();
-                self.create_matching_core(synthetic.id, synthetic.price_increment)
-            } else {
-                let instrument = self
-                    .cache
-                    .borrow()
-                    .instrument(&trigger_instrument_id)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Cannot emulate order: no instrument {} for trigger",
-                            trigger_instrument_id
-                        )
-                    })
-                    .unwrap()
-                    .clone();
-                self.create_matching_core(instrument.id(), instrument.price_increment())
-            }
-        };
-
-        // Handle trailing stop orders
-        if matches!(
-            order.order_type(),
-            OrderType::TrailingStopMarket | OrderType::TrailingStopLimit
-        ) {
-            // todo: fix
-            self.update_trailing_stop_order(
-                &mut matching_core,
-                &PassiveOrderAny::from(order.clone()),
-            );
-            if order.trigger_price().is_none() {
-                log::error!(
-                    "Cannot handle trailing stop order with no trigger_price and no market updates"
-                );
-                self.manager.cancel_order(order.clone());
-                return;
-            }
-        }
-
-        // Cache command
-        self.manager.cache_submit_order_command(command);
-
-        // Check if immediately marketable
-        // matching_core.match_order(&PassiveOrderAny::from(order), true);
-        matching_core.match_order(&PassiveOrderAny::from(order.clone()), true);
-
-        // Handle data subscriptions
-        match emulation_trigger.unwrap() {
-            TriggerType::Default | TriggerType::BidAsk => {
-                if !self.subscribed_quotes.contains(&trigger_instrument_id) {
-                    if !trigger_instrument_id.is_synthetic() {
-                        // todo: fix after completing Actor Trait
-                        // self.subscribe_order_book_deltas(&trigger_instrument_id);
-                    }
-                    // todo: fix
-                    // self.subscribe_quote_ticks(&trigger_instrument_id)?;
-                    self.subscribed_quotes.insert(trigger_instrument_id);
-                }
-            }
-            TriggerType::LastPrice => {
-                if !self.subscribed_trades.contains(&trigger_instrument_id) {
-                    // todo: fix
-                    // self.subscribe_trade_ticks(&trigger_instrument_id)?;
-                    self.subscribed_trades.insert(trigger_instrument_id);
-                }
-            }
-            _ => {
-                log::error!("Invalid TriggerType: {:?}", emulation_trigger);
-                return;
-            }
-        }
-
-        // Check if order was already released
-        if !self
-            .manager
-            .get_submit_order_commands()
-            .contains_key(&order.client_order_id())
-        {
-            return; // Already released
-        }
-
-        // Hold in matching core
-        matching_core
-            .add_order(PassiveOrderAny::from(order.clone()))
-            .unwrap();
-
-        // Generate emulated event if needed
-        if order.status() == OrderStatus::Initialized {
-            let event = OrderEmulated::new(
-                order.trader_id(),
-                order.strategy_id(),
-                order.instrument_id(),
-                order.client_order_id(),
-                UUID4::new(),
-                self.clock.borrow().timestamp_ns(),
-                self.clock.borrow().timestamp_ns(),
-            );
-
-            order.apply(OrderEventAny::Emulated(event)).unwrap();
-            self.cache.borrow_mut().update_order(&order).unwrap();
-            self.manager.send_risk_event(OrderEventAny::Emulated(event));
-
-            // todo: check diff of passing event directly vs wrapping in OrderEventAny??
-            self.msgbus.borrow().publish(
-                &format!("events.order.{}", order.strategy_id()).into(),
-                &OrderEventAny::Emulated(event),
-            );
-        }
-
-        // Since we are cloning the matching core, we need to insert it back into the map
-        self.matching_cores
-            .insert(trigger_instrument_id, matching_core);
-
-        log::info!("Emulating {}", order);
-    }
-
-    fn handle_submit_order_list(&mut self, command: SubmitOrderList) -> Result<()> {
-        // todo: fix unwrap
-        self.check_monitoring(command.strategy_id, command.position_id.unwrap());
-
-        for order in &command.order_list.orders {
-            if let Some(parent_order_id) = order.parent_order_id() {
-                let cache = self.cache.borrow();
-                let parent_order = cache.order(&parent_order_id).ok_or_else(|| {
-                    anyhow::anyhow!("Parent order for {} not found", order.client_order_id())
-                })?;
-
-                if parent_order.contingency_type() == Some(ContingencyType::Oto) {
-                    continue; // Process contingency order later once parent triggered
-                }
-            }
-
-            self.manager.create_new_submit_order(
-                order.clone(),
-                command.position_id,
-                Some(command.client_id),
-            )?;
-        }
-
-        Ok(())
-    }
-
-    fn handle_modify_order(&mut self, command: ModifyOrder) -> Result<()> {
-        let order = self
-            .cache
-            .borrow()
-            .order(&command.client_order_id)
-            .ok_or_else(|| {
-                log::error!("Cannot modify order: {} not found", command.client_order_id);
-            })
-            .unwrap()
-            .clone();
-
-        // Determine price values
-        let price = match command.price {
-            Some(price) => Some(price),
-            None => {
-                if order.has_price() {
-                    order.price()
-                } else {
-                    None
-                }
-            }
-        };
-
-        let trigger_price = match command.trigger_price {
-            Some(trigger_price) => Some(trigger_price),
-            None => {
-                if order.price().is_some() {
-                    order.trigger_price()
-                } else {
-                    None
-                }
-            }
-        };
-
-        // Generate event
-        let ts_now = self.clock.borrow().timestamp_ns();
-        let event = OrderUpdated::new(
-            order.trader_id(),
-            order.strategy_id(),
-            order.instrument_id(),
-            order.client_order_id(),
-            command.quantity.unwrap_or(order.quantity()),
-            UUID4::new(),
-            ts_now,
-            ts_now,
-            false,
-            order.venue_order_id(),
-            order.account_id(),
-            price,
-            trigger_price,
-        );
-
-        self.manager.send_exec_event(OrderEventAny::Updated(event));
-
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or_else(|| order.instrument_id());
-
-        let matching_core = self
-            .matching_cores
-            .get_mut(&trigger_instrument_id)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Cannot handle ModifyOrder: no matching core for trigger instrument {}",
-                    trigger_instrument_id
-                )
-            })?;
-
-        matching_core.match_order(&PassiveOrderAny::from(order), false);
-
-        // todo: complete this + fix clones
-        // match order.order_side() {
-        //     OrderSide::Buy => matching_core.sort_bid_orders(),
-        //     OrderSide::Sell => matching_core.sort_ask_orders(),
-        //     _ => return Err(anyhow::anyhow!("Invalid OrderSide")),
-        // }
-
-        Ok(())
-    }
-
-    fn handle_cancel_order(&mut self, command: CancelOrder) -> Result<()> {
-        let order = self
-            .cache
-            .borrow()
-            .order(&command.client_order_id)
-            .ok_or_else(|| {
-                anyhow::anyhow!("Cannot cancel order: {} not found", command.client_order_id)
-            })?
-            .clone();
-
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or_else(|| order.instrument_id());
-
-        let matching_core = if let Some(core) = self.matching_cores.get(&trigger_instrument_id) {
-            core
-        } else {
-            self.manager.cancel_order(order);
-            return Ok(());
-        };
-
-        if !matching_core.order_exists(order.client_order_id())
-            && order.is_open()
-            && !order.is_pending_cancel()
-        {
-            // Order not held in the emulator
-            self.manager
-                .send_exec_command(TradingCommand::CancelOrder(command));
-        } else {
-            self.manager.cancel_order(order);
-        }
-
-        Ok(())
-    }
-
-    fn handle_cancel_all_orders(&mut self, command: CancelAllOrders) -> Result<()> {
-        let matching_core = match self.matching_cores.get(&command.instrument_id) {
-            Some(core) => core,
-            None => return Ok(()), // No orders to cancel
-        };
-
-        let orders = match command.order_side {
-            // fix
-            // OrderSide::NoOrderSide => matching_core.get_orders(),
-            OrderSide::Buy => matching_core.get_orders_bid(),
-            OrderSide::Sell => matching_core.get_orders_ask(),
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "Invalid OrderSide: {:?}",
-                    command.order_side
-                ))
-            }
-        };
-
-        for order in orders {
-            // todo: fix
-            self.manager.cancel_order(order.clone().into());
-        }
-
-        Ok(())
-    }
-
-    fn check_monitoring(&mut self, strategy_id: StrategyId, position_id: PositionId) {
-        // todo: fix: add handler
-        if !self.subscribed_strategies.contains(&strategy_id) {
-            // Subscribe to all strategy events
-            // self.msgbus.borrow().subscribe(
-            //     format!("events.order.{}", strategy_id),
-            //     self.on_event,
-            //     None,
-            // );
-            // self.msgbus.borrow().subscribe(
-            //     format!("events.position.{}", strategy_id),
-            //     self.on_event,
-            //     None,
-            // );
-            self.subscribed_strategies.insert(strategy_id);
-            log::info!(
-                "Subscribed to strategy {} order and position events",
-                strategy_id
-            );
-        }
-
-        if !self.monitored_positions.contains(&position_id) {
-            self.monitored_positions.insert(position_id);
-        }
-    }
-
-    fn cancel_order(&mut self, order: &OrderAny) {
-        log::info!("Canceling order {}", order.client_order_id());
-
-        let mut order = order.clone();
-        order.set_emulation_trigger(Some(TriggerType::NoTrigger));
-
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or(order.instrument_id());
-        let matching_core = self.matching_cores.get_mut(&trigger_instrument_id);
-        if let Some(matching_core) = matching_core {
-            matching_core
-                .delete_order(&PassiveOrderAny::from(order.clone()))
-                .unwrap();
-        }
-
-        self.cache
-            .borrow_mut()
-            .update_order_pending_cancel_local(&order);
-
-        // Generate event
-        let ts_now = self.clock.borrow().timestamp_ns();
-        let event: OrderCanceled = OrderCanceled::new(
-            order.trader_id(),
-            order.strategy_id(),
-            order.instrument_id(),
-            order.client_order_id(),
-            UUID4::new(),
-            ts_now,
-            ts_now,
-            false,
-            order.venue_order_id(),
-            order.account_id(),
-        );
-        self.manager.send_exec_event(OrderEventAny::Canceled(event));
-    }
 
     fn update_order(&mut self, order: &mut OrderAny, new_quantity: Quantity) {
         log::info!(
@@ -674,78 +316,12 @@ impl OrderEmulator {
         order.apply(OrderEventAny::Updated(event)).unwrap();
         self.cache.borrow_mut().update_order(order).unwrap();
 
-        self.manager.send_risk_event(OrderEventAny::Updated(event));
+        self.manager
+            .borrow()
+            .send_risk_event(OrderEventAny::Updated(event));
     }
 
     // -----------------------------------------------------------------------------------------------
-
-    fn trigger_stop_order(&mut self, order: &OrderAny) {
-        match order.order_type() {
-            OrderType::StopLimit | OrderType::LimitIfTouched | OrderType::TrailingStopLimit => {
-                self.fill_limit_order(order);
-            }
-            OrderType::Market | OrderType::MarketIfTouched | OrderType::TrailingStopMarket => {
-                self.fill_market_order(order);
-            }
-            _ => panic!("invalid `OrderType`, was {}", order.order_type()),
-        }
-    }
-
-    fn fill_market_order(&mut self, order: &OrderAny) {
-        // Fetch command
-        let command = match self
-            .manager
-            .pop_submit_order_command(order.client_order_id())
-        {
-            Some(command) => command,
-            None => panic!("invalid operation `_fill_market_order` with no command"),
-        };
-
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or(order.instrument_id());
-        if let Some(matching_core) = self.matching_cores.get_mut(&trigger_instrument_id) {
-            matching_core
-                .delete_order(&PassiveOrderAny::from(order.clone()))
-                .unwrap();
-        }
-
-        let emulation_trigger = TriggerType::NoTrigger;
-
-        // TODO
-        // cdef MarketOrder transformed = MarketOrder.transform(order, self.clock.timestamp_ns())
-    }
-
-    fn fill_limit_order(&mut self, order: &OrderAny) {
-        if matches!(order.order_type(), OrderType::Limit) {
-            self.fill_market_order(order);
-            return;
-        }
-
-        // Fetch command
-        let command = match self
-            .manager
-            .pop_submit_order_command(order.client_order_id())
-        {
-            Some(command) => command,
-            None => return, // Order already released
-        };
-
-        let trigger_instrument_id = order
-            .trigger_instrument_id()
-            .unwrap_or(order.instrument_id());
-        let matching_core = self.matching_cores.get_mut(&trigger_instrument_id);
-        if let Some(matching_core) = matching_core {
-            matching_core
-                .delete_order(&PassiveOrderAny::from(order.clone()))
-                .unwrap();
-        }
-
-        let emulation_trigger = TriggerType::NoTrigger;
-
-        // TODO
-        // cdef MarketOrder transformed = MarketOrder.transform(order, self.clock.timestamp_ns())
-    }
 
     pub fn on_order_book_deltas(&mut self, deltas: OrderBookDeltas) {
         log::debug!("Processing OrderBookDeltas:{}", deltas);
@@ -834,20 +410,603 @@ impl OrderEmulator {
         matching_core.iterate();
 
         let orders = matching_core.get_orders_ask();
-        // for order in orders {
-        //     if order.is_closed() {
-        //         continue;
-        //     }
+        for order in orders {
+            if order.is_closed() {
+                continue;
+            }
 
-        //     // Manage trailing stop
-        //     if order.order_type() == OrderType::TrailingStopMarket
-        //         || order.order_type() == OrderType::TrailingStopLimit
-        //     {
-        //         self.update_trailing_stop_order(matching_core, order);
-        //     }
+            // Manage trailing stop
+            // if matches!(
+            //     order,
+            //     OrderType::TrailingStopMarket | OrderType::TrailingStopLimit
+            // ) {
+            //     self.update_trailing_stop_order(matching_core, order);
+            // }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct OrderEmulatorState {
+    clock: Rc<RefCell<dyn Clock>>,
+    cache: Rc<RefCell<Cache>>,
+    msgbus: Rc<RefCell<MessageBus>>,
+    manager: Rc<RefCell<OrderManager>>,
+    matching_cores: HashMap<InstrumentId, OrderMatchingCore>,
+    subscribed_quotes: HashSet<InstrumentId>,
+    subscribed_trades: HashSet<InstrumentId>,
+    subscribed_strategies: HashSet<StrategyId>,
+    monitored_positions: HashSet<PositionId>,
+}
+
+impl OrderEmulatorState {
+    pub fn new(
+        clock: Rc<RefCell<dyn Clock>>,
+        cache: Rc<RefCell<Cache>>,
+        msgbus: Rc<RefCell<MessageBus>>,
+        manager: Rc<RefCell<OrderManager>>,
+    ) -> Self {
+        Self {
+            manager,
+            matching_cores: HashMap::new(),
+            subscribed_quotes: HashSet::new(),
+            subscribed_trades: HashSet::new(),
+            subscribed_strategies: HashSet::new(),
+            monitored_positions: HashSet::new(),
+            clock,
+            cache,
+            msgbus,
+        }
+    }
+
+    pub fn execute(&mut self, command: TradingCommand) {
+        log::info!("{RECV}{CMD} {command}");
+
+        match command {
+            TradingCommand::SubmitOrder(command) => self.handle_submit_order(command),
+            TradingCommand::SubmitOrderList(command) => {
+                self.handle_submit_order_list(command).unwrap();
+            }
+            TradingCommand::ModifyOrder(command) => self.handle_modify_order(command).unwrap(),
+            TradingCommand::CancelOrder(command) => self.handle_cancel_order(command).unwrap(),
+            TradingCommand::CancelAllOrders(command) => {
+                self.handle_cancel_all_orders(command).unwrap();
+            }
+            _ => {
+                log::error!("Cannot handle command: unrecognized {:?}", command);
+            }
+        }
+    }
+
+    fn handle_submit_order(&mut self, command: SubmitOrder) {
+        let mut order = command.order.clone();
+        let emulation_trigger = order.emulation_trigger();
+
+        assert!(
+            emulation_trigger != Some(TriggerType::NoTrigger),
+            "command.order.emulation_trigger must not be TriggerType::NoTrigger"
+        );
+        assert!(
+            self.manager
+                .borrow()
+                .get_submit_order_commands()
+                .contains_key(&order.client_order_id()),
+            "command.order.client_order_id must be in submit_order_commands"
+        );
+
+        if !matches!(
+            emulation_trigger,
+            Some(TriggerType::Default | TriggerType::BidAsk | TriggerType::LastPrice)
+        ) {
+            log::error!(
+                "Cannot emulate order: `TriggerType` {:?} not supported",
+                emulation_trigger
+            );
+            self.manager_cancel_order(order.clone());
+            return;
+        }
+
+        // TODO: fix unwrap
+        self.check_monitoring(command.strategy_id, command.position_id.unwrap());
+
+        // Get or create matching core
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or_else(|| order.instrument_id());
+
+        let mut matching_core = if let Some(core) = self.matching_cores.get(&trigger_instrument_id)
+        {
+            core.clone()
+        } else {
+            // Handle synthetic instruments
+            // TODO: fix borrowing issues
+            if trigger_instrument_id.is_synthetic() {
+                let synthetic = if let Some(synthetic) =
+                    self.cache.borrow().synthetic(&trigger_instrument_id)
+                {
+                    synthetic.clone()
+                } else {
+                    log::error!(
+                        "Cannot emulate order: no synthetic instrument {} for trigger",
+                        trigger_instrument_id
+                    );
+                    // self.manager_cancel_order(order.clone());
+                    return;
+                };
+
+                self.create_matching_core(synthetic.id, synthetic.price_increment)
+            } else {
+                let instrument = if let Some(instrument) =
+                    self.cache.borrow().instrument(&trigger_instrument_id)
+                {
+                    instrument.clone()
+                } else {
+                    log::error!(
+                        "Cannot emulate order: no instrument {} for trigger",
+                        trigger_instrument_id
+                    );
+                    // self.manager_cancel_order(order.clone());
+                    return;
+                };
+
+                self.create_matching_core(instrument.id(), instrument.price_increment())
+            }
+        };
+
+        // Update trailing stop
+        if matches!(
+            order.order_type(),
+            OrderType::TrailingStopMarket | OrderType::TrailingStopLimit
+        ) {
+            self.update_trailing_stop_order(
+                &mut matching_core,
+                &PassiveOrderAny::from(order.clone()),
+            );
+            if order.trigger_price().is_none() {
+                log::error!(
+                    "Cannot handle trailing stop order with no trigger_price and no market updates"
+                );
+                self.manager_cancel_order(order.clone());
+                return;
+            }
+        }
+
+        // Cache command
+        // TODO: fix
+        self.manager
+            .borrow_mut()
+            .cache_submit_order_command(command);
+
+        // Check if immediately marketable
+        // matching_core.match_order(&PassiveOrderAny::from(order), true);
+        matching_core.match_order(&PassiveOrderAny::from(order.clone()), true);
+
+        // Handle data subscriptions
+        match emulation_trigger.unwrap() {
+            TriggerType::Default | TriggerType::BidAsk => {
+                if !self.subscribed_quotes.contains(&trigger_instrument_id) {
+                    if !trigger_instrument_id.is_synthetic() {
+                        // todo: fix after completing Actor Trait
+                        // self.subscribe_order_book_deltas(&trigger_instrument_id);
+                    }
+                    // todo: fix
+                    // self.subscribe_quote_ticks(&trigger_instrument_id)?;
+                    self.subscribed_quotes.insert(trigger_instrument_id);
+                }
+            }
+            TriggerType::LastPrice => {
+                if !self.subscribed_trades.contains(&trigger_instrument_id) {
+                    // todo: fix
+                    // self.subscribe_trade_ticks(&trigger_instrument_id)?;
+                    self.subscribed_trades.insert(trigger_instrument_id);
+                }
+            }
+            _ => {
+                log::error!("Invalid TriggerType: {:?}", emulation_trigger);
+                return;
+            }
+        }
+
+        // Check if order was already released
+        if !self
+            .manager
+            .borrow()
+            .get_submit_order_commands()
+            .contains_key(&order.client_order_id())
+        {
+            return; // Already released
+        }
+
+        // Hold in matching core
+        matching_core
+            .add_order(PassiveOrderAny::from(order.clone()))
+            .unwrap();
+
+        // Generate emulated event if needed
+        if order.status() == OrderStatus::Initialized {
+            let event = OrderEmulated::new(
+                order.trader_id(),
+                order.strategy_id(),
+                order.instrument_id(),
+                order.client_order_id(),
+                UUID4::new(),
+                self.clock.borrow().timestamp_ns(),
+                self.clock.borrow().timestamp_ns(),
+            );
+
+            order.apply(OrderEventAny::Emulated(event)).unwrap();
+            self.cache.borrow_mut().update_order(&order).unwrap();
+            self.manager
+                .borrow()
+                .send_risk_event(OrderEventAny::Emulated(event));
+
+            // todo: check diff of passing event directly vs wrapping in OrderEventAny??
+            self.msgbus.borrow().publish(
+                &format!("events.order.{}", order.strategy_id()).into(),
+                &OrderEventAny::Emulated(event),
+            );
+        }
+
+        // Since we are cloning the matching core, we need to insert it back into the map
+        self.matching_cores
+            .insert(trigger_instrument_id, matching_core);
+
+        log::info!("Emulating {}", order);
+    }
+
+    fn handle_submit_order_list(&mut self, command: SubmitOrderList) -> Result<()> {
+        // todo: fix unwrap
+        self.check_monitoring(command.strategy_id, command.position_id.unwrap());
+
+        for order in &command.order_list.orders {
+            if let Some(parent_order_id) = order.parent_order_id() {
+                let cache = self.cache.borrow();
+                let parent_order = if let Some(parent_order) = cache.order(&parent_order_id) {
+                    parent_order
+                } else {
+                    log::error!("Parent order for {} not found", order.client_order_id());
+                    continue;
+                };
+
+                if parent_order.contingency_type() == Some(ContingencyType::Oto) {
+                    continue; // Process contingency order later once parent triggered
+                }
+            }
+
+            // TODO: looks suspicious
+            self.manager.borrow_mut().create_new_submit_order(
+                order.clone(),
+                command.position_id,
+                Some(command.client_id),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_modify_order(&mut self, command: ModifyOrder) -> Result<()> {
+        let cache = self.cache.borrow();
+        let order = if let Some(order) = cache.order(&command.client_order_id) {
+            order
+        } else {
+            log::error!("Cannot modify order: {} not found", command.client_order_id);
+            return Ok(());
+        };
+
+        let price = match command.price {
+            Some(price) => Some(price),
+            None => order.price(),
+        };
+
+        let trigger_price = match command.trigger_price {
+            Some(trigger_price) => Some(trigger_price),
+            None => order.trigger_price(),
+        };
+
+        // Generate event
+        let ts_now = self.clock.borrow().timestamp_ns();
+        let event = OrderUpdated::new(
+            order.trader_id(),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            command.quantity.unwrap_or(order.quantity()),
+            UUID4::new(),
+            ts_now,
+            ts_now,
+            false,
+            order.venue_order_id(),
+            order.account_id(),
+            price,
+            trigger_price,
+        );
+
+        self.manager
+            .borrow()
+            .send_exec_event(OrderEventAny::Updated(event));
+
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or_else(|| order.instrument_id());
+
+        let matching_core = if let Some(core) = self.matching_cores.get_mut(&trigger_instrument_id)
+        {
+            core
+        } else {
+            log::error!(
+                "Cannot handle `ModifyOrder`: no matching core for trigger instrument {}",
+                trigger_instrument_id
+            );
+            return Ok(());
+        };
+
+        matching_core.match_order(&PassiveOrderAny::from(order.clone()), false);
+
+        // todo: complete this + fix clones
+        // match order.order_side() {
+        //     OrderSide::Buy => matching_core.sort_bid_orders(),
+        //     OrderSide::Sell => matching_core.sort_ask_orders(),
+        //     _ => return Err(anyhow::anyhow!("Invalid OrderSide")),
         // }
 
         Ok(())
+    }
+
+    fn handle_cancel_order(&mut self, command: CancelOrder) -> Result<()> {
+        let cache = self.cache.borrow();
+        let order = if let Some(order) = cache.order(&command.client_order_id) {
+            order
+        } else {
+            log::error!("Cannot cancel order: {} not found", command.client_order_id);
+            return Ok(());
+        };
+
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or_else(|| order.instrument_id());
+
+        // TODO: fix
+        let matching_core = if let Some(core) = self.matching_cores.get(&trigger_instrument_id) {
+            core
+        } else {
+            // self.manager_cancel_order(order.clone());
+            return Ok(());
+        };
+
+        if !matching_core.order_exists(order.client_order_id())
+            && order.is_open()
+            && !order.is_pending_cancel()
+        {
+            // Order not held in the emulator
+            self.manager
+                .borrow()
+                .send_exec_command(TradingCommand::CancelOrder(command));
+        } else {
+            // self.manager_cancel_order(order.clone());
+        }
+
+        Ok(())
+    }
+
+    fn handle_cancel_all_orders(&mut self, command: CancelAllOrders) -> Result<()> {
+        let matching_core = match self.matching_cores.get(&command.instrument_id) {
+            Some(core) => core,
+            None => return Ok(()), // No orders to cancel
+        };
+
+        let orders = match command.order_side {
+            // fix
+            // OrderSide::NoOrderSide => matching_core.get_orders(),
+            OrderSide::Buy => matching_core.get_orders_bid(),
+            OrderSide::Sell => matching_core.get_orders_ask(),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid OrderSide: {:?}",
+                    command.order_side
+                ))
+            }
+        };
+
+        // drop(matching_core);
+
+        for order in orders {
+            // todo: fix
+            // self.manager_cancel_order(order.clone().into());
+        }
+
+        Ok(())
+    }
+
+    // TODO: MANAGER Fns
+    pub fn manager_cancel_order(&mut self, order: OrderAny) {
+        if self
+            .cache
+            .borrow()
+            .is_order_pending_cancel_local(&order.client_order_id())
+        {
+            return;
+        }
+
+        if order.is_closed() {
+            log::warn!("Cannot cancel order: already closed");
+            return;
+        }
+
+        self.manager
+            .borrow_mut()
+            .pop_submit_order_command(order.client_order_id());
+
+        // called native emulator cancel_order
+        self.cancel_order(&order);
+    }
+    // MANAGER Fns
+
+    fn cancel_order(&mut self, order: &OrderAny) {
+        log::info!("Canceling order {}", order.client_order_id());
+
+        let mut order = order.clone();
+        order.set_emulation_trigger(Some(TriggerType::NoTrigger));
+
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or(order.instrument_id());
+        let matching_core = self.matching_cores.get_mut(&trigger_instrument_id);
+        if let Some(matching_core) = matching_core {
+            matching_core
+                .delete_order(&PassiveOrderAny::from(order.clone()))
+                .unwrap();
+        }
+
+        self.cache
+            .borrow_mut()
+            .update_order_pending_cancel_local(&order);
+
+        // Generate event
+        let ts_now = self.clock.borrow().timestamp_ns();
+        let event = OrderCanceled::new(
+            order.trader_id(),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            UUID4::new(),
+            ts_now,
+            ts_now,
+            false,
+            order.venue_order_id(),
+            order.account_id(),
+        );
+        self.manager
+            .borrow()
+            .send_exec_event(OrderEventAny::Canceled(event));
+    }
+
+    // TODO: keep it in Outer
+    fn check_monitoring(&mut self, strategy_id: StrategyId, position_id: PositionId) {
+        // todo: fix: add handler
+        if !self.subscribed_strategies.contains(&strategy_id) {
+            // Subscribe to all strategy events
+            // self.msgbus.borrow().subscribe(
+            //     format!("events.order.{}", strategy_id),
+            //     self.on_event,
+            //     None,
+            // );
+            // self.msgbus.borrow().subscribe(
+            //     format!("events.position.{}", strategy_id),
+            //     self.on_event,
+            //     None,
+            // );
+            self.subscribed_strategies.insert(strategy_id);
+            log::info!(
+                "Subscribed to strategy {} order and position events",
+                strategy_id
+            );
+        }
+
+        if !self.monitored_positions.contains(&position_id) {
+            self.monitored_positions.insert(position_id);
+        }
+    }
+
+    // TODO: remove this: keep it in Outer
+    pub fn create_matching_core(
+        &mut self,
+        instrument_id: InstrumentId,
+        price_increment: Price,
+    ) -> OrderMatchingCore {
+        // TODO: need _trigger_stop_order, _fill_market_order, _fill_limit_order in inner
+
+        // fn trigger_stop_order_handler(order: &StopOrderAny) {
+        //     let order = order;
+        //     TRIGGERED_STOPS.lock().unwrap().push(order.clone());
+        // }
+        // fn trigger_stop_order(order: &StopOrderAny) {
+        //     let order = order;
+        // }
+
+        // currently, not able to pass clock, manager to fill_market_order, which is necessary
+        let matching_core = OrderMatchingCore::new(
+            instrument_id,
+            price_increment,
+            None, // TBD (will be a function on the engine)
+            None, // TBD (will be a function on the engine)
+            None, // TBD (will be a function on the engine)
+        );
+        // self.matching_cores.insert(instrument_id, matching_core);
+        log::info!("Creating matching core for {:?}", instrument_id);
+        // matching_core
+        todo!()
+    }
+
+    fn trigger_stop_order(&mut self, order: &OrderAny) {
+        match order.order_type() {
+            OrderType::StopLimit | OrderType::LimitIfTouched | OrderType::TrailingStopLimit => {
+                self.fill_limit_order(order);
+            }
+            OrderType::Market | OrderType::MarketIfTouched | OrderType::TrailingStopMarket => {
+                self.fill_market_order(order);
+            }
+            _ => panic!("invalid `OrderType`, was {}", order.order_type()),
+        }
+    }
+
+    fn fill_limit_order(&mut self, order: &OrderAny) {
+        if matches!(order.order_type(), OrderType::Limit) {
+            self.fill_market_order(order);
+            return;
+        }
+
+        // Fetch command
+        let command = match self
+            .manager
+            .borrow_mut()
+            .pop_submit_order_command(order.client_order_id())
+        {
+            Some(command) => command,
+            None => return, // Order already released
+        };
+
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or(order.instrument_id());
+        let matching_core = self.matching_cores.get_mut(&trigger_instrument_id);
+        if let Some(matching_core) = matching_core {
+            matching_core
+                .delete_order(&PassiveOrderAny::from(order.clone()))
+                .unwrap();
+        }
+
+        let emulation_trigger = TriggerType::NoTrigger;
+
+        // TODO
+        // cdef MarketOrder transformed = MarketOrder.transform(order, self.clock.timestamp_ns())
+    }
+
+    fn fill_market_order(&mut self, order: &OrderAny) {
+        // Fetch command
+        let command = match self
+            .manager
+            .borrow_mut()
+            .pop_submit_order_command(order.client_order_id())
+        {
+            Some(command) => command,
+            None => panic!("invalid operation `_fill_market_order` with no command"),
+        };
+
+        let trigger_instrument_id = order
+            .trigger_instrument_id()
+            .unwrap_or(order.instrument_id());
+
+        if let Some(matching_core) = self.matching_cores.get_mut(&trigger_instrument_id) {
+            matching_core
+                .delete_order(&PassiveOrderAny::from(order.clone()))
+                .unwrap();
+        }
+
+        let emulation_trigger = TriggerType::NoTrigger;
+
+        // TODO
+        // cdef MarketOrder transformed = MarketOrder.transform(order, self.clock.timestamp_ns())
     }
 
     fn update_trailing_stop_order(
@@ -868,6 +1027,29 @@ impl OrderEmulator {
         // if matching_core.is_last_initialized {
         //     last = matching_core.last;
         // }
+
+        // let quote_tick = self
+        //     .cache
+        //     .borrow()
+        //     .quote(&matching_core.instrument_id)
+        //     .cloned();
+        // let trade_tick = self
+        //     .cache
+        //     .borrow()
+        //     .trade(&matching_core.instrument_id)
+        //     .cloned();
+
+        // if bid.is_none() && quote_tick.is_some() {
+        //     bid = Some(quote_tick.unwrap().bid_price);
+        // }
+        // if ask.is_none() && quote_tick.is_some() {
+        //     ask = Some(quote_tick.unwrap().ask_price);
+        // }
+        // if last.is_none() && trade_tick.is_some() {
+        //     last = Some(trade_tick.unwrap().price);
+        // }
+
+        // TODO:
 
         // TODO
         // let output = Trail::calculate(

--- a/nautilus_core/persistence/src/bin/to_json.rs
+++ b/nautilus_core/persistence/src/bin/to_json.rs
@@ -16,10 +16,10 @@
 use std::path::PathBuf;
 
 use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
-use nautilus_model::data::Data;
-use nautilus_model::data::{to_variant, Bar, OrderBookDelta, QuoteTick, TradeTick};
-use nautilus_persistence::backend::session::DataBackendSession;
-use nautilus_persistence::python::backend::session::NautilusDataType;
+use nautilus_model::data::{to_variant, Bar, Data, OrderBookDelta, QuoteTick, TradeTick};
+use nautilus_persistence::{
+    backend::session::DataBackendSession, python::backend::session::NautilusDataType,
+};
 use nautilus_serialization::arrow::{DecodeDataFromRecordBatch, EncodeToRecordBatch};
 use serde_json::to_writer_pretty;
 
@@ -85,8 +85,8 @@ where
     let stem = input_path.file_stem().unwrap().to_str().unwrap();
     let default = PathBuf::from(".");
     let parent = input_path.parent().unwrap_or(&default);
-    let json_path = parent.join(format!("{}.json", stem));
-    let metadata_path = parent.join(format!("{}.metadata.json", stem));
+    let json_path = parent.join(format!("{stem}.json"));
+    let metadata_path = parent.join(format!("{stem}.metadata.json"));
 
     // Read parquet metadata
     let parquet_file = std::fs::File::open(file_path)?;

--- a/nautilus_core/persistence/src/bin/to_parquet.rs
+++ b/nautilus_core/persistence/src/bin/to_parquet.rs
@@ -79,8 +79,8 @@ where
     let stem = json_path.file_stem().unwrap().to_str().unwrap();
     let parent_path = PathBuf::from(".");
     let parent = json_path.parent().unwrap_or(&parent_path);
-    let metadata_path = parent.join(format!("{}.metadata.json", stem));
-    let parquet_path = parent.join(format!("{}.parquet", stem));
+    let metadata_path = parent.join(format!("{stem}.metadata.json"));
+    let parquet_path = parent.join(format!("{stem}.parquet"));
 
     // Read JSON data
     let json_data = std::fs::read_to_string(json_path)?;


### PR DESCRIPTION
# Pull Request
- Refactored the order-emulator using the inner-outer pattern, setting self.execute as the handler for the message bus. 
- Cloned necessary components from order-manager, such as manager.cancel_order, renamed to manager_cancel_order.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?
- not tested