### PR TITLE
Fix Interactive Brokers options chain issue

### DIFF
--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -159,7 +159,8 @@ for_loading_instrument_range = IBContract(
 )
 ```
 
-> **Note**: The `secType` and `symbol` should be specified for the Underlying Contract.
+> **Note**: The `secType` and `symbol` should be specified for the Underlying Contract.\
+> To specify an options exchange other than the underlying's, use the `options_chain_exchange` parameter.
 
 Some more examples of building IBContracts:
 

--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -97,6 +97,8 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
         Search for full option chain
     build_futures_chain: bool (default: None)
         Search for full futures chain
+    options_chain_exchange: str (default : None)
+        optional exchange for options chain, in place of underlying exchange
     min_expiry_days: int (default: None)
         Filters the options_chain and futures_chain which are expiring after number of days specified.
     max_expiry_days: int (default: None)
@@ -156,6 +158,7 @@ class IBContract(NautilusConfig, frozen=True, repr_omit_defaults=True):
     # nautilus specific parameters
     build_futures_chain: bool | None = None
     build_options_chain: bool | None = None
+    options_chain_exchange: str | None = None
     min_expiry_days: int | None = None
     max_expiry_days: int | None = None
 

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -403,12 +403,14 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
                     option_contracts_detail = await self.get_option_chain_details_by_expiry(
                         underlying=detail.contract,
                         last_trading_date=contract.lastTradeDateOrContractMonth,
+                        exchange=contract.options_chain_exchange or contract.exchange,
                     )
                 else:
                     option_contracts_detail = await self.get_option_chain_details_by_range(
                         underlying=detail.contract,
                         min_expiry=min_expiry,
                         max_expiry=max_expiry,
+                        exchange=contract.options_chain_exchange or contract.exchange,
                     )
                 details.extend(option_contracts_detail)
 
@@ -464,7 +466,7 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         self,
         underlying: IBContract,
         last_trading_date: str,
-        exchange: str | None = None,
+        exchange: str,
     ) -> list[ContractDetails]:
         [option_details] = (
             await self._client.get_contract_details(
@@ -472,7 +474,7 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
                     secType=("FOP" if underlying.secType == "FUT" else "OPT"),
                     symbol=underlying.symbol,
                     lastTradeDateOrContractMonth=last_trading_date,
-                    exchange=exchange or "SMART",
+                    exchange=exchange,
                 ),
             ),
         )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->
Added optional "options_chain_exchange" parameter to IBcontract. Change option chain request to use this new parameter as exchange for options, if this parameter is not set will use underlying's exchange. 
This allow using a different exchange than the underlying's,  be it "SMART" or others.
ib doc updated accordingly

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->
Close issue #2622 

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [X ] Breaking change (impacts existing behavior)
- [X ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->
Before : by default for US markets, "SMART" was applied as exchange for options. Use of ANY other exchange, including US ones was impossible
Now : Those who wish "SMART" exchange, or an exchange different from the underlying's have to specify it with options_chain_exchange parameter. Use of the underlying's exchange is now functional and automatically done just by not using this parameter.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
unit tests for usual IBcontract (excluding options chain)
used MRE in #2622 and modified it to check various exchanges.
