### PR TITLE
Add immediate firing capability for time alerts and corresponding test

### DIFF
--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -463,8 +463,10 @@ impl Clock for TestClock {
 
         // Safe to calculate interval now that we've ensured alert_time_ns >= ts_now
         let interval_ns = create_valid_interval((alert_time_ns - ts_now).into());
+        // When alert time equals current time, fire immediately
+        let fire_immediately = alert_time_ns == ts_now;
 
-        let timer = TestTimer::new(name, interval_ns, ts_now, Some(alert_time_ns), false);
+        let timer = TestTimer::new(name, interval_ns, ts_now, Some(alert_time_ns), fire_immediately);
         self.timers.insert(name, timer);
 
         Ok(())
@@ -1643,5 +1645,25 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(*events[0].ts_event, *start_ns); // Immediate fire
         assert_eq!(*events[1].ts_event, *start_ns + interval_ns); // Regular interval
+    }
+
+    #[rstest]
+    fn test_set_time_alert_when_alert_time_equals_current_time(mut test_clock: TestClock) {
+        let current_time = test_clock.timestamp_ns();
+
+        // Set time alert for exactly the current time
+        test_clock
+            .set_time_alert_ns("alert_at_current_time", current_time, None, None)
+            .unwrap();
+
+        assert_eq!(test_clock.timer_count(), 1);
+
+        // Advance time by exactly 0 (to current time) - should fire immediately
+        let events = test_clock.advance_time(current_time, true);
+
+        // Should fire immediately since alert_time_ns == ts_now
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name.as_str(), "alert_at_current_time");
+        assert_eq!(*events[0].ts_event, *current_time);
     }
 }

--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -466,7 +466,13 @@ impl Clock for TestClock {
         // When alert time equals current time, fire immediately
         let fire_immediately = alert_time_ns == ts_now;
 
-        let timer = TestTimer::new(name, interval_ns, ts_now, Some(alert_time_ns), fire_immediately);
+        let timer = TestTimer::new(
+            name,
+            interval_ns,
+            ts_now,
+            Some(alert_time_ns),
+            fire_immediately,
+        );
         self.timers.insert(name, timer);
 
         Ok(())


### PR DESCRIPTION
## Summary
This pull request introduces a new feature to handle cases where a time alert is set for the exact current time in the `TestClock` implementation. It ensures that such alerts fire immediately and includes corresponding unit tests to validate this behavior.

### Bug fix: Immediate Firing for Current Time Alerts
* [`crates/common/src/clock.rs`](diffhunk://#diff-f55837cf1da7013b6444193e26e0a1c72e2e6efa2c94aff0877d4e89eeb8858dR466-R469): Modified the `TestTimer::new` invocation to include a new `fire_immediately` parameter, which is set to `true` when the alert time equals the current time. This ensures immediate firing of the alert.


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

### Testing Enhancements
* [`crates/common/src/clock.rs`](diffhunk://#diff-f55837cf1da7013b6444193e26e0a1c72e2e6efa2c94aff0877d4e89eeb8858dR1649-R1668): Added a new test case, `test_set_time_alert_when_alert_time_equals_current_time`, to verify that alerts set for the current time fire immediately. This test checks the timer count, advances the clock, and asserts the correct event behavior.# Pull Request

