### PR TITLE
Refine greeks computation

### DIFF
--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -4846,6 +4846,7 @@ class GreeksData(Data):
     quantity: float
     underlying_price: float
     interest_rate: float
+    cost_of_carry: float
     vol: float
     price: float
     delta: float
@@ -4867,6 +4868,7 @@ class GreeksData(Data):
         quantity: float = 0.0,
         underlying_price: float = 0.0,
         interest_rate: float = 0.0,
+        cost_of_carry: float = 0.0,
         vol: float = 0.0,
         price: float = 0.0,
         delta: float = 0.0,

--- a/nautilus_trader/model/greeks_data.py
+++ b/nautilus_trader/model/greeks_data.py
@@ -37,6 +37,7 @@ class GreeksData(Data):
 
     underlying_price: float = 0.0
     interest_rate: float = 0.0
+    cost_of_carry: float = 0.0
 
     vol: float = 0.0
     price: float = 0.0
@@ -44,6 +45,7 @@ class GreeksData(Data):
     gamma: float = 0.0
     vega: float = 0.0
     theta: float = 0.0
+
     # in the money probability, P(phi * S_T > phi * K), phi = 1 if is_call else -1
     itm_prob: float = 0.0
 
@@ -80,6 +82,7 @@ class GreeksData(Data):
             self.quantity,
             self.underlying_price,
             self.interest_rate,
+            self.cost_of_carry,
             self.vol,
             quantity * self.price,
             quantity * self.delta,


### PR DESCRIPTION
# Pull Request

Refine greeks computation

+ Allow other asset classes than futures, by just using a multiplier of 1 for non futures
+ Also we make the assumption american options are european for ease of computation, this is still a good approximation in most cases.
+ Added support for a flat dividend rate or a dividend curve stored in the cache with a name equal to the instrument id as string of the underlying of the option. If dividend curve is present or divident rate is not None, then the cost of carry  used to computed the implied volatility and the greeks is interest_rate - dividend_yield, else it's 0 for options on futures.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested databento_option_greeks.py notebook is still working
