### PR TITLE
Improve validations for TrailingStopLimitOrder

### DIFF
--- a/crates/model/src/orders/trailing_stop_limit.rs
+++ b/crates/model/src/orders/trailing_stop_limit.rs
@@ -21,6 +21,8 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
+use nautilus_core::correctness::{FAILED, check_predicate_true};
+
 use super::{Order, OrderAny, OrderCore, OrderError};
 use crate::{
     enums::{
@@ -32,7 +34,7 @@ use crate::{
         AccountId, ClientOrderId, ExecAlgorithmId, InstrumentId, OrderListId, PositionId,
         StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
-    types::{Currency, Money, Price, Quantity},
+    types::{Currency, Money, Price, Quantity, quantity::check_positive_quantity},
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -58,8 +60,15 @@ pub struct TrailingStopLimitOrder {
 
 impl TrailingStopLimitOrder {
     /// Creates a new [`TrailingStopLimitOrder`] instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The `quantity` is not positive.
+    /// - The `time_in_force` is `GTD` **and** `expire_time` is `None` or zero.
+    /// - The `display_qty` (when provided) exceeds `quantity`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_checked(
         trader_id: TraderId,
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
@@ -90,8 +99,20 @@ impl TrailingStopLimitOrder {
         tags: Option<Vec<Ustr>>,
         init_id: UUID4,
         ts_init: UnixNanos,
-    ) -> Self {
-        // TODO: Implement new_checked and check quantity positive, add error docs.
+    ) -> anyhow::Result<Self> {
+        check_positive_quantity(quantity, stringify!(quantity))?;
+
+        if let Some(q) = display_qty {
+            check_predicate_true(q <= quantity, "`display_qty` may not exceed `quantity`")?;
+        }
+
+        if time_in_force == TimeInForce::Gtd {
+            check_predicate_true(
+                expire_time.unwrap_or_default() > 0,
+                "`expire_time` is required for `GTD` order",
+            )?;
+        }
+
         let init_order = OrderInitialized::new(
             trader_id,
             strategy_id,
@@ -128,7 +149,7 @@ impl TrailingStopLimitOrder {
             tags,
         );
 
-        Self {
+        Ok(Self {
             core: OrderCore::new(init_order),
             price,
             trigger_price,
@@ -142,7 +163,80 @@ impl TrailingStopLimitOrder {
             trigger_instrument_id,
             is_triggered: false,
             ts_triggered: None,
-        }
+        })
+    }
+
+    /// Creates a new [`TrailingStopLimitOrder`] instance.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if any order validation fails (see [`TrailingStopLimitOrder::new_checked`]).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        quantity: Quantity,
+        price: Price,
+        trigger_price: Price,
+        trigger_type: TriggerType,
+        limit_offset: Decimal,
+        trailing_offset: Decimal,
+        trailing_offset_type: TrailingOffsetType,
+        time_in_force: TimeInForce,
+        expire_time: Option<UnixNanos>,
+        post_only: bool,
+        reduce_only: bool,
+        quote_quantity: bool,
+        display_qty: Option<Quantity>,
+        emulation_trigger: Option<TriggerType>,
+        trigger_instrument_id: Option<InstrumentId>,
+        contingency_type: Option<ContingencyType>,
+        order_list_id: Option<OrderListId>,
+        linked_order_ids: Option<Vec<ClientOrderId>>,
+        parent_order_id: Option<ClientOrderId>,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        exec_algorithm_params: Option<IndexMap<Ustr, Ustr>>,
+        exec_spawn_id: Option<ClientOrderId>,
+        tags: Option<Vec<Ustr>>,
+        init_id: UUID4,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self::new_checked(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            order_side,
+            quantity,
+            price,
+            trigger_price,
+            trigger_type,
+            limit_offset,
+            trailing_offset,
+            trailing_offset_type,
+            time_in_force,
+            expire_time,
+            post_only,
+            reduce_only,
+            quote_quantity,
+            display_qty,
+            emulation_trigger,
+            trigger_instrument_id,
+            contingency_type,
+            order_list_id,
+            linked_order_ids,
+            parent_order_id,
+            exec_algorithm_id,
+            exec_algorithm_params,
+            exec_spawn_id,
+            tags,
+            init_id,
+            ts_init,
+        )
+        .expect(FAILED)
     }
 }
 
@@ -480,5 +574,100 @@ impl From<OrderInitialized> for TrailingStopLimitOrder {
             event.event_id,
             event.ts_event,
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Tests
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{
+        enums::{OrderSide, OrderType, TimeInForce, TrailingOffsetType, TriggerType},
+        instruments::{CurrencyPair, stubs::*},
+        orders::{Order, builder::OrderTestBuilder},
+        types::{Price, Quantity},
+    };
+    use rust_decimal_macros::dec;
+
+    #[rstest]
+    fn test_initialize(_audusd_sim: CurrencyPair) {
+        let order = OrderTestBuilder::new(OrderType::TrailingStopLimit)
+            .instrument_id(_audusd_sim.id)
+            .side(OrderSide::Buy)
+            .price(Price::from("0.67500"))
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .limit_offset(dec!(5))
+            .trailing_offset(dec!(10))
+            .trailing_offset_type(TrailingOffsetType::Price)
+            .quantity(Quantity::from(1))
+            .build();
+
+        assert_eq!(order.price(), Some(Price::from("0.67500")));
+        assert_eq!(order.trigger_price(), Some(Price::from("0.68000")));
+        assert_eq!(order.time_in_force(), TimeInForce::Gtc);
+
+        assert_eq!(order.is_triggered(), Some(false));
+        assert_eq!(order.filled_qty(), Quantity::from(0));
+        assert_eq!(order.leaves_qty(), Quantity::from(1));
+
+        assert_eq!(order.display_qty(), None);
+        assert_eq!(order.trigger_instrument_id(), None);
+        assert_eq!(order.order_list_id(), None);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Condition failed: `display_qty` may not exceed `quantity`")]
+    fn test_display_qty_gt_quantity_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::TrailingStopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .price(Price::from("0.67500"))
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .limit_offset(dec!(5))
+            .trailing_offset(dec!(10))
+            .trailing_offset_type(TrailingOffsetType::Price)
+            .quantity(Quantity::from(1))
+            .display_qty(Quantity::from(2))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(
+        expected = "Condition failed: invalid `Quantity` for 'quantity' not positive, was 0"
+    )]
+    fn test_quantity_zero_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::TrailingStopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .price(Price::from("0.67500"))
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .limit_offset(dec!(5))
+            .trailing_offset(dec!(10))
+            .trailing_offset_type(TrailingOffsetType::Price)
+            .quantity(Quantity::from(0))
+            .build();
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Condition failed: `expire_time` is required for `GTD` order")]
+    fn test_gtd_without_expire_err(audusd_sim: CurrencyPair) {
+        OrderTestBuilder::new(OrderType::TrailingStopLimit)
+            .instrument_id(audusd_sim.id)
+            .side(OrderSide::Buy)
+            .price(Price::from("0.67500"))
+            .trigger_price(Price::from("0.68000"))
+            .trigger_type(TriggerType::LastPrice)
+            .limit_offset(dec!(5))
+            .trailing_offset(dec!(10))
+            .trailing_offset_type(TrailingOffsetType::Price)
+            .time_in_force(TimeInForce::Gtd)
+            .quantity(Quantity::from(1))
+            .build();
     }
 }


### PR DESCRIPTION

Strengthen *server-side* validation for `TrailingStopLimitOrder`.

* Introduced `new_checked`, a fallible constructor that enforces:
  * **Quantity must be positive** (`check_positive_quantity`).
  * **display_qty ≤ quantity**.
  * **GTD orders require a non-zero `expire_time`**.
* Existing `new` now delegates to `new_checked` and panics on failure, preserving the public API while centralising validation.
* Added 4 focused unit tests in `trailing_stop_limit.rs` to cover the happy path and each new invariant.
* Updated docs/comments to reflect the new behaviour.

These checks eliminate an entire class of runtime errors where an invalid order could slip through initialisation and fail deep in the matching or execution layers.
***

Related: https://github.com/nautechsystems/nautilus_trader/issues/2529