### PR TITLE
Betfair cleanup market id orderbook subscribe

### DIFF
--- a/nautilus_trader/adapters/betfair/data.py
+++ b/nautilus_trader/adapters/betfair/data.py
@@ -143,15 +143,15 @@ class BetfairDataClient(LiveMarketDataClient):
         if not self._keep_alive_task:
             self._keep_alive_task = self.create_task(self._keep_alive())
 
-        # Check for any global filters in instrument provider to subscribe
-        if self.instrument_provider._config.event_type_ids:
-            await self._stream.send_subscription_message(
-                event_type_ids=self.instrument_provider._config.event_type_ids,
-                country_codes=self.instrument_provider._config.country_codes,
-                market_types=self.instrument_provider._config.market_types,
-                conflate_ms=self._config.stream_conflate_ms,
-            )
-            self._subscription_status = SubscriptionStatus.SUBSCRIBED
+        # Subscribe to instrument provider config
+        await self._stream.send_subscription_message(
+            market_ids=self.instrument_provider.config.market_ids,
+            event_type_ids=self.instrument_provider.config.event_type_ids,
+            country_codes=self.instrument_provider.config.country_codes,
+            market_types=self.instrument_provider.config.market_types,
+            conflate_ms=self.config.stream_conflate_ms,
+        )
+        self._subscription_status = SubscriptionStatus.SUBSCRIBED
 
     async def _keep_alive(self) -> None:
         keep_alive_hrs = self.config.keep_alive_secs / (60 * 60)
@@ -191,19 +191,6 @@ class BetfairDataClient(LiveMarketDataClient):
             return
 
     # -- SUBSCRIPTIONS ----------------------------------------------------------------------------
-
-    async def _delayed_subscribe(self, delay: int = 0) -> None:
-        try:
-            self._log.debug(f"Scheduling subscribe for delay={delay}")
-            await asyncio.sleep(delay)
-            self._log.info(f"Sending subscribe for market_ids {self._subscribed_market_ids}")
-            await self._stream.send_subscription_message(
-                market_ids=list(self._subscribed_market_ids),
-            )
-            self._log.info(f"Added market_ids {self._subscribed_market_ids} for <OrderBook> data")
-        except asyncio.CancelledError:
-            self._log.warning("Canceled task 'delayed_subscribe'")
-
     async def _subscribe_order_book_deltas(
         self,
         instrument_id: InstrumentId,
@@ -211,59 +198,28 @@ class BetfairDataClient(LiveMarketDataClient):
         depth: int | None = None,
         params: dict[str, Any] | None = None,
     ) -> None:
-        PyCondition.not_none(instrument_id, "instrument_id")
-
-        instrument: BettingInstrument = self._instrument_provider.find(instrument_id)
-
-        if instrument.market_id in self._subscribed_market_ids:
-            self._log.warning(
-                f"Already subscribed to market_id: {instrument.market_id} "
-                f"[Instrument: {instrument_id.symbol}] <OrderBook> data",
-            )
-            return
-
-        if self._subscription_status == SubscriptionStatus.SUBSCRIBED:
-            self._log.debug("Already subscribed")
-            return
-
-        # If this is the first subscription request we're receiving, schedule a
-        # subscription after a short delay to allow other strategies to send
-        # their subscriptions (every change triggers a full snapshot).
-        self._subscribed_market_ids.add(instrument.market_id)
-        self._subscribed_instrument_ids.add(instrument.id)
-        if self._subscription_status == SubscriptionStatus.UNSUBSCRIBED:
-            delay = self.config.subscription_delay_secs or 0
-            self.create_task(self._delayed_subscribe(delay=delay))
-            self._subscription_status = SubscriptionStatus.PENDING_STARTUP
-        elif self._subscription_status == SubscriptionStatus.PENDING_STARTUP:
-            pass
-        elif self._subscription_status == SubscriptionStatus.RUNNING:
-            self.create_task(self._delayed_subscribe(delay=0))
-
-        self._log.info(
-            f"Added market_id {instrument.market_id} for {instrument_id.symbol} <OrderBook> data",
-        )
+        self._log.info("Skipping subscribe_order_book_deltas, Betfair subscribes automatically.")
 
     async def _subscribe_instrument(
         self,
         instrument_id: InstrumentId,
         params: dict[str, Any] | None = None,
     ) -> None:
-        self._log.info("Skipping subscribe_instrument, Betfair subscribes as part of orderbook")
+        self._log.info("Skipping subscribe_instrument, Betfair subscribes automatically.")
 
     async def _subscribe_quote_ticks(
         self,
         instrument_id: InstrumentId,
         params: dict[str, Any] | None = None,
     ) -> None:
-        self._log.info("Skipping subscribe_quote_ticks, Betfair subscribes as part of orderbook")
+        self._log.info("Skipping subscribe_quote_ticks, Betfair subscribes automatically.")
 
     async def _subscribe_trade_ticks(
         self,
         instrument_id: InstrumentId,
         params: dict[str, Any] | None = None,
     ) -> None:
-        self._log.info("Skipping subscribe_trade_ticks, Betfair subscribes as part of orderbook")
+        self._log.info("Skipping subscribe_trade_ticks, Betfair subscribes automatically.")
 
     async def _subscribe_instruments(self, params: dict[str, Any] | None = None) -> None:
         for instrument in self._instrument_provider.list_all():

--- a/nautilus_trader/adapters/betfair/data.py
+++ b/nautilus_trader/adapters/betfair/data.py
@@ -144,6 +144,11 @@ class BetfairDataClient(LiveMarketDataClient):
             self._keep_alive_task = self.create_task(self._keep_alive())
 
         # Subscribe to instrument provider config
+        await self.stream_subscribe()
+        self._subscription_status = SubscriptionStatus.SUBSCRIBED
+
+    async def stream_subscribe(self):
+        # Subscribe to instrument provider config
         await self._stream.send_subscription_message(
             market_ids=self.instrument_provider.config.market_ids,
             event_type_ids=self.instrument_provider.config.event_type_ids,
@@ -151,7 +156,6 @@ class BetfairDataClient(LiveMarketDataClient):
             market_types=self.instrument_provider.config.market_types,
             conflate_ms=self.config.stream_conflate_ms,
         )
-        self._subscription_status = SubscriptionStatus.SUBSCRIBED
 
     async def _keep_alive(self) -> None:
         keep_alive_hrs = self.config.keep_alive_secs / (60 * 60)

--- a/nautilus_trader/adapters/betfair/providers.py
+++ b/nautilus_trader/adapters/betfair/providers.py
@@ -66,8 +66,6 @@ class BetfairInstrumentProviderConfig(InstrumentProviderConfig, frozen=True, kw_
         The country codes to filter for.
     market_types : list[str], optional
         The market types to filter for.
-    event_type_names : list[str], optional
-        The event type names to filter for.
     min_market_start_time : pd.Timestamp, optional
         The minimum market start time (UTC) to filter from (date granularity only).
     max_market_start_time : pd.Timestamp, optional
@@ -113,7 +111,7 @@ class BetfairInstrumentProvider(InstrumentProvider):
         PyCondition.not_none(config, "config")
         super().__init__(config=config)
 
-        self._config = config
+        self.config: BetfairInstrumentProviderConfig = config
         self._client = client
         self._account_currency = config.account_currency
 
@@ -135,15 +133,15 @@ class BetfairInstrumentProvider(InstrumentProvider):
         currency = await self.get_account_currency()
         filters = filters or {}
 
-        self._log.info(f"Loading markets with market_filter={self._config}")
+        self._log.info(f"Loading markets with market_filter={self.config}")
         markets: list[FlattenedMarket] = await load_markets(
             self._client,
-            event_type_ids=filters.get("event_type_ids") or self._config.event_type_ids,
-            event_ids=filters.get("event_ids") or self._config.event_ids,
-            market_ids=filters.get("market_ids") or self._config.market_ids,
-            event_country_codes=filters.get("country_codes") or self._config.country_codes,
-            market_market_types=filters.get("market_types") or self._config.market_types,
-            event_type_names=filters.get("event_type_names") or self._config.event_type_names,
+            event_type_ids=filters.get("event_type_ids") or self.config.event_type_ids,
+            event_ids=filters.get("event_ids") or self.config.event_ids,
+            market_ids=filters.get("market_ids") or self.config.market_ids,
+            event_country_codes=filters.get("country_codes") or self.config.country_codes,
+            market_market_types=filters.get("market_types") or self.config.market_types,
+            event_type_names=filters.get("event_type_names") or self.config.event_type_names,
         )
 
         self._log.info(f"Found {len(markets)} markets, loading metadata")
@@ -151,15 +149,15 @@ class BetfairInstrumentProvider(InstrumentProvider):
             client=self._client,
             markets=markets,
             min_market_start_time=filters.get("min_market_start_time")
-            or self._config.min_market_start_time,
+            or self.config.min_market_start_time,
             max_market_start_time=filters.get("max_market_start_time")
-            or self._config.max_market_start_time,
+            or self.config.max_market_start_time,
         )
 
-        account_currency = Currency.from_str(self._config.account_currency)
+        account_currency = Currency.from_str(self.config.account_currency)
         default_min_notional = (
-            Money(self._config.default_min_notional, account_currency)
-            if self._config.default_min_notional
+            Money(self.config.default_min_notional, account_currency)
+            if self.config.default_min_notional
             else None
         )
 

--- a/tests/integration_tests/adapters/betfair/conftest.py
+++ b/tests/integration_tests/adapters/betfair/conftest.py
@@ -28,6 +28,7 @@ from nautilus_trader.adapters.betfair.execution import BetfairExecutionClient
 from nautilus_trader.adapters.betfair.factories import BetfairLiveDataClientFactory
 from nautilus_trader.adapters.betfair.factories import BetfairLiveExecClientFactory
 from nautilus_trader.adapters.betfair.parsing.core import BetfairParser
+from nautilus_trader.adapters.betfair.providers import BetfairInstrumentProviderConfig
 from nautilus_trader.model.events.account import AccountState
 from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import Venue
@@ -62,7 +63,14 @@ def betfair_client(event_loop):
 
 @pytest.fixture()
 def instrument_provider(betfair_client):
-    return BetfairTestStubs.instrument_provider(betfair_client=betfair_client)
+    config = BetfairInstrumentProviderConfig(
+        account_currency="GBP",
+        event_type_ids=[1, 2],
+    )
+    return BetfairTestStubs.instrument_provider(
+        betfair_client=betfair_client,
+        config=config,
+    )
 
 
 @pytest.fixture()
@@ -111,6 +119,9 @@ def data_client(
     patch(
         "nautilus_trader.adapters.betfair.data.BetfairDataClient._instrument_provider.get_account_currency",
         return_value="GBP",
+    )
+    mocker.patch(
+        "nautilus_trader.adapters.betfair.data.BetfairDataClient.stream_subscribe",
     )
     patch(
         "nautilus_trader.adapters.betfair.providers.BetfairInstrumentProvider._client.list_navigation",


### PR DESCRIPTION
# Pull Request

Remove market_id subscriptions via instrument_ids (use only instrument provider) 

## Type of change

Delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this change been tested?
Removing code only. 