### PR TITLE
Fix error on cancel order for IB

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -19,6 +19,7 @@ from ibapi.commission_report import CommissionReport
 from ibapi.contract import Contract
 from ibapi.execution import Execution
 from ibapi.order import Order as IBOrder
+from ibapi.order_cancel import OrderCancel as IBOrderCancel
 from ibapi.order_state import OrderState as IBOrderState
 
 from nautilus_trader.adapters.interactive_brokers.client.common import AccountOrderRef
@@ -70,7 +71,7 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             order.orderRef = f"{order.orderRef}:{order.orderId}"
             self._eclient.placeOrder(order.orderId, order.contract, order)
 
-    def cancel_order(self, order_id: int, manual_cancel_order_time: str = "") -> None:
+    def cancel_order(self, order_id: int, order_cancel: IBOrderCancel = None) -> None:
         """
         Cancel an order through the EClient.
 
@@ -78,11 +79,13 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         ----------
         order_id : int
             The unique identifier for the order to be canceled.
-        manual_cancel_order_time : str, optional
-            The timestamp indicating when the order was canceled manually.
+        order_cancel : OrderCancel object, optional.
+            The Order cancellation parameters when cancelling an order, when subject to CME Rule 576.
 
         """
-        self._eclient.cancelOrder(order_id, manual_cancel_order_time)
+        if order_cancel is None:
+            order_cancel = IBOrderCancel()
+        self._eclient.cancelOrder(order_id, order_cancel)
 
     def cancel_all_orders(self) -> None:
         """

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 import pytest
+from ibapi.order_cancel import OrderCancel as IBOrderCancel
 
 from nautilus_trader.adapters.interactive_brokers.client.common import AccountOrderRef
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
@@ -64,12 +65,12 @@ def test_cancel_order(ib_client):
     ib_client._eclient.cancelOrder = MagicMock()
 
     # Act
-    ib_client.cancel_order(order_id)
+    ib_client.cancel_order(order_id, IBOrderCancel)
 
     # Assert
     ib_client._eclient.cancelOrder.assert_called_with(
         order_id,
-        "",
+        IBOrderCancel,
     )
 
 


### PR DESCRIPTION
# Pull Request
Interactive Brokers adapter : 
Changing one parameter of cancel_order method 
manual_cancel_order_time is replaced with IB API's OrderCancel object

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
fix bug #2474

## How has this change been tested?

Tested in paper mode on develop branch
