### PR TITLE
Add log flush at end of backtest

### DIFF
--- a/crates/common/src/ffi/logging.rs
+++ b/crates/common/src/ffi/logging.rs
@@ -188,3 +188,12 @@ pub unsafe extern "C" fn logging_log_sysinfo(component_ptr: *const c_char) {
 pub extern "C" fn logger_drop(log_guard: LogGuard_API) {
     drop(log_guard);
 }
+
+/// Explicitly flush any buffered logs in the logging system.
+///
+/// This is useful when logs need to be flushed at specific points in time,
+/// such as at the end of a backtest run, especially when the log volume is small.
+#[unsafe(no_mangle)]
+pub extern "C" fn logger_flush() {
+    log::logger().flush();
+}

--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -427,7 +427,9 @@ impl Logger {
         while let Ok(event) = rx.recv() {
             match event {
                 LogEvent::Flush => {
-                    break;
+                    if let Some(ref mut writer) = file_writer_opt {
+                        writer.flush();
+                    }
                 }
                 LogEvent::Log(line) => {
                     let component_level = component_level.get(&line.component);

--- a/crates/common/src/python/logging.rs
+++ b/crates/common/src/python/logging.rs
@@ -180,3 +180,13 @@ pub fn py_logging_clock_set_realtime_mode() {
 pub fn py_logging_clock_set_static_time(time_ns: u64) {
     logging_clock_set_static_time(time_ns);
 }
+
+/// Explicitly flush any buffered logs in the logging system.
+///
+/// This is useful when logs need to be flushed at specific points in time,
+/// such as at the end of a backtest run, especially when the log volume is small.
+#[pyfunction]
+#[pyo3(name = "flush_logs")]
+pub fn py_flush_logs() {
+    log::logger().flush();
+}

--- a/crates/common/src/python/mod.rs
+++ b/crates/common/src/python/mod.rs
@@ -68,6 +68,7 @@ pub fn common(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         logging::py_logging_clock_set_static_time,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(logging::py_flush_logs, m)?)?;
     m.add_function(wrap_pyfunction!(xrate::py_get_exchange_rate, m)?)?;
 
     Ok(())

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -21,6 +21,7 @@ import pandas as pd
 from nautilus_trader.accounting.error import AccountError
 from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.common import Environment
+from nautilus_trader.common.component import flush_logs
 from nautilus_trader.common.component import is_logging_pyo3
 from nautilus_trader.common.config import InvalidConfiguration
 from nautilus_trader.config import BacktestEngineConfig
@@ -985,6 +986,7 @@ cdef class BacktestEngine:
 
         if not streaming:
             self.end()
+            flush_logs()
 
     def end(self):
         """

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -82,6 +82,7 @@ from nautilus_trader.core.rust.common cimport log_color_to_cstr
 from nautilus_trader.core.rust.common cimport log_level_from_cstr
 from nautilus_trader.core.rust.common cimport log_level_to_cstr
 from nautilus_trader.core.rust.common cimport logger_drop
+from nautilus_trader.core.rust.common cimport logger_flush
 from nautilus_trader.core.rust.common cimport logger_log
 from nautilus_trader.core.rust.common cimport logging_clock_set_realtime_mode
 from nautilus_trader.core.rust.common cimport logging_clock_set_static_mode
@@ -1222,6 +1223,21 @@ cpdef bint is_logging_pyo3():
 cpdef void set_logging_pyo3(bint value):
     global LOGGING_PYO3
     LOGGING_PYO3 = value
+
+
+cpdef void flush_logs():
+    """
+    Explicitly flush any buffered logs in the logging system.
+
+    This is useful when logs need to be flushed at specific points in time,
+    such as at the end of a backtest run, especially when the log volume is small.
+    """
+    if LOGGING_PYO3:
+        # For PyO3 implementation, we need to call the Rust logger's flush method
+        nautilus_pyo3.flush_logs()
+    else:
+        # For non-PyO3 implementation, we directly call the logger_flush function
+        logger_flush()
 
 
 cdef class Logger:

--- a/nautilus_trader/core/includes/common.h
+++ b/nautilus_trader/core/includes/common.h
@@ -605,6 +605,14 @@ void logging_log_sysinfo(const char *component_ptr);
 void logger_drop(struct LogGuard_API log_guard);
 
 /**
+ * Explicitly flush any buffered logs in the logging system.
+ *
+ * This is useful when logs need to be flushed at specific points in time,
+ * such as at the end of a backtest run, especially when the log volume is small.
+ */
+void logger_flush(void);
+
+/**
  * # Safety
  *
  * - Assumes `name_ptr` is borrowed from a valid Python UTF-8 `str`.

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -110,6 +110,8 @@ def log_header(
 
 def log_sysinfo(component: str) -> None: ...
 
+def flush_logs() -> None: ...
+
 # Messaging
 
 class BusMessage:

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -428,6 +428,12 @@ cdef extern from "../includes/common.h":
     # Flushes global logger buffers of any records.
     void logger_drop(LogGuard_API log_guard);
 
+    # Explicitly flush any buffered logs in the logging system.
+    #
+    # This is useful when logs need to be flushed at specific points in time,
+    # such as at the end of a backtest run, especially when the log volume is small.
+    void logger_flush();
+
     # # Safety
     #
     # - Assumes `name_ptr` is borrowed from a valid Python UTF-8 `str`.


### PR DESCRIPTION
# Pull Request

Add log flush at end of backtest

Allows to flush logs to files even the amount of logs is small

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Can be observed on databento_option_greeks.py with following config

```python
logging = LoggingConfig(
  bypass_logging=False,
  log_colors=True,
  log_level="WARN",
  log_level_file="WARN",
  log_directory=".",
  log_file_format=None,  # "json" or None
  log_file_name="databento_option_greeks",
  clear_log_file=True,
  print_config=False,
  use_pyo3=False,
)

engine_config = BacktestEngineConfig(
  logging=logging,
  actors=actors,
  strategies=strategies,
  streaming=(streaming if stream_data else None),
  catalogs=catalogs,
)
```
