### PR TITLE
Add OCA setting to IB order groups

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -64,6 +64,7 @@ from nautilus_trader.execution.reports import OrderStatusReport
 from nautilus_trader.execution.reports import PositionStatusReport
 from nautilus_trader.live.execution_client import LiveExecutionClient
 from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import ContingencyType
 from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OrderSide
@@ -560,6 +561,61 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         ib_order.account = self.account_id.get_id()
         ib_order.clearingAccount = self.account_id.get_id()
 
+        # Handle OCA (One-Cancels-All) settings - check order tags first, then contingency types
+        oca_group_from_tags = None
+        oca_type_from_tags = None
+
+        # Check if OCA settings are specified in order tags
+        if order.tags:
+            for tag in order.tags:
+                if tag.startswith("IBOrderTags:"):
+                    try:
+                        tags_dict = IBOrderTags.parse(tag.replace("IBOrderTags:", "")).dict()
+
+                        if tags_dict.get("ocaGroup"):
+                            oca_group_from_tags = tags_dict["ocaGroup"]
+
+                        # Get ocaType from tags, including 0 as a valid value
+                        if "ocaType" in tags_dict:
+                            oca_type_from_tags = tags_dict["ocaType"]
+                    except Exception as e:
+                        self._log.warning(f"Failed to parse IBOrderTags: {e}")
+
+        # Apply OCA settings from tags if specified
+        if oca_group_from_tags:
+            ib_order.ocaGroup = oca_group_from_tags
+
+            # If ocaType is explicitly set in tags (even to 0), use it; otherwise default to 1
+            if oca_type_from_tags is not None and oca_type_from_tags > 0:
+                ib_order.ocaType = oca_type_from_tags
+            else:
+                ib_order.ocaType = 1  # Default to type 1 for safety
+
+            self._log.info(
+                f"Setting OCA from tags - Group: {oca_group_from_tags}, Type: {ib_order.ocaType}",
+            )
+        # Otherwise, handle OCO/OUO contingency types automatically for bracket orders
+        elif (
+            order.contingency_type in (ContingencyType.OCO, ContingencyType.OUO)
+            and order.linked_order_ids
+            and order.parent_order_id
+        ):  # Child orders in bracket
+
+            # Generate unique OCA group identifier using order list ID
+            if order.order_list_id:
+                oca_group = f"OCA_{order.order_list_id.value}"
+            else:
+                # Fallback to using parent order ID for consistency
+                oca_group = f"OCA_{order.parent_order_id.value}"
+
+            ib_order.ocaGroup = oca_group
+            # Use OCA type 1 (cancel all remaining orders with block) for safety
+            ib_order.ocaType = 1
+
+            self._log.info(
+                f"Setting {order.contingency_type.name} order {order.client_order_id} to OCA group: {oca_group}",
+            )
+
         if order.tags:
             return self._attach_order_tags(ib_order, order)
         else:
@@ -577,6 +633,9 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             if tag == "conditions":
                 for condition in tags[tag]:
                     pass  # TODO:
+            elif tag in ("ocaGroup", "ocaType"):
+                # Skip OCA tags as they're handled in the main transformation logic
+                continue
             else:
                 setattr(ib_order, tag, tags[tag])
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
@@ -15,10 +15,20 @@
 
 import pytest
 
+from nautilus_trader.adapters.interactive_brokers.common import IBOrderTags
+from nautilus_trader.core.uuid import UUID4
+from nautilus_trader.model.enums import ContingencyType
+from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.enums import TriggerType
+from nautilus_trader.model.identifiers import ClientOrderId
+from nautilus_trader.model.identifiers import OrderListId
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.orders.limit import LimitOrder
+from nautilus_trader.model.orders.stop_market import StopMarketOrder
 from nautilus_trader.test_kit.stubs.data import TestInstrumentProvider
 from nautilus_trader.test_kit.stubs.execution import TestExecStubs
+from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 
 
 _AAPL = TestInstrumentProvider.equity("AAPL", "NASDAQ")
@@ -89,3 +99,297 @@ async def test_transform_order_to_ib_order_limit(
     ), f"{expected_order_type=}, but got {ib_order.orderType=}"
     assert ib_order.tif == expected_tif, f"{expected_tif=}, but got {ib_order.tif=}"
 # fmt: on
+
+
+@pytest.mark.asyncio
+async def test_transform_order_to_ib_order_oco_orders(exec_client):
+    """
+    Test that OCO orders are properly transformed with OCA group settings.
+    """
+    # Arrange
+    instrument = _EURUSD
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    order_list_id = OrderListId("OL-123")
+    parent_order_id = ClientOrderId("PARENT-1")
+    tp_order_id = ClientOrderId("TP-1")
+    sl_order_id = ClientOrderId("SL-1")
+
+    # Create take-profit order with OCO contingency
+    tp_order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=tp_order_id,
+        order_side=OrderSide.SELL,
+        quantity=instrument.make_qty(100),
+        price=instrument.make_price(1.1000),
+        time_in_force=TimeInForce.GTC,
+        expire_time_ns=0,
+        init_id=UUID4(),
+        ts_init=0,
+        post_only=False,
+        reduce_only=True,
+        display_qty=None,
+        contingency_type=ContingencyType.OCO,
+        order_list_id=order_list_id,
+        linked_order_ids=[sl_order_id],
+        parent_order_id=parent_order_id,
+        tags=None,
+    )
+
+    # Create stop-loss order with OCO contingency
+    sl_order = StopMarketOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=sl_order_id,
+        order_side=OrderSide.SELL,
+        quantity=instrument.make_qty(100),
+        trigger_price=instrument.make_price(1.0500),
+        trigger_type=TriggerType.DEFAULT,
+        time_in_force=TimeInForce.GTC,
+        init_id=UUID4(),
+        ts_init=0,
+        reduce_only=True,
+        contingency_type=ContingencyType.OCO,
+        order_list_id=order_list_id,
+        linked_order_ids=[tp_order_id],
+        parent_order_id=parent_order_id,
+        tags=None,
+    )
+
+    # Act
+    ib_tp_order = exec_client._transform_order_to_ib_order(tp_order)
+    ib_sl_order = exec_client._transform_order_to_ib_order(sl_order)
+
+    # Assert
+    expected_oca_group = f"OCA_{order_list_id.value}"
+
+    # Both orders should have the same OCA group
+    assert ib_tp_order.ocaGroup == expected_oca_group
+    assert ib_sl_order.ocaGroup == expected_oca_group
+
+    # Both orders should have OCA type 1 (cancel all with block)
+    assert ib_tp_order.ocaType == 1
+    assert ib_sl_order.ocaType == 1
+
+    # Parent order IDs should be set correctly
+    assert ib_tp_order.parentId == parent_order_id.value
+    assert ib_sl_order.parentId == parent_order_id.value
+
+
+@pytest.mark.asyncio
+async def test_transform_order_to_ib_order_ouo_orders(exec_client):
+    """
+    Test that OUO orders are properly transformed with OCA group settings.
+    """
+    # Arrange
+    instrument = _EURUSD
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    order_list_id = OrderListId("OL-456")
+    parent_order_id = ClientOrderId("PARENT-2")
+    tp_order_id = ClientOrderId("TP-2")
+    sl_order_id = ClientOrderId("SL-2")
+
+    # Create take-profit order with OUO contingency (default for bracket orders)
+    tp_order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=tp_order_id,
+        order_side=OrderSide.SELL,
+        quantity=instrument.make_qty(100),
+        price=instrument.make_price(1.1000),
+        time_in_force=TimeInForce.GTC,
+        expire_time_ns=0,
+        init_id=UUID4(),
+        ts_init=0,
+        post_only=False,
+        reduce_only=True,
+        display_qty=None,
+        contingency_type=ContingencyType.OUO,
+        order_list_id=order_list_id,
+        linked_order_ids=[sl_order_id],
+        parent_order_id=parent_order_id,
+        tags=None,
+    )
+
+    # Create stop-loss order with OUO contingency
+    sl_order = StopMarketOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=sl_order_id,
+        order_side=OrderSide.SELL,
+        quantity=instrument.make_qty(100),
+        trigger_price=instrument.make_price(1.0500),
+        trigger_type=TriggerType.DEFAULT,
+        time_in_force=TimeInForce.GTC,
+        init_id=UUID4(),
+        ts_init=0,
+        reduce_only=True,
+        contingency_type=ContingencyType.OUO,
+        order_list_id=order_list_id,
+        linked_order_ids=[tp_order_id],
+        parent_order_id=parent_order_id,
+        tags=None,
+    )
+
+    # Act
+    ib_tp_order = exec_client._transform_order_to_ib_order(tp_order)
+    ib_sl_order = exec_client._transform_order_to_ib_order(sl_order)
+
+    # Assert
+    expected_oca_group = f"OCA_{order_list_id.value}"
+
+    # Both orders should have the same OCA group
+    assert ib_tp_order.ocaGroup == expected_oca_group
+    assert ib_sl_order.ocaGroup == expected_oca_group
+
+    # Both orders should have OCA type 1 (cancel all with block)
+    assert ib_tp_order.ocaType == 1
+    assert ib_sl_order.ocaType == 1
+
+
+@pytest.mark.asyncio
+async def test_transform_order_with_custom_oca_tags(exec_client):
+    """
+    Test that custom OCA settings from IBOrderTags are properly applied.
+    """
+    # Arrange
+    instrument = _EURUSD
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    # Create custom OCA tags
+    custom_oca_tags = IBOrderTags(
+        ocaGroup="CUSTOM_OCA_GROUP_123",
+        ocaType=2,  # REDUCE_WITH_BLOCK
+    )
+
+    # Create order with custom OCA tags
+    order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=ClientOrderId("CUSTOM-OCA-1"),
+        order_side=OrderSide.BUY,
+        quantity=instrument.make_qty(100),
+        price=instrument.make_price(1.0500),
+        time_in_force=TimeInForce.GTC,
+        expire_time_ns=0,
+        init_id=UUID4(),
+        ts_init=0,
+        post_only=False,
+        reduce_only=False,
+        display_qty=None,
+        contingency_type=ContingencyType.NO_CONTINGENCY,  # No automatic contingency
+        order_list_id=None,
+        linked_order_ids=None,
+        parent_order_id=None,
+        tags=[custom_oca_tags.value],  # Apply custom OCA tags
+    )
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(order)
+
+    # Assert
+    assert ib_order.ocaGroup == "CUSTOM_OCA_GROUP_123"
+    assert ib_order.ocaType == 2
+
+
+@pytest.mark.asyncio
+async def test_transform_order_with_partial_oca_tags(exec_client):
+    """
+    Test that partial OCA settings from IBOrderTags work with defaults.
+    """
+    # Arrange
+    instrument = _EURUSD
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    # Create OCA tags with only group specified (type should default to 1)
+    partial_oca_tags = IBOrderTags(
+        ocaGroup="PARTIAL_OCA_GROUP",
+        ocaType=0,  # Explicitly set to 0 to test default behavior
+    )
+
+    # Create order with partial OCA tags
+    order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=ClientOrderId("PARTIAL-OCA-1"),
+        order_side=OrderSide.SELL,
+        quantity=instrument.make_qty(50),
+        price=instrument.make_price(1.1500),
+        time_in_force=TimeInForce.GTC,
+        expire_time_ns=0,
+        init_id=UUID4(),
+        ts_init=0,
+        post_only=False,
+        reduce_only=False,
+        display_qty=None,
+        contingency_type=ContingencyType.NO_CONTINGENCY,
+        order_list_id=None,
+        linked_order_ids=None,
+        parent_order_id=None,
+        tags=[partial_oca_tags.value],
+    )
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(order)
+
+    # Assert
+    assert ib_order.ocaGroup == "PARTIAL_OCA_GROUP"
+    assert ib_order.ocaType == 1  # Should default to 1
+
+
+@pytest.mark.asyncio
+async def test_custom_oca_tags_override_contingency_type(exec_client):
+    """
+    Test that custom OCA tags override automatic contingency type detection.
+    """
+    # Arrange
+    instrument = _EURUSD
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    order_list_id = OrderListId("OL-OVERRIDE")
+    parent_order_id = ClientOrderId("PARENT-OVERRIDE")
+    linked_order_id = ClientOrderId("LINKED-OVERRIDE")
+
+    # Create custom OCA tags that should override automatic detection
+    override_oca_tags = IBOrderTags(
+        ocaGroup="OVERRIDE_GROUP",
+        ocaType=3,  # REDUCE_NON_BLOCK
+    )
+
+    # Create order with OCO contingency AND custom tags (tags should win)
+    order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=ClientOrderId("OVERRIDE-1"),
+        order_side=OrderSide.BUY,
+        quantity=instrument.make_qty(200),
+        price=instrument.make_price(1.0800),
+        time_in_force=TimeInForce.GTC,
+        expire_time_ns=0,
+        init_id=UUID4(),
+        ts_init=0,
+        post_only=False,
+        reduce_only=True,
+        display_qty=None,
+        contingency_type=ContingencyType.OCO,  # This should be overridden
+        order_list_id=order_list_id,
+        linked_order_ids=[linked_order_id],
+        parent_order_id=parent_order_id,
+        tags=[override_oca_tags.value],  # This should take precedence
+    )
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(order)
+
+    # Assert - custom tags should override automatic contingency detection
+    assert ib_order.ocaGroup == "OVERRIDE_GROUP"  # Not "OCA_OL-OVERRIDE"
+    assert ib_order.ocaType == 3  # Not 1


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix issue mentioned here 
https://github.com/nautechsystems/nautilus_trader/issues/2890#issuecomment-3225475956

Related
https://www.interactivebrokers.com/campus/trading-lessons/using-the-one-cancels-another-oca-order-attribute-in-ibkrs-ibusopt/

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


