### PR TITLE
Implement add instrument for BacktestEngine

### DIFF
--- a/crates/backtest/src/config.rs
+++ b/crates/backtest/src/config.rs
@@ -55,6 +55,16 @@ impl BacktestEngineConfig {
     }
 }
 
+impl Default for BacktestEngineConfig {
+    fn default() -> Self {
+        Self {
+            kernel: NautilusKernelConfig::default(),
+            bypass_logging: false,
+            run_analysis: true,
+        }
+    }
+}
+
 /// Represents a venue configuration for one specific backtest engine.
 #[derive(Debug, Clone)]
 pub struct BacktestVenueConfig {

--- a/crates/backtest/src/data_client.rs
+++ b/crates/backtest/src/data_client.rs
@@ -35,9 +35,19 @@ use nautilus_model::{
 };
 
 pub struct BacktestDataClient {
-    cache: Rc<RefCell<Cache>>,
     pub client_id: ClientId,
     pub venue: Venue,
+    cache: Rc<RefCell<Cache>>,
+}
+
+impl BacktestDataClient {
+    pub fn new(client_id: ClientId, venue: Venue, cache: Rc<RefCell<Cache>>) -> Self {
+        Self {
+            client_id,
+            venue,
+            cache,
+        }
+    }
 }
 
 impl DataClient for BacktestDataClient {

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -280,8 +280,11 @@ impl SimulatedExchange {
     }
 
     #[must_use]
-    pub fn get_matching_engine(&self, instrument_id: InstrumentId) -> Option<&OrderMatchingEngine> {
-        self.matching_engines.get(&instrument_id)
+    pub fn get_matching_engine(
+        &self,
+        instrument_id: &InstrumentId,
+    ) -> Option<&OrderMatchingEngine> {
+        self.matching_engines.get(instrument_id)
     }
 
     #[must_use]
@@ -1188,7 +1191,7 @@ mod tests {
 
         let market_status = exchange
             .borrow()
-            .get_matching_engine(crypto_perpetual_ethusdt.id)
+            .get_matching_engine(&crypto_perpetual_ethusdt.id)
             .unwrap()
             .market_status;
         assert_eq!(market_status, MarketStatus::Closed);

--- a/crates/data/src/client.rs
+++ b/crates/data/src/client.rs
@@ -30,7 +30,7 @@ use std::{
 
 use indexmap::IndexMap;
 use nautilus_common::{
-    clock::{Clock, TestClock},
+    clock::Clock,
     messages::data::{Action, DataRequest, DataResponse, Payload, SubscriptionCommand},
 };
 use nautilus_core::{UUID4, UnixNanos};
@@ -241,7 +241,7 @@ pub trait DataClient {
 
 pub struct DataClientAdapter {
     client: Box<dyn DataClient>,
-    clock: Rc<RefCell<TestClock>>,
+    clock: Rc<RefCell<dyn Clock>>,
     pub client_id: ClientId,
     pub venue: Venue,
     pub handles_order_book_deltas: bool,
@@ -324,7 +324,7 @@ impl DataClientAdapter {
         handles_order_book_deltas: bool,
         handles_order_book_snapshots: bool,
         client: Box<dyn DataClient>,
-        clock: Rc<RefCell<TestClock>>,
+        clock: Rc<RefCell<dyn Clock>>,
     ) -> Self {
         Self {
             client,

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -193,7 +193,7 @@ impl DataEngine {
     }
 
     #[must_use]
-    pub fn registed_clients(&self) -> Vec<ClientId> {
+    pub fn registered_clients(&self) -> Vec<ClientId> {
         self.clients.keys().copied().collect()
     }
 

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -145,6 +145,10 @@ impl ExecutionEngine {
         self.default_client = Some(client);
     }
 
+    pub fn get_client(&self, client_id: &ClientId) -> Option<Rc<dyn ExecutionClient>> {
+        self.clients.get(client_id).cloned()
+    }
+
     pub fn register_venue_routing(
         &mut self,
         client_id: ClientId,

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -33,10 +33,10 @@ high-precision = [
 ]
 
 [dependencies]
-nautilus-core = { path = "../core" }
+nautilus-core = { path = "../core", features = ["ffi"] }
 nautilus-common = { path = "../common" }
 nautilus-model = { path = "../model", features = ["stubs"] }
-nautilus-serialization = { path = "../serialization" }
+nautilus-serialization = { path = "../serialization" , features = ["python"]}
 futures = { workspace = true }
 heck = { workspace = true }
 itertools = { workspace = true }

--- a/crates/system/src/config.rs
+++ b/crates/system/src/config.rs
@@ -115,3 +115,29 @@ impl NautilusKernelConfig {
         }
     }
 }
+
+impl Default for NautilusKernelConfig {
+    fn default() -> Self {
+        Self {
+            environment: Environment::Backtest,
+            trader_id: TraderId::default(),
+            load_state: false,
+            save_state: false,
+            logging: LoggerConfig::default(),
+            instance_id: None,
+            timeout_connection: 60,
+            timeout_reconciliation: 30,
+            timeout_portfolio: 10,
+            timeout_disconnection: 10,
+            timeout_post_stop: 10,
+            timeout_shutdown: 5,
+            cache: None,
+            msgbus: None,
+            data_engine: None,
+            risk_engine: None,
+            exec_engine: None,
+            portfolio: None,
+            streaming: None,
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

- added `Default` trait for `BacktestEngineConfig` and `NautilusKernelConfig`
- implemented `new` constructor for `BacktestDataClient`
- implemented `add_instrument` in `BacktestEngine` with proper testing 
- changed clock type for `DataClientAdapter`
- continue `NautilusKernel` initialization 
- fixed correct features in `nautilus-persistence` crate dependencies 