### PR TITLE
Catch BybitErrors when updating instruments for ByBit

### DIFF
--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -33,6 +33,7 @@ from nautilus_trader.adapters.bybit.common.enums import BybitEnumParser
 from nautilus_trader.adapters.bybit.common.enums import BybitProductType
 from nautilus_trader.adapters.bybit.common.parsing import get_interval_from_bar_type
 from nautilus_trader.adapters.bybit.common.symbol import BybitSymbol
+from nautilus_trader.adapters.bybit.http.errors import BybitError
 from nautilus_trader.adapters.bybit.http.market import BybitMarketHttpAPI
 from nautilus_trader.adapters.bybit.schemas.common import BYBIT_PONG
 from nautilus_trader.adapters.bybit.schemas.market.ticker import BybitTickerData
@@ -267,8 +268,12 @@ class BybitDataClient(LiveMarketDataClient):
                     f"Scheduled task 'update_instruments' to run in {interval_mins} minutes",
                 )
                 await asyncio.sleep(interval_mins * 60)
-                await self._instrument_provider.initialize(reload=True)
-                self._send_all_instruments_to_data_engine()
+
+                try:
+                    await self._instrument_provider.initialize(reload=True)
+                    self._send_all_instruments_to_data_engine()
+                except BybitError as e:
+                    self._log.error(f"Failed to update the instruments: {e}")
         except asyncio.CancelledError:
             self._log.debug("Canceled task 'update_instruments'")
 


### PR DESCRIPTION
# Pull Request

Catch BybitErrors when updating instruments for ByBit. When a BybitError `invalid request, please check your server timestamp or recv_window param.` occurs, the task tries again in 1 hour instead of canceling completely.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example