### PR TITLE
Improve Databento tutorial formatting

### DIFF
--- a/docs/tutorials/databento_overview.ipynb
+++ b/docs/tutorials/databento_overview.ipynb
@@ -184,12 +184,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "9",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "[{'publisher_id': 1,\n",
     "  'dataset': 'GLBX.MDP3',\n",
     "  'venue': 'GLBX',\n",
@@ -209,7 +210,8 @@
     " {'publisher_id': 5,\n",
     "  'dataset': 'BATS.PITCH',\n",
     "  'venue': 'BATS',\n",
-    "  'description': 'Cboe BZX Depth Pitch'}]"
+    "  'description': 'Cboe BZX Depth Pitch'}]\n",
+    "```"
    ]
   },
   {
@@ -236,12 +238,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "12",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "['ARCX.PILLAR',\n",
     " 'DBEQ.BASIC',\n",
     " 'EPRL.DOM',\n",
@@ -258,7 +261,8 @@
     " 'XNAS.BASIC',\n",
     " 'XNAS.ITCH',\n",
     " 'XNYS.PILLAR',\n",
-    " 'XPSX.ITCH']"
+    " 'XPSX.ITCH']\n",
+    "```"
    ]
   },
   {
@@ -283,12 +287,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "15",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "['mbo',\n",
     " 'mbp-1',\n",
     " 'mbp-10',\n",
@@ -302,7 +307,8 @@
     " 'ohlcv-1d',\n",
     " 'definition',\n",
     " 'statistics',\n",
-    " 'status']"
+    " 'status']\n",
+    "```"
    ]
   },
   {
@@ -332,12 +338,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "18",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "[{'date': '2022-06-06',\n",
     "  'condition': 'available',\n",
     "  'last_modified_date': '2024-05-18'},\n",
@@ -352,7 +359,8 @@
     "  'last_modified_date': '2024-05-21'},\n",
     " {'date': '2022-06-10',\n",
     "  'condition': 'available',\n",
-    "  'last_modified_date': '2024-05-22'}]"
+    "  'last_modified_date': '2024-05-22'}]\n",
+    "```"
    ]
   },
   {
@@ -380,14 +388,16 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "21",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "{'start': '2010-06-06T00:00:00.000000000Z',\n",
-    " 'end': '2025-01-18T00:00:00.000000000Z'}"
+    " 'end': '2025-01-18T00:00:00.000000000Z'}\n",
+    "```"
    ]
   },
   {
@@ -420,13 +430,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "24",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
-    "23"
+    "`23`"
    ]
   },
   {
@@ -458,13 +468,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "27",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
-    "0.00022791326"
+    "`0.00022791326`"
    ]
   },
   {
@@ -505,13 +515,15 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "30",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
-    "<DBNStore(schema=ohlcv-1h)>"
+    "`<DBNStore(schema=ohlcv-1h)>`"
    ]
   },
   {
@@ -588,12 +600,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "36",
    "metadata": {},
    "source": [
-    "# Example output:\n",
+    "Example output:\n",
     "\n",
+    "```python\n",
     "{'result': {'ESM2': [{'d0': '2022-06-01', 'd1': '2022-06-26', 's': '3403'}]},\n",
     " 'symbols': ['ESM2'],\n",
     " 'stype_in': 'raw_symbol',\n",
@@ -603,7 +616,8 @@
     " 'partial': [],\n",
     " 'not_found': [],\n",
     " 'message': 'OK',\n",
-    " 'status': 0}"
+    " 'status': 0}\n",
+    "```"
    ]
   },
   {
@@ -949,13 +963,28 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "65",
    "metadata": {},
    "source": [
     "Example output:\n",
     "\n",
-    "OhlcvMsg { hd: RecordHeader { length: 14, rtype: Ohlcv1H, publisher_id: GlbxMdp3Glbx, instrument_id: 3403, ts_event: 1654473600000000000 }, open: 4109.500000000, high: 4117.000000000, low: 4105.500000000, close: 4115.750000000, volume: 4543 }"
+    "```\n",
+    "OhlcvMsg {\n",
+    "    hd: RecordHeader {\n",
+    "        length: 14,\n",
+    "        rtype: Ohlcv1H,\n",
+    "        publisher_id: GlbxMdp3Glbx,\n",
+    "        instrument_id: 3403,\n",
+    "        ts_event: 1654473600000000000\n",
+    "    },\n",
+    "    open: 4109.500000000,\n",
+    "    high: 4117.000000000,\n",
+    "    low: 4105.500000000,\n",
+    "    close: 4115.750000000,\n",
+    "    volume: 4543\n",
+    "}\n",
+    "```"
    ]
   },
   {
@@ -971,13 +1000,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "67",
    "metadata": {},
    "source": [
     "Example output:\n",
     "\n",
-    "Bar open: 4108500000000"
+    "`Bar open: 4108500000000`"
    ]
   },
   {
@@ -1044,9 +1073,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "72",
+   "metadata": {},
+   "source": [
+    "Example output:\n",
+    "\n",
+    "`0.01$`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,7 +1106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1096,7 +1135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "Example output: *(not real data, just example of output format)*\n",


### PR DESCRIPTION
Convert Raw cells to Markdown cells in Jupyter notebook after discovering `Raw` cells were not correctly rendering in final documentation output (they are treated as classic `Markdown` cells). This ensures proper display of all content.

## Type of change

Delete options that are not relevant.

Just documentation formatting update.

## How has this change been tested?

✅ pre-commit passed
✅ checked output visually in JupyterLab
