### PR TITLE
Improve InstrumentProvider error handling when loading

### DIFF
--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -33,7 +33,6 @@ from nautilus_trader.adapters.bybit.common.enums import BybitEnumParser
 from nautilus_trader.adapters.bybit.common.enums import BybitProductType
 from nautilus_trader.adapters.bybit.common.parsing import get_interval_from_bar_type
 from nautilus_trader.adapters.bybit.common.symbol import BybitSymbol
-from nautilus_trader.adapters.bybit.http.errors import BybitError
 from nautilus_trader.adapters.bybit.http.market import BybitMarketHttpAPI
 from nautilus_trader.adapters.bybit.schemas.common import BYBIT_PONG
 from nautilus_trader.adapters.bybit.schemas.market.ticker import BybitTickerData
@@ -268,12 +267,8 @@ class BybitDataClient(LiveMarketDataClient):
                     f"Scheduled task 'update_instruments' to run in {interval_mins} minutes",
                 )
                 await asyncio.sleep(interval_mins * 60)
-
-                try:
-                    await self._instrument_provider.initialize(reload=True)
-                    self._send_all_instruments_to_data_engine()
-                except BybitError as e:
-                    self._log.error(f"Failed to update the instruments: {e}")
+                await self._instrument_provider.initialize(reload=True)
+                self._send_all_instruments_to_data_engine()
         except asyncio.CancelledError:
             self._log.debug("Canceled task 'update_instruments'")
 

--- a/nautilus_trader/common/providers.py
+++ b/nautilus_trader/common/providers.py
@@ -167,19 +167,24 @@ class InstrumentProvider:
         self._loading = True
         self._log.info("Initializing instruments...")
 
-        if self._load_all_on_start:
-            await self.load_all_async(self._filters)
-        elif self._load_ids_on_start:
-            instrument_ids = [
-                i if isinstance(i, InstrumentId) else InstrumentId.from_str(i)
-                for i in self._load_ids_on_start
-            ]
+        try:
+            if self._load_all_on_start:
+                await self.load_all_async(self._filters)
+            elif self._load_ids_on_start:
+                instrument_ids = [
+                    i if isinstance(i, InstrumentId) else InstrumentId.from_str(i)
+                    for i in self._load_ids_on_start
+                ]
 
-            instruments_str = ", ".join([i.value for i in instrument_ids])
-            filters_str = "..." if not self._filters else f" with filters {self._filters}..."
-            self._log.info(f"Loading instruments: {instruments_str}{filters_str}")
+                instruments_str = ", ".join([i.value for i in instrument_ids])
+                filters_str = "..." if not self._filters else f" with filters {self._filters}..."
+                self._log.info(f"Loading instruments: {instruments_str}{filters_str}")
 
-            await self.load_ids_async(instrument_ids, self._filters)
+                await self.load_ids_async(instrument_ids, self._filters)
+        except Exception as e:
+            # Catch unexpected exception to ensure that the self._loading flag
+            # is reset to False
+            self._log.error(f"Failed to load the instruments: {e}")
 
         if self._instruments:
             self._log.info(f"Loaded {self.count} instruments")


### PR DESCRIPTION
# Pull Request

Catch Exceptions when loading the instruments.

This is a follow up from https://github.com/nautechsystems/nautilus_trader/pull/2437. The state variable `self._loading` needs to be reset to `False`. Hence, the previous fix still resulted in the fact that the instruments were not being reloaded when a Bybit error occured.

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example