### PR TITLE
Update Makefile to use new docker compose syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,11 +268,11 @@ docker-push-jupyter:  #-- Push JupyterLab Docker image to registry
 
 .PHONY: start-services
 start-services:  #-- Start development services with docker-compose
-	docker-compose -f .docker/docker-compose.yml up -d
+	docker compose -f .docker/docker-compose.yml up -d
 
 .PHONY: stop-services
 stop-services:  #-- Stop development services
-	docker-compose -f .docker/docker-compose.yml down
+	docker compose -f .docker/docker-compose.yml down
 
 #== Python Testing
 


### PR DESCRIPTION
This pull request updates the `Makefile` to align with the latest Docker CLI syntax. The changes replace the deprecated `docker-compose` command with the newer `docker compose` command.

* **Updated Docker CLI commands**:
  * Replaced `docker-compose` with `docker compose` for starting development services in the `start-services` target. (`Makefile`, [MakefileL271-R275](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L271-R275))
  * Replaced `docker-compose` with `docker compose` for stopping development services in the `stop-services` target. (`Makefile`, [MakefileL271-R275](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L271-R275))
