### PR TITLE
Add support for historical data download with backtest node

### DIFF
--- a/examples/backtest/databento_backtest_with_data_client.py
+++ b/examples/backtest/databento_backtest_with_data_client.py
@@ -1,0 +1,258 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.17.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Databento Data Client with Backtest Node
+#
+# This example demonstrates how to use the Databento data client with a backtest node.
+
+# %% [markdown]
+# ## Imports
+
+# %%
+# Note: Use the python extension jupytext to be able to open this python file in jupyter as a notebook
+
+# %%
+import asyncio
+
+import nautilus_trader.adapters.databento.data_utils as db_data_utils
+from nautilus_trader.adapters.databento.config import DatabentoDataClientConfig
+from nautilus_trader.adapters.databento.data_utils import databento_data
+from nautilus_trader.adapters.databento.data_utils import load_catalog
+from nautilus_trader.adapters.databento.factories import DatabentoLiveDataClientFactory
+from nautilus_trader.backtest.config import BacktestEngineConfig
+from nautilus_trader.backtest.config import BacktestRunConfig
+from nautilus_trader.backtest.config import BacktestVenueConfig
+from nautilus_trader.backtest.node import BacktestNode
+from nautilus_trader.common.config import LoggingConfig
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import ImportableStrategyConfig
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.datetime import unix_nanos_to_iso8601
+from nautilus_trader.live.config import RoutingConfig
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.persistence.config import DataCatalogConfig
+from nautilus_trader.trading.strategy import Strategy
+
+
+# %%
+# We need to use nest_asyncio in a jupyter notebook to be able to run async code as sync for market data
+# requests in a backtest
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
+    pass  # No loop running
+else:
+    import nest_asyncio
+
+    nest_asyncio.apply()
+
+# %% [markdown]
+# ## Parameters
+
+# %%
+# Set the data path for Databento data
+# DATA_PATH = "/path/to/your/data"  # Use your own value here
+# db_data_utils.DATA_PATH = DATA_PATH
+
+catalog_folder = "options_catalog2"
+catalog = load_catalog(catalog_folder)
+
+future_symbols = ["ESM4"]
+
+# Small amount of data for testing
+start_time = "2024-05-09T10:00"
+end_time = "2024-05-09T10:05"
+
+# # A valid databento key can be entered here (or as an env variable of the same name)
+DATABENTO_API_KEY = None
+db_data_utils.init_databento_client(DATABENTO_API_KEY)
+
+# # Ensure data is available
+futures_data = databento_data(
+    future_symbols,
+    start_time,
+    end_time,
+    "definition",  # "ohlcv-1m"
+    "futures",
+    catalog_folder,
+)
+
+# %% [markdown]
+# ## Strategy
+
+
+# %%
+class FuturesStrategyConfig(StrategyConfig, frozen=True):
+    """
+    Configuration for the FuturesStrategy.
+    """
+
+    future_id: InstrumentId
+
+
+class FuturesStrategy(Strategy):
+    """
+    A simple futures trading strategy that subscribes to bar data.
+    """
+
+    def __init__(self, config: FuturesStrategyConfig) -> None:
+        super().__init__(config=config)
+        self.bar_type: BarType | None = None
+        self.position_opened = False
+
+    def on_start(self) -> None:
+        self.bar_type = BarType.from_str(f"{self.config.future_id}-1-MINUTE-LAST-EXTERNAL")
+
+        # Request instrument
+        now = self.clock.utc_now()
+        self.request_instrument(self.bar_type.instrument_id, end=now)
+        # instrument = self.cache.instrument(self.bar_type.instrument_id)
+        # self.log.warning(f"{instrument=}")
+
+        # Subscribe to bar data
+        self.subscribe_bars(self.bar_type)
+
+        self.user_log(f"Strategy started, subscribed to {self.bar_type}")
+
+    def on_bar(self, bar: Bar) -> None:
+        self.user_log(
+            f"Bar received: ts_init={unix_nanos_to_iso8601(bar.ts_init)}, close={bar.close}",
+        )
+
+        # Simple strategy: open a position on the first bar
+        if not self.position_opened:
+            self.user_log("Opening a position")
+            self.submit_market_order(self.config.future_id, 1)
+            self.position_opened = True
+
+    def submit_market_order(self, instrument_id: InstrumentId, quantity: int) -> None:
+        order = self.order_factory.market(
+            instrument_id=instrument_id,
+            order_side=(OrderSide.BUY if quantity > 0 else OrderSide.SELL),
+            quantity=Quantity.from_int(abs(quantity)),
+        )
+        self.submit_order(order)
+        self.user_log(f"Submitted order: {order}")
+
+    def user_log(self, msg: str) -> None:
+        self.log.warning(str(msg), color=LogColor.GREEN)
+
+    def on_stop(self) -> None:
+        self.unsubscribe_bars(self.bar_type)
+        self.user_log("Strategy stopped")
+
+
+# %% [markdown]
+# ## Backtest Configuration
+
+# %%
+# Create BacktestEngineConfig
+strategies = [
+    ImportableStrategyConfig(
+        strategy_path=FuturesStrategy.fully_qualified_name(),
+        config_path=FuturesStrategyConfig.fully_qualified_name(),
+        config={
+            "future_id": InstrumentId.from_str(f"{future_symbols[0]}.XCME"),
+        },
+    ),
+]
+
+logging = LoggingConfig(
+    bypass_logging=False,
+    log_colors=True,
+    log_level="WARN",
+    log_level_file="WARN",
+    log_directory=".",
+    log_file_format=None,
+    log_file_name="databento_backtest_with_data_client",
+    clear_log_file=True,
+    print_config=False,
+    use_pyo3=False,
+)
+
+# Configure the data catalog
+catalogs = [
+    DataCatalogConfig(
+        path=catalog.path,
+    ),
+]
+
+engine_config = BacktestEngineConfig(
+    logging=logging,
+    strategies=strategies,
+    # catalogs=catalogs,
+)
+
+# Create BacktestRunConfig
+venues = [
+    BacktestVenueConfig(
+        name="XCME",
+        oms_type="NETTING",
+        account_type="MARGIN",
+        base_currency="USD",
+        starting_balances=["1_000_000 USD"],
+    ),
+]
+
+databento_config = DatabentoDataClientConfig(
+    api_key=None,  # 'DATABENTO_API_KEY' env var
+    routing=RoutingConfig(
+        default=False,
+        venues=frozenset(["XCME"]),
+    ),
+)
+
+config = BacktestRunConfig(
+    engine=engine_config,
+    venues=venues,
+    data=[],  # Empty data list since we're using data clients
+    start=start_time,
+    end="2024-05-09T10:10",
+    data_clients={"databento-001": databento_config},
+)
+
+configs = [config]
+
+# Create the backtest node
+node = BacktestNode(configs=configs)
+
+# Register the Databento data client factory
+node.add_data_client_factory("databento", DatabentoLiveDataClientFactory)
+
+# Build the node (this will create and register the data clients)
+node.build()
+
+# node.get_engine(configs[0].id).kernel.data_engine.default_client
+# node.get_engine(configs[0].id).kernel.data_engine.routing_map
+
+# %%
+# Run the backtest
+node.run()
+
+# %%
+# # Display results
+# engine = node.get_engine(configs[0].id)
+# engine.trader.generate_order_fills_report()
+# engine.trader.generate_positions_report()
+# engine.trader.generate_account_report(Venue("GLBX"))
+
+# %%
+# # Clean up
+# node.dispose()

--- a/examples/backtest/databento_option_greeks.py
+++ b/examples/backtest/databento_option_greeks.py
@@ -58,8 +58,9 @@ from nautilus_trader.trading.strategy import Strategy
 # ## parameters
 
 # %%
+# Set the data path for Databento data
 # import nautilus_trader.adapters.databento.data_utils as db_data_utils
-# from option_trader import DATA_PATH # personal library, use your own value here
+# DATA_PATH = "/path/to/your/data"  # Use your own value here
 # db_data_utils.DATA_PATH = DATA_PATH
 
 catalog_folder = "options_catalog"
@@ -73,7 +74,7 @@ option_symbols = ["ESM4 P5230", "ESM4 P5250"]
 start_time = "2024-05-09T10:00"
 end_time = "2024-05-09T10:05"
 
-# a valid databento key can be entered here (or as an env variable of the same name)
+# A valid databento key can be entered here (or as an env variable of the same name)
 # DATABENTO_API_KEY = None
 # db_data_utils.init_databento_client(DATABENTO_API_KEY)
 
@@ -272,7 +273,7 @@ engine_config = BacktestEngineConfig(
 # BacktestRunConfig
 
 data = [
-    # TODO using instrument_id and bar_spec only, or instrument_ids and bar_spec only, or bar_types only
+    # # TODO using instrument_id and bar_spec only, or instrument_ids and bar_spec only, or bar_types only
     BacktestDataConfig(
         data_cls=Bar,
         catalog_path=catalog.path,

--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -49,8 +49,9 @@ from nautilus_trader.trading.strategy import Strategy
 # ## parameters
 
 # %%
+# Set the data path for Databento data
 # import nautilus_trader.adapters.databento.data_utils as db_data_utils
-# from option_trader import DATA_PATH # personal library, use your own value here
+# DATA_PATH = "/path/to/your/data"  # Use your own value here
 # db_data_utils.DATA_PATH = DATA_PATH
 
 catalog_folder = "historical_bars_catalog"
@@ -63,7 +64,7 @@ future_symbols = ["ESU4"]
 start_time = "2024-07-01T23:40"
 end_time = "2024-07-02T00:10"
 
-# a valid databento key can be entered here (or as an env variable of the same name)
+# A valid databento key can be entered here (or as an env variable of the same name)
 # DATABENTO_API_KEY = None
 # db_data_utils.init_databento_client(DATABENTO_API_KEY)
 

--- a/examples/live/databento/databento_historical_data.py
+++ b/examples/live/databento/databento_historical_data.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.17.0
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -43,9 +43,9 @@ from nautilus_trader.trading.strategy import Strategy
 # ## parameters
 
 # %%
+# Set the data path for Databento data
 # import nautilus_trader.adapters.databento.data_utils as db_data_utils
-# from nautilus_trader.adapters.databento.data_utils import init_databento_client
-# from option_trader import DATA_PATH, DATABENTO_API_KEY # personal library, use your own values especially for DATABENTO_API_KEY
+# DATA_PATH = "/path/to/your/data"  # Use your own value here
 # db_data_utils.DATA_PATH = DATA_PATH
 
 catalog_folder = "options_catalog"
@@ -57,9 +57,9 @@ option_symbols = ["ESM4 P5230", "ESM4 P5250"]
 start_time = "2024-05-09T10:00"
 end_time = "2024-05-09T10:05"
 
-# a valid databento key can be entered here, the example below runs with already saved test data
-# db_data_utils.DATABENTO_API_KEY = DATABENTO_API_KEY
-# init_databento_client()
+# A valid databento key can be entered here (or as an env variable of the same name)
+# DATABENTO_API_KEY = None
+# db_data_utils.init_databento_client(DATABENTO_API_KEY)
 
 # https://databento.com/docs/schemas-and-data-formats/whats-a-schema
 futures_data = databento_data(

--- a/nautilus_trader/adapters/databento/data.py
+++ b/nautilus_trader/adapters/databento/data.py
@@ -770,8 +770,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = start or available_end - pd.Timedelta(days=2)
         end = end or available_end
+        start = start or end - pd.Timedelta(days=1)
 
         self._log.info(
             f"Requesting {instrument_id} instrument status: "
@@ -803,8 +803,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = start or available_end - pd.Timedelta(days=2)
         end = end or available_end
+        start = start or end - pd.Timedelta(days=1)
 
         self._log.info(
             f"Requesting {instrument_id} imbalance: "
@@ -834,8 +834,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = start or available_end - pd.Timedelta(days=2)
         end = end or available_end
+        start = start or end - pd.Timedelta(days=1)
 
         self._log.info(
             f"Requesting {instrument_id} statistics: "
@@ -861,8 +861,9 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(request.instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = request.start or available_end - pd.Timedelta(days=2)
+        # NOTE: instruments are "published" every day at midnight
         end = request.end or available_end
+        start = request.start or end - pd.Timedelta(days=1)
 
         self._log.info(
             f"Requesting {request.instrument_id} instrument definition: "
@@ -891,8 +892,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(request.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = request.start or available_end - pd.Timedelta(days=2)
         end = request.end or available_end
+        start = request.start or end - pd.Timedelta(days=1)
 
         self._log.info(
             f"Requesting {request.venue} instrument definitions: "
@@ -921,8 +922,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(request.instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = request.start or available_end - pd.Timedelta(days=1)
         end = request.end or available_end
+        start = request.start or end - pd.Timedelta(days=1)
 
         if request.limit > 0:
             self._log.warning(
@@ -959,8 +960,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(request.instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = request.start or available_end - pd.Timedelta(days=1)
         end = request.end or available_end
+        start = request.start or end - pd.Timedelta(days=1)
 
         if request.limit > 0:
             self._log.warning(
@@ -987,8 +988,8 @@ class DatabentoDataClient(LiveMarketDataClient):
         dataset: Dataset = self._loader.get_dataset_for_venue(request.bar_type.instrument_id.venue)
         _, available_end = await self._get_dataset_range(dataset)
 
-        start = request.start or available_end - pd.Timedelta(days=1)
         end = request.end or available_end
+        start = request.start or end - pd.Timedelta(days=1)
 
         if request.limit > 0:
             self._log.warning(

--- a/nautilus_trader/adapters/databento/data_utils.py
+++ b/nautilus_trader/adapters/databento/data_utils.py
@@ -209,6 +209,7 @@ def databento_data(
             data = load_databento_data(data_file) if load_databento_files_if_exist else None
     else:
         data = None
+        data_file = None
 
     result = {
         "symbols": symbols,
@@ -226,7 +227,7 @@ def databento_data(
         del result["databento_data_file"]
         del result["databento_data"]
 
-    if to_catalog and schema != "definition":
+    if to_catalog:
         catalog_data = save_data_to_catalog(
             *folders,
             definition_file=definition_file,

--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -33,6 +33,7 @@ from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.datetime import dt_to_unix_nanos
 from nautilus_trader.data.config import DataEngineConfig
 from nautilus_trader.execution.config import ExecEngineConfig
+from nautilus_trader.live.config import LiveDataClientConfig
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.identifiers import InstrumentId
@@ -41,7 +42,7 @@ from nautilus_trader.risk.config import RiskEngineConfig
 from nautilus_trader.system.config import NautilusKernelConfig
 
 
-def parse_filters_expr(s: str | None):
+def parse_filters_expr(s: str | None) -> Any:
     # TODO (bm) - could we do this better, probably requires writing our own parser?
     """
     Parse a pyarrow.dataset filter expression from a string.
@@ -406,6 +407,8 @@ class BacktestRunConfig(NautilusConfig, frozen=True):
     end : datetime or str or int, optional
         The end datetime (UTC) for the backtest run.
         If ``None`` engine runs to the end of the data.
+    data_clients : dict[str, LiveDataClientConfig], optional
+        The data clients configuration for the backtest run.
 
     Notes
     -----
@@ -423,6 +426,7 @@ class BacktestRunConfig(NautilusConfig, frozen=True):
     dispose_on_completion: bool = True
     start: str | int | None = None
     end: str | int | None = None
+    data_clients: dict[str, LiveDataClientConfig] | None = None
 
 
 class SimulationModuleConfig(ActorConfig, frozen=True):

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -1658,6 +1658,16 @@ cdef class BacktestEngine:
             )
             self._kernel.data_engine.register_client(client)
 
+    def set_default_market_data_client(self) -> None:
+        cdef ClientId client_id = ClientId("default")
+        client = BacktestMarketDataClient(
+            client_id=client_id,
+            msgbus=self._kernel.msgbus,
+            cache=self._kernel.cache,
+            clock=self._kernel.clock,
+        )
+        self._kernel.data_engine.register_default_client(client)
+
 
 cdef class BacktestDataIterator:
     def __init__(self, empty_data_callback: Callable[[str, uint64_t], None] | None = None) -> None:

--- a/nautilus_trader/backtest/node_builder.py
+++ b/nautilus_trader/backtest/node_builder.py
@@ -1,0 +1,133 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import asyncio
+
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.common.component import Logger
+from nautilus_trader.config import ImportableConfig
+from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.live.config import LiveDataClientConfig
+from nautilus_trader.live.factories import LiveDataClientFactory
+from nautilus_trader.model.identifiers import Venue
+
+
+class BacktestNodeBuilder:
+    """
+    Provides building services for a backtest node.
+
+    Parameters
+    ----------
+    engine : BacktestEngine
+        The backtest engine for the node.
+    logger : Logger
+        The logger for building clients.
+
+    """
+
+    def __init__(
+        self,
+        engine: BacktestEngine,
+        logger: Logger,
+    ) -> None:
+        self._engine = engine
+        self._log = logger
+        self._data_factories: dict[str, type[LiveDataClientFactory]] = {}
+
+    def add_data_client_factory(self, name: str, factory: type[LiveDataClientFactory]) -> None:
+        """
+        Add the given data client factory to the builder.
+
+        Parameters
+        ----------
+        name : str
+            The name of the client.
+        factory : type[LiveDataClientFactory]
+            The factory to add.
+
+        Raises
+        ------
+        ValueError
+            If `name` is not a valid string.
+        KeyError
+            If `name` has already been added.
+
+        """
+        if not issubclass(factory, LiveDataClientFactory):
+            self._log.error(f"Factory was not of type `LiveDataClientFactory`, was {factory}")
+            return
+
+        self._data_factories[name] = factory
+
+    def build_data_clients(
+        self,
+        config: dict[str, LiveDataClientConfig],
+    ) -> None:
+        """
+        Build the data clients with the given configuration.
+
+        Parameters
+        ----------
+        config : dict[str, ImportableConfig | LiveExecClientConfig]
+            The execution clients configuration.
+
+        """
+        PyCondition.not_none(config, "config")
+
+        if not config:
+            self._log.warning("No `data_clients` configuration found")
+
+        for parts, cfg in config.items():
+            name = parts.partition("-")[0]
+            self._log.info(f"Building data client for {name}")
+
+            if isinstance(cfg, ImportableConfig):
+                if name not in self._data_factories and cfg.factory is not None:
+                    self._data_factories[name] = cfg.factory.create()
+
+                client_config: LiveDataClientConfig = cfg.create()
+            else:
+                client_config: LiveDataClientConfig = cfg  # type: ignore
+
+            if name not in self._data_factories:
+                self._log.error(f"No `LiveDataClientFactory` registered for {name}")
+                continue
+
+            factory = self._data_factories[name]
+
+            # We create an event loop here only to satisfy the linters, it won't be used
+            client = factory.create(
+                loop=asyncio.new_event_loop(),
+                name=name,
+                config=client_config,
+                msgbus=self._engine.kernel.msgbus,
+                cache=self._engine.kernel.cache,
+                clock=self._engine.kernel.clock,
+            )
+            client._is_sync = True
+            self._engine.kernel.data_engine.register_client(client)
+
+            # Default client config
+            if client_config.routing.default:
+                self._engine.kernel.data_engine.register_default_client(client)
+
+            # Venue routing config
+            venues: frozenset[str] = client_config.routing.venues or frozenset()
+
+            for venue in venues:
+                if not isinstance(venue, Venue):
+                    venue = Venue(venue)
+
+                self._engine.kernel.data_engine.register_venue_routing(client, venue)

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -193,7 +193,6 @@ cdef class DataEngine(Component):
 
 # -- REQUEST HANDLERS -----------------------------------------------------------------------------
 
-    cpdef tuple[datetime, object] _catalogs_timestamp_bound(self, type data_cls, InstrumentId instrument_id=*, BarType bar_type=*, str ts_column=*, bint is_last=*)
     cpdef void _handle_request(self, RequestData request)
     cpdef void _handle_request_instruments(self, DataClient client, RequestInstruments request)
     cpdef void _handle_request_instrument(self, DataClient client, RequestInstrument request)
@@ -227,6 +226,7 @@ cdef class DataEngine(Component):
     cpdef void _handle_response(self, DataResponse response)
     cpdef void _handle_instruments(self, list instruments, update_catalog_mode: CatalogWriteMode | None = *)
     cpdef void _update_catalog(self, list ticks, update_catalog_mode: CatalogWriteMode, bint is_instrument=*)
+    cpdef tuple[datetime, object] _catalogs_timestamp_bound(self, type data_cls, InstrumentId instrument_id=*, BarType bar_type=*, str ts_column=*, bint is_last=*)
     cpdef void _new_query_group(self, UUID4 correlation_id, int n_components)
     cpdef DataResponse _handle_query_group(self, DataResponse response)
     cdef DataResponse _handle_query_group_aux(self, DataResponse response)

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -213,7 +213,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1302  # UNIX
+        assert result == 1330  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_run_config_parse_obj(self) -> None:
@@ -234,7 +234,7 @@ class TestBacktestConfigParsing:
         assert isinstance(config, BacktestRunConfig)
         node = BacktestNode(configs=[config])
         assert isinstance(node, BacktestNode)
-        assert len(raw) == 975  # UNIX
+        assert len(raw) == 995  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_data_config_to_dict(self) -> None:
@@ -255,7 +255,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 2154
+        assert result == 2182
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_run_config_id(self) -> None:
@@ -263,7 +263,7 @@ class TestBacktestConfigParsing:
         print("token:", token)
         value: bytes = self.backtest_config.json()
         print("token_value:", value.decode())
-        assert token == "4f32604ec447b05be0c7a38746a01295b96a29f647638c385d4f668d01dacecc"
+        assert token == "c03d01fe1145ca971b9835dd4430f647f64b50d24a744334b09d380c32f58f8f"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request

Added possibility to request backtest data during a backtest using a LiveMarketDataClient adapter

- Add possibility to add LiveMarketDataClients to backtestnode
- Add possibility to query new historical data during a backtest (which can be future data from the point of view of a past backtest time point), using existing LiveMarketDataClients without any change to them
- Subscribed data can also be requested periodically with a duration parameter in order to avoid large data requests
- data_client.py has been updated so it's possible for tasks to run in a sync way during a backtest
- Subscription during backtests can be captured by the backtest engine and transformed into a request to LiveMarketDataClient in order to download the required data
- This downloaded data can then be saved to a catalog (the next PR improves the saving system in a catalog in order to handle arbritrary disjoint time ranges that may be created during the dynamic download of data)
- When a LiveMarketDataClient is registered for a venue, it can be used for requests but not for subscriptions, a default backtest market data client is used instead in this case

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Tested data requests from live market client using an included example that works with databento
databento_backtest_with_data_client.py

