### PR TITLE
Improve binary options parsing with no endDate

### DIFF
--- a/nautilus_trader/adapters/polymarket/common/parsing.py
+++ b/nautilus_trader/adapters/polymarket/common/parsing.py
@@ -48,7 +48,7 @@ def parse_order_side(order_side: PolymarketOrderSide) -> OrderSide:
             raise ValueError(f"invalid order side, was {order_side}")
 
 
-def parse_liquidity_side(liquidity_side: PolymarketLiquiditySide) -> OrderSide:
+def parse_liquidity_side(liquidity_side: PolymarketLiquiditySide) -> LiquiditySide:
     match liquidity_side:
         case PolymarketLiquiditySide.MAKER:
             return LiquiditySide.MAKER
@@ -59,7 +59,7 @@ def parse_liquidity_side(liquidity_side: PolymarketLiquiditySide) -> OrderSide:
             raise ValueError(f"invalid liquidity side, was {liquidity_side}")
 
 
-def parse_time_in_force(order_type: PolymarketOrderType) -> OrderSide:
+def parse_time_in_force(order_type: PolymarketOrderType) -> TimeInForce:
     match order_type:
         case PolymarketOrderType.GTC:
             return TimeInForce.GTC
@@ -103,7 +103,8 @@ def parse_instrument(
     if end_date_iso:
         expiration_ns = pd.Timestamp(end_date_iso).value
     else:
-        expiration_ns = 0
+        # end_date_iso can be missing in some conditions that are part of an event that has it
+        expiration_ns = (pd.Timestamp.now(tz="UTC") + pd.DateOffset(years=10)).value
 
     maker_fee = Decimal(str(market_info["maker_base_fee"]))
     taker_fee = Decimal(str(market_info["taker_base_fee"]))

--- a/nautilus_trader/adapters/polymarket/providers.py
+++ b/nautilus_trader/adapters/polymarket/providers.py
@@ -213,7 +213,7 @@ class PolymarketInstrumentProvider(InstrumentProvider):
             outcome=outcome,
             ts_init=self._clock.timestamp_ns(),
         )
-        if instrument.expiration_ns == 0:
-            self._log.warning(f"{instrument.id} expiration was `None`")
+        if market_info["end_date_iso"] is None:
+            self._log.warning(f"{instrument.id} expiration is missing, assuming it is still active")
         self.add(instrument)
         return instrument


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Negative risk events can legally contain binary options with no endDateIso as long as the event itself has a valid end date. For example, see https://[gamma-api.polymarket.com/markets?condition_ids=0x7c4e73cf119d7c61d2da474e6a66adcff499dbe9b3a008913bb84bfc600d7f17](https://gamma-api.polymarket.com/markets?condition_ids=0x7c4e73cf119d7c61d2da474e6a66adcff499dbe9b3a008913bb84bfc600d7f17) and compare it to https://[gamma-api.polymarket.com/markets?condition_ids=0x2abd463d4058a682d30f442ad7215caa8bc1e39bf7d0d3f695fe3f283774e9b3](https://gamma-api.polymarket.com/markets?condition_ids=0x2abd463d4058a682d30f442ad7215caa8bc1e39bf7d0d3f695fe3f283774e9b3) - both of them are part of Czech election events. In the current implementation, the entire first market is ignored and won't be loaded by Nautilus, however, it is normally tradeable here: https://polymarket.com/event/ano-of-vote-in-czech-election?tid=1756673454650

My change removes this limitation and artificially sets the end date to 10 years in the future - feel free to change this to max_date. 

I've also adjusted a few typings in this file that I felt off.

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

Tested that this change allows loading the said market that was completely ignored before.