### PR TITLE
Support both Enum and String types for BacktestVenueConfig

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -36,6 +36,9 @@ from nautilus_trader.execution.config import ExecEngineConfig
 from nautilus_trader.live.config import LiveDataClientConfig
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import TraderId
 from nautilus_trader.risk.config import RiskEngineConfig
@@ -110,10 +113,10 @@ class BacktestVenueConfig(NautilusConfig, frozen=True):
     ----------
     name : str
         The name of the venue.
-    oms_type : str
+    oms_type : OmsType | str
         The order management system type for the exchange. If ``HEDGING`` will
         generate new position IDs.
-    account_type : str
+    account_type : AccountType | str
         The account type for the exchange.
     starting_balances : list[Money | str]
         The starting account balances (specify one for a single asset account).
@@ -169,8 +172,8 @@ class BacktestVenueConfig(NautilusConfig, frozen=True):
     """
 
     name: str
-    oms_type: str
-    account_type: str
+    oms_type: OmsType | str
+    account_type: AccountType | str
     starting_balances: list[str]
     base_currency: str | None = None
     default_leverage: float = 1.0
@@ -180,7 +183,7 @@ class BacktestVenueConfig(NautilusConfig, frozen=True):
     fill_model: ImportableFillModelConfig | None = None
     latency_model: ImportableLatencyModelConfig | None = None
     fee_model: ImportableFeeModelConfig | None = None
-    book_type: str = "L1_MBP"
+    book_type: BookType | str = "L1_MBP"
     routing: bool = False
     reject_stop_orders: bool = True
     support_gtd_orders: bool = True

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -58,7 +58,9 @@ from nautilus_trader.model.data import capsule_to_list
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.enums import account_type_from_str
 from nautilus_trader.model.enums import book_type_from_str
+from nautilus_trader.model.enums import oms_type_from_str
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
@@ -378,14 +380,14 @@ class BacktestNode:
         for venue_config in venue_configs:
             engine.add_venue(
                 venue=Venue(venue_config.name),
-                oms_type=OmsType[venue_config.oms_type],
-                account_type=AccountType[venue_config.account_type],
+                oms_type=get_oms_type(venue_config),
+                account_type=get_account_type(venue_config),
                 base_currency=get_base_currency(venue_config),
                 starting_balances=get_starting_balances(venue_config),
                 default_leverage=Decimal(venue_config.default_leverage),
                 leverages=get_leverages(venue_config),
                 margin_model=get_margin_model(venue_config),
-                book_type=book_type_from_str(venue_config.book_type),
+                book_type=get_book_type(venue_config),
                 routing=venue_config.routing,
                 modules=[ActorFactory.create(module) for module in (venue_config.modules or [])],
                 fill_model=get_fill_model(venue_config),
@@ -728,6 +730,24 @@ def get_instrument_ids(config: BacktestDataConfig) -> list[InstrumentId]:
         instrument_ids = [bar_type.instrument_id for bar_type in bar_types]
 
     return instrument_ids
+
+
+def get_oms_type(config: BacktestVenueConfig) -> OmsType:
+    oms_type = config.oms_type
+
+    return oms_type_from_str(oms_type) if type(oms_type) is str else oms_type
+
+
+def get_account_type(config: BacktestVenueConfig) -> AccountType:
+    account_type = config.account_type
+
+    return account_type_from_str(account_type) if type(account_type) is str else account_type
+
+
+def get_book_type(config: BacktestVenueConfig) -> BookType | None:
+    book_type = config.book_type
+
+    return book_type_from_str(book_type) if type(book_type) is str else book_type
 
 
 def get_starting_balances(config: BacktestVenueConfig) -> list[Money]:

--- a/nautilus_trader/common/config.py
+++ b/nautilus_trader/common/config.py
@@ -31,6 +31,9 @@ from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model.data import BarSpecification
 from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.identifiers import ComponentId
 from nautilus_trader.model.identifiers import Identifier
 from nautilus_trader.model.identifiers import InstrumentId
@@ -113,6 +116,8 @@ def msgspec_encoding_hook(obj: Any) -> Any:  # noqa: C901 (too complex)
         return str(obj)
     if isinstance(obj, (Price | Quantity | Money | Currency)):
         return str(obj)
+    if isinstance(obj, (OmsType | AccountType | BookType)):
+        return obj.name
     if isinstance(obj, (pd.Timestamp | pd.Timedelta)):
         return obj.isoformat()
     if isinstance(obj, Environment):
@@ -147,6 +152,12 @@ def msgspec_decoding_hook(obj_type: type, obj: Any) -> Any:  # noqa: C901 (too c
         return Money.from_str(obj)
     if obj_type == Currency:
         return Currency.from_str(obj)
+    if obj_type == OmsType:
+        return OmsType[obj]
+    if obj_type == AccountType:
+        return AccountType[obj]
+    if obj_type == BookType:
+        return BookType[obj]
     if obj_type == Environment:
         return obj_type(obj)
     if obj_type in CUSTOM_DECODINGS:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Added functions to accept both enum and string type parameters (oms_type, account_type, book_type) in the constructor of the BacktestVenueConfig class. Also added related msg encoding/decoding cases.

## Related Issues/PRs

https://github.com/nautechsystems/nautilus_trader/issues/2843

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added a test `def test_backtest_obj_data_config_to_dict(self)` in `tests/unit_tests/backtest/test_config.py`
