### PR TITLE
Fix Bybit balance precision errors for high-value tokens

### DIFF
--- a/nautilus_trader/adapters/bybit/schemas/account/balance.py
+++ b/nautilus_trader/adapters/bybit/schemas/account/balance.py
@@ -51,14 +51,14 @@ class BybitCoinBalance(msgspec.Struct):
 
     def parse_to_account_balance(self) -> AccountBalance:
         currency = Currency.from_str(self.coin)
-        total = Decimal(self.walletBalance)
-        locked = Decimal(self.locked)  # TODO: Locked only valid for Spot
-        free = total - locked
+        total_money = Money(Decimal(self.walletBalance), currency)
+        locked_money = Money(Decimal(self.locked), currency)  # TODO: Locked only valid for Spot
+        free_money = Money.from_raw(total_money.raw - locked_money.raw, currency)
 
         return AccountBalance(
-            total=Money(total, currency),
-            locked=Money(locked, currency),
-            free=Money(free, currency),
+            total=total_money,
+            locked=locked_money,
+            free=free_money,
         )
 
     def parse_to_margin_balance(self) -> MarginBalance:


### PR DESCRIPTION
When parsing balances from Bybit, tokens with very high values (like MOG with trillions in circulation) can have floating point precision issues where the API returns values that don't exactly add up (total - locked != free).
This fix uses raw integer arithmetic to calculate the free balance, ensuring the AccountBalance invariant is always satisfied.