### PR TITLE
Port process cancel for OrderMatchingEngine in Rust 

### DIFF
--- a/nautilus_core/execution/src/matching_core.rs
+++ b/nautilus_core/execution/src/matching_core.rs
@@ -84,6 +84,18 @@ impl OrderMatchingCore {
     }
 
     #[must_use]
+    pub fn get_order(&self, client_order_id: ClientOrderId) -> Option<&PassiveOrderAny> {
+        self.orders_bid
+            .iter()
+            .find(|o| o.client_order_id() == client_order_id)
+            .or_else(|| {
+                self.orders_ask
+                    .iter()
+                    .find(|o| o.client_order_id() == client_order_id)
+            })
+    }
+
+    #[must_use]
     pub fn get_orders_bid(&self) -> &[PassiveOrderAny] {
         self.orders_bid.as_slice()
     }

--- a/nautilus_core/model/src/orders/any.rs
+++ b/nautilus_core/model/src/orders/any.rs
@@ -1248,6 +1248,22 @@ impl PassiveOrderAny {
     }
 
     #[must_use]
+    pub fn is_open(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_open(),
+            Self::Stop(order) => order.is_open(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_inflight(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_inflight(),
+            Self::Stop(order) => order.is_inflight(),
+        }
+    }
+
+    #[must_use]
     pub fn expire_time(&self) -> Option<UnixNanos> {
         match self {
             Self::Limit(order) => order.expire_time(),
@@ -1311,6 +1327,26 @@ impl LimitOrderAny {
             Self::MarketToLimit(order) => order.is_closed(),
             Self::StopLimit(order) => order.is_closed(),
             Self::TrailingStopLimit(order) => order.is_closed(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_open(),
+            Self::MarketToLimit(order) => order.is_open(),
+            Self::StopLimit(order) => order.is_open(),
+            Self::TrailingStopLimit(order) => order.is_open(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_inflight(&self) -> bool {
+        match self {
+            Self::Limit(order) => order.is_inflight(),
+            Self::MarketToLimit(order) => order.is_inflight(),
+            Self::StopLimit(order) => order.is_inflight(),
+            Self::TrailingStopLimit(order) => order.is_inflight(),
         }
     }
 
@@ -1392,6 +1428,30 @@ impl StopOrderAny {
             Self::StopMarket(order) => order.is_closed(),
             Self::TrailingStopLimit(order) => order.is_closed(),
             Self::TrailingStopMarket(order) => order.is_closed(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        match self {
+            Self::LimitIfTouched(order) => order.is_open(),
+            Self::MarketIfTouched(order) => order.is_open(),
+            Self::StopLimit(order) => order.is_open(),
+            Self::StopMarket(order) => order.is_open(),
+            Self::TrailingStopLimit(order) => order.is_open(),
+            Self::TrailingStopMarket(order) => order.is_open(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_inflight(&self) -> bool {
+        match self {
+            Self::LimitIfTouched(order) => order.is_inflight(),
+            Self::MarketIfTouched(order) => order.is_inflight(),
+            Self::StopLimit(order) => order.is_inflight(),
+            Self::StopMarket(order) => order.is_inflight(),
+            Self::TrailingStopLimit(order) => order.is_inflight(),
+            Self::TrailingStopMarket(order) => order.is_inflight(),
         }
     }
 


### PR DESCRIPTION
# Pull Request

- added `process_trading_command` in `SimulatedExchange` and scaffold command function in `OrderMatchingEngine` with todos
- implemented and tested from in `process_cancel` function in `OrderMatchingEngine`
- added `get_order` in `OrderMatchingCore`
- added `is_inflight` and `is_open` for `LimitOrderAny` and `PassiveOrderAny`