### PR TITLE
Add Arbitrum FluidDEX pool parsing

### DIFF
--- a/crates/adapters/blockchain/src/data/core.rs
+++ b/crates/adapters/blockchain/src/data/core.rs
@@ -770,10 +770,6 @@ impl BlockchainDataClientCore {
         pool_buffer: &mut Vec<PoolCreatedEvent>,
         dex: SharedDex,
     ) -> anyhow::Result<()> {
-        if token_buffer.is_empty() {
-            return Ok(());
-        }
-
         let batch_addresses: Vec<Address> = token_buffer.drain().collect();
         let token_infos = self.tokens.batch_fetch_token_info(&batch_addresses).await?;
 

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/fluid.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/fluid.rs
@@ -15,25 +15,54 @@
 
 use std::sync::LazyLock;
 
+use hypersync_client::simple_types::Log;
 use nautilus_model::defi::{
     chain::chains,
     dex::{AmmType, Dex, DexType},
 };
 
-use crate::exchanges::extended::DexExtended;
+use crate::{
+    events::pool_created::PoolCreatedEvent,
+    exchanges::extended::DexExtended,
+    hypersync::helpers::{
+        extract_address_from_topic, extract_block_number, validate_event_signature_hash,
+    },
+};
+
+const POOL_CREATED_EVENT_SIGNATURE_HASH: &str =
+    "3fecd5f7aca6136a20a999e7d11ff5dcea4bd675cb125f93ccd7d53f98ec57e4";
 
 /// Fluid DEX on Arbitrum.
 pub static FLUID_DEX: LazyLock<DexExtended> = LazyLock::new(|| {
-    let dex = Dex::new(
+    let mut dex = DexExtended::new(Dex::new(
         chains::ARBITRUM.clone(),
         DexType::FluidDEX,
         "0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085",
         269528370,
         AmmType::CLAMM,
+        "DexT1Deployed(address,uint256,address,address)",
         "",
         "",
         "",
-        "",
-    );
-    DexExtended::new(dex)
+    ));
+    dex.set_pool_created_event_parsing(parse_fluid_dex_pool_created_event);
+    dex
 });
+
+fn parse_fluid_dex_pool_created_event(log: Log) -> anyhow::Result<PoolCreatedEvent> {
+    validate_event_signature_hash("DexT1Deployed", POOL_CREATED_EVENT_SIGNATURE_HASH, &log)?;
+
+    let block_number = extract_block_number(&log)?;
+    let pool_address = extract_address_from_topic(&log, 1, "pool")?;
+    let supply_token_address = extract_address_from_topic(&log, 2, "supply_token")?;
+    let borrow_token_address = extract_address_from_topic(&log, 3, "borrow_token")?;
+
+    Ok(PoolCreatedEvent::new(
+        block_number,
+        supply_token_address,
+        borrow_token_address,
+        pool_address,
+        None,
+        None,
+    ))
+}


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- fixed the empty token flush buffer bug (when you have tokens in the cache, buffer is empty and we wont flush the pools with this check)
- Added pool parsing function and event signature for the FluidDex on Arbitrum

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


