### PR TITLE
Gracefully handle negative balances

### DIFF
--- a/nautilus_trader/accounting/manager.pyx
+++ b/nautilus_trader/accounting/manager.pyx
@@ -470,6 +470,13 @@ cdef class AccountsManager:
             return False
 
         # Calculate new balance
+        cdef Money new_value = balance.total.add(pnl)
+        if new_value.as_decimal() < 0:
+            raise AccountBalanceNegative(
+                balance=new_value.as_decimal(),
+                currency=pnl.currency,
+            )
+
         cdef AccountBalance new_balance = AccountBalance(
             total=balance.total.add(pnl),
             locked=balance.locked,

--- a/tests/unit_tests/portfolio/test_portfolio.py
+++ b/tests/unit_tests/portfolio/test_portfolio.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 
 import pytest
 
+from nautilus_trader.accounting.error import AccountBalanceNegative
 from nautilus_trader.accounting.factory import AccountFactory
 from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.component import TestClock
@@ -256,7 +257,7 @@ class TestPortfolio:
         self.exec_engine.process(TestEventStubs.order_submitted(order, account_id=account_id))
 
         # Act, Assert: push account to negative balance (wouldn't normally be allowed by risk engine)
-        with pytest.raises(ValueError):
+        with pytest.raises(AccountBalanceNegative):
             fill = TestEventStubs.order_filled(
                 order,
                 instrument=AUDUSD_SIM,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

Under certain scenarios when running backtests with a margin account I would end up with a negative balance, which was then unhandled and caused:
```
  File "nautilus_trader/portfolio/portfolio.pyx", line 504, in nautilus_trader.portfolio.portfolio.Portfolio.update_order
  File "nautilus_trader/accounting/manager.pyx", line 145, in nautilus_trader.accounting.manager.AccountsManager.update_balances
  File "nautilus_trader/accounting/manager.pyx", line 473, in nautilus_trader.accounting.manager.AccountsManager._update_balance_single_currency
  File "nautilus_trader/model/objects.pyx", line 1631, in nautilus_trader.model.objects.AccountBalance.__init__
  File "nautilus_trader/core/correctness.pyx", line 57, in nautilus_trader.core.correctness.Condition.is_true
ValueError: `total` amount was negative
```

This PR handles the problems by properly raising `AccountBalanceNegative`

## Related Issues/PRs


## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
