### PR TITLE
Implement processing of market-to-limit orders in matching engine

### DIFF
--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -860,6 +860,10 @@ impl OrderMatchingEngine {
 
         // Immediately fill marketable order
         self.fill_market_order(order);
+
+        if order.is_open() {
+            self.accept_order(order);
+        }
     }
 
     fn process_stop_market_order(&mut self, order: &mut OrderAny) {
@@ -1376,9 +1380,6 @@ impl OrderMatchingEngine {
             if order.filled_qty() == Quantity::zero(order.filled_qty().precision)
                 && order.order_type() == OrderType::MarketToLimit
             {
-                // Matching engine should the first accept order then update limit price
-                self.accept_order(order);
-
                 self.generate_order_updated(order, order.quantity(), Some(fill_px), None);
                 initial_market_to_limit_fill = true;
             }

--- a/crates/execution/src/matching_engine/tests.rs
+++ b/crates/execution/src/matching_engine/tests.rs
@@ -43,7 +43,10 @@ use nautilus_model::{
         CryptoPerpetual, Equity, InstrumentAny,
         stubs::{crypto_perpetual_ethusdt, equity_aapl, futures_contract_es},
     },
-    orders::{OrderAny, OrderTestBuilder, stubs::TestOrderStubs},
+    orders::{
+        OrderAny, OrderTestBuilder,
+        stubs::{TestOrderEventStubs, TestOrderStubs},
+    },
     types::{Price, Quantity},
 };
 use rstest::{fixture, rstest};
@@ -2480,4 +2483,83 @@ fn test_update_limit_if_touched_order_valid(
     };
     assert_eq!(order_updated.client_order_id, client_order_id);
     assert_eq!(order_updated.trigger_price.unwrap(), new_trigger_price);
+}
+
+#[rstest]
+fn test_process_market_to_limit_orders_not_fully_filled(
+    instrument_eth_usdt: InstrumentAny,
+    mut msgbus: MessageBus,
+    order_event_handler: ShareableMessageHandler,
+    account_id: AccountId,
+) {
+    msgbus.register(
+        msgbus.switchboard.exec_engine_process,
+        order_event_handler.clone(),
+    );
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Rc::new(RefCell::new(msgbus)),
+        None,
+        None,
+        None,
+    );
+
+    // Add SELL limit orderbook delta to have ask initialized
+    let orderbook_delta_sell = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .build();
+    engine_l2.process_order_book_delta(&orderbook_delta_sell);
+
+    // Create MARKET TO LIMIT order with quantity of 2 which will be half filled
+    // and order half will be accepted as limit order
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut market_to_limit_order = OrderTestBuilder::new(OrderType::MarketToLimit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("2.000"))
+        .client_order_id(client_order_id)
+        .build();
+    // Make order submitted
+    let order_submitted_event =
+        TestOrderEventStubs::order_submitted(&market_to_limit_order, account_id);
+    market_to_limit_order.apply(order_submitted_event).unwrap();
+    engine_l2.process_order(&mut market_to_limit_order, account_id);
+
+    // Check sequence of events for MARKET-TO-LIMIT order being not fully filled
+    // 1. OrderAccepted - order fill be transformed to limit so we must receive accepted event
+    // 2. OrderUpdated - order was updated to new limix price where market order stopped filling
+    // 3. OrderFilled - after inclusion in book we emit order filled event for market order at start
+    let saved_messages = get_order_event_handler_messages(order_event_handler);
+    assert_eq!(saved_messages.len(), 3);
+    let order_event_first = saved_messages.first().unwrap();
+    let order_accepted = match order_event_first {
+        OrderEventAny::Accepted(order_accepted) => order_accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    assert_eq!(order_accepted.client_order_id, client_order_id);
+    let order_event_second = saved_messages.get(1).unwrap();
+    let order_updated = match order_event_second {
+        OrderEventAny::Updated(order_updated) => order_updated,
+        _ => panic!("Expected OrderUpdated event in second message"),
+    };
+    assert_eq!(order_updated.client_order_id, client_order_id);
+    let order_event_third = saved_messages.get(2).unwrap();
+    let order_filled = match order_event_third {
+        OrderEventAny::Filled(order_filled) => order_filled,
+        _ => panic!("Expected OrderFilled event in third message"),
+    };
+    assert_eq!(order_filled.client_order_id, client_order_id);
+    assert_eq!(order_filled.last_px, Price::from("1500.00"));
+    assert_eq!(order_filled.last_qty, Quantity::from("1.000"));
+    // Check that we have one resting limit order in the matching core
+    let resting_orders = engine_l2.core.get_orders();
+    assert_eq!(resting_orders.len(), 1);
+    let first_order = resting_orders.first().unwrap();
+    assert_eq!(first_order.client_order_id(), client_order_id);
 }

--- a/crates/infrastructure/src/sql/queries.rs
+++ b/crates/infrastructure/src/sql/queries.rs
@@ -265,9 +265,6 @@ impl DatabaseQueries {
             OrderEventAny::Triggered(event) => {
                 DatabaseQueries::add_order_event(pool, Box::new(event), client_id).await
             }
-            OrderEventAny::PartiallyFilled(event) => {
-                DatabaseQueries::add_order_event(pool, Box::new(event), client_id).await
-            }
         }
     }
 

--- a/crates/model/src/events/order/any.rs
+++ b/crates/model/src/events/order/any.rs
@@ -48,7 +48,6 @@ pub enum OrderEventAny {
     ModifyRejected(OrderModifyRejected),
     CancelRejected(OrderCancelRejected),
     Updated(OrderUpdated),
-    PartiallyFilled(OrderFilled),
     Filled(OrderFilled),
 }
 
@@ -71,7 +70,6 @@ impl OrderEventAny {
             OrderEventAny::ModifyRejected(event) => Box::new(event),
             OrderEventAny::CancelRejected(event) => Box::new(event),
             OrderEventAny::Updated(event) => Box::new(event),
-            OrderEventAny::PartiallyFilled(event) => Box::new(event),
             OrderEventAny::Filled(event) => Box::new(event),
         }
     }
@@ -94,7 +92,6 @@ impl OrderEventAny {
             Self::ModifyRejected(_) => OrderEventType::ModifyRejected,
             Self::CancelRejected(_) => OrderEventType::CancelRejected,
             Self::Updated(_) => OrderEventType::Updated,
-            Self::PartiallyFilled(_) => OrderEventType::PartiallyFilled,
             Self::Filled(_) => OrderEventType::Filled,
         }
     }
@@ -117,7 +114,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.trader_id,
             Self::CancelRejected(event) => event.trader_id,
             Self::Updated(event) => event.trader_id,
-            Self::PartiallyFilled(event) => event.trader_id,
             Self::Filled(event) => event.trader_id,
         }
     }
@@ -140,7 +136,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.client_order_id,
             Self::CancelRejected(event) => event.client_order_id,
             Self::Updated(event) => event.client_order_id,
-            Self::PartiallyFilled(event) => event.client_order_id,
             Self::Filled(event) => event.client_order_id,
         }
     }
@@ -163,7 +158,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.venue_order_id(),
             Self::CancelRejected(event) => event.venue_order_id(),
             Self::Updated(event) => event.venue_order_id(),
-            Self::PartiallyFilled(event) => event.venue_order_id(),
             Self::Filled(event) => event.venue_order_id(),
         }
     }
@@ -186,7 +180,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.account_id(),
             Self::CancelRejected(event) => event.account_id(),
             Self::Updated(event) => event.account_id(),
-            Self::PartiallyFilled(event) => event.account_id(),
             Self::Filled(event) => event.account_id(),
         }
     }
@@ -209,7 +202,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.instrument_id(),
             Self::CancelRejected(event) => event.instrument_id(),
             Self::Updated(event) => event.instrument_id(),
-            Self::PartiallyFilled(event) => event.instrument_id(),
             Self::Filled(event) => event.instrument_id(),
         }
     }
@@ -232,7 +224,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.strategy_id,
             Self::CancelRejected(event) => event.strategy_id,
             Self::Updated(event) => event.strategy_id,
-            Self::PartiallyFilled(event) => event.strategy_id,
             Self::Filled(event) => event.strategy_id,
         }
     }
@@ -255,7 +246,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => event.ts_event,
             Self::CancelRejected(event) => event.ts_event,
             Self::Updated(event) => event.ts_event,
-            Self::PartiallyFilled(event) => event.ts_event,
             Self::Filled(event) => event.ts_event,
         }
     }
@@ -278,7 +268,6 @@ impl OrderEventAny {
             Self::ModifyRejected(event) => Some(event.reason),
             Self::CancelRejected(event) => Some(event.reason),
             Self::Updated(_) => None,
-            Self::PartiallyFilled(_) => None,
             Self::Filled(_) => None,
         }
     }

--- a/crates/model/src/orders/any.rs
+++ b/crates/model/src/orders/any.rs
@@ -1133,6 +1133,7 @@ impl From<OrderAny> for PassiveOrderAny {
             OrderAny::StopMarket(_) => PassiveOrderAny::Stop(order.into()),
             OrderAny::TrailingStopLimit(_) => PassiveOrderAny::Stop(order.into()),
             OrderAny::TrailingStopMarket(_) => PassiveOrderAny::Stop(order.into()),
+            OrderAny::MarketToLimit(_) => PassiveOrderAny::Limit(order.into()),
             _ => panic!("WIP: Implement trait bound to require `HasPrice`"),
         }
     }

--- a/crates/model/src/orders/base.rs
+++ b/crates/model/src/orders/base.rs
@@ -112,7 +112,6 @@ impl OrderStatus {
             (Self::Submitted, OrderEventAny::Rejected(_)) => Self::Rejected,
             (Self::Submitted, OrderEventAny::Canceled(_)) => Self::Canceled,  // FOK and IOC cases
             (Self::Submitted, OrderEventAny::Accepted(_)) => Self::Accepted,
-            (Self::Submitted, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::Submitted, OrderEventAny::Filled(_)) => Self::Filled,
             (Self::Accepted, OrderEventAny::Rejected(_)) => Self::Rejected,  // StopLimit order
             (Self::Accepted, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,
@@ -120,10 +119,8 @@ impl OrderStatus {
             (Self::Accepted, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::Accepted, OrderEventAny::Triggered(_)) => Self::Triggered,
             (Self::Accepted, OrderEventAny::Expired(_)) => Self::Expired,
-            (Self::Accepted, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::Accepted, OrderEventAny::Filled(_)) => Self::Filled,
             (Self::Accepted, OrderEventAny::Updated(_)) => Self::Accepted,  // Updates should preserve state
-            (Self::Canceled, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,  // Real world possibility
             (Self::Canceled, OrderEventAny::Filled(_)) => Self::Filled,  // Real world possibility
             (Self::PendingUpdate, OrderEventAny::Rejected(_)) => Self::Rejected,
             (Self::PendingUpdate, OrderEventAny::Accepted(_)) => Self::Accepted,
@@ -132,27 +129,23 @@ impl OrderStatus {
             (Self::PendingUpdate, OrderEventAny::Triggered(_)) => Self::Triggered,
             (Self::PendingUpdate, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,  // Allow multiple requests
             (Self::PendingUpdate, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,
-            (Self::PendingUpdate, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::PendingUpdate, OrderEventAny::Filled(_)) => Self::Filled,
             (Self::PendingCancel, OrderEventAny::Rejected(_)) => Self::Rejected,
             (Self::PendingCancel, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,  // Allow multiple requests
             (Self::PendingCancel, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::PendingCancel, OrderEventAny::Expired(_)) => Self::Expired,
             (Self::PendingCancel, OrderEventAny::Accepted(_)) => Self::Accepted,  // Allow failed cancel requests
-            (Self::PendingCancel, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::PendingCancel, OrderEventAny::Filled(_)) => Self::Filled,
             (Self::Triggered, OrderEventAny::Rejected(_)) => Self::Rejected,
             (Self::Triggered, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,
             (Self::Triggered, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,
             (Self::Triggered, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::Triggered, OrderEventAny::Expired(_)) => Self::Expired,
-            (Self::Triggered, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::Triggered, OrderEventAny::Filled(_)) => Self::Filled,
             (Self::PartiallyFilled, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,
             (Self::PartiallyFilled, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,
             (Self::PartiallyFilled, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::PartiallyFilled, OrderEventAny::Expired(_)) => Self::Expired,
-            (Self::PartiallyFilled, OrderEventAny::PartiallyFilled(_)) => Self::PartiallyFilled,
             (Self::PartiallyFilled, OrderEventAny::Filled(_)) => Self::Filled,
             _ => return Err(OrderError::InvalidStateTransition),
         };
@@ -508,7 +501,6 @@ impl OrderCore {
             OrderEventAny::Triggered(event) => self.triggered(event),
             OrderEventAny::Canceled(event) => self.canceled(event),
             OrderEventAny::Expired(event) => self.expired(event),
-            OrderEventAny::PartiallyFilled(event) => self.filled(event),
             OrderEventAny::Filled(event) => self.filled(event),
         }
 

--- a/crates/model/src/orders/base.rs
+++ b/crates/model/src/orders/base.rs
@@ -113,6 +113,7 @@ impl OrderStatus {
             (Self::Submitted, OrderEventAny::Canceled(_)) => Self::Canceled,  // FOK and IOC cases
             (Self::Submitted, OrderEventAny::Accepted(_)) => Self::Accepted,
             (Self::Submitted, OrderEventAny::Filled(_)) => Self::Filled,
+            (Self::Submitted, OrderEventAny::Updated(_)) => Self::Submitted,
             (Self::Accepted, OrderEventAny::Rejected(_)) => Self::Rejected,  // StopLimit order
             (Self::Accepted, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,
             (Self::Accepted, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,
@@ -147,6 +148,7 @@ impl OrderStatus {
             (Self::PartiallyFilled, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::PartiallyFilled, OrderEventAny::Expired(_)) => Self::Expired,
             (Self::PartiallyFilled, OrderEventAny::Filled(_)) => Self::Filled,
+            (Self::PartiallyFilled, OrderEventAny::Accepted(_)) => Self::Accepted,
             _ => return Err(OrderError::InvalidStateTransition),
         };
         Ok(new_state)

--- a/crates/model/src/python/events/order/mod.rs
+++ b/crates/model/src/python/events/order/mod.rs
@@ -57,7 +57,6 @@ pub fn order_event_to_pyobject(py: Python, order_event: OrderEventAny) -> PyResu
         OrderEventAny::ModifyRejected(event) => Ok(event.into_py_any_unwrap(py)),
         OrderEventAny::CancelRejected(event) => Ok(event.into_py_any_unwrap(py)),
         OrderEventAny::Updated(event) => Ok(event.into_py_any_unwrap(py)),
-        OrderEventAny::PartiallyFilled(event) => Ok(event.into_py_any_unwrap(py)),
         OrderEventAny::Filled(event) => Ok(event.into_py_any_unwrap(py)),
     }
 }

--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -1013,6 +1013,9 @@ cdef class OrderMatchingEngine:
         # Immediately fill marketable order
         self.fill_market_order(order)
 
+        if order.is_open_c():
+            self.accept_order(order)
+
     cdef void _process_limit_order(self, LimitOrder order):
         # Check AT_THE_OPEN/AT_THE_CLOSE time in force
         if order.time_in_force == TimeInForce.AT_THE_OPEN or order.time_in_force == TimeInForce.AT_THE_CLOSE:
@@ -1829,7 +1832,6 @@ cdef class OrderMatchingEngine:
 
             if order.filled_qty._mem.raw == 0:
                 if order.order_type == OrderType.MARKET_TO_LIMIT:
-                    self.accept_order(order)
                     self._generate_order_updated(
                         order,
                         qty=order.quantity,

--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -1013,9 +1013,6 @@ cdef class OrderMatchingEngine:
         # Immediately fill marketable order
         self.fill_market_order(order)
 
-        if order.is_open_c():
-            self.accept_order(order)
-
     cdef void _process_limit_order(self, LimitOrder order):
         # Check AT_THE_OPEN/AT_THE_CLOSE time in force
         if order.time_in_force == TimeInForce.AT_THE_OPEN or order.time_in_force == TimeInForce.AT_THE_CLOSE:
@@ -1832,6 +1829,7 @@ cdef class OrderMatchingEngine:
 
             if order.filled_qty._mem.raw == 0:
                 if order.order_type == OrderType.MARKET_TO_LIMIT:
+                    self.accept_order(order)
                     self._generate_order_updated(
                         order,
                         qty=order.quantity,


### PR DESCRIPTION
# Pull Request

- implemented function `process_market_to_limit_order` in `OrderMatchingEngine` and tested
- removed `PartiallyFilled` variant in `OrderEventAny`
- To account for valid scenario when processing market to limit orders, and correct sequence of emmited events:
### Sequence of emmited events    
 1. `OrderUpdated` - order was updated to new limit price where market order stopped filling
 2. `OrderFilled` - market order which was filled emits filled event
 3. `OrderAccepted` - remaining quantity of market order is accepted as limit order in the book
 
To account for this scenarios, two new order state transitions were aded:
-  `(Self::Submitted, OrderEventAny::Updated(_)) => Self::Submitted` order is submitted and we are first updating new limit price, order state after this event stays `Submitted` (we didnt fill it or accept it in the orderbook)
-  `(Self::PartiallyFilled, OrderEventAny::Accepted(_)) => Self::Accepted` - partially filling the order, after market fill, we are leaving it in the book and accepting it