### PR TITLE
Refine base_template behaviour in parquet write_data

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -304,7 +304,7 @@ if stream_data:
     catalog.convert_stream_to_data(
         results[0].instance_id,
         GreeksData,
-        basename_template="part-{i}.parquet",
+        basename_template="part-{i}",
         partitioning=["date"],
         # mode=CatalogWriteMode.NEWFILE, # TODO comment partitioning option above to test this writing mode
         existing_data_behavior="overwrite_or_ignore",

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -271,7 +271,7 @@ class ParquetDataCatalog(BaseDataCatalog):
             pds.write_dataset(
                 data=table,
                 base_dir=path,
-                basename_template=basename_template,
+                basename_template=f"{basename_template}.parquet",
                 format="parquet",
                 filesystem=self.fs,
                 min_rows_per_group=self.min_rows_per_group,


### PR DESCRIPTION
# Pull Request

Refine base_template behaviour in parquet write_data

So the same base_template name can be used when using partitioning or not when using catalog write_data.

Previously ".parquet" wasn't appended to the base_template when using partitioning so it had to be used inside the base template provided by the user which is a different behaviour from the default behaviour used most of the time.


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

tested with databento_option_greeks.py
