### PR TITLE
Port adjust account for SimulatedExchange in Rust

### DIFF
--- a/nautilus_core/analysis/src/analyzer.rs
+++ b/nautilus_core/analysis/src/analyzer.rs
@@ -547,6 +547,10 @@ mod tests {
         ) -> Result<Money, anyhow::Error> {
             todo!()
         }
+
+        fn balance(&self, currency: Option<Currency>) -> Option<&AccountBalance> {
+            todo!()
+        }
     }
 
     #[test]

--- a/nautilus_core/model/src/accounts/any.rs
+++ b/nautilus_core/model/src/accounts/any.rs
@@ -133,6 +133,13 @@ impl AccountAny {
             ),
         }
     }
+
+    pub fn balance(&self, currency: Option<Currency>) -> Option<&AccountBalance> {
+        match self {
+            AccountAny::Margin(margin) => margin.balance(currency),
+            AccountAny::Cash(cash) => cash.balance(currency),
+        }
+    }
 }
 
 impl From<AccountState> for AccountAny {

--- a/nautilus_core/model/src/accounts/base.rs
+++ b/nautilus_core/model/src/accounts/base.rs
@@ -65,6 +65,14 @@ impl BaseAccount {
     }
 
     #[must_use]
+    pub fn base_balance(&self, currency: Option<Currency>) -> Option<&AccountBalance> {
+        let currency = currency
+            .or(self.base_currency)
+            .expect("Currency must be specified");
+        self.balances.get(&currency)
+    }
+
+    #[must_use]
     pub fn base_balance_total(&self, currency: Option<Currency>) -> Option<Money> {
         let currency = currency
             .or(self.base_currency)
@@ -270,6 +278,7 @@ pub trait Account: 'static + Send {
     fn balances_free(&self) -> HashMap<Currency, Money>;
     fn balance_locked(&self, currency: Option<Currency>) -> Option<Money>;
     fn balances_locked(&self) -> HashMap<Currency, Money>;
+    fn balance(&self, currency: Option<Currency>) -> Option<&AccountBalance>;
     fn last_event(&self) -> Option<AccountState>;
     fn events(&self) -> Vec<AccountState>;
     fn event_count(&self) -> usize;

--- a/nautilus_core/model/src/accounts/cash.rs
+++ b/nautilus_core/model/src/accounts/cash.rs
@@ -143,6 +143,10 @@ impl Account for CashAccount {
         self.base_balances_locked()
     }
 
+    fn balance(&self, currency: Option<Currency>) -> Option<&AccountBalance> {
+        self.base_balance(currency)
+    }
+
     fn last_event(&self) -> Option<AccountState> {
         self.base_last_event()
     }

--- a/nautilus_core/model/src/accounts/margin.rs
+++ b/nautilus_core/model/src/accounts/margin.rs
@@ -310,6 +310,11 @@ impl Account for MarginAccount {
     fn balances_locked(&self) -> HashMap<Currency, Money> {
         self.base_balances_locked()
     }
+
+    fn balance(&self, currency: Option<Currency>) -> Option<&AccountBalance> {
+        self.base_balance(currency)
+    }
+
     fn last_event(&self) -> Option<AccountState> {
         self.base_last_event()
     }


### PR DESCRIPTION
# Pull Request

- added `balance` function to accounts so that it can query `AccountBalance` by the target `Currency`
- implemented `adjust_account` in `SimulatedExchange`
- refactored test `test_initialize_account` to `test_accounting` to also include testing of  account adjustment flow