### PR TITLE
Improve ERC20 token metadata handling and error recovery

### DIFF
--- a/crates/adapters/blockchain/src/contracts/erc20.rs
+++ b/crates/adapters/blockchain/src/contracts/erc20.rs
@@ -369,6 +369,19 @@ mod tests {
         address!("00000000049084A92F8964B76845ab6DE54EB229")
     }
 
+    #[fixture]
+    fn success_but_empty_result() -> Multicall3::Result {
+        Multicall3::Result {
+            success: true,
+            returnData: Bytes::from(vec![]),
+        }
+    }
+
+    #[fixture]
+    fn empty_token_address() -> Address {
+        address!("a5b00cEc63694319495d605AA414203F9714F47E")
+    }
+
     #[rstest]
     fn test_parse_erc20_string_result_name_success(
         successful_name_result: Multicall3::Result,
@@ -415,6 +428,45 @@ mod tests {
                 assert_eq!(reason, "Call failed without revert data");
             }
             _ => panic!("Expected DecodingError"),
+        }
+    }
+
+    #[rstest]
+    fn test_parse_erc20_string_result_success_but_empty_name(
+        success_but_empty_result: Multicall3::Result,
+        empty_token_address: Address,
+    ) {
+        let result = parse_erc20_string_result(
+            &success_but_empty_result,
+            Erc20Field::Name,
+            &empty_token_address,
+        );
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TokenInfoError::EmptyTokenField { field, address } => {
+                assert!(matches!(field, Erc20Field::Name));
+                assert_eq!(address, empty_token_address);
+            }
+            _ => panic!("Expected EmptyTokenField error"),
+        }
+    }
+
+    #[rstest]
+    fn test_parse_erc20_decimals_result_success_but_empty(
+        success_but_empty_result: Multicall3::Result,
+        empty_token_address: Address,
+    ) {
+        let result = parse_erc20_decimals_result(
+            &success_but_empty_result,
+            &empty_token_address,
+        );
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TokenInfoError::EmptyTokenField { field, address } => {
+                assert!(matches!(field, Erc20Field::Decimals));
+                assert_eq!(address, empty_token_address);
+            }
+            _ => panic!("Expected EmptyTokenField error"),
         }
     }
 }

--- a/crates/adapters/blockchain/src/contracts/erc20.rs
+++ b/crates/adapters/blockchain/src/contracts/erc20.rs
@@ -403,7 +403,10 @@ mod tests {
         // Returns raw string bytes without ABI encoding - "Rico" as raw bytes
         Multicall3::Result {
             success: true,
-            returnData: Bytes::from(hex::decode("5269636f00000000000000000000000000000000000000000000000000000000").unwrap()),
+            returnData: Bytes::from(
+                hex::decode("5269636f00000000000000000000000000000000000000000000000000000000")
+                    .unwrap(),
+            ),
         }
     }
 
@@ -417,7 +420,10 @@ mod tests {
         // Returns function selector instead of actual data
         Multicall3::Result {
             success: true,
-            returnData: Bytes::from(hex::decode("06fdde0300000000000000000000000000000000000000000000000000000000").unwrap()),
+            returnData: Bytes::from(
+                hex::decode("06fdde0300000000000000000000000000000000000000000000000000000000")
+                    .unwrap(),
+            ),
         }
     }
 
@@ -426,7 +432,10 @@ mod tests {
         // Returns raw string bytes without ABI encoding - longer string example
         Multicall3::Result {
             success: true,
-            returnData: Bytes::from(hex::decode("5269636f62616e6b205269736b20536861726500000000000000000000000000").unwrap()),
+            returnData: Bytes::from(
+                hex::decode("5269636f62616e6b205269736b20536861726500000000000000000000000000")
+                    .unwrap(),
+            ),
         }
     }
 
@@ -535,7 +544,10 @@ mod tests {
                 assert_eq!(field, "Name");
                 assert_eq!(address, non_abi_encoded_token_address);
                 assert!(reason.contains("type check failed"));
-                assert_eq!(raw_data, "0x5269636f00000000000000000000000000000000000000000000000000000000");
+                assert_eq!(
+                    raw_data,
+                    "0x5269636f00000000000000000000000000000000000000000000000000000000"
+                );
                 // Raw bytes "Rico" without ABI encoding
             }
             _ => panic!("Expected DecodingError"),
@@ -563,7 +575,10 @@ mod tests {
                 assert_eq!(field, "Name");
                 assert_eq!(address, token_address);
                 assert!(reason.contains("type check failed"));
-                assert_eq!(raw_data, "0x06fdde0300000000000000000000000000000000000000000000000000000000");
+                assert_eq!(
+                    raw_data,
+                    "0x06fdde0300000000000000000000000000000000000000000000000000000000"
+                );
             }
             _ => panic!("Expected DecodingError"),
         }
@@ -590,7 +605,10 @@ mod tests {
                 assert_eq!(field, "Name");
                 assert_eq!(address, token_address);
                 assert!(reason.contains("type check failed"));
-                assert_eq!(raw_data, "0x5269636f62616e6b205269736b20536861726500000000000000000000000000");
+                assert_eq!(
+                    raw_data,
+                    "0x5269636f62616e6b205269736b20536861726500000000000000000000000000"
+                );
                 // Example of longer non-ABI encoded string
             }
             _ => panic!("Expected DecodingError"),

--- a/crates/adapters/blockchain/src/contracts/erc20.rs
+++ b/crates/adapters/blockchain/src/contracts/erc20.rs
@@ -102,17 +102,17 @@ impl Erc20Contract {
         let calls = vec![
             ContractCall {
                 target: *token_address,
-                allow_failure: false,
+                allow_failure: true,
                 call_data: ERC20::nameCall.abi_encode(),
             },
             ContractCall {
                 target: *token_address,
-                allow_failure: false,
+                allow_failure: true,
                 call_data: ERC20::symbolCall.abi_encode(),
             },
             ContractCall {
                 target: *token_address,
-                allow_failure: false,
+                allow_failure: true,
                 call_data: ERC20::decimalsCall.abi_encode(),
             },
         ];

--- a/crates/adapters/blockchain/src/factories.rs
+++ b/crates/adapters/blockchain/src/factories.rs
@@ -107,6 +107,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         );
 
         assert_eq!(config.chain.name, Blockchain::Ethereum);

--- a/docs/integrations/blockchain.md
+++ b/docs/integrations/blockchain.md
@@ -1,0 +1,35 @@
+# Blockchain
+
+## Contracts
+
+High-performance interface for querying EVM smart contracts with type-safe Rust abstractions. Supports token metadata, DEX pools, and DeFi protocols through efficient batch operations.
+
+### Base (Multicall3)
+
+Batches multiple contract calls into a single RPC request using Multicall3 (`0xcA11bde05977b3631167028862bE2a173976CA11`).
+
+- Always uses `allow_failure: true` for partial success and detailed errors
+- Executes atomically in the same block
+- Errors: `RpcError` (network issues), `AbiDecodingError` (decode failures)
+
+### ERC20
+
+Inherits from `BaseContract` to leverage Multicall3 for efficient batch operations. Fetches token metadata with robust handling for non-standard implementations.
+
+**Methods:**
+
+- `fetch_token_info`: Single token metadata (uses multicall internally for name, symbol, decimals)
+- `batch_fetch_token_info`: Multiple tokens in one multicall (3 calls per token)
+- `enforce_token_fields`: Validate non-empty name/symbol
+
+**Error Types:**
+
+1. **`CallFailed`** - Contract missing or function not implemented → Skip token
+2. **`DecodingError`** - Raw bytes instead of ABI encoding (e.g., `0x5269636f...`) → Skip token
+3. **`EmptyTokenField`** - Function returns empty string → Skip if enforced
+
+**Best Practices:**
+
+- Skip pools with any token errors
+- `raw_data` field preserves original response for debugging
+- Non-standard tokens often have other issues (transfer fees, rebasing)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary
 
This PR enhances the blockchain adapter's ability to handle non-standard ERC20 tokens commonly found in production environments. The changes ensure robust pool synchronization by properly categorizing and handling various token implementation issues.

**Changes**

- Set `allow_failure: true` for all ERC20 multicall operations to enable partial success and detailed error information
- Separate error types: `CallFailed` (contract/function missing) vs `DecodingError` (non-ABI encoded responses) vs `EmptyTokenField`
- Add comprehensive test coverage for real-world edge cases including non-ABI encoded tokens and empty metadata
- Include raw response data in errors for better debugging and analysis

 **Notes**
- Non-standard tokens (raw bytes instead of ABI encoding) are now properly detected and excluded from pool processing
- Error messages preserve original response data to help identify problematic token implementations 
- Pools with any token metadata errors are automatically skipped during synchronization to ensure data reliability
- Documentation added for blockchain contract integrations covering Multicall3 and ERC20 patterns



## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


