### PR TITLE
Improve consistency of environment variables for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ build-wheel:
 build-wheel-debug:
 	BUILD_MODE=debug uv build --wheel
 
+.PHONY: build-dry-run
+build-dry-run:
+	DRY_RUN=true uv run --active --no-sync build.py
+
 .PHONY: clean
 clean:
 	find . -type d -name "__pycache" -print0 | xargs -0 rm -rf
@@ -55,7 +59,7 @@ format:
 
 .PHONY: pre-commit
 pre-commit:
-	uv run --active --no-sync pre-commit run --all-files
+	CC=clang CXX=clang++ VIRTUAL_ENV="/home/twitu/Code/nautilus_trader/.venv" uv run --active --no-sync pre-commit run --all-files
 
 .PHONY: ruff
 ruff:

--- a/build.py
+++ b/build.py
@@ -41,6 +41,8 @@ PARALLEL_BUILD = os.getenv("PARALLEL_BUILD", "true").lower() == "true"
 COPY_TO_SOURCE = os.getenv("COPY_TO_SOURCE", "true").lower() == "true"
 # If PyO3 only then don't build C extensions to reduce compilation time
 PYO3_ONLY = os.getenv("PYO3_ONLY", "").lower() != ""
+# If dry run only print the commands that would be executed
+DRY_RUN = bool(os.getenv("DRY_RUN", ""))
 
 # Precision mode configuration
 # https://nautilustrader.io/docs/nightly/getting_started/installation#precision-mode
@@ -120,6 +122,18 @@ RUST_LIB_PATHS: list[Path] = [
 RUST_LIBS: list[str] = [str(path) for path in RUST_LIB_PATHS]
 
 
+os.environ["CARGO_LOG"] = "cargo::core::compiler::fingerprint=info"
+os.environ["RUST_LOG"] = "trace"
+print(os.environ)
+
+
+def _set_feature_flags() -> list[str]:
+    if HIGH_PRECISION:
+        return ["--all-features"]
+    else:
+        return ["--features", "ffi,python,extension-module"]
+
+
 def _build_rust_libs() -> None:
     print("Compiling Rust libraries...")
 
@@ -130,14 +144,11 @@ def _build_rust_libs() -> None:
 
         build_options = " --release" if BUILD_MODE == "release" else ""
 
-        if HIGH_PRECISION:
-            features = ["--all-features"]
-        else:
-            # Enable features needed for main build, but not high_precision
-            features = ["--features", "ffi,python,extension-module"]
+        features = _set_feature_flags()
 
         cmd_args = [
             "cargo",
+            "-vv",
             "build",
             *build_options.split(),
             *features,
@@ -372,6 +383,38 @@ def _strip_unneeded_symbols() -> None:
         raise RuntimeError(f"Error when stripping symbols.\n{e}") from e
 
 
+def show_rustanalyzer_settings() -> None:
+    """
+    Show appropriate vscode settings for the build.
+    """
+    import json
+
+    # Set environment variables
+    settings: dict[str, object] = {}
+    for key in [
+        "rust-analyzer.check.extraEnv",
+        "rust-analyzer.runnables.extraEnv",
+        "rust-analyzer.cargo.features",
+    ]:
+        settings[key] = {
+            "CC": os.environ["CC"],
+            "CXX": os.environ["CXX"],
+            "VIRTUAL_ENV": os.environ["VIRTUAL_ENV"],
+        }
+
+    # Set features
+    features = _set_feature_flags()
+    if features[0] == "--all-features":
+        settings["rust-analyzer.cargo.features"] = "all"
+        settings["rust-analyzer.check.features"] = "all"
+    else:
+        settings["rust-analyzer.cargo.features"] = features[1].split(",")
+        settings["rust-analyzer.check.features"] = features[1].split(",")
+
+    print("Set these rust analyzer settings in .vscode/settings.json")
+    print(json.dumps(settings, indent=2))
+
+
 def build() -> None:
     """
     Construct the extensions and distribution.
@@ -435,9 +478,14 @@ if __name__ == "__main__":
     print_env_var_if_exists("LDFLAGS")
     print_env_var_if_exists("LD_LIBRARY_PATH")
     print_env_var_if_exists("RUSTFLAGS")
+    print_env_var_if_exists("DRY_RUN")
 
-    print("\nStarting build...")
-    ts_start = dt.datetime.now(dt.UTC)
-    build()
-    print(f"Build time: {dt.datetime.now(dt.UTC) - ts_start}")
-    print("\033[32m" + "Build completed" + "\033[0m")
+    if DRY_RUN:
+        print("Dry run")
+        show_rustanalyzer_settings()
+    else:
+        print("\nStarting build...")
+        ts_start = dt.datetime.now(dt.UTC)
+        build()
+        print(f"Build time: {dt.datetime.now(dt.UTC) - ts_start}")
+        print("\033[32m" + "Build completed" + "\033[0m")

--- a/build.py
+++ b/build.py
@@ -122,11 +122,6 @@ RUST_LIB_PATHS: list[Path] = [
 RUST_LIBS: list[str] = [str(path) for path in RUST_LIB_PATHS]
 
 
-os.environ["CARGO_LOG"] = "cargo::core::compiler::fingerprint=info"
-os.environ["RUST_LOG"] = "trace"
-print(os.environ)
-
-
 def _set_feature_flags() -> list[str]:
     if HIGH_PRECISION:
         return ["--all-features"]
@@ -148,7 +143,6 @@ def _build_rust_libs() -> None:
 
         cmd_args = [
             "cargo",
-            "-vv",
             "build",
             *build_options.split(),
             *features,


### PR DESCRIPTION
# Pull Request

Inconsistent environment variables cause frequent re-builds between
* make build-debug
* rust analyzer cargo check
* rust analyzer cargo test
* pre-commit
* cargo in cli

```
   0.359245532s  INFO prepare_target{force=false package_id=pyo3-build-config v0.24.1 target="build-script-build"}: cargo::core::compiler::fingerprint:     dirty: EnvVarChanged { name: "VIRTUAL_ENV", old_value: None, new_value: Some("/home/twitu/Code/nautilus_trader/.venv") }

       Dirty pyo3-build-config v0.24.1: the env variable VIRTUAL_ENV changed
[pyo3-build-config 0.24.1] cargo:rerun-if-env-changed=VIRTUAL_ENV
```

This PR adds a dry run feature that sets the appropriate environment variables in the terminal using `make build-dry-run`. It also prints the appropriate settings for vscode rust analyzer that can be set manually in `.vscode/settings.json`. These are the main settings.

```
{
  "rust-analyzer.check.extraEnv": {
    "CC": "clang",
    "CXX": "clang++",
    "VIRTUAL_ENV": "/home/twitu/Code/nautilus_trader/.venv"
  },
  "rust-analyzer.runnables.extraEnv": {
    "CC": "clang",
    "CXX": "clang++",
    "VIRTUAL_ENV": "/home/twitu/Code/nautilus_trader/.venv"
  },
  "rust-analyzer.cargo.features": "all",
  "rust-analyzer.check.features": "all"
}
```

This may not be consistent across OS and architecture. You can debug your build by running

```
export CARGO_LOG="cargo::core::compiler::fingerprint=info"
export RUST_LOG=trace
cargo build -vv <flags>
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

* make build-debug
* dummy change in common crate - triggers cargo check
* make build-debug (200 secs)
* make consistent build environment
* dummy change in common crate - triggers cargo check
* make build-debug (48 secs)


