### PR TITLE
Fix hang in rate limiter

### DIFF
--- a/nautilus_core/network/src/ratelimiter/mod.rs
+++ b/nautilus_core/network/src/ratelimiter/mod.rs
@@ -185,7 +185,9 @@ where
     pub async fn until_key_ready(&self, key: &K) {
         loop {
             match self.check_key(key) {
-                Ok(x) => x,
+                Ok(_) => {
+                    break;
+                },
                 Err(neg) => {
                     sleep(neg.wait_time_from(self.clock.now())).await;
                 }

--- a/nautilus_core/network/src/ratelimiter/mod.rs
+++ b/nautilus_core/network/src/ratelimiter/mod.rs
@@ -344,4 +344,21 @@ mod tests {
         assert!(mock_limiter.check_key(&"per_second".to_string()).is_ok());
         assert!(mock_limiter.check_key(&"per_minute".to_string()).is_err());
     }
+
+    #[tokio::test]
+    async fn test_await_keys_ready() {
+        let mock_limiter = initialize_mock_rate_limiter();
+
+        // Check base quota is not exceeded
+        assert!(mock_limiter.check_key(&"default".to_string()).is_ok());
+        assert!(mock_limiter.check_key(&"default".to_string()).is_ok());
+
+        // Check base quota is exceeded
+        assert!(mock_limiter.check_key(&"default".to_string()).is_err());
+
+        // Wait keys to be ready and check base quota is reset
+        mock_limiter.advance_clock(Duration::from_secs(1));
+        mock_limiter.await_keys_ready(Some(vec!["default".to_string()])).await;
+        assert!(mock_limiter.check_key(&"default".to_string()).is_ok());
+    }
 }

--- a/nautilus_core/network/src/ratelimiter/mod.rs
+++ b/nautilus_core/network/src/ratelimiter/mod.rs
@@ -187,7 +187,7 @@ where
             match self.check_key(key) {
                 Ok(_) => {
                     break;
-                },
+                }
                 Err(neg) => {
                     sleep(neg.wait_time_from(self.clock.now())).await;
                 }
@@ -358,7 +358,9 @@ mod tests {
 
         // Wait keys to be ready and check base quota is reset
         mock_limiter.advance_clock(Duration::from_secs(1));
-        mock_limiter.await_keys_ready(Some(vec!["default".to_string()])).await;
+        mock_limiter
+            .await_keys_ready(Some(vec!["default".to_string()]))
+            .await;
         assert!(mock_limiter.check_key(&"default".to_string()).is_ok());
     }
 }


### PR DESCRIPTION
# Pull Request
Fix hang in rate limiter. 

## Type of change

Break when the condition is met to prevent an infinite loop.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?

Add test for await_keys_ready function
