### PR TITLE
Fix retrying HTTP calls when a DecodeError occurs for dYdX

### DIFF
--- a/nautilus_trader/adapters/dydx/endpoints/endpoint.py
+++ b/nautilus_trader/adapters/dydx/endpoints/endpoint.py
@@ -16,10 +16,10 @@
 Define the base class for dYdX endpoints.
 """
 
-from json import JSONDecodeError
 from typing import Any
 
 import msgspec
+from msgspec import DecodeError
 
 from nautilus_trader.adapters.dydx.common.enums import DYDXEndpointType
 from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
@@ -65,7 +65,7 @@ class DYDXHttpEndpoint:
             max_retries=5,
             retry_delay_secs=1.0,
             logger=Logger(name="DYDXHttpEndpoint"),
-            exc_types=(HttpTimeoutError, HttpError, DYDXError, JSONDecodeError),
+            exc_types=(HttpTimeoutError, HttpError, DYDXError, DecodeError),
             retry_check=should_retry,
         )
 

--- a/nautilus_trader/adapters/dydx/http/errors.py
+++ b/nautilus_trader/adapters/dydx/http/errors.py
@@ -16,10 +16,10 @@
 Define a dYdX exception.
 """
 
-from json import JSONDecodeError
 from typing import Any
 
 from grpc.aio._call import AioRpcError
+from msgspec import DecodeError
 
 from nautilus_trader.adapters.dydx.common.constants import DYDX_RETRY_ERRORS_GRPC
 from nautilus_trader.adapters.dydx.grpc.errors import DYDXGRPCError
@@ -63,12 +63,7 @@ def should_retry(error: BaseException) -> bool:
 
     if isinstance(
         error,
-        AioRpcError
-        | DYDXError
-        | HttpError
-        | HttpTimeoutError
-        | WebSocketClientError
-        | JSONDecodeError,
+        AioRpcError | DYDXError | HttpError | HttpTimeoutError | WebSocketClientError | DecodeError,
     ):
         return True
 


### PR DESCRIPTION
# Pull Request

Fix retrying HTTP calls when a DecodeError occurs for dYdX

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Live example
