### PR TITLE
Rename start params to start_ns

### DIFF
--- a/nautilus_trader/adapters/databento/data.py
+++ b/nautilus_trader/adapters/databento/data.py
@@ -474,7 +474,7 @@ class DatabentoDataClient(LiveMarketDataClient):
     async def _subscribe_instrument(self, command: SubscribeInstrument) -> None:
         try:
             dataset: Dataset = self._loader.get_dataset_for_venue(command.instrument_id.venue)
-            start: int | None = command.params.get("start")
+            start: int | None = command.params.get("start_ns")
 
             live_client = self._get_live_client(dataset)
             live_client.subscribe(
@@ -652,7 +652,7 @@ class DatabentoDataClient(LiveMarketDataClient):
             ]:
                 schema = DatabentoSchema.MBP_1.value
 
-            start: int | None = command.params.get("start")
+            start: int | None = command.params.get("start_ns")
             dataset: Dataset = self._loader.get_dataset_for_venue(command.instrument_id.venue)
             live_client = self._get_live_client(dataset)
             live_client.subscribe(
@@ -686,7 +686,7 @@ class DatabentoDataClient(LiveMarketDataClient):
             ]:
                 schema = DatabentoSchema.TRADES.value
 
-            start: int | None = command.params.get("start")
+            start: int | None = command.params.get("start_ns")
             dataset: Dataset = self._loader.get_dataset_for_venue(command.instrument_id.venue)
             live_client = self._get_live_client(dataset)
             live_client.subscribe(
@@ -710,7 +710,7 @@ class DatabentoDataClient(LiveMarketDataClient):
                 self._log.error(f"Cannot subscribe: {e}")
                 return
 
-            start: int | None = command.params.get("start")
+            start: int | None = command.params.get("start_ns")
             live_client = self._get_live_client(dataset)
             live_client.subscribe(
                 schema=schema.value,
@@ -1011,7 +1011,10 @@ class DatabentoDataClient(LiveMarketDataClient):
             end = available_end
 
         # NOTE: instruments are "published" every day at midnight
-        start = request.start or end - pd.Timedelta(days=1)
+        start = request.start
+
+        if start == end:
+            end += pd.Timedelta(1, "ns")
 
         if request.limit > 0:
             self._log.warning(
@@ -1066,7 +1069,10 @@ class DatabentoDataClient(LiveMarketDataClient):
             end = available_end
 
         # NOTE: instruments are "published" every day at midnight
-        start = request.start or end - pd.Timedelta(days=1)
+        start = request.start
+
+        if start == end:
+            end += pd.Timedelta(1, "ns")
 
         if request.limit > 0:
             self._log.warning(
@@ -1105,7 +1111,10 @@ class DatabentoDataClient(LiveMarketDataClient):
             end = available_end
 
         # NOTE: instruments are "published" every day at midnight
-        start = request.start or end - pd.Timedelta(days=1)
+        start = request.start
+
+        if start == end:
+            end += pd.Timedelta(1, "ns")
 
         if request.limit > 0:
             self._log.warning(

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -441,7 +441,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         """
         name = str(bar_type)
         now = self._clock.timestamp_ns()
-        start = params.get("start")
+        start = params.get("start_ns")
 
         if start is not None:
             # start_time = pd.Timestamp(start)

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -75,7 +75,7 @@ cdef class BacktestEngine:
 
     cpdef void _handle_data_command(self, DataCommand command)
     cdef void _handle_subscribe(self, SubscribeData command)
-    cpdef void _update_subscription_data(self, str subscription_name, object duration_seconds)
+    cpdef void _update_subscription_data(self, str subscription_name, object duration_seconds, int iteration_index, bint point_data)
     cpdef void _handle_data_response(self, DataResponse response)
     cpdef void _handle_unsubscribe(self, UnsubscribeData command)
 

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -133,6 +133,7 @@ cdef class BacktestEngine:
     def __init__(self, config: BacktestEngineConfig | None = None) -> None:
         if config is None:
             config = BacktestEngineConfig()
+
         Condition.type(config, BacktestEngineConfig, "config")
 
         self._config: BacktestEngineConfig  = config
@@ -814,11 +815,12 @@ cdef class BacktestEngine:
         self._log.debug(f"Subscribing to {subscription_name}, {command.params.get('durations_seconds')=}")
 
         self._data_requests[subscription_name] = request
-        self._last_subscription_ts[subscription_name] = self._last_ns - 1
+        self._last_subscription_ts[subscription_name] = self._last_ns
         cdef bint append_data = request.params.get("append_data", True)
-        self._data_iterator.init_data(subscription_name, self._subscription_generator(subscription_name), append_data)
+        cdef bint point_data = request.params.get("point_data", False)
+        self._data_iterator.init_data(subscription_name, self._subscription_generator(subscription_name, point_data), append_data)
 
-    def _subscription_generator(self, str subscription_name):
+    def _subscription_generator(self, str subscription_name, bint point_data):
         iteration_index = 0
         durations_seconds = self._data_requests[subscription_name].params.get("durations_seconds", [None])
         durations_ns = [duration_seconds * 1e9 if duration_seconds else None for duration_seconds in durations_seconds]
@@ -829,15 +831,10 @@ cdef class BacktestEngine:
 
             # Possibility to use durations of various lengths to take into account weekends or market breaks
             for duration_ns in durations_ns:
-                self._update_subscription_data(subscription_name, duration_ns)
+                self._update_subscription_data(subscription_name, duration_ns, iteration_index, point_data)
 
                 if self._response_data:
                     break
-
-            if iteration_index == 0:
-                # First iteration for [a, a + duration], then ]a + duration, a + 2 * duration]
-                durations_ns = [duration_ns - 1 if duration_ns else None
-                                for duration_ns in durations_ns]
 
             iteration_index += 1
 
@@ -846,21 +843,37 @@ cdef class BacktestEngine:
             else:
                 break  # No more data, end generator
 
-    cpdef void _update_subscription_data(self, str subscription_name, object duration_ns):
+    cpdef void _update_subscription_data(self, str subscription_name, object duration_ns, int iteration_index, bint point_data):
         if subscription_name == "backtest_data" or subscription_name not in self._data_requests:
             return
 
-        cdef uint64_t start_time = self._last_subscription_ts[subscription_name] + 1 # to avoid duplicate data
+        # First iteration for [a, a + duration], then ]a + duration, a + 2 * duration]
+        # When point_data we do a query for [start_time, start_time] only
+
+        cdef uint64_t offset = 1 if iteration_index > 0 and not point_data else 0
+        cdef uint64_t start_time = self._last_subscription_ts[subscription_name] + offset
 
         if start_time > self._end_ns:
             return
 
-        cdef uint64_t end_time = min(start_time + duration_ns, self._end_ns) if duration_ns else self._end_ns
+        cdef uint64_t end_time
+        if duration_ns:
+            end_time = min(start_time + duration_ns - offset, self._end_ns)
+        else:
+            end_time = self._end_ns
+
         self._last_subscription_ts[subscription_name] = end_time
 
+        if point_data:
+            end_time = start_time
+
         cdef RequestData request = self._data_requests[subscription_name]
+        cdef RequestData new_request = request.with_dates(
+            unix_nanos_to_dt(start_time),
+            unix_nanos_to_dt(end_time),
+            self._last_ns
+        )
         self._log.debug(f"Renewing {request.data_type.type.__name__} data from {unix_nanos_to_dt(start_time)} to {unix_nanos_to_dt(end_time)}, {duration_ns=}")
-        cdef RequestData new_request = request.with_dates(unix_nanos_to_dt(start_time), unix_nanos_to_dt(end_time), self._last_ns)
         self._kernel._msgbus.request(endpoint="DataEngine.request", request=new_request)
 
     cpdef void _handle_data_response(self, DataResponse response):

--- a/tests/acceptance_tests/test_backtest.py
+++ b/tests/acceptance_tests/test_backtest.py
@@ -1245,7 +1245,10 @@ class OptionStrategy(Strategy):
             self.config.option_id,
             params={"durations_seconds": (pd.Timedelta(minutes=2).seconds,)},
         )
-        self.subscribe_quote_ticks(self.config.option_id2)
+        self.subscribe_quote_ticks(
+            self.config.option_id2,
+            params={"point_data": True, "durations_seconds": (pd.Timedelta(minutes=1).seconds,)},
+        )
         self.subscribe_bars(self.bar_type)
 
         # Request and subscribe to spread instrument


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Rename start params to start_ns used for databento and IB start time when subscribing to live data
- Add update_interval_seconds params for SpreadQuoteAggregator
- Add point_data params for on the fly download of data in order to download single points of data instead of ranges of data.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
