### PR TITLE
Fix invalid link in IB docs

### DIFF
--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -334,7 +334,7 @@ to accommodate IB-specific requirements. A `TradingNode` is then instantiated fr
 and factories for creating `InteractiveBrokersDataClient` and `InteractiveBrokersExecutionClient` are added.
 Finally, the node is built and run.
 
-For a comprehensive example, refer to this [script](https://github.com/nautechsystems/nautilus_trader/blob/master/examples/live/interactive_brokers/interactive_brokers_example.py).
+You can find additional examples here: https://github.com/nautechsystems/nautilus_trader/tree/develop/examples/live/interactive_brokers
 
 
 ```python


### PR DESCRIPTION
# Pull Request

Fixed invalid link in IB docs - solves [issue 2399](https://github.com/nautechsystems/nautilus_trader/issues/2399)

## Type of change

Just changed the link to real existing examples - as old link was obsolete.

## How has this change been tested?

✅  New links refers to the real examples
✅  precommit - passed