### PR TITLE
Binance Futures margin type

### DIFF
--- a/nautilus_trader/adapters/binance/config.py
+++ b/nautilus_trader/adapters/binance/config.py
@@ -17,6 +17,7 @@ from nautilus_trader.adapters.binance.common.constants import BINANCE_VENUE
 from nautilus_trader.adapters.binance.common.enums import BinanceAccountType
 from nautilus_trader.adapters.binance.common.enums import BinanceKeyType
 from nautilus_trader.adapters.binance.common.symbol import BinanceSymbol
+from nautilus_trader.adapters.binance.futures.enums import BinanceFuturesMarginType
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.config import PositiveInt
@@ -127,6 +128,8 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
         The maximum delay (milliseconds) between retries.
     futures_leverages : dict[BinanceSymbol, PositiveInt], optional
         The initial leverage to be used for each symbol. It's applicable to futures only.
+    futures_margin_types : dict[BinanceSymbol, BinanceFuturesMarginType], optional
+        Margin type (isolated or cross) to be used for each symbol. It's applicable to futures only.
 
     Warnings
     --------
@@ -153,3 +156,4 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
     retry_delay_initial_ms: PositiveInt | None = None
     retry_delay_max_ms: PositiveInt | None = None
     futures_leverages: dict[BinanceSymbol, PositiveInt] | None = None
+    futures_margin_types: dict[BinanceSymbol, BinanceFuturesMarginType] | None = None

--- a/nautilus_trader/adapters/binance/futures/enums.py
+++ b/nautilus_trader/adapters/binance/futures/enums.py
@@ -82,8 +82,8 @@ class BinanceFuturesMarginType(Enum):
     Represents a Binance Futures margin type.
     """
 
-    ISOLATED = "isolated"
-    CROSS = "cross"
+    ISOLATED = "ISOLATED"
+    CROSS = "CROSSED"
 
 
 @unique

--- a/nautilus_trader/adapters/binance/futures/schemas/account.py
+++ b/nautilus_trader/adapters/binance/futures/schemas/account.py
@@ -185,3 +185,12 @@ class BinanceFuturesLeverage(msgspec.Struct, frozen=True):
     leverage: int
     maxNotionalValue: str
     symbol: str
+
+
+class BinanceFuturesMarginTypeResponse(msgspec.Struct, frozen=True):
+    """
+    HTTP response from Binance Futures `POST /fapi/v1/marginType`.
+    """
+
+    code: int
+    msg: str


### PR DESCRIPTION
# Pull Request

## Summary

`/fapi/v1/marginType` endpoint was added to change margin type from crossed to isolated and vice versa

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

It was tested manually on Binance Testnet and Mainnet.
