### PR TITLE
Add flush of log file at end of backtest

### DIFF
--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -430,6 +430,13 @@ impl Logger {
                     break;
                 }
                 LogEvent::Log(line) => {
+                    if line.component == Ustr::from("__FLUSH__") {
+                        if let Some(ref mut writer) = file_writer_opt {
+                            writer.flush();
+                        }
+                        continue;
+                    }
+
                     let component_level = component_level.get(&line.component);
 
                     // Check if the component exists in level_filters,

--- a/crates/common/src/logging/writer.rs
+++ b/crates/common/src/logging/writer.rs
@@ -371,6 +371,11 @@ impl LogWriter for FileWriter {
             Ok(()) => {}
             Err(e) => tracing::error!("Error flushing file: {e:?}"),
         }
+
+        match self.buf.get_ref().sync_all() {
+            Ok(()) => {}
+            Err(e) => tracing::error!("Error syncing file: {e:?}"),
+        }
     }
 
     fn enabled(&self, line: &LogLine) -> bool {

--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -238,6 +238,8 @@ logging = LoggingConfig(
     log_directory=".",
     log_file_format=None,  # 'json' or None
     log_file_name="databento_option_greeks",
+    clear_log_file=True,
+    use_pyo3=False,
 )
 
 engine_config = BacktestEngineConfig(

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -986,6 +986,10 @@ cdef class BacktestEngine:
         if not streaming:
             self.end()
 
+            # Special signal through the component name to ensure flush of logs to file in rust logger.rs
+            logger = Logger("__FLUSH__")
+            logger.error("")
+
     def end(self):
         """
         Manually end the backtest.

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -177,22 +177,23 @@ class NautilusKernel:
         self._log_guard: nautilus_pyo3.LogGuard | LogGuard | None = None
         logging: LoggingConfig = config.logging or LoggingConfig()
 
+        # Clear log file if requested
+        if logging.clear_log_file and logging.log_directory and logging.log_file_name:
+            file_path = Path(
+                logging.log_directory,
+                f"{logging.log_file_name}.{'log' if logging.log_file_format is None else 'json'}",
+            )
+
+            if file_path.exists():
+                # Truncate log file to zero length and reset metadata
+                file_path.touch()
+                file_path.open("w").close()
+
         if not is_logging_initialized():
             if "RUST_LOG" not in os.environ:
                 os.environ["RUST_LOG"] = "off"
 
             if not logging.bypass_logging:
-                if logging.clear_log_file and logging.log_directory and logging.log_file_name:
-                    file_path = Path(
-                        logging.log_directory,
-                        f"{logging.log_file_name}.{'log' if logging.log_file_format is None else 'json'}",
-                    )
-
-                    if file_path.exists():
-                        # Truncate log file to zero length and reset metadata
-                        file_path.touch()
-                        file_path.open("w").close()
-
                 if logging.use_pyo3:
                     set_logging_pyo3(True)
 


### PR DESCRIPTION
# Pull Request

Add log flush at end of backtest

Allows to flush logs to files even the amount of logs is small

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Can be observed on databento_option_greeks.py
