### PR TITLE
Fix bars query for IBKR indices

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -1630,7 +1630,7 @@ class ParquetDataCatalog(BaseDataCatalog):
                 .replace(".", "_")
                 .replace("-", "_")
                 .replace(" ", "_")
-                .replace("^", "_")                
+                .replace("^", "_")
                 .lower()
             )
             safe_filename = _extract_sql_safe_filename(file)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

IBKR indices start with `^` so the Parquet data catalog was erroring out with invalid SQL table name.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic
