### PR TITLE
Improve ergonomics of messaging topics, patterns, and endpoints

### DIFF
--- a/crates/adapters/coinbase_intx/src/fix/client.rs
+++ b/crates/adapters/coinbase_intx/src/fix/client.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! FIX Client for the Coinbase International Drop Copy `MStr<Topic>`.
+//! FIX Client for the Coinbase International Drop Copy Endpoint.
 //!
 //! This implementation focuses specifically on processing execution reports
 //! via the FIX protocol, leveraging the existing `SocketClient` for TCP/TLS connectivity.

--- a/crates/adapters/coinbase_intx/src/fix/client.rs
+++ b/crates/adapters/coinbase_intx/src/fix/client.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! FIX Client for the Coinbase International Drop Copy Endpoint.
+//! FIX Client for the Coinbase International Drop Copy `MStr<Topic>`.
 //!
 //! This implementation focuses specifically on processing execution reports
 //! via the FIX protocol, leveraging the existing `SocketClient` for TCP/TLS connectivity.

--- a/crates/adapters/demo/src/big_brain_actor.rs
+++ b/crates/adapters/demo/src/big_brain_actor.rs
@@ -22,7 +22,6 @@ use nautilus_common::{
         UnsubscribeCommand, UnsubscribeData,
     },
     msgbus::{
-        Endpoint,
         handler::{MessageHandler, ShareableMessageHandler, TypedMessageHandler},
         register, register_response_handler, send,
     },
@@ -67,7 +66,7 @@ impl BigBrainActor {
     pub fn register_message_handlers() {
         let handler = TypedMessageHandler::from(negative_handler);
         let handler = ShareableMessageHandler::from(Rc::new(handler) as Rc<dyn MessageHandler>);
-        let endpoint = Endpoint::from("negative_stream");
+        let endpoint = "negative_stream".into();
         register(endpoint, handler);
     }
 }
@@ -118,7 +117,7 @@ pub fn negative_handler(msg: &i32) {
     };
     let cmd = DataCommand::Request(RequestCommand::Data(request));
 
-    send(&Endpoint::from("data_engine"), &cmd);
+    send("data_engine".into(), &cmd);
 }
 
 /// Positive integer stream handler
@@ -145,7 +144,7 @@ pub fn positive_handler(msg: &i32) {
             None,
         );
         let cmd = DataCommand::Subscribe(SubscribeCommand::Data(data));
-        send(&Endpoint::from("data_engine"), &cmd);
+        send("data_engine".into(), &cmd);
     }
 
     if big_brain_actor.pos_val > 8 {
@@ -158,6 +157,6 @@ pub fn positive_handler(msg: &i32) {
             None,
         );
         let cmd = DataCommand::Unsubscribe(UnsubscribeCommand::Data(data));
-        send(&Endpoint::from("data_engine"), &cmd);
+        send("data_engine".into(), &cmd);
     }
 }

--- a/crates/adapters/demo/src/lib.rs
+++ b/crates/adapters/demo/src/lib.rs
@@ -22,7 +22,7 @@ use nautilus_common::{
     clock::{Clock, LiveClock},
     messages::data::{DataCommand, DataResponse},
     msgbus::{
-        self, Endpoint,
+        self,
         handler::{ShareableMessageHandler, TypedMessageHandler},
     },
 };
@@ -90,7 +90,7 @@ impl LiveRunner {
     }
 
     pub async fn run(&mut self) {
-        let endpoint = Endpoint::from("negative_stream");
+        let endpoint = "negative_stream".into();
 
         loop {
             // TODO: push decoding logic into data client
@@ -104,7 +104,7 @@ impl LiveRunner {
                 }
                 message = self.message_stream.next() => {
                     if let Some(message) = message {
-                        msgbus::send(&endpoint, &message);
+                        msgbus::send(endpoint, &message);
                     }
                 }
             }

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -780,7 +780,7 @@ mod tests {
         cache::Cache,
         clock::TestClock,
         msgbus::{
-            self, Endpoint,
+            self,
             stubs::{get_message_saving_handler, get_saved_messages},
         },
     };
@@ -1262,7 +1262,7 @@ mod tests {
         let account_type = AccountType::Margin;
         let mut cache = Cache::default();
         let handler = get_message_saving_handler::<AccountState>(None);
-        msgbus::register(Endpoint::from("Portfolio.update_account"), handler.clone());
+        msgbus::register("Portfolio.update_account".into(), handler.clone());
         let margin_account = MarginAccount::new(
             AccountState::new(
                 AccountId::from("SIM-001"),

--- a/crates/common/benches/matching.rs
+++ b/crates/common/benches/matching.rs
@@ -14,10 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use nautilus_common::msgbus::{
-    core::{Pattern, Topic},
-    matching::is_matching_backtracking,
-};
+use nautilus_common::msgbus::matching::is_matching_backtracking;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use regex::Regex;
 use ustr::Ustr;
@@ -65,7 +62,7 @@ fn bench_matching(c: &mut Criterion) {
     {
         let mut rng = StdRng::seed_from_u64(42);
         let mut iter_group = c.benchmark_group("Iterative backtracking matching");
-        let pattern = Pattern::from(pattern);
+        let pattern = pattern.into();
 
         for ele in [1, 10, 100, 1000] {
             let topics = create_topics(ele, &mut rng);
@@ -73,8 +70,7 @@ fn bench_matching(c: &mut Criterion) {
             iter_group.bench_function(format!("{ele} topics"), |b| {
                 b.iter(|| {
                     for topic in &topics {
-                        let topic = Topic::from(topic);
-                        black_box(is_matching_backtracking(&topic, &pattern));
+                        black_box(is_matching_backtracking(topic.into(), pattern));
                     }
                 });
             });

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -371,9 +371,9 @@ fn test_subscribe_and_receive_custom_data(
 
     let topic = get_custom_topic(&data_type);
     let data = String::from("CustomData-01");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
     let data = String::from("CustomData-02");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
 
     assert_eq!(actor.received_data.len(), 2);
 }
@@ -393,17 +393,17 @@ fn test_unsubscribe_custom_data(
 
     let topic = get_custom_topic(&data_type);
     let data = String::from("CustomData-01");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
     let data = String::from("CustomData-02");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
 
     actor.unsubscribe_data::<TestDataActor>(data_type, None, None);
 
     // Publish more data
     let data = String::from("CustomData-03");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
     let data = String::from("CustomData-04");
-    msgbus::publish(&topic, &data);
+    msgbus::publish(topic, &data);
 
     // Actor should not receive new data
     assert_eq!(actor.received_data.len(), 2);
@@ -448,7 +448,7 @@ fn test_subscribe_and_receive_book_deltas(
     );
     let deltas = OrderBookDeltas::new(audusd_sim.id, vec![delta]);
 
-    msgbus::publish(&topic, &deltas);
+    msgbus::publish(topic, &deltas);
 
     assert_eq!(actor.received_deltas.len(), 1);
 }
@@ -492,7 +492,7 @@ fn test_unsubscribe_book_deltas(
     );
     let deltas = OrderBookDeltas::new(audusd_sim.id, vec![delta]);
 
-    msgbus::publish(&topic, &deltas);
+    msgbus::publish(topic, &deltas);
 
     // Unsubscribe
     actor.unsubscribe_book_deltas::<TestDataActor>(audusd_sim.id, None, None);
@@ -509,7 +509,7 @@ fn test_unsubscribe_book_deltas(
     let deltas2 = OrderBookDeltas::new(audusd_sim.id, vec![delta2]);
 
     // Publish again
-    msgbus::publish(&topic, &deltas2);
+    msgbus::publish(topic, &deltas2);
 
     // Should still only have one delta
     assert_eq!(actor.received_deltas.len(), 1);
@@ -541,7 +541,7 @@ fn test_subscribe_and_receive_book_at_interval(
     let topic = get_book_snapshots_topic(audusd_sim.id);
     let book = OrderBook::new(audusd_sim.id, book_type);
 
-    msgbus::publish(&topic, &book);
+    msgbus::publish(topic, &book);
 
     assert_eq!(actor.received_books.len(), 1);
 }
@@ -572,15 +572,15 @@ fn test_unsubscribe_book_at_interval(
     let topic = get_book_snapshots_topic(audusd_sim.id);
     let book = OrderBook::new(audusd_sim.id, book_type);
 
-    msgbus::publish(&topic, &book);
+    msgbus::publish(topic, &book);
 
     assert_eq!(actor.received_books.len(), 1);
 
     actor.unsubscribe_book_at_interval::<TestDataActor>(audusd_sim.id, interval_ms, None, None);
 
     // Publish more book refs
-    msgbus::publish(&topic, &book);
-    msgbus::publish(&topic, &book);
+    msgbus::publish(topic, &book);
+    msgbus::publish(topic, &book);
 
     // Should still only have one book
     assert_eq!(actor.received_books.len(), 1);
@@ -601,8 +601,8 @@ fn test_subscribe_and_receive_quotes(
 
     let topic = get_quotes_topic(audusd_sim.id);
     let quote = QuoteTick::default();
-    msgbus::publish(&topic, &quote);
-    msgbus::publish(&topic, &quote);
+    msgbus::publish(topic, &quote);
+    msgbus::publish(topic, &quote);
 
     assert_eq!(actor.received_quotes.len(), 2);
 }
@@ -622,14 +622,14 @@ fn test_unsubscribe_quotes(
 
     let topic = get_quotes_topic(audusd_sim.id);
     let quote = QuoteTick::default();
-    msgbus::publish(&topic, &quote);
-    msgbus::publish(&topic, &quote);
+    msgbus::publish(topic, &quote);
+    msgbus::publish(topic, &quote);
 
     actor.unsubscribe_quotes::<TestDataActor>(audusd_sim.id, None, None);
 
     // Publish more quotes
-    msgbus::publish(&topic, &quote);
-    msgbus::publish(&topic, &quote);
+    msgbus::publish(topic, &quote);
+    msgbus::publish(topic, &quote);
 
     // Actor should not receive new quotes
     assert_eq!(actor.received_quotes.len(), 2);
@@ -650,8 +650,8 @@ fn test_subscribe_and_receive_trades(
 
     let topic = get_trades_topic(audusd_sim.id);
     let trade = TradeTick::default();
-    msgbus::publish(&topic, &trade);
-    msgbus::publish(&topic, &trade);
+    msgbus::publish(topic, &trade);
+    msgbus::publish(topic, &trade);
 
     assert_eq!(actor.received_trades.len(), 2);
 }
@@ -671,14 +671,14 @@ fn test_unsubscribe_trades(
 
     let topic = get_trades_topic(audusd_sim.id);
     let trade = TradeTick::default();
-    msgbus::publish(&topic, &trade);
-    msgbus::publish(&topic, &trade);
+    msgbus::publish(topic, &trade);
+    msgbus::publish(topic, &trade);
 
     actor.unsubscribe_trades::<TestDataActor>(audusd_sim.id, None, None);
 
     // Publish more trades
-    msgbus::publish(&topic, &trade);
-    msgbus::publish(&topic, &trade);
+    msgbus::publish(topic, &trade);
+    msgbus::publish(topic, &trade);
 
     // Actor should not receive new trades
     assert_eq!(actor.received_trades.len(), 2);
@@ -700,7 +700,7 @@ fn test_subscribe_and_receive_bars(
 
     let topic = get_bars_topic(bar_type);
     let bar = Bar::default();
-    msgbus::publish(&topic, &bar);
+    msgbus::publish(topic, &bar);
 
     assert_eq!(actor.received_bars.len(), 1);
 }
@@ -721,14 +721,14 @@ fn test_unsubscribe_bars(
 
     let topic = get_bars_topic(bar_type);
     let bar = Bar::default();
-    msgbus::publish(&topic, &bar);
+    msgbus::publish(topic, &bar);
 
     // Unsubscribe
     actor.unsubscribe_bars::<TestDataActor>(bar_type, None, None);
 
     // Publish more bars
-    msgbus::publish(&topic, &bar);
-    msgbus::publish(&topic, &bar);
+    msgbus::publish(topic, &bar);
+    msgbus::publish(topic, &bar);
 
     // Should still only have one bar
     assert_eq!(actor.received_bars.len(), 1);
@@ -893,9 +893,9 @@ fn test_subscribe_and_receive_instruments(
 
     let topic = get_instruments_topic(venue);
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish(&topic, &inst1);
+    msgbus::publish(topic, &inst1);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst2);
+    msgbus::publish(topic, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
     assert_eq!(actor.received_instruments[0], inst1);
@@ -919,8 +919,8 @@ fn test_subscribe_and_receive_instrument(
     let topic = get_instrument_topic(audusd_sim.id);
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim.clone());
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst1);
-    msgbus::publish(&topic, &inst2);
+    msgbus::publish(topic, &inst1);
+    msgbus::publish(topic, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
     assert_eq!(actor.received_instruments[0], inst1);
@@ -947,14 +947,14 @@ fn test_subscribe_and_receive_mark_prices(
         UnixNanos::from(1),
         UnixNanos::from(2),
     );
-    msgbus::publish(&topic, &mp1);
+    msgbus::publish(topic, &mp1);
     let mp2 = MarkPriceUpdate::new(
         audusd_sim.id,
         Price::from("1.00010"),
         UnixNanos::from(3),
         UnixNanos::from(4),
     );
-    msgbus::publish(&topic, &mp2);
+    msgbus::publish(topic, &mp2);
 
     assert_eq!(actor.received_mark_prices.len(), 2);
     assert_eq!(actor.received_mark_prices[0], mp1);
@@ -981,7 +981,7 @@ fn test_subscribe_and_receive_index_prices(
         UnixNanos::from(1),
         UnixNanos::from(2),
     );
-    msgbus::publish(&topic, &ip);
+    msgbus::publish(topic, &ip);
 
     assert_eq!(actor.received_index_prices.len(), 1);
     assert_eq!(actor.received_index_prices[0], ip);
@@ -1002,7 +1002,7 @@ fn test_subscribe_and_receive_instrument_status(
     actor.subscribe_instrument_status::<TestDataActor>(instrument_id, None, None);
 
     let topic = get_instrument_status_topic(instrument_id);
-    msgbus::publish(&topic, &stub_instrument_status);
+    msgbus::publish(topic, &stub_instrument_status);
 
     assert_eq!(actor.received_status.len(), 1);
     assert_eq!(actor.received_status[0], stub_instrument_status);
@@ -1023,7 +1023,7 @@ fn test_subscribe_and_receive_instrument_close(
     actor.subscribe_instrument_close::<TestDataActor>(instrument_id, None, None);
 
     let topic = get_instrument_close_topic(instrument_id);
-    msgbus::publish(&topic, &stub_instrument_close);
+    msgbus::publish(topic, &stub_instrument_close);
 
     assert_eq!(actor.received_closes.len(), 1);
     assert_eq!(actor.received_closes[0], stub_instrument_close);
@@ -1046,18 +1046,18 @@ fn test_unsubscribe_instruments(
 
     let topic = get_instruments_topic(venue);
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish(&topic, &inst1);
+    msgbus::publish(topic, &inst1);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst2);
+    msgbus::publish(topic, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
 
     actor.unsubscribe_instruments::<TestDataActor>(venue, None, None);
 
     let inst3 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish(&topic, &inst3);
+    msgbus::publish(topic, &inst3);
     let inst4 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst4);
+    msgbus::publish(topic, &inst4);
 
     assert_eq!(actor.received_instruments.len(), 2);
 }
@@ -1078,18 +1078,18 @@ fn test_unsubscribe_instrument(
 
     let topic = get_instrument_topic(audusd_sim.id);
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish(&topic, &inst1);
+    msgbus::publish(topic, &inst1);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst2);
+    msgbus::publish(topic, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
 
     actor.unsubscribe_instrument::<TestDataActor>(audusd_sim.id, None, None);
 
     let inst3 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish(&topic, &inst3);
+    msgbus::publish(topic, &inst3);
     let inst4 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish(&topic, &inst4);
+    msgbus::publish(topic, &inst4);
 
     assert_eq!(actor.received_instruments.len(), 2);
 }
@@ -1114,14 +1114,14 @@ fn test_unsubscribe_mark_prices(
         UnixNanos::from(1),
         UnixNanos::from(2),
     );
-    msgbus::publish(&topic, &mp1);
+    msgbus::publish(topic, &mp1);
     let mp2 = MarkPriceUpdate::new(
         audusd_sim.id,
         Price::from("1.00010"),
         UnixNanos::from(3),
         UnixNanos::from(4),
     );
-    msgbus::publish(&topic, &mp2);
+    msgbus::publish(topic, &mp2);
 
     assert_eq!(actor.received_mark_prices.len(), 2);
 
@@ -1133,14 +1133,14 @@ fn test_unsubscribe_mark_prices(
         UnixNanos::from(5),
         UnixNanos::from(6),
     );
-    msgbus::publish(&topic, &mp3);
+    msgbus::publish(topic, &mp3);
     let mp4 = MarkPriceUpdate::new(
         audusd_sim.id,
         Price::from("1.00030"),
         UnixNanos::from(7),
         UnixNanos::from(8),
     );
-    msgbus::publish(&topic, &mp4);
+    msgbus::publish(topic, &mp4);
 
     assert_eq!(actor.received_mark_prices.len(), 2);
 }
@@ -1165,7 +1165,7 @@ fn test_unsubscribe_index_prices(
         UnixNanos::from(1),
         UnixNanos::from(2),
     );
-    msgbus::publish(&topic, &ip1);
+    msgbus::publish(topic, &ip1);
 
     assert_eq!(actor.received_index_prices.len(), 1);
 
@@ -1177,7 +1177,7 @@ fn test_unsubscribe_index_prices(
         UnixNanos::from(3),
         UnixNanos::from(4),
     );
-    msgbus::publish(&topic, &ip2);
+    msgbus::publish(topic, &ip2);
 
     assert_eq!(actor.received_index_prices.len(), 1);
 }
@@ -1197,14 +1197,14 @@ fn test_unsubscribe_instrument_status(
     actor.subscribe_instrument_status::<TestDataActor>(instrument_id, None, None);
 
     let topic = get_instrument_status_topic(instrument_id);
-    msgbus::publish(&topic, &stub_instrument_status);
+    msgbus::publish(topic, &stub_instrument_status);
 
     assert_eq!(actor.received_status.len(), 1);
 
     actor.unsubscribe_instrument_status::<TestDataActor>(instrument_id, None, None);
 
     let stub2 = stub_instrument_status.clone();
-    msgbus::publish(&topic, &stub2);
+    msgbus::publish(topic, &stub2);
 
     assert_eq!(actor.received_status.len(), 1);
 }
@@ -1224,14 +1224,14 @@ fn test_unsubscribe_instrument_close(
     actor.subscribe_instrument_close::<TestDataActor>(instrument_id, None, None);
 
     let topic = get_instrument_close_topic(instrument_id);
-    msgbus::publish(&topic, &stub_instrument_close);
+    msgbus::publish(topic, &stub_instrument_close);
 
     assert_eq!(actor.received_closes.len(), 1);
 
     actor.unsubscribe_instrument_close::<TestDataActor>(instrument_id, None, None);
 
     let stub2 = stub_instrument_close.clone();
-    msgbus::publish(&topic, &stub2);
+    msgbus::publish(topic, &stub2);
 
     assert_eq!(actor.received_closes.len(), 1);
 }

--- a/crates/common/src/msgbus/core.rs
+++ b/crates/common/src/msgbus/core.rs
@@ -44,133 +44,84 @@ fn check_fully_qualified_string(value: &Ustr, key: &str) -> anyhow::Result<()> {
     )
 }
 
-/// A string pattern for a subscription. The pattern is used to match topics.
-///
-/// A pattern is made of characters:
-/// - `*` - match 0 or more characters
-/// - `?` - match any character once
-/// - `a-z` - match the specific character
+/// Pattern is a string pattern for a subscription with special characters
+/// for pattern matching.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Pattern(pub Ustr);
+pub struct Pattern;
 
-impl<T: AsRef<str>> From<T> for Pattern {
-    fn from(value: T) -> Self {
-        Self(Ustr::from(value.as_ref()))
+/// Topic is a fully qualified string for publishing or sending data.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Topic;
+
+/// A message bus string type. It can be a pattern or a topic.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MStr<T> {
+    value: Ustr,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Display for MStr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
     }
 }
 
-impl Deref for Pattern {
+impl<T> Deref for MStr<T> {
     type Target = Ustr;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.value
     }
 }
 
-impl Display for Pattern {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+impl MStr<Pattern> {
+    /// Create a new pattern from a string.
+    pub fn pattern<T: AsRef<str>>(value: T) -> Self {
+        let value = Ustr::from(value.as_ref());
+
+        Self {
+            value,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
-impl From<Topic> for Pattern {
-    fn from(value: Topic) -> Self {
-        Self(value.0)
+impl<T: AsRef<str>> From<T> for MStr<Pattern> {
+    fn from(value: T) -> Self {
+        Self::pattern(value)
     }
 }
 
-impl From<&Topic> for Pattern {
-    fn from(value: &Topic) -> Self {
-        Self(value.0)
+impl From<MStr<Topic>> for MStr<Pattern> {
+    fn from(value: MStr<Topic>) -> Self {
+        Self {
+            value: value.value,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
-/// A string topic for publishing data. It is a fully qualified pattern i.e.
-/// wildcard characters are not allowed.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Topic(pub Ustr);
-
-impl Topic {
-    /// Creates a new [`Topic`] instance.
+impl MStr<Topic> {
+    /// Create a new topic from a fully qualified string.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - `value` string is empty, all whitespace, or contains non-ASCII characters.
-    /// - `value` string contains wildcard characters '*' or '?'.
-    pub fn new<T: AsRef<str>>(value: T) -> anyhow::Result<Self> {
+    /// Returns an error if the topic has white space or invalid characters.
+    pub fn topic<T: AsRef<str>>(value: T) -> anyhow::Result<Self> {
         let topic = Ustr::from(value.as_ref());
         check_valid_string(value, stringify!(value))?;
         check_fully_qualified_string(&topic, stringify!(Topic))?;
 
-        Ok(Self(topic))
-    }
-
-    pub fn as_pattern(&self) -> Pattern {
-        Pattern(self.0)
+        Ok(Self {
+            value: topic,
+            _marker: std::marker::PhantomData,
+        })
     }
 }
 
-impl<T: AsRef<str>> From<T> for Topic {
+impl<T: AsRef<str>> From<T> for MStr<Topic> {
     fn from(value: T) -> Self {
-        Self::new(value).expect(FAILED)
-    }
-}
-
-impl Deref for Topic {
-    type Target = Ustr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Display for Topic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// A component endpoint adderess.
-///
-/// It is a fully qualified pattern i.e. wildcard characters are not allowed.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Endpoint(pub Ustr);
-
-impl Endpoint {
-    /// Creates a new [`Endpoint`] instance.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - `value` string is empty, all whitespace, or contains non-ASCII characters.
-    /// - `value` string contains wildcard characters '*' or '?'.
-    pub fn new<T: AsRef<str>>(value: T) -> anyhow::Result<Self> {
-        let endpoint = Ustr::from(value.as_ref());
-        check_valid_string(value, stringify!(value))?;
-        check_fully_qualified_string(&endpoint, stringify!(Endpoint))?;
-
-        Ok(Self(endpoint))
-    }
-}
-
-impl<T: AsRef<str>> From<T> for Endpoint {
-    fn from(value: T) -> Self {
-        Self::new(value).expect(FAILED)
-    }
-}
-
-impl Deref for Endpoint {
-    type Target = Ustr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Display for Endpoint {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        Self::topic(value).expect(FAILED)
     }
 }
 
@@ -186,7 +137,7 @@ pub struct Subscription {
     /// Store a copy of the handler ID for faster equality checks.
     pub handler_id: Ustr,
     /// The pattern for the subscription.
-    pub pattern: Pattern,
+    pub pattern: MStr<Pattern>,
     /// The priority for the subscription determines the ordering of handlers receiving
     /// messages being processed, higher priority handlers will receive messages before
     /// lower priority handlers.
@@ -196,7 +147,11 @@ pub struct Subscription {
 impl Subscription {
     /// Creates a new [`Subscription`] instance.
     #[must_use]
-    pub fn new(pattern: Pattern, handler: ShareableMessageHandler, priority: Option<u8>) -> Self {
+    pub fn new(
+        pattern: MStr<Pattern>,
+        handler: ShareableMessageHandler,
+        priority: Option<u8>,
+    ) -> Self {
         Self {
             handler_id: handler.0.id(),
             pattern,
@@ -277,9 +232,9 @@ pub struct MessageBus {
     pub subscriptions: AHashSet<Subscription>,
     /// Maps a topic to all the handlers registered for it
     /// this is updated whenever a new subscription is created.
-    pub topics: IndexMap<Topic, Vec<Subscription>>,
+    pub topics: IndexMap<MStr<Topic>, Vec<Subscription>>,
     /// Index of endpoint addresses and their handlers.
-    pub endpoints: IndexMap<Endpoint, ShareableMessageHandler>,
+    pub endpoints: IndexMap<MStr<Topic>, ShareableMessageHandler>,
     /// Index of request correlation IDs and their response handlers.
     pub correlation_index: AHashMap<UUID4, ShareableMessageHandler>,
 }
@@ -340,13 +295,17 @@ impl MessageBus {
     }
 
     /// Returns the count of subscribers for the `topic`.
+    ///
+    /// # Panics
+    ///
+    /// Returns an error if the topic is not valid.
     #[must_use]
     pub fn subscriptions_count<T: AsRef<str>>(&self, topic: T) -> usize {
-        let topic = Topic::from(topic);
+        let topic = MStr::<Topic>::topic(topic).expect(FAILED);
         self.topics
             .get(&topic)
             .map(|subs| subs.len())
-            .unwrap_or_else(|| self.find_topic_matches(&topic).len())
+            .unwrap_or_else(|| self.find_topic_matches(topic).len())
     }
 
     /// Returns active subscriptions.
@@ -364,11 +323,15 @@ impl MessageBus {
             .collect()
     }
 
-    /// Returns whether there is a registered endpoint for the `pattern`.
+    /// Returns whether the endpoint is registered.
+    ///
+    /// # Panics
+    ///
+    /// Returns an error if the endpoint is not valid topic string.
     #[must_use]
     pub fn is_registered<T: AsRef<str>>(&self, endpoint: T) -> bool {
         self.endpoints
-            .contains_key(&Endpoint::from(endpoint.as_ref()))
+            .contains_key(&MStr::<Topic>::topic(endpoint).expect(FAILED))
     }
 
     /// Returns whether the `handler` is subscribed to the `pattern`.
@@ -378,7 +341,7 @@ impl MessageBus {
         pattern: T,
         handler: ShareableMessageHandler,
     ) -> bool {
-        let pattern = Pattern::from(pattern);
+        let pattern = MStr::<Pattern>::pattern(pattern);
         let sub = Subscription::new(pattern, handler, None);
         self.subscriptions.contains(&sub)
     }
@@ -395,8 +358,8 @@ impl MessageBus {
 
     /// Returns the handler for the `endpoint`.
     #[must_use]
-    pub fn get_endpoint(&self, endpoint: &Endpoint) -> Option<&ShareableMessageHandler> {
-        self.endpoints.get(endpoint)
+    pub fn get_endpoint(&self, endpoint: MStr<Topic>) -> Option<&ShareableMessageHandler> {
+        self.endpoints.get(&endpoint)
     }
 
     /// Returns the handler for the `correlation_id`.
@@ -406,11 +369,11 @@ impl MessageBus {
     }
 
     /// Finds the subscriptions with pattern matching the `topic`.
-    pub(crate) fn find_topic_matches(&self, topic: &Topic) -> Vec<Subscription> {
+    pub(crate) fn find_topic_matches(&self, topic: MStr<Topic>) -> Vec<Subscription> {
         self.subscriptions
             .iter()
             .filter_map(|sub| {
-                if is_matching_backtracking(topic, &sub.pattern) {
+                if is_matching_backtracking(topic, sub.pattern) {
                     Some(sub.clone())
                 } else {
                     None
@@ -423,15 +386,15 @@ impl MessageBus {
     /// results in the `patterns` map.
     #[must_use]
     pub fn matching_subscriptions<T: AsRef<str>>(&mut self, topic: T) -> Vec<Subscription> {
-        let topic = Topic::from(topic.as_ref());
-        self.inner_matching_subscriptions(&topic)
+        let topic = MStr::<Topic>::from(topic);
+        self.inner_matching_subscriptions(topic)
     }
 
-    pub(crate) fn inner_matching_subscriptions(&mut self, topic: &Topic) -> Vec<Subscription> {
-        self.topics.get(topic).cloned().unwrap_or_else(|| {
+    pub(crate) fn inner_matching_subscriptions(&mut self, topic: MStr<Topic>) -> Vec<Subscription> {
+        self.topics.get(&topic).cloned().unwrap_or_else(|| {
             let mut matches = self.find_topic_matches(topic);
             matches.sort();
-            self.topics.insert(*topic, matches.clone());
+            self.topics.insert(topic, matches.clone());
             matches
         })
     }

--- a/crates/common/src/msgbus/matching.rs
+++ b/crates/common/src/msgbus/matching.rs
@@ -13,14 +13,14 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use super::core::{Pattern, Topic};
+use super::core::{MStr, Pattern, Topic};
 
 /// Match a topic and a string pattern using iterative backtracking algorithm
 /// pattern can contains -
 /// '*' - match 0 or more characters after this
 /// '?' - match any character once
 /// 'a-z' - match the specific character
-pub fn is_matching_backtracking(topic: &Topic, pattern: &Pattern) -> bool {
+pub fn is_matching_backtracking(topic: MStr<Topic>, pattern: MStr<Pattern>) -> bool {
     let topic_bytes = topic.as_bytes();
     let pattern_bytes = pattern.as_bytes();
 

--- a/crates/common/src/msgbus/mod.rs
+++ b/crates/common/src/msgbus/mod.rs
@@ -43,7 +43,7 @@ use ustr::Ustr;
 
 use crate::messages::data::DataResponse;
 // Re-exports
-pub use crate::msgbus::core::{Endpoint, Pattern, Topic};
+pub use crate::msgbus::core::{MStr, Pattern, Topic};
 pub use crate::msgbus::message::BusMessage;
 
 #[derive(Debug)]
@@ -86,7 +86,7 @@ pub fn get_message_bus() -> Rc<RefCell<MessageBus>> {
 }
 
 /// Sends the `message` to the `endpoint`.
-pub fn send(endpoint: &Endpoint, message: &dyn Any) {
+pub fn send(endpoint: MStr<Topic>, message: &dyn Any) {
     // TODO: This should return a Result (in case endpoint doesn't exist)
     let handler = get_message_bus().borrow().get_endpoint(endpoint).cloned();
     if let Some(handler) = handler {
@@ -140,7 +140,7 @@ pub fn register_response_handler(correlation_id: &UUID4, handler: ShareableMessa
 }
 
 /// Publishes the `message` to the `topic`.
-pub fn publish(topic: &Topic, message: &dyn Any) {
+pub fn publish(topic: MStr<Topic>, message: &dyn Any) {
     log::trace!("Publishing topic '{topic}' {message:?}");
     let matching_subs = get_message_bus()
         .borrow_mut()
@@ -155,7 +155,7 @@ pub fn publish(topic: &Topic, message: &dyn Any) {
 }
 
 /// Registers the `handler` for the `endpoint` address.
-pub fn register(endpoint: Endpoint, handler: ShareableMessageHandler) {
+pub fn register(endpoint: MStr<Topic>, handler: ShareableMessageHandler) {
     log::debug!(
         "Registering endpoint '{endpoint}' with handler ID {}",
         handler.0.id(),
@@ -169,14 +169,14 @@ pub fn register(endpoint: Endpoint, handler: ShareableMessageHandler) {
 }
 
 /// Deregisters the handler for the `endpoint` address.
-pub fn deregister(endpoint: &Endpoint) {
+pub fn deregister(endpoint: MStr<Topic>) {
     log::debug!("Deregistering endpoint '{endpoint}'");
 
     // Removes entry if it exists for endpoint
     get_message_bus()
         .borrow_mut()
         .endpoints
-        .shift_remove(endpoint);
+        .shift_remove(&endpoint);
 }
 
 /// Subscribes the `handler` to the `pattern` with an optional `priority`.
@@ -189,7 +189,7 @@ pub fn deregister(endpoint: &Endpoint) {
 /// priority is assigned then the handler may receive messages before core
 /// system components have been able to process necessary calculations and
 /// produce potential side effects for logically sound behavior.
-pub fn subscribe(pattern: Pattern, handler: ShareableMessageHandler, priority: Option<u8>) {
+pub fn subscribe(pattern: MStr<Pattern>, handler: ShareableMessageHandler, priority: Option<u8>) {
     let msgbus = get_message_bus();
     let mut msgbus_ref_mut = msgbus.borrow_mut();
     let sub = core::Subscription::new(pattern, handler, priority);
@@ -207,7 +207,7 @@ pub fn subscribe(pattern: Pattern, handler: ShareableMessageHandler, priority: O
 
     // Find existing patterns which match this topic
     for (topic, subs) in msgbus_ref_mut.topics.iter_mut() {
-        if is_matching_backtracking(topic, &sub.pattern) {
+        if is_matching_backtracking(*topic, sub.pattern) {
             // TODO: Consider binary_search and then insert
             subs.push(sub.clone());
             subs.sort();
@@ -218,8 +218,8 @@ pub fn subscribe(pattern: Pattern, handler: ShareableMessageHandler, priority: O
     msgbus_ref_mut.subscriptions.insert(sub);
 }
 
-pub fn subscribe_topic(topic: Topic, handler: ShareableMessageHandler, priority: Option<u8>) {
-    subscribe(topic.as_pattern(), handler, priority);
+pub fn subscribe_topic(topic: MStr<Topic>, handler: ShareableMessageHandler, priority: Option<u8>) {
+    subscribe(topic.into(), handler, priority);
 }
 
 pub fn subscribe_str<T: AsRef<str>>(
@@ -227,12 +227,11 @@ pub fn subscribe_str<T: AsRef<str>>(
     handler: ShareableMessageHandler,
     priority: Option<u8>,
 ) {
-    let pattern = Pattern::from(pattern);
-    subscribe(pattern, handler, priority);
+    subscribe(MStr::from(pattern), handler, priority);
 }
 
 /// Unsubscribes the `handler` from the `pattern`.
-pub fn unsubscribe(pattern: Pattern, handler: ShareableMessageHandler) {
+pub fn unsubscribe(pattern: MStr<Pattern>, handler: ShareableMessageHandler) {
     log::debug!("Unsubscribing {handler:?} from pattern '{pattern}'");
 
     let sub = core::Subscription::new(pattern, handler, None);
@@ -256,17 +255,16 @@ pub fn unsubscribe(pattern: Pattern, handler: ShareableMessageHandler) {
     }
 }
 
-pub fn unsubscribe_topic(topic: Topic, handler: ShareableMessageHandler) {
-    unsubscribe(topic.as_pattern(), handler);
+pub fn unsubscribe_topic(topic: MStr<Topic>, handler: ShareableMessageHandler) {
+    unsubscribe(topic.into(), handler);
 }
 
 pub fn unsubscribe_str<T: AsRef<str>>(pattern: T, handler: ShareableMessageHandler) {
-    let pattern = Pattern::from(pattern);
-    unsubscribe(pattern, handler);
+    unsubscribe(MStr::from(pattern), handler);
 }
 
 pub fn is_subscribed<T: AsRef<str>>(pattern: T, handler: ShareableMessageHandler) -> bool {
-    let pattern = Pattern::from(pattern.as_ref());
+    let pattern = MStr::from(pattern.as_ref());
     let sub = Subscription::new(pattern, handler, None);
     get_message_bus().borrow().subscriptions.contains(&sub)
 }

--- a/crates/common/src/msgbus/mod.rs
+++ b/crates/common/src/msgbus/mod.rs
@@ -32,7 +32,7 @@ pub mod switchboard;
 mod tests;
 
 pub use core::MessageBus;
-use core::Subscription;
+use core::{Endpoint, Subscription};
 use std::{self, any::Any, cell::RefCell, fmt::Debug, rc::Rc, sync::OnceLock};
 
 use handler::ShareableMessageHandler;
@@ -86,7 +86,7 @@ pub fn get_message_bus() -> Rc<RefCell<MessageBus>> {
 }
 
 /// Sends the `message` to the `endpoint`.
-pub fn send(endpoint: MStr<Topic>, message: &dyn Any) {
+pub fn send(endpoint: MStr<Endpoint>, message: &dyn Any) {
     // TODO: This should return a Result (in case endpoint doesn't exist)
     let handler = get_message_bus().borrow().get_endpoint(endpoint).cloned();
     if let Some(handler) = handler {
@@ -155,7 +155,7 @@ pub fn publish(topic: MStr<Topic>, message: &dyn Any) {
 }
 
 /// Registers the `handler` for the `endpoint` address.
-pub fn register(endpoint: MStr<Topic>, handler: ShareableMessageHandler) {
+pub fn register(endpoint: MStr<Endpoint>, handler: ShareableMessageHandler) {
     log::debug!(
         "Registering endpoint '{endpoint}' with handler ID {}",
         handler.0.id(),
@@ -169,7 +169,7 @@ pub fn register(endpoint: MStr<Topic>, handler: ShareableMessageHandler) {
 }
 
 /// Deregisters the handler for the `endpoint` address.
-pub fn deregister(endpoint: MStr<Topic>) {
+pub fn deregister(endpoint: MStr<Endpoint>) {
     log::debug!("Deregistering endpoint '{endpoint}'");
 
     // Removes entry if it exists for endpoint

--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -20,7 +20,7 @@ use nautilus_model::{
     identifiers::{ClientOrderId, InstrumentId, PositionId, StrategyId, Venue},
 };
 
-use super::core::{MStr, Topic};
+use super::core::{Endpoint, MStr, Topic};
 use crate::msgbus::get_message_bus;
 
 pub const CLOSE_TOPIC: &str = "CLOSE";
@@ -210,22 +210,22 @@ impl Default for MessagingSwitchboard {
 
 impl MessagingSwitchboard {
     #[must_use]
-    pub fn data_engine_execute() -> MStr<Topic> {
+    pub fn data_engine_execute() -> MStr<Endpoint> {
         "DataEngine.execute".into()
     }
 
     #[must_use]
-    pub fn data_engine_process() -> MStr<Topic> {
+    pub fn data_engine_process() -> MStr<Endpoint> {
         "DataEngine.process".into()
     }
 
     #[must_use]
-    pub fn exec_engine_execute() -> MStr<Topic> {
+    pub fn exec_engine_execute() -> MStr<Endpoint> {
         "ExecEngine.execute".into()
     }
 
     #[must_use]
-    pub fn exec_engine_process() -> MStr<Topic> {
+    pub fn exec_engine_process() -> MStr<Endpoint> {
         "ExecEngine.process".into()
     }
 

--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -20,13 +20,13 @@ use nautilus_model::{
     identifiers::{ClientOrderId, InstrumentId, PositionId, StrategyId, Venue},
 };
 
-use super::core::{Endpoint, Topic};
+use super::core::{MStr, Topic};
 use crate::msgbus::get_message_bus;
 
 pub const CLOSE_TOPIC: &str = "CLOSE";
 
 #[must_use]
-pub fn get_custom_topic(data_type: &DataType) -> Topic {
+pub fn get_custom_topic(data_type: &DataType) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -34,7 +34,7 @@ pub fn get_custom_topic(data_type: &DataType) -> Topic {
 }
 
 #[must_use]
-pub fn get_instruments_topic(venue: Venue) -> Topic {
+pub fn get_instruments_topic(venue: Venue) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -42,7 +42,7 @@ pub fn get_instruments_topic(venue: Venue) -> Topic {
 }
 
 #[must_use]
-pub fn get_instrument_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_instrument_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -50,7 +50,7 @@ pub fn get_instrument_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_book_deltas_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_book_deltas_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -58,7 +58,7 @@ pub fn get_book_deltas_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_book_depth10_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_book_depth10_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -66,7 +66,7 @@ pub fn get_book_depth10_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_book_snapshots_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_book_snapshots_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -74,7 +74,7 @@ pub fn get_book_snapshots_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_quotes_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_quotes_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -82,7 +82,7 @@ pub fn get_quotes_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_trades_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_trades_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -90,7 +90,7 @@ pub fn get_trades_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_bars_topic(bar_type: BarType) -> Topic {
+pub fn get_bars_topic(bar_type: BarType) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -98,7 +98,7 @@ pub fn get_bars_topic(bar_type: BarType) -> Topic {
 }
 
 #[must_use]
-pub fn get_mark_price_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_mark_price_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -106,7 +106,7 @@ pub fn get_mark_price_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_index_price_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_index_price_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -114,7 +114,7 @@ pub fn get_index_price_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_instrument_status_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_instrument_status_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -122,7 +122,7 @@ pub fn get_instrument_status_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_instrument_close_topic(instrument_id: InstrumentId) -> Topic {
+pub fn get_instrument_close_topic(instrument_id: InstrumentId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -130,7 +130,7 @@ pub fn get_instrument_close_topic(instrument_id: InstrumentId) -> Topic {
 }
 
 #[must_use]
-pub fn get_order_snapshots_topic(client_order_id: ClientOrderId) -> Topic {
+pub fn get_order_snapshots_topic(client_order_id: ClientOrderId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -138,7 +138,7 @@ pub fn get_order_snapshots_topic(client_order_id: ClientOrderId) -> Topic {
 }
 
 #[must_use]
-pub fn get_positions_snapshots_topic(position_id: PositionId) -> Topic {
+pub fn get_positions_snapshots_topic(position_id: PositionId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -146,7 +146,7 @@ pub fn get_positions_snapshots_topic(position_id: PositionId) -> Topic {
 }
 
 #[must_use]
-pub fn get_event_orders_topic(strategy_id: StrategyId) -> Topic {
+pub fn get_event_orders_topic(strategy_id: StrategyId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -154,7 +154,7 @@ pub fn get_event_orders_topic(strategy_id: StrategyId) -> Topic {
 }
 
 #[must_use]
-pub fn get_event_positions_topic(strategy_id: StrategyId) -> Topic {
+pub fn get_event_positions_topic(strategy_id: StrategyId) -> MStr<Topic> {
     get_message_bus()
         .borrow_mut()
         .switchboard
@@ -164,23 +164,23 @@ pub fn get_event_positions_topic(strategy_id: StrategyId) -> Topic {
 /// Represents a switchboard of built-in messaging endpoint names.
 #[derive(Clone, Debug)]
 pub struct MessagingSwitchboard {
-    custom_topics: HashMap<DataType, Topic>,
-    instruments_topics: HashMap<Venue, Topic>,
-    instrument_topics: HashMap<InstrumentId, Topic>,
-    book_deltas_topics: HashMap<InstrumentId, Topic>,
-    book_depth10_topics: HashMap<InstrumentId, Topic>,
-    book_snapshots_topics: HashMap<InstrumentId, Topic>,
-    quote_topics: HashMap<InstrumentId, Topic>,
-    trade_topics: HashMap<InstrumentId, Topic>,
-    bar_topics: HashMap<BarType, Topic>,
-    mark_price_topics: HashMap<InstrumentId, Topic>,
-    index_price_topics: HashMap<InstrumentId, Topic>,
-    instrument_status_topics: HashMap<InstrumentId, Topic>,
-    instrument_close_topics: HashMap<InstrumentId, Topic>,
-    event_orders_topics: HashMap<StrategyId, Topic>,
-    event_positions_topics: HashMap<StrategyId, Topic>,
-    order_snapshots_topics: HashMap<ClientOrderId, Topic>,
-    positions_snapshots_topics: HashMap<PositionId, Topic>,
+    custom_topics: HashMap<DataType, MStr<Topic>>,
+    instruments_topics: HashMap<Venue, MStr<Topic>>,
+    instrument_topics: HashMap<InstrumentId, MStr<Topic>>,
+    book_deltas_topics: HashMap<InstrumentId, MStr<Topic>>,
+    book_depth10_topics: HashMap<InstrumentId, MStr<Topic>>,
+    book_snapshots_topics: HashMap<InstrumentId, MStr<Topic>>,
+    quote_topics: HashMap<InstrumentId, MStr<Topic>>,
+    trade_topics: HashMap<InstrumentId, MStr<Topic>>,
+    bar_topics: HashMap<BarType, MStr<Topic>>,
+    mark_price_topics: HashMap<InstrumentId, MStr<Topic>>,
+    index_price_topics: HashMap<InstrumentId, MStr<Topic>>,
+    instrument_status_topics: HashMap<InstrumentId, MStr<Topic>>,
+    instrument_close_topics: HashMap<InstrumentId, MStr<Topic>>,
+    event_orders_topics: HashMap<StrategyId, MStr<Topic>>,
+    event_positions_topics: HashMap<StrategyId, MStr<Topic>>,
+    order_snapshots_topics: HashMap<ClientOrderId, MStr<Topic>>,
+    positions_snapshots_topics: HashMap<PositionId, MStr<Topic>>,
 }
 
 impl Default for MessagingSwitchboard {
@@ -210,203 +210,213 @@ impl Default for MessagingSwitchboard {
 
 impl MessagingSwitchboard {
     #[must_use]
-    pub fn data_engine_execute() -> Endpoint {
-        Endpoint::from("DataEngine.execute")
+    pub fn data_engine_execute() -> MStr<Topic> {
+        "DataEngine.execute".into()
     }
 
     #[must_use]
-    pub fn data_engine_process() -> Endpoint {
-        Endpoint::from("DataEngine.process")
+    pub fn data_engine_process() -> MStr<Topic> {
+        "DataEngine.process".into()
     }
 
     #[must_use]
-    pub fn exec_engine_execute() -> Endpoint {
-        Endpoint::from("ExecEngine.execute")
+    pub fn exec_engine_execute() -> MStr<Topic> {
+        "ExecEngine.execute".into()
     }
 
     #[must_use]
-    pub fn exec_engine_process() -> Endpoint {
-        Endpoint::from("ExecEngine.process")
+    pub fn exec_engine_process() -> MStr<Topic> {
+        "ExecEngine.process".into()
     }
 
     #[must_use]
-    pub fn get_custom_topic(&mut self, data_type: &DataType) -> Topic {
+    pub fn get_custom_topic(&mut self, data_type: &DataType) -> MStr<Topic> {
         *self
             .custom_topics
             .entry(data_type.clone())
-            .or_insert_with(|| Topic::from(&format!("data.{}", data_type.topic())))
+            .or_insert_with(|| format!("data.{}", data_type.topic()).into())
     }
 
     #[must_use]
-    pub fn get_instruments_topic(&mut self, venue: Venue) -> Topic {
+    pub fn get_instruments_topic(&mut self, venue: Venue) -> MStr<Topic> {
         *self
             .instruments_topics
             .entry(venue)
-            .or_insert_with(|| Topic::from(&format!("data.instrument.{}", venue)))
+            .or_insert_with(|| format!("data.instrument.{}", venue).into())
     }
 
     #[must_use]
-    pub fn get_instrument_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_instrument_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .instrument_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.instrument.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_book_deltas_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_book_deltas_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .book_deltas_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.book.deltas.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_book_depth10_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_book_depth10_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .book_depth10_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.book.depth10.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_book_snapshots_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_book_snapshots_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .book_snapshots_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.book.snapshots.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_quotes_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_quotes_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self.quote_topics.entry(instrument_id).or_insert_with(|| {
-            Topic::from(&format!(
+            format!(
                 "data.quotes.{}.{}",
                 instrument_id.venue, instrument_id.symbol
-            ))
+            )
+            .into()
         })
     }
 
     #[must_use]
-    pub fn get_trades_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_trades_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self.trade_topics.entry(instrument_id).or_insert_with(|| {
-            Topic::from(&format!(
+            format!(
                 "data.trades.{}.{}",
                 instrument_id.venue, instrument_id.symbol
-            ))
+            )
+            .into()
         })
     }
 
     #[must_use]
-    pub fn get_bars_topic(&mut self, bar_type: BarType) -> Topic {
+    pub fn get_bars_topic(&mut self, bar_type: BarType) -> MStr<Topic> {
         *self
             .bar_topics
             .entry(bar_type)
-            .or_insert_with(|| Topic::from(&format!("data.bars.{bar_type}")))
+            .or_insert_with(|| format!("data.bars.{bar_type}").into())
     }
 
     #[must_use]
-    pub fn get_mark_price_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_mark_price_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .mark_price_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.mark_prices.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_index_price_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_index_price_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .index_price_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.index_prices.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_instrument_status_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_instrument_status_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .instrument_status_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.status.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_instrument_close_topic(&mut self, instrument_id: InstrumentId) -> Topic {
+    pub fn get_instrument_close_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
         *self
             .instrument_close_topics
             .entry(instrument_id)
             .or_insert_with(|| {
-                Topic::from(&format!(
+                format!(
                     "data.close.{}.{}",
                     instrument_id.venue, instrument_id.symbol
-                ))
+                )
+                .into()
             })
     }
 
     #[must_use]
-    pub fn get_order_snapshots_topic(&mut self, client_order_id: ClientOrderId) -> Topic {
+    pub fn get_order_snapshots_topic(&mut self, client_order_id: ClientOrderId) -> MStr<Topic> {
         *self
             .order_snapshots_topics
             .entry(client_order_id)
-            .or_insert_with(|| Topic::from(&format!("order.snapshots.{client_order_id}")))
+            .or_insert_with(|| format!("order.snapshots.{client_order_id}").into())
     }
 
     #[must_use]
-    pub fn get_positions_snapshots_topic(&mut self, position_id: PositionId) -> Topic {
+    pub fn get_positions_snapshots_topic(&mut self, position_id: PositionId) -> MStr<Topic> {
         *self
             .positions_snapshots_topics
             .entry(position_id)
-            .or_insert_with(|| Topic::from(&format!("positions.snapshots.{position_id}")))
+            .or_insert_with(|| format!("positions.snapshots.{position_id}").into())
     }
 
     #[must_use]
-    pub fn get_event_orders_topic(&mut self, strategy_id: StrategyId) -> Topic {
+    pub fn get_event_orders_topic(&mut self, strategy_id: StrategyId) -> MStr<Topic> {
         *self
             .event_orders_topics
             .entry(strategy_id)
-            .or_insert_with(|| Topic::from(&format!("events.order.{strategy_id}")))
+            .or_insert_with(|| format!("events.order.{strategy_id}").into())
     }
 
     #[must_use]
-    pub fn get_event_positions_topic(&mut self, strategy_id: StrategyId) -> Topic {
+    pub fn get_event_positions_topic(&mut self, strategy_id: StrategyId) -> MStr<Topic> {
         *self
             .event_positions_topics
             .entry(strategy_id)
-            .or_insert_with(|| Topic::from(&format!("events.position.{strategy_id}")))
+            .or_insert_with(|| format!("events.position.{strategy_id}").into())
     }
 }
 
@@ -436,7 +446,7 @@ mod tests {
     #[rstest]
     fn test_get_custom_topic(mut switchboard: MessagingSwitchboard) {
         let data_type = DataType::new("ExampleDataType", None);
-        let expected_topic = Topic::from("data.ExampleDataType");
+        let expected_topic = "data.ExampleDataType".into();
         let result = switchboard.get_custom_topic(&data_type);
         assert_eq!(result, expected_topic);
         assert!(switchboard.custom_topics.contains_key(&data_type));
@@ -447,7 +457,7 @@ mod tests {
         mut switchboard: MessagingSwitchboard,
         instrument_id: InstrumentId,
     ) {
-        let expected_topic = Topic::from("data.instrument.XCME.ESZ24");
+        let expected_topic = "data.instrument.XCME.ESZ24".into();
         let result = switchboard.get_instrument_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(switchboard.instrument_topics.contains_key(&instrument_id));
@@ -458,7 +468,7 @@ mod tests {
         mut switchboard: MessagingSwitchboard,
         instrument_id: InstrumentId,
     ) {
-        let expected_topic = Topic::from("data.book.deltas.XCME.ESZ24");
+        let expected_topic = "data.book.deltas.XCME.ESZ24".into();
         let result = switchboard.get_book_deltas_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(switchboard.book_deltas_topics.contains_key(&instrument_id));
@@ -469,7 +479,7 @@ mod tests {
         mut switchboard: MessagingSwitchboard,
         instrument_id: InstrumentId,
     ) {
-        let expected_topic = Topic::from("data.book.depth10.XCME.ESZ24");
+        let expected_topic = "data.book.depth10.XCME.ESZ24".into();
         let result = switchboard.get_book_depth10_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(switchboard.book_depth10_topics.contains_key(&instrument_id));
@@ -480,7 +490,7 @@ mod tests {
         mut switchboard: MessagingSwitchboard,
         instrument_id: InstrumentId,
     ) {
-        let expected_topic = Topic::from("data.book.snapshots.XCME.ESZ24");
+        let expected_topic = "data.book.snapshots.XCME.ESZ24".into();
         let result = switchboard.get_book_snapshots_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(
@@ -492,7 +502,7 @@ mod tests {
 
     #[rstest]
     fn test_get_quotes_topic(mut switchboard: MessagingSwitchboard, instrument_id: InstrumentId) {
-        let expected_topic = Topic::from("data.quotes.XCME.ESZ24");
+        let expected_topic = "data.quotes.XCME.ESZ24".into();
         let result = switchboard.get_quotes_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(switchboard.quote_topics.contains_key(&instrument_id));
@@ -500,7 +510,7 @@ mod tests {
 
     #[rstest]
     fn test_get_trades_topic(mut switchboard: MessagingSwitchboard, instrument_id: InstrumentId) {
-        let expected_topic = Topic::from("data.trades.XCME.ESZ24");
+        let expected_topic = "data.trades.XCME.ESZ24".into();
         let result = switchboard.get_trades_topic(instrument_id);
         assert_eq!(result, expected_topic);
         assert!(switchboard.trade_topics.contains_key(&instrument_id));
@@ -509,7 +519,7 @@ mod tests {
     #[rstest]
     fn test_get_bars_topic(mut switchboard: MessagingSwitchboard) {
         let bar_type = BarType::from("ESZ24.XCME-1-MINUTE-LAST-INTERNAL");
-        let expected_topic = Topic::from(&format!("data.bars.{bar_type}"));
+        let expected_topic = format!("data.bars.{bar_type}").into();
         let result = switchboard.get_bars_topic(bar_type);
         assert_eq!(result, expected_topic);
         assert!(switchboard.bar_topics.contains_key(&bar_type));
@@ -518,7 +528,7 @@ mod tests {
     #[rstest]
     fn test_get_order_snapshots_topic(mut switchboard: MessagingSwitchboard) {
         let client_order_id = ClientOrderId::from("O-123456789");
-        let expected_topic = Topic::from(&format!("order.snapshots.{client_order_id}"));
+        let expected_topic = format!("order.snapshots.{client_order_id}").into();
         let result = switchboard.get_order_snapshots_topic(client_order_id);
         assert_eq!(result, expected_topic);
         assert!(

--- a/crates/common/src/msgbus/tests.rs
+++ b/crates/common/src/msgbus/tests.rs
@@ -22,7 +22,7 @@ use ustr::Ustr;
 
 use crate::msgbus::{
     self, MessageBus,
-    core::{Endpoint, Pattern, Topic},
+    core::{MStr, Pattern, Subscription, Topic},
     get_message_bus,
     handler::ShareableMessageHandler,
     matching::is_matching_backtracking,
@@ -109,38 +109,38 @@ fn test_is_registered_when_no_registrations() {
 #[rstest]
 fn test_regsiter_endpoint() {
     let msgbus = get_message_bus();
-    let endpoint = Endpoint::from("MyEndpoint");
+    let endpoint = "MyEndpoint".into();
     let handler = get_stub_shareable_handler(None);
 
     msgbus::register(endpoint, handler);
 
     assert_eq!(msgbus.borrow().endpoints(), vec![endpoint.to_string()]);
-    assert!(msgbus.borrow().get_endpoint(&endpoint).is_some());
+    assert!(msgbus.borrow().get_endpoint(endpoint).is_some());
 }
 
 #[rstest]
 fn test_endpoint_send() {
     let msgbus = get_message_bus();
-    let endpoint = Endpoint::from("MyEndpoint");
+    let endpoint = "MyEndpoint".into();
     let handler = get_call_check_shareable_handler(None);
 
     msgbus::register(endpoint, handler.clone());
-    assert!(msgbus.borrow().get_endpoint(&endpoint).is_some());
+    assert!(msgbus.borrow().get_endpoint(endpoint).is_some());
     assert!(!check_handler_was_called(handler.clone()));
 
     // Send a message to the endpoint
-    msgbus::send(&endpoint, &"Test Message");
+    msgbus::send(endpoint, &"Test Message");
     assert!(check_handler_was_called(handler));
 }
 
 #[rstest]
 fn test_deregsiter_endpoint() {
     let msgbus = get_message_bus();
-    let endpoint = Endpoint::from("MyEndpoint");
+    let endpoint = "MyEndpoint".into();
     let handler = get_stub_shareable_handler(None);
 
     msgbus::register(endpoint, handler);
-    msgbus::deregister(&endpoint);
+    msgbus::deregister(endpoint);
 
     assert!(msgbus.borrow().endpoints().is_empty());
 }
@@ -199,7 +199,7 @@ fn test_matching_subscriptions() {
     assert_eq!(subscriptions_count(pattern), 4);
 
     let topic = pattern;
-    let subs = msgbus.borrow_mut().matching_subscriptions(&topic);
+    let subs = msgbus.borrow_mut().matching_subscriptions(topic);
     assert_eq!(subs.len(), 4);
     assert_eq!(subs[0].handler_id, handler_id4);
     assert_eq!(subs[1].handler_id, handler_id3);
@@ -226,7 +226,7 @@ fn test_matching_subscriptions() {
 #[case("data.trades.BINANCE.ETHUSDT", "data.*.BINANCE.ET[^ABC]USDT", false)]
 fn test_is_matching(#[case] topic: &str, #[case] pattern: &str, #[case] expected: bool) {
     assert_eq!(
-        is_matching_backtracking(&Topic::from(topic), &Pattern::from(pattern)),
+        is_matching_backtracking(topic.into(), pattern.into()),
         expected
     );
 }
@@ -291,7 +291,7 @@ fn test_matching_backtracking() {
         let regex_pattern = convert_pattern_to_regex(&pattern);
         let regex = Regex::new(&regex_pattern).unwrap();
         assert_eq!(
-            is_matching_backtracking(&Topic::from(topic), &Pattern::from(&pattern)),
+            is_matching_backtracking(topic.into(), pattern.as_str().into()),
             regex.is_match(topic),
             "Failed to match on iteration: {}, pattern: \"{}\", topic: {}, regex: \"{}\"",
             i,
@@ -315,7 +315,7 @@ fn test_subscription_pattern_matching() {
     assert_eq!(msgbus.borrow().subscriptions().len(), 3);
 
     let topic = "data.quotes.BINANCE.ETHUSDT";
-    assert_eq!(msgbus.borrow().find_topic_matches(&topic.into()).len(), 2);
+    assert_eq!(msgbus.borrow().find_topic_matches(topic.into()).len(), 2);
 
     let matches = msgbus.borrow_mut().matching_subscriptions(topic);
     assert_eq!(matches.len(), 2);
@@ -364,11 +364,11 @@ impl SimpleSubscriptionModel {
 
     /// Get all subscriptions that match a topic according to the matching rules
     fn matching_subscriptions(&self, topic: &str) -> Vec<(String, String)> {
-        let topic = Topic::from(topic);
+        let topic = topic.into();
 
         self.subscriptions
             .iter()
-            .filter(|(pat, _)| is_matching_backtracking(&topic, &Pattern::from(pat.as_str())))
+            .filter(|(pat, _)| is_matching_backtracking(topic, pat.into()))
             .map(|(pat, id)| (pat.clone(), id.clone()))
             .collect()
     }
@@ -414,18 +414,18 @@ fn subscription_model_fuzz_testing() {
                 let (handler_id, handler) = &handlers[handler_idx];
 
                 // Apply to reference model
-                model.subscribe(pattern, handler_id);
+                model.subscribe(&pattern, handler_id);
 
                 // Apply to message bus
-                let pattern = Pattern::from(pattern);
-                msgbus::subscribe(pattern, handler.clone(), None);
+                msgbus::subscribe(pattern.as_str().into(), handler.clone(), None);
 
                 assert_eq!(
                     model.subscription_count(),
                     msgbus.borrow().subscriptions().len()
                 );
+
                 assert_eq!(
-                    model.is_subscribed(pattern.as_str(), handler_id),
+                    msgbus.borrow().is_subscribed(pattern, handler.clone()),
                     true,
                     "Op {}: is_subscribed should return true after subscribe",
                     op_num
@@ -449,15 +449,14 @@ fn subscription_model_fuzz_testing() {
                         .unwrap();
 
                     // Apply to message bus
-                    let pattern = Pattern::from(pattern);
-                    msgbus::unsubscribe(pattern, handler.clone());
+                    msgbus::unsubscribe(pattern.as_str().into(), handler.clone());
 
                     assert_eq!(
                         model.subscription_count(),
                         msgbus.borrow().subscriptions().len()
                     );
                     assert_eq!(
-                        model.is_subscribed(&pattern, &handler_id),
+                        msgbus.borrow().is_subscribed(pattern, handler.clone()),
                         false,
                         "Op {}: is_subscribed should return false after unsubscribe",
                         op_num
@@ -488,7 +487,7 @@ fn subscription_model_fuzz_testing() {
                 // Generate a topic
                 let topic = create_topic(&mut rng);
 
-                let actual_matches = msgbus.borrow_mut().matching_subscriptions(&topic);
+                let actual_matches = msgbus.borrow_mut().matching_subscriptions(topic);
                 let expected_matches = model.matching_subscriptions(&topic);
 
                 assert_eq!(

--- a/crates/common/src/msgbus/tests.rs
+++ b/crates/common/src/msgbus/tests.rs
@@ -21,9 +21,7 @@ use rstest::rstest;
 use ustr::Ustr;
 
 use crate::msgbus::{
-    self, MessageBus,
-    core::{MStr, Pattern, Subscription, Topic},
-    get_message_bus,
+    self, MessageBus, get_message_bus,
     handler::ShareableMessageHandler,
     matching::is_matching_backtracking,
     stubs::{

--- a/crates/common/src/python/msgbus.rs
+++ b/crates/common/src/python/msgbus.rs
@@ -20,8 +20,8 @@ use pyo3::{PyObject, PyResult, pymethods};
 
 use super::handler::PythonMessageHandler;
 use crate::msgbus::{
-    BusMessage, MStr, MessageBus, Topic, deregister, handler::ShareableMessageHandler, publish,
-    register, send, subscribe, unsubscribe,
+    BusMessage, MStr, MessageBus, Topic, core::Endpoint, deregister,
+    handler::ShareableMessageHandler, publish, register, send, subscribe, unsubscribe,
 };
 
 #[pymethods]
@@ -56,7 +56,7 @@ impl MessageBus {
     /// Returns an error if `endpoint` is invalid.
     #[pyo3(name = "send")]
     pub fn py_send(&self, endpoint: &str, message: PyObject) -> PyResult<()> {
-        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
+        let endpoint = MStr::<Endpoint>::endpoint(endpoint).map_err(to_pyvalue_err)?;
         send(endpoint, &message);
         Ok(())
     }
@@ -84,7 +84,7 @@ impl MessageBus {
     #[pyo3(name = "register")]
     #[staticmethod]
     pub fn py_register(endpoint: &str, handler: PythonMessageHandler) -> PyResult<()> {
-        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
+        let endpoint = MStr::<Endpoint>::endpoint(endpoint).map_err(to_pyvalue_err)?;
         let handler = ShareableMessageHandler(Rc::new(handler));
         register(endpoint, handler);
         Ok(())
@@ -149,7 +149,7 @@ impl MessageBus {
     #[pyo3(name = "deregister")]
     #[staticmethod]
     pub fn py_deregister(endpoint: &str) -> PyResult<()> {
-        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
+        let endpoint = MStr::<Endpoint>::endpoint(endpoint).map_err(to_pyvalue_err)?;
         deregister(endpoint);
         Ok(())
     }

--- a/crates/common/src/python/msgbus.rs
+++ b/crates/common/src/python/msgbus.rs
@@ -20,8 +20,8 @@ use pyo3::{PyObject, PyResult, pymethods};
 
 use super::handler::PythonMessageHandler;
 use crate::msgbus::{
-    BusMessage, Endpoint, MessageBus, Pattern, Topic, deregister, handler::ShareableMessageHandler,
-    publish, register, send, subscribe, unsubscribe,
+    BusMessage, MStr, MessageBus, Topic, deregister, handler::ShareableMessageHandler, publish,
+    register, send, subscribe, unsubscribe,
 };
 
 #[pymethods]
@@ -56,8 +56,8 @@ impl MessageBus {
     /// Returns an error if `endpoint` is invalid.
     #[pyo3(name = "send")]
     pub fn py_send(&self, endpoint: &str, message: PyObject) -> PyResult<()> {
-        let endpoint = Endpoint::new(endpoint).map_err(to_pyvalue_err)?;
-        send(&endpoint, &message);
+        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
+        send(endpoint, &message);
         Ok(())
     }
 
@@ -69,8 +69,8 @@ impl MessageBus {
     #[pyo3(name = "publish")]
     #[staticmethod]
     pub fn py_publish(topic: &str, message: PyObject) -> PyResult<()> {
-        let topic = Topic::new(topic).map_err(to_pyvalue_err)?;
-        publish(&topic, &message);
+        let topic = MStr::<Topic>::topic(topic).map_err(to_pyvalue_err)?;
+        publish(topic, &message);
         Ok(())
     }
 
@@ -84,7 +84,7 @@ impl MessageBus {
     #[pyo3(name = "register")]
     #[staticmethod]
     pub fn py_register(endpoint: &str, handler: PythonMessageHandler) -> PyResult<()> {
-        let endpoint = Endpoint::new(endpoint).map_err(to_pyvalue_err)?;
+        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
         let handler = ShareableMessageHandler(Rc::new(handler));
         register(endpoint, handler);
         Ok(())
@@ -112,7 +112,7 @@ impl MessageBus {
     #[pyo3(signature = (topic, handler, priority=None))]
     #[staticmethod]
     pub fn py_subscribe(topic: &str, handler: PythonMessageHandler, priority: Option<u8>) {
-        let pattern = Pattern::from(topic);
+        let pattern = topic.into();
         let handler = ShareableMessageHandler(Rc::new(handler));
         subscribe(pattern, handler, priority);
     }
@@ -129,7 +129,7 @@ impl MessageBus {
     #[pyo3(name = "unsubscribe")]
     #[staticmethod]
     pub fn py_unsubscribe(topic: &str, handler: PythonMessageHandler) {
-        let pattern = Pattern::from(topic);
+        let pattern = topic.into();
         let handler = ShareableMessageHandler(Rc::new(handler));
         unsubscribe(pattern, handler);
     }
@@ -149,8 +149,8 @@ impl MessageBus {
     #[pyo3(name = "deregister")]
     #[staticmethod]
     pub fn py_deregister(endpoint: &str) -> PyResult<()> {
-        let endpoint = Endpoint::new(endpoint).map_err(to_pyvalue_err)?;
-        deregister(&endpoint);
+        let endpoint = MStr::<Topic>::topic(endpoint).map_err(to_pyvalue_err)?;
+        deregister(endpoint);
         Ok(())
     }
 }

--- a/crates/common/src/throttler.rs
+++ b/crates/common/src/throttler.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     clock::Clock,
     msgbus::{
-        self, Endpoint,
+        self,
         handler::{MessageHandler, ShareableMessageHandler},
     },
     timer::{TimeEvent, TimeEventCallback},
@@ -225,7 +225,7 @@ where
         // Register process endpoint
         let process_handler = ThrottlerProcess::<T, F>::new(self.actor_id);
         msgbus::register(
-            Endpoint::from(process_handler.id().as_str()),
+            process_handler.id().as_str().into(),
             ShareableMessageHandler::from(Rc::new(process_handler) as Rc<dyn MessageHandler>),
         );
 
@@ -308,9 +308,9 @@ impl<T, F> ThrottlerProcess<T, F> {
     }
 
     pub fn get_timer_callback(&self) -> TimeEventCallback {
-        let endpoint = Endpoint::from(self.endpoint); // TODO: Optimize this
+        let endpoint = self.endpoint.into(); // TODO: Optimize this
         let process_callback = Rc::new(move |_event: TimeEvent| {
-            msgbus::send(&endpoint, &());
+            msgbus::send(endpoint, &());
         });
         TimeEventCallback::Rust(process_callback)
     }
@@ -336,11 +336,11 @@ where
             if !throttler.buffer.is_empty() && throttler.delta_next() > 0 {
                 throttler.is_limiting = true;
 
-                let endpoint = Endpoint::from(self.endpoint); // TODO: Optimize this
+                let endpoint = self.endpoint.into(); // TODO: Optimize this
 
                 // Send message to throttler process endpoint to resume
                 let process_callback = Rc::new(move |_event: TimeEvent| {
-                    msgbus::send(&endpoint, &());
+                    msgbus::send(endpoint, &());
                 });
                 throttler.set_timer(Some(TimeEventCallback::Rust(process_callback)));
                 return;

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -1104,11 +1104,11 @@ fn test_process_instrument(
     let cmd = DataCommand::Subscribe(SubscribeCommand::Instrument(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let handler = get_message_saving_handler::<InstrumentAny>(None);
     let topic = switchboard::get_instrument_topic(audusd_sim.id());
-    msgbus::subscribe(topic.as_pattern(), handler.clone(), None);
+    msgbus::subscribe(topic.into(), handler.clone(), None);
 
     let mut data_engine = data_engine.borrow_mut();
     data_engine.process(&audusd_sim as &dyn Any);
@@ -1147,7 +1147,7 @@ fn test_process_book_delta(
     let cmd = DataCommand::Subscribe(SubscribeCommand::BookDeltas(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let delta = stub_delta();
     let handler = get_message_saving_handler::<OrderBookDeltas>(None);
@@ -1186,7 +1186,7 @@ fn test_process_book_deltas(
     let cmd = DataCommand::Subscribe(SubscribeCommand::BookDeltas(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     // TODO: Using FFI API wrapper temporarily until Cython gone
     let deltas = OrderBookDeltas_API::new(stub_deltas());
@@ -1227,7 +1227,7 @@ fn test_process_book_depth10(
     let cmd = DataCommand::Subscribe(SubscribeCommand::BookDepth10(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let depth = stub_depth10();
     let handler = get_message_saving_handler::<OrderBookDepth10>(None);
@@ -1264,7 +1264,7 @@ fn test_process_quote_tick(
     let cmd = DataCommand::Subscribe(SubscribeCommand::Quotes(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let quote = QuoteTick::default();
     let handler = get_message_saving_handler::<QuoteTick>(None);
@@ -1302,7 +1302,7 @@ fn test_process_trade_tick(
     let cmd = DataCommand::Subscribe(SubscribeCommand::Trades(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let trade = TradeTick::default();
     let handler = get_message_saving_handler::<TradeTick>(None);
@@ -1340,7 +1340,7 @@ fn test_process_mark_price(
     let cmd = DataCommand::Subscribe(SubscribeCommand::MarkPrices(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let mark_price = MarkPriceUpdate::new(
         audusd_sim.id,
@@ -1394,7 +1394,7 @@ fn test_process_index_price(
     let cmd = DataCommand::Subscribe(SubscribeCommand::IndexPrices(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let index_price = IndexPriceUpdate::new(
         audusd_sim.id,
@@ -1443,7 +1443,7 @@ fn test_process_bar(data_engine: Rc<RefCell<DataEngine>>, data_client: DataClien
     let cmd = DataCommand::Subscribe(SubscribeCommand::Bars(sub));
 
     let endpoint = MessagingSwitchboard::data_engine_execute();
-    msgbus::send(&endpoint, &cmd as &dyn Any);
+    msgbus::send(endpoint, &cmd as &dyn Any);
 
     let handler = get_message_saving_handler::<Bar>(None);
     let topic = switchboard::get_bars_topic(bar.bar_type);

--- a/crates/execution/src/client/base.rs
+++ b/crates/execution/src/client/base.rs
@@ -21,11 +21,7 @@
 
 use std::{any::Any, cell::RefCell, fmt::Debug, rc::Rc};
 
-use nautilus_common::{
-    cache::Cache,
-    clock::Clock,
-    msgbus::{self, Endpoint},
-};
+use nautilus_common::{cache::Cache, clock::Clock, msgbus};
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
     accounts::AccountAny,
@@ -412,32 +408,32 @@ impl BaseExecutionClient {
     }
 
     fn send_account_state(&self, account_state: AccountState) {
-        let endpoint = Endpoint::from("Portfolio.update_account");
-        msgbus::send(&endpoint, &account_state as &dyn Any);
+        let endpoint = "Portfolio.update_account".into();
+        msgbus::send(endpoint, &account_state as &dyn Any);
     }
 
     fn send_order_event(&self, event: OrderEventAny) {
-        let endpoint = Endpoint::from("ExecEngine.process");
-        msgbus::send(&endpoint, &event as &dyn Any);
+        let endpoint = "ExecEngine.process".into();
+        msgbus::send(endpoint, &event as &dyn Any);
     }
 
     fn send_mass_status_report(&self, report: ExecutionMassStatus) {
-        let endpoint = Endpoint::from("ExecEngine.reconcile_mass_status");
-        msgbus::send(&endpoint, &report as &dyn Any);
+        let endpoint = "ExecEngine.reconcile_mass_status".into();
+        msgbus::send(endpoint, &report as &dyn Any);
     }
 
     fn send_order_status_report(&self, report: OrderStatusReport) {
-        let endpoint = Endpoint::from("ExecEngine.reconcile_report");
-        msgbus::send(&endpoint, &report as &dyn Any);
+        let endpoint = "ExecEngine.reconcile_report".into();
+        msgbus::send(endpoint, &report as &dyn Any);
     }
 
     fn send_fill_report(&self, report: FillReport) {
-        let endpoint = Endpoint::from("ExecEngine.reconcile_report");
-        msgbus::send(&endpoint, &report as &dyn Any);
+        let endpoint = "ExecEngine.reconcile_report".into();
+        msgbus::send(endpoint, &report as &dyn Any);
     }
 
     fn send_position_report(&self, report: PositionStatusReport) {
-        let endpoint = Endpoint::from("ExecEngine.reconcile_report");
-        msgbus::send(&endpoint, &report as &dyn Any);
+        let endpoint = "ExecEngine.reconcile_report".into();
+        msgbus::send(endpoint, &report as &dyn Any);
     }
 }

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -493,7 +493,7 @@ impl ExecutionEngine {
 
         if get_message_bus().borrow().has_backing {
             let topic = switchboard::get_order_snapshots_topic(order.client_order_id());
-            msgbus::publish(&topic, order);
+            msgbus::publish(topic, order);
         }
     }
 
@@ -508,7 +508,7 @@ impl ExecutionEngine {
         // }
 
         let topic = switchboard::get_positions_snapshots_topic(position.id);
-        msgbus::publish(&topic, position);
+        msgbus::publish(topic, position);
     }
 
     // -- EVENT HANDLERS --------------------------------------------------------------------------
@@ -676,7 +676,7 @@ impl ExecutionEngine {
         }
 
         let topic = switchboard::get_event_orders_topic(event.strategy_id());
-        msgbus::publish(&topic, order);
+        msgbus::publish(topic, order);
 
         if self.config.snapshot_orders {
             self.create_order_state_snapshot(order);
@@ -773,7 +773,7 @@ impl ExecutionEngine {
         let ts_init = self.clock.borrow().timestamp_ns();
         let event = PositionOpened::create(&position, &fill, UUID4::new(), ts_init);
         let topic = switchboard::get_event_positions_topic(event.strategy_id);
-        msgbus::publish(&topic, &event);
+        msgbus::publish(topic, &event);
 
         Ok(position)
     }
@@ -795,10 +795,10 @@ impl ExecutionEngine {
 
         if position.is_closed() {
             let event = PositionClosed::create(position, &fill, UUID4::new(), ts_init);
-            msgbus::publish(&topic, &event);
+            msgbus::publish(topic, &event);
         } else {
             let event = PositionChanged::create(position, &fill, UUID4::new(), ts_init);
-            msgbus::publish(&topic, &event);
+            msgbus::publish(topic, &event);
         }
     }
 
@@ -1058,7 +1058,7 @@ impl ExecutionEngine {
         }
 
         let topic = switchboard::get_event_orders_topic(order.strategy_id());
-        msgbus::publish(&topic, &denied);
+        msgbus::publish(topic, &denied);
 
         if self.config.snapshot_orders {
             self.create_order_state_snapshot(&order);

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -28,11 +28,7 @@ use std::{
 };
 
 use chrono::TimeDelta;
-use nautilus_common::{
-    cache::Cache,
-    clock::Clock,
-    msgbus::{self, Endpoint},
-};
+use nautilus_common::{cache::Cache, clock::Clock, msgbus};
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
     data::{Bar, BarType, OrderBookDelta, OrderBookDeltas, QuoteTick, TradeTick, order::BookOrder},
@@ -2152,7 +2148,7 @@ impl OrderMatchingEngine {
             ts_now,
             false,
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     fn generate_order_accepted(&self, order: &mut OrderAny, venue_order_id: VenueOrderId) {
@@ -2172,7 +2168,7 @@ impl OrderMatchingEngine {
             ts_now,
             false,
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");
@@ -2203,7 +2199,7 @@ impl OrderMatchingEngine {
             venue_order_id,
             account_id,
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2231,7 +2227,7 @@ impl OrderMatchingEngine {
             Some(venue_order_id),
             Some(account_id),
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     fn generate_order_updated(
@@ -2257,7 +2253,7 @@ impl OrderMatchingEngine {
             price,
             trigger_price,
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");
@@ -2277,7 +2273,7 @@ impl OrderMatchingEngine {
             Some(venue_order_id),
             order.account_id(),
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     fn generate_order_triggered(&self, order: &OrderAny) {
@@ -2294,7 +2290,7 @@ impl OrderMatchingEngine {
             order.venue_order_id(),
             order.account_id(),
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     fn generate_order_expired(&self, order: &OrderAny) {
@@ -2311,7 +2307,7 @@ impl OrderMatchingEngine {
             order.venue_order_id(),
             order.account_id(),
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2351,7 +2347,7 @@ impl OrderMatchingEngine {
             venue_position_id,
             Some(commission),
         ));
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event as &dyn Any);
+        msgbus::send("ExecEngine.process".into(), &event as &dyn Any);
 
         // TODO remove this when execution engine msgbus handlers are correctly set
         order.apply(event).expect("Failed to apply order event");

--- a/crates/execution/src/order_emulator/adapter.rs
+++ b/crates/execution/src/order_emulator/adapter.rs
@@ -21,7 +21,7 @@ use std::{
 use nautilus_common::{
     cache::Cache,
     clock::Clock,
-    msgbus::{Endpoint, handler::ShareableMessageHandler, register},
+    msgbus::{handler::ShareableMessageHandler, register},
 };
 use nautilus_core::UUID4;
 use ustr::Ustr;
@@ -75,7 +75,7 @@ impl OrderEmulatorAdapter {
             emulator,
         }));
 
-        register(Endpoint::from("OrderEmulator.execute"), handler);
+        register("OrderEmulator.execute".into(), handler);
     }
 
     fn initialize_on_event_handler(emulator: Rc<RefCell<OrderEmulator>>) {
@@ -84,7 +84,7 @@ impl OrderEmulatorAdapter {
             emulator,
         }));
 
-        register(Endpoint::from("OrderEmulator.on_event"), handler);
+        register("OrderEmulator.on_event".into(), handler);
     }
 
     #[must_use]

--- a/crates/execution/src/order_emulator/emulator.rs
+++ b/crates/execution/src/order_emulator/emulator.rs
@@ -438,7 +438,7 @@ impl OrderEmulator {
             self.manager.send_risk_event(OrderEventAny::Emulated(event));
 
             msgbus::publish(
-                &format!("events.order.{}", order.strategy_id()).into(),
+                format!("events.order.{}", order.strategy_id()).into(),
                 &OrderEventAny::Emulated(event),
             );
         }
@@ -879,7 +879,7 @@ impl OrderEmulator {
             command.order = OrderAny::Limit(transformed.clone());
 
             msgbus::publish(
-                &format!("events.order.{}", order.strategy_id()).into(),
+                format!("events.order.{}", order.strategy_id()).into(),
                 transformed.last_event(),
             );
 
@@ -920,7 +920,7 @@ impl OrderEmulator {
 
             // Publish event
             msgbus::publish(
-                &format!("events.order.{}", transformed.strategy_id()).into(),
+                format!("events.order.{}", transformed.strategy_id()).into(),
                 &OrderEventAny::Released(event),
             );
 
@@ -1003,7 +1003,7 @@ impl OrderEmulator {
             command.order = OrderAny::Market(transformed.clone());
 
             msgbus::publish(
-                &format!("events.order.{}", order.strategy_id()).into(),
+                format!("events.order.{}", order.strategy_id()).into(),
                 transformed.last_event(),
             );
 
@@ -1045,7 +1045,7 @@ impl OrderEmulator {
 
             // Publish event
             msgbus::publish(
-                &format!("events.order.{}", order.strategy_id()).into(),
+                format!("events.order.{}", order.strategy_id()).into(),
                 &OrderEventAny::Released(event),
             );
 

--- a/crates/execution/src/order_manager/manager.rs
+++ b/crates/execution/src/order_manager/manager.rs
@@ -19,7 +19,7 @@ use nautilus_common::{
     cache::Cache,
     clock::Clock,
     logging::{CMD, EVT, SEND},
-    msgbus::{self, Endpoint},
+    msgbus,
 };
 use nautilus_core::UUID4;
 use nautilus_model::{
@@ -536,36 +536,33 @@ impl OrderManager {
     pub fn send_emulator_command(&self, command: TradingCommand) {
         log::info!("{CMD}{SEND} {command}");
 
-        msgbus::send(&Endpoint::from("OrderEmulator.execute"), &command);
+        msgbus::send("OrderEmulator.execute".into(), &command);
     }
 
     pub fn send_algo_command(&self, command: SubmitOrder, exec_algorithm_id: ExecAlgorithmId) {
         log::info!("{CMD}{SEND} {command}");
 
         let endpoint = format!("{exec_algorithm_id}.execute");
-        msgbus::send(
-            &Endpoint::from(&endpoint),
-            &TradingCommand::SubmitOrder(command),
-        );
+        msgbus::send(endpoint.into(), &TradingCommand::SubmitOrder(command));
     }
 
     pub fn send_risk_command(&self, command: TradingCommand) {
         log::info!("{CMD}{SEND} {command}");
-        msgbus::send(&Endpoint::from("RiskEngine.execute"), &command);
+        msgbus::send("RiskEngine.execute".into(), &command);
     }
 
     pub fn send_exec_command(&self, command: TradingCommand) {
         log::info!("{CMD}{SEND} {command}");
-        msgbus::send(&Endpoint::from("ExecEngine.execute"), &command);
+        msgbus::send("ExecEngine.execute".into(), &command);
     }
 
     pub fn send_risk_event(&self, event: OrderEventAny) {
         log::info!("{EVT}{SEND} {event}");
-        msgbus::send(&Endpoint::from("RiskEngine.process"), &event);
+        msgbus::send("RiskEngine.process".into(), &event);
     }
 
     pub fn send_exec_event(&self, event: OrderEventAny) {
         log::info!("{EVT}{SEND} {event}");
-        msgbus::send(&Endpoint::from("ExecEngine.process"), &event);
+        msgbus::send("ExecEngine.process".into(), &event);
     }
 }

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -29,7 +29,7 @@ use nautilus_common::{
     cache::Cache,
     clock::Clock,
     msgbus::{
-        self, Endpoint, Pattern, Topic,
+        self,
         handler::{ShareableMessageHandler, TypedMessageHandler},
     },
 };
@@ -182,37 +182,21 @@ impl Portfolio {
         };
 
         msgbus::register(
-            Endpoint::from("Portfolio.update_account"),
+            "Portfolio.update_account".into(),
             update_account_handler.clone(),
         );
 
-        msgbus::subscribe(
-            Pattern::from("data.quotes.*"),
-            update_quote_handler,
-            Some(10),
-        );
+        msgbus::subscribe("data.quotes.*".into(), update_quote_handler, Some(10));
         if bar_updates {
-            msgbus::subscribe(
-                Pattern::from("data.quotes.*EXTERNAL"),
-                update_bar_handler,
-                Some(10),
-            );
+            msgbus::subscribe("data.quotes.*EXTERNAL".into(), update_bar_handler, Some(10));
         }
+        msgbus::subscribe("events.order.*".into(), update_order_handler, Some(10));
         msgbus::subscribe(
-            Pattern::from("events.order.*"),
-            update_order_handler,
-            Some(10),
-        );
-        msgbus::subscribe(
-            Pattern::from("events.position.*"),
+            "events.position.*".into(),
             update_position_handler,
             Some(10),
         );
-        msgbus::subscribe(
-            Pattern::from("events.account.*"),
-            update_account_handler,
-            Some(10),
-        );
+        msgbus::subscribe("events.account.*".into(), update_account_handler, Some(10));
     }
 
     pub fn reset(&mut self) {
@@ -1273,7 +1257,7 @@ fn update_order(
 
     if let Some(account_state) = account_state {
         msgbus::publish(
-            &Topic::from(&format!("events.account.{}", account.id())),
+            format!("events.account.{}", account.id()).into(),
             &account_state,
         );
     } else {


### PR DESCRIPTION
# Pull Request

Use phantom types for Topic pattern for a more ergonomic and concise api. It also draws from design principle that both types have the same physical representation but have different validation properties. Also merged endpoints and topics since they are physically and functionally the same.

## Related Issues/PRs

#2646 

## Type of change

- [x] Refactor
