### PR TITLE
Implement latency modeling for SimulatedExchange in Rust

### DIFF
--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -148,7 +148,7 @@ impl ExecutionClient for BacktestExecutionClient {
         );
 
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::SubmitOrder(command));
         Ok(())
     }
@@ -164,42 +164,42 @@ impl ExecutionClient for BacktestExecutionClient {
         }
 
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::SubmitOrderList(command));
         Ok(())
     }
 
     fn modify_order(&self, command: ModifyOrder) -> anyhow::Result<()> {
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::ModifyOrder(command));
         Ok(())
     }
 
     fn cancel_order(&self, command: CancelOrder) -> anyhow::Result<()> {
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::CancelOrder(command));
         Ok(())
     }
 
     fn cancel_all_orders(&self, command: CancelAllOrders) -> anyhow::Result<()> {
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::CancelAllOrders(command));
         Ok(())
     }
 
     fn batch_cancel_orders(&self, command: BatchCancelOrders) -> anyhow::Result<()> {
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::BatchCancelOrders(command));
         Ok(())
     }
 
     fn query_order(&self, command: QueryOrder) -> anyhow::Result<()> {
         self.exchange
-            .borrow()
+            .borrow_mut()
             .send(TradingCommand::QueryOrder(command));
         Ok(())
     }

--- a/crates/execution/src/messages/mod.rs
+++ b/crates/execution/src/messages/mod.rs
@@ -24,6 +24,7 @@ pub mod reports;
 pub mod submit;
 pub mod submit_list;
 
+use nautilus_core::UnixNanos;
 use nautilus_model::identifiers::{ClientId, InstrumentId};
 use strum::Display;
 
@@ -35,7 +36,7 @@ pub use self::{
 
 // TODO
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Display)]
+#[derive(Clone, Debug, Eq, PartialEq, Display)]
 pub enum TradingCommand {
     SubmitOrder(SubmitOrder),
     SubmitOrderList(SubmitOrderList),
@@ -70,6 +71,19 @@ impl TradingCommand {
             Self::CancelAllOrders(command) => command.instrument_id,
             Self::BatchCancelOrders(command) => command.instrument_id,
             Self::QueryOrder(command) => command.instrument_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn ts_init(&self) -> UnixNanos {
+        match self {
+            Self::SubmitOrder(command) => command.ts_init,
+            Self::SubmitOrderList(command) => command.ts_init,
+            Self::ModifyOrder(command) => command.ts_init,
+            Self::CancelOrder(command) => command.ts_init,
+            Self::CancelAllOrders(command) => command.ts_init,
+            Self::BatchCancelOrders(command) => command.ts_init,
+            Self::QueryOrder(command) => command.ts_init,
         }
     }
 }

--- a/crates/execution/src/messages/submit_list.rs
+++ b/crates/execution/src/messages/submit_list.rs
@@ -25,7 +25,7 @@ use nautilus_model::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub struct SubmitOrderList {
     pub trader_id: TraderId,

--- a/crates/execution/src/models/latency.rs
+++ b/crates/execution/src/models/latency.rs
@@ -15,7 +15,30 @@
 
 use std::fmt::Display;
 
-pub struct LatencyModel;
+use nautilus_core::UnixNanos;
+
+pub struct LatencyModel {
+    pub base_latency_nanos: UnixNanos,
+    pub insert_latency_nanos: UnixNanos,
+    pub update_latency_nanos: UnixNanos,
+    pub delete_latency_nanos: UnixNanos,
+}
+
+impl LatencyModel {
+    pub fn new(
+        base_latency_nanos: UnixNanos,
+        insert_latency_nanos: UnixNanos,
+        update_latency_nanos: UnixNanos,
+        delete_latency_nanos: UnixNanos,
+    ) -> Self {
+        Self {
+            base_latency_nanos,
+            insert_latency_nanos,
+            update_latency_nanos,
+            delete_latency_nanos,
+        }
+    }
+}
 
 impl Display for LatencyModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/model/src/orders/list.rs
+++ b/crates/model/src/orders/list.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use super::any::OrderAny;
 use crate::identifiers::{InstrumentId, OrderListId, StrategyId};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")


### PR DESCRIPTION
# Pull Request

- added latency simulation to backtest exchange for more realistic order processing with supplied latency model with proper testing

## New components
Introduced `InflightCommand` structure to represent delayed commands with: 
1. Timestamp for execution
2. Counter for ordering same-timestamp commands
3. Target trading command
4. Custom ordering implementation for BinaryHeap (earliest timestamp first)

## Queue Management
Added two command queues to SimulatedExchange:
- `message_queue`: Standard FIFO queue for immediate processing
- `inflight_queue`: Priority queue (BinaryHeap) for latency-delayed commands

## Command Processing Flow
Implemented `send` method with three modes:  
1. Immediate processing (`use_message_queue` = false)
2. Queue-based processing (standard `message_queue`)
3. Latency-based processing (using `inflight_queue` with `LatencyModel`)

Implemented `process` method to:  
- Process delayed commands that have reached their target timestamp
- Maintain FIFO ordering for same-timestamp commands with help of counter
- Process regular message queue after correct inflight commands are executed
