### PR TITLE
Port stop limit order processing for OrderMatchingEngine in Rust

### DIFF
--- a/nautilus_core/model/src/orders/any.rs
+++ b/nautilus_core/model/src/orders/any.rs
@@ -1186,6 +1186,8 @@ impl From<OrderAny> for LimitOrderAny {
         match order {
             OrderAny::Limit(order) => LimitOrderAny::Limit(order),
             OrderAny::MarketToLimit(order) => LimitOrderAny::MarketToLimit(order),
+            OrderAny::StopLimit(order) => LimitOrderAny::StopLimit(order),
+            OrderAny::TrailingStopLimit(order) => LimitOrderAny::TrailingStopLimit(order),
             _ => panic!("WIP: Implement trait bound to require `HasLimitPrice`"),
         }
     }


### PR DESCRIPTION
# Pull Request

- implement `process_stop_limit_order` function in `OrderMatchingEngine` in Rust with tests

