### PR TITLE
Improve validations for MarketIfTouchedOrder

### DIFF
--- a/crates/model/src/orders/market_if_touched.rs
+++ b/crates/model/src/orders/market_if_touched.rs
@@ -465,27 +465,35 @@ impl Order for MarketIfTouchedOrder {
     fn is_triggered(&self) -> Option<bool> {
         Some(self.is_triggered)
     }
+
     fn set_position_id(&mut self, position_id: Option<PositionId>) {
-        self.position_id = position_id
+        self.position_id = position_id;
     }
+
     fn set_quantity(&mut self, quantity: Quantity) {
-        self.quantity = quantity
+        self.quantity = quantity;
     }
+
     fn set_leaves_qty(&mut self, leaves_qty: Quantity) {
-        self.leaves_qty = leaves_qty
+        self.leaves_qty = leaves_qty;
     }
+
     fn set_emulation_trigger(&mut self, emulation_trigger: Option<TriggerType>) {
-        self.emulation_trigger = emulation_trigger
+        self.emulation_trigger = emulation_trigger;
     }
+
     fn set_is_quote_quantity(&mut self, is_quote_quantity: bool) {
-        self.is_quote_quantity = is_quote_quantity
+        self.is_quote_quantity = is_quote_quantity;
     }
+
     fn set_liquidity_side(&mut self, liquidity_side: LiquiditySide) {
         self.liquidity_side = Some(liquidity_side)
     }
+
     fn would_reduce_only(&self, side: PositionSide, position_qty: Quantity) -> bool {
         self.core.would_reduce_only(side, position_qty)
     }
+
     fn previous_status(&self) -> Option<OrderStatus> {
         self.core.previous_status
     }

--- a/crates/model/src/orders/market_if_touched.rs
+++ b/crates/model/src/orders/market_if_touched.rs
@@ -16,12 +16,15 @@
 use std::ops::{Deref, DerefMut};
 
 use indexmap::IndexMap;
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{
+    UUID4, UnixNanos,
+    correctness::{FAILED, check_predicate_false},
+};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
-use super::{Order, OrderAny, OrderCore, OrderError};
+use super::{Order, OrderAny, OrderCore};
 use crate::{
     enums::{
         ContingencyType, LiquiditySide, OrderSide, OrderStatus, OrderType, PositionSide,
@@ -32,7 +35,10 @@ use crate::{
         AccountId, ClientOrderId, ExecAlgorithmId, InstrumentId, OrderListId, PositionId,
         StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
-    types::{Currency, Money, Price, Quantity},
+    types::{
+        Currency, Money, Price, Quantity, price::check_positive_price,
+        quantity::check_positive_quantity,
+    },
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -54,7 +60,7 @@ pub struct MarketIfTouchedOrder {
 impl MarketIfTouchedOrder {
     /// Creates a new [`MarketIfTouchedOrder`] instance.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_checked(
         trader_id: TraderId,
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
@@ -80,7 +86,22 @@ impl MarketIfTouchedOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
+        check_positive_quantity(quantity, "quantity")?;
+        check_positive_price(trigger_price, "trigger_price")?;
+
+        if let Some(disp) = display_qty {
+            check_positive_quantity(disp, "display_qty")?;
+            check_predicate_false(disp > quantity, "`display_qty` may not exceed `quantity`")?;
+        }
+
+        if time_in_force == TimeInForce::Gtd {
+            check_predicate_false(
+                expire_time.unwrap_or_default() == 0,
+                "Condition failed: `expire_time` is required for `GTD` order",
+            )?;
+        }
+
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -116,7 +137,8 @@ impl MarketIfTouchedOrder {
             exec_spawn_id,
             tags,
         );
-        Self {
+
+        Ok(Self {
             core: OrderCore::new(init_order),
             trigger_price,
             trigger_type,
@@ -125,7 +147,65 @@ impl MarketIfTouchedOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        expire_time: Option<UnixNanos>,
+        reduce_only: bool,
+        quote_quantity: bool,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<IndexMap<Ustr, Ustr>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<Vec<Ustr>>,
+        init_id: UUID4,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags,
+            init_id,
+            ts_init,
+        )
+        .expect(FAILED)
     }
 }
 
@@ -356,28 +436,27 @@ impl Order for MarketIfTouchedOrder {
         self.trade_ids.iter().collect()
     }
 
-    fn apply(&mut self, event: OrderEventAny) -> Result<(), OrderError> {
-        if let OrderEventAny::Updated(ref event) = event {
-            self.update(event);
-        };
-        let is_order_filled = matches!(event, OrderEventAny::Filled(_));
-
+    fn apply(&mut self, event: OrderEventAny) -> Result<(), super::OrderError> {
+        if let OrderEventAny::Updated(ref ev) = event {
+            self.update(ev);
+        }
+        let was_filled = matches!(event, OrderEventAny::Filled(_));
         self.core.apply(event)?;
-
-        if is_order_filled {
+        if was_filled {
             self.core.set_slippage(self.trigger_price);
-        };
-
+        }
         Ok(())
     }
 
     fn update(&mut self, event: &OrderUpdated) {
-        assert!(event.price.is_none(), "{}", OrderError::InvalidOrderEvent);
-
-        if let Some(trigger_price) = event.trigger_price {
-            self.trigger_price = trigger_price;
+        assert!(
+            event.price.is_none(),
+            "{}",
+            super::OrderError::InvalidOrderEvent
+        );
+        if let Some(tp) = event.trigger_price {
+            self.trigger_price = tp;
         }
-
         self.quantity = event.quantity;
         self.leaves_qty = self.quantity - self.filled_qty;
     }
@@ -385,35 +464,27 @@ impl Order for MarketIfTouchedOrder {
     fn is_triggered(&self) -> Option<bool> {
         Some(self.is_triggered)
     }
-
     fn set_position_id(&mut self, position_id: Option<PositionId>) {
-        self.position_id = position_id;
+        self.position_id = position_id
     }
-
     fn set_quantity(&mut self, quantity: Quantity) {
-        self.quantity = quantity;
+        self.quantity = quantity
     }
-
     fn set_leaves_qty(&mut self, leaves_qty: Quantity) {
-        self.leaves_qty = leaves_qty;
+        self.leaves_qty = leaves_qty
     }
-
     fn set_emulation_trigger(&mut self, emulation_trigger: Option<TriggerType>) {
-        self.emulation_trigger = emulation_trigger;
+        self.emulation_trigger = emulation_trigger
     }
-
     fn set_is_quote_quantity(&mut self, is_quote_quantity: bool) {
-        self.is_quote_quantity = is_quote_quantity;
+        self.is_quote_quantity = is_quote_quantity
     }
-
     fn set_liquidity_side(&mut self, liquidity_side: LiquiditySide) {
         self.liquidity_side = Some(liquidity_side)
     }
-
     fn would_reduce_only(&self, side: PositionSide, position_qty: Quantity) -> bool {
         self.core.would_reduce_only(side, position_qty)
     }
-
     fn previous_status(&self) -> Option<OrderStatus> {
         self.core.previous_status
     }
@@ -429,13 +500,13 @@ impl From<OrderInitialized> for MarketIfTouchedOrder {
             event.order_side,
             event.quantity,
             event
-                .trigger_price // TODO: Improve this error, model order domain errors
-                .expect(
-                    "Error initializing order: `trigger_price` was `None` for `MarketIfTouchedOrder`",
-                ),
-            event
-                .trigger_type
-                .expect("Error initializing order: `trigger_type` was `None` for `MarketIfTouchedOrder`"),
+            .trigger_price // TODO: Improve this error, model order domain errors
+            .expect(
+                "Error initializing order: `trigger_price` was `None` for `MarketIfTouchedOrder`",
+            ),
+            event.trigger_type.expect(
+                "Error initializing order: `trigger_type` was `None` for `MarketIfTouchedOrder`",
+            ),
             event.time_in_force,
             event.expire_time,
             event.reduce_only,
@@ -454,5 +525,71 @@ impl From<OrderInitialized> for MarketIfTouchedOrder {
             event.event_id,
             event.ts_event,
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{
+        enums::{OrderSide, OrderType, TimeInForce, TriggerType},
+        instruments::{CurrencyPair, stubs::*},
+        orders::builder::OrderTestBuilder,
+        types::{Price, Quantity},
+    };
+
+    #[rstest]
+    fn ok(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::MarketIfTouched)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(
+        expected = "Condition failed: invalid `Quantity` for 'quantity' not positive, was 0"
+    )]
+    fn quantity_zero(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::MarketIfTouched)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(0))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Condition failed: `expire_time` is required for `GTD` order")]
+    fn gtd_without_expire(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::MarketIfTouched)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .time_in_force(TimeInForce::Gtd)
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(expected = "`display_qty` may not exceed `quantity`")]
+    fn display_qty_gt_quantity(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::MarketIfTouched)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .display_qty(Quantity::from(2))
+            .build();
     }
 }


### PR DESCRIPTION
This PR hardens the `MarketIfTouchedOrder` construction path and tightens several related invariants:

* **New validation layer** – extracted a `new_checked` constructor that returns `anyhow::Result<Self>` and performs all semantic checks (`check_positive_quantity`, `check_positive_price`, GTD expiry present, `display_qty ≤ quantity`, etc.).  
  * The existing `new` constructor is now a thin wrapper that calls `new_checked` and panics on failure, preserving the ergonomic API for quick-and-dirty tests while providing a fall-through path for production code that wants explicit error handling.
* **Cleaner failure semantics** – Leveraged `nautilus_core::correctness::{check_predicate_false, FAILED}` so that violations propagate meaningful messages instead of opaque panics.

* **API hygiene** – redundant imports removed, naming clarified (`is_order_filled → was_filled`, etc.).
* **Comprehensive test-suite** – 4 new rstest cases proving the positive path and three critical failure paths (zero qty, GTD without expiry, `display_qty > quantity`).

## Type of change

- [x] **Improvement / hardening** (non-breaking in normal usage; may surface latent bugs by rejecting invalid input earlier)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change — behaviour is technically stricter, but the public signature of `new` remains; if callers relied on constructing invalid orders this will now panic sooner.
- [ ] Documentation update

## Rationale

Fail-fast validation at the domain-model level prevents invalid orders from leaking into matching, risk, and persistence layers, where they are far more expensive (and dangerous) to handle.  
Returning a `Result` enables users of the model to decide whether to propagate, map, or surface these errors, instead of being forced into a panic-driven flow.
