### PR TITLE
Fix Binance spot trade fee fetching for single symbol

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -73,6 +73,7 @@ Released on TBD (UTC).
 - Fixed Partially filled bracket order and SL triggered for IBKR (#2704, #2717), thanks @bartlaw
 - Fixed instrument message decoding when no `exchange` value for Databento US equities
 - Restore task error logs for IBKR (#2716), thanks @bartlaw
+- Fixed fetching single-instrument trading fees for `Binance`, thanks @petioptrv
 
 ### Documentation Updates
 None

--- a/nautilus_trader/adapters/binance/spot/http/wallet.py
+++ b/nautilus_trader/adapters/binance/spot/http/wallet.py
@@ -50,7 +50,6 @@ class BinanceSpotTradeFeeHttp(BinanceHttpEndpoint):
             methods,
             base_endpoint + "tradeFee",
         )
-        self._get_obj_resp_decoder = msgspec.json.Decoder(BinanceSpotTradeFee)
         self._get_arr_resp_decoder = msgspec.json.Decoder(list[BinanceSpotTradeFee])
 
     class GetParameters(msgspec.Struct, omit_defaults=True, frozen=True):
@@ -75,10 +74,7 @@ class BinanceSpotTradeFeeHttp(BinanceHttpEndpoint):
     async def get(self, params: GetParameters) -> list[BinanceSpotTradeFee]:
         method_type = HttpMethod.GET
         raw = await self._method(method_type, params)
-        if params.symbol is not None:
-            return [self._get_obj_resp_decoder.decode(raw)]
-        else:
-            return self._get_arr_resp_decoder.decode(raw)
+        return self._get_arr_resp_decoder.decode(raw)
 
 
 class BinanceSpotWalletHttpAPI:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

This PR fixes fetching single-instrument trading fees from `Binance` spot.

## Related Issues/PRs

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

The changes were tested manually.
