### PR TITLE
Fix AttributeError when loading cached IBContract objects

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -695,8 +695,10 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         processed_instrument_ids = []
 
         for details in copy.deepcopy(contract_details):
-            details.contract = IBContract(**details.contract.__dict__)
-            details = IBContractDetails(**details.__dict__)
+            if not isinstance(details.contract, IBContract):
+                details.contract = IBContract(**details.contract.__dict__)
+            if not isinstance(details, IBContractDetails):
+                details = IBContractDetails(**details.__dict__)
             self._log.debug(f"Attempting to create instrument from {details}")
 
             try:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This fix skips conversions to IBContract and IBContractDetails if these have been pulled from cache and are handed in as such already


## Related Issues/PRs

Fixes #2860

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
