### PR TITLE
Add Python memory leak detection for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,11 @@ else
 	uv run --active --no-sync pytest --new-first --failed-first --tb=short -n logical --dist=loadgroup
 endif
 
+.PHONY: pytest-memory-tracking
+pytest-memory-tracking:  #-- Run Python tests with memory tracking enabled
+	$(info $(M) Running Python tests with memory tracking enabled...)
+	MEMORY_TRACKING_ENABLED_PY=true uv run --active --no-sync pytest --new-first --failed-first -v -n logical --dist=loadgroup
+
 .PHONY: test-performance
 test-performance:  #-- Run performance tests with codspeed benchmarking
 	uv run --active --no-sync pytest tests/performance_tests --benchmark-disable-gc --codspeed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,11 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import gc
+import os
+import tracemalloc
+
+import psutil
 import pytest
 
 from nautilus_trader.common.component import init_logging
@@ -23,6 +28,89 @@ from nautilus_trader.model.instruments import CurrencyPair
 from nautilus_trader.persistence.wranglers import QuoteTickDataWrangler
 from nautilus_trader.test_kit.providers import TestDataProvider
 from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+
+# Global memory tracking configuration
+# Read from environment variables, with defaults
+MEMORY_TRACKING_ENABLED = bool(
+    os.environ.get("MEMORY_TRACKING_ENABLED_PY", "False").lower() in ("true", "1", "yes", "on"),
+)
+MEMORY_LEAK_THRESHOLD_BYTES = int(
+    os.environ.get("MEMORY_LEAK_THRESHOLD_BYTES_PY", 1024 * 1024 * 10),
+)  # Default 10 MB
+
+
+@pytest.fixture(autouse=True)
+def memory_tracker(request):
+    """
+    Automatic memory tracking fixture that runs for all tests.
+    """
+    if not MEMORY_TRACKING_ENABLED:
+        yield
+        return
+
+    # Start tracemalloc for detailed memory tracking
+    tracemalloc.start()
+    initial_tracemalloc, _ = tracemalloc.get_traced_memory()
+
+    # Force garbage collection before test
+    gc.collect()
+
+    # Store initial memory state
+    process = psutil.Process()
+    initial_memory_bytes = process.memory_info().rss
+
+    # Run the test
+    yield
+
+    # Force garbage collection after test
+    gc.collect()
+
+    final_tracemalloc, peak = tracemalloc.get_traced_memory()
+
+    # Calculate memory usage
+    process = psutil.Process()
+    final_memory_bytes = process.memory_info().rss
+    memory_increase_bytes = final_memory_bytes - initial_memory_bytes
+
+    try:
+        # Only report and fail if memory increase is significant
+        if memory_increase_bytes > MEMORY_LEAK_THRESHOLD_BYTES:
+            test_name = request.node.nodeid
+            initial_mb = initial_memory_bytes / 1024 / 1024
+            final_mb = final_memory_bytes / 1024 / 1024
+            increase_mb = memory_increase_bytes / 1024 / 1024
+            initial_tracemalloc_mb = initial_tracemalloc / 1024 / 1024
+            final_tracemalloc_mb = final_tracemalloc / 1024 / 1024
+            peak_tracemalloc_mb = peak / 1024 / 1024
+            threshold_mb = MEMORY_LEAK_THRESHOLD_BYTES / 1024 / 1024
+
+            print(f"\nMemory Leak Detected in {test_name}")
+            print(f"  Initial RSS: {initial_mb:.2f} MB")
+            print(f"  Final RSS: {final_mb:.2f} MB")
+            print(f"  Memory Growth: {increase_mb:.2f} MB")
+            print(f"  Initial Tracemalloc: {initial_tracemalloc_mb:.2f} MB")
+            print(f"  Final Tracemalloc: {final_tracemalloc_mb:.2f} MB")
+            print(f"  Peak Tracemalloc: {peak_tracemalloc_mb:.2f} MB")
+            print(f"  Threshold: {threshold_mb:.2f} MB")
+            print("")
+
+            # Get and print top 10 memory allocations
+            snapshot = tracemalloc.take_snapshot()
+            top_stats = snapshot.statistics("lineno")
+
+            print("\n  Top 10 Memory Allocations:")
+            print("  " + "-" * 80)
+            for index, stat in enumerate(top_stats[:10], 1):
+                traceback = f"{stat.traceback}"
+                size_mb = stat.size / 1024 / 1024
+                print(f"  {index:2d}. {traceback:<60} {size_mb:>8.2f} MB ({stat.count:,} blocks)")
+            print("  " + "-" * 80)
+
+            raise MemoryError("Memory leak detected during test execution.")
+    finally:
+        # Stop tracemalloc
+        tracemalloc.stop()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
- Add memory tracking fixture to pytest that monitors RSS memory usage and tracemalloc
- Configure via environment variables:
  - MEMORY_TRACKING_ENABLED_PY (default: false)
  - MEMORY_LEAK_THRESHOLD_BYTES_PY (default: 1024 * 1024 * 10 bytes)
- Add parallel `make pytest-memory-tracking` target to run tests with tracking enabled
- Report memory leaks with initial, final, increase in MB, tracemalloc stats and snapshot with a test failure

## Type of change

- New feature for tests
