### PR TITLE
Fix missing funding_rates for Cache Debug impl

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -118,6 +118,7 @@ impl Debug for Cache {
             .field("mark_xrates", &self.mark_xrates)
             .field("mark_prices", &self.mark_prices)
             .field("index_prices", &self.index_prices)
+            .field("funding_rates", &self.funding_rates)
             .field("bars", &self.bars)
             .field("greeks", &self.greeks)
             .field("yield_curves", &self.yield_curves)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR adds the missing `funding_rates` field to the Debug implementation for Cache.

## Related Issues/PRs

Closes #2893 

## Type of change

- [ ] Bug fix (non-breaking)
