### PR TITLE
Refine bars timestamp decoding and backtest execution usage

### DIFF
--- a/crates/adapters/databento/src/loader.rs
+++ b/crates/adapters/databento/src/loader.rs
@@ -807,14 +807,12 @@ mod tests {
 
         assert_eq!(bars.len(), 2);
 
-        // When bars_timestamp_on_close is true, both ts_event and ts_init should be equal (close time)
+        // When bars_timestamp_on_close is true, both ts_event and ts_init should be close time
         for bar in &bars {
             assert_eq!(
                 bar.ts_event, bar.ts_init,
-                "ts_event and ts_init should be equal when bars_timestamp_on_close=true"
+                "ts_event and ts_init should both be close time when bars_timestamp_on_close=true"
             );
-            // For 1-second bars, ts_event should be 1 second after the open time
-            // This confirms the bar is timestamped at close
         }
     }
 
@@ -828,12 +826,14 @@ mod tests {
 
         assert_eq!(bars.len(), 2);
 
-        // When bars_timestamp_on_close is false, both ts_event and ts_init should be equal (open time)
+        // When bars_timestamp_on_close is false, ts_event is open time and ts_init is close time
         for bar in &bars {
-            assert_eq!(
+            assert_ne!(
                 bar.ts_event, bar.ts_init,
-                "ts_event and ts_init should be equal when bars_timestamp_on_close=false"
+                "ts_event should be open time and ts_init should be close time when bars_timestamp_on_close=false"
             );
+            // For 1-second bars, ts_init (close) should be 1 second after ts_event (open)
+            assert_eq!(bar.ts_init.as_u64(), bar.ts_event.as_u64() + 1_000_000_000);
         }
     }
 

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -254,7 +254,7 @@ impl OrderMatchingEngine {
             self.book.apply_delta(delta);
         }
 
-        self.iterate(delta.ts_event);
+        self.iterate(delta.ts_init);
     }
 
     pub fn process_order_book_deltas(&mut self, deltas: &OrderBookDeltas) {
@@ -264,7 +264,7 @@ impl OrderMatchingEngine {
             self.book.apply_deltas(deltas);
         }
 
-        self.iterate(deltas.ts_event);
+        self.iterate(deltas.ts_init);
     }
 
     /// # Panics
@@ -277,7 +277,7 @@ impl OrderMatchingEngine {
             self.book.update_quote_tick(quote).unwrap();
         }
 
-        self.iterate(quote.ts_event);
+        self.iterate(quote.ts_init);
     }
 
     /// # Panics
@@ -361,8 +361,8 @@ impl OrderMatchingEngine {
             size,
             aggressor_side,
             self.ids_generator.generate_trade_id(),
-            bar.ts_event,
-            bar.ts_event,
+            bar.ts_init,
+            bar.ts_init,
         );
 
         // Open
@@ -424,7 +424,7 @@ impl OrderMatchingEngine {
         // Wait for next bar
         if self.last_bar_bid.is_none()
             || self.last_bar_ask.is_none()
-            || self.last_bar_bid.unwrap().ts_event != self.last_bar_ask.unwrap().ts_event
+            || self.last_bar_bid.unwrap().ts_init != self.last_bar_ask.unwrap().ts_init
         {
             return;
         }
@@ -482,7 +482,7 @@ impl OrderMatchingEngine {
         }
         self.core.set_last_raw(trade.price);
 
-        self.iterate(trade.ts_event);
+        self.iterate(trade.ts_init);
     }
 
     pub fn process_status(&mut self, action: MarketStatusAction) {

--- a/docs/concepts/backtesting.md
+++ b/docs/concepts/backtesting.md
@@ -118,6 +118,12 @@ Failing to do so will result in data aggregation: L2 data will be reduced to a s
 
 ## Execution
 
+### Prevention of look-ahead bias by construction
+
+In the main backtesting loop, new market data is first processed for the execution of existing orders before being processed
+by the data engine that will then send data to strategies. So if a strategy creates an order at the same time as the market data it receives,
+the order will have to be executed with future data, by construction.
+
 ### Bar based execution
 
 Bar data provides a summary of market activity with four key prices for each time period (assuming bars are aggregated by trades):
@@ -137,11 +143,6 @@ This is why Nautilus processes bar data through a sophisticated system that atte
 the most realistic yet conservative market behavior possible, despite these limitations.
 At its core, the platform always maintains an order book simulation - even when you provide less
 granular data such as quotes, trades, or bars (although the simulation will only have a top level book).
-
-:::warning
-When using bars for execution simulation (enabled by default with `bar_execution=True` in venue configurations), Nautilus strictly expects the timestamp (`ts_event`) of each bar to represent its **closing time**.
-This ensures accurate chronological processing, prevents look-ahead bias, and aligns market updates (Open → High → Low → Close) with the moment the bar is complete.
-:::
 
 #### Bar timestamp convention
 

--- a/nautilus_trader/backtest/matching_engine.pyx
+++ b/nautilus_trader/backtest/matching_engine.pyx
@@ -786,8 +786,8 @@ cdef class OrderMatchingEngine:
             size,
             AggressorSide.BUYER if not self._core.is_last_initialized or bar._mem.open.raw > self._core.last_raw else AggressorSide.SELLER,
             self._generate_trade_id(),
-            bar.ts_event,
-            bar.ts_event,
+            bar.ts_init,
+            bar.ts_init,
         )
 
     cdef void _process_trade_bar_open(self, Bar bar, TradeTick tick):
@@ -835,7 +835,7 @@ cdef class OrderMatchingEngine:
         if self._last_bid_bar is None or self._last_ask_bar is None:
             return  # Wait for next bar
 
-        if self._last_bid_bar.ts_event != self._last_ask_bar.ts_event:
+        if self._last_bid_bar.ts_init != self._last_ask_bar.ts_init:
             return  # Wait for next bar
 
         cdef double size_increment_f64 = self.instrument.size_increment.as_double()
@@ -872,7 +872,7 @@ cdef class OrderMatchingEngine:
             self._last_ask_bar.open,
             bid_size,
             ask_size,
-            self._last_bid_bar.ts_event,
+            self._last_bid_bar.ts_init,
             self._last_ask_bar.ts_init,
         )
 

--- a/tests/integration_tests/adapters/databento/test_loaders.py
+++ b/tests/integration_tests/adapters/databento/test_loaders.py
@@ -619,8 +619,8 @@ def test_loader_ohlcv_1s() -> None:
 @pytest.mark.parametrize(
     ("bars_timestamp_on_close", "expected_ts_event", "expected_ts_init"),
     [
-        (True, 1715248860000000000, 1715248860000000000),  # Close time (default)
-        (False, 1715248800000000000, 1715248800000000000),  # Open time
+        (True, 1715248860000000000, 1715248860000000000),  # Both close time
+        (False, 1715248800000000000, 1715248860000000000),  # ts_event=open, ts_init=close
     ],
 )
 def test_loader_with_ohlcv_1m(
@@ -659,7 +659,7 @@ def test_loader_with_ohlcv_1m(
     ("bars_timestamp_on_close", "expected_ts_event", "expected_ts_init"),
     [
         (True, 1715248860000000000, 1715248860000000000),  # Close time (default)
-        (False, 1715248800000000000, 1715248800000000000),  # Open time
+        (False, 1715248800000000000, 1715248860000000000),  # ts_event=open, ts_init=close
     ],
 )
 def test_loader_with_ohlcv_1m_and_xcme(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Refine timestamp parsing for databento bars
- Changed trade ticks and quote ticks to use ts_init when creating them from bars in the matching engine
- Synced implementation of matching engine in rust compared to cython, to use ts_init when processing market data.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
