### PR TITLE
Fix gateway/TWS reconnect process for IBKR

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -44,6 +44,7 @@ Released on TBD (UTC).
 - Fixed spot and futures sandbox for Binance (#2687), thanks @petioptrv
 - Fixed `clean` and `distclean` make targets entering `.venv` and corrupting the Python virtual env, thanks @faysou
 - Fixed last value updating for RSI indicator (#2703), thanks @barlaw
+- Fixed IBKR reconnection problems
 
 ### Documentation Updates
 None

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -70,7 +70,7 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
             self._log.info("Connection failed.")
             if self._eclient.wrapper:
                 self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._log.info("Connection timeout.")
             if self._eclient.wrapper:
                 self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -66,14 +66,16 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
                 f"at {self._eclient.connTime.decode()} from {self._host}:{self._port} "
                 f"with client id: {self._client_id}.",
             )
+        except ConnectionError:
+            self._log.info("Connection failed.")
+        except asyncio.TimeoutError:
+            self._log.info("Connection timeout.")
         except asyncio.CancelledError:
             self._log.info("Connection cancelled.")
-            await self._disconnect()
         except Exception as e:
             self._log.exception("Connection failed", e)
             if self._eclient.wrapper:
                 self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
-            await self._handle_reconnect()
 
     async def _disconnect(self) -> None:
         """
@@ -122,7 +124,13 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         self._log.info(
             f"Connecting to {self._host}:{self._port} with client id: {self._client_id}",
         )
-        await asyncio.to_thread(self._eclient.conn.connect)
+        await asyncio.to_thread(self._connect_socket_safe)
+
+    def _connect_socket_safe(self) -> None:
+        try:
+            self._eclient.conn.connect()
+        except:
+            raise ConnectionError("Failed to connect to TWS/Gateway.")
 
     async def _send_version_info(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -68,8 +68,12 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
             )
         except ConnectionError:
             self._log.info("Connection failed.")
+            if self._eclient.wrapper:
+                self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
         except asyncio.TimeoutError:
             self._log.info("Connection timeout.")
+            if self._eclient.wrapper:
+                self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
         except asyncio.CancelledError:
             self._log.info("Connection cancelled.")
         except Exception as e:

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -133,7 +133,7 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
     def _connect_socket_safe(self) -> None:
         try:
             self._eclient.conn.connect()
-        except:
+        except Exception:
             raise ConnectionError("Failed to connect to TWS/Gateway.")
 
     async def _send_version_info(self) -> None:

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
@@ -33,7 +33,7 @@ async def test_connect_cancelled(ib_client):
 
     await ib_client._connect()
 
-    ib_client._disconnect.assert_awaited_once()
+    ib_client._disconnect.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -51,7 +51,7 @@ async def test_connect_fail(ib_client):
         CONNECT_FAIL.code(),
         CONNECT_FAIL.msg(),
     )
-    ib_client._handle_reconnect.assert_awaited_once()
+    ib_client._handle_reconnect.assert_not_awaited()
 
 
 # Test for successful reconnection


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

When IBKR connection is broken or not connected on the first try, it fails to reconnect.
Many exceptions are thrown during this process. Logic is not working correctly.
The number of threads/tasks doing reconnection simultaneously is growing over time, making many attempts per second.

If anybody wishes to comment on proposed changes, it would be great.

## Related Issues/PRs

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

I tested manually connection/reconnection
