### PR TITLE
Fix RPC client content type header

### DIFF
--- a/crates/adapters/blockchain/src/rpc/http.rs
+++ b/crates/adapters/blockchain/src/rpc/http.rs
@@ -62,12 +62,15 @@ impl BlockchainHttpRpcClient {
             BlockchainRpcClientError::ClientError(format!("Failed to serialize request: {e}"))
         })?;
 
+        let mut headers = HashMap::new();
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+
         match self
             .http_client
             .request(
                 Method::POST,
                 self.http_rpc_url.clone(),
-                None,
+                Some(headers),
                 Some(body_bytes),
                 None,
                 None,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- added `Content-Type` header of `application/json` in all RPC requests from  `BlockchainHttpRpcClient`, which should be mandatory for most providers JSON-RPC endpoints

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


