### PR TITLE
Fix command bugs in adapters

### DIFF
--- a/nautilus_trader/adapters/databento/data.py
+++ b/nautilus_trader/adapters/databento/data.py
@@ -331,7 +331,11 @@ class DatabentoDataClient(LiveMarketDataClient):
                 return
 
             self._instrument_ids[dataset].add(instrument_id)
-            await self._subscribe_instrument(instrument_id)
+
+            command_id = UUID4()
+            await self._subscribe_instrument(
+                SubscribeInstrument(command_id, instrument_id, venue=instrument_id.venue),
+            )
         except asyncio.CancelledError:
             self._log.warning(
                 "Canceled task 'ensure_subscribed_for_instrument'",

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -789,7 +789,6 @@ class DYDXDataClient(LiveMarketDataClient):
                 command_id=command.id,
                 instrument_id=command.instrument_id,
                 book_type=book_type,
-                # below is just to propagate information
                 client_id=command.client_id,
                 venue=command.venue,
                 ts_init=command.ts_init,
@@ -831,7 +830,6 @@ class DYDXDataClient(LiveMarketDataClient):
             order_book_command = UnsubscribeOrderBook(
                 command_id=command.id,
                 instrument_id=command.instrument_id,
-                # below is just to propagate information
                 client_id=command.client_id,
                 venue=command.venue,
                 ts_init=command.ts_init,

--- a/nautilus_trader/adapters/okx/data.py
+++ b/nautilus_trader/adapters/okx/data.py
@@ -265,7 +265,15 @@ class OKXDataClient(LiveMarketDataClient):
             return
 
         if command.depth == 1 or command.book_type == BookType.L1_MBP:
-            await self._subscribe_quote_ticks(command.instrument_id)
+            quote_ticks_subscription = SubscribeQuoteTicks(
+                command_id=command.id,
+                instrument_id=command.instrument_id,
+                client_id=command.client_id,
+                venue=command.venue,
+                ts_init=command.ts_init,
+                params=command.params,
+            )
+            await self._subscribe_quote_ticks(quote_ticks_subscription)
             return
 
         if command.depth is None:
@@ -288,7 +296,15 @@ class OKXDataClient(LiveMarketDataClient):
                     f"requested subscription for depth {depth}. Replacing subscription of "
                     f"depth {_depth} with depth {depth}.",
                 )
-                await self._unsubscribe_order_book_deltas(command.instrument_id)
+                order_book_unsubscription = UnsubscribeOrderBook(
+                    command_id=command.id,
+                    instrument_id=command.instrument_id,
+                    client_id=command.client_id,
+                    venue=command.venue,
+                    ts_init=command.ts_init,
+                    params=command.params,
+                )
+                await self._unsubscribe_order_book_deltas(order_book_unsubscription)
 
         ws_client = await self._get_ws_client(OKXWsBaseUrlType.PUBLIC, tbt_books=True)
 

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1894,9 +1894,7 @@ cdef class DataEngine(Component):
                     )
                     continue
 
-                # Create aggregator
                 aggregator = self._create_bar_aggregator(instrument, bar_type)
-
                 if params["update_subscriptions"]:
                     self._bar_aggregators[bar_type.standard()] = aggregator
 
@@ -2044,7 +2042,6 @@ cdef class DataEngine(Component):
         aggregator = self._bar_aggregators.get(command.bar_type.standard())
 
         if aggregator is None:
-            # Create aggregator
             aggregator = self._create_bar_aggregator(instrument, command.bar_type)
 
         # Set if awaiting initial partial bar


### PR DESCRIPTION
# Pull Request

Fixed command bugs in adapters

Some subscribe calls were using the old signatures without commands.

Also checked all subscribes, unsusubcribes and requests in all adapters are fine now.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Only checked that commands have correct syntax
