### PR TITLE
Refactor mixed catalog client requests

### DIFF
--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -15,7 +15,7 @@
 
 from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
-from nautilus_trader.persistence.catalog.types import CatalogWriteMode
+from nautilus_trader.common.enums import UpdateCatalogMode
 
 from nautilus_trader.cache.base cimport CacheFacade
 from nautilus_trader.common.component cimport Clock
@@ -187,7 +187,7 @@ cdef class Actor(Component):
         datetime end=*,
         int limit=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_instrument(
@@ -197,7 +197,7 @@ cdef class Actor(Component):
         datetime end=*,
         ClientId client_id=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_instruments(
@@ -207,7 +207,7 @@ cdef class Actor(Component):
         datetime end=*,
         ClientId client_id=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_order_book_snapshot(
@@ -226,7 +226,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_trade_ticks(
@@ -237,7 +237,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_bars(
@@ -248,7 +248,7 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef UUID4 request_aggregated_bars(
@@ -261,7 +261,7 @@ cdef class Actor(Component):
         callback=*,
         bint include_external_data=*,
         bint update_subscriptions=*,
-        update_catalog_mode: CatalogWriteMode | None = *,
+        update_catalog_mode: UpdateCatalogMode | None = *,
         dict[str, object] params=*,
     )
     cpdef bint is_pending_request(self, UUID4 request_id)

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -33,10 +33,10 @@ import cython
 
 from nautilus_trader.common.config import ActorConfig
 from nautilus_trader.common.config import ImportableActorConfig
+from nautilus_trader.common.enums import UpdateCatalogMode
 from nautilus_trader.common.executor import ActorExecutor
 from nautilus_trader.common.executor import TaskId
 from nautilus_trader.common.signal import generate_signal_class
-from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 
 from cpython.datetime cimport datetime
 from libc.stdint cimport uint64_t
@@ -2080,7 +2080,7 @@ cdef class Actor(Component):
         datetime end = None,
         int limit = 0,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2108,11 +2108,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2161,7 +2161,7 @@ cdef class Actor(Component):
         datetime end = None,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2190,11 +2190,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2255,7 +2255,7 @@ cdef class Actor(Component):
         datetime end = None,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2284,11 +2284,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2368,11 +2368,11 @@ cdef class Actor(Component):
             If None, it will be inferred from the venue in the instrument ID.
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2418,7 +2418,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2449,11 +2449,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2482,6 +2482,8 @@ cdef class Actor(Component):
             Condition.is_true(start <= now, "start was > now")
         if end is not None:
             Condition.is_true(end <= now, "end was > now")
+            Condition.is_true(update_catalog_mode is None,
+                     "end and update_catalog_mode cannot be set at the same time to prevent data holes.")
         if start is not None and end is not None:
             Condition.is_true(start < end, "start was >= end")
         Condition.callable_or_none(callback, "callback")
@@ -2516,7 +2518,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2547,11 +2549,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2580,6 +2582,8 @@ cdef class Actor(Component):
             Condition.is_true(start <= now, "start was > now")
         if end is not None:
             Condition.is_true(end <= now, "end was > now")
+            Condition.is_true(update_catalog_mode is None,
+                      "end and update_catalog_mode cannot be set at the same time to prevent data holes.")
         if start is not None and end is not None:
             Condition.is_true(start < end, "start was >= end")
         Condition.callable_or_none(callback, "callback")
@@ -2614,7 +2618,7 @@ cdef class Actor(Component):
         int limit = 0,
         ClientId client_id = None,
         callback: Callable[[UUID4], None] | None = None,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2645,11 +2649,11 @@ cdef class Actor(Component):
         callback : Callable[[UUID4], None], optional
             The registered callback, to be called with the request ID when the response has
             completed processing.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2678,6 +2682,8 @@ cdef class Actor(Component):
             Condition.is_true(start <= now, "start was > now")
         if end is not None:
             Condition.is_true(end <= now, "end was > now")
+            Condition.is_true(update_catalog_mode is None,
+                      "end and update_catalog_mode cannot be set at the same time to prevent data holes.")
         if start is not None and end is not None:
             Condition.is_true(start < end, "start was >= end")
         Condition.callable_or_none(callback, "callback")
@@ -2714,7 +2720,7 @@ cdef class Actor(Component):
         callback: Callable[[UUID4], None] | None = None,
         bint include_external_data = False,
         bint update_subscriptions = False,
-        update_catalog_mode: CatalogWriteMode | None = None,
+        update_catalog_mode: UpdateCatalogMode | None = None,
         dict[str, object] params = None,
     ):
         """
@@ -2755,11 +2761,11 @@ cdef class Actor(Component):
             If True, includes the queried external data in the response.
         update_subscriptions : bool, default False
             If True, updates the aggregators of any existing or future subscription with the queried external data.
-        update_catalog_mode : CatalogWriteMode, optional
+        update_catalog_mode : UpdateCatalogMode, optional
             If not None, then updates the catalog with new data received from a client.
             Recommended catalog write modes are:
-            - CatalogWriteMode.APPEND (appends new data to the catalog by concatenating it to the existing unique parquet file).
-            - CatalogWriteMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
+            - UpdateCatalogMode.MODIFY (appends or prepends new data to the catalog by concatenating it to the existing unique parquet file).
+            - UpdateCatalogMode.NEWFILE (appends new data to the catalog by creating a new parquet file).
         params : dict[str, Any], optional
             Additional parameters potentially used by a specific client.
 
@@ -2793,6 +2799,8 @@ cdef class Actor(Component):
             Condition.is_true(start <= now, "start was > now")
         if end is not None:
             Condition.is_true(end <= now, "end was > now")
+            Condition.is_true(update_catalog_mode is None,
+                      "end and update_catalog_mode cannot be set at the same time to prevent data holes.")
         if start is not None and end is not None:
             Condition.is_true(start < end, "start was >= end")
         Condition.callable_or_none(callback, "callback")

--- a/nautilus_trader/common/enums.py
+++ b/nautilus_trader/common/enums.py
@@ -37,6 +37,7 @@ __all__ = [
     "ComponentTrigger",
     "LogColor",
     "LogLevel",
+    "UpdateCatalogMode",
     "component_state_from_str",
     "component_state_to_str",
     "component_trigger_from_str",
@@ -46,6 +47,18 @@ __all__ = [
 ]
 
 # mypy: disable-error-code=no-redef
+
+
+@unique
+class UpdateCatalogMode(Enum):
+    """
+    Represents a catalog update mode.
+    """
+
+    MODIFY = 0
+    NEWFILE = 1
+    OVERWRITE = 2
+
 
 if TYPE_CHECKING:
 

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -180,11 +180,13 @@ cdef class DataEngine(Component):
 
 # -- REQUEST HANDLERS -----------------------------------------------------------------------------
 
-    cpdef tuple[datetime, object] _catalogs_last_timestamp(self, type data_cls, InstrumentId instrument_id=*, BarType bar_type=*, str ts_column=*)
+    cpdef tuple[datetime, object] _catalogs_timestamp_bound(self, type data_cls, InstrumentId instrument_id=*, BarType bar_type=*, str ts_column=*, bint is_last=*)
     cpdef void _handle_request(self, RequestData request)
     cpdef void _handle_request_instruments(self, DataClient client, RequestInstruments request)
     cpdef void _handle_request_instrument(self, DataClient client, RequestInstrument request)
     cpdef void _handle_request_order_book_snapshot(self, DataClient client, RequestOrderBookSnapshot request)
+    cpdef void _date_range_client_request(self, DataClient client, RequestData request)
+    cpdef void _handle_date_range_request(self, DataClient client, RequestData request, datetime start_catalog, datetime end_catalog)
     cpdef void _handle_request_quote_ticks(self, DataClient client, RequestQuoteTicks request)
     cpdef void _handle_request_trade_ticks(self, DataClient client, RequestTradeTicks request)
     cpdef void _handle_request_bars(self, DataClient client, RequestBars request)
@@ -209,7 +211,7 @@ cdef class DataEngine(Component):
 
     cpdef void _handle_response(self, DataResponse response)
     cpdef void _handle_instruments(self, list instruments, update_catalog_mode: CatalogWriteMode | None = *)
-    cpdef void _update_catalog(self, list ticks, update_catalog_mode: CatalogWriteMode | None, bint is_instrument=*)
+    cpdef void _update_catalog(self, list ticks, update_catalog_mode: CatalogWriteMode, bint is_instrument=*)
     cpdef void _new_query_group(self, UUID4 correlation_id, int n_components)
     cpdef object _handle_query_group(self, UUID4 correlation_id, list ticks)
     cdef object _handle_query_group_aux(self, UUID4 correlation_id, list ticks)

--- a/nautilus_trader/data/messages.pyx
+++ b/nautilus_trader/data/messages.pyx
@@ -1292,6 +1292,20 @@ cdef class RequestData(Request):
         self.venue = venue
         self.params = params or {}
 
+    def with_dates(self, datetime start, datetime end):
+        return RequestData(
+            data_type=self.data_type,
+            start=start,
+            end=end,
+            limit=self.limit,
+            client_id=self.client_id,
+            venue=self.venue,
+            callback=self.callback,
+            request_id=self.id,
+            ts_init=self.ts_init,
+            params=self.params.copy(),
+        )
+
     def __str__(self) -> str:
         return (
             f"{type(self).__name__}("
@@ -1619,6 +1633,20 @@ cdef class RequestQuoteTicks(RequestData):
 
         self.instrument_id = instrument_id
 
+    def with_dates(self, datetime start, datetime end):
+        return RequestQuoteTicks(
+            instrument_id=self.instrument_id,
+            start=start,
+            end=end,
+            limit=self.limit,
+            client_id=self.client_id,
+            venue=self.venue,
+            callback=self.callback,
+            request_id=self.id,
+            ts_init=self.ts_init,
+            params=self.params.copy(),
+        )
+
     def __str__(self) -> str:
         return (
             f"{type(self).__name__}("
@@ -1706,6 +1734,20 @@ cdef class RequestTradeTicks(RequestData):
         )
 
         self.instrument_id = instrument_id
+
+    def with_dates(self, datetime start, datetime end):
+        return RequestTradeTicks(
+            instrument_id=self.instrument_id,
+            start=start,
+            end=end,
+            limit=self.limit,
+            client_id=self.client_id,
+            venue=self.venue,
+            callback=self.callback,
+            request_id=self.id,
+            ts_init=self.ts_init,
+            params=self.params.copy(),
+        )
 
     def __str__(self) -> str:
         return (
@@ -1795,6 +1837,20 @@ cdef class RequestBars(RequestData):
         )
 
         self.bar_type = bar_type
+
+    def with_dates(self, datetime start, datetime end):
+        return RequestBars(
+            bar_type=self.bar_type,
+            start=start,
+            end=end,
+            limit=self.limit,
+            client_id=self.client_id,
+            venue=self.venue,
+            callback=self.callback,
+            request_id=self.id,
+            ts_init=self.ts_init,
+            params=self.params.copy(),
+        )
 
     def __str__(self) -> str:
         return (

--- a/nautilus_trader/persistence/catalog/base.py
+++ b/nautilus_trader/persistence/catalog/base.py
@@ -70,12 +70,13 @@ class BaseDataCatalog(ABC, metaclass=_CombinedMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def query_last_timestamp(
+    def query_timestamp_bound(
         self,
         data_cls: type,
         instrument_id: str | None = None,
         bar_type: str | None = None,
         ts_column: str = "ts_init",
+        is_last: bool = True,
     ) -> pd.Timestamp | None:
         raise NotImplementedError
 

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -24,6 +24,7 @@ from nautilus_trader.adapters.databento.loaders import DatabentoDataLoader
 from nautilus_trader.backtest.data_client import BacktestMarketDataClient
 from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.component import TestClock
+from nautilus_trader.common.enums import UpdateCatalogMode
 from nautilus_trader.core.data import Data
 from nautilus_trader.core.datetime import time_object_to_dt
 from nautilus_trader.core.uuid import UUID4
@@ -72,7 +73,6 @@ from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
-from nautilus_trader.persistence.catalog.types import CatalogWriteMode
 from nautilus_trader.portfolio.portfolio import Portfolio
 from nautilus_trader.test_kit.mocks.data import MockMarketDataClient
 from nautilus_trader.test_kit.mocks.data import setup_catalog
@@ -2343,7 +2343,7 @@ class TestDataEngine:
             callback=handler.append,
             request_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
-            params={"update_catalog_mode": CatalogWriteMode.APPEND},
+            params={"update_catalog_mode": UpdateCatalogMode.MODIFY},
         )
 
         self.clock.advance_time(pd.Timestamp("2024-3-25").value)
@@ -2355,7 +2355,7 @@ class TestDataEngine:
         assert self.data_engine.request_count == 1
         assert len(handler) == 1
         assert handler[0].data == [bar, bar2]
-        assert catalog.query_last_timestamp(Bar, bar_type=bar_type) == time_object_to_dt(
+        assert catalog.query_timestamp_bound(Bar, bar_type=bar_type) == time_object_to_dt(
             pd.Timestamp("2024-3-25"),
         )
 
@@ -2470,7 +2470,7 @@ class TestDataEngine:
             callback=handler.append,
             request_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
-            params={"update_catalog_mode": CatalogWriteMode.APPEND},
+            params={"update_catalog_mode": UpdateCatalogMode.MODIFY},
         )
 
         self.clock.advance_time(pd.Timestamp("2024-3-25").value)
@@ -2482,7 +2482,7 @@ class TestDataEngine:
         assert self.data_engine.request_count == 1
         assert len(handler) == 1
         # assert handler[0].data == [quote_tick, quote_tick2]
-        assert catalog.query_last_timestamp(
+        assert catalog.query_timestamp_bound(
             QuoteTick,
             instrument_id=ETHUSDT_BINANCE.id,
         ) == time_object_to_dt(
@@ -2514,7 +2514,7 @@ class TestDataEngine:
             callback=handler.append,
             request_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
-            params={"update_catalog_mode": CatalogWriteMode.APPEND},
+            params={"update_catalog_mode": UpdateCatalogMode.MODIFY},
         )
 
         # Act
@@ -2602,7 +2602,7 @@ class TestDataEngine:
             callback=handler.append,
             request_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
-            params={"update_catalog_mode": CatalogWriteMode.APPEND},
+            params={"update_catalog_mode": UpdateCatalogMode.MODIFY},
         )
 
         self.clock.advance_time(pd.Timestamp("2024-3-25").value)
@@ -2614,7 +2614,7 @@ class TestDataEngine:
         assert self.data_engine.request_count == 1
         assert len(handler) == 1
         # assert handler[0].data == [trade_tick, trade_tick2]
-        assert catalog.query_last_timestamp(
+        assert catalog.query_timestamp_bound(
             TradeTick,
             instrument_id=ETHUSDT_BINANCE.id,
         ) == time_object_to_dt(
@@ -2659,7 +2659,7 @@ class TestDataEngine:
             callback=handler.append,
             request_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
-            params={"update_catalog_mode": CatalogWriteMode.NEWFILE},
+            params={"update_catalog_mode": UpdateCatalogMode.NEWFILE},
         )
 
         self.clock.advance_time(pd.Timestamp("2024-3-25").value)
@@ -2671,7 +2671,7 @@ class TestDataEngine:
         assert self.data_engine.request_count == 1
         assert len(handler) == 1
         # assert handler[0].data == [trade_tick, trade_tick2]
-        assert catalog.query_last_timestamp(
+        assert catalog.query_timestamp_bound(
             TradeTick,
             instrument_id=ETHUSDT_BINANCE.id,
         ) == time_object_to_dt(


### PR DESCRIPTION
# Pull Request

Refine mixed catalog client requests

- Allow to extend a catalog after its last datetime or before its first date time
- Automatic determination of append and prepend catalog write mode
- Note: to avoid creating holes in the data, priviledge only using start date and not end date in data requests when updating the catalog as well. Update: I've added a condition enforcing not using both end and update_catalog_mode at the same time.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Existing tests passing, more tests needed, possibly after a merge. Found and fixed bugs to make existing tests work. Also the key logic is concentrated in _handle_date_range_request and is easy to understand.
