### PR TITLE
Fix submitting stop market orders and OrderStatusReport for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/endpoints/endpoint.py
+++ b/nautilus_trader/adapters/dydx/endpoints/endpoint.py
@@ -16,6 +16,7 @@
 Define the base class for dYdX endpoints.
 """
 
+from json import JSONDecodeError
 from typing import Any
 
 import msgspec
@@ -64,7 +65,7 @@ class DYDXHttpEndpoint:
             max_retries=5,
             retry_delay_secs=1.0,
             logger=Logger(name="DYDXHttpEndpoint"),
-            exc_types=(HttpTimeoutError, HttpError, DYDXError),
+            exc_types=(HttpTimeoutError, HttpError, DYDXError, JSONDecodeError),
             retry_check=should_retry,
         )
 

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -1130,17 +1130,17 @@ class DYDXExecutionClient(LiveExecutionClient):
             return
 
         if dydx_order_tags.is_short_term_order:
+            order_flags = OrderFlags.SHORT_TERM
             good_til_block = self._block_height + dydx_order_tags.num_blocks_open
-
-        elif order.order_type in [OrderType.STOP_LIMIT, OrderType.STOP_MARKET]:
-            good_til_block = None
-            order_flags = OrderFlags.CONDITIONAL
+        else:
+            order_flags = OrderFlags.LONG_TERM
             good_til_date_secs = (
                 int(nanos_to_secs(order.expire_time_ns)) if order.expire_time_ns else None
             )
 
-        else:
-            order_flags = OrderFlags.LONG_TERM
+        if order.order_type in [OrderType.STOP_LIMIT, OrderType.STOP_MARKET]:
+            order_flags = OrderFlags.CONDITIONAL
+            good_til_block = None
             good_til_date_secs = (
                 int(nanos_to_secs(order.expire_time_ns)) if order.expire_time_ns else None
             )

--- a/nautilus_trader/adapters/dydx/execution.py
+++ b/nautilus_trader/adapters/dydx/execution.py
@@ -431,31 +431,34 @@ class DYDXExecutionClient(LiveExecutionClient):
         Create an order status report for a specific order.
         """
         self._log.debug("Requesting OrderStatusReport...")
+
+        client_order_id = command.client_order_id
+        venue_order_id = command.venue_order_id
         PyCondition.is_false(
-            command.client_order_id is None and command.venue_order_id is None,
+            client_order_id is None and venue_order_id is None,
             "both `client_order_id` and `venue_order_id` were `None`",
         )
 
         max_retries = 3
-        retries = self._generate_order_status_retries.get(command.client_order_id, 0)
+        retries = self._generate_order_status_retries.get(client_order_id, 0)
 
         if retries > max_retries:
             self._log.error(
                 f"Reached maximum retries {retries}/{max_retries} for generating OrderStatusReport for "
-                f"{repr(command.client_order_id) if command.client_order_id else ''} "
-                f"{repr(command.venue_order_id) if command.venue_order_id else ''}",
+                f"{repr(client_order_id) if client_order_id else ''} "
+                f"{repr(venue_order_id) if venue_order_id else ''}",
             )
             return None
 
         self._log.info(
-            f"Generating OrderStatusReport for {repr(command.client_order_id) if command.client_order_id else ''} {repr(command.venue_order_id) if command.venue_order_id else ''}",  # noqa: E501
+            f"Generating OrderStatusReport for {repr(client_order_id) if client_order_id else ''} {repr(venue_order_id) if venue_order_id else ''}",
         )
 
         report = None
         order = None
 
-        if command.client_order_id is None:
-            client_order_id = self._cache.client_order_id(command.venue_order_id)
+        if client_order_id is None:
+            client_order_id = self._cache.client_order_id(venue_order_id)
 
         if client_order_id:
             order = self._cache.order(client_order_id)
@@ -468,7 +471,7 @@ class DYDXExecutionClient(LiveExecutionClient):
         if order.is_closed:
             return None  # Nothing else to do
 
-        if command.venue_order_id is None:
+        if venue_order_id is None:
             venue_order_id = order.venue_order_id
 
         try:

--- a/nautilus_trader/adapters/dydx/http/errors.py
+++ b/nautilus_trader/adapters/dydx/http/errors.py
@@ -16,6 +16,7 @@
 Define a dYdX exception.
 """
 
+from json import JSONDecodeError
 from typing import Any
 
 from grpc.aio._call import AioRpcError
@@ -62,7 +63,12 @@ def should_retry(error: BaseException) -> bool:
 
     if isinstance(
         error,
-        AioRpcError | DYDXError | HttpError | HttpTimeoutError | WebSocketClientError,
+        AioRpcError
+        | DYDXError
+        | HttpError
+        | HttpTimeoutError
+        | WebSocketClientError
+        | JSONDecodeError,
     ):
         return True
 


### PR DESCRIPTION
# Pull Request

- Refine conditional orders for dYdX: submit stop limit or stop market orders without setting dYdX specific order tags
- Retry HTTP requests when JSONDecodeError occurs to malformed JSON messages
- Fix unbound venue_order_id and client_order_id when creating an OrderStatusReport
- Fix submitting stop_market orders

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example