### PR TITLE
Implement update_limit_order in OrderMatchingEngine

### DIFF
--- a/crates/execution/src/matching_core/handlers.rs
+++ b/crates/execution/src/matching_core/handlers.rs
@@ -48,7 +48,7 @@ impl FillMarketOrderHandler for FillMarketOrderHandlerAny {
 pub struct ShareableFillMarketOrderHandler(pub FillMarketOrderHandlerAny);
 
 pub trait FillLimitOrderHandler {
-    fn fill_limit_order(&mut self, order: &OrderAny);
+    fn fill_limit_order(&mut self, order: &mut OrderAny);
 }
 
 #[derive(Clone)]
@@ -58,13 +58,13 @@ pub enum FillLimitOrderHandlerAny {
 }
 
 impl FillLimitOrderHandler for FillLimitOrderHandlerAny {
-    fn fill_limit_order(&mut self, order: &OrderAny) {
+    fn fill_limit_order(&mut self, order: &mut OrderAny) {
         match self {
             Self::OrderMatchingEngine(engine) => {
                 engine.borrow_mut().fill_limit_order(order);
             }
             Self::OrderEmulator(emulator) => {
-                emulator.borrow_mut().fill_limit_order(&mut order.clone());
+                emulator.borrow_mut().fill_limit_order(order);
             }
         }
     }
@@ -74,7 +74,7 @@ impl FillLimitOrderHandler for FillLimitOrderHandlerAny {
 pub struct ShareableFillLimitOrderHandler(pub FillLimitOrderHandlerAny);
 
 pub trait TriggerStopOrderHandler {
-    fn trigger_stop_order(&mut self, order: &OrderAny);
+    fn trigger_stop_order(&mut self, order: &mut OrderAny);
 }
 
 #[derive(Clone)]
@@ -84,13 +84,13 @@ pub enum TriggerStopOrderHandlerAny {
 }
 
 impl TriggerStopOrderHandler for TriggerStopOrderHandlerAny {
-    fn trigger_stop_order(&mut self, order: &OrderAny) {
+    fn trigger_stop_order(&mut self, order: &mut OrderAny) {
         match self {
             Self::OrderMatchingEngine(engine) => {
-                engine.borrow_mut().trigger_stop_order(&mut order.clone());
+                engine.borrow_mut().trigger_stop_order(order);
             }
             Self::OrderEmulator(emulator) => {
-                emulator.borrow_mut().trigger_stop_order(&mut order.clone());
+                emulator.borrow_mut().trigger_stop_order(order);
             }
         }
     }

--- a/crates/execution/src/matching_engine/tests.rs
+++ b/crates/execution/src/matching_engine/tests.rs
@@ -1847,3 +1847,171 @@ fn test_process_modify_order_rejected_not_found(
     };
     assert_eq!(order_rejected.client_order_id, client_order_id);
 }
+
+#[rstest]
+fn test_update_limit_order_post_only_matched(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+) {
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // Add SELL limit orderbook delta to have ask initialized
+    let orderbook_delta_sell = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .build();
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+
+    // Create BUY LIMIT order post only which will won't be filled
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1495.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(client_order_id)
+        .post_only(true)
+        .build();
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    // Create ModifyOrder command to update price of the order to be matched
+    let modify_order_command = ModifyOrder::new(
+        TraderId::from("TRADER-001"),
+        ClientId::from("CLIENT-001"),
+        StrategyId::from("STRATEGY-001"),
+        instrument_eth_usdt.id(),
+        client_order_id,
+        VenueOrderId::from("V1"),
+        None,
+        Some(Price::from("1500.00")), // Set price which will be matched
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+    )
+    .unwrap();
+    engine_l2.process_modify(&modify_order_command, account_id);
+
+    // Check that we have received OrderAccepted and then OrderModifyRejected event because of post only
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 2);
+    let order_event_first = saved_messages.first().unwrap();
+    let order_accepted = match order_event_first {
+        OrderEventAny::Accepted(order_accepted) => order_accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    assert_eq!(order_accepted.client_order_id, client_order_id);
+    let order_event_second = saved_messages.get(1).unwrap();
+    let order_rejected = match order_event_second {
+        OrderEventAny::ModifyRejected(order_rejected) => order_rejected,
+        _ => panic!("Expected OrderModifyRejected event in second message"),
+    };
+    assert_eq!(order_rejected.client_order_id, client_order_id);
+    assert_eq!(
+        order_rejected.reason,
+        Ustr::from("POST_ONLY LIMIT BUY order with new limit px of 1500.00 would have been a TAKER: bid=None, ask=1500.00")
+    );
+}
+
+#[rstest]
+fn test_update_limit_order_valid(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+) {
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // Add SELL limit orderbook delta to have ask initialized
+    let orderbook_delta_sell = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .build();
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+
+    // Create BUY LIMIT order post only which will won't be filled
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1495.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(client_order_id)
+        .build();
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    // Create ModifyOrder command to update price to 1500.00 where it will be matched immediately
+    let new_limit_price = Price::from("1500.00");
+    let modify_order_command = ModifyOrder::new(
+        TraderId::from("TRADER-001"),
+        ClientId::from("CLIENT-001"),
+        StrategyId::from("STRATEGY-001"),
+        instrument_eth_usdt.id(),
+        client_order_id,
+        VenueOrderId::from("V1"),
+        None,
+        Some(new_limit_price),
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+    )
+    .unwrap();
+    engine_l2.process_modify(&modify_order_command, account_id);
+
+    // Check that we have received OrderAccepted and then OrderUpdated
+    // and then OrderFilled as limit order was matched immediately
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 3);
+    let order_event_first = saved_messages.first().unwrap();
+    let order_accepted = match order_event_first {
+        OrderEventAny::Accepted(order_accepted) => order_accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    assert_eq!(order_accepted.client_order_id, client_order_id);
+    let order_event_second = saved_messages.get(1).unwrap();
+    let order_updated = match order_event_second {
+        OrderEventAny::Updated(order_updated) => order_updated,
+        _ => panic!("Expected OrderUpdated event in second message"),
+    };
+    assert_eq!(order_updated.client_order_id, client_order_id);
+    assert_eq!(order_updated.price.unwrap(), new_limit_price);
+    let order_event_third = saved_messages.get(2).unwrap();
+    let order_filled = match order_event_third {
+        OrderEventAny::Filled(order_filled) => order_filled,
+        _ => panic!("Expected OrderFilled event in third message"),
+    };
+    assert_eq!(order_filled.client_order_id, client_order_id);
+    assert_eq!(order_filled.last_px, new_limit_price);
+    assert_eq!(order_filled.last_qty, Quantity::from("1.000"));
+}

--- a/crates/model/src/orders/base.rs
+++ b/crates/model/src/orders/base.rs
@@ -122,6 +122,7 @@ impl OrderStatus {
             (Self::Accepted, OrderEventAny::Expired(_)) => Self::Expired,
             (Self::Accepted, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::Accepted, OrderEventAny::Filled(_)) => Self::Filled,
+            (Self::Accepted, OrderEventAny::Updated(_)) => Self::Accepted,  // Updates should preserve state
             (Self::Canceled, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,  // Real world possibility
             (Self::Canceled, OrderEventAny::Filled(_)) => Self::Filled,  // Real world possibility
             (Self::PendingUpdate, OrderEventAny::Rejected(_)) => Self::Rejected,


### PR DESCRIPTION
# Pull Request

- implemented `update_limit_order` in `OrderMatchingEngine`
- changed the interface for `is_limit_matched` function in `OrderMatchingCore` to also accept optional `Price` parameter which will be used in updating commands where price is not read from
- added manual order applying in `generate_order_updated` so that new updated prices is reflected in the order object( with TODO so remove when updating is done inside execution engine msgbus handlers)
- added order transition case when order status is `Accepted` and it receives `OrderUpdated` event, which is not currently a match and we receive an invalid transition error. Order status should remain `Accepted` in that case
- added `test_update_limit_order_post_only_matched` which checks target `OrderModifyRejected` event was emitted if post-only order was updated which limit matched
- added  `test_update_limit_order_valid` which checks full update limit flow
