### PR TITLE
Add Arbitrum PancakeSwapV3 pool parsing

### DIFF
--- a/crates/adapters/blockchain/src/exchanges/arbitrum/pancakeswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/pancakeswap_v3.rs
@@ -24,16 +24,19 @@ use crate::exchanges::extended::DexExtended;
 
 /// PancakeSwap V3 DEX on Arbitrum.
 pub static PANCAKESWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
-    let dex = Dex::new(
+    let mut dex = DexExtended::new(Dex::new(
         chains::ARBITRUM.clone(),
         DexType::PancakeSwapV3,
         "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865",
         105068129,
         AmmType::CLAMM,
+        "PoolCreated(address,address,uint24,int24,address)",
         "",
         "",
         "",
-        "",
+    ));
+    dex.set_pool_created_event_parsing(
+        crate::exchanges::ethereum::uniswap_v3::parse_pool_created_event,
     );
-    DexExtended::new(dex)
+    dex
 });


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- added Pool created event signature for Arbitrum PancakeSwapV3
- reused pool parsing from Ethereum Uniswapv3 as they share the same pool created event signature

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

