### PR TITLE
Add submit order list support for sandbox

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@ Released on TBD (UTC).
 - Added support for Pool liquidity updates for blockchain adapter (#2692), thanks @filipmacek
 - Added fill report reconciliation warning when discrepancy with existing fill (#2706), thanks @faysou
 - Added `bid_levels` and `ask_levels` for `OrderBook.pprint`
+- Added support for order-list submission in the sandbox execution client.
 
 ### Breaking Changes
 - Changed timer `allow_past=False` behavior: now validates the `next_event_time` instead of the `start_time`. This allows timers with past start times as long as their next scheduled event is still in the future

--- a/nautilus_trader/adapters/sandbox/execution.py
+++ b/nautilus_trader/adapters/sandbox/execution.py
@@ -187,6 +187,9 @@ class SandboxExecutionClient(LiveExecutionClient):
     def submit_order(self, command):
         return self._client.submit_order(command)
 
+    def submit_order_list(self, command):
+        return self._client.submit_order_list(command)
+
     def modify_order(self, command):
         return self._client.modify_order(command)
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

This PR adds support for submitting order lists when using the sandbox execution client.

## Related Issues/PRs

N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

I attempted to add a unit test in the `tests/integration_tests/adapters/sandbox/test_execution.py` file, however, the current unit tests around sandbox execution are WIP, so I am not sure if my test case makes sense.
