### PR TITLE
Fix balance updates on fill

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -106,6 +106,7 @@ Released on TBD (UTC).
 - Fixed Bybit Unknown Error (#2742), thanks @DeevsDeevs
 - Fixed margin balance parsing for Bybit
 - Restore task error logs for IBKR (#2716), thanks @bartlaw
+- Fixed balance calculations on order fill to allow operating at near account balance capacity, thanks @petioptrv
 
 ### Documentation Updates
 - Updated IB adapter documentation (#2729), thanks @faysou

--- a/nautilus_trader/accounting/manager.pyx
+++ b/nautilus_trader/accounting/manager.pyx
@@ -530,7 +530,8 @@ cdef class AccountsManager:
                 new_total = new_total.add(pnl)
                 instrument = self._cache.instrument(fill._instrument_id)
                 if (
-                    fill.order_type == OrderType.MARKET
+                    pnl.is_positive()
+                    or fill.order_type == OrderType.MARKET
                     or instrument.instrument_class in [InstrumentClass.SPORTS_BETTING]
                 ):
                     new_free = new_free.add(pnl)

--- a/nautilus_trader/accounting/manager.pyx
+++ b/nautilus_trader/accounting/manager.pyx
@@ -28,6 +28,8 @@ from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.rust.model cimport OrderSide
 from nautilus_trader.core.rust.model cimport PriceType
 from nautilus_trader.core.uuid cimport UUID4
+from nautilus_trader.model.enums import InstrumentClass
+from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.identifiers cimport PositionId
 from nautilus_trader.model.instruments.base cimport Instrument
 from nautilus_trader.model.objects cimport AccountBalance
@@ -521,10 +523,25 @@ cdef class AccountsManager:
                     free=pnl,
                 )
             else:
-                new_total = balance.total.as_decimal() + pnl.as_decimal()
-                new_free = balance.free.as_decimal() + pnl.as_decimal()
-                total = Money(new_total, pnl.currency)
-                free = Money(new_free, pnl.currency)
+                new_total = balance.total
+                new_free = balance.free
+                new_locked = balance.locked
+
+                new_total = new_total.add(pnl)
+                instrument = self._cache.instrument(fill._instrument_id)
+                if (
+                    fill.order_type == OrderType.MARKET
+                    or instrument.instrument_class in [InstrumentClass.SPORTS_BETTING]
+                ):
+                    new_free = new_free.add(pnl)
+                else:
+                    new_locked = new_locked.add(pnl)
+
+                if apply_commission and pnl.currency == commission.currency:
+                    new_total = new_total.sub(commission)
+                    new_free = new_free.sub(commission)
+                    # Ensure we only apply commission once
+                    apply_commission = False
 
                 # TODO: Until the platform can accurately track account equity and
                 # cross-margin requirements this condition check is inaccurate and
@@ -537,9 +554,9 @@ cdef class AccountsManager:
                 #     )
 
                 new_balance = AccountBalance(
-                    total=total,
-                    locked=balance.locked,
-                    free=free,
+                    total=new_total,
+                    locked=new_locked,
+                    free=new_free,
                 )
 
             balances.append(new_balance)

--- a/tests/unit_tests/accounting/test_cash.py
+++ b/tests/unit_tests/accounting/test_cash.py
@@ -686,10 +686,10 @@ def test_cash_account_update_with_fill_to_zero():
                 Money(0.0, USDT),
                 Money(10000.0, USDT),
             ),
-            AccountBalance(
+            AccountBalance(  # simulating an existing order in our account
+                Money(10.0, ETH),
                 Money(10.0, ETH),
                 Money(0.0, ETH),
-                Money(10.0, ETH),
             ),
         ],
         margins=[],


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

The previous sequence was

Order accepted -> Lock capital / margin init -> fill order using *free* capital -> release locked capital / margin init

This PR changes the calculations on order fill to use the proper balance.

## Related Issues/PRs

--

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not breaking.

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

PR introduces new test cases.
