### PR TITLE
Improve validations for StopLimitOrder

### DIFF
--- a/crates/model/src/orders/stop_limit.rs
+++ b/crates/model/src/orders/stop_limit.rs
@@ -64,6 +64,10 @@ pub struct StopLimitOrder {
 
 impl StopLimitOrder {
     /// Creates a new [`StopLimitOrder`] instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the order is invalid.
     #[allow(clippy::too_many_arguments)]
     pub fn new_checked(
         trader_id: TraderId,

--- a/crates/model/src/orders/stop_limit.rs
+++ b/crates/model/src/orders/stop_limit.rs
@@ -19,7 +19,10 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{
+    UUID4, UnixNanos,
+    correctness::{FAILED, check_predicate_false},
+};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
@@ -35,7 +38,10 @@ use crate::{
         AccountId, ClientOrderId, ExecAlgorithmId, InstrumentId, OrderListId, PositionId,
         StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
-    types::{Currency, Money, Price, Quantity},
+    types::{
+        Currency, Money, Price, Quantity, price::check_positive_price,
+        quantity::check_positive_quantity,
+    },
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -59,7 +65,7 @@ pub struct StopLimitOrder {
 impl StopLimitOrder {
     /// Creates a new [`StopLimitOrder`] instance.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_checked(
         trader_id: TraderId,
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
@@ -87,8 +93,23 @@ impl StopLimitOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> Self {
-        // TODO: Implement new_checked and check quantity positive, add error docs.
+    ) -> anyhow::Result<Self> {
+        check_positive_quantity(quantity, stringify!(quantity))?;
+        check_positive_price(price, stringify!(price))?;
+        check_positive_price(trigger_price, stringify!(trigger_price))?;
+
+        if let Some(disp) = display_qty {
+            check_positive_quantity(disp, stringify!(display_qty))?;
+            check_predicate_false(disp > quantity, "`display_qty` may not exceed `quantity`")?;
+        }
+
+        if time_in_force == TimeInForce::Gtd {
+            check_predicate_false(
+                expire_time.unwrap_or_default().is_zero(),
+                "`expire_time` is required for `GTD` order",
+            )?;
+        }
+
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -125,7 +146,7 @@ impl StopLimitOrder {
             tags,
         );
 
-        Self {
+        Ok(Self {
             core: OrderCore::new(init_order),
             price,
             trigger_price,
@@ -136,13 +157,74 @@ impl StopLimitOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        expire_time: Option<UnixNanos>,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<IndexMap<Ustr, Ustr>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<Vec<Ustr>>,
+        init_id: UUID4,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            price,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time,
+            post_only,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags,
+            init_id,
+            ts_init,
+        )
+        .expect(FAILED)
     }
 }
 
 impl Deref for StopLimitOrder {
     type Target = OrderCore;
-
     fn deref(&self) -> &Self::Target {
         &self.core
     }
@@ -449,15 +531,13 @@ impl From<OrderInitialized> for StopLimitOrder {
             event.client_order_id,
             event.order_side,
             event.quantity,
+            event.price.expect("`price` was None for StopLimitOrder"),
             event
-                .price // TODO: Improve this error, model order domain errors
-                .expect("Error initializing order: `price` was `None` for `StopLimitOrder"),
-            event
-                .trigger_price // TODO: Improve this error, model order domain errors
-                .expect("Error initializing order: `trigger_price` was `None` for `StopLimitOrder"),
+                .trigger_price
+                .expect("`trigger_price` was None for StopLimitOrder"),
             event
                 .trigger_type
-                .expect("Error initializing order: `trigger_type` was `None`"),
+                .expect("`trigger_type` was None for StopLimitOrder"),
             event.time_in_force,
             event.expire_time,
             event.post_only,
@@ -507,5 +587,68 @@ impl Display for StopLimitOrder {
                 .collect::<Vec<String>>()
                 .join(", ")),
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{
+        enums::{OrderSide, OrderType, TriggerType},
+        instruments::{CurrencyPair, stubs::*},
+        orders::builder::OrderTestBuilder,
+        types::{Price, Quantity},
+    };
+
+    #[rstest]
+    fn buy_breakout_ok(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::StopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30300"))
+            .price(Price::from("30100"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
+    }
+
+    #[rstest]
+    fn buy_dip_ok(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::StopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("30100"))
+            .price(Price::from("30300"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
+    }
+
+    #[rstest]
+    fn sell_breakout_ok(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::StopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Sell)
+            .trigger_price(Price::from("30100"))
+            .price(Price::from("30300"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
+    }
+
+    #[rstest]
+    fn sell_fade_ok(audusd_sim: CurrencyPair) {
+        let _ = OrderTestBuilder::new(OrderType::StopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Sell)
+            .trigger_price(Price::from("30300"))
+            .price(Price::from("30100"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
     }
 }


### PR DESCRIPTION

* **Implemented `new_checked`** for `StopLimitOrder`, bringing it in line with `MarketOrder`, `LimitOrder`, `LimitIfTouchedOrder`, and `MarketToLimitOrder`.
* **Dropped the side-specific trigger/limit inequality**
  *BUY* orders may now use either `trigger ≥ limit` **or** `trigger ≤ limit`; the mirror applies to *SELL*.
  This unblocks “limit-if-touched” and similar strategies that were previously rejected.
* Added complete **domain-level validations**:

  * quantity > 0
  * price > 0
  * trigger\_price > 0
  * optional `display_qty ≤ quantity`
  * `TimeInForce::Gtd` ⇒ non-zero `expire_time` required
* **Legacy `new` now wraps `new_checked`**, preserving the historical *panic-on-error* behaviour for external callers.
* Extended rust-doc explaining the two legal stop-limit styles (break-out vs. mean-reversion).
* Added a concise `Display` implementation for easier debugging/logging.
* **Unit-tests (4)** live in the same module and cover the happy path plus each validation branch.

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update


Fixes #2529

***

Note: this PR takes into consideration changes introduced in this commit https://github.com/nautechsystems/nautilus_trader/commit/c44604c060becc664e57fc4b85079447593ddfbe
