### PR TITLE
Improve zero size trade logging for Binance Futures

### DIFF
--- a/nautilus_trader/adapters/binance/futures/schemas/market.py
+++ b/nautilus_trader/adapters/binance/futures/schemas/market.py
@@ -177,6 +177,19 @@ class BinanceFuturesTradeData(msgspec.Struct, frozen=True):
         instrument_id: InstrumentId,
         ts_init: int,
     ) -> TradeTick:
+        """
+        Parameters
+        ----------
+        instrument_id : InstrumentId
+            The trade instrument ID.
+        ts_init : uint64_t
+            UNIX timestamp (nanoseconds) when the data object was initialized.
+
+        Raises
+        ------
+        ValueError
+            If trade tick data are incorrect
+        """
         return TradeTick(
             instrument_id=instrument_id,
             price=Price.from_str(self.p),


### PR DESCRIPTION
# Pull Request

Binance sends empty trade tick messages from time to time. This leads to error messages and noise in logs: `Error handling trade tick message b'{"stream":"xrpusdt@trade","data":{"e":"trade","E":1746194730699,"T":1746194730699,"s":"XRPUSDT","t":2332526925,"p":"0","q":"0","X":"NA","m":false}}', 'size' not a positive integer, was 0`

Such messages should have `DEBUG` level in logs.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Manually
