### PR TITLE
Standardize symbol validation for DEX pool InstrumentId

### DIFF
--- a/crates/adapters/blockchain/src/cache/rows.rs
+++ b/crates/adapters/blockchain/src/cache/rows.rs
@@ -17,7 +17,7 @@ use alloy::primitives::Address;
 use nautilus_core::UnixNanos;
 use sqlx::{FromRow, Row, postgres::PgRow};
 
-use crate::validation::validate_address;
+use nautilus_model::defi::validation::validate_address;
 
 /// A data transfer object that maps database rows to token data.
 ///

--- a/crates/adapters/blockchain/src/cache/rows.rs
+++ b/crates/adapters/blockchain/src/cache/rows.rs
@@ -15,9 +15,8 @@
 
 use alloy::primitives::Address;
 use nautilus_core::UnixNanos;
-use sqlx::{FromRow, Row, postgres::PgRow};
-
 use nautilus_model::defi::validation::validate_address;
+use sqlx::{FromRow, Row, postgres::PgRow};
 
 /// A data transfer object that maps database rows to token data.
 ///

--- a/crates/adapters/blockchain/src/contracts/base.rs
+++ b/crates/adapters/blockchain/src/contracts/base.rs
@@ -15,12 +15,9 @@
 
 use std::sync::Arc;
 
+use crate::rpc::{error::BlockchainRpcClientError, http::BlockchainHttpRpcClient};
 use alloy::{primitives::Address, sol, sol_types::SolCall};
-
-use crate::{
-    rpc::{error::BlockchainRpcClientError, http::BlockchainHttpRpcClient},
-    validation::validate_address,
-};
+use nautilus_model::defi::validation::validate_address;
 
 sol! {
     #[sol(rpc)]

--- a/crates/adapters/blockchain/src/data.rs
+++ b/crates/adapters/blockchain/src/data.rs
@@ -15,31 +15,6 @@
 
 use std::{cmp::max, collections::HashSet, sync::Arc};
 
-use alloy::primitives::{Address, U256};
-use futures_util::StreamExt;
-use nautilus_common::{
-    messages::{
-        DataEvent,
-        defi::{
-            DefiDataCommand, DefiSubscribeCommand, DefiUnsubscribeCommand, SubscribeBlocks,
-            SubscribePool, SubscribePoolLiquidityUpdates, SubscribePoolSwaps, UnsubscribeBlocks,
-            UnsubscribePool, UnsubscribePoolLiquidityUpdates, UnsubscribePoolSwaps,
-        },
-    },
-    runner::get_data_event_sender,
-};
-use nautilus_core::UnixNanos;
-use nautilus_data::client::DataClient;
-use nautilus_infrastructure::sql::pg::PostgresConnectOptions;
-use nautilus_model::{
-    defi::{
-        Block, Blockchain, DefiData, Pool, PoolLiquidityUpdate, PoolLiquidityUpdateType, PoolSwap,
-        SharedChain, SharedDex, SharedPool, Token,
-    },
-    identifiers::{ClientId, Venue},
-};
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-
 use crate::{
     cache::BlockchainCache,
     config::BlockchainDataClientConfig,
@@ -58,8 +33,32 @@ use crate::{
         http::BlockchainHttpRpcClient,
         types::BlockchainMessage,
     },
-    validation::validate_address,
 };
+use alloy::primitives::{Address, U256};
+use futures_util::StreamExt;
+use nautilus_common::{
+    messages::{
+        DataEvent,
+        defi::{
+            DefiDataCommand, DefiSubscribeCommand, DefiUnsubscribeCommand, SubscribeBlocks,
+            SubscribePool, SubscribePoolLiquidityUpdates, SubscribePoolSwaps, UnsubscribeBlocks,
+            UnsubscribePool, UnsubscribePoolLiquidityUpdates, UnsubscribePoolSwaps,
+        },
+    },
+    runner::get_data_event_sender,
+};
+use nautilus_core::UnixNanos;
+use nautilus_data::client::DataClient;
+use nautilus_infrastructure::sql::pg::PostgresConnectOptions;
+use nautilus_model::defi::validation::validate_address;
+use nautilus_model::{
+    defi::{
+        Block, Blockchain, DefiData, Pool, PoolLiquidityUpdate, PoolLiquidityUpdateType, PoolSwap,
+        SharedChain, SharedDex, SharedPool, Token,
+    },
+    identifiers::{ClientId, Venue},
+};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 const BLOCKS_PROCESS_IN_SYNC_REPORT: u64 = 50000;
 

--- a/crates/adapters/blockchain/src/lib.rs
+++ b/crates/adapters/blockchain/src/lib.rs
@@ -49,7 +49,6 @@ pub mod decode;
 pub mod events;
 pub mod math;
 pub mod rpc;
-pub mod validation;
 
 #[cfg(feature = "hypersync")]
 pub mod cache;

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -1573,7 +1573,7 @@ fn test_unsubscribe_pool_swaps(
     let actor = get_actor_unchecked::<TestDataActor>(&actor_id);
     actor.start().unwrap();
 
-    use nautilus_model::defi::{Dex, DexType, Pool, Token, chain::chains, dex::AmmType};
+    use nautilus_model::defi::{Dex, DexType, Pool, chain::chains, dex::AmmType};
 
     let chain = Arc::new(chains::ETHEREUM.clone());
     let dex = Dex::new(
@@ -1587,22 +1587,8 @@ fn test_unsubscribe_pool_swaps(
         "Mint",
         "Burn",
     );
-    let token0 = Token::new(
-        chain.clone(),
-        Address::from([0x11; 20]),
-        "WETH".to_string(),
-        "WETH".to_string(),
-        18,
-    );
-    let token1 = Token::new(
-        chain.clone(),
-        Address::from([0x22; 20]),
-        "USDC".to_string(),
-        "USDC".to_string(),
-        6,
-    );
     let pool_address = Address::from_str("0xC31E54c7A869B9fCbECC14363CF510d1C41Fa443").unwrap();
-    let instrument_id = Pool::create_instrument_id(chain.name, &dex, &token0, &token1, 50);
+    let instrument_id = Pool::create_instrument_id(chain.name, &dex, &pool_address);
 
     actor.subscribe_pool_swaps(instrument_id, None, None);
 

--- a/crates/data/tests/client.rs
+++ b/crates/data/tests/client.rs
@@ -1679,7 +1679,8 @@ fn test_defi_pool_swaps_subscription(
     let client = Box::new(MockDataClient::new(clock, cache, client_id, Some(venue)));
     let mut adapter = DataClientAdapter::new(client_id, Some(venue), false, false, client);
 
-    let instrument_id = InstrumentId::from("WETH/USDT-3000.Arbitrum:UniswapV3");
+    let instrument_id =
+        InstrumentId::from("0x11b815efB8f581194ae79006d24E0d814B7697F6.Arbitrum:UniswapV3");
 
     let sub = DefiSubscribeCommand::PoolSwaps(SubscribePoolSwaps {
         instrument_id,
@@ -1778,7 +1779,8 @@ fn test_defi_pool_swaps_unsubscribe_noop(
     let client = Box::new(MockDataClient::new(clock, cache, client_id, Some(venue)));
     let mut adapter = DataClientAdapter::new(client_id, Some(venue), false, false, client);
 
-    let instrument_id = InstrumentId::from("WETH/USDT-3000.Arbitrum:UniswapV3");
+    let instrument_id =
+        InstrumentId::from("0x11b815efB8f581194ae79006d24E0d814B7697F6.Arbitrum:UniswapV3");
 
     // Unsubscribe without prior subscribe should be no-op
     let unsub = DefiUnsubscribeCommand::PoolSwaps(UnsubscribePoolSwaps {
@@ -1804,7 +1806,8 @@ fn test_defi_pool_swaps_unsubscribe_idempotent(
     let client = Box::new(MockDataClient::new(clock, cache, client_id, Some(venue)));
     let mut adapter = DataClientAdapter::new(client_id, Some(venue), false, false, client);
 
-    let instrument_id = InstrumentId::from("WETH/USDT-3000.Arbitrum:UniswapV3");
+    let instrument_id =
+        InstrumentId::from("0x11b815efB8f581194ae79006d24E0d814B7697F6.Arbitrum:UniswapV3");
 
     // Subscribe then unsubscribe twice
     let sub = DefiSubscribeCommand::PoolSwaps(SubscribePoolSwaps {

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -1552,7 +1552,8 @@ fn test_execute_subscribe_pool_swaps(
         &mut data_engine,
     );
 
-    let instrument_id = InstrumentId::from("WETH/USDT-3000.Arbitrum:UniswapV3");
+    let instrument_id =
+        InstrumentId::from("0x11b815efB8f581194ae79006d24E0d814B7697F6.Arbitrum:UniswapV3");
 
     let sub_cmd = DataCommand::DefiSubscribe(DefiSubscribeCommand::PoolSwaps(SubscribePoolSwaps {
         instrument_id,

--- a/crates/model/src/defi/mod.rs
+++ b/crates/model/src/defi/mod.rs
@@ -33,6 +33,7 @@ pub mod hex;
 pub mod rpc;
 pub mod token;
 pub mod types;
+pub mod validation;
 
 // Re-exports
 pub use amm::{Pool, SharedPool};

--- a/crates/model/src/defi/validation.rs
+++ b/crates/model/src/defi/validation.rs
@@ -19,8 +19,9 @@
 //! of blockchain-related data, particularly Ethereum addresses and other EVM-compatible
 //! blockchain identifiers.
 
-use alloy_primitives::Address;
 use std::str::FromStr;
+
+use alloy_primitives::Address;
 
 /// Validates an Ethereum address format, checksum, and returns the parsed address.
 ///

--- a/crates/model/src/defi/validation.rs
+++ b/crates/model/src/defi/validation.rs
@@ -19,9 +19,8 @@
 //! of blockchain-related data, particularly Ethereum addresses and other EVM-compatible
 //! blockchain identifiers.
 
+use alloy_primitives::Address;
 use std::str::FromStr;
-
-use alloy::primitives::Address;
 
 /// Validates an Ethereum address format, checksum, and returns the parsed address.
 ///

--- a/crates/model/src/identifiers/venue.rs
+++ b/crates/model/src/identifiers/venue.rs
@@ -15,15 +15,17 @@
 
 //! Represents a valid trading venue ID.
 
-#[cfg(feature = "defi")]
-use crate::defi::{Chain, DexType};
-use crate::venues::VENUE_MAP;
-use nautilus_core::correctness::{FAILED, check_valid_string};
 use std::{
     fmt::{Debug, Display, Formatter},
     hash::Hash,
 };
+
+use nautilus_core::correctness::{FAILED, check_valid_string};
 use ustr::Ustr;
+
+#[cfg(feature = "defi")]
+use crate::defi::{Chain, DexType};
+use crate::venues::VENUE_MAP;
 
 pub const SYNTHETIC_VENUE: &str = "SYNTH";
 
@@ -119,6 +121,13 @@ impl Venue {
     #[must_use]
     pub fn is_synthetic(&self) -> bool {
         self.0.as_str() == SYNTHETIC_VENUE
+    }
+
+    /// Returns true if the venue represents a decentralized exchange (contains ':').
+    #[cfg(feature = "defi")]
+    #[must_use]
+    pub fn is_dex(&self) -> bool {
+        self.0.as_str().contains(':')
     }
 }
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- added `is_dex` function in `Venue` to check if venue is DEX
- moved `validation.rs` from blockchain adapter package to the `model` crate in `defi` module
- finish `InstrumentId` validation to account for `{address}.{Chain}:{Dex}` methodology
- refactored `create_instrument_id` function to `Pool` to account for the new symbol in address format
- added tests

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


