### PR TITLE
Add support for Binance's mark price stream across all markets

### DIFF
--- a/nautilus_trader/adapters/binance/futures/schemas/market.py
+++ b/nautilus_trader/adapters/binance/futures/schemas/market.py
@@ -248,3 +248,12 @@ class BinanceFuturesMarkPriceMsg(msgspec.Struct, frozen=True):
 
     stream: str
     data: BinanceFuturesMarkPriceData
+
+
+class BinanceFuturesMarkPriceAllMsg(msgspec.Struct, frozen=True):
+    """
+    WebSocket message from Binance Futures All Mark Price Update events.
+    """
+
+    stream: str
+    data: list[BinanceFuturesMarkPriceData]

--- a/nautilus_trader/adapters/binance/futures/types.py
+++ b/nautilus_trader/adapters/binance/futures/types.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from __future__ import annotations
+
 from decimal import Decimal
 from typing import Any
 
@@ -47,7 +49,7 @@ class BinanceFuturesMarkPriceUpdate(Data):
 
     References
     ----------
-    https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream
+    https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream
 
     """
 
@@ -109,7 +111,7 @@ class BinanceFuturesMarkPriceUpdate(Data):
         return self._ts_init
 
     @staticmethod
-    def from_dict(values: dict[str, Any]) -> "BinanceFuturesMarkPriceUpdate":
+    def from_dict(values: dict[str, Any]) -> BinanceFuturesMarkPriceUpdate:
         """
         Return a Binance Futures mark price update parsed from the given values.
 
@@ -135,7 +137,7 @@ class BinanceFuturesMarkPriceUpdate(Data):
         )
 
     @staticmethod
-    def to_dict(obj: "BinanceFuturesMarkPriceUpdate") -> dict[str, Any]:
+    def to_dict(obj: BinanceFuturesMarkPriceUpdate) -> dict[str, Any]:
         """
         Return a dictionary representation of this object.
 

--- a/nautilus_trader/adapters/binance/websocket/client.py
+++ b/nautilus_trader/adapters/binance/websocket/client.py
@@ -225,7 +225,7 @@ class BinanceWebSocketClient:
             msg = self._create_subscribe_msg(streams=streams[1:])
             await self._send(client_id, msg)
             self._log.debug(
-                f"Client {client_id}: Subscribed to additional {len(streams)-1} streams",
+                f"Client {client_id}: Subscribed to additional {len(streams) - 1} streams",
             )
 
     def _handle_ping(self, client_id: int, raw: bytes) -> None:
@@ -557,12 +557,17 @@ class BinanceWebSocketClient:
         """
         Subscribe to aggregate mark price stream.
         """
-        if speed not in (1000, 3000):
+        if speed and speed not in (1000, 3000):
             raise ValueError(f"`speed` options are 1000ms or 3000ms only, was {speed}")
+
         if symbol is None:
             stream = "!markPrice@arr"
         else:
-            stream = f"{BinanceSymbol(symbol).lower()}@markPrice@{int(speed / 1000)}s"
+            stream = f"{BinanceSymbol(symbol).lower()}@markPrice"
+
+        if speed:
+            stream += f"@{int(speed / 1000)}s"
+
         await self._subscribe(stream)
 
     async def unsubscribe_mark_price(


### PR DESCRIPTION
# Pull Request

## Summary

Add support for Binance's Mark Price Stream across all markets.

```python
# Subscribe to the mark price of a specific instrument_id
self.subscribe_data(
    data_type=DataType(
        BinanceFuturesMarkPriceUpdate,
        metadata={"instrument_id": self.instrument_id},
    ),
    client_id=ClientId("BINANCE"),
)

# Subscribe to the mark price of all market
self.subscribe_data(
    data_type=DataType(BinanceFuturesMarkPriceUpdate),
    client_id=ClientId("BINANCE"),
)
```

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

Tested in the live environment.
