### PR TITLE
Harden pgadmin container in CI with no-new-privileges flag

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
       - pgadmin:/root/.pgadmin
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "${PGADMIN_PORT:-5051}:80"
     networks:


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'pgadmin' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** .docker/docker-compose.yml
- **Lines Affected:** 20 - 20

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `.docker/docker-compose.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.