### PR TITLE
Fix last value updating for RSI indicator

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -37,6 +37,7 @@ Released on TBD (UTC).
 - Fixed Arrow schema registration for `BinanceBar`
 - Fixed spot and futures sandbox for Binance (#2687), thanks @petioptrv
 - Fixed `clean` and `distclean` make targets entering `.venv` and corrupting the Python virtual env, thanks @faysou
+- Fixed RSI indicator bug
 
 ### Documentation Updates
 None

--- a/nautilus_trader/indicators/rsi.pyx
+++ b/nautilus_trader/indicators/rsi.pyx
@@ -101,6 +101,7 @@ cdef class RelativeStrengthIndex(Indicator):
 
         if self._average_loss.value == 0:
             self.value = self._rsi_max
+            self._last_value = value
             return
 
         cdef double rs = self._average_gain.value / self._average_loss.value

--- a/tests/unit_tests/indicators/test_rsi.py
+++ b/tests/unit_tests/indicators/test_rsi.py
@@ -125,6 +125,20 @@ class TestRelativeStrengthIndex:
         # Act, Assert
         assert self.rsi.value == 0.7615344667662725
 
+    def test_min_value_as_first(self):
+        # Arrange
+        self.rsi.update_raw(1.00000)
+        self.rsi.update_raw(2.00000)
+        self.rsi.update_raw(3.00000)
+        self.rsi.update_raw(4.00000)
+        self.rsi.update_raw(5.00000)
+        self.rsi.update_raw(6.00000)
+        self.rsi.update_raw(7.00000)
+        self.rsi.update_raw(2.00000)
+
+        # Act, Assert
+        assert self.rsi.value == 0.38650828748031707
+
     def test_reset_successfully_returns_indicator_to_fresh_state(self):
         # Arrange
         self.rsi.update_raw(1.00020)


### PR DESCRIPTION
# Pull Request

It fixes this issue: https://github.com/nautechsystems/nautilus_trader/issues/2673

## Summary

It sets the previous indicator value for next iteration in case of division by 0

## Related Issues/PRs

https://github.com/nautechsystems/nautilus_trader/issues/2673

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

I've tested code by running extensive backtest and comparing results.
