### PR TITLE
Clear cache temporary workaround

### DIFF
--- a/crates/common/src/cache/config.rs
+++ b/crates/common/src/cache/config.rs
@@ -37,6 +37,10 @@ pub struct CacheConfig {
     pub flush_on_start: bool,
     /// If instrument data should be dropped from the cache's memory on reset.
     pub drop_instruments_on_reset: bool,
+    /// If account data should be dropped from the cache's memory on reset.
+    pub drop_accounts_on_reset: bool,
+    /// If position data should be dropped from the cache's memory on reset.
+    pub drop_positions_on_reset: bool,
     /// The maximum length for internal tick deques.
     pub tick_capacity: usize,
     /// The maximum length for internal bar deques.
@@ -57,6 +61,8 @@ impl Default for CacheConfig {
             use_instance_id: false,
             flush_on_start: false,
             drop_instruments_on_reset: true,
+            drop_accounts_on_reset: true,
+            drop_positions_on_reset: true,
             tick_capacity: 10_000,
             bar_capacity: 10_000,
             save_market_data: false,
@@ -77,6 +83,8 @@ impl CacheConfig {
         use_instance_id: bool,
         flush_on_start: bool,
         drop_instruments_on_reset: bool,
+        drop_accounts_on_reset: bool,
+        drop_positions_on_reset: bool,
         tick_capacity: usize,
         bar_capacity: usize,
         save_market_data: bool,
@@ -90,6 +98,8 @@ impl CacheConfig {
             use_instance_id,
             flush_on_start,
             drop_instruments_on_reset,
+            drop_accounts_on_reset,
+            drop_positions_on_reset,
             tick_capacity,
             bar_capacity,
             save_market_data,

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -112,6 +112,8 @@ cache_config = CacheConfig(
     use_instance_id: bool = False,           # Include instance ID in keys
     flush_on_start: bool = False,            # Clear database on startup
     drop_instruments_on_reset: bool = True,  # Clear instruments on reset
+    drop_accounts_on_reset: bool = True,     # Clear accounts on reset
+    drop_positions_on_reset: bool = True,    # Clear positions on reset
     tick_capacity: int = 10_000,             # Maximum ticks stored per instrument
     bar_capacity: int = 10_000,              # Maximum bars stored per each bar-type
 )

--- a/nautilus_trader/cache/cache.pxd
+++ b/nautilus_trader/cache/cache.pxd
@@ -107,6 +107,8 @@ cdef class Cache(CacheFacade):
     cdef set _index_strategies
     cdef set _index_exec_algorithms
     cdef bint _drop_instruments_on_reset
+    cdef bint _drop_accounts_on_reset
+    cdef bint _drop_positions_on_reset
 
     cdef readonly bint has_backing
     """If the cache has a database backing.\n\n:returns: `bool`"""

--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -106,6 +106,8 @@ cdef class Cache(CacheFacade):
 
         # Configuration
         self._drop_instruments_on_reset = config.drop_instruments_on_reset
+        self._drop_accounts_on_reset = config.drop_accounts_on_reset
+        self._drop_positions_on_reset = config.drop_positions_on_reset
         self.has_backing = database is not None
         self.tick_capacity = config.tick_capacity
         self.bar_capacity = config.bar_capacity
@@ -813,15 +815,20 @@ cdef class Cache(CacheFacade):
         self._bars_ask.clear()
         self._currencies.clear()
         self._synthetics.clear()
-        self._accounts.clear()
         self._orders.clear()
         self._order_lists.clear()
-        self._positions.clear()
-        self._position_snapshots.clear()
-        self.clear_index()
 
         if self._drop_instruments_on_reset:
             self._instruments.clear()
+
+        if self._drop_accounts_on_reset:
+            self._accounts.clear()
+
+        if self._drop_positions_on_reset:
+            self._positions.clear()
+            self._position_snapshots.clear()
+
+        self.clear_index()
 
         self._log.info(f"Reset")
 

--- a/nautilus_trader/cache/config.py
+++ b/nautilus_trader/cache/config.py
@@ -45,6 +45,10 @@ class CacheConfig(NautilusConfig, frozen=True):
         If database should be flushed on start.
     drop_instruments_on_reset : bool, default True
         If instruments data should be dropped from the caches memory on reset.
+    drop_accounts_on_reset : bool, default True
+        If accounts data should be dropped from the caches memory on reset.
+    drop_positions_on_reset : bool, default True
+        If positions data should be dropped from the caches memory on reset.
     tick_capacity : PositiveInt, default 10_000
         The maximum length for internal tick dequeues.
     bar_capacity : PositiveInt, default 10_000
@@ -60,5 +64,7 @@ class CacheConfig(NautilusConfig, frozen=True):
     use_instance_id: bool = False
     flush_on_start: bool = False
     drop_instruments_on_reset: bool = True
+    drop_accounts_on_reset: bool = True
+    drop_positions_on_reset: bool = True
     tick_capacity: PositiveInt = 10_000
     bar_capacity: PositiveInt = 10_000


### PR DESCRIPTION
# Pull Request

Add `drop_accounts_on_reset` & `drop_positions_on_reset` for `CacheConfig` (default `True` to retain current behavior).

In the case of a large number of orders, `.reset()` can be used to clear the cache to prevent memory usage from growing.

A toggle can be provided to control whether accounts and positions information is retained.

This is especially important for account information, as it is essential for the strategy's execution. Otherwise, it will trigger a `no account registered for` error.

## Type of change

- [x] New feature (non-breaking change which adds functionality)