### PR TITLE
Add 'activation_price' property, and tests for str(), repr() of trailing stop orders

### DIFF
--- a/nautilus_trader/model/orders/base.pyx
+++ b/nautilus_trader/model/orders/base.pyx
@@ -602,6 +602,18 @@ cdef class Order:
         return self.has_trigger_price_c()
 
     @property
+    def has_activation_price(self):
+        """
+        Return whether the order has a `activation_price` property.
+
+        Returns
+        -------
+        bool
+
+        """
+        return self.has_activation_price_c()
+
+    @property
     def is_buy(self):
         """
         Return whether the order side is ``BUY``.

--- a/tests/unit_tests/model/test_orders.py
+++ b/tests/unit_tests/model/test_orders.py
@@ -1051,6 +1051,73 @@ class TestOrders:
             == "TrailingStopMarketOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_MARKET[DEFAULT] 0.00050-TRAILING_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
         )
 
+    def test_initialize_trailing_stop_market_order_with_activation_price(self):
+        # Arrange, Act
+        order = self.order_factory.trailing_stop_market(
+            AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+            activation_price=Price.from_str("1.00000"),
+            trailing_offset=Decimal("0.00050"),
+        )
+
+        # Assert
+        assert order.order_type == OrderType.TRAILING_STOP_MARKET
+        assert order.status == OrderStatus.INITIALIZED
+        assert order.time_in_force == TimeInForce.GTC
+        assert order.expire_time is None
+        assert order.has_activation_price
+        assert not order.has_trigger_price
+        assert order.trailing_offset_type == TrailingOffsetType.PRICE
+        assert order.is_passive
+        assert not order.is_aggressive
+        assert not order.is_open
+        assert not order.is_closed
+        assert not order.is_activated
+        assert isinstance(order.init_event, OrderInitialized)
+        assert (
+            str(order)
+            == "TrailingStopMarketOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_MARKET[DEFAULT] @ 1.00000-ACTIVATION 0.00050-TRAILING_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+        assert (
+            repr(order)
+            == "TrailingStopMarketOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_MARKET[DEFAULT] @ 1.00000-ACTIVATION 0.00050-TRAILING_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+
+    def test_initialize_trailing_stop_market_order_with_activation_price_and_trigger(self):
+        # Arrange, Act
+        order = self.order_factory.trailing_stop_market(
+            AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+            activation_price=Price.from_str("1.00000"),
+            trigger_price=Price.from_str("1.01000"),
+            trailing_offset=Decimal("0.00050"),
+        )
+
+        # Assert
+        assert order.order_type == OrderType.TRAILING_STOP_MARKET
+        assert order.status == OrderStatus.INITIALIZED
+        assert order.time_in_force == TimeInForce.GTC
+        assert order.expire_time is None
+        assert order.has_activation_price
+        assert order.has_trigger_price
+        assert order.trailing_offset_type == TrailingOffsetType.PRICE
+        assert order.is_passive
+        assert not order.is_activated
+        assert not order.is_aggressive
+        assert not order.is_open
+        assert not order.is_closed
+        assert isinstance(order.init_event, OrderInitialized)
+        assert (
+            str(order)
+            == "TrailingStopMarketOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_MARKET[DEFAULT] @ 1.00000-ACTIVATION @ 1.01000-STOP 0.00050-TRAILING_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+        assert (
+            repr(order)
+            == "TrailingStopMarketOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_MARKET[DEFAULT] @ 1.00000-ACTIVATION @ 1.01000-STOP 0.00050-TRAILING_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+
     def test_trailing_stop_market_order_to_dict(self):
         # Arrange
         order = self.order_factory.trailing_stop_market(
@@ -1221,6 +1288,75 @@ class TestOrders:
         assert (
             repr(order)
             == "TrailingStopLimitOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_LIMIT[DEFAULT] [DEFAULT] None-LIMIT 10-TRAILING_OFFSET[PRICE] 5-LIMIT_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+
+    def test_initialize_trailing_stop_limit_order_with_activation_price(self):
+        # Arrange, Act
+        order = self.order_factory.trailing_stop_limit(
+            AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+            activation_price=Price.from_str("1.00000"),
+            price=Price.from_str("1.00000"),
+            limit_offset=Decimal("5"),
+            trailing_offset=Decimal("10"),
+        )
+
+        # Assert
+        assert order.order_type == OrderType.TRAILING_STOP_LIMIT
+        assert order.status == OrderStatus.INITIALIZED
+        assert order.time_in_force == TimeInForce.GTC
+        assert order.expire_time is None
+        assert order.has_price
+        assert order.has_activation_price
+        assert not order.has_trigger_price
+        assert order.trailing_offset_type == TrailingOffsetType.PRICE
+        assert order.is_passive
+        assert not order.is_aggressive
+        assert not order.is_closed
+        assert not order.is_activated
+        assert isinstance(order.init_event, OrderInitialized)
+        assert (
+            str(order)
+            == "TrailingStopLimitOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_LIMIT[DEFAULT] @ 1.00000-ACTIVATION [DEFAULT] 1.00000-LIMIT 10-TRAILING_OFFSET[PRICE] 5-LIMIT_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+        assert (
+            repr(order)
+            == "TrailingStopLimitOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_LIMIT[DEFAULT] @ 1.00000-ACTIVATION [DEFAULT] 1.00000-LIMIT 10-TRAILING_OFFSET[PRICE] 5-LIMIT_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+
+    def test_initialize_trailing_stop_market_order_with_activation_price_and_no_initial_price(self):
+        # Arrange, Act
+        order = self.order_factory.trailing_stop_limit(
+            AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+            activation_price=Price.from_str("1.00000"),
+            limit_offset=Decimal("5"),
+            trailing_offset=Decimal("10"),
+        )
+
+        # Assert
+        assert order.order_type == OrderType.TRAILING_STOP_LIMIT
+        assert order.status == OrderStatus.INITIALIZED
+        assert order.time_in_force == TimeInForce.GTC
+        assert order.expire_time is None
+        assert not order.has_price
+        assert order.has_activation_price
+        assert not order.has_trigger_price
+        assert order.trailing_offset_type == TrailingOffsetType.PRICE
+        assert order.is_passive
+        assert not order.is_activated
+        assert not order.is_aggressive
+        assert not order.is_closed
+        assert isinstance(order.init_event, OrderInitialized)
+        assert (
+            str(order)
+            == "TrailingStopLimitOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_LIMIT[DEFAULT] @ 1.00000-ACTIVATION [DEFAULT] None-LIMIT 10-TRAILING_OFFSET[PRICE] 5-LIMIT_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
+        )
+        assert (
+            repr(order)
+            == "TrailingStopLimitOrder(BUY 100_000 AUD/USD.SIM TRAILING_STOP_LIMIT[DEFAULT] @ 1.00000-ACTIVATION [DEFAULT] None-LIMIT 10-TRAILING_OFFSET[PRICE] 5-LIMIT_OFFSET[PRICE] GTC, status=INITIALIZED, client_order_id=O-19700101-000000-000-001-1, venue_order_id=None, position_id=None, tags=None)"  # noqa
         )
 
     def test_trailing_stop_limit_order_to_dict(self):


### PR DESCRIPTION

# Pull Request

- Add 'activation_price' property to Order class 
- Add tests for str(), repr() format of trailing stop orders to test_orders.py 

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [v] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?

Passed the existing pytests, and newly added pytests. 
