### PR TITLE
Use cargo codspeed for running Rust benchmarks

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -80,6 +80,12 @@ runs:
       with:
         tool: nextest
 
+    - name: Install cargo-codspeed
+      # https://github.com/taiki-e/install-action # v2.50.10
+      uses: taiki-e/install-action@83254c543806f3224380bf1001d6fac8feaf2d0b
+      with:
+        tool: cargo-codspeed
+
     # > --------------------------------------------------
     # > sccache
     - name: Set sccache env vars (common)

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -78,3 +78,15 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: uv run --no-sync pytest tests/performance_tests --benchmark-disable-gc --codspeed
+
+      - name: Build the benchmark target(s)
+        run: |
+          # Replace criterion with codspeed-criterion-compat in Cargo.toml files
+          find . -name "Cargo.toml" -exec sed -i 's/criterion = "0.5.1"/criterion = { version = "2.10.1", package = "codspeed-criterion-compat" }/g' {} +
+          cargo codspeed build
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: cargo codspeed run

--- a/crates/adapters/coinbase_intx/Cargo.toml
+++ b/crates/adapters/coinbase_intx/Cargo.toml
@@ -75,7 +75,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-criterion = { workspace = true }
 rstest = { workspace = true }
 tracing-test = { workspace = true }
 

--- a/crates/adapters/databento/Cargo.toml
+++ b/crates/adapters/databento/Cargo.toml
@@ -67,7 +67,6 @@ time = "0.3.41"
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-criterion = { workspace = true }
 rstest = { workspace = true }
 tracing-test = { workspace = true }
 

--- a/crates/adapters/demo/Cargo.toml
+++ b/crates/adapters/demo/Cargo.toml
@@ -67,7 +67,6 @@ tokio-stream = "0.1.17"
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-criterion = { workspace = true }
 rstest = { workspace = true }
 tracing-test = { workspace = true }
 

--- a/crates/adapters/tardis/Cargo.toml
+++ b/crates/adapters/tardis/Cargo.toml
@@ -71,7 +71,6 @@ urlencoding = "2.1.3"
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-criterion = { workspace = true }
 rstest = { workspace = true }
 tracing-test = { workspace = true }
 

--- a/crates/analysis/Cargo.toml
+++ b/crates/analysis/Cargo.toml
@@ -47,5 +47,4 @@ pyo3 = { workspace = true, optional = true }
 rust_decimal = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 rstest = { workspace = true }

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -62,5 +62,4 @@ pyo3 = { workspace = true, optional = true }
 ustr = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 rstest = { workspace = true }

--- a/crates/portfolio/Cargo.toml
+++ b/crates/portfolio/Cargo.toml
@@ -52,5 +52,4 @@ thiserror = { workspace = true }
 ustr = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 rstest = { workspace = true }

--- a/crates/risk/Cargo.toml
+++ b/crates/risk/Cargo.toml
@@ -52,5 +52,4 @@ thiserror = { workspace = true }
 ustr = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 rstest = { workspace = true }

--- a/crates/serialization/Cargo.toml
+++ b/crates/serialization/Cargo.toml
@@ -45,6 +45,5 @@ strum = { workspace = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-criterion = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }

--- a/crates/trading/Cargo.toml
+++ b/crates/trading/Cargo.toml
@@ -57,5 +57,4 @@ pyo3 = { workspace = true, optional = true }
 strum = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 rstest = { workspace = true }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

Use cargo codspeed to run and record benchmarks in nightly

## Type of change

- [x] New feature (non-breaking)

## Testing

Tested cargo codspeed locally. Need to test in CI.
