### PR TITLE
Add consumer for WebSocketClient

### DIFF
--- a/crates/adapters/coinbase_intx/src/websocket/client.rs
+++ b/crates/adapters/coinbase_intx/src/websocket/client.rs
@@ -31,7 +31,7 @@ use nautilus_model::{
     identifiers::InstrumentId,
     instruments::{Instrument, InstrumentAny},
 };
-use nautilus_network::websocket::{MessageReader, WebSocketClient, WebSocketConfig};
+use nautilus_network::websocket::{self, MessageReader, WebSocketClient, WebSocketConfig};
 use reqwest::header::USER_AGENT;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::{Error, Message};
@@ -153,7 +153,7 @@ impl CoinbaseIntxWebSocketClient {
             headers: vec![(USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string())],
             heartbeat: self.heartbeat,
             heartbeat_msg: None,
-            handler: None,
+            handler: websocket::Consumer::Python(None),
             ping_handler: None,
             reconnect_timeout_ms: Some(5_000),
             reconnect_delay_initial_ms: None, // Use default

--- a/crates/network/src/python/websocket.rs
+++ b/crates/network/src/python/websocket.rs
@@ -25,7 +25,7 @@ use tokio_tungstenite::tungstenite::{Message, Utf8Bytes};
 use crate::{
     mode::ConnectionMode,
     ratelimiter::quota::Quota,
-    websocket::{WebSocketClient, WebSocketConfig, WriterCommand},
+    websocket::{Consumer, WebSocketClient, WebSocketConfig, WriterCommand},
 };
 
 // Python exception class for websocket errors
@@ -55,7 +55,7 @@ impl WebSocketConfig {
     ) -> Self {
         Self {
             url,
-            handler: Some(Arc::new(handler)),
+            handler: Consumer::Python(Some(Arc::new(handler))),
             headers,
             heartbeat,
             heartbeat_msg,


### PR DESCRIPTION
# Pull Request

Allow websockets to have Python callback style consumer or Rust stream style consumers

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tests passing
