### PR TITLE
Add bar_build_delay to data engine config

### DIFF
--- a/examples/backtest/databento_test_request_bars.py
+++ b/examples/backtest/databento_test_request_bars.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.17.0
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -268,9 +268,12 @@ catalogs = [
 ]
 
 data_engine = DataEngineConfig(
-    time_bars_origins={
+    time_bars_origin_offset={
         BarAggregation.MINUTE: pd.Timedelta(seconds=0),
     },
+    bar_build_delay=20,
+    # default is 15 when using composite bars aggregating internal bars
+    # also useful in live context to account for network delay
 )
 
 engine_config = BacktestEngineConfig(
@@ -332,3 +335,5 @@ node = BacktestNode(configs=configs)
 
 # %%
 results = node.run()
+
+# %%

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -99,17 +99,16 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef bint _build_on_next_tick
     cdef uint64_t _stored_open_ns
     cdef uint64_t _stored_close_ns
-    cdef tuple _cached_update
     cdef str _timer_name
     cdef bint _is_left_open
     cdef bint _timestamp_on_close
     cdef bint _skip_first_non_full_bar
     cdef bint _build_with_no_updates
-    cdef int _composite_bar_build_delay
+    cdef int _bar_build_delay
     cdef bint _add_delay
     cdef uint64_t _batch_open_ns
     cdef uint64_t _batch_next_close_ns
-    cdef object _time_bars_origin
+    cdef object _time_bars_origin_offset
 
     cdef readonly timedelta interval
     """The aggregators time interval.\n\n:returns: `timedelta`"""

--- a/nautilus_trader/data/config.py
+++ b/nautilus_trader/data/config.py
@@ -36,8 +36,12 @@ class DataEngineConfig(NautilusConfig, frozen=True):
         If time bar aggregators will skip emitting a bar if the aggregation starts mid-interval.
     time_bars_build_with_no_updates : bool, default True
         If time bar aggregators will build and emit bars with no new market updates.
-    time_bars_origins : dict[BarAggregation, pd.Timedelta | pd.DateOffset], optional
+    time_bars_origin_offset : dict[BarAggregation, pd.Timedelta | pd.DateOffset], optional
         A dictionary mapping time bar aggregations to their origin time offsets.
+    bar_build_delay : int, default 0
+        The time delay (microseconds) before building and emitting a composite bar type.
+        15 microseconds can be useful in a backtest context, when aggregating internal bars
+        from internal bars several times so all messages are processed before a timer triggers.
     validate_data_sequence : bool, default False
         If data objects timestamp sequencing will be validated and handled.
     buffer_deltas : bool, default False
@@ -54,7 +58,8 @@ class DataEngineConfig(NautilusConfig, frozen=True):
     time_bars_timestamp_on_close: bool = True
     time_bars_skip_first_non_full_bar: bool = False
     time_bars_build_with_no_updates: bool = True
-    time_bars_origins: dict | None = None
+    time_bars_origin_offset: dict | None = None
+    bar_build_delay: int = 0
     validate_data_sequence: bool = False
     buffer_deltas: bool = False
     external_clients: list[ClientId] | None = None

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -102,7 +102,8 @@ cdef class DataEngine(Component):
     cdef readonly bint _time_bars_timestamp_on_close
     cdef readonly bint _time_bars_skip_first_non_full_bar
     cdef readonly bint _time_bars_build_with_no_updates
-    cdef readonly dict[BarAggregation, object] _time_bars_origins # pd.Timedelta or pd.DateOffset
+    cdef readonly dict[BarAggregation, object] _time_bars_origin_offset # pd.Timedelta or pd.DateOffset
+    cdef readonly int _bar_build_delay
     cdef readonly bint _validate_data_sequence
     cdef readonly bint _buffer_deltas
 

--- a/tests/unit_tests/backtest/test_config.py
+++ b/tests/unit_tests/backtest/test_config.py
@@ -285,7 +285,7 @@ class TestBacktestConfigParsing:
                 TestConfigStubs.backtest_engine_config,
                 ("catalog",),
                 {"persist": True},
-                ("f39654b91400406374e3e4e3e7ff433e890adcae5f623d1ef6af7f823ce88449",),
+                ("f7d56cc577f56aa583466d1d61dbcc8378f44109cf51ce6fa7235f490150560b",),
             ),
             (
                 TestConfigStubs.risk_engine_config,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

+ Add bar_build_delay as params for SubscribeBars and request_aggregated_bars
Set through data engine config
Can be useful in a live context to account for network delays.
Can be useful in a backtest context when aggregating interal bars (themselves aggregated).

Allows a delay when aggregating bars to ensure they are received.
Refactors existing code to allow this.

Set through data engine config
subscribe_bars has a default value of 0
request_aggregated_bars has a default value of 15 and used only when aggregating bars from internal bars (INTERNAL@INTERNAL)

+ Also rename of time_bars_origin to time_bars_origin_offset

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- New feature (non-breaking)

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
