### PR TITLE
Implement add venue for BacktestEngine

### DIFF
--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -21,7 +21,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use nautilus_common::{cache::Cache, clock::Clock, msgbus::MessageBus};
+use nautilus_common::{cache::Cache, clock::Clock};
 use nautilus_core::UnixNanos;
 use nautilus_execution::{
     client::{ExecutionClient, base::BaseExecutionClient},
@@ -56,7 +56,6 @@ impl BacktestExecutionClient {
         account_id: AccountId,
         exchange: Rc<RefCell<SimulatedExchange>>,
         cache: Rc<RefCell<Cache>>,
-        msgbus: Rc<RefCell<MessageBus>>,
         clock: Rc<RefCell<dyn Clock>>,
         routing: Option<bool>,
         frozen_account: Option<bool>,
@@ -74,7 +73,6 @@ impl BacktestExecutionClient {
             exchange.borrow().base_currency,
             clock.clone(),
             cache,
-            msgbus,
         );
 
         if !frozen_account {

--- a/crates/execution/src/client/base.rs
+++ b/crates/execution/src/client/base.rs
@@ -24,7 +24,7 @@ use std::{any::Any, cell::RefCell, rc::Rc};
 use nautilus_common::{
     cache::Cache,
     clock::Clock,
-    msgbus::{MessageBus, send},
+    msgbus::{self},
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
@@ -59,7 +59,6 @@ pub struct BaseExecutionClient {
     pub is_connected: bool,
     clock: Rc<RefCell<dyn Clock>>,
     cache: Rc<RefCell<Cache>>,
-    msgbus: Rc<RefCell<MessageBus>>,
 }
 
 impl BaseExecutionClient {
@@ -74,7 +73,6 @@ impl BaseExecutionClient {
         base_currency: Option<Currency>,
         clock: Rc<RefCell<dyn Clock>>,
         cache: Rc<RefCell<Cache>>,
-        msgbus: Rc<RefCell<MessageBus>>,
     ) -> Self {
         Self {
             trader_id,
@@ -87,7 +85,6 @@ impl BaseExecutionClient {
             is_connected: false,
             clock,
             cache,
-            msgbus,
         }
     }
 
@@ -406,31 +403,31 @@ impl BaseExecutionClient {
 
     fn send_account_state(&self, account_state: AccountState) {
         let endpoint = Ustr::from("Portfolio.update_account");
-        send(&endpoint, &account_state as &dyn Any);
+        msgbus::send(&endpoint, &account_state as &dyn Any);
     }
 
     fn send_order_event(&self, event: OrderEventAny) {
         let endpoint = Ustr::from("ExecEngine.process");
-        send(&endpoint, &event as &dyn Any);
+        msgbus::send(&endpoint, &event as &dyn Any);
     }
 
     fn send_mass_status_report(&self, report: ExecutionMassStatus) {
         let endpoint = Ustr::from("ExecEngine.reconcile_mass_status");
-        send(&endpoint, &report as &dyn Any);
+        msgbus::send(&endpoint, &report as &dyn Any);
     }
 
     fn send_order_status_report(&self, report: OrderStatusReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        send(&endpoint, &report as &dyn Any);
+        msgbus::send(&endpoint, &report as &dyn Any);
     }
 
     fn send_fill_report(&self, report: FillReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        send(&endpoint, &report as &dyn Any);
+        msgbus::send(&endpoint, &report as &dyn Any);
     }
 
     fn send_position_report(&self, report: PositionStatusReport) {
         let endpoint = Ustr::from("ExecEngine.reconcile_report");
-        send(&endpoint, &report as &dyn Any);
+        msgbus::send(&endpoint, &report as &dyn Any);
     }
 }

--- a/crates/execution/src/matching_engine/adapter.rs
+++ b/crates/execution/src/matching_engine/adapter.rs
@@ -18,8 +18,7 @@ use std::{
     rc::Rc,
 };
 
-use nautilus_common::cache::Cache;
-use nautilus_core::AtomicTime;
+use nautilus_common::{cache::Cache, clock::Clock};
 use nautilus_model::{
     enums::{AccountType, BookType, OmsType},
     instruments::InstrumentAny,
@@ -49,7 +48,7 @@ impl OrderEngineAdapter {
         book_type: BookType,
         oms_type: OmsType,
         account_type: AccountType,
-        clock: &'static AtomicTime,
+        clock: Rc<RefCell<dyn Clock>>,
         cache: Rc<RefCell<Cache>>,
         config: OrderMatchingEngineConfig,
     ) -> Self {

--- a/crates/execution/src/matching_engine/adapter.rs
+++ b/crates/execution/src/matching_engine/adapter.rs
@@ -18,7 +18,7 @@ use std::{
     rc::Rc,
 };
 
-use nautilus_common::{cache::Cache, msgbus::MessageBus};
+use nautilus_common::cache::Cache;
 use nautilus_core::AtomicTime;
 use nautilus_model::{
     enums::{AccountType, BookType, OmsType},
@@ -50,7 +50,6 @@ impl OrderEngineAdapter {
         oms_type: OmsType,
         account_type: AccountType,
         clock: &'static AtomicTime,
-        msgbus: Rc<RefCell<MessageBus>>,
         cache: Rc<RefCell<Cache>>,
         config: OrderMatchingEngineConfig,
     ) -> Self {
@@ -63,7 +62,6 @@ impl OrderEngineAdapter {
             oms_type,
             account_type,
             clock,
-            msgbus,
             cache,
             config,
         )));

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -29,7 +29,7 @@ use std::{
 use chrono::TimeDelta;
 use nautilus_common::{
     cache::Cache,
-    msgbus::{MessageBus, send},
+    msgbus::{self},
 };
 use nautilus_core::{AtomicTime, UUID4, UnixNanos};
 use nautilus_model::{
@@ -85,7 +85,6 @@ pub struct OrderMatchingEngine {
     /// The config for the matching engine.
     pub config: OrderMatchingEngineConfig,
     clock: &'static AtomicTime,
-    msgbus: Rc<RefCell<MessageBus>>,
     cache: Rc<RefCell<Cache>>,
     book: OrderBook,
     pub core: OrderMatchingCore,
@@ -114,7 +113,6 @@ impl OrderMatchingEngine {
         oms_type: OmsType,
         account_type: AccountType,
         clock: &'static AtomicTime,
-        msgbus: Rc<RefCell<MessageBus>>,
         cache: Rc<RefCell<Cache>>,
         config: OrderMatchingEngineConfig,
     ) -> Self {
@@ -145,7 +143,6 @@ impl OrderMatchingEngine {
             oms_type,
             account_type,
             clock,
-            msgbus,
             cache,
             book,
             core,
@@ -2124,8 +2121,7 @@ impl OrderMatchingEngine {
             ts_now,
             false,
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any)
     }
 
     fn generate_order_accepted(&self, order: &mut OrderAny, venue_order_id: VenueOrderId) {
@@ -2145,8 +2141,7 @@ impl OrderMatchingEngine {
             ts_now,
             false,
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");
@@ -2177,8 +2172,7 @@ impl OrderMatchingEngine {
             venue_order_id,
             account_id,
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2206,8 +2200,7 @@ impl OrderMatchingEngine {
             Some(venue_order_id),
             Some(account_id),
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
     }
 
     fn generate_order_updated(
@@ -2233,8 +2226,7 @@ impl OrderMatchingEngine {
             price,
             trigger_price,
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");
@@ -2254,8 +2246,7 @@ impl OrderMatchingEngine {
             Some(venue_order_id),
             order.account_id(),
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any)
     }
 
     fn generate_order_triggered(&self, order: &OrderAny) {
@@ -2272,8 +2263,7 @@ impl OrderMatchingEngine {
             order.venue_order_id(),
             order.account_id(),
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any)
     }
 
     fn generate_order_expired(&self, order: &OrderAny) {
@@ -2290,8 +2280,7 @@ impl OrderMatchingEngine {
             order.venue_order_id(),
             order.account_id(),
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2331,8 +2320,7 @@ impl OrderMatchingEngine {
             venue_position_id,
             Some(commission),
         ));
-        let msgbus = self.msgbus.as_ref().borrow();
-        send(&msgbus.switchboard.exec_engine_process, &event as &dyn Any);
+        msgbus::send(&Ustr::from("ExecEngine.process"), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");


### PR DESCRIPTION
# Pull Request

- removed the local msgbus dependency and used a global approach for order matching engine and simulated exchange, and fixed tests where each test needed to call `register_message_bus` function
- initialized cace, clock and exec engine in `NautilusKernel`
- changed clock type for order matching engine and fix tests where ES instrument is used (setting the test clock current time to be higher than ES activation ns)
- implemented `add_venue` for `BacktestEngine`
- added TODO comment in `iterate` function of `OrderMatchingEngine` were generic clock were introduced and we lost `set_time` function which needs to be added later