### PR TITLE
Add instrument_ids and bar_types for BacktestDataConfig

### DIFF
--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -198,6 +198,8 @@ class OptionStrategy(Strategy):
 
 # for saving and loading custom data greeks, use True, False then False, True below
 stream_data, load_greeks = False, False
+# stream_data, load_greeks = True, False
+# stream_data, load_greeks = False, True
 
 actors = [
     ImportableActorConfig(
@@ -248,17 +250,21 @@ engine_config = BacktestEngineConfig(
 # BacktestRunConfig
 
 data = [
+    # TODO using instrument_id and bar_spec only, or instrument_ids and bar_spec only, or bar_types only
     BacktestDataConfig(
         data_cls=Bar,
         catalog_path=catalog.path,
         instrument_id=InstrumentId.from_str(f"{future_symbols[0]}.GLBX"),
+        # instrument_ids=[InstrumentId.from_str(f"{future_symbols[0]}.GLBX")],
         bar_spec="1-MINUTE-LAST",
+        # bar_types=[f"{future_symbols[0]}.GLBX-1-MINUTE-LAST-EXTERNAL"],
         # start_time=start_time,
         # end_time=end_time,
     ),
     BacktestDataConfig(
         data_cls=QuoteTick,
         catalog_path=catalog.path,
+        # instrument_ids=[InstrumentId.from_str(f"{option_symbols[0]}.GLBX"), InstrumentId.from_str(f"{option_symbols[1]}.GLBX")],
     ),
 ]
 
@@ -289,7 +295,7 @@ configs = [
         engine=engine_config,
         data=data,
         venues=venues,
-        chunk_size=None,  # use None when loading custom data
+        chunk_size=None,  # use None when loading custom data, else a value of 10_000 for example
     ),
 ]
 

--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -29,6 +29,7 @@ from nautilus_trader.core.datetime import dt_to_unix_nanos
 from nautilus_trader.data.config import DataEngineConfig
 from nautilus_trader.execution.config import ExecEngineConfig
 from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import TraderId
 from nautilus_trader.risk.config import RiskEngineConfig
@@ -58,9 +59,11 @@ def parse_filters_expr(s: str | None):
     def safer_eval(input_string):
         allowed_names = {"field": field}
         code = compile(input_string, "<string>", "eval")
+
         for name in code.co_names:
             if name not in allowed_names:
                 raise NameError(f"Use of {name} not allowed")
+
         return eval(code, {}, allowed_names)  # noqa
 
     return safer_eval(s)  # Only allow use of the field object
@@ -173,6 +176,13 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         The metadata for the data catalog query.
     bar_spec : str, optional
         The bar specification for the data catalog query.
+    instrument_ids : list[str], optional
+        The instrument IDs for the data catalog query.
+        Can be used if instrument_id is not specified.
+        If bar_spec is specified an equivalent list of bar_types will be constructed.
+    bar_types : list[str], optional
+        The bar types for the data catalog query.
+        Can be used if instrument_id is not specified.
 
     """
 
@@ -187,6 +197,8 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
     client_id: str | None = None
     metadata: dict | None = None
     bar_spec: str | None = None
+    instrument_ids: list[str] | None = None
+    bar_types: list[str] | None = None
 
     @property
     def data_type(self) -> type:
@@ -204,7 +216,7 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
             return self.data_cls
 
     @property
-    def query(self) -> dict[str, Any]:
+    def query(self) -> dict[str, Any]:  # noqa: C901
         """
         Return a catalog query object for the configuration.
 
@@ -213,15 +225,48 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         dict[str, Any]
 
         """
-        if self.data_cls is Bar and self.bar_spec:
-            bar_type = f"{self.instrument_id}-{self.bar_spec}-EXTERNAL"
-            filter_expr: str | None = f'field("bar_type") == "{bar_type}"'
+        filter_expr: str | None = None
+
+        if self.data_cls is Bar:
+            used_bar_types = []
+
+            if self.bar_types is None and self.instrument_ids is None:
+                assert self.instrument_id, "No `instrument_id` for Bar data config"
+                assert self.bar_spec, "No `bar_spec` for Bar data config"
+
+            if self.instrument_id is not None and self.bar_spec is not None:
+                bar_type = f"{self.instrument_id}-{self.bar_spec}-EXTERNAL"
+                used_bar_types = [bar_type]
+            elif self.bar_types is not None:
+                used_bar_types = self.bar_types
+            elif self.instrument_ids is not None and self.bar_spec is not None:
+                for instrument_id in self.instrument_ids:
+                    used_bar_types.append(f"{instrument_id}-{self.bar_spec}-EXTERNAL")
+
+            if len(used_bar_types) > 0:
+                filter_expr = f'(field("bar_type") == "{used_bar_types[0]}")'
+
+            for bar_type in used_bar_types[1:]:
+                filter_expr = f'{filter_expr} | (field("bar_type") == "{bar_type}")'
         else:
             filter_expr = self.filter_expr
 
+        used_instrument_ids = None
+
+        if self.instrument_id is not None:
+            used_instrument_ids = [self.instrument_id]
+        elif self.instrument_ids is not None:
+            used_instrument_ids = self.instrument_ids
+        elif self.bar_types is not None:
+            bar_types: list[BarType] = [
+                BarType.from_str(bar_type) if type(bar_type) is str else bar_type
+                for bar_type in self.bar_types
+            ]
+            used_instrument_ids = [bar_type.instrument_id for bar_type in bar_types]
+
         return {
             "data_cls": self.data_type,
-            "instrument_ids": [self.instrument_id] if self.instrument_id else None,
+            "instrument_ids": used_instrument_ids,
             "start": self.start_time,
             "end": self.end_time,
             "filter_expr": parse_filters_expr(filter_expr),
@@ -242,6 +287,7 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         """
         if self.start_time is None:
             return 0
+
         return dt_to_unix_nanos(self.start_time)
 
     @property
@@ -258,6 +304,7 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         """
         if self.end_time is None:
             return sys.maxsize
+
         return dt_to_unix_nanos(self.end_time)
 
 

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -672,6 +672,7 @@ cdef class BacktestEngine:
 
         if validate:
             first = data[0]
+
             if hasattr(first, "instrument_id"):
                 Condition.is_true(
                     first.instrument_id in self.kernel.cache.instrument_ids(),

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -570,9 +570,9 @@ class ParquetDataCatalog(BaseDataCatalog):
 
         if not is_nautilus_class(data_cls):
             # Special handling for generic data
+            metadata = kwargs.get("metadata")
             data = [
-                CustomData(data_type=DataType(data_cls, metadata=kwargs.get("metadata")), data=d)
-                for d in data
+                CustomData(data_type=DataType(data_cls, metadata=metadata), data=d) for d in data
             ]
 
         return data
@@ -825,8 +825,10 @@ class ParquetDataCatalog(BaseDataCatalog):
 
         if start is not None:
             filters.append(pds.field(ts_column) >= pd.Timestamp(start).value)
+
         if end is not None:
             filters.append(pds.field(ts_column) <= pd.Timestamp(end).value)
+
         if filters:
             filter_ = combine_filters(*filters)
         else:
@@ -935,18 +937,6 @@ class ParquetDataCatalog(BaseDataCatalog):
         return self.fs.glob(os.path.join(directory, "*.parquet"))
 
     # -- OVERLOADED BASE METHODS ------------------------------------------------------------------
-
-    def instruments(
-        self,
-        instrument_type: type | None = None,
-        instrument_ids: list[str] | None = None,
-        **kwargs: Any,
-    ) -> list[Instrument]:
-        return super().instruments(
-            instrument_type=instrument_type,
-            instrument_ids=instrument_ids,
-            **kwargs,
-        )
 
     def _list_directory_stems(self, subdirectory: str) -> list[str]:
         glob_path = f"{self.path}/{subdirectory}/*"

--- a/nautilus_trader/persistence/catalog/types.py
+++ b/nautilus_trader/persistence/catalog/types.py
@@ -32,7 +32,7 @@ class CatalogDataResult:
 
     data_cls: type
     data: list[Data]
-    instrument: Instrument | None = None
+    instruments: list[Instrument] | None = None
     client_id: ClientId | None = None
 
 

--- a/nautilus_trader/persistence/funcs.py
+++ b/nautilus_trader/persistence/funcs.py
@@ -27,8 +27,10 @@ def class_to_filename(cls: type) -> str:
     """
     filename_mappings = {"OrderBookDeltas": "OrderBookDelta"}
     name = f"{convert_to_snake_case(filename_mappings.get(cls.__name__, cls.__name__))}"
+
     if not is_nautilus_class(cls):
         name = f"{CUSTOM_DATA_PREFIX}{name}"
+
     return name
 
 
@@ -38,17 +40,21 @@ def urisafe_instrument_id(instrument_id: InstrumentId | str) -> str:
     """
     if isinstance(instrument_id, InstrumentId):
         instrument_id = instrument_id.value
+
     return instrument_id.replace("/", "")
 
 
 def combine_filters(*filters):
     filters = tuple(x for x in filters if x is not None)
+
     if len(filters) == 0:
         return None
     elif len(filters) == 1:
         return filters[0]
     else:
         expr = filters[0]
+
         for f in filters[1:]:
             expr = expr & f
+
         return expr

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -112,7 +112,7 @@ class TestBacktestConfig:
 
         # Assert
         assert len(result.data) == 86985
-        assert result.instrument is None
+        assert result.instruments is None
         assert result.client_id == ClientId("NewsClient")
         assert result.data[0].data_type.metadata == {"kind": "news"}
 
@@ -153,7 +153,7 @@ class TestBacktestConfig:
 
         # Assert
         assert len(result.data) == 2
-        assert result.instrument is None
+        assert result.instruments is None
         assert result.client_id is None
 
     def test_resolve_cls(self):
@@ -213,7 +213,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1146  # UNIX
+        assert result == 1198  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_run_config_parse_obj(self) -> None:
@@ -234,7 +234,7 @@ class TestBacktestConfigParsing:
         assert isinstance(config, BacktestRunConfig)
         node = BacktestNode(configs=[config])
         assert isinstance(node, BacktestNode)
-        assert len(raw) == 856  # UNIX
+        assert len(raw) == 895  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_data_config_to_dict(self) -> None:
@@ -255,7 +255,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1894
+        assert result == 2050
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_run_config_id(self) -> None:
@@ -263,7 +263,7 @@ class TestBacktestConfigParsing:
         print("token:", token)
         value: bytes = self.backtest_config.json()
         print("token_value:", value.decode())
-        assert token == "1401fab0644a974c8879852405102b4c94dba62e4a6a087cf42f9fc0a62805c4"
+        assert token == "bb8070e2b9c260bd6e51b1ef57c93d338b0d31a3798e0b6bc4787cbc7f25fd1b"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     @pytest.mark.parametrize(
@@ -279,7 +279,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_data_config,
                 ("catalog",),
                 {},
-                ("949ef3abd03a447949d298f38a9aab669afc740720d747d4df2a9a121d78d110",),
+                ("22a83df0e65c304aff0a92070c6c55cef8a91392892a99dd6a992ad6ed829556",),
             ),
             (
                 TestConfigStubs.backtest_engine_config,


### PR DESCRIPTION
# Pull Request

Refine BacktestDataConfig with instrument_ids and bar_types

+ Allow to reduce the number of required queries to backtest catalog data and sorting data several times in the backtest engine.
+ Added instrument_ids and bar_types to BacktestDataConfig
+ Made the feature work with rust sessions and pyarrow queries

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested manually in databento_option_greeks.py for chunk_size = None and not None (I think chunk_size should be renamed to something better like batch_data_size else it's hard to know what it's doing except by looking at the code)
