### PR TITLE
Request order books snapshots with HTTP for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -164,10 +164,9 @@ class DYDXDataClient(LiveMarketDataClient):
         self._update_instruments_interval_mins: int | None = config.update_instruments_interval_mins
         self._update_orderbook_interval_secs: int = 60  # Once every 60 seconds (hard-coded for now)
         self._update_instruments_task: asyncio.Task | None = None
-        self._resubscribe_orderbook_task: asyncio.Task | None = None
+        self._fetch_orderbook_task: asyncio.Task | None = None
         self._last_quotes: dict[InstrumentId, QuoteTick] = {}
         self._orderbook_subscriptions: set[str] = set()
-        self._resubscribe_orderbook_lock = asyncio.Lock()
 
         # Hot caches
         self._bars: dict[BarType, Bar] = {}
@@ -180,8 +179,8 @@ class DYDXDataClient(LiveMarketDataClient):
             self._update_instruments_task = self.create_task(
                 self._update_instruments(self._update_instruments_interval_mins),
             )
-        self._resubscribe_orderbook_task = self.create_task(
-            self._resubscribe_orderbooks_on_interval(),
+        self._fetch_orderbook_task = self.create_task(
+            self._fetch_orderbooks_on_interval(),
         )
 
         self._log.info("Initializing websocket connection")
@@ -195,10 +194,10 @@ class DYDXDataClient(LiveMarketDataClient):
             self._update_instruments_task.cancel()
             self._update_instruments_task = None
 
-        if self._resubscribe_orderbook_task:
-            self._log.debug("Cancelling 'resubscribe_orderbook' task")
-            self._resubscribe_orderbook_task.cancel()
-            self._resubscribe_orderbook_task = None
+        if self._fetch_orderbook_task:
+            self._log.debug("Cancelling 'fetch_orderbook' task")
+            self._fetch_orderbook_task.cancel()
+            self._fetch_orderbook_task = None
 
         await self._ws_client.unsubscribe_markets()
         await self._ws_client.disconnect()
@@ -215,10 +214,10 @@ class DYDXDataClient(LiveMarketDataClient):
         except asyncio.CancelledError:
             self._log.debug("Canceled task 'update_instruments'")
 
-    async def _resubscribe_orderbooks_on_interval(self) -> None:
+    async def _fetch_orderbooks_on_interval(self) -> None:
         """
-        Resubscribe to the orderbook on a fixed interval `update_orderbook_interval` to
-        ensure it does not become outdated.
+        Fetch the orderbook on a fixed interval `update_orderbook_interval` to ensure it
+        does not become outdated.
         """
         try:
             while True:
@@ -226,21 +225,47 @@ class DYDXDataClient(LiveMarketDataClient):
                     f"Scheduled `resubscribe_order_book` to run in {self._update_orderbook_interval_secs}s",
                 )
                 await asyncio.sleep(self._update_orderbook_interval_secs)
-                await self._resubscribe_orderbooks()
+                await self._fetch_orderbooks()
         except asyncio.CancelledError:
-            self._log.debug("Canceled task 'resubscribe_orderbook'")
+            self._log.debug("Canceled task 'fetch_orderbook'")
 
-    async def _resubscribe_orderbooks(self) -> None:
+    async def _fetch_orderbooks(self) -> None:
         """
-        Resubscribe to the orderbook.
+        Request a new orderbook snapshot for all order book subscriptions.
         """
-        async with self._resubscribe_orderbook_lock:
-            for symbol in self._orderbook_subscriptions:
-                await self._ws_client.unsubscribe_order_book(symbol, remove_subscription=False)
-                await self._ws_client.subscribe_order_book(
-                    symbol,
-                    bypass_subscription_validation=True,
+        tasks = []
+
+        for symbol in self._orderbook_subscriptions:
+            tasks.append(self._fetch_orderbook(symbol))
+
+        await asyncio.gather(*tasks)
+
+    async def _fetch_orderbook(self, symbol: str) -> None:
+        """
+        Request a new orderbook snapshot.
+        """
+        msg = await self._http_market.get_orderbook(symbol=symbol)
+
+        if msg is not None:
+            instrument_id: InstrumentId = self._get_cached_instrument_id(symbol)
+            instrument = self._cache.instrument(instrument_id)
+
+            if instrument is None:
+                self._log.error(
+                    f"Cannot parse orderbook snapshot: no instrument for {instrument_id}",
                 )
+                return
+
+            ts_init = self._clock.timestamp_ns()
+            deltas = msg.parse_to_snapshot(
+                instrument_id=instrument_id,
+                price_precision=instrument.price_precision,
+                size_precision=instrument.size_precision,
+                ts_event=ts_init,
+                ts_init=ts_init,
+            )
+
+            self._handle_deltas(instrument_id=instrument_id, deltas=deltas)
 
     def _send_all_instruments_to_data_engine(self) -> None:
         for instrument in self._instrument_provider.get_all().values():

--- a/nautilus_trader/adapters/dydx/endpoints/endpoint.py
+++ b/nautilus_trader/adapters/dydx/endpoints/endpoint.py
@@ -25,6 +25,7 @@ from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
 from nautilus_trader.adapters.dydx.http.errors import DYDXError
 from nautilus_trader.adapters.dydx.http.errors import should_retry
 from nautilus_trader.common.component import Logger
+from nautilus_trader.core.nautilus_pyo3 import HttpError
 from nautilus_trader.core.nautilus_pyo3 import HttpMethod
 from nautilus_trader.core.nautilus_pyo3 import HttpTimeoutError
 from nautilus_trader.live.retry import RetryManagerPool
@@ -63,7 +64,7 @@ class DYDXHttpEndpoint:
             max_retries=5,
             retry_delay_secs=1.0,
             logger=Logger(name="DYDXHttpEndpoint"),
-            exc_types=(HttpTimeoutError, DYDXError),
+            exc_types=(HttpTimeoutError, HttpError, DYDXError),
             retry_check=should_retry,
         )
 

--- a/nautilus_trader/adapters/dydx/http/market.py
+++ b/nautilus_trader/adapters/dydx/http/market.py
@@ -27,7 +27,9 @@ from nautilus_trader.adapters.dydx.endpoints.market.candles import DYDXCandlesRe
 from nautilus_trader.adapters.dydx.endpoints.market.instruments_info import DYDXListPerpetualMarketsEndpoint
 from nautilus_trader.adapters.dydx.endpoints.market.instruments_info import DYDXListPerpetualMarketsResponse
 from nautilus_trader.adapters.dydx.endpoints.market.instruments_info import ListPerpetualMarketsGetParams
+from nautilus_trader.adapters.dydx.endpoints.market.orderbook import DYDXOrderBookSnapshotEndpoint
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
+from nautilus_trader.adapters.dydx.schemas.ws import DYDXWsOrderbookMessageSnapshotContents
 
 # fmt: on
 from nautilus_trader.common.component import LiveClock
@@ -53,6 +55,7 @@ class DYDXMarketHttpAPI:
 
         self._endpoint_instruments = DYDXListPerpetualMarketsEndpoint(client)
         self._endpoint_candles = DYDXCandlesEndpoint(client)
+        self._endpoint_orderbook = DYDXOrderBookSnapshotEndpoint(client)
 
     async def fetch_instruments(
         self,
@@ -65,6 +68,23 @@ class DYDXMarketHttpAPI:
         return await self._endpoint_instruments.get(
             ListPerpetualMarketsGetParams(ticker=symbol, limit=limit),
         )
+
+    async def get_orderbook(self, symbol: str) -> DYDXWsOrderbookMessageSnapshotContents | None:
+        """
+        Request an orderbook snapshot.
+
+        Parameters
+        ----------
+        symbol : str
+            The ticker or symbol to request the order book snapshot for.
+
+        Returns
+        -------
+        DYDXWsOrderbookMessageSnapshotContents | None
+            The order book snapshot message.
+
+        """
+        return await self._endpoint_orderbook.get(symbol=symbol)
 
     async def get_candles(
         self,

--- a/nautilus_trader/adapters/dydx/websocket/client.py
+++ b/nautilus_trader/adapters/dydx/websocket/client.py
@@ -265,7 +265,6 @@ class DYDXWebsocketClient:
     async def subscribe_order_book(
         self,
         symbol: str,
-        bypass_subscription_validation: bool = False,
     ) -> None:
         """
         Subscribe to order book messages.
@@ -274,9 +273,6 @@ class DYDXWebsocketClient:
         ----------
         symbol : str
             Symbol of the instrument to subscribe to.
-        bypass_subscription_validation : bool, default False
-            Whether to bypass the subscription validation step before sending the
-            subscribe message to the venue.
 
         """
         if self._client is None:
@@ -284,7 +280,7 @@ class DYDXWebsocketClient:
             return
 
         subscription = ("v4_orderbook", symbol)
-        if subscription in self._subscriptions and bypass_subscription_validation is False:
+        if subscription in self._subscriptions:
             self._log.warning(f"Cannot subscribe '{subscription}': already subscribed")
             return
 
@@ -435,7 +431,7 @@ class DYDXWebsocketClient:
         msg = {"type": "unsubscribe", "channel": "v4_trades", "id": symbol}
         await self._send(msg)
 
-    async def unsubscribe_order_book(self, symbol: str, remove_subscription: bool = True) -> None:
+    async def unsubscribe_order_book(self, symbol: str) -> None:
         """
         Unsubscribe from order book messages.
 
@@ -443,8 +439,6 @@ class DYDXWebsocketClient:
         ----------
         symbol : str
             Symbol of the instrument to unsubscribe from.
-        remove_subscription : bool, optional default True
-            Whether to remove the symbol from the list of subscriptions for order book updates.
 
         """
         if self._client is None:
@@ -456,8 +450,7 @@ class DYDXWebsocketClient:
             self._log.warning(f"Cannot unsubscribe '{subscription}': not subscribed")
             return
 
-        if remove_subscription:
-            self._subscriptions.remove(subscription)
+        self._subscriptions.remove(subscription)
 
         msg = {"type": "unsubscribe", "channel": "v4_orderbook", "id": symbol}
         await self._send(msg)


### PR DESCRIPTION
# Pull Request

Request order books snapshots with HTTP for dYdX to improve robustness when subscribing to order books or quotes.
Internally, the venue uses an HTTP request as well when requesting a snapshot via the websocket. However, that request often fails resulting in "internal errors". Now we can use retries in case of failed requests.

## How has this change been tested?

Live example
