### PR TITLE
Fix dYdX Take Profit order type mapping error

### DIFF
--- a/nautilus_trader/adapters/dydx/common/enums.py
+++ b/nautilus_trader/adapters/dydx/common/enums.py
@@ -239,10 +239,15 @@ class DYDXEnumParser:
             DYDXOrderType.MARKET: OrderType.MARKET,
             DYDXOrderType.STOP_LIMIT: OrderType.STOP_LIMIT,
             DYDXOrderType.STOP_MARKET: OrderType.STOP_MARKET,
+            DYDXOrderType.TAKE_PROFIT: OrderType.LIMIT_IF_TOUCHED,
+            DYDXOrderType.TAKE_PROFIT_MARKET: OrderType.MARKET_IF_TOUCHED,
         }
 
         self.nautilus_to_dydx_order_type = {
-            value: key for key, value in self.dydx_to_nautilus_order_type.items()
+            OrderType.LIMIT: DYDXOrderType.LIMIT,
+            OrderType.MARKET: DYDXOrderType.MARKET,
+            OrderType.STOP_LIMIT: DYDXOrderType.STOP_LIMIT,
+            OrderType.STOP_MARKET: DYDXOrderType.STOP_MARKET,
         }
 
         self.dydx_to_nautilus_order_side = {

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -53,7 +53,7 @@ def enum_parser() -> DYDXEnumParser:
         (DYDXOrderType.STOP_MARKET, OrderType.STOP_MARKET),
         (DYDXOrderType.TAKE_PROFIT, OrderType.LIMIT_IF_TOUCHED),
         (DYDXOrderType.TAKE_PROFIT_MARKET, OrderType.MARKET_IF_TOUCHED),
-    ]
+    ],
 )
 def test_parse_order_type(
     dydx_order_type: DYDXOrderType,

--- a/tests/integration_tests/adapters/dydx/test_parsing.py
+++ b/tests/integration_tests/adapters/dydx/test_parsing.py
@@ -51,7 +51,9 @@ def enum_parser() -> DYDXEnumParser:
         (DYDXOrderType.MARKET, OrderType.MARKET),
         (DYDXOrderType.STOP_LIMIT, OrderType.STOP_LIMIT),
         (DYDXOrderType.STOP_MARKET, OrderType.STOP_MARKET),
-    ],
+        (DYDXOrderType.TAKE_PROFIT, OrderType.LIMIT_IF_TOUCHED),
+        (DYDXOrderType.TAKE_PROFIT_MARKET, OrderType.MARKET_IF_TOUCHED),
+    ]
 )
 def test_parse_order_type(
     dydx_order_type: DYDXOrderType,
@@ -274,3 +276,34 @@ def test_parse_dydx_kline_incorrect(bar_type: str) -> None:
     """
     with pytest.raises(KeyError):
         get_interval_from_bar_type(BarType.from_str(bar_type))
+
+
+def test_order_type_bidirectional_mapping_consistency(
+    enum_parser: DYDXEnumParser,
+) -> None:
+    """
+    Test that bidirectional order type mapping is consistent.
+    """
+    basic_nautilus_types = [
+        OrderType.LIMIT,
+        OrderType.MARKET,
+        OrderType.STOP_LIMIT,
+        OrderType.STOP_MARKET,
+    ]
+
+    for nautilus_type in basic_nautilus_types:
+        dydx_type = enum_parser.parse_nautilus_order_type(nautilus_type)
+        back_to_nautilus = enum_parser.parse_dydx_order_type(dydx_type)
+        assert back_to_nautilus == nautilus_type, f"Inconsistent mapping for {nautilus_type}"
+
+    take_profit_mappings = [
+        (DYDXOrderType.TAKE_PROFIT, OrderType.LIMIT_IF_TOUCHED),
+        (DYDXOrderType.TAKE_PROFIT_MARKET, OrderType.MARKET_IF_TOUCHED),
+    ]
+
+    for dydx_type, expected_nautilus_type in take_profit_mappings:
+        actual_nautilus_type = enum_parser.parse_dydx_order_type(dydx_type)
+        assert actual_nautilus_type == expected_nautilus_type, (
+            f"DYDX {dydx_type} should map to Nautilus {expected_nautilus_type}, "
+            f"got {actual_nautilus_type}"
+        )


### PR DESCRIPTION
Resolves KeyError in Nautilus Trader DYDX adapter by adding missing enum mappings for TAKE_PROFIT and TAKE_PROFIT_MARKET order types to prevent execution reconciliation failures.

***

![image](https://github.com/user-attachments/assets/f7eac16e-1b5e-4056-adbf-8c2190744f55)
