### PR TITLE
Refactor reconciliation interfaces into messages

### DIFF
--- a/nautilus_trader/adapters/_template/execution.py
+++ b/nautilus_trader/adapters/_template/execution.py
@@ -13,11 +13,14 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import pandas as pd
 
 from nautilus_trader.execution.messages import BatchCancelOrders
 from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.messages import ModifyOrder
 from nautilus_trader.execution.messages import QueryOrder
 from nautilus_trader.execution.messages import SubmitOrder
@@ -26,9 +29,6 @@ from nautilus_trader.execution.reports import FillReport
 from nautilus_trader.execution.reports import OrderStatusReport
 from nautilus_trader.execution.reports import PositionStatusReport
 from nautilus_trader.live.execution_client import LiveExecutionClient
-from nautilus_trader.model.identifiers import ClientOrderId
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import VenueOrderId
 
 
 # The 'pragma: no cover' comment excludes a method from test coverage.
@@ -92,9 +92,7 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_report(
         self,
-        instrument_id: InstrumentId,
-        client_order_id: ClientOrderId | None = None,
-        venue_order_id: VenueOrderId | None = None,
+        command: GenerateOrderStatusReport,
     ) -> OrderStatusReport | None:
         raise NotImplementedError(
             "method `generate_order_status_report` must be implemented in the subclass",
@@ -102,10 +100,7 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
-        open_only: bool = False,
+        command: GenerateOrderStatusReports,
     ) -> list[OrderStatusReport]:
         raise NotImplementedError(
             "method `generate_order_status_reports` must be implemented in the subclass",
@@ -113,10 +108,7 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
 
     async def generate_fill_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        venue_order_id: VenueOrderId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GenerateFillReports,
     ) -> list[FillReport]:
         raise NotImplementedError(
             "method `generate_fill_reports` must be implemented in the subclass",
@@ -124,9 +116,7 @@ class TemplateLiveExecutionClient(LiveExecutionClient):
 
     async def generate_position_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
         raise NotImplementedError(
             "method `generate_position_status_reports` must be implemented in the subclass",

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -18,7 +18,6 @@ import json
 from decimal import Decimal
 from typing import Any
 
-import pandas as pd
 from ibapi.commission_report import CommissionReport
 from ibapi.common import UNSET_DECIMAL
 from ibapi.common import UNSET_DOUBLE
@@ -51,6 +50,10 @@ from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.messages import BatchCancelOrders
 from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.messages import ModifyOrder
 from nautilus_trader.execution.messages import SubmitOrder
 from nautilus_trader.execution.messages import SubmitOrderList
@@ -72,7 +75,6 @@ from nautilus_trader.model.enums import trailing_offset_type_to_str
 from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import ClientOrderId
-from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.objects import AccountBalance
@@ -217,45 +219,20 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_report(
         self,
-        instrument_id: InstrumentId,
-        client_order_id: ClientOrderId | None = None,
-        venue_order_id: VenueOrderId | None = None,
+        command: GenerateOrderStatusReport,
     ) -> OrderStatusReport | None:
-        """
-        Generate an `OrderStatusReport` for the given order identifier parameter(s). If
-        the order is not found, or an error occurs, then logs and returns ``None``.
-
-        Parameters
-        ----------
-        instrument_id : InstrumentId
-            The instrument ID for the report.
-        client_order_id : ClientOrderId, optional
-            The client order ID for the report.
-        venue_order_id : VenueOrderId, optional
-            The venue order ID for the report.
-
-        Returns
-        -------
-        OrderStatusReport or ``None``
-
-        Raises
-        ------
-        ValueError
-            If both the `client_order_id` and `venue_order_id` are ``None``.
-
-        """
-        PyCondition.type_or_none(client_order_id, ClientOrderId, "client_order_id")
-        PyCondition.type_or_none(venue_order_id, VenueOrderId, "venue_order_id")
-        if not (client_order_id or venue_order_id):
+        PyCondition.type_or_none(command.client_order_id, ClientOrderId, "client_order_id")
+        PyCondition.type_or_none(command.venue_order_id, VenueOrderId, "venue_order_id")
+        if not (command.client_order_id or command.venue_order_id):
             self._log.debug("Both `client_order_id` and `venue_order_id` cannot be None")
             return None
 
         report = None
         ib_orders = await self._client.get_open_orders(self.account_id.get_id())
         for ib_order in ib_orders:
-            if (client_order_id and client_order_id.value == ib_order.orderRef) or (
-                venue_order_id
-                and venue_order_id.value
+            if (command.client_order_id and command.client_order_id.value == ib_order.orderRef) or (
+                command.venue_order_id
+                and command.venue_order_id.value
                 == str(
                     ib_order.orderId,
                 )
@@ -264,10 +241,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 break
         if report is None:
             self._log.warning(
-                f"Order {client_order_id=}, {venue_order_id} not found, canceling",
+                f"Order {command.client_order_id=}, {command.venue_order_id} not found, canceling",
             )
             self._on_order_status(
-                order_ref=client_order_id.value,
+                order_ref=command.client_order_id.value,
                 order_status="Cancelled",
                 reason="Not found in query",
             )
@@ -338,31 +315,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
-        open_only: bool = False,
+        command: GenerateOrderStatusReports,
     ) -> list[OrderStatusReport]:
-        """
-        Generate a list of `OrderStatusReport`s with optional query filters. The
-        returned list may be empty if no orders match the given parameters.
-
-        Parameters
-        ----------
-        instrument_id : InstrumentId, optional
-            The instrument ID query filter.
-        start : pd.Timestamp, optional
-            The start datetime (UTC) query filter.
-        end : pd.Timestamp, optional
-            The end datetime (UTC) query filter.
-        open_only : bool, default False
-            If the query is for open orders only.
-
-        Returns
-        -------
-        list[OrderStatusReport]
-
-        """
         report = []
         # Create the Filled OrderStatusReport from Open Positions
         positions: list[IBPosition] = await self._client.get_positions(
@@ -426,59 +380,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     async def generate_fill_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        venue_order_id: VenueOrderId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GenerateFillReports,
     ) -> list[FillReport]:
-        """
-        Generate a list of `FillReport`s with optional query filters. The returned list
-        may be empty if no trades match the given parameters.
-
-        Parameters
-        ----------
-        instrument_id : InstrumentId, optional
-            The instrument ID query filter.
-        venue_order_id : VenueOrderId, optional
-            The venue order ID (assigned by the venue) query filter.
-        start : pd.Timestamp, optional
-            The start datetime (UTC) query filter.
-        end : pd.Timestamp, optional
-            The end datetime (UTC) query filter.
-
-        Returns
-        -------
-        list[FillReport]
-
-        """
         self._log.warning("Cannot generate `list[FillReport]`: not yet implemented")
-
         return []  # TODO: Implement
 
     async def generate_position_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
-        """
-        Generate a list of `PositionStatusReport`s with optional query filters. The
-        returned list may be empty if no positions match the given parameters.
-
-        Parameters
-        ----------
-        instrument_id : InstrumentId, optional
-            The instrument ID query filter.
-        start : pd.Timestamp, optional
-            The start datetime (UTC) query filter.
-        end : pd.Timestamp, optional
-            The end datetime (UTC) query filter.
-
-        Returns
-        -------
-        list[PositionStatusReport]
-
-        """
         report = []
         positions: list[IBPosition] | None = await self._client.get_positions(
             self.account_id.get_id(),

--- a/nautilus_trader/adapters/okx/execution.py
+++ b/nautilus_trader/adapters/okx/execution.py
@@ -18,7 +18,6 @@ from decimal import Decimal
 from uuid import UUID
 
 import msgspec
-import pandas as pd
 
 from nautilus_trader.adapters.okx.common.constants import OKX_VENUE
 from nautilus_trader.adapters.okx.common.credentials import get_api_key
@@ -63,6 +62,10 @@ from nautilus_trader.core.datetime import unix_nanos_to_dt
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.messages import ModifyOrder
 from nautilus_trader.execution.messages import SubmitOrder
 from nautilus_trader.execution.messages import SubmitOrderList
@@ -78,7 +81,6 @@ from nautilus_trader.model.enums import TimeInForce
 from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import ClientOrderId
-from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import VenueOrderId
@@ -304,15 +306,12 @@ class OKXExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_reports(  # noqa: C901
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
-        open_only: bool = False,
+        command: GenerateOrderStatusReports,
     ) -> list[OrderStatusReport]:
         reports: list[OrderStatusReport] = []
         ordIds: list[str] = []  # for possible pagination in fetch order history
 
-        _symbol = instrument_id.symbol.value if instrument_id is not None else None
+        _symbol = command.instrument_id.symbol.value if command.instrument_id is not None else None
         symbol = OKXSymbol(_symbol) if _symbol is not None else None
         try:
             if symbol:
@@ -362,9 +361,9 @@ class OKXExecutionClient(LiveExecutionClient):
                     self._log.info(f"Received {len(reports)} OrderStatusReport{plural}")
                     return reports
 
-                if start:
+                if command.start:
                     # Maybe paginate to get the remaining history
-                    while unix_nanos_to_dt(reports[-1].ts_event) > start:  # -1 is oldest
+                    while unix_nanos_to_dt(reports[-1].ts_event) > command.start:  # -1 is oldest
                         hist_order_response = await self._http_trade.fetch_orders_pending(
                             instType=symbol.instrument_type,
                             instId=symbol.raw_symbol,
@@ -440,9 +439,11 @@ class OKXExecutionClient(LiveExecutionClient):
                     if not _reports:
                         continue
 
-                    if start:
+                    if command.start:
                         # Maybe paginate to get the remaining history
-                        while unix_nanos_to_dt(_reports[-1].ts_event) > start:  # -1 is oldest
+                        while (
+                            unix_nanos_to_dt(_reports[-1].ts_event) > command.start
+                        ):  # -1 is oldest
                             hist_order_response = await self._http_trade.fetch_orders_pending(
                                 instType=instrument_type,
                                 after=_ordIds[-1],
@@ -489,10 +490,14 @@ class OKXExecutionClient(LiveExecutionClient):
         # Sort and filter by `ts_accepted` because `cTime` (order creation/acceptance time) is the
         # basis of OKX's chronological sorting of orders
         reports = sorted(dedup_report_dict.values(), key=lambda r: r.ts_accepted)
-        if start:
-            reports = list(filter(lambda r: start <= unix_nanos_to_dt(r.ts_accepted), reports))
-        if end:
-            reports = list(filter(lambda r: unix_nanos_to_dt(r.ts_accepted) <= end, reports))
+        if command.start:
+            reports = list(
+                filter(lambda r: command.start <= unix_nanos_to_dt(r.ts_accepted), reports),
+            )
+        if command.end:
+            reports = list(
+                filter(lambda r: unix_nanos_to_dt(r.ts_accepted) <= command.end, reports),
+            )
 
         len_reports = len(reports)
         plural = "" if len_reports == 1 else "s"
@@ -502,30 +507,28 @@ class OKXExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_report(
         self,
-        instrument_id: InstrumentId,
-        client_order_id: ClientOrderId | None = None,
-        venue_order_id: VenueOrderId | None = None,
+        command: GenerateOrderStatusReport,
     ) -> OrderStatusReport | None:
         PyCondition.is_false(
-            client_order_id is None and venue_order_id is None,
+            command.client_order_id is None and command.venue_order_id is None,
             "both `client_order_id` and `venue_order_id` were `None`",
         )
 
-        okx_symbol = OKXSymbol(instrument_id.symbol.value)
+        okx_symbol = OKXSymbol(command.instrument_id.symbol.value)
         okx_client_order_id = self._client_order_id_generator.get_okx_client_order_id(
-            client_order_id,
+            command.client_order_id,
         )
 
-        id_str = f"{instrument_id!r}"
-        id_str += f", {client_order_id!r}" if client_order_id else ""
-        id_str += f", {venue_order_id!r}" if venue_order_id else ""
+        id_str = f"{command.instrument_id!r}"
+        id_str += f", {command.client_order_id!r}" if command.client_order_id else ""
+        id_str += f", {command.venue_order_id!r}" if command.venue_order_id else ""
         id_str += f", {okx_client_order_id=!r}" if okx_client_order_id else ""
         self._log.info(f"Generating OrderStatusReport for {id_str}")
 
         try:
             order_details = await self._http_trade.fetch_order_details(
                 instId=okx_symbol.raw_symbol,
-                ordId=venue_order_id.value if venue_order_id else None,
+                ordId=command.venue_order_id.value if command.venue_order_id else None,
                 clOrdId=okx_client_order_id,
             )
             if len(order_details.data) == 0:
@@ -546,7 +549,7 @@ class OKXExecutionClient(LiveExecutionClient):
 
             order_report = target_order.parse_to_order_status_report(
                 account_id=self.account_id,
-                instrument_id=instrument_id,
+                instrument_id=command.instrument_id,
                 report_id=UUID4(),
                 enum_parser=self._enum_parser,
                 ts_init=self._clock.timestamp_ns(),
@@ -561,16 +564,13 @@ class OKXExecutionClient(LiveExecutionClient):
 
     async def generate_fill_reports(  # noqa: C901
         self,
-        instrument_id: InstrumentId | None = None,
-        venue_order_id: VenueOrderId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GenerateFillReports,
     ) -> list[FillReport]:
         self._log.debug("Requesting FillReports...")
         reports: list[FillReport] = []
         billIds: list[str] = []  # for possible pagination
 
-        _symbol = instrument_id.symbol.value if instrument_id is not None else None
+        _symbol = command.instrument_id.symbol.value if command.instrument_id is not None else None
         symbol = OKXSymbol(_symbol) if _symbol is not None else None
         try:
             if symbol:
@@ -578,7 +578,7 @@ class OKXExecutionClient(LiveExecutionClient):
                 fills_response = await self._http_trade.fetch_fills_history(
                     instType=symbol.instrument_type,
                     instId=symbol.raw_symbol,
-                    ordId=venue_order_id.value if venue_order_id else None,
+                    ordId=command.venue_order_id.value if command.venue_order_id else None,
                 )
                 for fill_data in fills_response.data:
                     client_order_id = self._client_order_id_generator.get_client_order_id(
@@ -602,13 +602,13 @@ class OKXExecutionClient(LiveExecutionClient):
                     self._log.info(f"Received {len(reports)} FillReport{plural}")
                     return reports
 
-                if start:
+                if command.start:
                     # Maybe paginate to get the remaining history
-                    while unix_nanos_to_dt(reports[-1].ts_event) > start:  # -1 is oldest
+                    while unix_nanos_to_dt(reports[-1].ts_event) > command.start:  # -1 is oldest
                         fills_response = await self._http_trade.fetch_fills_history(
                             instType=symbol.instrument_type,
                             instId=symbol.raw_symbol,
-                            ordId=venue_order_id.value if venue_order_id else None,
+                            ordId=command.venue_order_id.value if command.venue_order_id else None,
                             after=billIds[-1],
                         )
                         for fill_data in fills_response.data:
@@ -633,7 +633,7 @@ class OKXExecutionClient(LiveExecutionClient):
                     # Gets latest 3 months of fills, up to a max of 100 records per request
                     fills_response = await self._http_trade.fetch_fills_history(
                         instType=instrument_type,
-                        ordId=venue_order_id.value if venue_order_id else None,
+                        ordId=command.venue_order_id.value if command.venue_order_id else None,
                     )
                     for fill_data in fills_response.data:
                         okx_symbol = OKXSymbol.from_raw_symbol(
@@ -659,12 +659,16 @@ class OKXExecutionClient(LiveExecutionClient):
                     if not _reports:
                         continue
 
-                    if start:
+                    if command.start:
                         # Maybe paginate to get the remaining history
-                        while unix_nanos_to_dt(_reports[-1].ts_event) > start:  # -1 is oldest
+                        while (
+                            unix_nanos_to_dt(_reports[-1].ts_event) > command.start
+                        ):  # -1 is oldest
                             fills_response = await self._http_trade.fetch_fills_history(
                                 instType=instrument_type,
-                                ordId=venue_order_id.value if venue_order_id else None,
+                                ordId=(
+                                    command.venue_order_id.value if command.venue_order_id else None
+                                ),
                                 after=_billIds[-1],
                             )
                             for fill_data in fills_response.data:
@@ -692,10 +696,10 @@ class OKXExecutionClient(LiveExecutionClient):
             self._log.exception("Failed to generate FillReports", e)
 
         reports = sorted(reports, key=lambda report: report.ts_event)
-        if start:
-            reports = list(filter(lambda r: start <= unix_nanos_to_dt(r.ts_event), reports))
-        if end:
-            reports = list(filter(lambda r: unix_nanos_to_dt(r.ts_event) <= end, reports))
+        if command.start:
+            reports = list(filter(lambda r: command.start <= unix_nanos_to_dt(r.ts_event), reports))
+        if command.end:
+            reports = list(filter(lambda r: unix_nanos_to_dt(r.ts_event) <= command.end, reports))
 
         len_reports = len(reports)
         plural = "" if len_reports == 1 else "s"
@@ -705,16 +709,14 @@ class OKXExecutionClient(LiveExecutionClient):
 
     async def generate_position_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
         reports: list[PositionStatusReport] = []
 
         try:
-            if instrument_id:
-                self._log.debug(f"Requesting PositionStatusReport for {instrument_id}")
-                okx_symbol = OKXSymbol(instrument_id.symbol.value)
+            if command.instrument_id:
+                self._log.debug(f"Requesting PositionStatusReport for {command.instrument_id}")
+                okx_symbol = OKXSymbol(command.instrument_id.symbol.value)
                 positions_response = await self._http_account.fetch_positions(
                     instType=okx_symbol.instrument_type,
                     instId=okx_symbol.raw_symbol,
@@ -722,7 +724,7 @@ class OKXExecutionClient(LiveExecutionClient):
                 for position in positions_response.data:
                     position_report = position.parse_to_position_status_report(
                         account_id=self.account_id,
-                        instrument_id=instrument_id,
+                        instrument_id=command.instrument_id,
                         report_id=UUID4(),
                         ts_init=self._clock.timestamp_ns(),
                     )

--- a/nautilus_trader/adapters/polymarket/execution.py
+++ b/nautilus_trader/adapters/polymarket/execution.py
@@ -19,7 +19,6 @@ from collections.abc import Coroutine
 from typing import Any
 
 import msgspec
-import pandas as pd
 from py_clob_client.client import BalanceAllowanceParams
 from py_clob_client.client import ClobClient
 from py_clob_client.client import OpenOrderParams
@@ -65,6 +64,10 @@ from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.messages import BatchCancelOrders
 from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.messages import SubmitOrder
 from nautilus_trader.execution.reports import FillReport
 from nautilus_trader.execution.reports import OrderStatusReport
@@ -308,19 +311,16 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
     # -- EXECUTION REPORTS ------------------------------------------------------------------------
 
-    async def generate_order_status_reports(  # noqa: C901 (too complex)
+    async def generate_order_status_reports(  # noqa: C901
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
-        open_only: bool = False,
+        command: GenerateOrderStatusReports,
     ) -> list[OrderStatusReport]:
         self._log.debug("Requesting OrderStatusReports...")
         reports: list[OrderStatusReport] = []
 
-        if instrument_id is not None:
-            condition_id = get_polymarket_condition_id(instrument_id)
-            asset_id = get_polymarket_token_id(instrument_id)
+        if command.instrument_id is not None:
+            condition_id = get_polymarket_condition_id(command.instrument_id)
+            asset_id = get_polymarket_token_id(command.instrument_id)
             params = OpenOrderParams(market=condition_id, asset_id=asset_id)
         else:
             params = None
@@ -329,7 +329,7 @@ class PolymarketExecutionClient(LiveExecutionClient):
         async with self._retry_manager_pool as retry_manager:
             response: list[JSON] | None = await retry_manager.run(
                 "generate_order_status_reports",
-                [instrument_id],
+                [command.instrument_id],
                 asyncio.to_thread,
                 self._http_client.get_orders,
                 params=params,
@@ -374,11 +374,15 @@ class PolymarketExecutionClient(LiveExecutionClient):
             for order in self._cache.orders_open(venue=POLYMARKET_VENUE):
                 if order.client_order_id in reported_client_order_ids:
                     continue  # Already reported
-                maybe_report = await self.generate_order_status_report(
+
+                order_status_command = GenerateOrderStatusReport(
                     instrument_id=order.instrument_id,
                     client_order_id=order.client_order_id,
                     venue_order_id=order.venue_order_id,
+                    command_id=UUID4(),
+                    ts_init=self._clock.timestamp_ns(),
                 )
+                maybe_report = await self.generate_order_status_report(order_status_command)
                 if maybe_report:
                     reports.append(maybe_report)
 
@@ -388,7 +392,15 @@ class PolymarketExecutionClient(LiveExecutionClient):
             known_venue_order_ids.update({r.venue_order_id for r in reports})
 
             # Check fills to generate order reports
-            fill_reports = await self.generate_fill_reports(instrument_id)
+            fill_reports_command = GenerateFillReports(
+                instrument_id=instrument_id,
+                venue_order_id=None,
+                start=None,
+                end=None,
+                command_id=UUID4(),
+                ts_init=self._clock.timestamp_ns(),
+            )
+            fill_reports = await self.generate_fill_reports(fill_reports_command)
             if fill_reports and not known_venue_order_ids:
                 self._log.warning(
                     "No previously known venue order IDs found in cache or from active orders",
@@ -471,14 +483,12 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_report(
         self,
-        instrument_id: InstrumentId,
-        client_order_id: ClientOrderId | None = None,
-        venue_order_id: VenueOrderId | None = None,
+        command: GenerateOrderStatusReport,
     ) -> OrderStatusReport | None:
-        await self._maintain_active_market(instrument_id)
+        await self._maintain_active_market(command.instrument_id)
 
-        if venue_order_id is None:
-            venue_order_id = self._cache.venue_order_id(client_order_id)
+        if command.venue_order_id is None:
+            venue_order_id = self._cache.venue_order_id(command.client_order_id)
             if venue_order_id is None:
                 self._log.error(
                     "Cannot generate an order status report for Polymarket without the venue order ID",
@@ -487,14 +497,14 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
         self._log.info(
             f"Generating OrderStatusReport for "
-            f"{repr(client_order_id) if client_order_id else ''} "
+            f"{repr(command.client_order_id) if command.client_order_id else ''} "
             f"{repr(venue_order_id) if venue_order_id else ''}",
         )
 
         async with self._retry_manager_pool as retry_manager:
             response: JSON | None = await retry_manager.run(
                 "generate_order_status_report",
-                [client_order_id, venue_order_id],
+                [command.client_order_id, venue_order_id],
                 asyncio.to_thread,
                 self._http_client.get_order,
                 order_id=venue_order_id.value,
@@ -519,30 +529,27 @@ class PolymarketExecutionClient(LiveExecutionClient):
             return polymarket_order.parse_to_order_status_report(
                 account_id=self.account_id,
                 instrument=instrument,
-                client_order_id=client_order_id,
+                client_order_id=command.client_order_id,
                 ts_init=self._clock.timestamp_ns(),
             )
 
     async def generate_fill_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        venue_order_id: VenueOrderId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GenerateFillReports,
     ) -> list[FillReport]:
         self._log.debug("Requesting FillReports...")
         reports: list[FillReport] = []
 
         params = TradeParams()
-        if instrument_id:
-            condition_id = get_polymarket_condition_id(instrument_id)
-            asset_id = get_polymarket_token_id(instrument_id)
+        if command.instrument_id:
+            condition_id = get_polymarket_condition_id(command.instrument_id)
+            asset_id = get_polymarket_token_id(command.instrument_id)
             params.market = condition_id
             params.asset_id = asset_id
 
         details = []
-        if instrument_id:
-            details.append(instrument_id)
+        if command.instrument_id:
+            details.append(command.instrument_id)
 
         async with self._retry_manager_pool as retry_manager:
             response: JSON | None = await retry_manager.run(
@@ -595,14 +602,12 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
     async def generate_position_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
         reports: list[PositionStatusReport] = []
 
-        if instrument_id is not None:
-            instrument_ids = [instrument_id]
+        if command.instrument_id is not None:
+            instrument_ids = [command.instrument_id]
         else:
             instrument_ids = [inst.id for inst in self._cache.instruments(venue=POLYMARKET_VENUE)]
 

--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -15,8 +15,6 @@
 
 import asyncio
 
-import pandas as pd
-
 from nautilus_trader.adapters.sandbox.config import SandboxExecutionClientConfig
 from nautilus_trader.backtest.exchange import SimulatedExchange
 from nautilus_trader.backtest.execution_client import BacktestExecClient
@@ -29,6 +27,10 @@ from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.component import TestClock
 from nautilus_trader.common.providers import InstrumentProvider
 from nautilus_trader.core.data import Data
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.reports import FillReport
 from nautilus_trader.execution.reports import OrderStatusReport
 from nautilus_trader.execution.reports import PositionStatusReport
@@ -42,10 +44,7 @@ from nautilus_trader.model.enums import account_type_from_str
 from nautilus_trader.model.enums import book_type_from_str
 from nautilus_trader.model.enums import oms_type_from_str
 from nautilus_trader.model.identifiers import ClientId
-from nautilus_trader.model.identifiers import ClientOrderId
-from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
-from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.objects import Currency
 from nautilus_trader.model.objects import Money
 from nautilus_trader.portfolio.base import PortfolioFacade
@@ -162,35 +161,25 @@ class SandboxExecutionClient(LiveExecutionClient):
 
     async def generate_order_status_report(
         self,
-        instrument_id: InstrumentId,
-        client_order_id: ClientOrderId | None = None,
-        venue_order_id: VenueOrderId | None = None,
+        command: GenerateOrderStatusReport,
     ) -> OrderStatusReport | None:
         return None
 
     async def generate_order_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
-        open_only: bool = False,
+        command: GenerateOrderStatusReports,
     ) -> list[OrderStatusReport]:
         return []
 
     async def generate_fill_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        venue_order_id: VenueOrderId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GenerateFillReports,
     ) -> list[FillReport]:
         return []
 
     async def generate_position_status_reports(
         self,
-        instrument_id: InstrumentId | None = None,
-        start: pd.Timestamp | None = None,
-        end: pd.Timestamp | None = None,
+        command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
         return []
 

--- a/nautilus_trader/execution/messages.pxd
+++ b/nautilus_trader/execution/messages.pxd
@@ -13,6 +13,8 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from cpython.datetime cimport datetime
+
 from nautilus_trader.core.message cimport Command
 from nautilus_trader.core.rust.model cimport OrderSide
 from nautilus_trader.model.identifiers cimport ClientId
@@ -27,6 +29,37 @@ from nautilus_trader.model.objects cimport Price
 from nautilus_trader.model.objects cimport Quantity
 from nautilus_trader.model.orders.base cimport Order
 from nautilus_trader.model.orders.list cimport OrderList
+
+
+cdef class TradingReportCommand(Command):
+    cdef readonly InstrumentId instrument_id
+    """The instrument ID associated with the command.\n\n:returns: `InstrumentId`"""
+    cdef readonly datetime start
+    """The start datetime (UTC) of request time range (inclusive)."""
+    cdef readonly datetime end
+    """The end datetime (UTC) of request time range."""
+    cdef readonly dict[str, object] params
+    """Additional specific parameters for the command.\n\n:returns: `dict[str, object]` or ``None``"""
+
+
+cdef class GenerateOrderStatusReport(TradingReportCommand):
+    cdef readonly ClientOrderId client_order_id
+    """The client order ID associated with the command.\n\n:returns: `ClientOrderId`"""
+    cdef readonly VenueOrderId venue_order_id
+    """The venue order ID associated with the command.\n\n:returns: `VenueOrderId` or ``None``"""
+
+
+cdef class GenerateOrderStatusReports(TradingReportCommand):
+    cdef readonly bint open_only
+
+
+cdef class GenerateFillReports(TradingReportCommand):
+    cdef readonly VenueOrderId venue_order_id
+    """The venue order ID associated with the command.\n\n:returns: `VenueOrderId` or ``None``"""
+
+
+cdef class GeneratePositionStatusReports(TradingReportCommand):
+    pass
 
 
 cdef class TradingCommand(Command):

--- a/tests/integration_tests/adapters/betfair/test_betfair_execution.py
+++ b/tests/integration_tests/adapters/betfair/test_betfair_execution.py
@@ -36,6 +36,10 @@ from nautilus_trader.adapters.betfair.parsing.common import betfair_instrument_i
 from nautilus_trader.core.rust.model import OrderSide
 from nautilus_trader.core.rust.model import OrderStatus
 from nautilus_trader.core.rust.model import TimeInForce
+from nautilus_trader.core.uuid import UUID4
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
 from nautilus_trader.execution.reports import OrderStatusReport
 from nautilus_trader.model.currencies import GBP
 from nautilus_trader.model.enums import LiquiditySide
@@ -842,10 +846,15 @@ async def test_generate_order_status_report_client_id(
     instrument_provider.add(instrument)
 
     # Act
-    report: OrderStatusReport | None = await exec_client.generate_order_status_report(
+    order_status_command = GenerateOrderStatusReport(
         instrument_id=instrument.id,
-        venue_order_id=VenueOrderId("1"),
         client_order_id=None,
+        venue_order_id=VenueOrderId("1"),
+        command_id=UUID4(),
+        ts_init=0,
+    )
+    report: OrderStatusReport | None = await exec_client.generate_order_status_report(
+        order_status_command,
     )
 
     # Assert
@@ -872,10 +881,15 @@ async def test_generate_order_status_report_venue_order_id(
     venue_order_id = VenueOrderId("323427122115")
 
     # Act
-    report: OrderStatusReport | None = await exec_client.generate_order_status_report(
+    order_status_command = GenerateOrderStatusReport(
         instrument_id=instrument.id,
-        venue_order_id=venue_order_id,
         client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+    report: OrderStatusReport | None = await exec_client.generate_order_status_report(
+        order_status_command,
     )
 
     # Assert
@@ -988,7 +1002,15 @@ async def test_generate_order_status_reports_executable(exec_client):
     mock_betfair_request(exec_client._client, BetfairResponses.list_current_orders_executable())
 
     # Act
-    reports = await exec_client.generate_order_status_reports()
+    order_status_command = GenerateOrderStatusReports(
+        instrument_id=None,
+        start=None,
+        end=None,
+        open_only=False,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+    reports = await exec_client.generate_order_status_reports(order_status_command)
 
     # Assert
     assert len(reports) == 2
@@ -1016,7 +1038,15 @@ async def test_generate_order_status_reports_executable_limit_on_close(exec_clie
     )
 
     # Act
-    reports = await exec_client.generate_order_status_reports()
+    order_status_command = GenerateOrderStatusReports(
+        instrument_id=None,
+        start=None,
+        end=None,
+        open_only=False,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+    reports = await exec_client.generate_order_status_reports(order_status_command)
 
     # Assert
     assert len(reports) == 2
@@ -1047,7 +1077,15 @@ async def test_generate_fill_reports(exec_client):
     )
 
     # Act
-    reports = await exec_client.generate_fill_reports()
+    fill_reports_command = GenerateFillReports(
+        instrument_id=None,
+        venue_order_id=None,
+        start=None,
+        end=None,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+    reports = await exec_client.generate_fill_reports(fill_reports_command)
 
     # Assert
     assert len(reports) == 2


### PR DESCRIPTION
# Pull Request

Refactor order report interfaces into messages

Similar refactor as for data messages.
Using messages makes it clearer to understand where interfaces between component are located.

This also opens up the way to call execution client's order report functionalities from other components through messages if necessary in the future.

## Type of change

- Refactor

## How has this change been tested?

Adapted existing tests
