### PR TITLE
Refine underlying filtering in portfolio_greeks

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -155,6 +155,7 @@ class OptionStrategy(Strategy):
         portfolio_greeks = self.greeks.portfolio_greeks(
             use_cached_greeks=self.config.load_greeks,
             publish_greeks=(not self.config.load_greeks),
+            # underlyings=["ES"],
             # spot_shock=10.,
             # vol_shock=0.0,
             # percent_greeks=True,


### PR DESCRIPTION
# Pull Request

Refine underlying filtering in portfolio_greeks

Allows to filter several underlyings for portfolio_greeks which is useful for beta-weighted portfolio greeks.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

test on databento_option_greeks.py example
