### PR TITLE
Add YEAR aggregation and bar specification validation

### DIFF
--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -298,6 +298,68 @@ pub fn add_n_months_nanos(unix_nanos: UnixNanos, n: u32) -> anyhow::Result<UnixN
     Ok(UnixNanos::from(timestamp as u64))
 }
 
+/// Add `n` years to a chrono `DateTime<Utc>`.
+///
+/// # Errors
+///
+/// Returns an error if the resulting date would be invalid or out of range.
+pub fn add_n_years(datetime: DateTime<Utc>, n: u32) -> anyhow::Result<DateTime<Utc>> {
+    // Use checked_add_months with n * 12 months
+    match datetime.checked_add_months(chrono::Months::new(n * 12)) {
+        Some(result) => Ok(result),
+        None => anyhow::bail!("Failed to add {n} years to {datetime}"),
+    }
+}
+
+/// Subtract `n` years from a chrono `DateTime<Utc>`.
+///
+/// # Errors
+///
+/// Returns an error if the resulting date would be invalid or out of range.
+pub fn subtract_n_years(datetime: DateTime<Utc>, n: u32) -> anyhow::Result<DateTime<Utc>> {
+    // Use checked_sub_months with n * 12 months
+    match datetime.checked_sub_months(chrono::Months::new(n * 12)) {
+        Some(result) => Ok(result),
+        None => anyhow::bail!("Failed to subtract {n} years from {datetime}"),
+    }
+}
+
+/// Add `n` years to a given UNIX nanoseconds timestamp.
+///
+/// # Errors
+///
+/// Returns an error if the resulting timestamp is out of range or invalid.
+pub fn add_n_years_nanos(unix_nanos: UnixNanos, n: u32) -> anyhow::Result<UnixNanos> {
+    let datetime = unix_nanos.to_datetime_utc();
+    let result = add_n_years(datetime, n)?;
+    let timestamp = match result.timestamp_nanos_opt() {
+        Some(ts) => ts,
+        None => anyhow::bail!("Timestamp out of range after adding {n} years"),
+    };
+
+    Ok(UnixNanos::from(timestamp as u64))
+}
+
+/// Subtract `n` years from a given UNIX nanoseconds timestamp.
+///
+/// # Errors
+///
+/// Returns an error if the resulting timestamp is out of range or invalid.
+pub fn subtract_n_years_nanos(unix_nanos: UnixNanos, n: u32) -> anyhow::Result<UnixNanos> {
+    let datetime = unix_nanos.to_datetime_utc();
+    let result = subtract_n_years(datetime, n)?;
+    let timestamp = match result.timestamp_nanos_opt() {
+        Some(ts) => ts,
+        None => anyhow::bail!("Timestamp out of range after subtracting {n} years"),
+    };
+
+    if timestamp < 0 {
+        anyhow::bail!("Negative timestamp not allowed");
+    }
+
+    Ok(UnixNanos::from(timestamp as u64))
+}
+
 /// Returns the last valid day of `(year, month)`.
 #[must_use]
 pub const fn last_day_of_month(year: i32, month: u32) -> u32 {

--- a/crates/infrastructure/src/sql/models/enums.rs
+++ b/crates/infrastructure/src/sql/models/enums.rs
@@ -248,6 +248,7 @@ impl sqlx::Encode<'_, sqlx::Postgres> for BarAggregationModel {
             BarAggregation::Day => "DAY",
             BarAggregation::Week => "WEEK",
             BarAggregation::Month => "MONTH",
+            BarAggregation::Year => "YEAR",
         };
         <&str as sqlx::Encode<sqlx::Postgres>>::encode(bar_aggregation_str, buf)
     }

--- a/crates/model/src/enums.rs
+++ b/crates/model/src/enums.rs
@@ -312,6 +312,8 @@ pub enum BarAggregation {
     Week = 15,
     /// Based on time intervals with month granularity.
     Month = 16,
+    /// Based on time intervals with year granularity.
+    Year = 17,
 }
 
 /// The interval type for bar aggregation.

--- a/nautilus_trader/model/data.pxd
+++ b/nautilus_trader/model/data.pxd
@@ -102,6 +102,13 @@ cpdef enum BarAggregation:
     DAY = 14
     WEEK = 15
     MONTH = 16
+    YEAR = 17
+
+
+cpdef enum BarIntervalType:
+    LEFT_OPEN=0
+    RIGHT_OPEN=1
+
 
 
 cdef class BarSpecification:
@@ -109,6 +116,8 @@ cdef class BarSpecification:
 
     cdef str to_str(self)
     cdef str aggregation_string_c(self)
+
+    cpdef uint64_t get_interval_ns(self)
 
     @staticmethod
     cdef BarSpecification from_mem_c(BarSpecification_t raw)

--- a/tests/integration_tests/adapters/binance/test_parsing_common.py
+++ b/tests/integration_tests/adapters/binance/test_parsing_common.py
@@ -169,10 +169,10 @@ class TestBinanceCommonParsing:
                 ),
             ],
             [
-                BinanceKlineInterval("3d"),
+                BinanceKlineInterval("1d"),
                 BarType(
                     BTCUSDT_BINANCE.id,
-                    BarSpecification(3, BarAggregation.DAY, PriceType.LAST),
+                    BarSpecification(1, BarAggregation.DAY, PriceType.LAST),
                     AggregationSource.EXTERNAL,
                 ),
             ],

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -1722,11 +1722,11 @@ class TestTimeBarAggregator:
                 pd.Timestamp(1970, 1, 1, 0, 0, 10).value,
             ],
             [
-                BarSpecification(60, BarAggregation.SECOND, PriceType.MID),
+                BarSpecification(1, BarAggregation.MINUTE, PriceType.MID),
                 pd.Timestamp(1970, 1, 1, 0, 1, 0).value,
             ],
             [
-                BarSpecification(300, BarAggregation.SECOND, PriceType.MID),
+                BarSpecification(5, BarAggregation.MINUTE, PriceType.MID),
                 pd.Timestamp(1970, 1, 1, 0, 5, 0).value,
             ],
             [
@@ -1734,7 +1734,7 @@ class TestTimeBarAggregator:
                 pd.Timestamp(1970, 1, 1, 0, 1).value,
             ],
             [
-                BarSpecification(60, BarAggregation.MINUTE, PriceType.MID),
+                BarSpecification(1, BarAggregation.HOUR, PriceType.MID),
                 pd.Timestamp(1970, 1, 1, 1, 0).value,
             ],
             [
@@ -2350,20 +2350,7 @@ class TestTimeBarAggregator:
         assert bar.volume == Quantity.from_int(3)
         assert bar.ts_init == 3 * 60 * NANOSECONDS_IN_SECOND
 
-    @pytest.mark.parametrize(
-        ("step", "aggregation"),
-        [
-            [
-                1,
-                BarAggregation.SECOND,
-            ],
-            [
-                1000,
-                BarAggregation.MILLISECOND,
-            ],
-        ],
-    )
-    def test_aggregation_for_same_sec_and_minute_intervals(self, step, aggregation):
+    def test_aggregation_for_same_sec_and_minute_intervals(self):
         # Arrange - prepare data
         path = TEST_DATA_DIR / "binance/btcusdt-quotes.parquet"
         df_ticks = ParquetTickDataLoader.load(path)
@@ -2374,7 +2361,7 @@ class TestTimeBarAggregator:
         clock.set_time(ticks[0].ts_init)
         handler = []
 
-        bar_spec = BarSpecification(step, aggregation, PriceType.BID)
+        bar_spec = BarSpecification(1, BarAggregation.SECOND, PriceType.BID)
         bar_type = BarType(BTCUSDT_BINANCE.id, bar_spec, AggregationSource.INTERNAL)
         aggregator = TimeBarAggregator(
             BTCUSDT_BINANCE,


### PR DESCRIPTION
## Sumary
- Add YEAR aggregation type to BarAggregation enum across Rust, Cython, and SQL models
- Add year-based datetime manipulation functions (add_n_years, subtract_n_years) in core
- Implement comprehensive bar specification step validation for time-based aggregations
- Add get_interval_ns() method
- Enhance BarSpecification documentation with comprehensive examples and usage notes
- Add BarIntervalType enum (LEFT_OPEN, RIGHT_OPEN) for future aggregation refactorization
- Update tests to use valid bar specification steps, add validation coverage and interval_ns/timedelta coverage

## Breaking change
Bar specifications with invalid steps for time-based aggregations will now raise ValueError on construction.

## Note
The YEAR bar aggregation is not fully implemented yet. This is preparation for a future refactorization.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
