### PR TITLE
Add custom event with msgbus example

### DIFF
--- a/examples/backtest/example_09_custom_event_with_msgbus/README.md
+++ b/examples/backtest/example_09_custom_event_with_msgbus/README.md
@@ -1,0 +1,19 @@
+# Example: Custom events and Message Bus Publish/Subscribe Pattern
+
+This example demonstrates:
+* how to create and use custom events with the message bus in a **NautilusTrader** strategy.
+* how to create a custom event, publish it when specific conditions are met and subscribe to handle these events.
+
+This pattern is not only useful for proper event-driven communication between different parts of your trading system,
+but also for generating and receiving events within the same Actor/Strategy.
+
+This self-communication pattern through the message bus provides a clean and consistent way to handle
+state changes or conditional notifications within your strategy.
+
+**What this example demonstrates:**
+
+- Creating custom events using Python dataclasses
+- Publishing events using the message bus
+- Subscribing to events using the message bus
+- Handling received events in the strategy
+- Using events for condition-based notifications (every 10th bar in this case)

--- a/examples/backtest/example_09_custom_event_with_msgbus/run_example.py
+++ b/examples/backtest/example_09_custom_event_with_msgbus/run_example.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from decimal import Decimal
+
+from strategy import DemoStrategy
+from strategy import DemoStrategyConfig
+
+from examples.utils.data_provider import prepare_demo_data_eurusd_futures_1min
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.config import BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model import Bar
+from nautilus_trader.model import TraderId
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments.base import Instrument
+from nautilus_trader.model.objects import Money
+
+
+if __name__ == "__main__":
+
+    # ----------------------------------------------------------------------------------
+    # 1. Configure and create backtest engine
+    # ----------------------------------------------------------------------------------
+
+    engine_config = BacktestEngineConfig(
+        trader_id=TraderId("BACKTEST-EVENTS-001"),  # Unique identifier for this backtest
+        logging=LoggingConfig(log_level="INFO"),
+    )
+    engine = BacktestEngine(config=engine_config)
+
+    # ----------------------------------------------------------------------------------
+    # 2. Prepare market data
+    # ----------------------------------------------------------------------------------
+
+    prepared_data: dict = prepare_demo_data_eurusd_futures_1min()
+    venue_name: str = prepared_data["venue_name"]
+    eurusd_instrument: Instrument = prepared_data["instrument"]
+    eurusd_1min_bartype = prepared_data["bar_type"]
+    eurusd_1min_bars: list[Bar] = prepared_data["bars_list"]
+
+    # ----------------------------------------------------------------------------------
+    # 3. Configure trading environment
+    # ----------------------------------------------------------------------------------
+
+    # Set up the trading venue with a margin account
+    engine.add_venue(
+        venue=Venue(venue_name),
+        oms_type=OmsType.NETTING,  # Use a netting order management system
+        account_type=AccountType.MARGIN,  # Use a margin trading account
+        starting_balances=[Money(1_000_000, USD)],  # Set initial capital
+        base_currency=USD,  # Account currency
+        default_leverage=Decimal(1),  # No leverage (1:1)
+    )
+
+    # Register the trading instrument
+    engine.add_instrument(eurusd_instrument)
+
+    # Load historical market data
+    engine.add_data(eurusd_1min_bars)
+
+    # ----------------------------------------------------------------------------------
+    # 4. Configure and run strategy
+    # ----------------------------------------------------------------------------------
+
+    # Create strategy configuration
+    strategy_config = DemoStrategyConfig(
+        instrument=eurusd_instrument,
+        bar_type=eurusd_1min_bartype,
+    )
+
+    # Create and register the strategy
+    strategy = DemoStrategy(config=strategy_config)
+    engine.add_strategy(strategy)
+
+    # Execute the backtest
+    engine.run()
+
+    # Clean up resources
+    engine.dispose()

--- a/examples/backtest/example_09_custom_event_with_msgbus/strategy.py
+++ b/examples/backtest/example_09_custom_event_with_msgbus/strategy.py
@@ -1,0 +1,102 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from dataclasses import dataclass
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.datetime import unix_nanos_to_dt
+from nautilus_trader.core.message import Event
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.trading.strategy import Strategy
+
+
+@dataclass
+class Each10thBarEvent(Event):
+    """
+    A custom event that is published every 10th bar.
+    """
+
+    bar: Bar  # The 10th bar related to this event
+    TOPIC: str = "each_10th_bar_event"  # Topic name for message bus publish/subscribe
+
+
+class DemoStrategyConfig(StrategyConfig, frozen=True):
+    instrument: Instrument
+    bar_type: BarType
+
+
+class DemoStrategy(Strategy):
+    """
+    A demonstration strategy showing how to use custom events and the message bus.
+    """
+
+    def __init__(self, config: DemoStrategyConfig):
+        super().__init__(config)
+
+        # Counter for processed bars
+        self.bars_processed = 0
+
+    def on_start(self):
+        # Subscribe to market data
+        self.subscribe_bars(self.config.bar_type)
+        self.log.info(f"Subscribed to {self.config.bar_type}", color=LogColor.YELLOW)
+
+        # Subscribe to our custom event
+        # First argument is the topic name to subscribe to, second is the custom handler method
+        self.msgbus.subscribe(Each10thBarEvent.TOPIC, self.on_each_10th_bar)
+        self.log.info(f"Subscribed to {Each10thBarEvent.TOPIC}", color=LogColor.YELLOW)
+
+    def on_bar(self, bar: Bar):
+        # Count processed bars
+        self.bars_processed += 1
+        self.log.info(
+            f"Bar #{self.bars_processed} | "
+            f"Bar: {bar} | "
+            f"Time={unix_nanos_to_dt(bar.ts_event)}",
+        )
+
+        # Every 10th bar, publish our custom event
+        if self.bars_processed % 10 == 0:
+            # Log our plans
+            self.log.info(
+                f"Going to publish event for topic: {Each10thBarEvent.TOPIC}",
+                color=LogColor.GREEN,
+            )
+
+            # Create and publish the event
+            # This demonstrates how to use the message bus to send events
+            event = Each10thBarEvent(bar=bar)
+            self.msgbus.publish(Each10thBarEvent.TOPIC, event)
+
+    def on_each_10th_bar(self, event: Each10thBarEvent):
+        """
+        Event handler for Each10thBarEvent.
+
+        This method is called automatically when an Each10thBarEvent is published,
+        thanks to our subscription in on_start.
+
+        """
+        # Log the event details
+        self.log.info(
+            f"Received event for topic: {Each10thBarEvent.TOPIC} at bar # {self.bars_processed}| "
+            f"Bar detail: {event.bar}",
+            color=LogColor.RED,
+        )
+
+    def on_stop(self):
+        self.log.info(f"Strategy stopped. Processed {self.bars_processed} bars.")


### PR DESCRIPTION
# Pull Request

New tutorial style example for beginners -Hhow to use: Custom event with msgbus.

# Thing to note:

I have used standard `@dataclass` and it works without visible problems.
Is that OK, or is there any motivation and benefits using `@customdataclass` instead.

As it is now in the example, probably no data are serialized (they live just in memory),
so this implementation looks like a quick & easy way how to publish/subscribe data/events,
when there is no need for serialization... (or is it always required to handle serialization in all cases?)

I got some hints from @faysou , that `@customdataclass` should be used to allow serialization
like here: https://nautilustrader.io/docs/nightly/concepts/data/#option-greeks-example,
but is this increased complexity always required, or is it completely OK use this lightweight
version and having simple code, when we don't expect any serialization in our strategy?

In this example, I inherited from `nautilus_trader.core.message.Event`.
* Is that valid approach or is there some reason to inherit from `nautilus_trader.core.Data`?
* Or what if we don't inherit from anything at all - I tested it and the strategy still works!

Just asking, to understand if there are some strong requirements (or reasonable recommendations) how to interact with msgbus, or we can simply publish/subscribe to the msgbus what-ever object we want (no need for any subclass).
After testing it, it looks there is really no need to subclass anything and strategy still works great! 😊 

## Type of change

New example added.

## How has this change been tested?

✅  Strategy generates expected output in Terminal
✅  pre-commit passed
