### PR TITLE
Add logic to handle fractional volume for historical bar #2427

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -650,6 +650,10 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         ts_event = await self._ib_bar_to_ts_event(bar, bar_type)
         # used to be _convert_ib_bar_date_to_unix_nanos
 
+        # handle fractional quantity that likely caused by stock reverse split
+        if instrument.size_precision == 0 and instrument.size_increment >= 1 and bar.volume < 1:
+            bar.volume = round(bar.volume)
+
         return Bar(
             bar_type=bar_type,
             open=instrument.make_price(bar.open),


### PR DESCRIPTION

# Pull Request

Stock reverse split caused some bar's volume < 1, which resulted ValueError('Invalid `value` for quantity: 0.24 was rounded to zero due to size increment 1 and size precision 0') was thrown. The fix is to round fractional volume before passing it to instrument.make_qty

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested?

Tested with script to call HistoricInteractiveBrokersClient.request_bars with specific date range, e.g. 2023-01-17 that as <1 volume on some bars to compare behavior before and after code change
