### PR TITLE
Refactor matching functions for OrderMatchingCore

### DIFF
--- a/crates/execution/src/matching_core/mod.rs
+++ b/crates/execution/src/matching_core/mod.rs
@@ -248,7 +248,7 @@ impl OrderMatchingCore {
     }
 
     pub fn match_stop_order(&mut self, order: &StopOrderAny) {
-        if self.is_stop_matched(order) {
+        if self.is_stop_matched(order.order_side_specified(), order.stop_px()) {
             if let Some(handler) = &mut self.trigger_stop_order {
                 handler
                     .0
@@ -266,10 +266,10 @@ impl OrderMatchingCore {
     }
 
     #[must_use]
-    pub fn is_stop_matched(&self, order: &StopOrderAny) -> bool {
-        match order.order_side_specified() {
-            OrderSideSpecified::Buy => self.ask.is_some_and(|a| a >= order.stop_px()),
-            OrderSideSpecified::Sell => self.bid.is_some_and(|b| b <= order.stop_px()),
+    pub fn is_stop_matched(&self, side: OrderSideSpecified, price: Price) -> bool {
+        match side {
+            OrderSideSpecified::Buy => self.ask.is_some_and(|a| a >= price),
+            OrderSideSpecified::Sell => self.bid.is_some_and(|b| b <= price),
         }
     }
 }
@@ -469,7 +469,8 @@ mod tests {
             .quantity(Quantity::from("100"))
             .build();
 
-        let result = matching_core.is_limit_matched(order.order_side_specified(), order.price().unwrap());
+        let result =
+            matching_core.is_limit_matched(order.order_side_specified(), order.price().unwrap());
         assert_eq!(result, expected);
     }
 
@@ -537,7 +538,8 @@ mod tests {
             .quantity(Quantity::from("100"))
             .build();
 
-        let result = matching_core.is_stop_matched(&order.into());
+        let result = matching_core
+            .is_stop_matched(order.order_side_specified(), order.trigger_price().unwrap());
         assert_eq!(result, expected);
     }
 }

--- a/crates/execution/src/matching_core/mod.rs
+++ b/crates/execution/src/matching_core/mod.rs
@@ -238,7 +238,7 @@ impl OrderMatchingCore {
     }
 
     pub fn match_limit_order(&mut self, order: &LimitOrderAny) {
-        if self.is_limit_matched(order, None) {
+        if self.is_limit_matched(order.order_side_specified(), order.limit_px()) {
             if let Some(handler) = &mut self.fill_limit_order {
                 handler
                     .0
@@ -258,11 +258,10 @@ impl OrderMatchingCore {
     }
 
     #[must_use]
-    pub fn is_limit_matched(&self, order: &LimitOrderAny, price: Option<Price>) -> bool {
-        let target_price = price.unwrap_or(order.limit_px());
-        match order.order_side_specified() {
-            OrderSideSpecified::Buy => self.ask.is_some_and(|a| a <= target_price),
-            OrderSideSpecified::Sell => self.bid.is_some_and(|b| b >= target_price),
+    pub fn is_limit_matched(&self, side: OrderSideSpecified, price: Price) -> bool {
+        match side {
+            OrderSideSpecified::Buy => self.ask.is_some_and(|a| a <= price),
+            OrderSideSpecified::Sell => self.bid.is_some_and(|b| b >= price),
         }
     }
 
@@ -470,7 +469,7 @@ mod tests {
             .quantity(Quantity::from("100"))
             .build();
 
-        let result = matching_core.is_limit_matched(&order.into(), None);
+        let result = matching_core.is_limit_matched(order.order_side_specified(), order.price().unwrap());
         assert_eq!(result, expected);
     }
 

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -47,7 +47,7 @@ use nautilus_model::{
     instruments::{InstrumentAny, EXPIRING_INSTRUMENT_TYPES},
     orderbook::OrderBook,
     orders::{
-        LimitOrderAny, Order, OrderAny, PassiveOrderAny, StopLimitOrder, StopMarketOrder,
+        Order, OrderAny, PassiveOrderAny, StopLimitOrder, StopMarketOrder,
         StopOrderAny, TrailingStopLimitOrder, TrailingStopMarketOrder,
     },
     position::Position,
@@ -801,10 +801,11 @@ impl OrderMatchingEngine {
     }
 
     fn process_limit_order(&mut self, order: &mut OrderAny) {
+        let limit_px = order.price().expect("Limit order must have a price");
         if order.is_post_only()
             && self
                 .core
-                .is_limit_matched(&LimitOrderAny::from(order.to_owned()), None)
+                .is_limit_matched(order.order_side_specified(), limit_px)
         {
             self.generate_order_rejected(
                 order,
@@ -831,7 +832,7 @@ impl OrderMatchingEngine {
         // Check for immediate fill
         if self
             .core
-            .is_limit_matched(&LimitOrderAny::from(order.to_owned()), None)
+            .is_limit_matched(order.order_side_specified(), limit_px)
         {
             // Filling as liquidity taker
             if order.liquidity_side().is_some()
@@ -908,9 +909,10 @@ impl OrderMatchingEngine {
             self.generate_order_triggered(order);
 
             // Check for immediate fill
+            let limit_px = order.price().expect("Stop limit order must have a price");
             if self
                 .core
-                .is_limit_matched(&LimitOrderAny::from(order.to_owned()), None)
+                .is_limit_matched(order.order_side_specified(), limit_px)
             {
                 order.set_liquidity_side(LiquiditySide::Taker);
                 self.fill_limit_order(order);
@@ -1431,7 +1433,7 @@ impl OrderMatchingEngine {
     fn update_limit_order(&mut self, order: &mut OrderAny, quantity: Quantity, price: Price) {
         if self
             .core
-            .is_limit_matched(&LimitOrderAny::from(order.clone()), Some(price))
+            .is_limit_matched(order.order_side_specified(), price)
         {
             if order.is_post_only() {
                 self.generate_order_modify_rejected(

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -47,8 +47,8 @@ use nautilus_model::{
     instruments::{InstrumentAny, EXPIRING_INSTRUMENT_TYPES},
     orderbook::OrderBook,
     orders::{
-        Order, OrderAny, PassiveOrderAny, StopLimitOrder, StopMarketOrder,
-        StopOrderAny, TrailingStopLimitOrder, TrailingStopMarketOrder,
+        Order, OrderAny, PassiveOrderAny, StopLimitOrder, StopMarketOrder, StopOrderAny,
+        TrailingStopLimitOrder, TrailingStopMarketOrder,
     },
     position::Position,
     types::{fixed::FIXED_PRECISION, Currency, Money, Price, Quantity},
@@ -851,9 +851,12 @@ impl OrderMatchingEngine {
     }
 
     fn process_stop_market_order(&mut self, order: &mut OrderAny) {
+        let stop_px = order
+            .trigger_price()
+            .expect("Stop order must have a trigger price");
         if self
             .core
-            .is_stop_matched(&StopOrderAny::from(order.to_owned()))
+            .is_stop_matched(order.order_side_specified(), stop_px)
         {
             if self.config.reject_stop_orders {
                 self.generate_order_rejected(
@@ -882,9 +885,12 @@ impl OrderMatchingEngine {
     }
 
     fn process_stop_limit_order(&mut self, order: &mut OrderAny) {
+        let stop_px = order
+            .trigger_price()
+            .expect("Stop order must have a trigger price");
         if self
             .core
-            .is_stop_matched(&StopOrderAny::from(order.to_owned()))
+            .is_stop_matched(order.order_side_specified(), stop_px)
         {
             if self.config.reject_stop_orders {
                 self.generate_order_rejected(


### PR DESCRIPTION
# Pull Request

- change the function signature of `is_limit_matched` and `is_stop_matched` to only accept order side and price
- this change removes unnecessary cloning from `OrderAny` to `LimitOrderAny` and `StopOrderAny` when calling this functions
- we immediately panic if price is not supplied in limit or stop limit orders