### PR TITLE
Update PostgreSQL connection parameters to use 'nautilus' user

### DIFF
--- a/crates/infrastructure/src/sql/pg.rs
+++ b/crates/infrastructure/src/sql/pg.rs
@@ -66,7 +66,7 @@ impl PostgresConnectOptions {
         Self::new(
             String::from("localhost"),
             5432,
-            String::from("postgres"),
+            String::from("nautilus"),
             String::from("pass"),
             String::from("nautilus"),
         )


### PR DESCRIPTION
This is needed for the consistency with docker-compose.yml setup.