### PR TITLE
Refine Makefile to install uv venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,19 @@ install-debug:
 install-just-deps:
 	uv sync --active --all-groups --all-extras --no-install-package nautilus_trader
 
+# Install instructions that also set up a uv venv inside the nautilus directory
+.PHONY: install-uv
+install-uv:
+	BUILD_MODE=release uv sync --all-groups --all-extras
+
+.PHONY: install-debug-uv
+install-debug-uv:
+	BUILD_MODE=debug uv sync --all-groups --all-extras
+
+.PHONY: install-just-deps-uv
+install-just-deps-uv:
+	uv sync --all-groups --all-extras --no-install-package nautilus_trader
+
 .PHONY: build
 build:
 	BUILD_MODE=release uv run --active --no-sync build.py


### PR DESCRIPTION
# Pull Request

Refine Makefile to install uv venv

Add additional instructions to allow installation of a uv venv, the default behaviour, that is now hard to access when using --active

Having make install and make install-uv for example allows both possibilities, installing in a pyenv venv or installing a uv venv in the nautilus folder, that can be then activated with source .venv/bin/activate

## Type of change

- Improvement

## How has this change been tested?

Tested it works as expected
