### PR TITLE
Improve validations for StopMarketOrder

### DIFF
--- a/crates/model/src/orders/stop_limit.rs
+++ b/crates/model/src/orders/stop_limit.rs
@@ -703,7 +703,7 @@ mod tests {
             .instrument_id(audusd_sim.id)
             .side(OrderSide::Buy)
             .trigger_price(Price::from("30300"))
-            .price(Price::from("-1")) // <-- bad
+            .price(Price::from("-1"))
             .trigger_type(TriggerType::LastPrice)
             .quantity(Quantity::from(1))
             .build();

--- a/crates/model/src/orders/stop_market.rs
+++ b/crates/model/src/orders/stop_market.rs
@@ -33,9 +33,9 @@ use crate::{
         StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
     orders::OrderError,
-    types::{Currency, Money, Price, Quantity},
+    types::{Currency, Money, Price, Quantity, quantity::check_positive_quantity},
 };
-
+use nautilus_core::correctness::{FAILED, check_predicate_true};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "python",
@@ -54,8 +54,15 @@ pub struct StopMarketOrder {
 
 impl StopMarketOrder {
     /// Creates a new [`StopMarketOrder`] instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The `quantity` is not positive.
+    /// - The `time_in_force` is `GTD` **and** `expire_time` is `None` or zero.
+    /// - The `display_qty` (when provided) exceeds `quantity`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_checked(
         trader_id: TraderId,
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
@@ -81,8 +88,20 @@ impl StopMarketOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> Self {
-        // TODO: Implement new_checked and check quantity positive, add error docs.
+    ) -> anyhow::Result<Self> {
+        check_positive_quantity(quantity, stringify!(quantity))?;
+
+        if let Some(q) = display_qty {
+            check_predicate_true(q <= quantity, "`display_qty` may not exceed `quantity`")?;
+        }
+
+        if time_in_force == TimeInForce::Gtd {
+            check_predicate_true(
+                expire_time.unwrap_or_default() > 0,
+                "`expire_time` is required for `GTD` order",
+            )?;
+        }
+
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -119,7 +138,7 @@ impl StopMarketOrder {
             tags,
         );
 
-        Self {
+        Ok(Self {
             core: OrderCore::new(init_order),
             trigger_price,
             trigger_type,
@@ -128,7 +147,70 @@ impl StopMarketOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        }
+        })
+    }
+
+    /// Creates a new [`StopMarketOrder`] instance.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if any order validation fails (see [`StopMarketOrder::new_checked`]).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        time_in_force: TimeInForce,
+        expire_time: Option<UnixNanos>,
+        reduce_only: bool,
+        quote_quantity: bool,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<IndexMap<Ustr, Ustr>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<Vec<Ustr>>,
+        init_id: UUID4,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            trigger_price,
+            trigger_type,
+            time_in_force,
+            expire_time,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags,
+            init_id,
+            ts_init,
+        )
+        .expect(FAILED)
     }
 }
 
@@ -431,11 +513,9 @@ impl From<OrderInitialized> for StopMarketOrder {
             event.client_order_id,
             event.order_side,
             event.quantity,
-            event
-                .trigger_price // TODO: Improve this error, model order domain errors
-                .expect(
-                    "Error initializing order: `trigger_price` was `None` for `StopMarketOrder`",
-                ),
+            event.trigger_price.expect(
+                "Error initializing order: `trigger_price` was `None` for `StopMarketOrder`",
+            ),
             event.trigger_type.expect(
                 "Error initializing order: `trigger_type` was `None` for `StopMarketOrder`",
             ),
@@ -457,5 +537,84 @@ impl From<OrderInitialized> for StopMarketOrder {
             event.event_id,
             event.ts_event,
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{
+        enums::{OrderSide, OrderType, TimeInForce, TriggerType},
+        instruments::{CurrencyPair, stubs::*},
+        orders::{Order, builder::OrderTestBuilder},
+        types::{Price, Quantity},
+    };
+
+    #[rstest]
+    fn test_initialize(_audusd_sim: CurrencyPair) {
+        let order = OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(_audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .build();
+
+        assert_eq!(order.trigger_price(), Some(Price::from("0.68000")));
+        assert_eq!(order.price(), None);
+
+        assert_eq!(order.time_in_force(), TimeInForce::Gtc);
+
+        assert_eq!(order.is_triggered(), Some(false));
+        assert_eq!(order.filled_qty(), Quantity::from(0));
+        assert_eq!(order.leaves_qty(), Quantity::from(1));
+
+        assert_eq!(order.display_qty(), None);
+        assert_eq!(order.trigger_instrument_id(), None);
+        assert_eq!(order.order_list_id(), None);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Condition failed: `display_qty` may not exceed `quantity`")]
+    fn test_display_qty_gt_quantity_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(1))
+            .display_qty(Quantity::from(2))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(
+        expected = "Condition failed: invalid `Quantity` for 'quantity' not positive, was 0"
+    )]
+    fn test_quantity_zero_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .quantity(Quantity::from(0))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Condition failed: `expire_time` is required for `GTD` order")]
+    fn test_gtd_without_expire_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .time_in_force(TimeInForce::Gtd)
+            .quantity(Quantity::from(1))
+            .build();
     }
 }


### PR DESCRIPTION
This PR introduces **stronger domain-level correctness checks** for `StopMarketOrder` construction in `crates/model/src/orders/stop_market.rs`, adds comprehensive unit tests, and performs a minor cleanup in `stop_limit.rs` test code.

### Key points

* **`StopMarketOrder::new_checked`** – new fallible constructor that enforces invariants *before* the order is initialised:

  * `quantity` must be strictly positive (`check_positive_quantity`)
  * `display_qty` (when present) cannot exceed `quantity`
  * `expire_time` is mandatory and non-zero when `time_in_force` = `GTD`
* **`StopMarketOrder::new`** now delegates to `new_checked` and panics on failure (`expect(FAILED)`), preserving the original infallible API for existing callers.
* **Unit-test suite** extended with four rstest cases that assert:

  * successful initialisation (`test_initialize`)
  * failure when `display_qty > quantity`
  * failure when `quantity == 0`
  * failure when `time_in_force == GTD` but `expire_time` is missing
* **Test fixture cleanup** in `stop_limit.rs`: removed the “bad” inline comment and redundant diff annotation.
* No behavioural changes at runtime other than the new validation paths; existing public API remains source-compatible.

Fixes #2529
