### PR TITLE
Fix Polymarket websocket 500 tokens per connection limitation

### DIFF
--- a/nautilus_trader/adapters/polymarket/data.py
+++ b/nautilus_trader/adapters/polymarket/data.py
@@ -217,7 +217,11 @@ class PolymarketDataClient(LiveMarketDataClient):
 
     async def _subscribe_asset_book(self, instrument_id):
         create_connect_task = False
-        if self._ws_client_pending_connection is None:
+        # Polymarket only supports 500 subscriptions per client
+        if (
+            self._ws_client_pending_connection is None
+            or len(self._ws_client_pending_connection.asset_subscriptions()) >= 500
+        ):
             self._ws_client_pending_connection = self._create_websocket_client()
             create_connect_task = True
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The polymarket adapter no longer works correctly if we exceed 500 order book deltas subscriptions. When that happens, no OrderBookDeltas messages are received anymore; this seems to be due to an undocumented WS API limitation of a maximum of 500 tokens per connection.

I've tried to address it by creating a new connection once we hit this limit, and for every 500 more thereafter.

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

My case was breaking when I exceeded 500 subscriptions, now it works with many more hundreds of them. However, I would still like to test whether the extra subscriptions are being received, although my preliminary findings seem to confirm that, as I see updates from markets I haven't seen before. Still, please verify that all the connections are registered correctly, if possible. 