### PR TITLE
Fix example load bars from custom CSV

### DIFF
--- a/examples/backtest/example_01_load_bars_from_custom_csv/run_example.py
+++ b/examples/backtest/example_01_load_bars_from_custom_csv/run_example.py
@@ -56,7 +56,11 @@ if __name__ == "__main__":
     )
 
     # Step 3: Create instrument definition and add it to the engine
-    EURUSD_FUTURES_INSTRUMENT = TestInstrumentProvider.eurusd_future(2024, 3)
+    EURUSD_FUTURES_INSTRUMENT = TestInstrumentProvider.eurusd_future(
+        expiry_year=2024,
+        expiry_month=3,
+        venue_name="XCME",
+    )
     engine.add_instrument(EURUSD_FUTURES_INSTRUMENT)
 
     # ==========================================================================================


### PR DESCRIPTION
# Pull Request

fix example_01_load_bars_from_custom_csv\run_example.py runtime errors when run this file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

nautilus_trader\examples\backtest\example_01_load_bars_from_custom_csv> python .\run_example.py
get errors like below：
2025-02-28T17:27:32.197954500Z [INFO] BACKTEST_TRADER-001.BacktestEngine: Added SimulatedExchange(id=XCME, oms_type=NETTING, account_type=MARGIN)
Traceback (most recent call last):
  File "U:\xxx\nautilus_trader\examples\backtest\example_01_load_bars_from_custom_csv\run_example.py", line 60, in <module>
    engine.add_instrument(EURUSD_FUTURES_INSTRUMENT)
  File "nautilus_trader/backtest/engine.pyx", line 587, in nautilus_trader.backtest.engine.BacktestEngine.add_instrument
    raise InvalidConfiguration(
nautilus_trader.common.config.InvalidConfiguration: Cannot add an `Instrument` object without first adding its associated venue. Add the GLBX venue using the `add_venue` method.

now  fix the errors.
