### PR TITLE
Fix update order in Rust cache

### DIFF
--- a/nautilus_core/common/src/cache/mod.rs
+++ b/nautilus_core/common/src/cache/mod.rs
@@ -1518,6 +1518,9 @@ impl Cache {
             // }
         }
 
+        // update the order in the cache
+        self.orders.insert(client_order_id, order.clone());
+
         Ok(())
     }
 

--- a/nautilus_core/common/src/cache/tests.rs
+++ b/nautilus_core/common/src/cache/tests.rs
@@ -143,6 +143,10 @@ mod tests {
         order.apply(OrderEventAny::Submitted(submitted)).unwrap();
         cache.update_order(&order).unwrap();
 
+        // check the status change of the cached order
+        let cached_order = cache.order(&client_order_id).unwrap();
+        assert_eq!(cached_order.status(), OrderStatus::Submitted);
+
         let result = cache.order(&order.client_order_id()).unwrap();
 
         assert_eq!(order.status(), OrderStatus::Submitted);
@@ -182,6 +186,10 @@ mod tests {
         let rejected = OrderRejected::default();
         order.apply(OrderEventAny::Rejected(rejected)).unwrap();
         cache.update_order(&order).unwrap();
+
+        // check the status change of the cached order
+        let cached_order = cache.order(&order.client_order_id()).unwrap();
+        assert_eq!(cached_order.status(), OrderStatus::Rejected);
 
         let result = cache.order(&order.client_order_id()).unwrap();
 


### PR DESCRIPTION
# Pull Request

- cache contains owned values which should be updated after every `update_order` call
- added a few status checks in cache tests to validate that the order was correctly updated inside cache order hashmap