### PR TITLE
Use make target distclean instead of clean to run git clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,18 @@ build-wheel-debug:
 
 .PHONY: clean
 clean:
+	find . -type d -name "__pycache" -print0 | xargs -0 rm -rf
+	find . -type f -a \( -name "*.so" -o -name "*.dll" \) -print0 | xargs -0 rm -f
+	rm -rf \
+		nautilus_core/target/ \
+		.benchmarks/ \
+		.mypy_cache/ \
+		.pytest_cache/ \
+		.ruff_cache/ \
+		build/
+
+.PHONY: distclean
+distclean: clean
 	git clean -fxd -e tests/test_data/large/
 
 .PHONY: format

--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ A `Makefile` is provided to automate most installation and build tasks for devel
 - `make build-debug`: Runs the build script in `debug` build mode.
 - `make build-wheel`: Runs the Poetry build with a wheel format in `release` mode.
 - `make build-wheel-debug`: Runs the Poetry build with a wheel format in `debug` mode.
-- `make clean`: **CAUTION** removes all non-source artifacts from the repository.
+- `make clean`: Deletes all build results, such as `.so` or `.dll` files.
+- `make distclean`: **CAUTION** Removes all artifacts not in the git index from the repository. This includes source files which have not been `git add`ed.
 - `make docs`: Builds the documentation HTML using Sphinx.
 - `make pre-commit`: Runs the pre-commit checks over all files.
 - `make ruff`: Runs ruff over all files using the `pyproject.toml` config (with autofix).


### PR DESCRIPTION
# Pull Request

Use make target `distclean` instead of clean to run git clean. Make target `clean` now only removes intermediate build files.
The `clean` target previously deleted non-committed files, which might not be expected of this make target from the description on https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tried it locally.
