### PR TITLE
Fix bad ts_init value in IB weekly and monthly bar (#2355)

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -543,8 +543,8 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         int
 
         """
-        if bar_type.spec.aggregation == 14:
-            # Day bars are always returned with bar date in YYYYMMDD format
+        if bar_type.spec.aggregation in [14, 15, 16]:
+            # Day/Week/Month bars are always returned with bar date in YYYYMMDD format
             ts = pd.to_datetime(bar.date, format="%Y%m%d", utc=True)
         else:
             ts = pd.Timestamp.fromtimestamp(int(bar.date), tz=pytz.utc)


### PR DESCRIPTION
Fix bug that caused IB monthly and weekly bar date not handled correctly

# Pull Request

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?
Tested with a copy of https://github.com/nautechsystems/nautilus_trader/blob/master/examples/live/interactive_brokers/historical_download.py to ensure the weekly bar data has correct date
