### PR TITLE
Refine streaming parameter description

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -961,8 +961,11 @@ cdef class BacktestEngine:
         run_config_id : str, optional
             The tokenized `BacktestRunConfig` ID.
         streaming : bool, default False
-            If running in streaming mode. If False, then will end the backtest
-            following the run iterations.
+            Controls how data are loaded and processed:
+            - If False (default mode): All data is loaded at once
+              This is currently the only supported mode for custom data (e.g. option Greeks).
+            - If True (streaming mode): Data is loaded in chunks, enabling more efficient memory
+              usage when backtesting large datasets.
 
         Raises
         ------


### PR DESCRIPTION
Based on [Discord discussion](https://discord.com/channels/924497682343550976/924506736927334400/1337380339194265612) with @faysou,
I have updated documentation to be more specific about what really happens under the hood
regarding the `streaming` parameter in `BacktestEngine.run(..., streaming=True)`.

🥇  Credit for this goes to: @faysou

@cjdsellers, feel free to modify the wording if there are any inconsistencies / inaccuracies, please 🙏 

## Type of change

Code documentation refined.

## How has this change been tested?

✅ pre-commit passed