### PR TITLE
Remove catalog basename_template argument

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -162,13 +162,13 @@ impl ParquetDataCatalog {
         let path = self.make_directory_path(type_name, instrument_id);
         std::fs::create_dir_all(&path)?;
         let used_write_mode = write_mode.unwrap_or(ParquetWriteMode::Overwrite);
-        let mut file_path = path.join("data-0.parquet");
+        let mut file_path = path.join("part-0.parquet");
         let mut empty_path = file_path.clone();
         let mut i = 0;
 
         while empty_path.exists() {
             i += 1;
-            let name = format!("data-{i}.parquet");
+            let name = format!("part-{i}.parquet");
             empty_path = path.join(name);
         }
 

--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -537,34 +537,22 @@ The following example shows the above list of Binance `OrderBookDelta` objects b
 catalog.write_data(deltas)
 ```
 
-### Basename template
-
-Nautilus makes no assumptions about how data may be partitioned between files for a particular
-data type and instrument ID.
-
-The `basename_template` keyword argument is an additional optional naming component for the output files.
-The template should include placeholders that will be filled in with actual values at runtime.
-These values can be automatically derived from the data or provided as additional keyword arguments.
-
-For example, using a basename template like `"{date}"` for AUD/USD.SIM quote tick data,
-and assuming `"date"` is a provided or derivable field, could result in a filename like
-`"2023-01-01.parquet"` under the `"quote_tick/audusd.sim/"` catalog directory.
-If not provided, a default naming scheme will be applied. This parameter should be specified as a
-keyword argument, like `write_data(data, basename_template="{date}")`.
-
-:::warning
-Any data which already exists under a filename will be overwritten.
-If a `basename_template` is not provided, then its very likely existing data for the data type and instrument ID will
-be overwritten. To prevent data loss, ensure that the `basename_template` (or the default naming scheme)
-generates unique filenames for different data sets.
-:::
-
 Rust Arrow schema implementations are available for the follow data types (enhanced performance):
 
 - `OrderBookDelta`
 - `QuoteTick`
 - `TradeTick`
 - `Bar`
+
+:::warning
+By default any data which already exists under a filename will be overwritten.
+
+You can use one of the following write mode with catalog.write_data:
+- CatalogWriteMode.OVERWRITE
+- CatalogWriteMode.APPEND
+- CatalogWriteMode.PREPEND
+- CatalogWriteMode.NEWFILE, which will create a file name of the form `part-{i}.parquet` where `i` is an integer starting at 0.
+:::
 
 ### Reading data
 Any stored data can then be read back into memory:

--- a/docs/tutorials/databento_data_catalog.ipynb
+++ b/docs/tutorials/databento_data_catalog.ipynb
@@ -219,7 +219,8 @@
     "\n",
     "from nautilus_trader.adapters.databento.loaders import DatabentoDataLoader\n",
     "from nautilus_trader.model import InstrumentId\n",
-    "from nautilus_trader.persistence.catalog import ParquetDataCatalog"
+    "from nautilus_trader.persistence.catalog import ParquetDataCatalog\n",
+    "from nautilus_trader.persistence.catalog.types import CatalogWriteMode"
    ]
   },
   {
@@ -420,9 +421,7 @@
    "id": "35",
    "metadata": {},
    "source": [
-    "Here we'll organize our data as a file per month, this is an arbitrary choice as a file per day could be just as valid.\n",
-    "\n",
-    "It may also be a good idea to create a function which can return the correct `basename_template` value for a given chunk of data."
+    "Finally we'll save the data into the catalog. You can use one of the following catalog write modes: CalalogWriteMode.OVERWRITE, CatalogWriteMode.APPEND, CatalogWriteMode.PREPEND or CalalogWriteMode.NEWFILE, which will create a file name of the form `part-{i}.parquet` where `i` is an integer starting at 0."
    ]
   },
   {
@@ -433,7 +432,7 @@
    "outputs": [],
    "source": [
     "# Write data to catalog\n",
-    "catalog.write_data(trades, basename_template=\"2024-01\")"
+    "catalog.write_data(trades, mode=CatalogWriteMode.OVERWRITE)"
    ]
   },
   {


### PR DESCRIPTION
# Pull Request

Remove catalog basename_template argument

This argument is not used in general and can cause problems if modified wih update_catalog in data requests, so better to remove it.

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this change been tested?

Existing test passing
