### PR TITLE
Add integration test service management targets

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: nautilus-database
     image: postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-nautilus}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
       POSTGRES_DATABASE: nautilus
       PGDATA: /data/postgres

--- a/Makefile
+++ b/Makefile
@@ -338,8 +338,7 @@ purge-services:  #-- Purge all development services (stop containers and remove 
 .PHONY: init-db
 init-db:  #-- Initialize PostgreSQL database schema
 	$(info $(M) Initializing PostgreSQL database schema...)
-	cat schema/sql/tables.sql | docker exec -i nautilus-database psql -U nautilus -d nautilus
-	cat schema/sql/functions.sql | docker exec -i nautilus-database psql -U nautilus -d nautilus
+	cat schema/sql/*.sql | docker exec -i nautilus-database psql -U nautilus -d nautilus
 
 #== Python Testing
 

--- a/Makefile
+++ b/Makefile
@@ -312,13 +312,33 @@ docker-build-jupyter:  #-- Build JupyterLab Docker image
 docker-push-jupyter:  #-- Push JupyterLab Docker image to registry
 	docker push $(IMAGE):jupyter
 
+.PHONY: init-services
+init-services:  #-- Initialize development services eg. for integration tests (start containers and setup database)
+	$(info $(M) Initializing development services...)
+	@$(MAKE) start-services
+	@sleep 5  # Wait for PostgreSQL to be ready
+	@$(MAKE) init-db
+
 .PHONY: start-services
-start-services:  #-- Start development services with docker-compose
+start-services:  #-- Start development services (without reinitializing database)
+	$(info $(M) Starting development services...)
 	docker compose -f .docker/docker-compose.yml up -d
 
 .PHONY: stop-services
-stop-services:  #-- Stop development services
+stop-services:  #-- Stop development services (preserves data)
+	$(info $(M) Stopping development services...)
 	docker compose -f .docker/docker-compose.yml down
+
+.PHONY: purge-services
+purge-services:  #-- Purge all development services (stop containers and remove volumes)
+	$(info $(M) Purging integration test services...)
+	docker compose -f .docker/docker-compose.yml down -v
+
+.PHONY: init-db
+init-db:  #-- Initialize PostgreSQL database schema
+	$(info $(M) Initializing PostgreSQL database schema...)
+	cat schema/sql/tables.sql | docker exec -i nautilus-database psql -U nautilus -d nautilus
+	cat schema/sql/functions.sql | docker exec -i nautilus-database psql -U nautilus -d nautilus
 
 #== Python Testing
 

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,8 @@ docker-push-jupyter:  #-- Push JupyterLab Docker image to registry
 init-services:  #-- Initialize development services eg. for integration tests (start containers and setup database)
 	$(info $(M) Initializing development services...)
 	@$(MAKE) start-services
-	@sleep 5  # Wait for PostgreSQL to be ready
+	@echo "${PURPLE}Waiting for PostgreSQL to be ready...${RESET}"
+	@sleep 10
 	@$(MAKE) init-db
 
 .PHONY: start-services

--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ A `Makefile` is provided to automate most installation and build tasks for devel
 >
 > Run `make help` for documentation on all available make targets.
 
+> [!TIP]
+>
+> See the [crates/infrastructure/TESTS.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/infrastructure/TESTS.md) file for running the infrastructure integration tests.
+
 ## Examples
 
 Indicators and strategies can be developed in both Python and Cython. For performance and

--- a/crates/infrastructure/TESTS.md
+++ b/crates/infrastructure/TESTS.md
@@ -1,0 +1,78 @@
+# Infrastructure integration Tests
+
+This directory contains infrastructure integration tests that require external services.
+
+## Service Requirements
+All required services are defined in `.docker/docker-compose.yml`.
+
+The integration tests require the following services to be running:
+
+- PostgreSQL on `localhost:5432`
+- Redis on `localhost:6379`
+
+### Service Configuration
+
+- **PostgreSQL**: Username `nautilus`, Password `pass`, Database `nautilus`
+- **Redis**: Default configuration, no authentication
+- **PgAdmin** (Optional): Available at `http://localhost:5051` (<admin@mail.com> / admin)
+
+## Running Integration Test Services
+Use the following make targets to manage the services:
+
+### Initial Setup
+
+```bash
+make init-services  # Start containers and initialize database schema
+```
+
+### Managing Services
+
+```bash
+make stop-services   # Stop development services (preserves data)
+make start-services  # Start development services (without reinitializing database)
+make purge-services  # Remove everything including data volumes
+```
+
+### Typical Workflow
+
+1. First time: `make init-services`
+2. Stop when done: `make stop-services`
+3. Resume work: `make start-services`
+4. Clean slate: `make purge-services` then `make init-services`
+
+## Running Tests
+Once services are running (and Nautilus Trader installed by `uv` or `make`):
+
+### Python Infrastructure Integration Tests
+
+```bash
+# Run all infrastructure tests
+uv run --no-sync pytest tests/integration_tests/infrastructure/
+
+# Run specific test file
+uv run --no-sync pytest tests/integration_tests/infrastructure/test_cache_database_redis.py
+uv run --no-sync pytest tests/integration_tests/infrastructure/test_cache_database_postgres.py
+```
+
+### Rust Infrastructure Integration Tests
+The Rust integration tests are located in `crates/infrastructure/tests/` and require the same services.
+
+```bash
+# Run all Rust integration tests (includes Redis and PostgreSQL tests)
+make cargo-test-crate-nautilus-infrastructure
+
+# Using cargo nextest directly with the standard profile
+# Run all infrastructure test with output visible for debugging
+cargo nextest run --lib --no-fail-fast --cargo-profile nextest -p nautilus-infrastructure --features redis,postgres --no-capture
+
+# Run only Redis integration tests
+cargo nextest run --lib --no-fail-fast --cargo-profile nextest -p nautilus-infrastructure --features redis,postgres -E 'test(test_cache_redis)'
+
+# Run only PostgreSQL integration tests
+cargo nextest run --lib --no-fail-fast --cargo-profile nextest -p nautilus-infrastructure --features redis,postgres -E 'test(test_cache_postgres) or test(test_cache_database_postgres)'
+
+```
+
+**Note**: Both redis and postgres feature flags are in given examples to avoid rebuild.
+Rust infrastructure integration tests are marked with `#[cfg(target_os = "linux")]` and will only run on Linux.
+They use the `serial_test` crate to ensure tests that access the same database don't run concurrently.

--- a/tests/integration_tests/infrastructure/README.md
+++ b/tests/integration_tests/infrastructure/README.md
@@ -1,0 +1,1 @@
+../../../crates/infrastructure/TESTS.md


### PR DESCRIPTION
# Pull Request: Add integration test service management targets

## Summary

  - Add `init-services` target to initialize containers and database schema
  - Add `purge-services` target to remove containers and volumes
  - Update `start-services` and `stop-services` comment for clarity
  - Add comprehensive infrastructure integration test documentation with Python and Rust examples

This improves the developer experience by providing clear, chainable make targets for managing integration test services with proper initialization and cleanup workflows.

## Type of change


- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [x] Maintenance / chore

