### PR TITLE
Fix race-condition on node shutdown in async InteractiveBrokersDataClient._disconnect()

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -149,7 +149,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             self._handle_data(instrument)
 
     async def _disconnect(self):
-        self._client.registered_nautilus_clients.remove(self.id)
+        self._client.registered_nautilus_clients.discard(self.id)
 
         if self._client.is_running and self._client.registered_nautilus_clients == set():
             self._client.stop()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix now handles multiple invocations if _disconnect() gracefully

## Related Issues/PRs

Fixes #2864

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
