### PR TITLE
Add support for Pool liquidity updates for blockchain adapter

### DIFF
--- a/crates/adapters/blockchain/bin/sync_pool_events.rs
+++ b/crates/adapters/blockchain/bin/sync_pool_events.rs
@@ -94,9 +94,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::select! {
             () = notify.notified() => break,
              () = async {
-                // Sync the pools from the creation block to the next block
-                // so that we have it processed and in the cache
-
                 data_client.sync_exchange_pools(
                     dex_id.as_str(),
                     Some(pool_creation_block),
@@ -108,8 +105,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     from_block,
                     None,
                 ).await.unwrap();
-
-
+                data_client.sync_pool_mints(
+                    dex_id.as_str(),
+                    weth_usdc_pool.to_string(),
+                    from_block,
+                    None,
+                ).await.unwrap();
+                data_client.sync_pool_burns(
+                    dex_id.as_str(),
+                    weth_usdc_pool.to_string(),
+                    from_block,
+                    None,
+                ).await.unwrap();
             } => break,
         }
     }

--- a/crates/adapters/blockchain/src/cache/mod.rs
+++ b/crates/adapters/blockchain/src/cache/mod.rs
@@ -24,6 +24,7 @@ use nautilus_model::defi::{
     amm::{Pool, SharedPool},
     block::Block,
     chain::SharedChain,
+    liquidity::PoolLiquidityUpdate,
     swap::Swap,
     token::Token,
 };
@@ -178,10 +179,24 @@ impl BlockchainCache {
         Ok(())
     }
 
-    /// Adds a swap transaction to the database if available.
+    /// Adds a [`Swap`] to the cache database if available.
     pub async fn add_swap(&self, swap: Swap) -> anyhow::Result<()> {
         if let Some(database) = &self.database {
             database.add_swap(self.chain.chain_id, &swap).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Adds a [`PoolLiquidityUpdate`] to the cache database if available.
+    pub async fn add_pool_liquidity_update(
+        &self,
+        liquidity_update: PoolLiquidityUpdate,
+    ) -> anyhow::Result<()> {
+        if let Some(database) = &self.database {
+            database
+                .add_pool_liquidity_update(self.chain.chain_id, &liquidity_update)
+                .await?;
         }
 
         Ok(())

--- a/crates/adapters/blockchain/src/events/burn.rs
+++ b/crates/adapters/blockchain/src/events/burn.rs
@@ -13,15 +13,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use alloy::primitives::{Address, I256, U160};
+use alloy::primitives::{Address, U256};
 
-/// Represents a token swap event from liquidity pools emitted from smart contract.
-///
-/// This struct captures the essential data from a swap transaction on decentralized
-/// exchanges (DEXs) that use automated market maker (AMM) protocols.
+/// Represents a burn event that occurs when liquidity is removed from a position in a liquidity pool.
 #[derive(Debug, Clone)]
-pub struct SwapEvent {
-    /// The block number in which this swap transaction was included.
+pub struct BurnEvent {
+    /// The block number when the burn occurred.
     pub block_number: u64,
     /// The unique hash identifier of the transaction containing this event.
     pub transaction_hash: String,
@@ -29,46 +26,47 @@ pub struct SwapEvent {
     pub transaction_index: u32,
     /// The position of this event log within the transaction.
     pub log_index: u32,
-    /// The address that initiated the swap transaction.
-    pub sender: Address,
-    /// The address that received the swapped tokens.
-    pub receiver: Address,
-    /// The amount of token0 involved in the swap.
-    /// Negative values indicate tokens flowing out of the pool, positive values indicate tokens flowing in.
-    pub amount0: I256,
-    /// The amount of token1 involved in the swap.
-    /// Negative values indicate tokens flowing out of the pool, positive values indicate tokens flowing in.
-    pub amount1: I256,
-    /// The square root of the price ratio encoded as a Q64.96 fixed-point number.
-    /// This represents the price of token1 in terms of token0 after the swap.
-    pub sqrt_price_x96: U160,
+    /// The owner of the position.
+    pub owner: Address,
+    /// The lower tick boundary of the position.
+    pub tick_lower: i32,
+    /// The upper tick boundary of the position.
+    pub tick_upper: i32,
+    /// The amount of liquidity burned to the position range.
+    pub amount: u128,
+    /// The amount of token0 withdrawn.
+    pub amount0: U256,
+    /// The amount of token1 withdrawn.
+    pub amount1: U256,
 }
 
-impl SwapEvent {
-    /// Creates a new [`SwapEvent`] instance with the specified parameters.
+impl BurnEvent {
+    /// Creates a new [`BurnEvent`] instance with the specified parameters.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
-    pub const fn new(
+    pub fn new(
         block_number: u64,
         transaction_hash: String,
         transaction_index: u32,
         log_index: u32,
-        sender: Address,
-        receiver: Address,
-        amount0: I256,
-        amount1: I256,
-        sqrt_price_x96: U160,
+        owner: Address,
+        tick_lower: i32,
+        tick_upper: i32,
+        amount: u128,
+        amount0: U256,
+        amount1: U256,
     ) -> Self {
         Self {
             block_number,
             transaction_hash,
             transaction_index,
             log_index,
-            sender,
-            receiver,
+            owner,
+            tick_lower,
+            tick_upper,
+            amount,
             amount0,
             amount1,
-            sqrt_price_x96,
         }
     }
 }

--- a/crates/adapters/blockchain/src/events/mint.rs
+++ b/crates/adapters/blockchain/src/events/mint.rs
@@ -13,15 +13,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use alloy::primitives::{Address, I256, U160};
+use alloy::primitives::{Address, U256};
 
-/// Represents a token swap event from liquidity pools emitted from smart contract.
-///
-/// This struct captures the essential data from a swap transaction on decentralized
-/// exchanges (DEXs) that use automated market maker (AMM) protocols.
+/// Represents a mint event that occurs when liquidity is added to a position in a liquidity pool.
 #[derive(Debug, Clone)]
-pub struct SwapEvent {
-    /// The block number in which this swap transaction was included.
+pub struct MintEvent {
+    /// The block number when the mint occurred.
     pub block_number: u64,
     /// The unique hash identifier of the transaction containing this event.
     pub transaction_hash: String,
@@ -29,35 +26,38 @@ pub struct SwapEvent {
     pub transaction_index: u32,
     /// The position of this event log within the transaction.
     pub log_index: u32,
-    /// The address that initiated the swap transaction.
+    /// The address that sent the transaction.
     pub sender: Address,
-    /// The address that received the swapped tokens.
-    pub receiver: Address,
-    /// The amount of token0 involved in the swap.
-    /// Negative values indicate tokens flowing out of the pool, positive values indicate tokens flowing in.
-    pub amount0: I256,
-    /// The amount of token1 involved in the swap.
-    /// Negative values indicate tokens flowing out of the pool, positive values indicate tokens flowing in.
-    pub amount1: I256,
-    /// The square root of the price ratio encoded as a Q64.96 fixed-point number.
-    /// This represents the price of token1 in terms of token0 after the swap.
-    pub sqrt_price_x96: U160,
+    /// The owner of the position.
+    pub owner: Address,
+    /// The lower tick boundary of the position.
+    pub tick_lower: i32,
+    /// The upper tick boundary of the position.
+    pub tick_upper: i32,
+    /// The amount of liquidity minted.
+    pub amount: u128,
+    /// The amount of token0 deposited.
+    pub amount0: U256,
+    /// The amount of token1 deposited.
+    pub amount1: U256,
 }
 
-impl SwapEvent {
-    /// Creates a new [`SwapEvent`] instance with the specified parameters.
+impl MintEvent {
+    /// Creates a new [`MintEvent`] instance with the specified parameters.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
-    pub const fn new(
+    pub fn new(
         block_number: u64,
         transaction_hash: String,
         transaction_index: u32,
         log_index: u32,
         sender: Address,
-        receiver: Address,
-        amount0: I256,
-        amount1: I256,
-        sqrt_price_x96: U160,
+        owner: Address,
+        tick_lower: i32,
+        tick_upper: i32,
+        amount: u128,
+        amount0: U256,
+        amount1: U256,
     ) -> Self {
         Self {
             block_number,
@@ -65,10 +65,12 @@ impl SwapEvent {
             transaction_index,
             log_index,
             sender,
-            receiver,
+            owner,
+            tick_lower,
+            tick_upper,
+            amount,
             amount0,
             amount1,
-            sqrt_price_x96,
         }
     }
 }

--- a/crates/adapters/blockchain/src/events/mod.rs
+++ b/crates/adapters/blockchain/src/events/mod.rs
@@ -13,5 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+pub mod burn;
+pub mod mint;
 pub mod pool_created;
 pub mod swap;

--- a/crates/adapters/blockchain/src/events/pool_created.rs
+++ b/crates/adapters/blockchain/src/events/pool_created.rs
@@ -19,7 +19,7 @@ use alloy::primitives::Address;
 ///
 // This struct models the data structure of a pool creation event emitted by DEX factory contracts.
 #[derive(Debug, Clone)]
-pub struct PoolCreated {
+pub struct PoolCreatedEvent {
     /// The block number when the pool was created.
     pub block_number: u64,
     /// The blockchain address of the first token in the pair.
@@ -34,8 +34,8 @@ pub struct PoolCreated {
     pub pool_address: Address,
 }
 
-impl PoolCreated {
-    /// Creates a new [`PoolCreated`] instance with the specified parameters.
+impl PoolCreatedEvent {
+    /// Creates a new [`PoolCreatedEvent`] instance with the specified parameters.
     #[must_use]
     pub const fn new(
         block_number: u64,

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/camelot_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/camelot_v3.rs
@@ -31,6 +31,8 @@ pub static CAMELOT_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/curve_finance.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/curve_finance.rs
@@ -31,6 +31,8 @@ pub static CURVE_FINANCE: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::StableSwap,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/fluid.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/fluid.rs
@@ -31,6 +31,8 @@ pub static FLUID_DEX: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/pancakeswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/pancakeswap_v3.rs
@@ -31,6 +31,8 @@ pub static PANCAKESWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/sushiswap_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/sushiswap_v2.rs
@@ -31,6 +31,8 @@ pub static SUSHISWAP_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CPAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/sushiswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/sushiswap_v3.rs
@@ -31,6 +31,8 @@ pub static SUSHISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v3.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v4.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v4.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V4: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMEnhanced,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/aerodrome_slipstream.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/aerodrome_slipstream.rs
@@ -31,6 +31,8 @@ pub static AERODROME_SLIPSTREAM: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::StableSwap,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/aerodrome_v1.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/aerodrome_v1.rs
@@ -31,6 +31,8 @@ pub static AERODROME_V1: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CPAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/baseswap_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/baseswap_v2.rs
@@ -31,6 +31,8 @@ pub static BASESWAP_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CPAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/basex.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/basex.rs
@@ -31,6 +31,8 @@ pub static BASEX: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/maverick_v1.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/maverick_v1.rs
@@ -31,6 +31,8 @@ pub static MAVERICK_V1: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/maverick_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/maverick_v2.rs
@@ -31,6 +31,8 @@ pub static MAVERICK_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/pancakeswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/pancakeswap_v3.rs
@@ -31,6 +31,8 @@ pub static PANCAKESWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/sushiswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/sushiswap_v3.rs
@@ -31,6 +31,8 @@ pub static SUSHISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/uniswap_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/uniswap_v2.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CPAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/uniswap_v3.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/base/uniswap_v4.rs
+++ b/crates/adapters/blockchain/src/exchanges/base/uniswap_v4.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V4: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMEnhanced,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/balancer_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/balancer_v2.rs
@@ -31,6 +31,8 @@ pub static BALANCER_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::WeightedPool,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/balancer_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/balancer_v3.rs
@@ -31,6 +31,8 @@ pub static BALANCER_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::ComposablePool,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/curve_finance.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/curve_finance.rs
@@ -31,6 +31,8 @@ pub static CURVE_FINANCE: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::StableSwap,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/fluid.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/fluid.rs
@@ -31,6 +31,8 @@ pub static FLUID_DEX: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/maverick_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/maverick_v2.rs
@@ -31,6 +31,8 @@ pub static MAVERICK_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/pancakeswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/pancakeswap_v3.rs
@@ -31,6 +31,8 @@ pub static PANCAKESWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v2.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v2.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V2: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CPAMM,
         "PoolCreated(address,address,address,uint256)",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
@@ -16,7 +16,7 @@
 use std::sync::LazyLock;
 
 use alloy::{
-    primitives::{Address, I256, Signed, U160, U256},
+    primitives::{Address, Signed, U160, U256},
     sol,
     sol_types::SolType,
 };
@@ -32,15 +32,23 @@ use nautilus_model::{
 };
 
 use crate::{
-    events::{pool_created::PoolCreated, swap::SwapEvent},
+    events::{burn::BurnEvent, mint::MintEvent, pool_created::PoolCreatedEvent, swap::SwapEvent},
     exchanges::extended::DexExtended,
-    hypersync::helpers::validate_event_signature_hash,
+    hypersync::helpers::{
+        extract_block_number, extract_log_index, extract_transaction_hash,
+        extract_transaction_index, validate_event_signature_hash,
+    },
+    math::convert_i256_to_f64,
 };
 
 const POOL_CREATED_EVENT_SIGNATURE_HASH: &str =
     "783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118";
 const SWAP_EVENT_SIGNATURE_HASH: &str =
     "c42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67";
+const MINT_EVENT_SIGNATURE_HASH: &str =
+    "7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde";
+const BURN_EVENT_SIGNATURE_HASH: &str =
+    "0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c";
 
 /// Uniswap V3 DEX on Ethereum.
 pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
@@ -51,14 +59,18 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMM,
         "PoolCreated(address,address,uint24,int24,address)",
         "Swap(address,address,int256,int256,uint160,uint128,int24)",
+        "Mint(address,address,int24,int24,uint128,uint256,uint256)",
+        "Burn(address,int24,int24,uint128,uint256,uint256)",
     ));
     dex.set_pool_created_event_parsing(parse_pool_created_event);
     dex.set_swap_event_parsing(parse_swap_event);
     dex.set_convert_trade_data(convert_to_trade_data);
+    dex.set_mint_event_parsing(parse_mint_event);
+    dex.set_burn_event_parsing(parse_burn_event);
     dex
 });
 
-fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreated> {
+fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreatedEvent> {
     validate_event_signature_hash("PoolCreatedEvent", POOL_CREATED_EVENT_SIGNATURE_HASH, &log)?;
 
     let block_number = log
@@ -69,19 +81,19 @@ fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreated> {
         // Address is stored in the last 20 bytes of the 32-byte topic
         Address::from_slice(&topic.as_ref()[12..32])
     } else {
-        anyhow::bail!("Missing token0 address in topic1");
+        anyhow::bail!("Missing token0 address in topic1 when parsing pool created event");
     };
 
     let token1 = if let Some(topic) = log.topics.get(2).and_then(|t| t.as_ref()) {
         Address::from_slice(&topic.as_ref()[12..32])
     } else {
-        anyhow::bail!("Missing token1 address in topic2");
+        anyhow::bail!("Missing token1 address in topic2 when parsing pool created event");
     };
 
     let fee = if let Some(topic) = log.topics.get(3).and_then(|t| t.as_ref()) {
         U256::from_be_slice(topic.as_ref()).as_limbs()[0] as u32
     } else {
-        anyhow::bail!("Missing fee in topic3");
+        anyhow::bail!("Missing fee in topic3 when parsing pool created event");
     };
 
     if let Some(data) = log.data {
@@ -96,7 +108,7 @@ fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreated> {
         let pool_address_bytes: [u8; 32] = data_bytes[32..64].try_into()?;
         let pool_address = Address::from_slice(&pool_address_bytes[12..32]);
 
-        Ok(PoolCreated::new(
+        Ok(PoolCreatedEvent::new(
             block_number.into(),
             token,
             token1,
@@ -109,8 +121,8 @@ fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreated> {
     }
 }
 
-// Define sol macro for easier parsing of data log object
-// Data contains 5 parameters of 32 bytes each:
+// Define sol macro for easier parsing of Swap event data
+// It contains 5 parameters of 32 bytes each:
 // amount0 (int256), amount1 (int256), sqrtPriceX96 (uint160), liquidity (uint128), tick (int24)
 sol! {
     struct SwapEventData {
@@ -125,21 +137,17 @@ sol! {
 fn parse_swap_event(log: Log) -> anyhow::Result<SwapEvent> {
     validate_event_signature_hash("SwapEvent", SWAP_EVENT_SIGNATURE_HASH, &log)?;
 
-    let block_number = log
-        .block_number
-        .expect("Block number should be set in logs");
-
     let sender = match log.topics.get(1).and_then(|t| t.as_ref()) {
         Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing sender address in topic1"),
+        None => anyhow::bail!("Missing sender address in topic1 when parsing swap event"),
     };
 
     let recipient = match log.topics.get(2).and_then(|t| t.as_ref()) {
         Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing recipient address in topic2"),
+        None => anyhow::bail!("Missing recipient address in topic2 when parsing swap event"),
     };
 
-    if let Some(data) = log.data {
+    if let Some(data) = &log.data {
         let data_bytes = data.as_ref();
 
         // Validate if data contains 5 parameters of 32 bytes each
@@ -155,7 +163,10 @@ fn parse_swap_event(log: Log) -> anyhow::Result<SwapEvent> {
         decoded.amount0;
 
         Ok(SwapEvent::new(
-            block_number.into(),
+            extract_block_number(&log)?,
+            extract_transaction_hash(&log)?,
+            extract_transaction_index(&log)?,
+            extract_log_index(&log)?,
             sender,
             recipient,
             decoded.amount0,
@@ -165,13 +176,6 @@ fn parse_swap_event(log: Log) -> anyhow::Result<SwapEvent> {
     } else {
         Err(anyhow::anyhow!("Missing data in swap event log"))
     }
-}
-
-fn convert_amount_to_f64(amount: I256, decimals: u8) -> f64 {
-    let amount_str = amount.to_string();
-    let amount_f64: f64 = amount_str.parse().expect("Failed to parse I256 to f64");
-    let factor = 10f64.powi(i32::from(decimals));
-    amount_f64 / factor
 }
 
 /// <https://blog.uniswap.org/uniswap-v3-math-primer>
@@ -207,7 +211,7 @@ fn convert_to_trade_data(
         price_f64,
         precision = FIXED_PRECISION as usize
     ));
-    let quantity_f64 = convert_amount_to_f64(swap_event.amount1, token1.decimals).abs();
+    let quantity_f64 = convert_i256_to_f64(swap_event.amount1, token1.decimals)?.abs();
     let quantity = Quantity::from(format!(
         "{:.precision$}",
         quantity_f64,
@@ -220,4 +224,236 @@ fn convert_to_trade_data(
         OrderSide::Buy
     };
     Ok((side, quantity, price))
+}
+
+// Define sol macro for easier parsing of Mint event data
+// It contains 4 parameters of 32 bytes each:
+// sender (address), amount (uint128), amount0 (uint256), amount1 (uint256)
+sol! {
+    struct MintEventData {
+        address sender;
+        uint128 amount;
+        uint256 amount0;
+        uint256 amount1;
+    }
+}
+
+fn parse_mint_event(log: Log) -> anyhow::Result<MintEvent> {
+    validate_event_signature_hash("Mint", MINT_EVENT_SIGNATURE_HASH, &log)?;
+
+    let owner = match log.topics.get(1).and_then(|t| t.as_ref()) {
+        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
+        None => anyhow::bail!("Missing owner address in topic1 when parsing mint event"),
+    };
+
+    // Extract int24 tickLower from topic2 (stored as a 32-byte padded value)
+    let tick_lower = match log.topics.get(2).and_then(|t| t.as_ref()) {
+        Some(topic) => {
+            let tick_lower_bytes: [u8; 32] = topic.as_ref().try_into()?;
+            i32::from_be_bytes(tick_lower_bytes[28..32].try_into()?)
+        }
+        None => anyhow::bail!("Missing tickLower in topic2 when parsing mint event"),
+    };
+
+    // Extract int24 tickUpper from topic3 (stored as a 32-byte padded value)
+    let tick_upper = match log.topics.get(3).and_then(|t| t.as_ref()) {
+        Some(topic) => {
+            let tick_upper_bytes: [u8; 32] = topic.as_ref().try_into()?;
+            i32::from_be_bytes(tick_upper_bytes[28..32].try_into()?)
+        }
+        None => anyhow::bail!("Missing tickUpper in topic3 when parsing mint event"),
+    };
+
+    if let Some(data) = &log.data {
+        let data_bytes = data.as_ref();
+
+        // Validate if data contains 4 parameters of 32 bytes each
+        if data_bytes.len() < 4 * 32 {
+            anyhow::bail!("Mint event data is too short");
+        }
+
+        // Decode the data using the MintEventData struct
+        let decoded = match <MintEventData as SolType>::abi_decode(data_bytes) {
+            Ok(decoded) => decoded,
+            Err(e) => anyhow::bail!("Failed to decode mint event data: {e}"),
+        };
+
+        Ok(MintEvent::new(
+            extract_block_number(&log)?,
+            extract_transaction_hash(&log)?,
+            extract_transaction_index(&log)?,
+            extract_log_index(&log)?,
+            decoded.sender,
+            owner,
+            tick_lower,
+            tick_upper,
+            decoded.amount,
+            decoded.amount0,
+            decoded.amount1,
+        ))
+    } else {
+        Err(anyhow::anyhow!("Missing data in mint event log"))
+    }
+}
+
+// Define sol macro for easier parsing of Burn event data
+// It contains 3 parameters of 32 bytes each:
+// amount (uint128), amount0 (uint256), amount1 (uint256)
+sol! {
+    struct BurnEventData {
+        uint128 amount;
+        uint256 amount0;
+        uint256 amount1;
+    }
+}
+
+fn parse_burn_event(log: Log) -> anyhow::Result<BurnEvent> {
+    validate_event_signature_hash("Burn", BURN_EVENT_SIGNATURE_HASH, &log)?;
+
+    let owner = match log.topics.get(1).and_then(|t| t.as_ref()) {
+        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
+        None => anyhow::bail!("Missing owner address in topic1 when parsing burn event"),
+    };
+
+    // Extract int24 tickLower from topic2 (stored as a 32-byte padded value)
+    let tick_lower = match log.topics.get(2).and_then(|t| t.as_ref()) {
+        Some(topic) => {
+            let tick_lower_bytes: [u8; 32] = topic.as_ref().try_into()?;
+            i32::from_be_bytes(tick_lower_bytes[28..32].try_into()?)
+        }
+        None => anyhow::bail!("Missing tickLower in topic2 when parsing burn event"),
+    };
+
+    // Extract int24 tickUpper from topic3 (stored as a 32-byte padded value)
+    let tick_upper = match log.topics.get(3).and_then(|t| t.as_ref()) {
+        Some(topic) => {
+            let tick_upper_bytes: [u8; 32] = topic.as_ref().try_into()?;
+            i32::from_be_bytes(tick_upper_bytes[28..32].try_into()?)
+        }
+        None => anyhow::bail!("Missing tickUpper in topic3 when parsing burn event"),
+    };
+
+    if let Some(data) = &log.data {
+        let data_bytes = data.as_ref();
+
+        // Validate if data contains 3 parameters of 32 bytes each
+        if data_bytes.len() < 3 * 32 {
+            anyhow::bail!("Burn event data is too short");
+        }
+
+        // Decode the data using the BurnEventData struct
+        let decoded = match <BurnEventData as SolType>::abi_decode(data_bytes) {
+            Ok(decoded) => decoded,
+            Err(e) => anyhow::bail!("Failed to decode burn event data: {e}"),
+        };
+
+        Ok(BurnEvent::new(
+            extract_block_number(&log)?,
+            extract_transaction_hash(&log)?,
+            extract_transaction_index(&log)?,
+            extract_log_index(&log)?,
+            owner,
+            tick_lower,
+            tick_upper,
+            decoded.amount,
+            decoded.amount0,
+            decoded.amount1,
+        ))
+    } else {
+        Err(anyhow::anyhow!("Missing data in burn event log"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[fixture]
+    fn mint_event_log() -> Log {
+        serde_json::from_str(r#"{
+            "removed": null,
+            "log_index": null,
+            "transaction_index": null,
+            "transaction_hash": null,
+            "block_hash": null,
+            "block_number": "0x1581756",
+            "address": null,
+            "data": "0x000000000000000000000000f5a96d43e4b9a2c47f302b54d006d7e20f038658000000000000000000000000000000000000000000000028c8b4995ae1ad0e9e000000000000000000000000000000000000000000000000000009423c32486c0000000000000000000000000000000000000000000000bb5bc19aa32e5d05b4",
+            "topics": [
+                "0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde",
+                "0x000000000000000000000000a69babef1ca67a37ffaf7a485dfff3382056e78c",
+                "0x00000000000000000000000000000000000000000000000000000000000304e4",
+                "0x00000000000000000000000000000000000000000000000000000000000304ee"
+            ]
+        }"#).unwrap()
+    }
+
+    #[rstest]
+    fn test_parse_mint_event(mint_event_log: Log) {
+        let result = parse_mint_event(mint_event_log);
+        assert!(result.is_ok());
+        let mint_event = result.unwrap();
+
+        assert_eq!(mint_event.block_number, 0x1581756);
+        assert_eq!(
+            mint_event.owner.to_string().to_lowercase(),
+            "0xa69babef1ca67a37ffaf7a485dfff3382056e78c"
+        );
+        assert_eq!(mint_event.tick_lower, 197860); // 0x304e4
+        assert_eq!(mint_event.tick_upper, 197870); // 0x304ee
+        assert_eq!(
+            mint_event.sender.to_string().to_lowercase(),
+            "0xf5a96d43e4b9a2c47f302b54d006d7e20f038658"
+        );
+        assert_eq!(mint_event.amount, 0x28c8b4995ae1ad0e9e);
+        assert_eq!(mint_event.amount0.to_string(), "10180082419820");
+        assert_eq!(mint_event.amount1.to_string(), "3456152877537290945972");
+    }
+
+    #[rstest]
+    fn test_parse_mint_event_missing_data() {
+        let mut log = mint_event_log();
+        log.data = None;
+
+        let result = parse_mint_event(log);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Missing data"));
+    }
+
+    #[rstest]
+    fn test_parse_mint_event_missing_topics() {
+        let mut log = mint_event_log();
+
+        // Test missing owner
+        log.topics.truncate(1);
+        let result = parse_mint_event(log.clone());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Missing owner"));
+
+        // Test missing tickLower
+        log = mint_event_log();
+        log.topics.truncate(2);
+        let result = parse_mint_event(log.clone());
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing tickLower")
+        );
+
+        // Test missing tickUpper
+        log = mint_event_log();
+        log.topics.truncate(3);
+        let result = parse_mint_event(log);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing tickUpper")
+        );
+    }
 }

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v4.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v4.rs
@@ -31,6 +31,8 @@ pub static UNISWAP_V4: LazyLock<DexExtended> = LazyLock::new(|| {
         AmmType::CLAMEnhanced,
         "",
         "",
+        "",
+        "",
     );
     DexExtended::new(dex)
 });

--- a/crates/adapters/blockchain/src/hypersync/client.rs
+++ b/crates/adapters/blockchain/src/hypersync/client.rs
@@ -97,6 +97,9 @@ impl HyperSyncClient {
             "field_selection": {
                 "log": [
                     "block_number",
+                    "transaction_hash",
+                    "transaction_index",
+                    "log_index",
                     "data",
                     "topic0",
                     "topic1",

--- a/crates/adapters/blockchain/src/lib.rs
+++ b/crates/adapters/blockchain/src/lib.rs
@@ -59,4 +59,5 @@ pub mod factories;
 
 #[cfg(feature = "hypersync")]
 pub mod hypersync;
+pub mod math;
 pub mod validation;

--- a/crates/adapters/blockchain/src/math.rs
+++ b/crates/adapters/blockchain/src/math.rs
@@ -1,0 +1,341 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use alloy::primitives::{I256, U256};
+
+/// Convert an alloy's I256 value to f64, accounting for token decimals.
+///
+/// # Errors
+///
+/// Returns an error if the I256 value cannot be parsed to f64.
+pub fn convert_i256_to_f64(amount: I256, decimals: u8) -> anyhow::Result<f64> {
+    // Handle the sign separately
+    let is_negative = amount.is_negative();
+    let abs_amount = if is_negative { -amount } else { amount };
+
+    // Convert to string to avoid precision loss for large numbers
+    let amount_str = abs_amount.to_string();
+    let mut amount_f64: f64 = amount_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse I256 to f64: {}", e))?;
+
+    // Apply sign
+    if is_negative {
+        amount_f64 = -amount_f64;
+    }
+
+    // Apply decimal scaling
+    let factor = 10f64.powi(i32::from(decimals));
+    Ok(amount_f64 / factor)
+}
+
+/// Convert an alloy's U256 value to f64, accounting for token decimals.
+///
+/// # Errors
+///
+/// Returns an error if the U256 value cannot be parsed to f64.
+pub fn convert_u256_to_f64(amount: U256, decimals: u8) -> anyhow::Result<f64> {
+    // Convert to string to avoid precision loss for large numbers
+    let amount_str = amount.to_string();
+    let amount_f64: f64 = amount_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse U256 to f64: {}", e))?;
+
+    // Apply decimal scaling
+    let factor = 10f64.powi(i32::from(decimals));
+    Ok(amount_f64 / factor)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy::primitives::{I256, U256};
+
+    use super::*;
+
+    #[test]
+    fn test_convert_positive_i256_to_f64() {
+        // Test with 6 decimals (USDC-like)
+        let amount = I256::from_str("1000000").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 1.0);
+
+        // Test with 18 decimals (ETH-like)
+        let amount = I256::from_str("1000000000000000000").unwrap();
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1.0);
+    }
+
+    #[test]
+    fn test_convert_negative_i256_to_f64() {
+        // Test negative value with 6 decimals
+        let amount = I256::from_str("-1000000").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, -1.0);
+
+        // Test negative value with 18 decimals
+        let amount = I256::from_str("-2500000000000000000").unwrap();
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, -2.5);
+    }
+
+    #[test]
+    fn test_convert_zero_i256_to_f64() {
+        let amount = I256::ZERO;
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.0);
+
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 0.0);
+    }
+
+    #[test]
+    fn test_convert_fractional_amounts() {
+        // Test 0.5 with 6 decimals
+        let amount = I256::from_str("500000").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.5);
+
+        // Test 0.123456 with 6 decimals
+        let amount = I256::from_str("123456").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.123456);
+
+        // Test negative fractional
+        let amount = I256::from_str("-123456").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, -0.123456);
+    }
+
+    #[test]
+    fn test_convert_large_i256_values() {
+        // Test very large positive value
+        let large_value = U256::from(10).pow(U256::from(30)); // 10^30
+        let amount = I256::try_from(large_value).unwrap();
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1e12); // 10^30 / 10^18 = 10^12
+
+        // Test maximum safe integer range
+        let amount = I256::from_str("9007199254740991").unwrap(); // MAX_SAFE_INTEGER
+        let result = convert_i256_to_f64(amount, 0).unwrap();
+        assert_eq!(result, 9_007_199_254_740_991.0);
+    }
+
+    #[test]
+    fn test_convert_with_different_decimals() {
+        let amount = I256::from_str("1000000000").unwrap();
+
+        // 0 decimals
+        let result = convert_i256_to_f64(amount, 0).unwrap();
+        assert_eq!(result, 1_000_000_000.0);
+
+        // 9 decimals
+        let result = convert_i256_to_f64(amount, 9).unwrap();
+        assert_eq!(result, 1.0);
+
+        // 12 decimals
+        let result = convert_i256_to_f64(amount, 12).unwrap();
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_convert_edge_cases() {
+        // Test very small positive amount with high decimals
+        let amount = I256::from_str("1").unwrap();
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1e-18);
+
+        // Test amount smaller than decimal places
+        let amount = I256::from_str("100").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.0001);
+    }
+
+    #[test]
+    fn test_convert_real_world_examples() {
+        // Example: 1234.567890 USDC (6 decimals)
+        let amount = I256::from_str("1234567890").unwrap();
+        let result = convert_i256_to_f64(amount, 6).unwrap();
+        assert!((result - 1234.567890).abs() < f64::EPSILON);
+
+        // Example: -0.005 ETH (18 decimals)
+        let amount = I256::from_str("-5000000000000000").unwrap();
+        let result = convert_i256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, -0.005);
+
+        // Example: Large swap amount - 100,000 tokens with 8 decimals
+        let amount = I256::from_str("10000000000000").unwrap();
+        let result = convert_i256_to_f64(amount, 8).unwrap();
+        assert_eq!(result, 100_000.0);
+    }
+
+    #[test]
+    fn test_precision_boundaries() {
+        // Test precision near f64 boundaries
+        // f64 can accurately represent integers up to 2^53
+        let max_safe = I256::from_str("9007199254740992").unwrap(); // 2^53
+        let result = convert_i256_to_f64(max_safe, 0).unwrap();
+        assert_eq!(result, 9_007_199_254_740_992.0);
+
+        // Test with scientific notation result
+        let amount = I256::from_str("1234567890123456789").unwrap();
+        let result = convert_i256_to_f64(amount, 9).unwrap();
+        assert!((result - 1_234_567_890.123456789).abs() < 1.0); // Some precision loss expected
+    }
+
+    // U256 Tests
+    #[test]
+    fn test_convert_positive_u256_to_f64() {
+        // Test with 6 decimals (USDC-like)
+        let amount = U256::from_str("1000000").unwrap();
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 1.0);
+
+        // Test with 18 decimals (ETH-like)
+        let amount = U256::from_str("1000000000000000000").unwrap();
+        let result = convert_u256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1.0);
+    }
+
+    #[test]
+    fn test_convert_zero_u256_to_f64() {
+        let amount = U256::ZERO;
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.0);
+
+        let result = convert_u256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 0.0);
+    }
+
+    #[test]
+    fn test_convert_fractional_u256_amounts() {
+        // Test 0.5 with 6 decimals
+        let amount = U256::from_str("500000").unwrap();
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.5);
+
+        // Test 0.123456 with 6 decimals
+        let amount = U256::from_str("123456").unwrap();
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.123456);
+    }
+
+    #[test]
+    fn test_convert_large_u256_values() {
+        // Test very large positive value
+        let large_value = U256::from(10).pow(U256::from(30)); // 10^30
+        let result = convert_u256_to_f64(large_value, 18).unwrap();
+        assert_eq!(result, 1e12); // 10^30 / 10^18 = 10^12
+
+        // Test maximum safe integer range
+        let amount = U256::from_str("9007199254740991").unwrap(); // MAX_SAFE_INTEGER
+        let result = convert_u256_to_f64(amount, 0).unwrap();
+        assert_eq!(result, 9_007_199_254_740_991.0);
+    }
+
+    #[test]
+    fn test_convert_u256_with_different_decimals() {
+        let amount = U256::from_str("1000000000").unwrap();
+
+        // 0 decimals
+        let result = convert_u256_to_f64(amount, 0).unwrap();
+        assert_eq!(result, 1_000_000_000.0);
+
+        // 9 decimals
+        let result = convert_u256_to_f64(amount, 9).unwrap();
+        assert_eq!(result, 1.0);
+
+        // 12 decimals
+        let result = convert_u256_to_f64(amount, 12).unwrap();
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_convert_u256_edge_cases() {
+        // Test very small positive amount with high decimals
+        let amount = U256::from_str("1").unwrap();
+        let result = convert_u256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1e-18);
+
+        // Test amount smaller than decimal places
+        let amount = U256::from_str("100").unwrap();
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert_eq!(result, 0.0001);
+    }
+
+    #[test]
+    fn test_convert_u256_real_world_examples() {
+        // Example: 1234.567890 USDC (6 decimals)
+        let amount = U256::from_str("1234567890").unwrap();
+        let result = convert_u256_to_f64(amount, 6).unwrap();
+        assert!((result - 1234.567890).abs() < f64::EPSILON);
+
+        // Example: Large liquidity amount - 100,000 tokens with 8 decimals
+        let amount = U256::from_str("10000000000000").unwrap();
+        let result = convert_u256_to_f64(amount, 8).unwrap();
+        assert_eq!(result, 100_000.0);
+
+        // Example: Very large supply - 1 trillion tokens with 18 decimals
+        let amount = U256::from_str("1000000000000000000000000000000").unwrap(); // 10^30
+        let result = convert_u256_to_f64(amount, 18).unwrap();
+        assert_eq!(result, 1e12);
+    }
+
+    #[test]
+    fn test_convert_u256_precision_boundaries() {
+        // Test precision near f64 boundaries
+        // f64 can accurately represent integers up to 2^53
+        let max_safe = U256::from_str("9007199254740992").unwrap(); // 2^53
+        let result = convert_u256_to_f64(max_safe, 0).unwrap();
+        assert_eq!(result, 9_007_199_254_740_992.0);
+
+        // Test with scientific notation result
+        let amount = U256::from_str("1234567890123456789").unwrap();
+        let result = convert_u256_to_f64(amount, 9).unwrap();
+        assert!((result - 1_234_567_890.123456789).abs() < 1.0); // Some precision loss expected
+    }
+
+    #[test]
+    fn test_convert_u256_vs_i256_consistency() {
+        // Test that positive values give same results for U256 and I256
+        let u256_amount = U256::from_str("1000000000000000000").unwrap();
+        let i256_amount = I256::from_str("1000000000000000000").unwrap();
+
+        let u256_result = convert_u256_to_f64(u256_amount, 18).unwrap();
+        let i256_result = convert_i256_to_f64(i256_amount, 18).unwrap();
+
+        assert_eq!(u256_result, i256_result);
+        assert_eq!(u256_result, 1.0);
+    }
+
+    #[test]
+    fn test_convert_u256_max_values() {
+        // Test very large U256 values that wouldn't fit in I256
+        let large_u256 = U256::from(2).pow(U256::from(255)); // Close to U256::MAX
+        let result = convert_u256_to_f64(large_u256, 0).unwrap();
+        // Should be a very large number but not infinite
+        assert!(result.is_finite());
+        assert!(result > 0.0);
+
+        // Test with decimals to bring it down to reasonable range
+        let large_u256_with_decimals = U256::from(2).pow(U256::from(60)); // 2^60
+        let result = convert_u256_to_f64(large_u256_with_decimals, 18).unwrap();
+        // 2^60 ≈ 1.15e18, so 2^60 / 10^18 ≈ 1.15
+        assert!(result.is_finite());
+        assert!(result > 1.0);
+        assert!(result < 2.0); // Should be around 1.15
+    }
+}

--- a/crates/model/src/defi/chain.rs
+++ b/crates/model/src/defi/chain.rs
@@ -130,6 +130,8 @@ pub struct Chain {
     pub hypersync_url: String,
     /// URL endpoint for the default RPC connection.
     pub rpc_url: Option<String>,
+    /// The number of decimals for the native currency
+    pub native_currency_decimals: u8,
 }
 
 /// A thread-safe shared pointer to a `Chain`, enabling efficient reuse across multiple components.
@@ -142,6 +144,7 @@ impl Chain {
             name,
             hypersync_url: format!("https://{}.hypersync.xyz", chain_id),
             rpc_url: None,
+            native_currency_decimals: 18, // Default to 18 for EVM chains
         }
     }
 

--- a/crates/model/src/defi/dex.rs
+++ b/crates/model/src/defi/dex.rs
@@ -47,6 +47,10 @@ pub struct Dex {
     pub pool_created_event: Cow<'static, str>,
     /// The event signature or identifier used to detect swap events.
     pub swap_created_event: Cow<'static, str>,
+    /// The event signature or identifier used to detect mint events
+    pub mint_created_event: Cow<'static, str>,
+    /// The event signature or identifier used to detect burn events
+    pub burn_created_event: Cow<'static, str>,
     /// The type of automated market maker (AMM) algorithm used by this DEX.
     pub amm_type: AmmType,
     /// Collection of liquidity pools managed by this DEX.
@@ -60,6 +64,7 @@ pub type SharedDex = Arc<Dex>;
 impl Dex {
     /// Creates a new [`Dex`] instance with the specified properties.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain: Chain,
         name: impl Into<Cow<'static, str>>,
@@ -67,6 +72,8 @@ impl Dex {
         amm_type: AmmType,
         pool_created_event: impl Into<Cow<'static, str>>,
         swap_created_event: impl Into<Cow<'static, str>>,
+        mint_created_event: impl Into<Cow<'static, str>>,
+        burn_created_event: impl Into<Cow<'static, str>>,
     ) -> Self {
         Self {
             chain,
@@ -74,6 +81,8 @@ impl Dex {
             factory: factory.into(),
             pool_created_event: pool_created_event.into(),
             swap_created_event: swap_created_event.into(),
+            mint_created_event: mint_created_event.into(),
+            burn_created_event: burn_created_event.into(),
             amm_type,
             pairs: vec![],
         }

--- a/crates/model/src/defi/liquidity.rs
+++ b/crates/model/src/defi/liquidity.rs
@@ -1,0 +1,126 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use alloy_primitives::Address;
+use nautilus_core::UnixNanos;
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
+
+use crate::{
+    defi::{amm::SharedPool, chain::SharedChain, dex::SharedDex},
+    types::Quantity,
+};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialOrd,
+    PartialEq,
+    Ord,
+    Eq,
+    Display,
+    EnumString,
+    Serialize,
+    Deserialize,
+)]
+/// Represents the type of liquidity update operation in a DEX pool.
+pub enum PoolLiquidityUpdateType {
+    /// Liquidity is being added to the pool
+    Mint,
+    /// Liquidity is being removed from the pool
+    Burn,
+}
+
+/// Represents a liquidity update event in a decentralized exchange (DEX) pool.
+#[derive(Debug, Clone)]
+pub struct PoolLiquidityUpdate {
+    /// The blockchain network where the liquidity update occurred.
+    pub chain: SharedChain,
+    /// The decentralized exchange where the liquidity update was executed.
+    pub dex: SharedDex,
+    /// The DEX liquidity pool
+    pub pool: SharedPool,
+    /// The type of the pool liquidity update.
+    pub kind: PoolLiquidityUpdateType,
+    /// The blockchain block number where the liquidity update occurred.
+    pub block: u64,
+    /// The unique hash identifier of the blockchain transaction containing the liquidity update.
+    pub transaction_hash: String,
+    /// The index position of the transaction within the block.
+    pub transaction_index: u32,
+    /// The index position of the liquidity update event log within the transaction.
+    pub log_index: u32,
+    /// The blockchain address that initiated the liquidity update transaction.
+    pub sender: Option<Address>,
+    /// The blockchain address that owns the liquidity position.
+    pub owner: Address,
+    /// The amount of liquidity tokens affected in the position.
+    pub position_liquidity: Quantity,
+    /// The amount of the first token in the pool pair.
+    pub amount0: Quantity,
+    /// The amount of the second token in the pool pair.
+    pub amount1: Quantity,
+    /// The lower price tick boundary of the liquidity position.
+    pub tick_lower: i32,
+    /// The upper price tick boundary of the liquidity position.
+    pub tick_upper: i32,
+    /// The timestamp of the liquidity update in Unix nanoseconds.
+    pub timestamp: UnixNanos,
+}
+
+impl PoolLiquidityUpdate {
+    /// Creates a new [`PoolLiquidityUpdate`] instance with the specified properties.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        chain: SharedChain,
+        dex: SharedDex,
+        pool: SharedPool,
+        kind: PoolLiquidityUpdateType,
+        block: u64,
+        transaction_hash: String,
+        transaction_index: u32,
+        log_index: u32,
+        sender: Option<Address>,
+        owner: Address,
+        position_liquidity: Quantity,
+        amount0: Quantity,
+        amount1: Quantity,
+        tick_lower: i32,
+        tick_upper: i32,
+        timestamp: UnixNanos,
+    ) -> Self {
+        Self {
+            chain,
+            dex,
+            pool,
+            kind,
+            block,
+            transaction_hash,
+            transaction_index,
+            log_index,
+            sender,
+            owner,
+            position_liquidity,
+            amount0,
+            amount1,
+            tick_lower,
+            tick_upper,
+            timestamp,
+        }
+    }
+}

--- a/crates/model/src/defi/mod.rs
+++ b/crates/model/src/defi/mod.rs
@@ -18,6 +18,7 @@ pub mod block;
 pub mod chain;
 pub mod dex;
 pub mod hex;
+pub mod liquidity;
 pub mod rpc;
 pub mod swap;
 pub mod token;

--- a/crates/model/src/defi/swap.rs
+++ b/crates/model/src/defi/swap.rs
@@ -35,6 +35,12 @@ pub struct Swap {
     pub pool: SharedPool,
     /// The blockchain block number at which the swap was executed.
     pub block: u64,
+    /// The unique hash identifier of the blockchain transaction containing the swap.
+    pub transaction_hash: String,
+    /// The index position of the transaction within the block.
+    pub transaction_index: u32,
+    /// The index position of the swap event log within the transaction.
+    pub log_index: u32,
     /// The blockchain address of the user or contract that initiated the swap.
     pub sender: Address,
     /// The direction of the swap from the perspective of the base token.
@@ -56,6 +62,9 @@ impl Swap {
         dex: SharedDex,
         pool: SharedPool,
         block: u64,
+        transaction_hash: String,
+        transaction_index: u32,
+        log_index: u32,
         timestamp: UnixNanos,
         sender: Address,
         side: OrderSide,
@@ -67,6 +76,9 @@ impl Swap {
             dex,
             pool,
             block,
+            transaction_hash,
+            transaction_index,
+            log_index,
             timestamp,
             sender,
             side,

--- a/schema/sql/tables.sql
+++ b/schema/sql/tables.sql
@@ -344,15 +344,40 @@ CREATE TABLE IF NOT EXISTS "pool" (
     FOREIGN KEY (chain_id, dex_name) REFERENCES dex(chain_id, name)
 );
 
-CREATE TABLE IF NOT EXISTS "swap" (
+CREATE TABLE IF NOT EXISTS "pool_swap" (
     id BIGSERIAL PRIMARY KEY,
     chain_id INTEGER NOT NULL REFERENCES chain(chain_id) ON DELETE CASCADE,
     pool_address TEXT NOT NULL,
     block BIGINT NOT NULL,
-    sender TEXT,
-    side TEXT,
-    quantity TEXT,
-    price TEXT,
+    transaction_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    log_index INTEGER NOT NULL,
+    sender TEXT NOT NULL,
+    side TEXT NOT NULL,
+    quantity TEXT NOT NULL,
+    price TEXT NOT NULL,
     FOREIGN KEY (chain_id, pool_address) REFERENCES pool(chain_id, address),
-    FOREIGN KEY (chain_id, block) REFERENCES block(chain_id, number)
+    FOREIGN KEY (chain_id, block) REFERENCES block(chain_id, number),
+    UNIQUE(chain_id, transaction_hash, log_index)
+);
+
+CREATE TABLE IF NOT EXISTS "pool_liquidity" (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL REFERENCES chain(chain_id) ON DELETE CASCADE,
+    pool_address TEXT NOT NULL,
+    block BIGINT NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    log_index INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    sender TEXT,
+    owner TEXT NOT NULL,
+    position_liquidity TEXT NOT NULL,
+    amount0 TEXT NOT NULL,
+    amount1 TEXT NOT NULL,
+    tick_lower INTEGER NOT NULL,
+    tick_upper INTEGER NOT NULL,
+    FOREIGN KEY (chain_id, pool_address) REFERENCES pool(chain_id, address),
+    FOREIGN KEY (chain_id, block) REFERENCES block(chain_id, number),
+    UNIQUE(chain_id, transaction_hash, log_index)
 );


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

 - Added `PoolLiquidityUpdate` domain entity for mint/burn events with chain, DEX, pool, transaction details, owner, liquidity amounts, and tick ranges
  - Implemented mint/burn event processing - added `BurnEvent` and `MintEvent` structures with decoding logic for concentrated liquidity pools
  - Added mathematical utilities for converting `U256/I256` blockchain values to `f64` with decimal scaling and precision handling
  - Extended database schema - created `pool_liquidity` table and refactored swap to `pool_swap` with transaction metadata
  - Added UniswapV3 mint/burn event decoding with signature validation, topic extraction, and data parsing
  - Implemented `sync_pool_mints` and `sync_pool_burns` methods for historical liquidity event backfilling with streaming support
  - Enhanced cache layer with pool liquidity update persistence and conflict resolution
  - Improved `DexExtended` abstraction with mint/burn event parsing capabilities across multiple AMM implementations
  - Updated `sync_pool_events` binary to include mint and burn event synchronization
  - https://github.com/nautechsystems/nautilus_trader/issues/1335


## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

