### PR TITLE
Fix #2359 IB adapter handling of IB UTC format

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
@@ -102,8 +102,15 @@ MAP_ORDER_STATUS = {
 
 
 def timestring_to_timestamp(timestring: str) -> pd.Timestamp:
-    # Support string conversion not supported directly by pd.to_datetime
-    # 20230223 00:43:36 America/New_York
-    # 20230223 00:43:36 Universal
+    """
+    Support string conversion not supported directly by pd.to_datetime
+        20230223 00:43:36 America/New_York
+        20230223 00:43:36 Universal
+    Convert IB's possible string format in case of Universal time, ie :
+        20250224-15:45:00
+        to a normal one
+    """
+    if '-' in timestring and ' ' not in timestring:
+        timestring = timestring.replace('-', ' ', 1) + " Universal"
     dt, tz = timestring.rsplit(" ", 1)
     return pd.Timestamp(dt, tz=tz)


### PR DESCRIPTION
# Pull Request

In IB's adapter parsing/execution.py, in timestring_to_timestamp function : Addition of a check to verify the timestring in case of an unusual format and, if necessary, correction of the timestring.

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- Tested performance of different string manipulation.
- Tested executions with different versions of IB API, in paper and in live mode.
