### PR TITLE
Introduce efficient pool syncing command in the cli

### DIFF
--- a/crates/adapters/blockchain/src/cache/database.rs
+++ b/crates/adapters/blockchain/src/cache/database.rs
@@ -13,9 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use alloy::primitives::U256;
+use alloy::primitives::{Address, U256};
 use nautilus_model::defi::{
     Block, Chain, Pool, PoolLiquidityUpdate, PoolSwap, SharedChain, SharedDex, Token,
+    validation::validate_address,
 };
 use sqlx::{PgPool, postgres::PgConnectOptions};
 
@@ -86,6 +87,27 @@ impl BlockchainCacheDatabase {
             .map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to call create_block_partition for chain {}: {e}",
+                    chain.chain_id
+                )
+            })?;
+
+        Ok(result.0)
+    }
+
+    /// Creates a table partition for the token table specific to the given chain
+    /// by calling the existing PostgreSQL function create_token_partition.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub async fn create_token_partition(&self, chain: &Chain) -> anyhow::Result<String> {
+        let result: (String,) = sqlx::query_as("SELECT create_token_partition($1)")
+            .bind(chain.chain_id as i32)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to call create_token_partition for chain {}: {e}",
                     chain.chain_id
                 )
             })?;
@@ -402,6 +424,35 @@ impl BlockchainCacheDatabase {
         .map_err(|e| anyhow::anyhow!("Failed to insert into token table: {e}"))
     }
 
+    /// Records an invalid token address with associated error information.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database insertion fails.
+    pub async fn add_invalid_token(
+        &self,
+        chain_id: u32,
+        address: &Address,
+        error_string: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO token (
+                chain_id, address, error
+            ) VALUES ($1, $2, $3)
+            ON CONFLICT (chain_id, address)
+            DO NOTHING;
+        ",
+        )
+        .bind(chain_id as i32)
+        .bind(address.to_string())
+        .bind(error_string)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("Failed to insert into token table: {e}"))
+    }
+
     /// Persists a token swap transaction event to the `pool_swap` table.
     ///
     /// # Errors
@@ -474,13 +525,16 @@ impl BlockchainCacheDatabase {
         .map_err(|e| anyhow::anyhow!("Failed to insert into pool_liquidity table: {e}"))
     }
 
-    /// Retrieves all token records for the given chain and converts them into `Token` domain objects.
+    /// Retrieves all valid token records for the given chain and converts them into `Token` domain objects.
+    ///
+    /// Only returns tokens that do not contain error information, filtering out invalid tokens
+    /// that were previously recorded with error details.
     ///
     /// # Errors
     ///
     /// Returns an error if the database query fails.
     pub async fn load_tokens(&self, chain: SharedChain) -> anyhow::Result<Vec<Token>> {
-        sqlx::query_as::<_, TokenRow>("SELECT * FROM token WHERE chain_id = $1")
+        sqlx::query_as::<_, TokenRow>("SELECT * FROM token WHERE chain_id = $1 AND error IS NULL")
             .bind(chain.chain_id as i32)
             .fetch_all(&self.pool)
             .await
@@ -498,6 +552,27 @@ impl BlockchainCacheDatabase {
                     .collect::<Vec<_>>()
             })
             .map_err(|e| anyhow::anyhow!("Failed to load tokens: {e}"))
+    }
+
+    /// Retrieves all invalid token addresses for a given chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails or address validation fails.
+    pub async fn load_invalid_token_addresses(
+        &self,
+        chain_id: u32,
+    ) -> anyhow::Result<Vec<Address>> {
+        sqlx::query_as::<_, (String,)>(
+            "SELECT address FROM token WHERE chain_id = $1 AND error IS NOT NULL",
+        )
+        .bind(chain_id as i32)
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(|(address,)| validate_address(&address))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow::anyhow!("Failed to load invalid token addresses: {e}"))
     }
 
     /// Loads pool data from the database for the specified chain and DEX.
@@ -581,5 +656,54 @@ impl BlockchainCacheDatabase {
         }
 
         Ok(())
+    }
+
+    /// Saves the checkpoint block number indicating the last completed pool synchronization for a specific DEX.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub async fn update_dex_last_synced_block(
+        &self,
+        chain_id: u32,
+        dex_name: &str,
+        block_number: u64,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            r"
+            UPDATE dex
+            SET last_full_sync_pools_block_number = $3
+            WHERE chain_id = $1 AND name = $2
+            ",
+        )
+        .bind(chain_id as i32)
+        .bind(dex_name)
+        .bind(block_number as i64)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("Failed to update dex last synced block: {e}"))
+    }
+
+    /// Retrieves the saved checkpoint block number from the last completed pool synchronization for a specific DEX.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn get_dex_last_synced_block(
+        &self,
+        chain_id: u32,
+        dex_name: &str,
+    ) -> anyhow::Result<Option<u64>> {
+        let result = sqlx::query_as::<_, (Option<i64>,)>(
+            "SELECT last_full_sync_pools_block_number FROM dex WHERE chain_id = $1 AND name = $2",
+        )
+        .bind(chain_id as i32)
+        .bind(dex_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get dex last synced block: {e}"))?;
+
+        Ok(result.and_then(|(block_number,)| block_number.map(|b| b as u64)))
     }
 }

--- a/crates/adapters/blockchain/src/exchanges/mod.rs
+++ b/crates/adapters/blockchain/src/exchanges/mod.rs
@@ -38,3 +38,19 @@ pub fn get_dex_extended(
         _ => None,
     }
 }
+
+/// Returns the supported DEX names for a given blockchain.
+#[must_use]
+pub fn get_supported_dexes_for_chain(blockchain: Blockchain) -> Vec<String> {
+    let dex_types: Vec<DexType> = match blockchain {
+        Blockchain::Ethereum => ETHEREUM_DEX_EXTENDED_MAP.keys().copied().collect(),
+        Blockchain::Base => BASE_DEX_EXTENDED_MAP.keys().copied().collect(),
+        Blockchain::Arbitrum => ARBITRUM_DEX_EXTENDED_MAP.keys().copied().collect(),
+        _ => vec![],
+    };
+
+    dex_types
+        .into_iter()
+        .map(|dex_type| format!("{}", dex_type))
+        .collect()
+}

--- a/crates/adapters/blockchain/src/reporting.rs
+++ b/crates/adapters/blockchain/src/reporting.rs
@@ -17,6 +17,28 @@
 
 use std::{fmt::Display, time::Instant};
 
+/// Formats a number with comma separators for better readability.
+/// Works with both integers and floats (floats are rounded to integers).
+/// Example: 1234567 -> "1,234,567", 1234567.8 -> "1,234,568"
+fn format_number<T>(n: T) -> String
+where
+    T: Into<f64>,
+{
+    let num = n.into().round() as u64;
+    let mut result = String::new();
+    let s = num.to_string();
+    let chars: Vec<char> = s.chars().collect();
+
+    for (i, ch) in chars.iter().enumerate() {
+        if i > 0 && (chars.len() - i) % 3 == 0 {
+            result.push(',');
+        }
+        result.push(*ch);
+    }
+
+    result
+}
+
 #[derive(Debug, Clone)]
 pub enum BlockchainItem {
     Blocks,
@@ -91,12 +113,12 @@ impl BlockchainSyncReporter {
             (self.blocks_processed as f64 / self.total_blocks as f64 * 100.0).min(100.0);
 
         tracing::info!(
-            "Syncing {} progress: {:.1}% | Block: {} | Rate: {:.0} blocks/s | Avg: {:.0} blocks/s",
+            "Syncing {} progress: {:.1}% | Block: {} | Rate: {} blocks/s | Avg: {} blocks/s",
             self.item,
             progress_pct,
-            block_number,
-            current_rate,
-            avg_rate,
+            format_number(block_number as f64),
+            format_number(current_rate),
+            format_number(avg_rate),
         );
 
         self.next_progress_threshold = block_number + self.progress_update_interval;
@@ -108,11 +130,11 @@ impl BlockchainSyncReporter {
         let total_elapsed = self.start_time.elapsed();
         let avg_rate = self.blocks_processed as f64 / total_elapsed.as_secs_f64();
         tracing::info!(
-            "Finished syncing {} | Total: {} blocks in {:.1}s | Avg rate: {:.0} blocks/s",
+            "Finished syncing {} | Total: {} blocks in {:.1}s | Avg rate: {} blocks/s",
             self.item,
-            self.blocks_processed,
+            format_number(self.blocks_processed as f64),
             total_elapsed.as_secs_f64(),
-            avg_rate,
+            format_number(avg_rate),
         );
     }
 }

--- a/crates/cli/src/blockchain/sync.rs
+++ b/crates/cli/src/blockchain/sync.rs
@@ -17,11 +17,31 @@ use std::sync::Arc;
 
 use nautilus_blockchain::{
     config::BlockchainDataClientConfig, data::core::BlockchainDataClientCore,
+    exchanges::get_supported_dexes_for_chain,
 };
 use nautilus_infrastructure::sql::pg::get_postgres_connect_options;
-use nautilus_model::defi::chain::Chain;
+use nautilus_model::defi::{chain::Chain, dex::DexType};
 
 use crate::opt::{BlockchainCommand, BlockchainOpt};
+
+/// Attempts to match a DEX name in a case-insensitive manner.
+fn find_dex_type_case_insensitive(dex_name: &str, chain: &Chain) -> Option<DexType> {
+    let supported_dexes = get_supported_dexes_for_chain(chain.name);
+
+    // First try exact match (for performance)
+    if let Some(dex_type) = DexType::from_dex_name(dex_name) {
+        return Some(dex_type);
+    }
+
+    // Try case-insensitive match
+    for supported_dex in supported_dexes {
+        if supported_dex.to_lowercase() == dex_name.to_lowercase() {
+            return DexType::from_dex_name(&supported_dex);
+        }
+    }
+
+    None
+}
 
 /// Runs blockchain commands based on the provided options.
 ///
@@ -67,6 +87,78 @@ pub async fn run_blockchain_command(opt: BlockchainOpt) -> anyhow::Result<()> {
                 .sync_blocks_checked(from_block, to_block)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to sync blocks: {}", e))?;
+        }
+        BlockchainCommand::SyncPools {
+            chain,
+            dex,
+            rpc_url,
+            database,
+        } => {
+            let chain = Chain::from_chain_name(&chain)
+                .ok_or_else(|| anyhow::anyhow!("Invalid chain name: {}", chain))?;
+            let chain_arc = Arc::new(chain.to_owned());
+
+            let dex_type = find_dex_type_case_insensitive(&dex, &chain).ok_or_else(|| {
+                let supported_dexes = get_supported_dexes_for_chain(chain.name);
+                if supported_dexes.is_empty() {
+                    anyhow::anyhow!(
+                        "Invalid DEX name '{}' (case-insensitive). Chain '{}' is not supported for pool syncing.",
+                        dex, chain.name
+                    )
+                } else {
+                    anyhow::anyhow!(
+                        "Invalid DEX name '{}' (case-insensitive). Supported DEXes for chain '{}': {}",
+                        dex,
+                        chain.name,
+                        supported_dexes.join(", ")
+                    )
+                }
+            })?;
+
+            let postgres_connect_options = get_postgres_connect_options(
+                database.host,
+                database.port,
+                database.username,
+                database.password,
+                database.database,
+            );
+            // Get RPC HTTP URL from CLI argument or environment variable
+            let rpc_http_url = rpc_url
+                .or_else(|| std::env::var("RPC_HTTP_URL").ok())
+                .unwrap_or_default();
+
+            log::info!("Using RPC HTTP URL: '{}'", rpc_http_url);
+
+            if rpc_http_url.is_empty() {
+                log::warn!(
+                    "No RPC HTTP URL provided via --rpc-url or RPC_HTTP_URL environment variable - some operations may fail"
+                );
+            }
+
+            let config = BlockchainDataClientConfig::new(
+                chain_arc.clone(),
+                vec![dex_type],
+                rpc_http_url,
+                None,
+                None,
+                true,
+                None,
+                None,
+                Some(postgres_connect_options),
+            );
+            let mut data_client = BlockchainDataClientCore::new(config, None);
+            data_client.initialize_cache_database().await;
+
+            data_client.cache.initialize_chain().await;
+            data_client
+                .register_dex_exchange(dex_type)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to register DEX exchange: {}", e))?;
+            // We want to have full pool sync, so from 0 to last.
+            data_client
+                .sync_exchange_pools(&dex_type, 0, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to sync pools: {}", e))?;
         }
     }
     Ok(())

--- a/crates/cli/src/opt.rs
+++ b/crates/cli/src/opt.rs
@@ -104,4 +104,19 @@ pub enum BlockchainCommand {
         #[clap(flatten)]
         database: DatabaseConfig,
     },
+    /// Syncs exchange pools for a specific DEX.
+    SyncPools {
+        /// The blockchain chain name (case-insensitive). Examples: ethereum, arbitrum, base, polygon, bsc
+        #[arg(long)]
+        chain: String,
+        /// The DEX name (case-insensitive). Examples: UniswapV3, uniswapv3, SushiSwapV2, PancakeSwapV3
+        #[arg(long)]
+        dex: String,
+        /// RPC HTTP URL for blockchain calls (optional, falls back to RPC_HTTP_URL env var)
+        #[arg(long)]
+        rpc_url: Option<String>,
+        /// Database configuration options
+        #[clap(flatten)]
+        database: DatabaseConfig,
+    },
 }

--- a/schema/sql/functions.sql
+++ b/schema/sql/functions.sql
@@ -112,6 +112,87 @@ BEGIN
 END
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
+CREATE OR REPLACE FUNCTION create_token_partition(blockchain_id INTEGER)
+    RETURNS TEXT AS $$
+DECLARE
+    blockchain_name TEXT;
+    partition_name TEXT;
+BEGIN
+    -- Get the blockchain name from the chain table
+    SELECT lower(name) INTO blockchain_name FROM chain where chain.chain_id = blockchain_id;
+    -- Check if blockchain was found
+    IF blockchain_name IS NULL THEN
+        RETURN 'Chain ID ' || blockchain_id || ' not found';
+    END IF;
+
+    partition_name := 'token_' || blockchain_name;
+
+    -- Check if partition already exists
+    IF EXISTS(
+        SELECT 1 FROM pg_class c
+                          JOIN pg_namespace ON pg_namespace.oid = c.relnamespace
+        WHERE c."relkind" = 'r' AND c."relname" = partition_name
+    ) THEN
+        RETURN 'Partition ' || partition_name || ' already exists';
+    END IF;
+
+    -- Create the partition
+    BEGIN
+        EXECUTE format('CREATE TABLE %I PARTITION OF token FOR VALUES IN (%s)', partition_name, blockchain_id);
+        RETURN 'Created partition ' || partition_name;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN 'Failed to create partition ' || partition_name || ': ' || SQLERRM;
+    END;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION delete_token_partition(blockchain_id INTEGER, force_delete BOOLEAN DEFAULT FALSE)
+    RETURNS TEXT AS $$
+DECLARE
+    blockchain_name TEXT;
+    partition_name TEXT;
+    data_count BIGINT;
+BEGIN
+    -- Get the blockchain name from the chain table
+    SELECT lower(name) INTO blockchain_name FROM chain where chain.chain_id = blockchain_id;
+
+    -- Check if a blockchain was found
+    IF blockchain_name IS NULL THEN
+        RETURN 'Chain ID ' || blockchain_id || ' not found';
+    END IF;
+
+    partition_name := 'token_' || blockchain_name;
+
+    -- Check if partition exists
+    IF NOT EXISTS(
+        SELECT 1 FROM pg_class c
+                          JOIN pg_namespace ON pg_namespace.oid = c.relnamespace
+        WHERE c."relkind" = 'r' AND c."relname" = partition_name
+    ) THEN
+        RETURN 'Partition ' || partition_name || ' does not exist';
+    END IF;
+
+    -- Check if partition has data
+    EXECUTE format('SELECT COUNT(*) FROM %I', partition_name) INTO data_count;
+
+    IF data_count > 0 AND NOT force_delete THEN
+        RETURN format('Partition %s contains %s tokens. Use force=true to delete anyway', partition_name, data_count);
+    END IF;
+
+    -- Actually delete the partition and all data
+    BEGIN
+        -- WARNING: CASCADE will also delete all dependent token data from other tables
+        -- This permanently removes ALL tokens and related data for this chain
+        EXECUTE format('DROP TABLE %I CASCADE', partition_name);
+        RETURN format('Successfully dropped partition %s (contained %s tokens)', partition_name, data_count);
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN 'Failed to drop partition ' || partition_name || ': ' || SQLERRM;
+    END;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 CREATE OR REPLACE FUNCTION get_last_continuous_block(blockchain_id INTEGER)
   RETURNS BIGINT AS $$
   DECLARE

--- a/schema/sql/tables.sql
+++ b/schema/sql/tables.sql
@@ -325,13 +325,17 @@ CREATE TABLE IF NOT EXISTS "token"(
     symbol TEXT,
     name TEXT,
     decimals INTEGER,
+    error TEXT,
     PRIMARY KEY (chain_id, address)
-);
+) PARTITION BY LIST (chain_id);
+CREATE TABLE IF NOT EXISTS "token_default" PARTITION OF "token" DEFAULT;
+
 CREATE TABLE IF NOT EXISTS "dex" (
     chain_id INTEGER NOT NULL REFERENCES chain(chain_id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     factory_address TEXT UNIQUE,
     creation_block BIGINT NOT NULL,
+    last_full_sync_pools_block_number BIGINT,
     PRIMARY KEY (chain_id, name)
 );
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Introduced table partitioning on `chain_id` for the `token` table with dedicated PL/pgSQL functions to create and drop partitions
- Improve DEX pool sync process with checkpoint saving and caching properly all the related pools and tokens
- Implement pool batching insertion in the Postgres cache database
- Separate invalid from valid tokens, persist the error message
- Added new CLI command `sync-pools` with proper parameters, enabling usage like `nautilus blockchain sync-pools --chain arbitrum  --dex uniswapv3`

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
