### PR TITLE
Fix RequestInstrument in query_catalog

### DIFF
--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1674,6 +1674,13 @@ cdef class DataEngine(Component):
                 f"data[-1].ts_init={data[-1].ts_init}, {ts_now=}",
             )
 
+        if isinstance(request, RequestInstrument):
+            if len(data) == 0:
+                self._log.error(f"Cannot find instrument for {request.instrument_id}")
+                return
+
+            data = data[0]
+
         params = request.params.copy()
         params["update_catalog_mode"] = None
 

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -75,6 +75,7 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.portfolio.portfolio import Portfolio
@@ -2229,7 +2230,7 @@ class TestDataEngine:
         # Assert
         assert self.data_engine.request_count == 1
         assert len(handler) == 1
-        assert len(handler[0].data) == 1
+        assert isinstance(handler[0].data, Instrument)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Failing on windows")
     def test_request_instruments_for_venue_when_catalog_registered(self):


### PR DESCRIPTION
# Pull Request

Fix RequestInstrument in query_catalog

Query catalog was returning a list for instrument requests instead of a single instrument as implemented by live market data clients.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

Tested on prototype, updated test
