### PR TITLE
Allow zero commission for PerContractFeeModel

### DIFF
--- a/nautilus_trader/backtest/models.pyx
+++ b/nautilus_trader/backtest/models.pyx
@@ -293,7 +293,7 @@ cdef class PerContractFeeModel(FeeModel):
     """
 
     def __init__(self, Money commission not None):
-        Condition.positive(commission, "commission")
+        Condition.not_negative(commission, "commission")
 
         self._commission = commission
 


### PR DESCRIPTION
Hi Chris,
I would like to enable setting zero commistion during backtest.

There are 4 reasonable use cases:

1. Testing pure strategy logic - helps verify if core idea works before adding friction
2. Comparing pure edge of various strategies without impact of various commission from different brokers
3. Parameter optimization - find optimal settings first, then add real costs to see degradation for various commision schemes
4. If user simply wishes (from any reasons) to backtest his strategy with zero commission, that should allowed as many other backtesting platforms allow to set any (even zero) commission in backtests.

Of course, everyone should use realistic commissions for final testing, but setting up zero commission if user intentionally wants that for specific use-case, that should not be blocked.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Note: this just extends possibilities to use zero commission if needed and does not block anything.