### PR TITLE
Improve CI to cancel superseded workflow runs with concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [develop]
 
+# Cancel older runs on the same branch / PR as soon as a new one starts
+concurrency:
+  # One group per workflow file and per branch/PR number
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04 # (glibc 2.35) wider runtime range than 24.04/glibc 2.39


### PR DESCRIPTION
Adds a top-level `concurrency` block to `.github/workflows/build.yml` so that any older run on the same branch or pull-request is automatically aborted when a newer commit is pushed.

### What changed
* **`concurrency.group`** → `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`  
  * one group per workflow file × branch/PR number  
* **`cancel-in-progress: true`** → GitHub immediately stops the previous run when a new one is queued
* No other job logic or pins were modified

### Why
* Saves runner minutes and queue time
* Keeps the Checks/Actions tab clean—only the run for the latest commit remains
* Avoids publishing artefacts or notifications from obsolete builds

### Links
* 📄 **GitHub docs – Using concurrency**  
  <https://docs.github.com/en/actions/using-jobs/using-concurrency>