### PR TITLE
Improve Docker configuration

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,13 +1,28 @@
-version: '3.5'
+version: "3.5"
 
 services:
+  nautilus:
+    build:
+      context: ..
+      dockerfile: .docker/nautilus_trader.dockerfile
+    environment:
+      NAUTILUS_PATH: /opt/nautilus
+    volumes:
+      - ./nautilus_data:/opt/nautilus
+    depends_on:
+      - postgres
+      - redis
+    networks:
+      - nautilus-network
+    restart: unless-stopped
+
   postgres:
     container_name: nautilus-database
     image: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-nautilus}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
-      POSTGRES_DATABASE: nautilus
+      POSTGRES_DB: ${POSTGRES_DB:-nautilus}
       PGDATA: /data/postgres
     volumes:
       - nautilus-database:/data/postgres
@@ -37,7 +52,7 @@ services:
     container_name: nautilus-redis
     image: redis
     ports:
-      - 6379:6379
+      - "6379:6379"
     restart: unless-stopped
     networks:
       - nautilus-network

--- a/.docker/nautilus_trader.dockerfile
+++ b/.docker/nautilus_trader.dockerfile
@@ -47,3 +47,4 @@ RUN find /usr/local/lib/python3.13/site-packages -name "*.pyc" -exec rm -f {} \;
 FROM base AS application
 
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin/ /usr/local/bin/

--- a/docs/integrations/tardis.md
+++ b/docs/integrations/tardis.md
@@ -155,7 +155,7 @@ The following environment variables are used by Tardis and NautilusTrader.
 - `TARDIS_API_KEY`: API key for NautilusTrader Tardis clients.
 - `TARDIS_MACHINE_WS_URL` (optional): WebSocket URL for the `TardisMachineClient` in NautilusTrader.
 - `TARDIS_BASE_URL` (optional): Base URL for the `TardisHttpClient` in NautilusTrader.
-- `NAUTILUS_PATH` (optional): Root directory for writing replay data in the Nautilus catalog.
+- `NAUTILUS_PATH` (optional): Parent directory containing the `catalog/` subdirectory for writing replay data in the Nautilus catalog format.
 
 ## Running Tardis Machine historical replays
 
@@ -179,8 +179,8 @@ You can request data for the first day of each month without an API key. For all
 :::
 
 This process is optimized for direct output to a Nautilus Parquet data catalog.
-Ensure that the `NAUTILUS_PATH` environment variable is set to the root `/catalog/` directory.
-Parquet files will then be organized under `/catalog/data/` in the expected subdirectories corresponding to data type and instrument.
+Ensure that the `NAUTILUS_PATH` environment variable is set to the parent directory containing the `catalog/` subdirectory.
+Parquet files will then be organized under `<NAUTILUS_PATH>/catalog/data/` in the expected subdirectories corresponding to data type and instrument.
 
 If no `output_path` is specified in the configuration file and the `NAUTILUS_PATH` environment variable is unset, the system will default to the current working directory.
 


### PR DESCRIPTION
## Fix Docker setup for console scripts and volume mounts

### Problem
- PostgreSQL database not created due to wrong env var (POSTGRES_DATABASE vs POSTGRES_DB)
- Console scripts missing in final Docker image (only copied site-packages)
- No example showing correct volume mount pattern for data persistence

### Solution
- Fix POSTGRES_DATABASE → POSTGRES_DB for proper database creation
- Copy /usr/local/bin/ to ensure console scripts are available
- Add Nautilus service example with correct mount: ./nautilus_data:/opt/nautilus
- Add test script for validating Docker setup

### Key Change
Critical volume mount pattern:
```yaml
environment:
  NAUTILUS_PATH: /opt/nautilus
volumes:
  - ./nautilus_data:/opt/nautilus  # RHS must equal NAUTILUS_PATH