### PR TITLE
IB adapter update v1030

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -24,8 +24,8 @@ from typing import Any
 from ibapi import comm
 from ibapi.client import EClient
 from ibapi.commission_report import CommissionReport
-from ibapi.common import MAX_MSG_LEN
-from ibapi.common import NO_VALID_ID
+from ibapi.const import MAX_MSG_LEN
+from ibapi.const import NO_VALID_ID
 from ibapi.common import BarData
 from ibapi.errors import BAD_LENGTH
 from ibapi.execution import Execution

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -19,7 +19,7 @@ import functools
 from ibapi import comm
 from ibapi import decoder
 from ibapi.client import EClient
-from ibapi.common import NO_VALID_ID
+from ibapi.const import NO_VALID_ID
 from ibapi.connection import Connection
 from ibapi.errors import CONNECT_FAIL
 from ibapi.server_versions import MAX_CLIENT_VER
@@ -133,8 +133,8 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         """
         v100prefix = "API\0"
         v100version = f"v{MIN_CLIENT_VER}..{MAX_CLIENT_VER}"
-        if self._eclient.connectionOptions:
-            v100version += f" {self._eclient.connectionOptions}"
+        if self._eclient.connectOptions:
+            v100version += f" {self._eclient.connectOptions}"
         msg = comm.make_msg(v100version)
         msg2 = str.encode(v100prefix, "ascii") + msg
         await asyncio.to_thread(functools.partial(self._eclient.conn.sendMsg, msg2))

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -72,7 +72,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             The market data type to be set
 
         """
-        self._log.info(f"Setting Market DataType to {MarketDataTypeEnum.to_str(market_data_type)}")
+        self._log.info(f"Setting Market DataType to {MarketDataTypeEnum.toStr(market_data_type)}")
         self._eclient.reqMarketDataType(market_data_type)
 
     async def _subscribe(

--- a/nautilus_trader/adapters/interactive_brokers/client/wrapper.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/wrapper.py
@@ -570,7 +570,6 @@ class InteractiveBrokersEWrapper(EWrapper):
             One of the following:
             - Groups: Offer traders a way to create a group of accounts and apply a single allocation method
             to all accounts in the group.
-            - Profiles: Let you allocate shares on an account-by-account basis using a predefined calculation value.
             - Account Aliases: Let you easily identify the accounts by meaningful names rather than account numbers.
         cxml : str
             The XML-formatted configuration.

--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -16,7 +16,9 @@
 from decimal import Decimal
 from typing import Final, Literal
 
-from ibapi.common import UNSET_DECIMAL
+from ibapi.const import UNSET_DECIMAL
+from ibapi.contract import FundAssetType
+from ibapi.contract import FundDistributionPolicyIndicator
 from ibapi.tag_value import TagValue
 
 from nautilus_trader.config import NautilusConfig
@@ -101,6 +103,8 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
         Filters the options_chain and futures_chain which are expiring before number of days specified.
     lastTradeDateOrContractMonth: str (%Y%m%d or %Y%m) (default: '')
         Filters the options_chain and futures_chain specific for this expiry date
+    lastTradeDate: str (default: '')
+        The contract last trading day.
 
     """
 
@@ -127,6 +131,7 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
 
     # options and futures
     lastTradeDateOrContractMonth: str = ""
+    lastTradeDate: str = ""
     multiplier: str = ""
 
     # options
@@ -240,3 +245,25 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
     nextOptionType: str = ""
     nextOptionPartial: bool = False
     notes: str = ""
+
+    # FUND values
+    fundName: str = ""
+    fundFamily: str = ""
+    fundType: str = ""
+    fundFrontLoad: str = ""
+    fundBackLoad: str = ""
+    fundBackLoadTimeInterval: str = ""
+    fundManagementFee: str = ""
+    fundClosed: bool = False
+    fundClosedForNewInvestors: bool = False
+    fundClosedForNewMoney: bool = False
+    fundNotifyAmount: str = ""
+    fundMinimumInitialPurchase: str = ""
+    fundSubsequentMinimumPurchase: str = ""
+    fundBlueSkyStates: str = ""
+    fundBlueSkyTerritories: str = ""
+    fundDistributionPolicyIndicator: FundDistributionPolicyIndicator = (
+        FundDistributionPolicyIndicator.NoneItem
+    )
+    fundAssetType: FundAssetType = FundAssetType.NoneItem
+    ineligibilityReasonList: list = None

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -19,8 +19,8 @@ from decimal import Decimal
 from typing import Any
 
 from ibapi.commission_report import CommissionReport
-from ibapi.common import UNSET_DECIMAL
-from ibapi.common import UNSET_DOUBLE
+from ibapi.const import UNSET_DECIMAL
+from ibapi.const import UNSET_DOUBLE
 from ibapi.execution import Execution
 from ibapi.order import Order as IBOrder
 from ibapi.order_state import OrderState as IBOrderState


### PR DESCRIPTION
# Pull Request

Minimum modifications of IB adapter to match IB API v10.30, the stable version as of now.
Details on what is not included below.

## Type of change

update

## How has this change been tested?

Tested in paper + live with TWS version 10.30.1t & NT Master then develop version.

# List of modifications
For context : 
IB API release notes : 
https://ibkrguides.com/releasenotes/tws-api.htm
IB API  changelog : 
https://www.interactivebrokers.com/campus/ibkr-api-page/tws-api-changelog-2/

Modifications done on the adapter, and IB TWS API related PR  :

[PR 1177 De-supported FADataType.PROFILES, and always go with "Unification of Groups and Profiles".](https://github.com/InteractiveBrokers/tws-api/pull/1177)  
remove comment in client/wrapper/receiveFA

[PR 975 reformatted to PEP8 standards using black](https://github.com/InteractiveBrokers/tws-api/pull/975)
Some imports modified : from ibapi.common to ibapi.const
in files execution, client/connection, client/client
Enum to_str => toStr in client/market_data

[PR 1211 : fund data fields to contractDetails](https://github.com/InteractiveBrokers/tws-api/pull/1211)
data fields added to class IBContractDetails in common.

[PR 1227 Added support of lastTradeDate field in contractDetails](https://github.com/InteractiveBrokers/tws-api/pull/1227)
common.py, field added to IBcontract class. Using it in downstream functions may be considered.


[PR 1249 Added PACEAPI connect option](https://github.com/InteractiveBrokers/tws-api/pull/1249)
client/connection
renaming connectionOptions to connectOptions

[PR 1260 Added ineligibilityReasons parameter to contractDetails](https://github.com/InteractiveBrokers/tws-api/pull/1260)
common
Parameter added to IBContractDetails.


# Changes not taken into account in this PR :
Some may be important & to be considered : 

PR 1218 Update market_depth.txt
https://github.com/InteractiveBrokers/tws-api/pull/1218/files

> 	An integral part of processing the incoming data is monitoring IBApi::EWrapper::error for message 317 "Market depth data has been RESET. Please empty deep book contents before applying any new entries."
> 	and handling it appropriately, otherwise the update process would be corrupted.
> 
> 	\section canceling Canceling
> 
> 	To cancel an active market depth request simply invoke the @ref IBApi::EClient::cancelMktDepth passing in the request's identifier.

PR 1262 & 1276 (Added / removed RFQ fields)
Made to comply with CME rule 576 : https://www.cmegroup.com/rulebook/files/cme-group-Rule-576.pdf
ExtOperator, ManualOrderIndicator fields added in TWS in  new OrderCancel object
externalUserId field was added then removed in version > 10.30
To be done in future versions, in particular for pro users subject to rule 576
Addition of new OrderCancel object
Will be 2d argument of OrderCancel object in 10.33, to be done then.

In changelog : 
2024/07/08 : 
"Please be aware that endDateTime must be left as an empty string when requesting continuous futures contracts when using the TWS API with Trader Workstation or IB Gateway releases of 10.30 and above."

PR 1202: New Price Revision Pending field
PendingPriceRevision : new field in IB execution class
pendingPriceRevision: bool. Describes if the execution is still pending price revision.

PR 1173 Support of delayed yield bid/ask

PR 1216 Added manual order time parameter to exersiceOptions

PR 1259 Added BondAccruedInterest field
