### PR TITLE
Refactor bar aggregators to use ts_init instead of ts_event

### DIFF
--- a/nautilus_trader/adapters/binance/data.py
+++ b/nautilus_trader/adapters/binance/data.py
@@ -578,7 +578,6 @@ class BinanceCommonDataClient(LiveMarketDataClient):
             ticks = await self._http_market.request_trade_ticks(
                 instrument_id=request.instrument_id,
                 limit=limit,
-                ts_init=self._clock.timestamp_ns(),
             )
         else:
             # Convert from timestamps to milliseconds
@@ -589,7 +588,6 @@ class BinanceCommonDataClient(LiveMarketDataClient):
                 limit=limit,
                 start_time=start_time_ms,
                 end_time=end_time_ms,
-                ts_init=self._clock.timestamp_ns(),
             )
 
         self._handle_trade_ticks(
@@ -645,7 +643,6 @@ class BinanceCommonDataClient(LiveMarketDataClient):
                 start_time=start_time_ms,
                 end_time=end_time_ms,
                 limit=request.limit if request.limit > 0 else None,
-                ts_init=self._clock.timestamp_ns(),
             )
 
             if request.bar_type.is_internally_aggregated():
@@ -743,7 +740,6 @@ class BinanceCommonDataClient(LiveMarketDataClient):
             interval=BinanceKlineInterval.MINUTE_1,
             start_time=start_time_ms,
             end_time=end_time_ms,
-            ts_init=self._clock.timestamp_ns(),
             limit=limit,
         )
 
@@ -880,7 +876,6 @@ class BinanceCommonDataClient(LiveMarketDataClient):
             instrument_id=instrument.id,
             start_time=start_time_ms,
             end_time=end_time_ms,
-            ts_init=self._clock.timestamp_ns(),
             limit=limit,
         )
 

--- a/nautilus_trader/adapters/binance/http/market.py
+++ b/nautilus_trader/adapters/binance/http/market.py
@@ -711,7 +711,6 @@ class BinanceMarketHttpAPI:
     async def request_trade_ticks(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
         limit: int | None = None,
     ) -> list[TradeTick]:
         """
@@ -721,7 +720,6 @@ class BinanceMarketHttpAPI:
         return [
             trade.parse_to_trade_tick(
                 instrument_id=instrument_id,
-                ts_init=ts_init,
             )
             for trade in trades
         ]
@@ -750,7 +748,6 @@ class BinanceMarketHttpAPI:
     async def request_agg_trade_ticks(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
         limit: int | None = 1000,
         start_time: int | None = None,
         end_time: int | None = None,
@@ -806,7 +803,6 @@ class BinanceMarketHttpAPI:
                 ticks.append(
                     trade.parse_to_trade_tick(
                         instrument_id=instrument_id,
-                        ts_init=ts_init,
                     ),
                 )
 
@@ -851,7 +847,6 @@ class BinanceMarketHttpAPI:
     async def request_historical_trade_ticks(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
         limit: int | None = None,
         from_id: int | None = None,
     ) -> list[TradeTick]:
@@ -866,7 +861,6 @@ class BinanceMarketHttpAPI:
         return [
             trade.parse_to_trade_tick(
                 instrument_id=instrument_id,
-                ts_init=ts_init,
             )
             for trade in historical_trades
         ]
@@ -895,7 +889,6 @@ class BinanceMarketHttpAPI:
     async def request_binance_bars(
         self,
         bar_type: BarType,
-        ts_init: int,
         interval: BinanceKlineInterval,
         limit: int | None = None,
         start_time: int | None = None,
@@ -914,9 +907,7 @@ class BinanceMarketHttpAPI:
                 start_time=start_time,
                 end_time=end_time,
             )
-            bars: list[BinanceBar] = [
-                kline.parse_to_binance_bar(bar_type, ts_init) for kline in klines
-            ]
+            bars: list[BinanceBar] = [kline.parse_to_binance_bar(bar_type) for kline in klines]
             all_bars.extend(bars)
 
             # Update the start_time to fetch the next set of bars

--- a/nautilus_trader/adapters/binance/spot/schemas/market.py
+++ b/nautilus_trader/adapters/binance/spot/schemas/market.py
@@ -202,16 +202,18 @@ class BinanceSpotTradeData(msgspec.Struct):
     def parse_to_trade_tick(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
+        ts_init: int | None = None,
     ) -> TradeTick:
+        ts_event = millis_to_nanos(self.T)
+
         return TradeTick(
             instrument_id=instrument_id,
             price=Price.from_str(self.p),
             size=Quantity.from_str(self.q),
             aggressor_side=AggressorSide.SELLER if self.m else AggressorSide.BUYER,
             trade_id=TradeId(str(self.t)),
-            ts_event=millis_to_nanos(self.T),
-            ts_init=ts_init,
+            ts_event=ts_event,
+            ts_init=(ts_init or ts_event),
         )
 
 

--- a/nautilus_trader/adapters/bybit/data.py
+++ b/nautilus_trader/adapters/bybit/data.py
@@ -595,7 +595,6 @@ class BybitDataClient(LiveMarketDataClient):
         trades = await self._http_market.request_bybit_trades(
             instrument_id=request.instrument_id,
             limit=limit,
-            ts_init=self._clock.timestamp_ns(),
         )
 
         # Filter trades to only include those within the requested time range
@@ -643,7 +642,6 @@ class BybitDataClient(LiveMarketDataClient):
             start=start_time_ms,
             end=end_time_ms,
             limit=request.limit if request.limit else None,
-            ts_init=self._clock.timestamp_ns(),
             timestamp_on_close=self._bars_timestamp_on_close,
         )
         # For historical data requests, all bars are complete (no partial bars)

--- a/nautilus_trader/adapters/bybit/http/market.py
+++ b/nautilus_trader/adapters/bybit/http/market.py
@@ -208,7 +208,6 @@ class BybitMarketHttpAPI:
     async def request_bybit_trades(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
         limit: int = 1000,
     ) -> list[Bar]:
         bybit_symbol = BybitSymbol(instrument_id.symbol.value)
@@ -217,14 +216,13 @@ class BybitMarketHttpAPI:
             product_type=bybit_symbol.product_type,
             limit=limit,
         )
-        trade_ticks: list[TradeTick] = [t.parse_to_trade(instrument_id, ts_init) for t in trades]
+        trade_ticks: list[TradeTick] = [t.parse_to_trade(instrument_id) for t in trades]
         return trade_ticks
 
     async def request_bybit_bars(
         self,
         bar_type: BarType,
         interval: BybitKlineInterval,
-        ts_init: int,
         timestamp_on_close: bool,
         limit: int | None = None,
         start: int | None = None,
@@ -256,7 +254,7 @@ class BybitMarketHttpAPI:
 
             klines.sort(key=lambda k: int(k.startTime))
             new_bars = [
-                kline.parse_to_bar(bar_type, ts_init, timestamp_on_close)
+                kline.parse_to_bar(bar_type, timestamp_on_close)
                 for kline in klines
                 if int(kline.startTime) not in seen_timestamps
             ]

--- a/nautilus_trader/adapters/bybit/schemas/market/kline.py
+++ b/nautilus_trader/adapters/bybit/schemas/market/kline.py
@@ -39,8 +39,8 @@ class BybitKline(msgspec.Struct, array_like=True):
     def parse_to_bar(
         self,
         bar_type: BarType,
-        ts_init: int,
         timestamp_on_close: bool,
+        ts_init: int | None = None,
     ) -> Bar:
         ts_event = millis_to_nanos(int(self.startTime))
 
@@ -56,7 +56,7 @@ class BybitKline(msgspec.Struct, array_like=True):
             close=Price.from_str(self.closePrice),
             volume=Quantity.from_str(self.volume),
             ts_event=ts_event,
-            ts_init=ts_init,
+            ts_init=(ts_init or ts_event),
         )
 
 

--- a/nautilus_trader/adapters/bybit/schemas/market/trades.py
+++ b/nautilus_trader/adapters/bybit/schemas/market/trades.py
@@ -44,16 +44,18 @@ class BybitTrade(msgspec.Struct):
     def parse_to_trade(
         self,
         instrument_id: InstrumentId,
-        ts_init: int,
+        ts_init: int | None = None,
     ) -> TradeTick:
+        ts_event = millis_to_nanos(int(self.time))
+
         return TradeTick(
             instrument_id=instrument_id,
             price=Price.from_str(self.price),
             size=Quantity.from_str(self.size),
             aggressor_side=parse_aggressor_side(self.side),
             trade_id=TradeId(self.execId),
-            ts_event=millis_to_nanos(int(self.time)),
-            ts_init=ts_init,
+            ts_event=ts_event,
+            ts_init=(ts_init or ts_event),
         )
 
 

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -17,17 +17,13 @@ from cpython.datetime cimport timedelta
 from libc.stdint cimport uint8_t
 from libc.stdint cimport uint64_t
 
-from nautilus_trader.cache.base cimport CacheFacade
 from nautilus_trader.common.component cimport Clock
-from nautilus_trader.common.component cimport Component
 from nautilus_trader.common.component cimport Logger
 from nautilus_trader.common.component cimport TimeEvent
 from nautilus_trader.model.data cimport Bar
 from nautilus_trader.model.data cimport BarType
 from nautilus_trader.model.data cimport QuoteTick
 from nautilus_trader.model.data cimport TradeTick
-from nautilus_trader.model.greeks cimport GreeksCalculator
-from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.objects cimport Price
 from nautilus_trader.model.objects cimport Quantity
 
@@ -55,7 +51,7 @@ cdef class BarBuilder:
     cdef Quantity volume
 
     cpdef void set_partial(self, Bar partial_bar)
-    cpdef void update(self, Price price, Quantity size, uint64_t ts_event)
+    cpdef void update(self, Price price, Quantity size, uint64_t ts_init)
     cpdef void update_bar(self, Bar bar, Quantity volume, uint64_t ts_init)
     cpdef void reset(self)
     cpdef Bar build_now(self)
@@ -78,7 +74,7 @@ cdef class BarAggregator:
     cpdef void handle_trade_tick(self, TradeTick tick)
     cpdef void handle_bar(self, Bar bar)
     cpdef void set_partial(self, Bar partial_bar)
-    cdef void _apply_update(self, Price price, Quantity size, uint64_t ts_event)
+    cdef void _apply_update(self, Price price, Quantity size, uint64_t ts_init)
     cdef void _apply_update_bar(self, Bar bar, Quantity volume, uint64_t ts_init)
     cdef void _build_now_and_send(self)
     cdef void _build_and_send(self, uint64_t ts_event, uint64_t ts_init)

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -198,7 +198,7 @@ class TestBarBuilder:
         )
 
         # Act
-        builder.update_bar(input_bar, input_bar.volume, input_bar.ts_event)
+        builder.update_bar(input_bar, input_bar.volume, input_bar.ts_init)
 
         # Assert
         assert builder.initialized
@@ -241,7 +241,7 @@ class TestBarBuilder:
             ts_event=1_000,
             ts_init=1_000,
         )
-        builder.update_bar(bar1, bar1.volume, bar1.ts_event)
+        builder.update_bar(bar1, bar1.volume, bar1.ts_init)
 
         bar2 = Bar(
             bar_type=bar_type,
@@ -255,7 +255,7 @@ class TestBarBuilder:
         )
 
         # Act
-        builder.update_bar(bar2, bar2.volume, bar2.ts_event)
+        builder.update_bar(bar2, bar2.volume, bar2.ts_init)
 
         # Assert
         assert builder.initialized


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Refactor bar aggregators to use ts_init instead of ts_event
- Modify binance and bybit adapters so the result of historical data requests uses ts_init=ts_event

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
