### PR TITLE
Introduce initial DEX Pool Filtering Configuration

### DIFF
--- a/crates/adapters/blockchain/bin/node_test.rs
+++ b/crates/adapters/blockchain/bin/node_test.rs
@@ -20,7 +20,8 @@ use std::{
 };
 
 use nautilus_blockchain::{
-    config::BlockchainDataClientConfig, factories::BlockchainDataClientFactory,
+    config::{BlockchainDataClientConfig, DexPoolFilters},
+    factories::BlockchainDataClientFactory,
 };
 use nautilus_common::{
     actor::{DataActor, DataActorCore, data_actor::DataActorConfig},
@@ -60,6 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // let from_block = Some(348_860_000_u64); // Arbitrum
     let from_block = None; // No sync
 
+    let dex_pool_filter = DexPoolFilters::new(Some(true));
+
     let client_factory = BlockchainDataClientFactory::new();
     let client_config = BlockchainDataClientConfig::new(
         Arc::new(chain.clone()),
@@ -70,6 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         true, // Use HyperSync for live data
         // Some(from_block), // from_block
         from_block,
+        Some(dex_pool_filter),
         Some(PostgresConnectOptions::default()),
     );
 

--- a/crates/adapters/blockchain/src/data/core.rs
+++ b/crates/adapters/blockchain/src/data/core.rs
@@ -640,11 +640,6 @@ impl BlockchainDataClientCore {
                 }
                 Err(token_info_error) => match token_info_error {
                     TokenInfoError::EmptyTokenField { .. } => {
-                        // Empty token name/symbol indicates non-standard implementations:
-                        // - Non-conforming ERC20 tokens (name/symbol are optional in the standard)
-                        // - Minimal proxy contracts without proper metadata forwarding
-                        // - Malicious or deprecated tokens
-                        // We skip these pools as they're not suitable for trading.
                         empty_tokens.insert(token_address);
                     }
                     _ => {

--- a/crates/adapters/blockchain/src/data/core.rs
+++ b/crates/adapters/blockchain/src/data/core.rs
@@ -89,7 +89,10 @@ impl BlockchainDataClientCore {
             config.http_rpc_url.clone(),
             config.rpc_requests_per_second,
         ));
-        let erc20_contract = Erc20Contract::new(http_rpc_client);
+        let erc20_contract = Erc20Contract::new(
+            http_rpc_client,
+            config.pools_filters.remove_pools_with_empty_erc20fields,
+        );
 
         let hypersync_client = HyperSyncClient::new(chain.clone(), hypersync_tx);
         let data_sender = get_data_event_sender();

--- a/crates/adapters/blockchain/src/python/config.rs
+++ b/crates/adapters/blockchain/src/python/config.rs
@@ -21,14 +21,23 @@ use nautilus_infrastructure::sql::pg::PostgresConnectOptions;
 use nautilus_model::defi::{Chain, DexType};
 use pyo3::prelude::*;
 
-use crate::config::BlockchainDataClientConfig;
+use crate::config::{BlockchainDataClientConfig, DexPoolFilters};
+
+#[pymethods]
+impl DexPoolFilters {
+    /// Creates a new `DexPoolFilters` instance.
+    #[new]
+    pub fn py_new(remove_pools_with_empty_erc20_fields: Option<bool>) -> Self {
+        Self::new(remove_pools_with_empty_erc20_fields)
+    }
+}
 
 #[pymethods]
 impl BlockchainDataClientConfig {
     /// Creates a new `BlockchainDataClientConfig` instance.
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, postgres_cache_database_config=None))]
+    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None))]
     fn py_new(
         chain: &Chain,
         dex_ids: Vec<DexType>,
@@ -37,6 +46,7 @@ impl BlockchainDataClientConfig {
         wss_rpc_url: Option<String>,
         use_hypersync_for_live_data: bool,
         from_block: Option<u64>,
+        pool_filters: Option<DexPoolFilters>,
         postgres_cache_database_config: Option<PostgresConnectOptions>,
     ) -> Self {
         Self::new(
@@ -47,6 +57,7 @@ impl BlockchainDataClientConfig {
             wss_rpc_url,
             use_hypersync_for_live_data,
             from_block,
+            pool_filters,
             postgres_cache_database_config,
         )
     }

--- a/crates/adapters/blockchain/src/python/mod.rs
+++ b/crates/adapters/blockchain/src/python/mod.rs
@@ -60,6 +60,7 @@ fn extract_blockchain_config(py: Python<'_>, config: PyObject) -> PyResult<Box<d
 #[pymodule]
 pub fn blockchain(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::config::BlockchainDataClientConfig>()?;
+    m.add_class::<crate::config::DexPoolFilters>()?;
     #[cfg(feature = "hypersync")]
     m.add_class::<crate::factories::BlockchainDataClientFactory>()?;
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

 Added configurable filtering for DEX pools through the new `DexPoolFilters` struct, which defines the pool universe that the blockchain data client will monitor. 
The first filter `remove_pools_with_empty_erc20fields` (defaults to true) excludes pools containing tokens with missing name or symbol metadata - addressing edge cases from non-conforming ERC20 implementations, proxy contracts, or deprecated tokens. 
The configuration integrates with `Erc20Contract` through the `enforce_token_fields` parameter for conditional validation, and is fully exposed to Python bindings.


## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)