### PR TITLE
Enable debugging in cargo test profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,3 +11,7 @@ test-group = 'serial-tests'
 [[profile.default.overrides]]
 filter = 'test(test_order_book)'
 slow-timeout = { period = "300s" }
+
+[profile.nextest]
+filter = "package(*)"
+cargo-options = ["--profile=nextest"]

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -69,18 +69,18 @@ runs:
       with:
         tool: nextest
 
-    - name: Cached cargo
-      id: cached-cargo
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-
+#    - name: Cached cargo
+#      id: cached-cargo
+#      uses: actions/cache@v4
+#      with:
+#        path: |
+#          ~/.cargo/bin/
+#          ~/.cargo/registry/index/
+#          ~/.cargo/registry/cache/
+#          ~/.cargo/git/db/
+#          target/
+#        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+#        restore-keys: ${{ runner.os }}-cargo-
 
     # > --------------------------------------------------
     # > sccache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,13 +100,18 @@ codegen-units = 256
 
 [profile.test]
 opt-level = 0
-debug = false  # Improves compile times
+debug = true
 debug-assertions = true  # Fails Cython build if true
 overflow-checks = true
-strip = "debuginfo"  # Improves compile times
+strip = false
 lto = false
 incremental = true
 codegen-units = 256
+
+[profile.nextest]
+inherits = "test"
+debug = false # Improves compile times
+strip = "debuginfo" # Improves compile times
 
 [profile.release]
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -105,32 +105,44 @@ cargo-build:
 cargo-update:
 	cargo update && cargo install cargo-nextest && cargo install cargo-llvm-cov
 
-.PHONY: cargo-test
-cargo-test: RUST_BACKTRACE=1
-cargo-test: HIGH_PRECISION=true
-cargo-test:
+.PHONY: check-nextest
+check-nextest:
 	@if ! cargo nextest --version >/dev/null 2>&1; then \
 		echo "cargo-nextest is not installed. You can install it using 'cargo install cargo-nextest'"; \
 		exit 1; \
 	fi
-	RUST_BACKTRACE=$(RUST_BACKTRACE) HIGH_PRECISION=$(HIGH_PRECISION) cargo nextest run --workspace --features "python,ffi,high-precision"
+
+.PHONY: cargo-test
+cargo-test: RUST_BACKTRACE=1
+cargo-test: HIGH_PRECISION=true
+cargo-test: check-nextest
+cargo-test:
+	RUST_BACKTRACE=$(RUST_BACKTRACE) HIGH_PRECISION=$(HIGH_PRECISION) cargo nextest run --workspace --features "python,ffi,high-precision" --profile nextest
 
 .PHONY: cargo-test-standard-precision
 cargo-test-standard-precision: RUST_BACKTRACE=1
 cargo-test-standard-precision: HIGH_PRECISION=false
+cargo-test-standard-precision: check-nextest
 cargo-test-standard-precision:
-	@if ! cargo nextest --version >/dev/null 2>&1; then \
-    echo "cargo-nextest is not installed. You can install it using 'cargo install cargo-nextest'"; \
-    exit 1; \
-	fi
+	RUST_BACKTRACE=$(RUST_BACKTRACE) HIGH_PRECISION=$(HIGH_PRECISION) cargo nextest run --workspace --features "python,ffi" --profile nextest
+
+.PHONY: cargo-test-debug
+cargo-test-debug: RUST_BACKTRACE=1
+cargo-test-debug: HIGH_PRECISION=true
+cargo-test-debug: check-nextest
+cargo-test-debug:
+	RUST_BACKTRACE=$(RUST_BACKTRACE) HIGH_PRECISION=$(HIGH_PRECISION) cargo nextest run --workspace --features "python,ffi,high-precision"
+
+.PHONY: cargo-test-standard-precision-debug
+cargo-test-standard-precision-debug: RUST_BACKTRACE=1
+cargo-test-standard-precision-debug: HIGH_PRECISION=false
+cargo-test-standard-precision-debug: check-nextest
+cargo-test-standard-precision-debug:
 	RUST_BACKTRACE=$(RUST_BACKTRACE) HIGH_PRECISION=$(HIGH_PRECISION) cargo nextest run --workspace --features "python,ffi"
 
 .PHONY: cargo-test-coverage
+cargo-test-coverage: check-nextest
 cargo-test-coverage:
-	@if ! cargo nextest --version >/dev/null 2>&1; then \
-		echo "cargo-nextest is not installed. You can install it using 'cargo install cargo-nextest'"; \
-		exit 1; \
-	fi
 	@if ! cargo llvm-cov --version >/dev/null 2>&1; then \
 		echo "cargo-llvm-cov is not installed. You can install it using 'cargo install cargo-llvm-cov'"; \
 		exit 1; \

--- a/docs/developer_guide/testing.md
+++ b/docs/developer_guide/testing.md
@@ -50,18 +50,16 @@ removed when no longer appropriate, and its use *restricted* to the above cases.
 
 ## Debugging Rust Tests
 
-If you want to debug a Rust test in an IDE, you should modify the `profile.test` section of the
-root `Cargo.toml` file, setting the `debug` field to `true` and the `strip` field to `false`.
-It should look like this after the modification:
+Rust tests can be debugged using the default test configuration.
 
-```toml
-[profile.test]
-opt-level = 0
-debug = true  # Improves compile times
-debug-assertions = true  # Fails Cython build if true
-overflow-checks = true
-strip = false  # Improves compile times
-lto = false
-incremental = true
-codegen-units = 256
-```
+If you want to run all tests while compiling with debug symbols for later debugging some tests individually,
+run `make cargo-test-debug` instead of `make cargo-test`.
+
+In IntellijIdea, to debug parametrised tests starting with `#[rstest]` with arguments defined in the header of the test
+you need to modify the run configuration of the test so it looks like
+`test --package nautilus-model --lib data::bar::tests::test_get_time_bar_start::case_1`
+(remove ` -- --exact` at the end of the string and append `::case_n` where `n` is an integer corresponding to
+the n-th parametrised test starting at 1).
+The reason for this is [here](https://github.com/rust-lang/rust-analyzer/issues/8964#issuecomment-871592851)
+(the test is expanded into a module with several functions named `case_n`).
+In VSCode, it is possible to directly select which test case to debug.


### PR DESCRIPTION
# Pull Request

- Modify default test profile to enable debug symbols
- Add nextest profile to be equal to the previous test profile, disabling debug symbols.
- Modify existing make cargo-test comands to use nextest profile
- Add new make cargo-test commands to use the default modified test profile
- Modify documentation accordingly

This way there's no change in behaviour in CI when doing make cargo-test. Also make cargo-test-debug allows to compile everything using debug symbols so when using the debugger in intellijidea for example, there's no need to recompile everything.

This should improve the dev experience for people not familiar with nautilus by making debugging easy compared to before.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Existing rust tests still passing
