### PR TITLE
Refine BacktestDataConfig allowed queries for Bars

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -276,10 +276,6 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         if self.data_cls is Bar:
             used_bar_types = []
 
-            if self.bar_types is None and self.instrument_ids is None:
-                assert self.instrument_id, "No `instrument_id` for Bar data config"
-                assert self.bar_spec, "No `bar_spec` for Bar data config"
-
             if self.instrument_id is not None and self.bar_spec is not None:
                 bar_type = f"{self.instrument_id}-{self.bar_spec}-EXTERNAL"
                 used_bar_types = [bar_type]
@@ -292,8 +288,8 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
             if len(used_bar_types) > 0:
                 filter_expr = f'(field("bar_type") == "{used_bar_types[0]}")'
 
-            for bar_type in used_bar_types[1:]:
-                filter_expr = f'{filter_expr} | (field("bar_type") == "{bar_type}")'
+                for bar_type in used_bar_types[1:]:
+                    filter_expr = f'{filter_expr} | (field("bar_type") == "{bar_type}")'
         else:
             filter_expr = self.filter_expr
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Allow to avoid requiring instrument_id or bar_spec in BacktestDataConfig for Bar queries as the code works without them.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Tested on databento_option_greeks.py
