### PR TITLE
Add catalog write modes

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -21,6 +21,7 @@
 
 # %%
 # from nautilus_trader.model.data import DataType
+# from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 from nautilus_trader.adapters.databento.data_utils import data_path
 from nautilus_trader.adapters.databento.data_utils import databento_data
 from nautilus_trader.adapters.databento.data_utils import load_catalog
@@ -121,8 +122,8 @@ class OptionStrategy(Strategy):
         self.subscribe_quote_ticks(self.config.option_id)
         self.subscribe_quote_ticks(self.config.option_id2)
 
-        bar_type = BarType.from_str(f"{self.config.future_id}-1-MINUTE-LAST-EXTERNAL")
-        self.subscribe_bars(bar_type)
+        self.bar_type = BarType.from_str(f"{self.config.future_id}-1-MINUTE-LAST-EXTERNAL")
+        self.subscribe_bars(self.bar_type)
 
         if self.config.load_greeks:
             self.greeks.subscribe_greeks("ES")
@@ -154,7 +155,7 @@ class OptionStrategy(Strategy):
         portfolio_greeks = self.greeks.portfolio_greeks(
             use_cached_greeks=self.config.load_greeks,
             publish_greeks=(not self.config.load_greeks),
-            vol_shock=0.0,
+            # vol_shock=0.0,
             # percent_greeks=True,
             # index_instrument_id=self.config.future_id,
             # beta_weights={self.config.future_id: 2.}
@@ -182,6 +183,9 @@ class OptionStrategy(Strategy):
 
     def user_log(self, msg):
         self.log.warning(str(msg), color=LogColor.GREEN)
+
+    def on_stop(self):
+        self.unsubscribe_bars(self.bar_type)
 
 
 # %% [markdown]
@@ -300,6 +304,7 @@ if stream_data:
         GreeksData,
         basename_template="part-{i}.parquet",
         partitioning=["date"],
+        # mode=CatalogWriteMode.NEWFILE, # TODO comment partitioning option above to test this writing mode
         existing_data_behavior="overwrite_or_ignore",
     )
 

--- a/nautilus_trader/adapters/databento/data_utils.py
+++ b/nautilus_trader/adapters/databento/data_utils.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from nautilus_trader import PACKAGE_ROOT
 from nautilus_trader.adapters.databento.loaders import DatabentoDataLoader
 from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 
 
 # Note: when using the functions below, change the variable below to a folder path
@@ -106,7 +107,7 @@ def databento_data(
     dataset="GLBX.MDP3",
     to_catalog=True,
     base_path=None,
-    write_data_mode="overwrite",
+    write_data_mode: CatalogWriteMode = CatalogWriteMode.OVERWRITE,
     use_exchange_as_venue=False,
     **kwargs,
 ):
@@ -134,8 +135,8 @@ def databento_data(
         Whether to save the data to a catalog, defaults to True.
     base_path : str, optional
         The base path to use for the data folder, defaults to None.
-    write_data_mode : str, optional
-        Whether to "append", "prepend" or "overwrite" data to an existing catalog, defaults to "overwrite".
+    write_data_mode : enum, optional
+        How to add or overwrite data to an existing catalog, defaults to CatalogWriteMode.OVERWRITE.
     use_exchange_as_venue : bool, optional
         Whether to use actual exchanges for instrument ids or GLBX, defaults to False.
     **kwargs
@@ -159,7 +160,7 @@ def databento_data(
     definition_file = used_path / definition_file_name
 
     if not definition_file.exists():
-        definition = client.timeseries.get_range(
+        definition = client.timeseries.get_range(  # type: ignore[union-attr]
             schema="definition",
             dataset=dataset,
             symbols=symbols,
@@ -177,7 +178,7 @@ def databento_data(
 
     if schema != "definition":
         if not data_file.exists():
-            data = client.timeseries.get_range(
+            data = client.timeseries.get_range(  # type: ignore[union-attr]
                 schema=schema,
                 dataset=dataset,
                 symbols=symbols,
@@ -245,8 +246,8 @@ def save_data_to_catalog(
         Path to the Databento data file.
     base_path : str or Path, optional
         Base path for the catalog.
-    write_data_mode : str, optional
-        Mode for writing data to the catalog. Default is "overwrite".
+    write_data_mode : enum, optional
+        Mode for writing data to the catalog. defaults to CatalogWriteMode.OVERWRITE.
     use_exchange_as_venue : bool, optional
         Whether to use actual exchanges for instrument ids or GLBX, defaults to False.
 

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -15,6 +15,7 @@
 
 from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
+from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 
 from nautilus_trader.cache.base cimport CacheFacade
 from nautilus_trader.common.component cimport Clock
@@ -186,7 +187,7 @@ cdef class Actor(Component):
         datetime end=*,
         int limit=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_instrument(
@@ -196,7 +197,7 @@ cdef class Actor(Component):
         datetime end=*,
         ClientId client_id=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_instruments(
@@ -206,7 +207,7 @@ cdef class Actor(Component):
         datetime end=*,
         ClientId client_id=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_order_book_snapshot(
@@ -225,7 +226,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_trade_ticks(
@@ -236,7 +237,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_bars(
@@ -247,7 +248,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_aggregated_bars(
@@ -260,7 +261,7 @@ cdef class Actor(Component):
         callback=*,
         bint include_external_data=*,
         bint update_subscriptions=*,
-        bint update_catalog=*,
+        update_catalog_mode: CatalogWriteMode | None = *,
         dict[str, object] params=*,
     )
     cpdef bint is_pending_request(self, UUID4 request_id)

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -36,6 +36,7 @@ from nautilus_trader.common.config import ImportableActorConfig
 from nautilus_trader.common.executor import ActorExecutor
 from nautilus_trader.common.executor import TaskId
 from nautilus_trader.common.signal import generate_signal_class
+from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 
 from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
@@ -2079,7 +2080,7 @@ cdef class Actor(Component):
         datetime end = None,
         int limit = 0,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2107,8 +2108,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2129,7 +2133,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestData request = RequestData(
@@ -2157,7 +2161,7 @@ cdef class Actor(Component):
         datetime end = None,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2186,8 +2190,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2221,7 +2228,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestInstrument request = RequestInstrument(
@@ -2248,7 +2255,7 @@ cdef class Actor(Component):
         datetime end = None,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2277,8 +2284,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2312,7 +2322,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestInstruments request = RequestInstruments(
@@ -2358,8 +2368,11 @@ cdef class Actor(Component):
             If None, it will be inferred from the venue in the instrument ID.
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2405,7 +2418,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2436,8 +2449,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2471,7 +2487,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestQuoteTicks request = RequestQuoteTicks(
@@ -2500,7 +2516,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2531,8 +2547,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2566,7 +2585,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestTradeTicks request = RequestTradeTicks(
@@ -2595,7 +2614,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2626,8 +2645,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2661,7 +2683,7 @@ cdef class Actor(Component):
         Condition.callable_or_none(callback, "callback")
 
         params = params if params else {}
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         cdef UUID4 request_id = UUID4()
         cdef RequestBars request = RequestBars(
@@ -2692,7 +2714,7 @@ cdef class Actor(Component):
         callback: Callable[[UUID4], None] | None = None,
         bint include_external_data = False,
         bint update_subscriptions = False,
-        bint update_catalog = False,
+        update_catalog_mode: CatalogWriteMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2733,8 +2755,11 @@ cdef class Actor(Component):
             If True, includes the queried external data in the response.
         update_subscriptions : bool, default False
             If True, updates the aggregators of any existing or future subscription with the queried external data.
-        update_catalog : bool, default False
-            If True, then updates the catalog with new data received from a client.
+        update_catalog_mode : enum, optional
+            If not None, then updates the catalog with new data received from a client.
+            Recommended catalog write modes are:
+            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file)
+            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2785,7 +2810,7 @@ cdef class Actor(Component):
         params["bar_types"] = tuple(bar_types)
         params["include_external_data"] = include_external_data
         params["update_subscriptions"] = update_subscriptions
-        params["update_catalog"] = update_catalog
+        params["update_catalog_mode"] = update_catalog_mode
 
         if first_bar_type.is_composite():
             params["bars_market_data_type"] = "bars"

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -17,6 +17,7 @@ from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
 
 from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 
 from nautilus_trader.cache.cache cimport Cache
 from nautilus_trader.common.component cimport Component
@@ -193,7 +194,7 @@ cdef class DataEngine(Component):
 # -- DATA HANDLERS --------------------------------------------------------------------------------
 
     cpdef void _handle_data(self, Data data)
-    cpdef void _handle_instrument(self, Instrument instrument, bint update_catalog=*)
+    cpdef void _handle_instrument(self, Instrument instrument, update_catalog_mode: CatalogWriteMode | None = *)
     cpdef void _handle_order_book_delta(self, OrderBookDelta delta)
     cpdef void _handle_order_book_deltas(self, OrderBookDeltas deltas)
     cpdef void _handle_order_book_depth(self, OrderBookDepth10 depth)
@@ -207,8 +208,8 @@ cdef class DataEngine(Component):
 # -- RESPONSE HANDLERS ----------------------------------------------------------------------------
 
     cpdef void _handle_response(self, DataResponse response)
-    cpdef void _handle_instruments(self, list instruments, bint update_catalog=*)
-    cpdef void _update_catalog(self, list ticks, bint is_instrument=*)
+    cpdef void _handle_instruments(self, list instruments, update_catalog_mode: CatalogWriteMode | None = *)
+    cpdef void _update_catalog(self, list ticks, update_catalog_mode: CatalogWriteMode | None, bint is_instrument=*)
     cpdef void _new_query_group(self, UUID4 correlation_id, int n_components)
     cpdef object _handle_query_group(self, UUID4 correlation_id, list ticks)
     cdef object _handle_query_group_aux(self, UUID4 correlation_id, list ticks)

--- a/nautilus_trader/persistence/catalog/types.py
+++ b/nautilus_trader/persistence/catalog/types.py
@@ -16,6 +16,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
+from enum import unique
 
 from nautilus_trader.core.data import Data
 from nautilus_trader.model.identifiers import ClientId
@@ -32,3 +34,11 @@ class CatalogDataResult:
     data: list[Data]
     instrument: Instrument | None = None
     client_id: ClientId | None = None
+
+
+@unique
+class CatalogWriteMode(Enum):
+    APPEND = 1
+    PREPEND = 2
+    OVERWRITE = 3
+    NEWFILE = 4

--- a/nautilus_trader/persistence/loaders.py
+++ b/nautilus_trader/persistence/loaders.py
@@ -251,6 +251,9 @@ class InterestRateProvider(Actor):
             override=True,
         )
 
+    def on_stop(self):
+        self.clock.cancel_timers()
+
 
 # example file usd_short_term_rate.xml in the current repo
 # Can be downloaded from below link

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -40,6 +40,7 @@ from nautilus_trader.model.instruments import Equity
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.persistence.catalog.parquet import ParquetDataCatalog
+from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 from nautilus_trader.persistence.wranglers_v2 import QuoteTickDataWranglerV2
 from nautilus_trader.persistence.wranglers_v2 import TradeTickDataWranglerV2
 from nautilus_trader.test_kit.mocks.data import NewsEventData
@@ -292,7 +293,7 @@ def test_catalog_append_data(catalog: ParquetDataCatalog) -> None:
     catalog.write_data(stub_bars)
 
     # Act
-    catalog.write_data(stub_bars, mode="append")
+    catalog.write_data(stub_bars, mode=CatalogWriteMode.APPEND)
 
     # Assert
     bars = catalog.bars(bar_types=[str(bar_type)])


### PR DESCRIPTION
# Pull Request

Add "new_file" catalog write mode

- Allows to append data to a catalog by creating a new file when using write_data without the partitioning optional argument , which uses the _fast_write function
- Also modified the update_catalog argument of data requests in actors to update_catalog_mode so a catalog write mode can be passed as argument
- Can be useful if you have data of various quality types and don't want to take the risk to degrade the quality of some existing data by appending/concatenating new data

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added a test, also tested with own code
