### PR TITLE
Add support for Fill, Latency and Fee models in BacktestNode

### DIFF
--- a/examples/backtest/model_configs_example.py
+++ b/examples/backtest/model_configs_example.py
@@ -1,0 +1,195 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+
+from nautilus_trader.backtest.config import BacktestDataConfig
+from nautilus_trader.backtest.config import BacktestEngineConfig
+from nautilus_trader.backtest.config import BacktestRunConfig
+from nautilus_trader.backtest.config import BacktestVenueConfig
+from nautilus_trader.backtest.config import ImportableFeeModelConfig
+from nautilus_trader.backtest.config import ImportableFillModelConfig
+from nautilus_trader.backtest.config import ImportableLatencyModelConfig
+from nautilus_trader.backtest.node import BacktestNode
+from nautilus_trader.config import ImportableStrategyConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TraderId
+
+
+if __name__ == "__main__":
+    # Example strategy configuration
+    strategy_config = ImportableStrategyConfig(
+        strategy_path="nautilus_trader.examples.strategies.ema_cross:EMACross",
+        config_path="nautilus_trader.examples.strategies.ema_cross:EMACrossConfig",
+        config={
+            "instrument_id": "AAPL.NASDAQ",
+            "bar_type": "AAPL.NASDAQ-1-MINUTE-LAST-EXTERNAL",
+            "fast_ema_period": 10,
+            "slow_ema_period": 20,
+            "trade_size": 100,
+        },
+    )
+
+    # Configure backtest engine
+    engine_config = BacktestEngineConfig(
+        trader_id=TraderId("BACKTESTER-001"),
+        logging=LoggingConfig(log_level="INFO"),
+        strategies=[strategy_config],
+    )
+
+    # Create importable fill model configs
+    fill_model_config = ImportableFillModelConfig(
+        fill_model_path="nautilus_trader.backtest.models:FillModel",
+        config_path="nautilus_trader.backtest.config:FillModelConfig",
+        config={
+            "prob_fill_on_limit": 0.95,  # 95% chance of limit orders filling
+            "prob_fill_on_stop": 0.98,  # 98% chance of stop orders filling
+            "prob_slippage": 0.05,  # 5% chance of slippage
+            "random_seed": 42,  # For reproducibility
+        },
+    )
+
+    # Create importable latency model configs
+    latency_model_config = ImportableLatencyModelConfig(
+        latency_model_path="nautilus_trader.backtest.models:LatencyModel",
+        config_path="nautilus_trader.backtest.config:LatencyModelConfig",
+        config={
+            "base_latency_nanos": 5_000_000,  # 5 milliseconds base latency
+            "insert_latency_nanos": 2_000_000,  # Additional 2ms for inserts
+            "update_latency_nanos": 3_000_000,  # Additional 3ms for updates
+            "cancel_latency_nanos": 1_000_000,  # Additional 1ms for cancels
+        },
+    )
+
+    # Example of different importable fee models
+    maker_taker_fee_model_config = ImportableFeeModelConfig(
+        fee_model_path="nautilus_trader.backtest.models:MakerTakerFeeModel",
+        config_path="nautilus_trader.backtest.config:MakerTakerFeeModelConfig",
+        config={},  # Empty config for MakerTakerFeeModel as it doesn't require parameters
+    )
+
+    fixed_fee_model_config = ImportableFeeModelConfig(
+        fee_model_path="nautilus_trader.backtest.models:FixedFeeModel",
+        config_path="nautilus_trader.backtest.config:FixedFeeModelConfig",
+        config={
+            "commission": "1.50 USD",
+            "charge_commission_once": True,
+        },
+    )
+
+    per_contract_fee_model_config = ImportableFeeModelConfig(
+        fee_model_path="nautilus_trader.backtest.models:PerContractFeeModel",
+        config_path="nautilus_trader.backtest.config:PerContractFeeModelConfig",
+        config={
+            "commission": "0.01 USD",
+        },
+    )
+
+    # Another example with different parameters
+    custom_fixed_fee_model_config = ImportableFeeModelConfig(
+        fee_model_path="nautilus_trader.backtest.models:FixedFeeModel",
+        config_path="nautilus_trader.backtest.config:FixedFeeModelConfig",
+        config={
+            "commission": "2.00 USD",
+            "charge_commission_once": False,
+        },
+    )
+
+    # Create venue configs with different models
+    venue_config1 = BacktestVenueConfig(
+        name="NASDAQ",
+        oms_type="NETTING",
+        account_type="CASH",
+        base_currency="USD",
+        starting_balances=["1000000 USD"],
+        book_type="L1_MBP",
+        fill_model=fill_model_config,
+        latency_model=latency_model_config,
+        fee_model=maker_taker_fee_model_config,
+    )
+
+    venue_config2 = BacktestVenueConfig(
+        name="NYSE",
+        oms_type="NETTING",
+        account_type="CASH",
+        base_currency="USD",
+        starting_balances=["1000000 USD"],
+        book_type="L1_MBP",
+        fill_model=fill_model_config,
+        latency_model=latency_model_config,
+        fee_model=fixed_fee_model_config,
+    )
+
+    venue_config3 = BacktestVenueConfig(
+        name="CME",
+        oms_type="NETTING",
+        account_type="MARGIN",
+        base_currency="USD",
+        starting_balances=["1000000 USD"],
+        book_type="L1_MBP",
+        fill_model=fill_model_config,
+        latency_model=latency_model_config,
+        fee_model=per_contract_fee_model_config,
+    )
+
+    # Create venue config with custom fixed fee model
+    venue_config4 = BacktestVenueConfig(
+        name="BATS",
+        oms_type="NETTING",
+        account_type="CASH",
+        base_currency="USD",
+        starting_balances=["1000000 USD"],
+        book_type="L1_MBP",
+        fill_model=fill_model_config,
+        latency_model=latency_model_config,
+        fee_model=custom_fixed_fee_model_config,
+    )
+
+    # Create data config (this is just a placeholder - you would need actual data)
+    data_config = BacktestDataConfig(
+        catalog_path="./data",
+        data_cls=QuoteTick,
+        instrument_id=InstrumentId.from_str("AAPL.NASDAQ"),
+    )
+
+    # Create BacktestRunConfig
+    run_config = BacktestRunConfig(
+        engine=engine_config,
+        venues=[venue_config1, venue_config2, venue_config3, venue_config4],
+        data=[data_config],
+    )
+
+    # Create and run the backtest node
+    node = BacktestNode(configs=[run_config])
+
+    # Note: This example won't actually run without proper data
+    # results = node.run()
+
+    print("Example of using importable model configs in BacktestVenueConfig")
+    print(
+        f"Venue 1 uses ImportableFeeModelConfig with MakerTakerFeeModel: {venue_config1.fee_model}",
+    )
+    print(
+        f"Venue 2 uses ImportableFeeModelConfig with FixedFeeModel: {venue_config2.fee_model.config}",
+    )
+    print(
+        f"Venue 3 uses ImportableFeeModelConfig with PerContractFeeModel: {venue_config3.fee_model.config}",
+    )
+    print(
+        f"Venue 4 uses ImportableFeeModelConfig with custom FixedFeeModel: {venue_config4.fee_model.config}",
+    )
+    print(f"Fill model config: {venue_config1.fill_model.config}")
+    print(f"Latency model config: {venue_config1.latency_model.config}")

--- a/nautilus_trader/backtest/models.pyx
+++ b/nautilus_trader/backtest/models.pyx
@@ -58,7 +58,15 @@ cdef class FillModel:
         double prob_fill_on_stop = 1.0,
         double prob_slippage = 0.0,
         random_seed: int | None = None,
+        config = None,
     ):
+        if config is not None:
+            # Initialize from config
+            prob_fill_on_limit = config.prob_fill_on_limit
+            prob_fill_on_stop = config.prob_fill_on_stop
+            prob_slippage = config.prob_slippage
+            random_seed = config.random_seed
+
         Condition.in_range(prob_fill_on_limit, 0.0, 1.0, "prob_fill_on_limit")
         Condition.in_range(prob_fill_on_stop, 0.0, 1.0, "prob_fill_on_stop")
         Condition.in_range(prob_slippage, 0.0, 1.0, "prob_slippage")
@@ -149,7 +157,15 @@ cdef class LatencyModel:
         uint64_t insert_latency_nanos = 0,
         uint64_t update_latency_nanos = 0,
         uint64_t cancel_latency_nanos = 0,
+        config = None,
     ):
+        if config is not None:
+            # Initialize from config
+            base_latency_nanos = config.base_latency_nanos
+            insert_latency_nanos = config.insert_latency_nanos
+            update_latency_nanos = config.update_latency_nanos
+            cancel_latency_nanos = config.cancel_latency_nanos
+
         Condition.not_negative_int(base_latency_nanos, "base_latency_nanos")
         Condition.not_negative_int(insert_latency_nanos, "insert_latency_nanos")
         Condition.not_negative_int(update_latency_nanos, "update_latency_nanos")
@@ -200,7 +216,15 @@ cdef class MakerTakerFeeModel(FeeModel):
     Provide a fee model for trades based on a maker/taker fee schedule
     and notional value of the trade.
 
+    Parameters
+    ----------
+    config : MakerTakerFeeModelConfig, optional
+        The configuration for the fee model.
     """
+
+    def __init__(self, config=None):
+        # No configuration needed for this model
+        pass
 
     cpdef Money get_commission(
         self,
@@ -254,9 +278,15 @@ cdef class FixedFeeModel(FeeModel):
 
     def __init__(
         self,
-        Money commission not None,
+        Money commission not None = None,
         bint charge_commission_once: bool = True,
+        config = None,
     ):
+        if config is not None:
+            # Initialize from config
+            commission = Money.from_str(config.commission)
+            charge_commission_once = config.charge_commission_once
+
         Condition.positive(commission, "commission")
 
         self._commission = commission
@@ -292,7 +322,11 @@ cdef class PerContractFeeModel(FeeModel):
 
     """
 
-    def __init__(self, Money commission not None):
+    def __init__(self, Money commission not None = None, config = None):
+        if config is not None:
+            # Initialize from config
+            commission = Money.from_str(config.commission)
+
         Condition.not_negative(commission, "commission")
 
         self._commission = commission

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -21,8 +21,14 @@ import pandas as pd
 from nautilus_trader.backtest.config import BacktestDataConfig
 from nautilus_trader.backtest.config import BacktestRunConfig
 from nautilus_trader.backtest.config import BacktestVenueConfig
+from nautilus_trader.backtest.config import FeeModelFactory
+from nautilus_trader.backtest.config import FillModelFactory
+from nautilus_trader.backtest.config import LatencyModelFactory
 from nautilus_trader.backtest.engine import BacktestEngine
 from nautilus_trader.backtest.engine import BacktestEngineConfig
+from nautilus_trader.backtest.models import FeeModel
+from nautilus_trader.backtest.models import FillModel
+from nautilus_trader.backtest.models import LatencyModel
 from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.common.component import Logger
 from nautilus_trader.common.component import LogGuard
@@ -246,6 +252,9 @@ class BacktestNode:
                 book_type=book_type_from_str(config.book_type),
                 routing=config.routing,
                 modules=[ActorFactory.create(module) for module in (config.modules or [])],
+                fill_model=get_fill_model(config),
+                fee_model=get_fee_model(config),
+                latency_model=get_latency_model(config),
                 frozen_account=config.frozen_account,
                 reject_stop_orders=config.reject_stop_orders,
                 support_gtd_orders=config.support_gtd_orders,
@@ -584,3 +593,33 @@ def get_leverages(config: BacktestVenueConfig) -> dict[InstrumentId, Decimal]:
         if config.leverages
         else {}
     )
+
+
+def get_fill_model(config: BacktestVenueConfig) -> FillModel | None:
+    """
+    Create a FillModel from an ImportableFillModelConfig.
+    """
+    if config.fill_model is None:
+        return None
+
+    return FillModelFactory.create(config.fill_model)
+
+
+def get_latency_model(config: BacktestVenueConfig) -> LatencyModel | None:
+    """
+    Create a LatencyModel from an ImportableLatencyModelConfig.
+    """
+    if config.latency_model is None:
+        return None
+
+    return LatencyModelFactory.create(config.latency_model)
+
+
+def get_fee_model(config: BacktestVenueConfig) -> FeeModel | None:
+    """
+    Create a FeeModel from an ImportableFeeModelConfig.
+    """
+    if config.fee_model is None:
+        return None
+
+    return FeeModelFactory.create(config.fee_model)

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -213,7 +213,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 1198  # UNIX
+        assert result == 1270  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_run_config_parse_obj(self) -> None:
@@ -234,7 +234,7 @@ class TestBacktestConfigParsing:
         assert isinstance(config, BacktestRunConfig)
         node = BacktestNode(configs=[config])
         assert isinstance(node, BacktestNode)
-        assert len(raw) == 895  # UNIX
+        assert len(raw) == 951  # UNIX
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_data_config_to_dict(self) -> None:
@@ -255,7 +255,7 @@ class TestBacktestConfigParsing:
         )
         json = msgspec.json.encode(run_config)
         result = len(msgspec.json.encode(json))
-        assert result == 2050
+        assert result == 2122
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     def test_backtest_run_config_id(self) -> None:
@@ -263,7 +263,7 @@ class TestBacktestConfigParsing:
         print("token:", token)
         value: bytes = self.backtest_config.json()
         print("token_value:", value.decode())
-        assert token == "bb8070e2b9c260bd6e51b1ef57c93d338b0d31a3798e0b6bc4787cbc7f25fd1b"
+        assert token == "42f5abf042666be6e4539868b9b66e4e56f26743662af4ddd5eb1ea1f733c21c"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="redundant to also test Windows")
     @pytest.mark.parametrize(
@@ -273,7 +273,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.venue_config,
                 (),
                 {},
-                ("71b17265090437aaef857215e9abda4d1e95e6c52d29434df9bb3a70c9c2523b",),
+                ("03972e1b8abc649b22a211df779ce47b5a5791adaedcae3f4345fb0ae0e3c88a",),
             ),
             (
                 TestConfigStubs.backtest_data_config,


### PR DESCRIPTION
# Pull Request

Add support for Fill, Latency and Fee models in BacktestNode

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added example showing how to use the model configs
