### PR TITLE
Fix parquet catalog loading error

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -1631,7 +1631,9 @@ class ParquetDataCatalog(BaseDataCatalog):
             self._register_object_store_with_session(session)
 
         for idx, file in enumerate(file_list):
-            table = f"{file_prefix}_{idx}"
+            identifier = file.split("/")[-2]
+            safe_sql_identifier = urisafe_identifier(identifier).replace(".", "_").replace("-", "_").lower()
+            table = f"{file_prefix}_{safe_sql_identifier}_{idx}"
             query = self._build_query(
                 table,
                 start=start,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

When the catalog contains several parquet files for the same instrument, the engine tried to name them all bar_0, bar_1, etc., leading to a name conflict. Also the name of the table contains hyphens after the fix, so it should be quoted.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
