### PR TITLE
Add pnl information to greeks data

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -155,6 +155,7 @@ class OptionStrategy(Strategy):
         portfolio_greeks = self.greeks.portfolio_greeks(
             use_cached_greeks=self.config.load_greeks,
             publish_greeks=(not self.config.load_greeks),
+            # spot_shock=10.,
             # vol_shock=0.0,
             # percent_greeks=True,
             # index_instrument_id=self.config.future_id,


### PR DESCRIPTION
# Pull Request

Add pnl information to greeks data

This way GreeksData contains a unified view of an instrument or portfolio greeks and prices

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested on databento_option_greeks.py using logs of each instrument greeks
