### PR TITLE
Improve security for Credential struct

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,15 +1,14 @@
+# Global flags that work across all platforms
 [target.'cfg(all())']
 rustflags = [
     # https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
     # Disable this lint as we explicitly drop even when `Drop` is not implemented
     "-Aclippy::drop_non_drop",
-    # Size optimization flags
-    "-C", "link-arg=-Wl,--gc-sections",
-    "-C", "link-arg=-Wl,--as-needed",
     "-C", "relocation-model=pic",
     "-C", "embed-bitcode=no",
 ]
 
+# macOS-specific configuration
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",
@@ -22,6 +21,7 @@ rustflags = [
     "-C", "link-arg=dynamic_lookup",
 ]
 
+# Linux-specific configuration with size optimization
 [target.'cfg(target_os = "linux")']
 rustflags = [
     "-C", "link-arg=-Wl,--gc-sections",
@@ -30,6 +30,7 @@ rustflags = [
     "-C", "relocation-model=pic",
 ]
 
+# Windows-specific configuration
 [target.x86_64-pc-windows-msvc]
 rustflags = [
     "-C", "target-feature=+crt-static",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,15 @@
-# Global flags that work across all platforms
 [target.'cfg(all())']
 rustflags = [
     # https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
     # Disable this lint as we explicitly drop even when `Drop` is not implemented
     "-Aclippy::drop_non_drop",
+    # Size optimization flags
+    "-C", "link-arg=-Wl,--gc-sections",
+    "-C", "link-arg=-Wl,--as-needed",
     "-C", "relocation-model=pic",
     "-C", "embed-bitcode=no",
 ]
 
-# macOS-specific configuration
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",
@@ -21,7 +22,6 @@ rustflags = [
     "-C", "link-arg=dynamic_lookup",
 ]
 
-# Linux-specific configuration with size optimization
 [target.'cfg(target_os = "linux")']
 rustflags = [
     "-C", "link-arg=-Wl,--gc-sections",
@@ -30,7 +30,6 @@ rustflags = [
     "-C", "relocation-model=pic",
 ]
 
-# Windows-specific configuration
 [target.x86_64-pc-windows-msvc]
 rustflags = [
     "-C", "target-feature=+crt-static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4454,6 +4454,7 @@ dependencies = [
  "url",
  "ustr",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4545,6 +4546,7 @@ dependencies = [
  "tracing-test",
  "ustr",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4932,6 +4934,7 @@ dependencies = [
  "tracing-test",
  "url",
  "ustr",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ urlencoding = "2.1.3"
 ustr = { version = "1.1.0", features = ["serde"] }
 uuid = { version = "1.18.0", features = ["v4", "serde"] }
 webpki-roots = "1.0.2"
+zeroize = { version = "1.8.1", features = ["alloc", "zeroize_derive"] }
 
 # dev-dependencies
 axum = { version = "0.8.4", default-features = false, features = ["tokio", "http1"] }

--- a/crates/adapters/bitmex/Cargo.toml
+++ b/crates/adapters/bitmex/Cargo.toml
@@ -77,6 +77,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }  # Needed for example binaries
 ustr = { workspace = true }
 uuid = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }

--- a/crates/adapters/bitmex/src/common/credential.rs
+++ b/crates/adapters/bitmex/src/common/credential.rs
@@ -15,30 +15,43 @@
 
 use aws_lc_rs::hmac;
 use ustr::Ustr;
+use zeroize::ZeroizeOnDrop;
 
 /// BitMEX API credentials for signing requests.
 ///
 /// Uses HMAC SHA256 for request signing as per BitMEX API specifications.
-#[derive(Debug, Clone)]
+/// Secrets are automatically zeroized on drop for security.
+#[derive(Clone, ZeroizeOnDrop)]
 pub struct Credential {
+    #[zeroize(skip)]
     pub api_key: Ustr,
-    api_secret: Vec<u8>,
+    api_secret: Box<[u8]>,
+}
+impl core::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Credential")
+            .field("api_key", &self.api_key)
+            .field("api_secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl Credential {
     /// Creates a new [`Credential`] instance.
     #[must_use]
     pub fn new(api_key: String, api_secret: String) -> Self {
+        let boxed: Box<[u8]> = api_secret.into_bytes().into_boxed_slice();
         Self {
             api_key: api_key.into(),
-            api_secret: api_secret.into_bytes(),
+            api_secret: boxed,
         }
     }
 
     /// Signs a request message according to the BitMEX authentication scheme.
     pub fn sign(&self, verb: &str, endpoint: &str, expires: i64, data: &str) -> String {
         let sign_message = format!("{verb}{endpoint}{expires}{data}");
-        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret);
+        // Access the boxed slice directly
+        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret[..]);
         let signature = hmac::sign(&key, sign_message.as_bytes());
         hex::encode(signature.as_ref())
     }
@@ -94,6 +107,20 @@ mod tests {
         assert_eq!(
             signature,
             "1749cd2ccae4aa49048ae09f0b95110cee706e0944e6a14ad0b3a8cb45bd336b"
+        );
+    }
+
+    #[rstest]
+    fn test_debug_redacts_secret() {
+        let credential = Credential::new(API_KEY.to_string(), API_SECRET.to_string());
+        let dbg_out = format!("{:?}", credential);
+        assert!(dbg_out.contains("api_secret: \"<redacted>\""));
+        // Should not contain obvious fragments of the secret or its byte dump.
+        assert!(!dbg_out.contains("chNOO"));
+        let secret_bytes_dbg = format!("{:?}", API_SECRET.as_bytes());
+        assert!(
+            !dbg_out.contains(&secret_bytes_dbg),
+            "Debug output must not contain raw secret bytes"
         );
     }
 }

--- a/crates/adapters/bitmex/src/common/credential.rs
+++ b/crates/adapters/bitmex/src/common/credential.rs
@@ -115,7 +115,6 @@ mod tests {
         let credential = Credential::new(API_KEY.to_string(), API_SECRET.to_string());
         let dbg_out = format!("{:?}", credential);
         assert!(dbg_out.contains("api_secret: \"<redacted>\""));
-        // Should not contain obvious fragments of the secret or its byte dump.
         assert!(!dbg_out.contains("chNOO"));
         let secret_bytes_dbg = format!("{:?}", API_SECRET.as_bytes());
         assert!(

--- a/crates/adapters/coinbase_intx/Cargo.toml
+++ b/crates/adapters/coinbase_intx/Cargo.toml
@@ -69,6 +69,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }  # Needed for example binaries
 ustr = { workspace = true }
 uuid = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }

--- a/crates/adapters/coinbase_intx/src/common/credential.rs
+++ b/crates/adapters/coinbase_intx/src/common/credential.rs
@@ -16,15 +16,29 @@
 use aws_lc_rs::hmac;
 use base64::prelude::*;
 use ustr::Ustr;
+use zeroize::ZeroizeOnDrop;
 
 /// Coinbase International API credentials for signing requests.
 ///
 /// Uses HMAC SHA256 for request signing as per API specifications.
-#[derive(Debug, Clone)]
+/// Secrets are automatically zeroized on drop for security.
+#[derive(Clone, ZeroizeOnDrop)]
 pub struct Credential {
+    #[zeroize(skip)]
     pub api_key: Ustr,
+    #[zeroize(skip)]
     pub api_passphrase: Ustr,
-    api_secret: Vec<u8>,
+    api_secret: Box<[u8]>,
+}
+
+impl core::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Credential")
+            .field("api_key", &self.api_key)
+            .field("api_passphrase", &self.api_passphrase)
+            .field("api_secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl Credential {
@@ -42,7 +56,7 @@ impl Credential {
         Self {
             api_key: api_key.into(),
             api_passphrase: api_passphrase.into(),
-            api_secret: decoded_secret,
+            api_secret: decoded_secret.into_boxed_slice(),
         }
     }
 
@@ -61,7 +75,7 @@ impl Credential {
         let message = format!("{timestamp}{method}{request_path}{body}");
         tracing::trace!("Signing message: {message}");
 
-        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret);
+        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret[..]);
         let tag = hmac::sign(&key, message.as_bytes());
         BASE64_STANDARD.encode(tag.as_ref())
     }
@@ -75,7 +89,7 @@ impl Credential {
         let message = format!("{timestamp}{}CBINTLMD{}", self.api_key, self.api_passphrase);
         tracing::trace!("Signing message: {message}");
 
-        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret);
+        let key = hmac::Key::new(hmac::HMAC_SHA256, &self.api_secret[..]);
         let tag = hmac::sign(&key, message.as_bytes());
         BASE64_STANDARD.encode(tag.as_ref())
     }
@@ -102,5 +116,22 @@ mod tests {
         let signature = credential.sign(timestamp, "GET", "/api/v1/fee-rate-tiers", "");
 
         assert_eq!(signature, "h/9tnYzD/nsEbH1sV7dkB5uJ3Vygr4TjmOOxJNQB8ts=");
+    }
+
+    #[rstest]
+    fn test_debug_redacts_secret() {
+        let credential = Credential::new(
+            API_KEY.to_string(),
+            API_SECRET.to_string(),
+            API_PASSPHRASE.to_string(),
+        );
+        let dbg_out = format!("{:?}", credential);
+        assert!(dbg_out.contains("api_secret: \"<redacted>\""));
+        assert!(!dbg_out.contains("dGVz")); // base64 fragment
+        let secret_bytes_dbg = format!("{:?}", BASE64_STANDARD.decode(API_SECRET).unwrap());
+        assert!(
+            !dbg_out.contains(&secret_bytes_dbg),
+            "Debug output must not contain raw secret bytes"
+        );
     }
 }

--- a/crates/adapters/okx/Cargo.toml
+++ b/crates/adapters/okx/Cargo.toml
@@ -71,6 +71,7 @@ tokio-tungstenite = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }  # Needed for example binaries
 ustr = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }


### PR DESCRIPTION


Harden BitMEX credential handling and improve ergonomics.

* Store `api_secret` as `Box<[u8]>` and derive `ZeroizeOnDrop` (skipping `api_key`) so secrets are wiped from memory on drop.
* Implement a custom `Debug` that redacts the secret and add `Clone` for `Credential`.
* `sign()` behavior and public constructor remain unchanged; no breaking API changes.
* Adds `zeroize` (with `alloc`/`zeroize_derive`) and a unit test asserting debug redaction.
