### PR TITLE
Fix venue_order_id handling for Polymarket order status request

### DIFF
--- a/nautilus_trader/adapters/polymarket/execution.py
+++ b/nautilus_trader/adapters/polymarket/execution.py
@@ -480,7 +480,8 @@ class PolymarketExecutionClient(LiveExecutionClient):
     ) -> OrderStatusReport | None:
         await self._maintain_active_market(command.instrument_id)
 
-        if command.venue_order_id is None:
+        venue_order_id = command.venue_order_id
+        if venue_order_id is None:
             venue_order_id = self._cache.venue_order_id(command.client_order_id)
             if venue_order_id is None:
                 self._log.error(
@@ -498,10 +499,10 @@ class PolymarketExecutionClient(LiveExecutionClient):
         try:
             response: JSON | None = await retry_manager.run(
                 "generate_order_status_report",
-                [command.client_order_id, command.venue_order_id],
+                [command.client_order_id, venue_order_id],
                 asyncio.to_thread,
                 self._http_client.get_order,
-                order_id=command.venue_order_id.value,
+                order_id=venue_order_id.value,
             )
             if not response:
                 return None


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

There are cases when reconciling polymarket orders doesn't fill in the command.venue_order_id, but it is obtained from the cache (see line 485). However, this case appears not to have been thought of on line 504, which uses the immutable command.venue_order_id (despite the fact that a new venue_order_id variable was created on line 485), leading to an exception even if we got the venue from the cache.

This PR allows the query to go through in case we had to get the venue_order_id from the cache.

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested on my strategy that was previously randomly failing due to exceptions here (usually happening when there were some slow orders in-flight)
