### PR TITLE
Refine databento venue dataset mapping

### DIFF
--- a/nautilus_trader/adapters/databento/config.py
+++ b/nautilus_trader/adapters/databento/config.py
@@ -13,8 +13,10 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from nautilus_trader.adapters.databento.types import Dataset
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Venue
 
 
 class DatabentoDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -44,6 +46,8 @@ class DatabentoDataClientConfig(LiveDataClientConfig, frozen=True):
         e.g. {'GLBX.MDP3', ['ES.FUT', 'ES.OPT']} (for all E-mini S&P 500 futures and options products).
     instrument_ids : list[InstrumentId], optional
         The instrument IDs to request instrument definitions for on start.
+    venue_dataset_map: dict[Venue, Dataset], option
+        A dictionary to override the default Dataset used for a Venue
 
     """
 
@@ -55,3 +59,4 @@ class DatabentoDataClientConfig(LiveDataClientConfig, frozen=True):
     mbo_subscriptions_delay: float | None = 3.0  # Need to have received all definitions
     instrument_ids: list[InstrumentId] | None = None
     parent_symbols: dict[str, set[str]] | None = None
+    venue_dataset_map: dict[Venue, Dataset] | None = None

--- a/nautilus_trader/adapters/databento/loaders.py
+++ b/nautilus_trader/adapters/databento/loaders.py
@@ -103,12 +103,9 @@ class DatabentoDataLoader:
 
         """
         dataset = self._pyo3_loader.get_dataset_for_venue(nautilus_pyo3.Venue(venue.value))
+
         if dataset is None:
             raise ValueError(f"No Databento dataset for venue '{venue}'")
-
-        # TODO: Temporary workaround
-        if dataset == "XNAS.BASIC":
-            return "XNAS.ITCH"
 
         return dataset
 
@@ -171,16 +168,18 @@ class DatabentoDataLoader:
             if instrument_id is not None
             else None
         )
-
         schema = self._pyo3_loader.schema_for_file(str(path))
+
         if schema is None:
             raise RuntimeError("Loading files with mixed schemas not currently supported")
 
         match schema:
             case DatabentoSchema.DEFINITION.value:
                 data = self._pyo3_loader.load_instruments(str(path), use_exchange_as_venue)
+
                 if as_legacy_cython:
                     data = instruments_from_pyo3(data)
+
                 return data
             case DatabentoSchema.MBO.value:
                 if as_legacy_cython:
@@ -193,6 +192,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     if include_trades:
@@ -200,6 +200,7 @@ class DatabentoDataLoader:
                             "Cannot load `OrderBookDelta` and `Trade` objects together, "
                             "set `include_trades` to False",
                         )
+
                     return self._pyo3_loader.load_order_book_deltas(
                         filepath=str(path),
                         instrument_id=pyo3_instrument_id,
@@ -216,6 +217,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     if include_trades:
@@ -223,6 +225,7 @@ class DatabentoDataLoader:
                             "Cannot load `QuoteTick` and `TradeTick` objects together, "
                             "set `include_trades` to False",
                         )
+
                     return self._pyo3_loader.load_quotes(
                         filepath=str(path),
                         instrument_id=pyo3_instrument_id,
@@ -238,6 +241,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     return self._pyo3_loader.load_bbo_quotes(
@@ -255,6 +259,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     return self._pyo3_loader.load_order_book_depth10(str(path), pyo3_instrument_id)
@@ -268,6 +273,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     return self._pyo3_loader.load_trades(str(path), pyo3_instrument_id)
@@ -287,6 +293,7 @@ class DatabentoDataLoader:
                     data = capsule_to_list(capsule)
                     # Drop encapsulated `CVec` as data is now transferred
                     drop_cvec_pycapsule(capsule)
+
                     return data
                 else:
                     return self._pyo3_loader.load_bars(
@@ -301,12 +308,14 @@ class DatabentoDataLoader:
                 )
                 if as_legacy_cython:
                     return InstrumentStatus.from_pyo3_list(data)
+
                 return data
             case DatabentoSchema.IMBALANCE.value:
                 if as_legacy_cython:
                     raise ValueError(
                         "Cannot load `DatabentoImbalance` as Cython objects, set `as_legacy_cython` to False",
                     )
+
                 return self._pyo3_loader.load_imbalance(
                     filepath=str(path),
                     instrument_id=pyo3_instrument_id,
@@ -317,6 +326,7 @@ class DatabentoDataLoader:
                     raise ValueError(
                         "Cannot load `DatabentoStatistics` as Cython objects, set `as_legacy_cython` to False",
                     )
+
                 return self._pyo3_loader.load_statistics(
                     filepath=str(path),
                     instrument_id=pyo3_instrument_id,

--- a/nautilus_trader/adapters/databento/providers.py
+++ b/nautilus_trader/adapters/databento/providers.py
@@ -115,10 +115,9 @@ class DatabentoInstrumentProvider(InstrumentProvider):
 
         """
         PyCondition.not_empty(instrument_ids, "instrument_ids")
-
         instrument_ids_to_decode: set[str] = {i.value for i in instrument_ids}
-
         dataset = self._check_all_datasets_equal(instrument_ids)
+
         live_client = nautilus_pyo3.DatabentoLiveClient(
             key=self._live_api_key,
             dataset=dataset,
@@ -174,8 +173,10 @@ class DatabentoInstrumentProvider(InstrumentProvider):
 
         async def monitor_inactivity():
             nonlocal last_received_time
+
             while True:
                 await asyncio.sleep(check_interval_secs)
+
                 if started_receiving and (
                     self._clock.timestamp() - last_received_time > timeout_secs
                 ):
@@ -275,16 +276,17 @@ class DatabentoInstrumentProvider(InstrumentProvider):
             end=pd.Timestamp(end, tz=pytz.utc).value if end is not None else None,
             use_exchange_as_venue=use_exchange_as_venue,
         )
-
         instruments = instruments_from_pyo3(pyo3_instruments)
-
         instruments = sorted(instruments, key=lambda x: x.ts_init)
+
         return instruments
 
     def _check_all_datasets_equal(self, instrument_ids: list[InstrumentId]) -> str:
         first_dataset = self._loader.get_dataset_for_venue(instrument_ids[0].venue)
+
         for instrument_id in instrument_ids:
             next_dataset = self._loader.get_dataset_for_venue(instrument_id.venue)
+
             if first_dataset != next_dataset:
                 raise ValueError(
                     "Databento datasets for the provided `instrument_ids` were not equal, "


### PR DESCRIPTION
# Pull Request

Refine databento venue dataset mapping

+ Add DatabentoDataClientConfig.venue_dataset_map which allows to use another dataset than the default for a venue
+ Retain first dataset in the databento publishers.json file as default dataset for a venue

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Not tested, but will likely work, someone with a databento live access should test it
