### PR TITLE
Fix catalog query of multiple instruments of same type

### DIFF
--- a/crates/persistence/src/backend/catalog_operations.rs
+++ b/crates/persistence/src/backend/catalog_operations.rs
@@ -1626,6 +1626,9 @@ impl ParquetDataCatalog {
         let mut files_to_remove = std::collections::HashSet::new();
 
         for operation in operations_to_execute {
+            // Reset the session before each operation to ensure fresh data is loaded
+            // This clears any cached table registrations that might interfere with file operations
+            self.reset_session();
             match operation.operation_type.as_str() {
                 "split_before" => {
                     // Query data before the deletion range and write it

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -2128,3 +2128,125 @@ def test_delete_data_range_zero_timestamp_edge_case(catalog: ParquetDataCatalog)
     timestamps = [q.ts_init for q in remaining_data]
     timestamps.sort()
     assert timestamps == [2, 3]
+
+
+def test_backend_session_table_naming_multiple_instruments(catalog: ParquetDataCatalog) -> None:
+    """
+    Test that backend_session creates identifier-dependent table names for multiple
+    instruments.
+
+    This test verifies the fix for the table naming bug where multiple instruments would
+    cause table name conflicts in DataFusion queries.
+
+    """
+    # Arrange - Create bars for multiple instruments
+    bar_type1 = TestDataStubs.bartype_adabtc_binance_1min_last()
+    instrument1 = TestInstrumentProvider.adabtc_binance()
+    bars1 = TestDataStubs.binance_bars_from_csv(
+        "ADABTC-1m-2021-11-27.csv",
+        bar_type1,
+        instrument1,
+    )[
+        :5
+    ]  # Use fewer bars for faster test
+
+    bar_type2 = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+    instrument2 = TestInstrumentProvider.btcusdt_binance()
+    bars2 = TestDataStubs.binance_bars_from_csv(
+        "ADABTC-1m-2021-11-27.csv",  # Reuse same CSV data but with different bar_type
+        bar_type2,
+        instrument2,
+    )[
+        :5
+    ]  # Use fewer bars for faster test
+
+    # Write data for both instruments
+    catalog.write_data(bars1)
+    catalog.write_data(bars2)
+
+    # Act - Create backend session with multiple instruments
+    identifiers = [str(bar_type1), str(bar_type2)]
+    session = catalog.backend_session(
+        data_cls=Bar,
+        identifiers=identifiers,
+    )
+
+    # Assert - Session should be created successfully without table name conflicts
+    assert session is not None
+
+    # Query data using the session to verify it works correctly
+    result = session.to_query_result()
+    data = []
+    for chunk in result:
+        from nautilus_trader.model.data import capsule_to_list
+
+        data.extend(capsule_to_list(chunk))
+
+    # Should get data from both instruments
+    assert len(data) == 10  # 5 bars from each instrument
+
+    # Verify we have data from both instruments
+    instrument_ids = {bar.bar_type.instrument_id.value for bar in data}
+    assert len(instrument_ids) == 2
+    assert instrument1.id.value in instrument_ids
+    assert instrument2.id.value in instrument_ids
+
+
+def test_backend_session_table_naming_special_characters(catalog: ParquetDataCatalog) -> None:
+    """
+    Test that backend_session handles special characters in identifiers correctly.
+
+    This test verifies that identifiers with dots, hyphens, and slashes are properly
+    converted to safe SQL table names.
+
+    """
+    # Arrange - Create quote ticks for instruments with special characters
+    eurusd_instrument = TestInstrumentProvider.default_fx_ccy("EUR/USD", Venue("SIM"))
+    btcusd_instrument = TestInstrumentProvider.default_fx_ccy("BTC-USD", Venue("COINBASE"))
+
+    quotes_eurusd = [
+        TestDataStubs.quote_tick(
+            instrument=eurusd_instrument,
+            ts_init=i * 1000,
+        )
+        for i in range(3)
+    ]
+
+    quotes_btc_usd = [
+        TestDataStubs.quote_tick(
+            instrument=btcusd_instrument,
+            ts_init=i * 1000 + 500,
+        )
+        for i in range(3)
+    ]
+
+    # Write data
+    catalog.write_data(quotes_eurusd)
+    catalog.write_data(quotes_btc_usd)
+
+    # Act - Create backend session with identifiers containing special characters
+    identifiers = [str(eurusd_instrument.id), str(btcusd_instrument.id)]
+    session = catalog.backend_session(
+        data_cls=QuoteTick,
+        identifiers=identifiers,
+    )
+
+    # Assert - Session should be created successfully
+    assert session is not None
+
+    # Query data to verify it works
+    result = session.to_query_result()
+    data = []
+    for chunk in result:
+        from nautilus_trader.model.data import capsule_to_list
+
+        data.extend(capsule_to_list(chunk))
+
+    # Should get data from both instruments
+    assert len(data) == 6  # 3 quotes from each instrument
+
+    # Verify we have data from both instruments
+    instrument_ids = {quote.instrument_id.value for quote in data}
+    assert len(instrument_ids) == 2
+    assert str(eurusd_instrument.id) in instrument_ids
+    assert str(btcusd_instrument.id) in instrument_ids


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixed bug where tables in a parquet.py backend_session could have the same name when querying multiple instruments. Now an identifier information is also used in the table name as well as timestamp information start and end from the file name used for a table.

Thank you @lisiyuan656

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/pull/2772

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
