### PR TITLE
Add Parallel Config Processing to BacktestNode

### DIFF
--- a/tests/unit_tests/backtest/test_node.py
+++ b/tests/unit_tests/backtest/test_node.py
@@ -128,6 +128,18 @@ class TestBacktestNode:
 
         # Assert
         assert len(results) == 1
+    
+    def test_run_parallel(self):
+        # Arrange
+        node = BacktestNode(configs=self.backtest_configs)
+        
+        # Act: Run backtests in parallel with a limited number of workers.
+        results = node.run_parallel(max_workers=2)
+        
+        # Assert: Ensure that a list of results is returned and the count is as expected.
+        assert isinstance(results, list)
+        assert len(results) == len(self.backtest_configs)
+
 
     def test_backtest_run_batch_sync(self):
         # Arrange


### PR DESCRIPTION
# Pull Request

As shown in #2372 , `BacktestNode` currently has no way to run backtests in parallel for multiple configs even though parallelization in this part of code wouldn't effect the event-driven architecture but will simply give a performance boost. 

I've hence added a `run_parallel()` function that can be used as a drop in replacement for run() when working with multiple configs / instruments.
Since this functionality is abstracted out in a separate function, current functionality of run won't be affected and shall work same as before. 

## Type of change

Delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How has this change been tested?

Earlier snippet (configs needed to be wrapped externally to run backtests in parallel) : 

```python
with multiprocessing.Pool(NUM_PROCESSES) as pool:
        results = pool.starmap(run_backtest, [(split, i) for i, split in enumerate(instrument_splits)])

where run_backtest : 
def run_backtest(instrument_subset, process_id):
 <code to initialize BacktestRunConfig>
 node = BacktestNode(configs=configs)
 results = node.run()
 return results

and instrument_splits : 
NUM_PROCESSES = min(8, num_instruments)
instrument_splits = [instruments[i::NUM_PROCESSES] for i in range(NUM_PROCESSES)]
```

New Snippet : 

```python
NUM_PROCESSES = min(8, num_instruments)  # Use up to 8 processes (adjust based on CPU cores)
instrument_splits = [instruments[i::NUM_PROCESSES] for i in range(NUM_PROCESSES)]
configs = []

for i, instrument_subset in enumerate(instrument_splits):
 <code to initialize BacktestRunConfig>
 configs.append(run_config)


node = BacktestNode(configs=configs)
all_results = node.run_parallel(max_workers=NUM_PROCESSES)
```

Both the results are verified to be the same.
