### PR TITLE
Contingent orders handling for order matching engine

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -573,14 +573,12 @@ impl SimulatedExchange {
                 TradingCommand::BatchCancelOrders(ref command) => {
                     matching_engine.process_batch_cancel(command, account_id);
                 }
-                TradingCommand::QueryOrder(ref command) => {
-                    matching_engine.process_query_order(command, account_id);
-                }
                 TradingCommand::SubmitOrderList(mut command) => {
                     for order in &mut command.order_list.orders {
                         matching_engine.process_order(order, account_id);
                     }
                 }
+                _ => {}
             }
         } else {
             panic!("Matching engine should be initialized");

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -1229,7 +1229,7 @@ impl Cache {
     pub fn add_position_id(
         &mut self,
         position_id: &PositionId,
-        _venue: &Venue,
+        venue: &Venue,
         client_order_id: &ClientOrderId,
         strategy_id: &StrategyId,
     ) -> anyhow::Result<()> {
@@ -1258,6 +1258,13 @@ impl Cache {
         self.index
             .strategy_positions
             .entry(*strategy_id)
+            .or_default()
+            .insert(*position_id);
+
+        // Index: Venue -> set[PositionId]
+        self.index
+            .venue_positions
+            .entry(*venue)
             .or_default()
             .insert(*position_id);
 

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -766,10 +766,6 @@ impl OrderMatchingEngine {
         }
     }
 
-    pub fn process_query_order(&self, command: &QueryOrder, account_id: AccountId) {
-        todo!("implement process_query_order")
-    }
-
     fn process_market_order(&mut self, order: &mut OrderAny) {
         if order.time_in_force() == TimeInForce::AtTheOpen
             || order.time_in_force() == TimeInForce::AtTheClose

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -55,7 +55,7 @@ use ustr::Ustr;
 use crate::{
     matching_core::OrderMatchingCore,
     matching_engine::{config::OrderMatchingEngineConfig, ids_generator::IdsGenerator},
-    messages::{BatchCancelOrders, CancelAllOrders, CancelOrder, ModifyOrder, QueryOrder},
+    messages::{BatchCancelOrders, CancelAllOrders, CancelOrder, ModifyOrder},
     models::{
         fee::{FeeModel, FeeModelAny},
         fill::FillModel,
@@ -1527,7 +1527,117 @@ impl OrderMatchingEngine {
             return;
         }
 
-        todo!("Check for contingent orders")
+        if let Some(contingency_type) = order.contingency_type() {
+            match contingency_type {
+                ContingencyType::Oto => {
+                    if let Some(linked_orders_ids) = order.linked_order_ids() {
+                        for client_order_id in &linked_orders_ids {
+                            let mut child_order = match self.cache.borrow().order(client_order_id) {
+                                Some(child_order) => child_order.clone(),
+                                None => panic!("Order {client_order_id} not found in cache"),
+                            };
+
+                            if child_order.is_closed() || child_order.is_active_local() {
+                                continue;
+                            }
+
+                            // Check if we need to index position id
+                            if let (None, Some(position_id)) =
+                                (child_order.position_id(), order.position_id())
+                            {
+                                self.cache
+                                    .borrow_mut()
+                                    .add_position_id(
+                                        &position_id,
+                                        &self.venue,
+                                        client_order_id,
+                                        &child_order.strategy_id(),
+                                    )
+                                    .unwrap();
+                                log::debug!(
+                                    "Added position id {} to cache for order {}",
+                                    position_id,
+                                    client_order_id
+                                )
+                            }
+
+                            if (!child_order.is_open())
+                                || (matches!(child_order.status(), OrderStatus::PendingUpdate)
+                                    && child_order
+                                        .previous_status()
+                                        .is_some_and(|s| matches!(s, OrderStatus::Submitted)))
+                            {
+                                let account_id = order.account_id().unwrap_or_else(|| {
+                                    self.account_ids
+                                        .get(&order.trader_id())
+                                        .unwrap_or_else(|| {
+                                            panic!(
+                                                "Account ID not found for trader {}",
+                                                order.trader_id()
+                                            )
+                                        })
+                                        .clone()
+                                });
+                                self.process_order(&mut child_order, account_id);
+                            }
+                        }
+                    } else {
+                        log::error!(
+                            "OTO order {} does not have linked orders",
+                            order.client_order_id()
+                        );
+                        return;
+                    }
+                }
+                ContingencyType::Oco => {
+                    if let Some(linked_orders_ids) = order.linked_order_ids() {
+                        for client_order_id in &linked_orders_ids {
+                            let mut child_order = match self.cache.borrow().order(client_order_id) {
+                                Some(child_order) => child_order.clone(),
+                                None => panic!("Order {client_order_id} not found in cache"),
+                            };
+
+                            if child_order.is_closed() || child_order.is_active_local() {
+                                continue;
+                            }
+
+                            self.cancel_order(&child_order, None);
+                        }
+                    }
+                }
+                ContingencyType::Ouo => {
+                    if let Some(linked_orders_ids) = order.linked_order_ids() {
+                        for client_order_id in &linked_orders_ids {
+                            let mut child_order = match self.cache.borrow().order(client_order_id) {
+                                Some(child_order) => child_order.clone(),
+                                None => panic!("Order {client_order_id} not found in cache"),
+                            };
+
+                            if child_order.is_active_local() {
+                                continue;
+                            }
+
+                            if order.is_closed() && child_order.is_open() {
+                                self.cancel_order(&child_order, None);
+                            } else if !order.leaves_qty().is_zero()
+                                && order.leaves_qty() != child_order.leaves_qty()
+                            {
+                                let price = child_order.price();
+                                let trigger_price = child_order.trigger_price();
+                                self.update_order(
+                                    &mut child_order,
+                                    Some(order.leaves_qty()),
+                                    price,
+                                    trigger_price,
+                                    Some(false),
+                                )
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     fn update_limit_order(&mut self, order: &mut OrderAny, quantity: Quantity, price: Price) {
@@ -1938,7 +2048,33 @@ impl OrderMatchingEngine {
     }
 
     fn update_contingent_order(&mut self, order: &OrderAny) {
-        todo!("update_contingent_order")
+        log::debug!("Updating OUO orders from {}", order.client_order_id());
+        if let Some(linked_order_ids) = order.linked_order_ids() {
+            for client_order_id in &linked_order_ids {
+                let mut child_order = match self.cache.borrow().order(client_order_id) {
+                    Some(order) => order.clone(),
+                    None => panic!("Order {client_order_id} not found in cache."),
+                };
+
+                if child_order.is_active_local() {
+                    continue;
+                }
+
+                if order.leaves_qty().is_zero() {
+                    self.cancel_order(&child_order, None);
+                } else if child_order.leaves_qty() != order.leaves_qty() {
+                    let price = child_order.price();
+                    let trigger_price = child_order.trigger_price();
+                    self.update_order(
+                        &mut child_order,
+                        Some(order.leaves_qty()),
+                        price,
+                        trigger_price,
+                        Some(false),
+                    )
+                }
+            }
+        }
     }
 
     fn cancel_contingent_orders(&mut self, order: &OrderAny) {

--- a/crates/model/src/orders/any.rs
+++ b/crates/model/src/orders/any.rs
@@ -1009,6 +1009,21 @@ impl OrderAny {
         }
     }
 
+    #[must_use]
+    pub fn previous_status(&self) -> Option<OrderStatus> {
+        match self {
+            Self::Limit(order) => order.previous_status,
+            Self::LimitIfTouched(order) => order.previous_status,
+            Self::Market(order) => order.previous_status,
+            Self::MarketIfTouched(order) => order.previous_status,
+            Self::MarketToLimit(order) => order.previous_status,
+            Self::StopLimit(order) => order.previous_status,
+            Self::StopMarket(order) => order.previous_status,
+            Self::TrailingStopLimit(order) => order.previous_status,
+            Self::TrailingStopMarket(order) => order.previous_status,
+        }
+    }
+
     pub fn set_position_id(&mut self, position_id: Option<PositionId>) {
         match self {
             Self::Limit(order) => order.position_id = position_id,


### PR DESCRIPTION
# Pull Request

- removed obsolete processing of `QueryOrder` command from matching engine (it's not present in Cython implementation and doesn't need to be here as its used mainly for inflight live orders)
- add missing indexing of `Venue` and `PositionId`  indexing in cache function `add_position_id`
- full contingent order handling, in both updating and processing orders functions
- tested in `test_updating_of_contingent_orders`