### PR TITLE
[WIP] Support for selecting memory allocator

### DIFF
--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -3041,7 +3041,6 @@ dependencies = [
  "strum",
  "sysinfo",
  "tempfile",
- "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5454,26 +5453,6 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/nautilus_core/Cargo.lock
+++ b/nautilus_core/Cargo.lock
@@ -2795,6 +2795,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3009,6 +3028,7 @@ dependencies = [
  "indexmap",
  "itertools 0.13.0",
  "log",
+ "mimalloc",
  "nautilus-core",
  "nautilus-model",
  "proptest",
@@ -3021,6 +3041,7 @@ dependencies = [
  "strum",
  "sysinfo",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5433,6 +5454,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/nautilus_core/common/Cargo.toml
+++ b/nautilus_core/common/Cargo.toml
@@ -37,8 +37,8 @@ sysinfo = "0.33.1"
 mimalloc = { version = "0.1", optional = true }
 
 # Jemallocator does not work on aarch64 with musl
-[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+# [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+# tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/nautilus_core/common/Cargo.toml
+++ b/nautilus_core/common/Cargo.toml
@@ -34,6 +34,11 @@ ustr = { workspace = true }
 uuid = { workspace = true }
 bincode = "1.3.3"
 sysinfo = "0.33.1"
+mimalloc = { version = "0.1", optional = true }
+
+# Jemallocator does not work on aarch64 with musl
+[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -52,3 +57,5 @@ extension-module = [
 ffi = ["cbindgen", "nautilus-core/ffi", "nautilus-model/ffi"]
 "clock_v2" = []
 python = ["pyo3", "nautilus-core/python", "nautilus-model/python"]
+allocator-jemalloc = ["tikv-jemallocator"]
+allocator-mimalloc = ["mimalloc"]

--- a/nautilus_core/common/Cargo.toml
+++ b/nautilus_core/common/Cargo.toml
@@ -57,5 +57,5 @@ extension-module = [
 ffi = ["cbindgen", "nautilus-core/ffi", "nautilus-model/ffi"]
 "clock_v2" = []
 python = ["pyo3", "nautilus-core/python", "nautilus-model/python"]
-allocator-jemalloc = ["tikv-jemallocator"]
+# allocator-jemalloc = ["tikv-jemallocator"]
 allocator-mimalloc = ["mimalloc"]

--- a/nautilus_core/common/src/allocator.rs
+++ b/nautilus_core/common/src/allocator.rs
@@ -1,23 +1,23 @@
-#[cfg(all(feature = "allocator-jemalloc", feature = "allocator-mimalloc"))]
-compile_error!("Cannot enable both jemalloc and mimalloc allocators simultaneously");
+// #[cfg(all(feature = "allocator-jemalloc", feature = "allocator-mimalloc"))]
+// compile_error!("Cannot enable both jemalloc and mimalloc allocators simultaneously");
 
 #[cfg(feature = "allocator-mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(all(
-    feature = "allocator-jemalloc",
-    any(target_os = "macos", target_os = "linux"),
-    not(all(target_arch = "aarch64", target_env = "musl"))
-))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+// #[cfg(all(
+//     feature = "allocator-jemalloc",
+//     any(target_os = "macos", target_os = "linux"),
+//     not(all(target_arch = "aarch64", target_env = "musl"))
+// ))]
+// #[global_allocator]
+// static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// Jemallocator does not work on aarch64 with musl, fallback to system allocator
-#[cfg(all(
-    feature = "allocator-jemalloc",
-    target_arch = "aarch64",
-    target_env = "musl",
-))]
-#[global_allocator]
-static GLOBAL: std::alloc::System = std::alloc::System;
+// // Jemallocator does not work on aarch64 with musl, fallback to system allocator
+// #[cfg(all(
+//     feature = "allocator-jemalloc",
+//     target_arch = "aarch64",
+//     target_env = "musl",
+// ))]
+// #[global_allocator]
+// static GLOBAL: std::alloc::System = std::alloc::System;

--- a/nautilus_core/common/src/allocator.rs
+++ b/nautilus_core/common/src/allocator.rs
@@ -1,0 +1,23 @@
+#[cfg(all(feature = "allocator-jemalloc", feature = "allocator-mimalloc"))]
+compile_error!("Cannot enable both jemalloc and mimalloc allocators simultaneously");
+
+#[cfg(feature = "allocator-mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(
+    feature = "allocator-jemalloc",
+    any(target_os = "macos", target_os = "linux"),
+    not(all(target_arch = "aarch64", target_env = "musl"))
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Jemallocator does not work on aarch64 with musl, fallback to system allocator
+#[cfg(all(
+    feature = "allocator-jemalloc",
+    target_arch = "aarch64",
+    target_env = "musl",
+))]
+#[global_allocator]
+static GLOBAL: std::alloc::System = std::alloc::System;

--- a/nautilus_core/common/src/lib.rs
+++ b/nautilus_core/common/src/lib.rs
@@ -41,6 +41,7 @@
 #![allow(deprecated)]
 
 pub mod actor;
+pub mod allocator;
 pub mod cache;
 pub mod clock;
 pub mod component;


### PR DESCRIPTION
# Pull Request

Support for selecting memory allocator.

- Added as features:
  - `allocator-jemalloc`
  - `allocator-mimalloc`
- In one of my Rust projects with heavy network and computational I/O workloads, both `mimalloc` and `jemalloc` outperformed the system allocator:
  - `mimalloc + glibc` performed better than `jemalloc + glibc`
    - Both outperformed configurations using `+ musl`
  - Therefore, `mimalloc + glibc` is recommended.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Issue

Since the `cargo` checks in `pre-commit` are run with `--all-features`, the logic for choosing between allocators fails to pass the checks. As a temporary workaround, the code related to `jemalloc` has been commented out. So:

- Is there a better approach to support a mutually exclusive choice between the two?  
- Or should we simply remove `jemalloc` and keep only `mimalloc`?
- Use tools like https://github.com/taiki-e/cargo-hack ?