### PR TITLE
Add vault endpoints for MegaVault operations

### DIFF
--- a/nautilus_trader/adapters/dydx/common/enums.py
+++ b/nautilus_trader/adapters/dydx/common/enums.py
@@ -225,6 +225,18 @@ class DYDXTransferType(Enum):
     WITHDRAWAL = "WITHDRAWAL"
 
 
+@unique
+class DYDXPnlTickInterval(str, Enum):
+    """
+    Define the resolution intervals for PnL queries.
+    """
+
+    ONE_HOUR = "ONE_HOUR"
+    ONE_DAY = "ONE_DAY"
+    SEVEN_DAYS = "SEVEN_DAYS"
+    THIRTY_DAYS = "THIRTY_DAYS"
+
+
 class DYDXEnumParser:
     """
     Convert dYdX enums to Nautilus enums.

--- a/nautilus_trader/adapters/dydx/endpoints/vault/__init__.py
+++ b/nautilus_trader/adapters/dydx/endpoints/vault/__init__.py
@@ -1,0 +1,43 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from .megavault_historical_pnl import DYDXMegaVaultHistoricalPnlEndpoint
+from .megavault_historical_pnl import DYDXMegaVaultHistoricalPnlGetParams
+from .megavault_historical_pnl import DYDXMegaVaultHistoricalPnlResponse
+from .megavault_historical_pnl import DYDXPnlTicksResponseObject
+from .megavault_positions import DYDXMegaVaultPositionResponse
+from .megavault_positions import DYDXMegaVaultPositionsEndpoint
+from .megavault_positions import DYDXMegaVaultPositionsGetParams
+from .megavault_positions import DYDXVaultPosition
+from .vaults_historical_pnl import DYDXVaultHistoricalPnl
+from .vaults_historical_pnl import DYDXVaultsHistoricalPnlEndpoint
+from .vaults_historical_pnl import DYDXVaultsHistoricalPnlGetParams
+from .vaults_historical_pnl import DYDXVaultsHistoricalPnlResponse
+
+
+__all__ = [
+    "DYDXMegaVaultHistoricalPnlEndpoint",
+    "DYDXMegaVaultHistoricalPnlGetParams",
+    "DYDXMegaVaultHistoricalPnlResponse",
+    "DYDXMegaVaultPositionResponse",
+    "DYDXMegaVaultPositionsEndpoint",
+    "DYDXMegaVaultPositionsGetParams",
+    "DYDXPnlTicksResponseObject",
+    "DYDXVaultHistoricalPnl",
+    "DYDXVaultPosition",
+    "DYDXVaultsHistoricalPnlEndpoint",
+    "DYDXVaultsHistoricalPnlGetParams",
+    "DYDXVaultsHistoricalPnlResponse",
+]

--- a/nautilus_trader/adapters/dydx/endpoints/vault/megavault_historical_pnl.py
+++ b/nautilus_trader/adapters/dydx/endpoints/vault/megavault_historical_pnl.py
@@ -1,0 +1,84 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Define the MegaVault historical PnL endpoint.
+"""
+import msgspec
+
+from nautilus_trader.adapters.dydx.common.enums import DYDXEndpointType
+from nautilus_trader.adapters.dydx.common.enums import DYDXPnlTickInterval
+from nautilus_trader.adapters.dydx.endpoints.endpoint import DYDXHttpEndpoint
+from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
+from nautilus_trader.core.nautilus_pyo3 import HttpMethod
+
+
+class DYDXMegaVaultHistoricalPnlGetParams(msgspec.Struct, omit_defaults=True):
+    """
+    Represent the MegaVault historical PnL request parameters.
+    """
+
+    resolution: DYDXPnlTickInterval
+
+
+class DYDXPnlTicksResponseObject(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent a single PnL tick response object.
+    """
+
+    # Based on dYdX API documentation
+    id: str
+    subaccountId: str
+    equity: str
+    totalPnl: str
+    createdAt: str
+    blockHeight: str
+    blockTime: str
+
+
+class DYDXMegaVaultHistoricalPnlResponse(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent the MegaVault historical PnL response object.
+    """
+
+    megavault_pnl: list[DYDXPnlTicksResponseObject]
+
+
+class DYDXMegaVaultHistoricalPnlEndpoint(DYDXHttpEndpoint):
+    """
+    Define the MegaVault historical PnL endpoint.
+    """
+
+    def __init__(self, client: DYDXHttpClient) -> None:
+        url_path = "/v4/vault/v1/megavault/historicalPnl"
+        super().__init__(
+            client=client,
+            url_path=url_path,
+            endpoint_type=DYDXEndpointType.NONE,
+            name="DYDXMegaVaultHistoricalPnlEndpoint",
+        )
+        self.method_type = HttpMethod.GET
+        self._decoder = msgspec.json.Decoder(DYDXMegaVaultHistoricalPnlResponse)
+
+    async def get(
+        self,
+        params: DYDXMegaVaultHistoricalPnlGetParams,
+    ) -> DYDXMegaVaultHistoricalPnlResponse | None:
+        """
+        Call the MegaVault historical PnL endpoint.
+        """
+        raw = await self._method(self.method_type, params=params)
+        if raw is not None:
+            return self._decoder.decode(raw)
+        return None

--- a/nautilus_trader/adapters/dydx/endpoints/vault/megavault_positions.py
+++ b/nautilus_trader/adapters/dydx/endpoints/vault/megavault_positions.py
@@ -1,0 +1,81 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Define the MegaVault positions endpoint.
+"""
+import msgspec
+
+from nautilus_trader.adapters.dydx.common.enums import DYDXEndpointType
+from nautilus_trader.adapters.dydx.endpoints.endpoint import DYDXHttpEndpoint
+from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
+from nautilus_trader.core.nautilus_pyo3 import HttpMethod
+
+
+class DYDXMegaVaultPositionsGetParams(msgspec.Struct, omit_defaults=True):
+    """
+    Represent the MegaVault positions request parameters.
+    """
+
+    # No params for this endpoint
+
+
+class DYDXVaultPosition(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent a single MegaVault position object.
+    """
+
+    # Based on dYdX API documentation
+    market: str
+    side: str
+    size: str
+    maxSize: str
+    entryPrice: str
+    realizedPnl: str
+    createdAt: str
+    updatedAt: str
+
+
+class DYDXMegaVaultPositionResponse(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent the MegaVault positions response object.
+    """
+
+    positions: list[DYDXVaultPosition]
+
+
+class DYDXMegaVaultPositionsEndpoint(DYDXHttpEndpoint):
+    """
+    Define the MegaVault positions endpoint.
+    """
+
+    def __init__(self, client: DYDXHttpClient) -> None:
+        url_path = "/v4/vault/v1/megavault/positions"
+        super().__init__(
+            client=client,
+            url_path=url_path,
+            endpoint_type=DYDXEndpointType.NONE,
+            name="DYDXMegaVaultPositionsEndpoint",
+        )
+        self.method_type = HttpMethod.GET
+        self._decoder = msgspec.json.Decoder(DYDXMegaVaultPositionResponse)
+
+    async def get(self) -> DYDXMegaVaultPositionResponse | None:
+        """
+        Call the MegaVault positions endpoint.
+        """
+        raw = await self._method(self.method_type)
+        if raw is not None:
+            return self._decoder.decode(raw)
+        return None

--- a/nautilus_trader/adapters/dydx/endpoints/vault/vaults_historical_pnl.py
+++ b/nautilus_trader/adapters/dydx/endpoints/vault/vaults_historical_pnl.py
@@ -1,0 +1,83 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Define the Vaults historical PnL endpoint.
+"""
+import msgspec
+
+from nautilus_trader.adapters.dydx.common.enums import DYDXEndpointType
+from nautilus_trader.adapters.dydx.common.enums import DYDXPnlTickInterval
+from nautilus_trader.adapters.dydx.endpoints.endpoint import DYDXHttpEndpoint
+from nautilus_trader.adapters.dydx.http.client import DYDXHttpClient
+from nautilus_trader.core.nautilus_pyo3 import HttpMethod
+
+
+class DYDXVaultsHistoricalPnlGetParams(msgspec.Struct, omit_defaults=True):
+    """
+    Represent the Vaults historical PnL request parameters.
+    """
+
+    resolution: DYDXPnlTickInterval
+
+
+class DYDXVaultHistoricalPnl(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent a single Vault historical PnL object.
+    """
+
+    # Based on dYdX API documentation
+    vaultId: str
+    equity: str
+    totalPnl: str
+    createdAt: str
+    blockHeight: str
+    blockTime: str
+
+
+class DYDXVaultsHistoricalPnlResponse(msgspec.Struct, forbid_unknown_fields=True):
+    """
+    Represent the Vaults historical PnL response object.
+    """
+
+    vaults_pnl: list[DYDXVaultHistoricalPnl]
+
+
+class DYDXVaultsHistoricalPnlEndpoint(DYDXHttpEndpoint):
+    """
+    Define the Vaults historical PnL endpoint.
+    """
+
+    def __init__(self, client: DYDXHttpClient) -> None:
+        url_path = "/v4/vault/v1/vaults/historicalPnl"
+        super().__init__(
+            client=client,
+            url_path=url_path,
+            endpoint_type=DYDXEndpointType.NONE,
+            name="DYDXVaultsHistoricalPnlEndpoint",
+        )
+        self.method_type = HttpMethod.GET
+        self._decoder = msgspec.json.Decoder(DYDXVaultsHistoricalPnlResponse)
+
+    async def get(
+        self,
+        params: DYDXVaultsHistoricalPnlGetParams,
+    ) -> DYDXVaultsHistoricalPnlResponse | None:
+        """
+        Call the Vaults historical PnL endpoint.
+        """
+        raw = await self._method(self.method_type, params=params)
+        if raw is not None:
+            return self._decoder.decode(raw)
+        return None


### PR DESCRIPTION
Add vault endpoints for MegaVault operations

## Summary
Adds comprehensive vault endpoints for dYdX v4 MegaVault operations, including historical PnL queries and position management.

## API Coverage
- ✅ `/v4/vault/v1/megavault/historicalPnl` - MegaVault historical PnL
- ✅ `/v4/vault/v1/vaults/historicalPnl` - Individual vault historical PnL  
- ✅ `/v4/vault/v1/megavault/positions` - MegaVault positions
- ✅ MegaVault deposit/withdraw operations (Rust only)
