### PR TITLE
Clarify partial fills in backtesting docs

### DIFF
--- a/docs/concepts/backtesting.md
+++ b/docs/concepts/backtesting.md
@@ -364,7 +364,7 @@ When using less granular data, the same behaviors apply as L1:
 
 The `FillModel` has certain limitations to keep in mind:
 
-- Partial fills are not simulated - orders either fill completely or not at all.
+- **Partial fills are supported** with L2/L3 order book data - when there is no longer any size available in the order book, no more fills will be generated and the order will remain in a partially filled state. This accurately simulates real market conditions where not enough liquidity is available at the desired price levels.
 - With L1 data, slippage is limited to a fixed 1-tick, at which entire order's quantity is filled.
 
 :::note


### PR DESCRIPTION
# Pull Request

Docs updated / fixed on topic of partial fills.

@cjdsellers 
Chris feel free to modify the wording or make it more precise, if not fully correct.
Primarily this part is of interest: `Partial fills are supported with **L2/L3 order book** data`.

## Type of change

Delete options that are not relevant.

Just docs update

## How has this change been tested?

✅  pre-commit formatting OK
✅ @cjdsellers (Chris will do quick 1 sec double check of the information 🙏 )
