### PR TITLE
Fix colored logging 

### DIFF
--- a/crates/common/src/enums.rs
+++ b/crates/common/src/enums.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Debug;
 
+use log::Level;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, FromRepr};
 
@@ -288,6 +289,18 @@ impl From<u8> for LogColor {
             5 => Self::Yellow,
             6 => Self::Red,
             _ => Self::Normal,
+        }
+    }
+}
+
+impl From<Level> for LogColor {
+    fn from(value: Level) -> Self {
+        match value {
+            Level::Error => Self::Red,
+            Level::Warn => Self::Yellow,
+            Level::Info => Self::Green,
+            Level::Debug => Self::Blue,
+            Level::Trace => Self::Normal,
         }
     }
 }

--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -772,7 +772,7 @@ mod tests {
 
         assert_eq!(
             log_contents,
-            "{\"timestamp\":\"1970-01-20T02:20:00.000000000Z\",\"trader_id\":\"TRADER-001\",\"level\":\"INFO\",\"color\":\"NORMAL\",\"component\":\"RiskEngine\",\"message\":\"This is a test.\"}\n"
+            "{\"timestamp\":\"1970-01-20T02:20:00.000000000Z\",\"trader_id\":\"TRADER-001\",\"level\":\"INFO\",\"color\":\"GREEN\",\"component\":\"RiskEngine\",\"message\":\"This is a test.\"}\n"
         );
     }
 }

--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -292,11 +292,12 @@ impl Log for Logger {
             } else {
                 get_atomic_clock_static().get_time_ns()
             };
+            let level = record.level();
             let key_values = record.key_values();
-            let color = key_values
+            let color: LogColor = key_values
                 .get("color".into())
                 .and_then(|v| v.to_u64().map(|v| (v as u8).into()))
-                .unwrap_or(LogColor::Normal);
+                .unwrap_or(level.into());
             let component = key_values.get("component".into()).map_or_else(
                 || Ustr::from(record.metadata().target()),
                 |v| Ustr::from(&v.to_string()),
@@ -304,7 +305,7 @@ impl Log for Logger {
 
             let line = LogLine {
                 timestamp,
-                level: record.level(),
+                level,
                 color,
                 component,
                 message: format!("{}", record.args()),


### PR DESCRIPTION
# Pull Request

- color was not showing because key value store was empty for default logging, so we should get the color from log level instead (it was defaulting to `Normal`, which is without color or grey)
