### PR TITLE
Update Rust parquet catalog with recent features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,6 +3355,7 @@ dependencies = [
 name = "nautilus-persistence"
 version = "0.43.0"
 dependencies = [
+ "anyhow",
  "binary-heap-plus",
  "compare",
  "criterion",
@@ -3382,6 +3383,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -3446,6 +3448,7 @@ dependencies = [
 name = "nautilus-serialization"
 version = "0.43.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "criterion",
  "nautilus-core",

--- a/crates/adapters/tardis/src/replay.rs
+++ b/crates/adapters/tardis/src/replay.rs
@@ -104,7 +104,7 @@ async fn gather_instruments_info(
 
 pub async fn run_tardis_machine_replay_from_config(config_filepath: &Path) -> anyhow::Result<()> {
     tracing::info!("Starting replay");
-    tracing::info!("Config filepath: {}", config_filepath.display());
+    tracing::info!("Config filepath: {config_filepath:?}");
 
     let config_data = fs::read_to_string(config_filepath).expect("Failed to read config file");
     let config: TardisReplayConfig =
@@ -122,7 +122,7 @@ pub async fn run_tardis_machine_replay_from_config(config_filepath: &Path) -> an
         })
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
 
-    tracing::info!("Output path: {}", path.display());
+    tracing::info!("Output path: {path:?}");
 
     let normalize_symbols = config.normalize_symbols.unwrap_or(true);
     tracing::info!("normalize_symbols={normalize_symbols}");
@@ -416,9 +416,9 @@ fn batch_and_write_bars(bars: Vec<Bar>, bar_type: &BarType, date: NaiveDate, pat
     };
 
     let filepath = path.join(parquet_filepath_bars(bar_type, date));
-    match write_batch_to_parquet(batch, &filepath, None) {
-        Ok(()) => tracing::info!("File written: {}", filepath.display()),
-        Err(e) => tracing::error!("Error writing {}: {e:?}", filepath.display()),
+    match write_batch_to_parquet(batch, &filepath, None, None) {
+        Ok(()) => tracing::info!("File written: {filepath:?}"),
+        Err(e) => tracing::error!("Error writing {filepath:?}: {e:?}"),
     }
 }
 
@@ -449,9 +449,9 @@ fn write_batch(
     path: &Path,
 ) {
     let filepath = path.join(parquet_filepath(typename, instrument_id, date));
-    match write_batch_to_parquet(batch, &filepath, None) {
-        Ok(()) => tracing::info!("File written: {}", filepath.display()),
-        Err(e) => tracing::error!("Error writing {}: {e:?}", filepath.display()),
+    match write_batch_to_parquet(batch, &filepath, None, None) {
+        Ok(()) => tracing::info!("File written: {filepath:?}"),
+        Err(e) => tracing::error!("Error writing {filepath:?}: {e:?}"),
     }
 }
 

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -35,6 +35,7 @@ pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
+anyhow = { workspace = true }
 thiserror = { workspace = true }
 parquet = { workspace = true }
 binary-heap-plus = "0.5.0"
@@ -46,6 +47,7 @@ datafusion = { version = "46.0.0", default-features = false, features = [
   "unicode_expressions",
 ] }
 object_store = "0.11.2"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 nautilus-test-kit = { path = "../test_kit" }

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -15,7 +15,8 @@
 
 use std::path::PathBuf;
 
-use datafusion::{arrow::record_batch::RecordBatch, error::Result};
+use anyhow::Result;
+use datafusion::arrow::record_batch::RecordBatch;
 use heck::ToSnakeCase;
 use itertools::Itertools;
 use log::info;
@@ -25,7 +26,10 @@ use nautilus_model::data::{
 };
 use nautilus_serialization::{
     arrow::{DecodeDataFromRecordBatch, EncodeToRecordBatch},
-    parquet::write_batches_to_parquet,
+    parquet::{
+        ParquetWriteMode, combine_data_files, min_max_from_parquet_metadata,
+        write_batches_to_parquet,
+    },
 };
 use serde::Serialize;
 
@@ -48,171 +52,7 @@ impl ParquetDataCatalog {
         }
     }
 
-    fn make_path(&self, type_name: &str, instrument_id: Option<&String>) -> PathBuf {
-        let mut path = self.base_path.join("data").join(type_name);
-
-        if let Some(id) = instrument_id {
-            path = path.join(id);
-        }
-
-        std::fs::create_dir_all(&path).expect("Failed to create directory");
-        let file_path = path.join("data.parquet");
-        info!("Created directory path: {:?}", file_path);
-        file_path
-    }
-
-    fn check_ascending_timestamps<T: GetTsInit>(data: &[T], type_name: &str) {
-        assert!(
-            data.windows(2).all(|w| w[0].ts_init() <= w[1].ts_init()),
-            "{type_name} timestamps must be in ascending order"
-        );
-    }
-
-    #[must_use]
-    pub fn data_to_record_batches<T>(&self, data: Vec<T>) -> Vec<RecordBatch>
-    where
-        T: GetTsInit + EncodeToRecordBatch,
-    {
-        data.into_iter()
-            .chunks(self.batch_size)
-            .into_iter()
-            .map(|chunk| {
-                // Take first element and extract metadata
-                // SAFETY: Unwrap safe as already checked that `data` not empty
-                let data = chunk.collect_vec();
-                let metadata = EncodeToRecordBatch::chunk_metadata(&data);
-                T::encode_batch(&metadata, &data).expect("Expected to encode batch")
-            })
-            .collect()
-    }
-
-    #[must_use]
-    pub fn write_to_json<T>(
-        &self,
-        data: Vec<T>,
-        path: Option<PathBuf>,
-        write_metadata: bool,
-    ) -> PathBuf
-    where
-        T: GetTsInit + Serialize + CatalogPathPrefix + EncodeToRecordBatch,
-    {
-        let type_name = std::any::type_name::<T>().to_snake_case();
-        Self::check_ascending_timestamps(&data, &type_name);
-
-        let json_path = path.unwrap_or_else(|| {
-            let path = self.make_path(T::path_prefix(), None);
-            path.with_extension("json")
-        });
-
-        info!(
-            "Writing {} records of {type_name} data to {json_path:?}",
-            data.len(),
-        );
-
-        if write_metadata {
-            let metadata = T::chunk_metadata(&data);
-            let metadata_path = json_path.with_extension("metadata.json");
-            info!("Writing metadata to {:?}", metadata_path);
-            let metadata_file = std::fs::File::create(&metadata_path)
-                .unwrap_or_else(|_| panic!("Failed to create metadata file at {metadata_path:?}"));
-            serde_json::to_writer_pretty(metadata_file, &metadata)
-                .unwrap_or_else(|_| panic!("Failed to write metadata to JSON"));
-        }
-
-        let file = std::fs::File::create(&json_path)
-            .unwrap_or_else(|_| panic!("Failed to create JSON file at {json_path:?}"));
-
-        serde_json::to_writer_pretty(file, &serde_json::to_value(data).unwrap())
-            .unwrap_or_else(|_| panic!("Failed to write {type_name} to JSON"));
-
-        json_path
-    }
-
-    #[must_use]
-    pub fn write_to_parquet<T>(
-        &self,
-        data: Vec<T>,
-        path: Option<PathBuf>,
-        compression: Option<parquet::basic::Compression>,
-        max_row_group_size: Option<usize>,
-    ) -> PathBuf
-    where
-        T: GetTsInit + EncodeToRecordBatch + CatalogPathPrefix,
-    {
-        let type_name = std::any::type_name::<T>().to_snake_case();
-        Self::check_ascending_timestamps(&data, &type_name);
-
-        let batches = self.data_to_record_batches(data);
-        let batch = batches.first().expect("Expected at least one batch");
-        let schema = batch.schema();
-        let instrument_id = schema.metadata.get("instrument_id");
-        let path = path.unwrap_or_else(|| self.make_path(T::path_prefix(), instrument_id));
-
-        // Write all batches to parquet file
-        info!(
-            "Writing {} batches of {} data to {:?}",
-            batches.len(),
-            type_name,
-            path
-        );
-
-        write_batches_to_parquet(&batches, &path, compression, max_row_group_size)
-            .unwrap_or_else(|_| panic!("Failed to write {type_name} to parquet"));
-
-        path
-    }
-
-    /// Query data loaded in the catalog
-    pub fn query_file<T>(
-        &mut self,
-        path: PathBuf,
-        start: Option<UnixNanos>,
-        end: Option<UnixNanos>,
-        where_clause: Option<&str>,
-    ) -> Result<QueryResult>
-    where
-        T: DecodeDataFromRecordBatch + CatalogPathPrefix,
-    {
-        let path_str = path.to_str().unwrap();
-        let table_name = path.file_stem().unwrap().to_str().unwrap();
-        let query = build_query(table_name, start, end, where_clause);
-        self.session
-            .add_file::<T>(table_name, path_str, Some(&query))?;
-        Ok(self.session.get_query_result())
-    }
-
-    /// Query data loaded in the catalog
-    pub fn query_directory<T>(
-        &mut self,
-        // use instrument_ids or bar_types to query specific subset of the data
-        instrument_ids: Vec<String>,
-        start: Option<UnixNanos>,
-        end: Option<UnixNanos>,
-        where_clause: Option<&str>,
-    ) -> Result<QueryResult>
-    where
-        T: DecodeDataFromRecordBatch + CatalogPathPrefix,
-    {
-        let mut paths = Vec::new();
-        for instrument_id in &instrument_ids {
-            paths.push(self.make_path(T::path_prefix(), Some(instrument_id)));
-        }
-
-        // If no specific instrument_id is selected query all files for the data type
-        if paths.is_empty() {
-            paths.push(self.make_path(T::path_prefix(), None));
-        }
-
-        for path in &paths {
-            let path = path.to_str().unwrap();
-            let query = build_query(path, start, end, where_clause);
-            self.session.add_file::<T>(path, path, Some(&query))?;
-        }
-
-        Ok(self.session.get_query_result())
-    }
-
-    pub fn write_data_enum(&self, data: Vec<Data>) {
+    pub fn write_data_enum(&self, data: Vec<Data>, write_mode: Option<ParquetWriteMode>) {
         let mut delta: Vec<OrderBookDelta> = Vec::new();
         let mut depth10: Vec<OrderBookDepth10> = Vec::new();
         let mut quote: Vec<QuoteTick> = Vec::new();
@@ -240,11 +80,326 @@ impl ParquetDataCatalog {
             }
         }
 
-        let _ = self.write_to_parquet(delta, None, None, None);
-        let _ = self.write_to_parquet(depth10, None, None, None);
-        let _ = self.write_to_parquet(quote, None, None, None);
-        let _ = self.write_to_parquet(trade, None, None, None);
-        let _ = self.write_to_parquet(bar, None, None, None);
+        let _ = self.write_to_parquet(delta, None, None, None, write_mode);
+        let _ = self.write_to_parquet(depth10, None, None, None, write_mode);
+        let _ = self.write_to_parquet(quote, None, None, None, write_mode);
+        let _ = self.write_to_parquet(trade, None, None, None, write_mode);
+        let _ = self.write_to_parquet(bar, None, None, None, write_mode);
+    }
+
+    #[must_use]
+    pub fn write_to_parquet<T>(
+        &self,
+        data: Vec<T>,
+        path: Option<PathBuf>,
+        compression: Option<parquet::basic::Compression>,
+        max_row_group_size: Option<usize>,
+        write_mode: Option<ParquetWriteMode>,
+    ) -> PathBuf
+    where
+        T: GetTsInit + EncodeToRecordBatch + CatalogPathPrefix,
+    {
+        let type_name = std::any::type_name::<T>().to_snake_case();
+        Self::check_ascending_timestamps(&data, &type_name);
+
+        let batches = self.data_to_record_batches(data);
+        let batch = batches.first().expect("Expected at least one batch");
+        let schema = batch.schema();
+        let instrument_id = schema.metadata.get("instrument_id");
+        let path =
+            path.unwrap_or_else(|| self.make_path(T::path_prefix(), instrument_id, write_mode));
+
+        // Write all batches to parquet file
+        info!(
+            "Writing {} batches of {type_name} data to {path:?}",
+            batches.len()
+        );
+
+        write_batches_to_parquet(&batches, &path, compression, max_row_group_size, write_mode)
+            .unwrap_or_else(|_| panic!("Failed to write {type_name} to parquet"));
+
+        path
+    }
+
+    fn check_ascending_timestamps<T: GetTsInit>(data: &[T], type_name: &str) {
+        assert!(
+            data.windows(2).all(|w| w[0].ts_init() <= w[1].ts_init()),
+            "{type_name} timestamps must be in ascending order"
+        );
+    }
+
+    #[must_use]
+    pub fn data_to_record_batches<T>(&self, data: Vec<T>) -> Vec<RecordBatch>
+    where
+        T: GetTsInit + EncodeToRecordBatch,
+    {
+        data.into_iter()
+            .chunks(self.batch_size)
+            .into_iter()
+            .map(|chunk| {
+                // Take first element and extract metadata
+                // SAFETY: Unwrap safe as already checked that `data` not empty
+                let data = chunk.collect_vec();
+                let metadata = EncodeToRecordBatch::chunk_metadata(&data);
+                T::encode_batch(&metadata, &data).expect("Expected to encode batch")
+            })
+            .collect()
+    }
+
+    fn make_path(
+        &self,
+        type_name: &str,
+        instrument_id: Option<&String>,
+        write_mode: Option<ParquetWriteMode>,
+    ) -> PathBuf {
+        let used_write_mode = write_mode.unwrap_or(ParquetWriteMode::Overwrite);
+        let mut path = self.base_path.join("data").join(type_name);
+
+        if let Some(id) = instrument_id {
+            path = path.join(id);
+        }
+
+        std::fs::create_dir_all(&path).expect("Failed to create directory");
+        let mut file_path = path.join("data-0.parquet");
+
+        if used_write_mode == ParquetWriteMode::NewFile {
+            let mut i = 0;
+
+            while file_path.exists() {
+                i += 1;
+                let name = format!("data-{i}.parquet");
+                file_path = path.join(name);
+            }
+        }
+
+        info!("Created directory path: {file_path:?}");
+        file_path
+    }
+
+    #[must_use]
+    pub fn write_to_json<T>(
+        &self,
+        data: Vec<T>,
+        path: Option<PathBuf>,
+        write_metadata: bool,
+    ) -> PathBuf
+    where
+        T: GetTsInit + Serialize + CatalogPathPrefix + EncodeToRecordBatch,
+    {
+        let type_name = std::any::type_name::<T>().to_snake_case();
+        Self::check_ascending_timestamps(&data, &type_name);
+
+        let json_path = path.unwrap_or_else(|| {
+            let path = self.make_path(T::path_prefix(), None, None);
+            path.with_extension("json")
+        });
+
+        info!(
+            "Writing {} records of {type_name} data to {json_path:?}",
+            data.len(),
+        );
+
+        if write_metadata {
+            let metadata = T::chunk_metadata(&data);
+            let metadata_path = json_path.with_extension("metadata.json");
+            info!("Writing metadata to {metadata_path:?}");
+            let metadata_file = std::fs::File::create(&metadata_path)
+                .unwrap_or_else(|_| panic!("Failed to create metadata file at {metadata_path:?}"));
+            serde_json::to_writer_pretty(metadata_file, &metadata)
+                .unwrap_or_else(|_| panic!("Failed to write metadata to JSON"));
+        }
+
+        let file = std::fs::File::create(&json_path)
+            .unwrap_or_else(|_| panic!("Failed to create JSON file at {json_path:?}"));
+
+        serde_json::to_writer_pretty(file, &serde_json::to_value(data).unwrap())
+            .unwrap_or_else(|_| panic!("Failed to write {type_name} to JSON"));
+
+        json_path
+    }
+
+    pub fn consolidate_data(&self, type_name: &str, instrument_id: Option<&String>) -> Result<()> {
+        let parquet_files = self.query_parquet_files(type_name, instrument_id)?;
+
+        if !parquet_files.is_empty() {
+            combine_data_files(parquet_files, "ts_init", None, None)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn consolidate_catalog(&self) -> Result<()> {
+        let leaf_directories = self.find_leaf_data_directories()?;
+
+        for directory in leaf_directories {
+            let parquet_files: Vec<PathBuf> = std::fs::read_dir(directory)?
+                .filter_map(|entry| {
+                    let path = entry.ok()?.path();
+
+                    if path.extension().and_then(|s| s.to_str()) == Some("parquet") {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if !parquet_files.is_empty() {
+                combine_data_files(parquet_files, "ts_init", None, None)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn find_leaf_data_directories(&self) -> Result<Vec<PathBuf>> {
+        let mut all_paths: Vec<PathBuf> = Vec::new();
+        let data_dir = self.base_path.join("data");
+
+        for entry in walkdir::WalkDir::new(data_dir) {
+            all_paths.push(entry?.path().to_path_buf());
+        }
+
+        let all_dirs = all_paths
+            .iter()
+            .filter(|p| p.is_dir())
+            .cloned()
+            .collect::<Vec<PathBuf>>();
+        let mut leaf_dirs = Vec::new();
+
+        for directory in all_dirs {
+            let items = std::fs::read_dir(&directory)?;
+            let has_subdirs = items.into_iter().any(|entry| {
+                let entry = entry.unwrap();
+                entry.path().is_dir()
+            });
+
+            let has_files = std::fs::read_dir(&directory)?.any(|entry| {
+                let entry = entry.unwrap();
+                entry.path().is_file()
+            });
+
+            if has_files && !has_subdirs {
+                leaf_dirs.push(directory);
+            }
+        }
+
+        Ok(leaf_dirs)
+    }
+
+    /// Query data loaded in the catalog
+    pub fn query_file<T>(
+        &mut self,
+        path: PathBuf,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+        where_clause: Option<&str>,
+    ) -> datafusion::error::Result<QueryResult>
+    where
+        T: DecodeDataFromRecordBatch + CatalogPathPrefix,
+    {
+        let path_str = path.to_str().unwrap();
+        let table_name = path.file_stem().unwrap().to_str().unwrap();
+        let query = build_query(table_name, start, end, where_clause);
+        self.session
+            .add_file::<T>(table_name, path_str, Some(&query))?;
+        Ok(self.session.get_query_result())
+    }
+
+    /// Query data loaded in the catalog
+    pub fn query_directory<T>(
+        &mut self,
+        // use instrument_ids or bar_types to query specific subset of the data
+        instrument_ids: Vec<String>,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+        where_clause: Option<&str>,
+    ) -> datafusion::error::Result<QueryResult>
+    where
+        T: DecodeDataFromRecordBatch + CatalogPathPrefix,
+    {
+        let mut paths = Vec::new();
+        for instrument_id in &instrument_ids {
+            paths.push(self.make_path(T::path_prefix(), Some(instrument_id), None));
+        }
+
+        // If no specific instrument_id is selected query all files for the data type
+        if paths.is_empty() {
+            paths.push(self.make_path(T::path_prefix(), None, None));
+        }
+
+        for path in &paths {
+            let path = path.to_str().unwrap();
+            let query = build_query(path, start, end, where_clause);
+            self.session.add_file::<T>(path, path, Some(&query))?;
+        }
+
+        Ok(self.session.get_query_result())
+    }
+
+    #[allow(dead_code)]
+    fn query_timestamp_bound(
+        &self,
+        data_cls: &str,
+        instrument_id: Option<&String>,
+        is_last: bool,
+    ) -> Result<Option<i64>> {
+        let parquet_files = self.query_parquet_files(data_cls, instrument_id)?;
+
+        if parquet_files.is_empty() {
+            return Ok(None);
+        }
+
+        let min_max_per_file: Vec<(i64, i64)> = parquet_files
+            .iter()
+            .map(|file| min_max_from_parquet_metadata(file, "ts_init"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut timestamps: Vec<i64> = Vec::new();
+        for min_max in min_max_per_file {
+            let (min, max) = min_max;
+
+            if is_last {
+                timestamps.push(max);
+            } else {
+                timestamps.push(min);
+            }
+        }
+
+        if timestamps.is_empty() {
+            return Ok(None);
+        }
+
+        if is_last {
+            Ok(timestamps.iter().max().cloned())
+        } else {
+            Ok(timestamps.iter().min().cloned())
+        }
+    }
+
+    fn query_parquet_files(
+        &self,
+        type_name: &str,
+        instrument_id: Option<&String>,
+    ) -> Result<Vec<PathBuf>> {
+        let mut path = self.base_path.join("data").join(type_name);
+
+        if let Some(id) = instrument_id {
+            path = path.join(id);
+        }
+
+        let mut files = Vec::new();
+
+        if path.exists() {
+            for entry in std::fs::read_dir(path)? {
+                let path = entry?.path();
+                if path.is_file() && path.extension().unwrap() == "parquet" {
+                    files.push(path);
+                }
+            }
+        }
+
+        Ok(files)
     }
 }
 

--- a/crates/persistence/src/python/catalog.rs
+++ b/crates/persistence/src/python/catalog.rs
@@ -16,6 +16,7 @@
 use std::path::PathBuf;
 
 use nautilus_model::data::{Bar, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick};
+use nautilus_serialization::parquet::ParquetWriteMode;
 use pyo3::prelude::*;
 
 use crate::backend::catalog::ParquetDataCatalog;
@@ -41,23 +42,46 @@ impl PyParquetDataCatalogV2 {
     // TODO: Cannot pass mixed data across pyo3 as a single type
     // pub fn write_data(mut slf: PyRefMut<'_, Self>, data_type: NautilusDataType, data: Vec<Data>) {}
 
-    pub fn write_quote_ticks(&self, data: Vec<QuoteTick>) {
-        let _ = self.inner.write_to_parquet(data, None, None, None);
+    #[pyo3(signature = (data, write_mode=None))]
+    pub fn write_quote_ticks(&self, data: Vec<QuoteTick>, write_mode: Option<ParquetWriteMode>) {
+        let _ = self
+            .inner
+            .write_to_parquet(data, None, None, None, write_mode);
     }
 
-    pub fn write_trade_ticks(&self, data: Vec<TradeTick>) {
-        let _ = self.inner.write_to_parquet(data, None, None, None);
+    #[pyo3(signature = (data, write_mode=None))]
+    pub fn write_trade_ticks(&self, data: Vec<TradeTick>, write_mode: Option<ParquetWriteMode>) {
+        let _ = self
+            .inner
+            .write_to_parquet(data, None, None, None, write_mode);
     }
 
-    pub fn write_order_book_deltas(&self, data: Vec<OrderBookDelta>) {
-        let _ = self.inner.write_to_parquet(data, None, None, None);
+    #[pyo3(signature = (data, write_mode=None))]
+    pub fn write_order_book_deltas(
+        &self,
+        data: Vec<OrderBookDelta>,
+        write_mode: Option<ParquetWriteMode>,
+    ) {
+        let _ = self
+            .inner
+            .write_to_parquet(data, None, None, None, write_mode);
     }
 
-    pub fn write_bars(&self, data: Vec<Bar>) {
-        let _ = self.inner.write_to_parquet(data, None, None, None);
+    #[pyo3(signature = (data, write_mode=None))]
+    pub fn write_bars(&self, data: Vec<Bar>, write_mode: Option<ParquetWriteMode>) {
+        let _ = self
+            .inner
+            .write_to_parquet(data, None, None, None, write_mode);
     }
 
-    pub fn write_order_book_depths(&self, data: Vec<OrderBookDepth10>) {
-        let _ = self.inner.write_to_parquet(data, None, None, None);
+    #[pyo3(signature = (data, write_mode=None))]
+    pub fn write_order_book_depths(
+        &self,
+        data: Vec<OrderBookDepth10>,
+        write_mode: Option<ParquetWriteMode>,
+    ) {
+        let _ = self
+            .inner
+            .write_to_parquet(data, None, None, None, write_mode);
     }
 }

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -468,7 +468,8 @@ fn test_catalog_export_functionality() {
 
     // Write back to parquet
     let parquet_path = temp_dir.path().join("temp.parquet");
-    let parquet_path = catalog.write_to_parquet(quotes_from_json, Some(parquet_path), None, None);
+    let parquet_path =
+        catalog.write_to_parquet(quotes_from_json, Some(parquet_path), None, None, None);
 
     // Read parquet and verify data
     let final_result = catalog

--- a/crates/serialization/Cargo.toml
+++ b/crates/serialization/Cargo.toml
@@ -21,6 +21,7 @@ python = ["pyo3", "nautilus-core/python", "nautilus-model/python"]
 high-precision = ["nautilus-model/high-precision"]
 
 [dependencies]
+anyhow = { workspace = true }
 nautilus-core = { path = "../core" }
 nautilus-model = { path = "../model", features = ["stubs"] }
 arrow = { workspace = true }

--- a/crates/serialization/src/parquet.rs
+++ b/crates/serialization/src/parquet.rs
@@ -13,38 +13,195 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{error::Error, fs::File, path::Path};
+use std::{fs, fs::File, path::PathBuf};
 
+use anyhow::{Result, anyhow};
 use arrow::record_batch::RecordBatch;
-use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+use parquet::{
+    arrow::{ArrowWriter, arrow_reader::ParquetRecordBatchReaderBuilder},
+    file::{
+        properties::WriterProperties,
+        reader::{FileReader, SerializedFileReader},
+        statistics::Statistics,
+    },
+};
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(
+        eq,
+        eq_int,
+        module = "nautilus_trader.core.nautilus_pyo3.serialization.enums"
+    )
+)]
+pub enum ParquetWriteMode {
+    Append = 0,
+    Prepend = 1,
+    Overwrite = 2,
+    NewFile = 3,
+}
 
 /// Writes a `RecordBatch` to a Parquet file at the specified `filepath`, with optional compression.
 pub fn write_batch_to_parquet(
     batch: RecordBatch,
-    filepath: &Path,
+    filepath: &PathBuf,
     compression: Option<parquet::basic::Compression>,
-) -> Result<(), Box<dyn Error>> {
-    write_batches_to_parquet(&[batch], filepath, compression, None)
+    write_mode: Option<ParquetWriteMode>,
+) -> Result<()> {
+    write_batches_to_parquet(&[batch], filepath, compression, None, write_mode)
 }
 
-/// Writes a `RecordBatch` to a Parquet file at the specified `filepath`, with optional compression.
 pub fn write_batches_to_parquet(
     batches: &[RecordBatch],
-    filepath: &Path,
+    filepath: &PathBuf,
     compression: Option<parquet::basic::Compression>,
     max_row_group_size: Option<usize>,
-) -> Result<(), Box<dyn Error>> {
+    write_mode: Option<ParquetWriteMode>,
+) -> Result<()> {
+    let used_write_mode = write_mode.unwrap_or(ParquetWriteMode::Overwrite);
+
     // Ensure the parent directory exists
     if let Some(parent) = filepath.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    let file = File::create(filepath)?;
+    if (used_write_mode == ParquetWriteMode::Append || used_write_mode == ParquetWriteMode::Prepend)
+        && filepath.exists()
+    {
+        // Read existing parquet file
+        let file = File::open(filepath)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let existing_batches: Vec<RecordBatch> = reader.build()?.collect::<Result<Vec<_>, _>>()?;
 
-    // Configure writer properties, defaulting to Zstandard compression if not specified
-    let default_compression = parquet::basic::Compression::SNAPPY;
+        if !existing_batches.is_empty() {
+            // Get the schema of the existing data.
+            let existing_schema = existing_batches[0].schema();
+
+            // Cast new batches to the existing schema.
+            let mut cast_batches: Vec<RecordBatch> = Vec::with_capacity(batches.len());
+
+            for batch in batches {
+                if batch.schema() != existing_schema {
+                    let cast_batch = batch.clone().with_schema(existing_schema.clone())?; // Attempt to cast.
+                    cast_batches.push(cast_batch);
+                } else {
+                    cast_batches.push(batch.clone()); // No cast needed, just clone.
+                }
+            }
+
+            // Combine batches in the appropriate order
+            let combined_batches = if used_write_mode == ParquetWriteMode::Append {
+                let mut combined = existing_batches;
+                combined.extend(cast_batches);
+                combined
+            } else {
+                // Prepend mode
+                let mut combined = Vec::with_capacity(cast_batches.len() + existing_batches.len());
+                combined.extend(cast_batches);
+                combined.extend(existing_batches);
+                combined
+            };
+
+            return write_batches_to_file(
+                &combined_batches,
+                filepath,
+                compression,
+                max_row_group_size,
+            );
+        }
+    }
+
+    // Default case: create new file or overwrite existing
+    write_batches_to_file(batches, filepath, compression, max_row_group_size)
+}
+
+pub fn combine_data_files(
+    parquet_files: Vec<PathBuf>,
+    column_name: &str,
+    compression: Option<parquet::basic::Compression>,
+    max_row_group_size: Option<usize>,
+) -> Result<()> {
+    let n_files = parquet_files.len();
+
+    if n_files <= 1 {
+        return Ok(());
+    }
+
+    // Get min/max for each file
+    let min_max_per_file = parquet_files
+        .iter()
+        .map(|file| min_max_from_parquet_metadata(file, column_name))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Create ordering by first timestamp
+    let mut ordering: Vec<usize> = (0..n_files).collect();
+    ordering.sort_by_key(|&i| min_max_per_file[i].0);
+
+    // Check for timestamp intersection
+    for i in 1..n_files {
+        if min_max_per_file[ordering[i - 1]].1 >= min_max_per_file[ordering[i]].0 {
+            return Err(anyhow!(
+                "Merging not safe due to intersection of timestamps between files. Aborting."
+            ));
+        }
+    }
+
+    // Create sorted list of files
+    let sorted_parquet_files = ordering
+        .into_iter()
+        .map(|i| parquet_files[i].clone())
+        .collect();
+
+    // Combine the files
+    combine_parquet_files(sorted_parquet_files, compression, max_row_group_size)
+}
+
+pub fn combine_parquet_files(
+    file_list: Vec<PathBuf>,
+    compression: Option<parquet::basic::Compression>,
+    max_row_group_size: Option<usize>,
+) -> Result<()> {
+    if file_list.len() <= 1 {
+        return Ok(());
+    }
+
+    // Create readers and immediately build them.  Store the *readers*, not the builders.
+    let mut readers = Vec::new();
+    for file in &file_list {
+        let file = File::open(file)?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        readers.push(builder.build()?); // Build immediately and store the reader.
+    }
+
+    // Collect all batches into a single vector
+    let mut all_batches: Vec<RecordBatch> = Vec::new();
+    for reader in &mut readers {
+        for batch in reader.by_ref() {
+            all_batches.push(batch?);
+        }
+    }
+
+    // Use write_batches_to_file to write the combined batches
+    write_batches_to_file(&all_batches, &file_list[0], compression, max_row_group_size)?;
+
+    // Remove the merged files.
+    for file_path in file_list.iter().skip(1) {
+        fs::remove_file(file_path)?;
+    }
+
+    Ok(())
+}
+
+fn write_batches_to_file(
+    batches: &[RecordBatch],
+    filepath: &PathBuf,
+    compression: Option<parquet::basic::Compression>,
+    max_row_group_size: Option<usize>,
+) -> Result<()> {
+    let file = File::create(filepath)?;
     let writer_props = WriterProperties::builder()
-        .set_compression(compression.unwrap_or(default_compression))
+        .set_compression(compression.unwrap_or(parquet::basic::Compression::SNAPPY))
         .set_max_row_group_size(max_row_group_size.unwrap_or(5000))
         .build();
 
@@ -55,4 +212,64 @@ pub fn write_batches_to_parquet(
     writer.close()?;
 
     Ok(())
+}
+
+pub fn min_max_from_parquet_metadata(file_path: &PathBuf, column_name: &str) -> Result<(i64, i64)> {
+    // Open the parquet file
+    let file = File::open(file_path)?;
+    let reader = SerializedFileReader::new(file)?;
+
+    let metadata = reader.metadata();
+    let mut overall_min_value: Option<i64> = None;
+    let mut overall_max_value: Option<i64> = None;
+
+    // Iterate through all row groups
+    for i in 0..metadata.num_row_groups() {
+        let row_group = metadata.row_group(i);
+
+        // Iterate through all columns in this row group
+        for j in 0..row_group.num_columns() {
+            let col_metadata = row_group.column(j);
+
+            if col_metadata.column_path().string() == column_name {
+                if let Some(stats) = col_metadata.statistics() {
+                    // Check if we have Int64 statistics
+                    if let Statistics::Int64(int64_stats) = stats {
+                        // Extract min value if available
+                        if let Some(&min_value) = int64_stats.min_opt() {
+                            if overall_min_value.is_none() || min_value < overall_min_value.unwrap()
+                            {
+                                overall_min_value = Some(min_value);
+                            }
+                        }
+
+                        // Extract max value if available
+                        if let Some(&max_value) = int64_stats.max_opt() {
+                            if overall_max_value.is_none() || max_value > overall_max_value.unwrap()
+                            {
+                                overall_max_value = Some(max_value);
+                            }
+                        }
+                    } else {
+                        return Err(anyhow!(
+                            "Warning: Column name '{column_name}' is not of type i64."
+                        ));
+                    }
+                } else {
+                    return Err(anyhow!(
+                        "Warning: Statistics not available for column '{column_name}' in row group {i}."
+                    ));
+                }
+            }
+        }
+    }
+
+    // Return the min/max pair if both are available
+    if let (Some(min), Some(max)) = (overall_min_value, overall_max_value) {
+        Ok((min, max))
+    } else {
+        Err(anyhow!(
+            "Column '{column_name}' not found or has no Int64 statistics in any row group."
+        ))
+    }
 }

--- a/tests/test_data/large/checksums.json
+++ b/tests/test_data/large/checksums.json
@@ -1,5 +1,5 @@
 {
-  "databento_mbo_xnas_itch.csv": "sha256:5481466e7776659f7f093b1ca8b05c7e88b8d586036692089cca5decc7965099",
+  "databento_mbo_xnas_itch.csv": "sha256:ac66f2775ebbfd71b5ac1e62f47df5d151150b18323eaeb4bcc88b330ee7a456",
   "tardis_binance-futures_book_snapshot_25_2020-09-01_BTCUSDT.csv.gz": "sha256:c9ce8ae07da3fe22ed2b8bca00290c8875f9234cbe9e7734ff3ef662eb4d4712",
   "tardis_binance-futures_book_snapshot_5_2020-09-01_BTCUSDT.csv.gz": "sha256:d62035442308aa139b7771bb22c8cdb3be989cfc88693507a306c35b98b630de",
   "tardis_bitmex_trades_2020-03-01_XBTUSD.csv.gz": "sha256:bafdeba528965322baeb0a01b8c3d6bac73891c5a929713b6a6a2f75361200ab",


### PR DESCRIPTION
# Pull Request

Update rust parquet catalog with recent features

Added different kinds of adding data to an existing parquet file as well as the ability to consolidate several parquet files into one to match what is already done in python, and timestamp_bound

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Not tested yet
