### PR TITLE
Add docs overview of example locations in repository

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -10,6 +10,20 @@ The **Installation** guide will help to ensure that NautilusTrader is properly i
 ## [Quickstart](quickstart.md)
 The **Quickstart** provides a step-by-step walk through for setting up your first backtest.
 
+## Examples in repository
+
+The examples presented in the [online documentation](https://nautilustrader.io/docs/latest/) cover only a portion of all
+available examples. For a complete collection, we recommend downloading the [GitHub repository](https://github.com/nautechsystems/nautilus_trader).
+
+The following table lists example locations ordered by recommended learning progression:
+
+| Directory           | Contains                                                                                                                     |
+|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------|
+| `/examples`         | Fully runnable self-contained examples.                                                                                      |
+| `/docs/tutorials`   | Various examples in form of Jupyter notebooks.                                                                               |
+| `/tests/unit_tests` | Unit-tests can be useful when looking for specific implementation details not covered in the examples.                       |
+| `/docs/concepts`    | Contains numerous small code snippets that provide an overview of available features, but examples are mostly not runnable. |
+
 ## Backtesting API levels
 
 Backtesting involves running simulated trading systems on historical data.


### PR DESCRIPTION
# Pull Request

I extended the primary **Getting started** section and added overview of **example locations** in repository,
so we do not have to answear the same questions: "Where to look for examples" again and again on the Discord.

## Type of change

Extending documentation.

## How has this change been tested?

✅ pre-commit checks passed
✅ markdown rendering checked locally
