### PR TITLE
Add optional params dict to order strategy functions

### DIFF
--- a/nautilus_trader/execution/messages.pxd
+++ b/nautilus_trader/execution/messages.pxd
@@ -38,6 +38,8 @@ cdef class TradingCommand(Command):
     """The strategy ID associated with the command.\n\n:returns: `StrategyId`"""
     cdef readonly InstrumentId instrument_id
     """The instrument ID associated with the command.\n\n:returns: `InstrumentId`"""
+    cdef readonly dict[str, object] params
+    """Additional specific parameters for the command.\n\n:returns: `dict[str, object]` or ``None``"""
 
 
 cdef class SubmitOrder(TradingCommand):

--- a/nautilus_trader/execution/messages.pyx
+++ b/nautilus_trader/execution/messages.pyx
@@ -52,6 +52,8 @@ cdef class TradingCommand(Command):
         The commands ID.
     ts_init : uint64_t
         UNIX timestamp (nanoseconds) when the object was initialized.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     Warnings
     --------
@@ -66,6 +68,7 @@ cdef class TradingCommand(Command):
         InstrumentId instrument_id not None,
         UUID4 command_id not None,
         uint64_t ts_init,
+        dict[str, object] params: dict | None = None,
     ):
         super().__init__(command_id, ts_init)
 
@@ -73,6 +76,7 @@ cdef class TradingCommand(Command):
         self.trader_id = trader_id
         self.strategy_id = strategy_id
         self.instrument_id = instrument_id
+        self.params = params
 
 
 cdef class SubmitOrder(TradingCommand):
@@ -95,6 +99,8 @@ cdef class SubmitOrder(TradingCommand):
         The position ID for the command.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     References
     ----------
@@ -110,6 +116,7 @@ cdef class SubmitOrder(TradingCommand):
         uint64_t ts_init,
         PositionId position_id: PositionId | None = None,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -118,6 +125,7 @@ cdef class SubmitOrder(TradingCommand):
             instrument_id=order.instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.order = order
@@ -229,6 +237,8 @@ cdef class SubmitOrderList(TradingCommand):
         The position ID for the command.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     References
     ----------
@@ -244,6 +254,7 @@ cdef class SubmitOrderList(TradingCommand):
         uint64_t ts_init,
         PositionId position_id: PositionId | None = None,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -252,6 +263,7 @@ cdef class SubmitOrderList(TradingCommand):
             instrument_id=order_list.instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.order_list = order_list
@@ -372,6 +384,8 @@ cdef class ModifyOrder(TradingCommand):
         UNIX timestamp (nanoseconds) when the object was initialized.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     References
     ----------
@@ -391,6 +405,7 @@ cdef class ModifyOrder(TradingCommand):
         UUID4 command_id not None,
         uint64_t ts_init,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -399,6 +414,7 @@ cdef class ModifyOrder(TradingCommand):
             instrument_id=instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.client_order_id = client_order_id
@@ -526,6 +542,8 @@ cdef class CancelOrder(TradingCommand):
         UNIX timestamp (nanoseconds) when the object was initialized.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     References
     ----------
@@ -542,6 +560,7 @@ cdef class CancelOrder(TradingCommand):
         UUID4 command_id not None,
         uint64_t ts_init,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         if client_id is None:
             client_id = ClientId(instrument_id.venue.value)
@@ -552,6 +571,7 @@ cdef class CancelOrder(TradingCommand):
             instrument_id=instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.client_order_id = client_order_id
@@ -659,6 +679,8 @@ cdef class CancelAllOrders(TradingCommand):
         UNIX timestamp (nanoseconds) when the object was initialized.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
     """
 
     def __init__(
@@ -670,6 +692,7 @@ cdef class CancelAllOrders(TradingCommand):
         UUID4 command_id not None,
         uint64_t ts_init,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         super().__init__(
             client_id=client_id,
@@ -678,6 +701,7 @@ cdef class CancelAllOrders(TradingCommand):
             instrument_id=instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.order_side = order_side
@@ -779,6 +803,8 @@ cdef class BatchCancelOrders(TradingCommand):
         UNIX timestamp (nanoseconds) when the object was initialized.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
 
     Raises
     ------
@@ -797,6 +823,7 @@ cdef class BatchCancelOrders(TradingCommand):
         UUID4 command_id not None,
         uint64_t ts_init,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         Condition.not_empty(cancels, "cancels")
         Condition.list_type(cancels, CancelOrder, "cancels")
@@ -807,6 +834,7 @@ cdef class BatchCancelOrders(TradingCommand):
             instrument_id=instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.cancels = cancels
@@ -910,6 +938,8 @@ cdef class QueryOrder(TradingCommand):
         UNIX timestamp (nanoseconds) when the object was initialized.
     client_id : ClientId, optional
         The execution client ID for the command.
+    params : dict[str, object], optional
+        Additional parameters for the command.
     """
 
     def __init__(
@@ -922,6 +952,7 @@ cdef class QueryOrder(TradingCommand):
         UUID4 command_id not None,
         uint64_t ts_init,
         ClientId client_id = None,
+        dict[str, object] params: dict | None = None,
     ):
         if client_id is None:
             client_id = ClientId(instrument_id.venue.value)
@@ -932,6 +963,7 @@ cdef class QueryOrder(TradingCommand):
             instrument_id=instrument_id,
             command_id=command_id,
             ts_init=ts_init,
+            params=params,
         )
 
         self.client_order_id = client_order_id

--- a/nautilus_trader/trading/strategy.pxd
+++ b/nautilus_trader/trading/strategy.pxd
@@ -25,11 +25,6 @@ from nautilus_trader.core.rust.model cimport PositionSide
 from nautilus_trader.execution.manager cimport OrderManager
 from nautilus_trader.execution.messages cimport CancelOrder
 from nautilus_trader.execution.messages cimport ModifyOrder
-from nautilus_trader.execution.messages cimport TradingCommand
-from nautilus_trader.model.data cimport Bar
-from nautilus_trader.model.data cimport BarType
-from nautilus_trader.model.data cimport QuoteTick
-from nautilus_trader.model.data cimport TradeTick
 from nautilus_trader.model.events.order cimport OrderAccepted
 from nautilus_trader.model.events.order cimport OrderCanceled
 from nautilus_trader.model.events.order cimport OrderCancelRejected
@@ -53,7 +48,6 @@ from nautilus_trader.model.events.position cimport PositionEvent
 from nautilus_trader.model.events.position cimport PositionOpened
 from nautilus_trader.model.identifiers cimport ClientId
 from nautilus_trader.model.identifiers cimport ClientOrderId
-from nautilus_trader.model.identifiers cimport ExecAlgorithmId
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport PositionId
 from nautilus_trader.model.identifiers cimport StrategyId
@@ -125,13 +119,13 @@ cdef class Strategy(Actor):
         self,
         Order order,
         PositionId position_id=*,
-        ClientId client_id=*,
+        ClientId client_id=*, dict[str, object] params=*,
     )
     cpdef void submit_order_list(
         self,
         OrderList order_list,
         PositionId position_id=*,
-        ClientId client_id=*,
+        ClientId client_id=*, dict[str, object] params=*,
     )
     cpdef void modify_order(
         self,
@@ -139,14 +133,14 @@ cdef class Strategy(Actor):
         Quantity quantity=*,
         Price price=*,
         Price trigger_price=*,
-        ClientId client_id=*,
+        ClientId client_id=*, dict[str, object] params=*,
     )
-    cpdef void cancel_order(self, Order order, ClientId client_id=*)
-    cpdef void cancel_orders(self, list orders, ClientId client_id=*)
-    cpdef void cancel_all_orders(self, InstrumentId instrument_id, OrderSide order_side=*, ClientId client_id=*)
-    cpdef void close_position(self, Position position, ClientId client_id=*, list[str] tags=*, bint reduce_only=*)
-    cpdef void close_all_positions(self, InstrumentId instrument_id, PositionSide position_side=*, ClientId client_id=*, list[str] tags=*, bint reduce_only=*)
-    cpdef void query_order(self, Order order, ClientId client_id=*)
+    cpdef void cancel_order(self, Order order, ClientId client_id=*,dict[str, object] params=*)
+    cpdef void cancel_orders(self, list orders, ClientId client_id=*,dict[str, object] params=*)
+    cpdef void cancel_all_orders(self, InstrumentId instrument_id, OrderSide order_side=*, ClientId client_id=*, dict[str, object] params=*)
+    cpdef void close_position(self, Position position, ClientId client_id=*, list[str] tags=*, bint reduce_only=*, dict[str, object] params=*)
+    cpdef void close_all_positions(self, InstrumentId instrument_id, PositionSide position_side=*, ClientId client_id=*, list[str] tags=*, bint reduce_only=*, dict[str, object] params=*)
+    cpdef void query_order(self, Order order, ClientId client_id=*, dict[str, object] params=*)
     cdef ModifyOrder _create_modify_order(
         self,
         Order order,
@@ -154,8 +148,9 @@ cdef class Strategy(Actor):
         Price price=*,
         Price trigger_price=*,
         ClientId client_id=*,
+        dict[str, object] params=*,
     )
-    cdef CancelOrder _create_cancel_order(self, Order order, ClientId client_id=*)
+    cdef CancelOrder _create_cancel_order(self, Order order, ClientId client_id=*, dict[str, object] params=*)
 
     cpdef void cancel_gtd_expiry(self, Order order)
     cdef bint _has_gtd_expiry_timer(self, ClientOrderId client_order_id)


### PR DESCRIPTION
# Pull Request

Add optional params to order strategy functions

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Doesn't change any functionality, just adds flexbility to handle arguments specific to execution clients if needed
