### PR TITLE
Fix _process_trade_ticks_from_bar for low volume

### DIFF
--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -643,7 +643,12 @@ cdef class OrderMatchingEngine:
         #         )
 
     cdef void _process_trade_ticks_from_bar(self, Bar bar):
-        cdef double size_value = max(bar.volume.as_double() / 4.0, self.instrument.size_increment.as_double())
+        cdef double bar_volume = bar.volume.as_double()
+        if bar_volume == 0.0:
+            return
+
+        # Note: we make the approximation that volume is at least 4 if it's not 0
+        cdef double size_value = max(bar.volume.as_double() / 4.0, self.instrument.size_increment.as_double(), 1.0)
         cdef Quantity size = Quantity(size_value, bar._mem.volume.precision)
 
         # Create base tick template


### PR DESCRIPTION
# Pull Request

Fix _process_trade_ticks_from_bar for low volume
Floored size of tick at 1 if bar volume is not 0

Solving issue here https://github.com/nautechsystems/nautilus_trader/issues/2275

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?


