### PR TITLE
Improve event parsing and integrate Arbitrum Camelotv3 new pools signature

### DIFF
--- a/crates/adapters/blockchain/src/cache/database.rs
+++ b/crates/adapters/blockchain/src/cache/database.rs
@@ -386,8 +386,8 @@ impl BlockchainCacheDatabase {
         .bind(pool.token0.address.to_string())
         .bind(pool.token1.chain.chain_id as i32)
         .bind(pool.token1.address.to_string())
-        .bind(pool.fee as i32)
-        .bind(pool.tick_spacing as i32)
+        .bind(pool.fee.map(|fee| fee as i32))
+        .bind(pool.tick_spacing.map(|tick_spacing| tick_spacing as i32))
         .execute(&self.pool)
         .await
         .map(|_| ())
@@ -412,8 +412,8 @@ impl BlockchainCacheDatabase {
         let mut token0_addresses: Vec<String> = Vec::with_capacity(pools.len());
         let mut token1_chains: Vec<i32> = Vec::with_capacity(pools.len());
         let mut token1_addresses: Vec<String> = Vec::with_capacity(pools.len());
-        let mut fees: Vec<i32> = Vec::with_capacity(pools.len());
-        let mut tick_spacings: Vec<i32> = Vec::with_capacity(pools.len());
+        let mut fees: Vec<Option<i32>> = Vec::with_capacity(pools.len());
+        let mut tick_spacings: Vec<Option<i32>> = Vec::with_capacity(pools.len());
         let mut chain_ids: Vec<i32> = Vec::with_capacity(pools.len());
 
         // Fill vectors from pools
@@ -426,8 +426,11 @@ impl BlockchainCacheDatabase {
             token0_addresses.push(pool.token0.address.to_string());
             token1_chains.push(pool.token1.chain.chain_id as i32);
             token1_addresses.push(pool.token1.address.to_string());
-            fees.push(pool.fee as i32);
-            tick_spacings.push(pool.tick_spacing as i32);
+            fees.push(pool.fee.map_or(None, |fee| Some(fee as i32)));
+            tick_spacings.push(
+                pool.tick_spacing
+                    .map_or(None, |tick_spacing| Some(tick_spacing as i32)),
+            );
         }
 
         // Execute batch insert with UNNEST

--- a/crates/adapters/blockchain/src/cache/mod.rs
+++ b/crates/adapters/blockchain/src/cache/mod.rs
@@ -253,8 +253,10 @@ impl BlockchainCache {
                     pool_row.creation_block as u64,
                     token0.clone(),
                     token1.clone(),
-                    pool_row.fee as u32,
-                    pool_row.tick_spacing as u32,
+                    pool_row.fee.map(|fee| fee as u32),
+                    pool_row
+                        .tick_spacing
+                        .map(|tick_spacing| tick_spacing as u32),
                     UnixNanos::default(), // TODO use default for now
                 );
 

--- a/crates/adapters/blockchain/src/cache/rows.rs
+++ b/crates/adapters/blockchain/src/cache/rows.rs
@@ -56,8 +56,8 @@ pub struct PoolRow {
     pub token0_address: Address,
     pub token1_chain: i32,
     pub token1_address: Address,
-    pub fee: i32,
-    pub tick_spacing: i32,
+    pub fee: Option<i32>,
+    pub tick_spacing: Option<i32>,
 }
 
 impl<'r> FromRow<'r, PgRow> for PoolRow {
@@ -71,8 +71,8 @@ impl<'r> FromRow<'r, PgRow> for PoolRow {
         let token1_chain = row.try_get::<i32, _>("token1_chain")?;
         let token1_address =
             validate_address(row.try_get::<String, _>("token1_address")?.as_str()).unwrap();
-        let fee = row.try_get::<i32, _>("fee")?;
-        let tick_spacing = row.try_get::<i32, _>("tick_spacing")?;
+        let fee = row.try_get::<Option<i32>, _>("fee")?;
+        let tick_spacing = row.try_get::<Option<i32>, _>("tick_spacing")?;
 
         Ok(Self {
             address,

--- a/crates/adapters/blockchain/src/events/pool_created.rs
+++ b/crates/adapters/blockchain/src/events/pool_created.rs
@@ -26,12 +26,12 @@ pub struct PoolCreatedEvent {
     pub token0: Address,
     /// The blockchain address of the second token in the pair.
     pub token1: Address,
-    /// The fee tier of the pool, specified in basis points (e.g., 500 = 0.05%, 3000 = 0.3%).
-    pub fee: u32,
-    /// The tick spacing parameter that controls the granularity of price ranges.
-    pub tick_spacing: u32,
     /// The blockchain address of the created liquidity pool contract.
     pub pool_address: Address,
+    /// The fee tier of the pool, specified in basis points (e.g., 500 = 0.05%, 3000 = 0.3%).
+    pub fee: Option<u32>,
+    /// The tick spacing parameter that controls the granularity of price ranges.
+    pub tick_spacing: Option<u32>,
 }
 
 impl PoolCreatedEvent {
@@ -41,17 +41,17 @@ impl PoolCreatedEvent {
         block_number: u64,
         token0: Address,
         token1: Address,
-        fee: u32,
-        tick_spacing: u32,
         pool_address: Address,
+        fee: Option<u32>,
+        tick_spacing: Option<u32>,
     ) -> Self {
         Self {
             block_number,
             token0,
             token1,
+            pool_address,
             fee,
             tick_spacing,
-            pool_address,
         }
     }
 }

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/camelot_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/camelot_v3.rs
@@ -15,25 +15,63 @@
 
 use std::sync::LazyLock;
 
+use alloy::primitives::Address;
+use hypersync_client::simple_types::Log;
 use nautilus_model::defi::{
     chain::chains,
     dex::{AmmType, Dex, DexType},
 };
 
-use crate::exchanges::extended::DexExtended;
+use crate::{
+    events::pool_created::PoolCreatedEvent,
+    exchanges::extended::DexExtended,
+    hypersync::helpers::{
+        extract_address_from_topic, extract_block_number, validate_event_signature_hash,
+    },
+};
+
+const POOL_CREATED_EVENT_SIGNATURE_HASH: &str =
+    "91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db";
 
 /// Camelot V3 DEX on Arbitrum.
 pub static CAMELOT_V3: LazyLock<DexExtended> = LazyLock::new(|| {
-    let dex = Dex::new(
+    let mut dex = DexExtended::new(Dex::new(
         chains::ARBITRUM.clone(),
         DexType::CamelotV3,
         "0x1a3c9b1d2f0529d97f2afc5136cc23e58f1fd35b",
         102286676,
         AmmType::CLAMM,
+        "Pool(address,address,address)",
         "",
         "",
         "",
-        "",
-    );
-    DexExtended::new(dex)
+    ));
+    dex.set_pool_created_event_parsing(parse_camelot_v3_pool_created_event);
+    dex
 });
+
+fn parse_camelot_v3_pool_created_event(log: Log) -> anyhow::Result<PoolCreatedEvent> {
+    validate_event_signature_hash("Pool", POOL_CREATED_EVENT_SIGNATURE_HASH, &log)?;
+
+    let block_number = extract_block_number(&log)?;
+    let token = extract_address_from_topic(&log, 1, "token0")?;
+    let token1 = extract_address_from_topic(&log, 2, "token1")?;
+
+    if let Some(data) = log.data {
+        let data_bytes = data.as_ref();
+
+        // Extract pool address (only 32 bytes)
+        let pool_address = Address::from_slice(&data_bytes[12..32]);
+
+        Ok(PoolCreatedEvent::new(
+            block_number.into(),
+            token,
+            token1,
+            pool_address,
+            None,
+            None,
+        ))
+    } else {
+        anyhow::bail!("Missing data in the pool created event log")
+    }
+}

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
@@ -36,8 +36,8 @@ use crate::{
     events::{burn::BurnEvent, mint::MintEvent, pool_created::PoolCreatedEvent, swap::SwapEvent},
     exchanges::extended::DexExtended,
     hypersync::helpers::{
-        extract_block_number, extract_log_index, extract_transaction_hash,
-        extract_transaction_index, validate_event_signature_hash,
+        extract_address_from_topic, extract_block_number, extract_log_index,
+        extract_transaction_hash, extract_transaction_index, validate_event_signature_hash,
     },
     math::convert_i256_to_f64,
 };
@@ -84,22 +84,10 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
 pub fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreatedEvent> {
     validate_event_signature_hash("PoolCreatedEvent", POOL_CREATED_EVENT_SIGNATURE_HASH, &log)?;
 
-    let block_number = log
-        .block_number
-        .expect("Block number should be set in logs");
+    let block_number = extract_block_number(&log)?;
 
-    let token = if let Some(topic) = log.topics.get(1).and_then(|t| t.as_ref()) {
-        // Address is stored in the last 20 bytes of the 32-byte topic
-        Address::from_slice(&topic.as_ref()[12..32])
-    } else {
-        anyhow::bail!("Missing token0 address in topic1 when parsing pool created event");
-    };
-
-    let token1 = if let Some(topic) = log.topics.get(2).and_then(|t| t.as_ref()) {
-        Address::from_slice(&topic.as_ref()[12..32])
-    } else {
-        anyhow::bail!("Missing token1 address in topic2 when parsing pool created event");
-    };
+    let token = extract_address_from_topic(&log, 1, "token0")?;
+    let token1 = extract_address_from_topic(&log, 2, "token1")?;
 
     let fee = if let Some(topic) = log.topics.get(3).and_then(|t| t.as_ref()) {
         U256::from_be_slice(topic.as_ref()).as_limbs()[0] as u32
@@ -157,15 +145,8 @@ sol! {
 pub fn parse_swap_event(dex: SharedDex, log: Log) -> anyhow::Result<SwapEvent> {
     validate_event_signature_hash("SwapEvent", SWAP_EVENT_SIGNATURE_HASH, &log)?;
 
-    let sender = match log.topics.get(1).and_then(|t| t.as_ref()) {
-        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing sender address in topic1 when parsing swap event"),
-    };
-
-    let recipient = match log.topics.get(2).and_then(|t| t.as_ref()) {
-        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing recipient address in topic2 when parsing swap event"),
-    };
+    let sender = extract_address_from_topic(&log, 1, "sender")?;
+    let recipient = extract_address_from_topic(&log, 2, "recipient")?;
 
     if let Some(data) = &log.data {
         let data_bytes = data.as_ref();
@@ -326,10 +307,7 @@ sol! {
 pub fn parse_mint_event(dex: SharedDex, log: Log) -> anyhow::Result<MintEvent> {
     validate_event_signature_hash("Mint", MINT_EVENT_SIGNATURE_HASH, &log)?;
 
-    let owner = match log.topics.get(1).and_then(|t| t.as_ref()) {
-        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing owner address in topic1 when parsing mint event"),
-    };
+    let owner = extract_address_from_topic(&log, 1, "owner")?;
 
     // Extract int24 tickLower from topic2 (stored as a 32-byte padded value)
     let tick_lower = match log.topics.get(2).and_then(|t| t.as_ref()) {
@@ -412,10 +390,7 @@ sol! {
 pub fn parse_burn_event(dex: SharedDex, log: Log) -> anyhow::Result<BurnEvent> {
     validate_event_signature_hash("Burn", BURN_EVENT_SIGNATURE_HASH, &log)?;
 
-    let owner = match log.topics.get(1).and_then(|t| t.as_ref()) {
-        Some(topic) => Address::from_slice(&topic.as_ref()[12..32]),
-        None => anyhow::bail!("Missing owner address in topic1 when parsing burn event"),
-    };
+    let owner = extract_address_from_topic(&log, 1, "owner")?;
 
     // Extract int24 tickLower from topic2 (stored as a 32-byte padded value)
     let tick_lower = match log.topics.get(2).and_then(|t| t.as_ref()) {

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
@@ -111,9 +111,9 @@ pub fn parse_pool_created_event(log: Log) -> anyhow::Result<PoolCreatedEvent> {
             block_number.into(),
             token,
             token1,
-            fee,
-            tick_spacing,
             pool_address,
+            Some(fee),
+            Some(tick_spacing),
         ))
     } else {
         Err(anyhow::anyhow!("Missing data in pool created event log"))

--- a/crates/adapters/blockchain/src/hypersync/helpers.rs
+++ b/crates/adapters/blockchain/src/hypersync/helpers.rs
@@ -13,6 +13,31 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use alloy::primitives::Address;
+
+/// Extracts an address from a specific topic in a log entry
+///
+/// # Errors
+///
+/// Returns an error if the topic at the specified index is not present in the log.
+pub fn extract_address_from_topic(
+    log: &hypersync_client::simple_types::Log,
+    topic_index: usize,
+    description: &str,
+) -> anyhow::Result<Address> {
+    match log.topics.get(topic_index).and_then(|t| t.as_ref()) {
+        Some(topic) => {
+            // Address is stored in the last 20 bytes of the 32-byte topic
+            Ok(Address::from_slice(&topic.as_ref()[12..32]))
+        }
+        None => anyhow::bail!(
+            "Missing {} address in topic{} when parsing event",
+            description,
+            topic_index
+        ),
+    }
+}
+
 /// Extracts the transaction hash from a log entry
 ///
 /// # Errors
@@ -392,6 +417,71 @@ mod tests {
         assert_eq!(
             result.unwrap_err().to_string(),
             "Missing block number in the log"
+        );
+    }
+
+    #[rstest]
+    fn test_extract_address_from_topic_success(swap_log_1: Log) {
+        // Extract sender address from topic1
+        let result = extract_address_from_topic(&swap_log_1, 1, "sender");
+        assert!(result.is_ok());
+        let address = result.unwrap();
+        assert_eq!(
+            address.to_string().to_lowercase(),
+            "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad"
+        );
+    }
+
+    #[rstest]
+    fn test_extract_address_from_topic_success_log2(swap_log_2: Log) {
+        // Extract sender address from topic1
+        let result = extract_address_from_topic(&swap_log_2, 1, "sender");
+        assert!(result.is_ok());
+        let address = result.unwrap();
+        assert_eq!(
+            address.to_string().to_lowercase(),
+            "0x66a9893cc07d91d95644aedd05d03f95e1dba8af"
+        );
+
+        // Extract recipient address from topic2
+        let result = extract_address_from_topic(&swap_log_2, 2, "recipient");
+        assert!(result.is_ok());
+        let address = result.unwrap();
+        assert_eq!(
+            address.to_string().to_lowercase(),
+            "0xf90321d0ecad58ab2b0c8c79db8aaeeefa023578"
+        );
+    }
+
+    #[rstest]
+    fn test_extract_address_from_topic_missing_topic(swap_log_1: Log) {
+        // Try to extract from topic index 5 (doesn't exist)
+        let result = extract_address_from_topic(&swap_log_1, 5, "nonexistent");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Missing nonexistent address in topic5 when parsing event"
+        );
+    }
+
+    #[rstest]
+    fn test_extract_address_from_topic_none_topic(swap_log_1: Log) {
+        // Try to extract from topic index 3 (which is null in swap_log_1)
+        let result = extract_address_from_topic(&swap_log_1, 3, "null_topic");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Missing null_topic address in topic3 when parsing event"
+        );
+    }
+
+    #[rstest]
+    fn test_extract_address_from_topic_no_topics(log_without_topics: Log) {
+        let result = extract_address_from_topic(&log_without_topics, 1, "sender");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Missing sender address in topic1 when parsing event"
         );
     }
 }

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -1571,8 +1571,8 @@ fn test_subscribe_and_receive_pools(
         1000000,
         token0,
         token1,
-        3000,
-        60,
+        Some(3000),
+        Some(60),
         UnixNanos::from(1),
     );
 

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -781,8 +781,8 @@ fn test_pool() -> Pool {
         12345678,
         token0,
         token1,
-        3000,
-        60,
+        Some(3000),
+        Some(60),
         UnixNanos::from(1_234_567_890_000_000_000u64),
     )
 }
@@ -821,7 +821,7 @@ fn test_pool_mut_when_some(mut cache: Cache, test_pool: Pool) {
 
     assert!(result.is_some());
     if let Some(pool_ref) = result {
-        assert_eq!(pool_ref.fee, 3000);
+        assert_eq!(pool_ref.fee.unwrap(), 3000);
     }
 }
 

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -2240,8 +2240,8 @@ mod tests {
             12345,
             token0,
             token1,
-            500,
-            10,
+            Some(500),
+            Some(10),
             UnixNanos::default(),
         ));
 

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -1869,8 +1869,8 @@ fn test_process_pool_swap(data_engine: Rc<RefCell<DataEngine>>, data_client: Dat
         0u64,
         token0,
         token1,
-        500u32,
-        10u32,
+        Some(500u32),
+        Some(10u32),
         UnixNanos::from(1),
     );
 

--- a/crates/model/src/defi/amm.rs
+++ b/crates/model/src/defi/amm.rs
@@ -65,9 +65,9 @@ pub struct Pool {
     /// • `500`   →  0.05 %  (5 bps)
     /// • `3_000` →  0.30 %  (30 bps)
     /// • `10_000`→  1.00 %
-    pub fee: u32,
+    pub fee: Option<u32>,
     /// The minimum tick spacing for positions in concentrated liquidity AMMs.
-    pub tick_spacing: u32,
+    pub tick_spacing: Option<u32>,
     /// UNIX timestamp (nanoseconds) when the instance was created.
     pub ts_init: UnixNanos,
 }
@@ -86,8 +86,8 @@ impl Pool {
         creation_block: u64,
         token0: Token,
         token1: Token,
-        fee: u32,
-        tick_spacing: u32,
+        fee: Option<u32>,
+        tick_spacing: Option<u32>,
         ts_init: UnixNanos,
     ) -> Self {
         let instrument_id = Self::create_instrument_id(chain.name, &dex, &address);
@@ -118,7 +118,11 @@ impl Display for Pool {
         write!(
             f,
             "Pool(instrument_id={}, dex={}, fee={}, address={})",
-            self.instrument_id, self.dex.name, self.fee, self.address
+            self.instrument_id,
+            self.dex.name,
+            self.fee
+                .map_or("None".to_string(), |fee| format!("fee={}, ", fee)),
+            self.address
         )
     }
 }
@@ -189,8 +193,8 @@ mod tests {
             12345678,
             token0,
             token1,
-            3000,
-            60,
+            Some(3000),
+            Some(60),
             ts_init,
         );
 
@@ -200,8 +204,8 @@ mod tests {
         assert_eq!(pool.creation_block, 12345678);
         assert_eq!(pool.token0.symbol, "WETH");
         assert_eq!(pool.token1.symbol, "USDT");
-        assert_eq!(pool.fee, 3000);
-        assert_eq!(pool.tick_spacing, 60);
+        assert_eq!(pool.fee.unwrap(), 3000);
+        assert_eq!(pool.tick_spacing.unwrap(), 60);
         assert_eq!(pool.ts_init, ts_init);
         assert_eq!(
             pool.instrument_id.symbol.as_str(),
@@ -256,8 +260,8 @@ mod tests {
             0,
             token0,
             token1,
-            3000,
-            60,
+            Some(3000),
+            Some(60),
             UnixNanos::default(),
         );
 

--- a/crates/model/src/python/defi/types.rs
+++ b/crates/model/src/python/defi/types.rs
@@ -306,8 +306,8 @@ impl Pool {
         creation_block: u64,
         token0: Token,
         token1: Token,
-        fee: u32,
-        tick_spacing: u32,
+        fee: Option<u32>,
+        tick_spacing: Option<u32>,
         ts_init: u64,
     ) -> PyResult<Self> {
         let address = address.parse().map_err(to_pyvalue_err)?;
@@ -368,13 +368,13 @@ impl Pool {
 
     #[getter]
     #[pyo3(name = "fee")]
-    fn py_fee(&self) -> u32 {
+    fn py_fee(&self) -> Option<u32> {
         self.fee
     }
 
     #[getter]
     #[pyo3(name = "tick_spacing")]
-    fn py_tick_spacing(&self) -> u32 {
+    fn py_tick_spacing(&self) -> Option<u32> {
         self.tick_spacing
     }
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

 - Refactor DEX event parsing to use reusable `extract_address_from_topic` helper function, eliminating code duplication across UniswapV3 parsers and providing proper test coverage for address extraction from event topics.
 - Add Camelot V3 DEX support on Arbitrum with pool created event parsing and validation logic, enabling integration with this concentrated liquidity AMM.
 - Make pool `fee` and `tick_spacing` fields optional across all modules to support DEXs where these values are either unavailable in initial pool creation events or are dynamic rather than static parameters.



## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic
