### PR TITLE
Improve Polymarket instrument provider bulk loading

### DIFF
--- a/nautilus_trader/adapters/polymarket/providers.py
+++ b/nautilus_trader/adapters/polymarket/providers.py
@@ -81,7 +81,11 @@ class PolymarketInstrumentProvider(InstrumentProvider):
                 "POLYMARKET",
             )
 
-        await self._load_markets_seq(instrument_ids, filters)
+        if len(instrument_ids) > 200:
+            self._log.warning(f"Loading {len(instrument_ids)} instruments, using bulk load of all markets as a faster alternative")
+            await self._load_markets(instrument_ids, filters)
+        else:
+            await self._load_markets_seq(instrument_ids, filters)
 
     async def load_async(self, instrument_id: InstrumentId, filters: dict | None = None) -> None:
         PyCondition.not_none(instrument_id, "instrument_id")
@@ -154,13 +158,14 @@ class PolymarketInstrumentProvider(InstrumentProvider):
         filters_str = "..." if not filters else f" with filters {filters}..."
         self._log.info(f"Loading {instruments_str}{filters_str}")
 
-        condition_ids = [str(x.symbol) for x in instrument_ids]
+        condition_ids = [get_polymarket_condition_id(x) for x in instrument_ids]
 
         filter_is_active = filters.get("is_active", False)
 
+        markets_visited = 0
         next_cursor = filters.get("next_cursor", "MA==")
         while next_cursor != "LTE=":
-            self._log.info(f"Cursor = '{next_cursor}'")
+            self._log.info(f"Cursor = '{next_cursor}', markets visited = {markets_visited}")
             response: dict[str, Any] | str = await asyncio.to_thread(
                 self._client.get_markets,
                 next_cursor=next_cursor,
@@ -192,6 +197,7 @@ class PolymarketInstrumentProvider(InstrumentProvider):
                     self._log.error(f"Unable to parse market: {e}, {market_info}")
                     continue
             next_cursor = response["next_cursor"]
+            markets_visited += len(response["data"])
 
     def _load_instrument(
         self,

--- a/nautilus_trader/adapters/polymarket/providers.py
+++ b/nautilus_trader/adapters/polymarket/providers.py
@@ -83,7 +83,7 @@ class PolymarketInstrumentProvider(InstrumentProvider):
 
         if len(instrument_ids) > 200:
             self._log.warning(
-                f"Loading {len(instrument_ids)} instruments, using bulk load of all markets as a faster alternative"
+                f"Loading {len(instrument_ids)} instruments, using bulk load of all markets as a faster alternative",
             )
             await self._load_markets(instrument_ids, filters)
         else:

--- a/nautilus_trader/adapters/polymarket/providers.py
+++ b/nautilus_trader/adapters/polymarket/providers.py
@@ -82,7 +82,9 @@ class PolymarketInstrumentProvider(InstrumentProvider):
             )
 
         if len(instrument_ids) > 200:
-            self._log.warning(f"Loading {len(instrument_ids)} instruments, using bulk load of all markets as a faster alternative")
+            self._log.warning(
+                f"Loading {len(instrument_ids)} instruments, using bulk load of all markets as a faster alternative"
+            )
             await self._load_markets(instrument_ids, filters)
         else:
             await self._load_markets_seq(instrument_ids, filters)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Utilize bulk CLOB markets API when requested to load over 200 instruments (feel free to adjust), as sequential requests for each are no longer effective.

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [X] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested with 9000 instruments that were finally loaded using this path, which was impossible in the previous state. Note that iterating the entirety of CLOB markets still takes over 60 seconds, causing initialization warnings and general unease, but this step at least makes it possible to continue. 
