### PR TITLE
Execution client design in Rust

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -56,7 +56,7 @@ pub struct SimulatedExchange {
     starting_balances: Vec<Money>,
     book_type: BookType,
     default_leverage: Decimal,
-    exec_client: Option<Box<dyn ExecutionClient>>,
+    exec_client: Option<Rc<dyn ExecutionClient>>,
     pub base_currency: Option<Currency>,
     fee_model: FeeModelAny,
     fill_model: FillModel,
@@ -146,7 +146,7 @@ impl SimulatedExchange {
         })
     }
 
-    pub fn register_client(&mut self, client: Box<dyn ExecutionClient>) {
+    pub fn register_client(&mut self, client: Rc<dyn ExecutionClient>) {
         self.exec_client = Some(client);
     }
 
@@ -619,19 +619,17 @@ mod tests {
 
     use nautilus_common::{
         cache::Cache,
+        clock::TestClock,
         msgbus::{
             MessageBus, register,
             stubs::{get_message_saving_handler, get_saved_messages},
         },
     };
     use nautilus_core::{AtomicTime, UUID4, UnixNanos};
-    use nautilus_execution::{
-        client::ExecutionClient,
-        models::{
-            fee::{FeeModelAny, MakerTakerFeeModel},
-            fill::FillModel,
-            latency::LatencyModel,
-        },
+    use nautilus_execution::models::{
+        fee::{FeeModelAny, MakerTakerFeeModel},
+        fill::FillModel,
+        latency::LatencyModel,
     };
     use nautilus_model::{
         accounts::{AccountAny, MarginAccount},
@@ -644,14 +642,14 @@ mod tests {
             OmsType, OrderSide,
         },
         events::AccountState,
-        identifiers::{AccountId, ClientId, TradeId, TraderId, Venue},
+        identifiers::{AccountId, TradeId, TraderId, Venue},
         instruments::{CryptoPerpetual, InstrumentAny, stubs::crypto_perpetual_ethusdt},
         types::{AccountBalance, Currency, Money, Price, Quantity},
     };
     use rstest::rstest;
     use ustr::Ustr;
 
-    use crate::exchange::SimulatedExchange;
+    use crate::{exchange::SimulatedExchange, execution_client::BacktestExecutionClient};
 
     static ATOMIC_TIME: LazyLock<AtomicTime> =
         LazyLock::new(|| AtomicTime::new(true, UnixNanos::default()));
@@ -662,51 +660,54 @@ mod tests {
         book_type: BookType,
         msgbus: Option<Rc<RefCell<MessageBus>>>,
         cache: Option<Rc<RefCell<Cache>>>,
-    ) -> SimulatedExchange {
+    ) -> Rc<RefCell<SimulatedExchange>> {
         let msgbus = msgbus.unwrap_or(Rc::new(RefCell::new(MessageBus::default())));
         let cache = cache.unwrap_or(Rc::new(RefCell::new(Cache::default())));
 
-        let mut exchange = SimulatedExchange::new(
-            venue,
-            OmsType::Netting,
-            account_type,
-            vec![Money::new(1000.0, Currency::USD())],
-            None,
-            1.into(),
-            HashMap::new(),
-            vec![],
-            msgbus.clone(),
-            cache.clone(),
-            &ATOMIC_TIME,
-            FillModel::default(),
-            FeeModelAny::MakerTaker(MakerTakerFeeModel),
-            LatencyModel,
-            book_type,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+        let exchange = Rc::new(RefCell::new(
+            SimulatedExchange::new(
+                venue,
+                OmsType::Netting,
+                account_type,
+                vec![Money::new(1000.0, Currency::USD())],
+                None,
+                1.into(),
+                HashMap::new(),
+                vec![],
+                msgbus.clone(),
+                cache.clone(),
+                &ATOMIC_TIME,
+                FillModel::default(),
+                FeeModelAny::MakerTaker(MakerTakerFeeModel),
+                LatencyModel,
+                book_type,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
+        ));
 
-        let execution_client = ExecutionClient::new(
+        let clock = TestClock::new();
+        let execution_client = BacktestExecutionClient::new(
             TraderId::default(),
-            ClientId::default(),
-            venue,
-            OmsType::Netting,
             AccountId::default(),
-            account_type,
+            exchange.clone(),
+            cache.clone(),
+            msgbus.clone(),
+            Rc::new(RefCell::new(clock)),
             None,
-            &ATOMIC_TIME,
-            cache,
-            msgbus,
+            None,
         );
-        exchange.register_client(execution_client);
+        exchange
+            .borrow_mut()
+            .register_client(Rc::new(execution_client));
 
         exchange
     }
@@ -718,7 +719,7 @@ mod tests {
     fn test_venue_mismatch_between_exchange_and_instrument(
         crypto_perpetual_ethusdt: CryptoPerpetual,
     ) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("SIM"),
             AccountType::Margin,
             BookType::L1_MBP,
@@ -726,13 +727,13 @@ mod tests {
             None,
         );
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
     }
 
     #[rstest]
     #[should_panic(expected = "Cash account cannot trade futures or perpetuals")]
     fn test_cash_account_trading_futures_or_perpetuals(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Cash,
             BookType::L1_MBP,
@@ -740,12 +741,12 @@ mod tests {
             None,
         );
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
     }
 
     #[rstest]
     fn test_exchange_process_quote_tick(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L1_MBP,
@@ -755,7 +756,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // process tick
         let quote_tick = QuoteTick::new(
@@ -767,17 +768,21 @@ mod tests {
             UnixNanos::default(),
             UnixNanos::default(),
         );
-        exchange.process_quote_tick(&quote_tick);
+        exchange.borrow_mut().process_quote_tick(&quote_tick);
 
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_bid_price, Some(Price::from("1000")));
-        let best_ask_price = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask_price = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_ask_price, Some(Price::from("1001")));
     }
 
     #[rstest]
     fn test_exchange_process_trade_tick(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L1_MBP,
@@ -787,7 +792,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // process tick
         let trade_tick = TradeTick::new(
@@ -799,17 +804,21 @@ mod tests {
             UnixNanos::default(),
             UnixNanos::default(),
         );
-        exchange.process_trade_tick(&trade_tick);
+        exchange.borrow_mut().process_trade_tick(&trade_tick);
 
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_bid_price, Some(Price::from("1000")));
-        let best_ask = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_ask, Some(Price::from("1000")));
     }
 
     #[rstest]
     fn test_exchange_process_bar_last_bar_spec(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L1_MBP,
@@ -819,7 +828,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // process bar
         let bar = Bar::new(
@@ -832,18 +841,22 @@ mod tests {
             UnixNanos::default(),
             UnixNanos::default(),
         );
-        exchange.process_bar(bar);
+        exchange.borrow_mut().process_bar(bar);
 
         // this will be processed as ticks so both bid and ask will be the same as close of the bar
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_bid_price, Some(Price::from("1502.00")));
-        let best_ask_price = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask_price = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_ask_price, Some(Price::from("1502.00")));
     }
 
     #[rstest]
     fn test_exchange_process_bar_bid_ask_bar_spec(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L1_MBP,
@@ -853,7 +866,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // create both bid and ask based bars
         // add +1 on ask to make sure it is different from bid
@@ -879,19 +892,23 @@ mod tests {
         );
 
         // process them
-        exchange.process_bar(bar_bid);
-        exchange.process_bar(bar_ask);
+        exchange.borrow_mut().process_bar(bar_bid);
+        exchange.borrow_mut().process_bar(bar_ask);
 
         // current bid and ask prices will be the corresponding close of the ask and bid bar
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_bid_price, Some(Price::from("1502.00")));
-        let best_ask_price = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask_price = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_ask_price, Some(Price::from("1503.00")));
     }
 
     #[rstest]
     fn test_exchange_process_orderbook_delta(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L2_MBP,
@@ -901,7 +918,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // create order book delta at both bid and ask with incremented ts init and sequence
         let delta_buy = OrderBookDelta::new(
@@ -929,22 +946,30 @@ mod tests {
         );
 
         // process both deltas
-        exchange.process_order_book_delta(delta_buy);
-        exchange.process_order_book_delta(delta_sell);
+        exchange.borrow_mut().process_order_book_delta(delta_buy);
+        exchange.borrow_mut().process_order_book_delta(delta_sell);
 
-        let book = exchange.get_book(crypto_perpetual_ethusdt.id).unwrap();
+        let book = exchange
+            .borrow()
+            .get_book(crypto_perpetual_ethusdt.id)
+            .unwrap()
+            .clone();
         assert_eq!(book.update_count, 2);
         assert_eq!(book.sequence, 1);
         assert_eq!(book.ts_last, UnixNanos::from(2));
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_bid_price, Some(Price::from("1000.00")));
-        let best_ask_price = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask_price = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         assert_eq!(best_ask_price, Some(Price::from("1001.00")));
     }
 
     #[rstest]
     fn test_exchange_process_orderbook_deltas(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L2_MBP,
@@ -954,7 +979,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         // create two sell order book deltas with same timestamps and higher sequence
         let delta_sell_1 = OrderBookDelta::new(
@@ -991,23 +1016,33 @@ mod tests {
         );
 
         // process both deltas
-        exchange.process_order_book_deltas(orderbook_deltas);
+        exchange
+            .borrow_mut()
+            .process_order_book_deltas(orderbook_deltas);
 
-        let book = exchange.get_book(crypto_perpetual_ethusdt.id).unwrap();
+        let book = exchange
+            .borrow()
+            .get_book(crypto_perpetual_ethusdt.id)
+            .unwrap()
+            .clone();
         assert_eq!(book.update_count, 2);
         assert_eq!(book.sequence, 1);
         assert_eq!(book.ts_last, UnixNanos::from(1));
-        let best_bid_price = exchange.best_bid_price(crypto_perpetual_ethusdt.id);
+        let best_bid_price = exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id);
         // no bid orders in orderbook deltas
         assert_eq!(best_bid_price, None);
-        let best_ask_price = exchange.best_ask_price(crypto_perpetual_ethusdt.id);
+        let best_ask_price = exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id);
         // best ask price is the first order in orderbook deltas
         assert_eq!(best_ask_price, Some(Price::from("1000.00")));
     }
 
     #[rstest]
     fn test_exchange_process_instrument_status(crypto_perpetual_ethusdt: CryptoPerpetual) {
-        let mut exchange: SimulatedExchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("BINANCE"),
             AccountType::Margin,
             BookType::L2_MBP,
@@ -1017,7 +1052,7 @@ mod tests {
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
 
         // register instrument
-        exchange.add_instrument(instrument).unwrap();
+        exchange.borrow_mut().add_instrument(instrument).unwrap();
 
         let instrument_status = InstrumentStatus::new(
             crypto_perpetual_ethusdt.id,
@@ -1031,12 +1066,16 @@ mod tests {
             None,
         );
 
-        exchange.process_instrument_status(instrument_status);
+        exchange
+            .borrow_mut()
+            .process_instrument_status(instrument_status);
 
-        let matching_engine = exchange
+        let market_status = exchange
+            .borrow()
             .get_matching_engine(crypto_perpetual_ethusdt.id)
-            .unwrap();
-        assert_eq!(matching_engine.market_status, MarketStatus::Closed);
+            .unwrap()
+            .market_status;
+        assert_eq!(market_status, MarketStatus::Closed);
     }
 
     #[rstest]
@@ -1070,17 +1109,17 @@ mod tests {
         // build indexes
         cache.build_index();
 
-        let mut exchange = get_exchange(
+        let exchange = get_exchange(
             Venue::new("SIM"),
             account_type,
             BookType::L2_MBP,
             Some(msgbus.clone()),
             Some(Rc::new(RefCell::new(cache))),
         );
-        exchange.initialize_account();
+        exchange.borrow_mut().initialize_account();
 
         // Test adjust account, increase balance by 500 USD
-        exchange.adjust_account(Money::from("500 USD"));
+        exchange.borrow_mut().adjust_account(Money::from("500 USD"));
 
         // Check if we received two messages, one for initial account state and one for adjusted account state
         let messages = get_saved_messages::<AccountState>(handler);

--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -1,0 +1,192 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+// Under development
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+//! Provides a `BacktestExecutionClient` implementation for backtesting.
+
+use std::{cell::RefCell, rc::Rc};
+
+use nautilus_common::{cache::Cache, clock::Clock, msgbus::MessageBus};
+use nautilus_core::UnixNanos;
+use nautilus_execution::{
+    client::{ExecutionClient, base::BaseExecutionClient},
+    messages::{
+        BatchCancelOrders, CancelAllOrders, CancelOrder, ModifyOrder, QueryOrder, SubmitOrder,
+        SubmitOrderList, TradingCommand,
+    },
+};
+use nautilus_model::{
+    accounts::AccountAny,
+    enums::OmsType,
+    identifiers::{AccountId, ClientId, TraderId, Venue},
+    types::{AccountBalance, MarginBalance},
+};
+
+use crate::exchange::SimulatedExchange;
+
+pub struct BacktestExecutionClient {
+    base: BaseExecutionClient,
+    exchange: SimulatedExchange,
+    clock: Rc<RefCell<dyn Clock>>,
+    is_connected: bool,
+    routing: bool,
+    frozen_account: bool,
+}
+
+impl BacktestExecutionClient {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        account_id: AccountId,
+        exchange: SimulatedExchange,
+        cache: Rc<RefCell<Cache>>,
+        msgbus: Rc<RefCell<MessageBus>>,
+        clock: Rc<RefCell<dyn Clock>>,
+        routing: Option<bool>,
+        frozen_account: Option<bool>,
+    ) -> Self {
+        let routing = routing.unwrap_or(false);
+        let frozen_account = frozen_account.unwrap_or(false);
+        let base_client = BaseExecutionClient::new(
+            trader_id,
+            ClientId::from(exchange.id.as_str()),
+            Venue::from(exchange.id.as_str()),
+            exchange.oms_type,
+            account_id,
+            exchange.account_type,
+            exchange.base_currency,
+            clock.clone(),
+            cache.clone(),
+            msgbus.clone(),
+        );
+
+        if !frozen_account {
+            // TODO Register calculated account
+        }
+
+        Self {
+            exchange,
+            clock,
+            base: base_client,
+            is_connected: false,
+            routing,
+            frozen_account,
+        }
+    }
+}
+
+impl ExecutionClient for BacktestExecutionClient {
+    fn is_connected(&self) -> bool {
+        self.is_connected
+    }
+
+    fn client_id(&self) -> ClientId {
+        self.base.client_id
+    }
+
+    fn account_id(&self) -> AccountId {
+        self.base.account_id
+    }
+
+    fn venue(&self) -> Venue {
+        self.base.venue
+    }
+
+    fn oms_type(&self) -> OmsType {
+        self.base.oms_type
+    }
+
+    fn get_account(&self) -> Option<AccountAny> {
+        self.base.get_account()
+    }
+
+    fn generate_account_state(
+        &self,
+        balances: Vec<AccountBalance>,
+        margins: Vec<MarginBalance>,
+        reported: bool,
+        ts_event: UnixNanos,
+    ) -> anyhow::Result<()> {
+        self.base
+            .generate_account_state(balances, margins, reported, ts_event)
+    }
+
+    fn start(&mut self) -> anyhow::Result<()> {
+        self.is_connected = true;
+        log::info!("Backtest execution client started");
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        self.is_connected = false;
+        log::info!("Backtest execution client stopped");
+        Ok(())
+    }
+
+    fn submit_order(&self, command: SubmitOrder) -> anyhow::Result<()> {
+        self.base.generate_order_submitted(
+            command.strategy_id,
+            command.instrument_id,
+            command.client_order_id,
+            self.clock.borrow().timestamp_ns(),
+        );
+
+        self.exchange.send(TradingCommand::SubmitOrder(command));
+        Ok(())
+    }
+
+    fn submit_order_list(&self, command: SubmitOrderList) -> anyhow::Result<()> {
+        for order in &command.order_list.orders {
+            self.base.generate_order_submitted(
+                command.strategy_id,
+                order.instrument_id(),
+                order.client_order_id(),
+                self.clock.borrow().timestamp_ns(),
+            );
+        }
+
+        self.exchange.send(TradingCommand::SubmitOrderList(command));
+        Ok(())
+    }
+
+    fn modify_order(&self, command: ModifyOrder) -> anyhow::Result<()> {
+        self.exchange.send(TradingCommand::ModifyOrder(command));
+        Ok(())
+    }
+
+    fn cancel_order(&self, command: CancelOrder) -> anyhow::Result<()> {
+        self.exchange.send(TradingCommand::CancelOrder(command));
+        Ok(())
+    }
+
+    fn cancel_all_orders(&self, command: CancelAllOrders) -> anyhow::Result<()> {
+        self.exchange.send(TradingCommand::CancelAllOrders(command));
+        Ok(())
+    }
+
+    fn batch_cancel_orders(&self, command: BatchCancelOrders) -> anyhow::Result<()> {
+        self.exchange
+            .send(TradingCommand::BatchCancelOrders(command));
+        Ok(())
+    }
+
+    fn query_order(&self, command: QueryOrder) -> anyhow::Result<()> {
+        self.exchange.send(TradingCommand::QueryOrder(command));
+        Ok(())
+    }
+}

--- a/crates/backtest/src/lib.rs
+++ b/crates/backtest/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod data_client;
 pub mod engine;
 pub mod exchange;
+pub mod execution_client;
 pub mod modules;
 pub mod runner;
 

--- a/crates/execution/src/client/base.rs
+++ b/crates/execution/src/client/base.rs
@@ -23,6 +23,7 @@ use std::{any::Any, cell::RefCell, rc::Rc};
 
 use nautilus_common::{
     cache::Cache,
+    clock::Clock,
     msgbus::{MessageBus, send},
 };
 use nautilus_core::{UUID4, UnixNanos};
@@ -410,26 +411,26 @@ impl BaseExecutionClient {
 
     fn send_order_event(&self, event: OrderEventAny) {
         let endpoint = Ustr::from("ExecEngine.process");
-        self.msgbus.borrow().send(&endpoint, &event as &dyn Any);
+        send(&endpoint, &event as &dyn Any);
     }
 
     fn send_mass_status_report(&self, report: ExecutionMassStatus) {
         let endpoint = Ustr::from("ExecEngine.reconcile_mass_status");
-        self.msgbus.borrow().send(&endpoint, &report as &dyn Any);
+        send(&endpoint, &report as &dyn Any);
     }
 
     fn send_order_status_report(&self, report: OrderStatusReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        self.msgbus.borrow().send(&endpoint, &report as &dyn Any);
+        send(&endpoint, &report as &dyn Any);
     }
 
     fn send_fill_report(&self, report: FillReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        self.msgbus.borrow().send(&endpoint, &report as &dyn Any);
+        send(&endpoint, &report as &dyn Any);
     }
 
     fn send_position_report(&self, report: PositionStatusReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        self.msgbus.borrow().send(&endpoint, &report as &dyn Any);
+        send(&endpoint, &report as &dyn Any);
     }
 }

--- a/crates/execution/src/client/mod.rs
+++ b/crates/execution/src/client/mod.rs
@@ -1,0 +1,84 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::UnixNanos;
+use nautilus_model::{
+    accounts::AccountAny,
+    enums::OmsType,
+    identifiers::{AccountId, ClientId, Venue},
+    types::{AccountBalance, MarginBalance},
+};
+
+use crate::{
+    messages::{
+        BatchCancelOrders, CancelAllOrders, CancelOrder, ModifyOrder, QueryOrder, SubmitOrder,
+        SubmitOrderList,
+        reports::{GenerateFillReports, GenerateOrderStatusReport, GeneratePositionReports},
+    },
+    reports::{
+        fill::FillReport, mass_status::ExecutionMassStatus, order::OrderStatusReport,
+        position::PositionStatusReport,
+    },
+};
+
+pub mod base;
+
+pub trait ExecutionClient {
+    fn is_connected(&self) -> bool;
+    fn client_id(&self) -> ClientId;
+    fn account_id(&self) -> AccountId;
+    fn venue(&self) -> Venue;
+    fn oms_type(&self) -> OmsType;
+    fn get_account(&self) -> Option<AccountAny>;
+    fn generate_account_state(
+        &self,
+        balances: Vec<AccountBalance>,
+        margins: Vec<MarginBalance>,
+        reported: bool,
+        ts_event: UnixNanos,
+    ) -> anyhow::Result<()>;
+    fn start(&mut self) -> anyhow::Result<()>;
+    fn stop(&mut self) -> anyhow::Result<()>;
+    fn submit_order(&self, command: SubmitOrder) -> anyhow::Result<()>;
+    fn submit_order_list(&self, command: SubmitOrderList) -> anyhow::Result<()>;
+    fn modify_order(&self, command: ModifyOrder) -> anyhow::Result<()>;
+    fn cancel_order(&self, command: CancelOrder) -> anyhow::Result<()>;
+    fn cancel_all_orders(&self, command: CancelAllOrders) -> anyhow::Result<()>;
+    fn batch_cancel_orders(&self, command: BatchCancelOrders) -> anyhow::Result<()>;
+    fn query_order(&self, command: QueryOrder) -> anyhow::Result<()>;
+}
+
+pub trait LiveExecutionClient: ExecutionClient {
+    fn connect(&self) -> anyhow::Result<()>;
+    fn disconnect(&self) -> anyhow::Result<()>;
+    fn generate_order_status_report(
+        &self,
+        report: GenerateOrderStatusReport,
+    ) -> anyhow::Result<Option<OrderStatusReport>>;
+    fn generate_order_status_reports(
+        &self,
+        report: GenerateOrderStatusReport,
+    ) -> anyhow::Result<Vec<OrderStatusReport>>;
+    fn generate_fill_reports(&self, report: GenerateFillReports)
+    -> anyhow::Result<Vec<FillReport>>;
+    fn generate_position_status_reports(
+        &self,
+        report: GeneratePositionReports,
+    ) -> anyhow::Result<Vec<PositionStatusReport>>;
+    fn generate_mass_status(
+        &self,
+        lookback_mins: Option<u64>,
+    ) -> anyhow::Result<Option<ExecutionMassStatus>>;
+}

--- a/crates/execution/src/messages/mod.rs
+++ b/crates/execution/src/messages/mod.rs
@@ -20,6 +20,7 @@ pub mod cancel_all;
 pub mod cancel_batch;
 pub mod modify;
 pub mod query;
+pub mod reports;
 pub mod submit;
 pub mod submit_list;
 

--- a/crates/execution/src/messages/reports.rs
+++ b/crates/execution/src/messages/reports.rs
@@ -1,0 +1,131 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+// Under development
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use nautilus_core::{UUID4, UnixNanos};
+use nautilus_model::identifiers::{ClientOrderId, InstrumentId};
+
+pub struct GenerateOrderStatusReport {
+    command_id: UUID4,
+    ts_init: UnixNanos,
+    instrument_id: Option<InstrumentId>,
+    client_order_id: Option<ClientOrderId>,
+    venue_order_id: Option<ClientOrderId>,
+}
+
+impl GenerateOrderStatusReport {
+    pub fn new(
+        command_id: UUID4,
+        ts_init: UnixNanos,
+        instrument_id: Option<InstrumentId>,
+        client_order_id: Option<ClientOrderId>,
+        venue_order_id: Option<ClientOrderId>,
+    ) -> Self {
+        Self {
+            command_id,
+            ts_init,
+            instrument_id,
+            client_order_id,
+            venue_order_id,
+        }
+    }
+}
+
+pub struct GenerateOrderStatusReports {
+    command_id: UUID4,
+    ts_init: UnixNanos,
+    open_only: bool,
+    instrument_id: Option<InstrumentId>,
+    start: Option<UnixNanos>,
+    end: Option<UnixNanos>,
+}
+
+impl GenerateOrderStatusReports {
+    pub fn new(
+        command_id: UUID4,
+        ts_init: UnixNanos,
+        open_only: bool,
+        instrument_id: Option<InstrumentId>,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+    ) -> Self {
+        Self {
+            command_id,
+            ts_init,
+            instrument_id,
+            open_only,
+            start,
+            end,
+        }
+    }
+}
+
+pub struct GenerateFillReports {
+    command_id: UUID4,
+    ts_init: UnixNanos,
+    instrument_id: Option<InstrumentId>,
+    venue_order_id: Option<ClientOrderId>,
+    start: Option<UnixNanos>,
+    end: Option<UnixNanos>,
+}
+
+impl GenerateFillReports {
+    pub fn new(
+        command_id: UUID4,
+        ts_init: UnixNanos,
+        instrument_id: Option<InstrumentId>,
+        venue_order_id: Option<ClientOrderId>,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+    ) -> Self {
+        Self {
+            command_id,
+            ts_init,
+            instrument_id,
+            venue_order_id,
+            start,
+            end,
+        }
+    }
+}
+
+pub struct GeneratePositionReports {
+    command_id: UUID4,
+    ts_init: UnixNanos,
+    instrument_id: Option<InstrumentId>,
+    start: Option<UnixNanos>,
+    end: Option<UnixNanos>,
+}
+
+impl GeneratePositionReports {
+    pub fn new(
+        command_id: UUID4,
+        ts_init: UnixNanos,
+        instrument_id: Option<InstrumentId>,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+    ) -> Self {
+        Self {
+            command_id,
+            ts_init,
+            instrument_id,
+            start,
+            end,
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

- created various reports structs in execution crate: `GenerateOrderStatusReport`, `GenerateOrderStatusReports` ,  `GenerateFillReports ` and `GeneratePositionReports `
- refactored current `ExecutionClient` struct to be a trait and rename it to `BaseExecutionClient`, which will be used by both backtesting and live execution clients
-  `ExecutionClient` trait specifies trading commands and its supertype `LiveExecutionClient` adds additional generating reports functions for reconciliation
- created `BacktestExecutionClient` which contains base exec client and implements `ExecutionClient` trait in `backtest` crate
-  adapted execution engine to work with new `ExecutionClient` trait
