### PR TITLE
Add _send_position_status_report to base execution client

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1392,4 +1392,4 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             # Update tracking
             self._known_positions[contract_id] = new_quantity
         except Exception as e:
-            self._log.exception(f"Error handling position update: {e}")
+            self._log.error(f"Error handling position update: {e}")

--- a/nautilus_trader/execution/client.pxd
+++ b/nautilus_trader/execution/client.pxd
@@ -193,3 +193,4 @@ cdef class ExecutionClient(Component):
     cpdef void _send_mass_status_report(self, report)
     cpdef void _send_order_status_report(self, report)
     cpdef void _send_fill_report(self, report)
+    cpdef void _send_position_status_report(self, report)

--- a/nautilus_trader/execution/client.pyx
+++ b/nautilus_trader/execution/client.pyx
@@ -17,6 +17,7 @@ from nautilus_trader.common.config import NautilusConfig
 from nautilus_trader.execution.reports import ExecutionMassStatus
 from nautilus_trader.execution.reports import FillReport
 from nautilus_trader.execution.reports import OrderStatusReport
+from nautilus_trader.execution.reports import PositionStatusReport
 
 from libc.stdint cimport uint64_t
 
@@ -838,6 +839,12 @@ cdef class ExecutionClient(Component):
         )
 
     cpdef void _send_fill_report(self, report: FillReport):
+        self._msgbus.send(
+            endpoint="ExecEngine.reconcile_execution_report",
+            msg=report,
+        )
+
+    cpdef void _send_position_status_report(self, report: PositionStatusReport):
         self._msgbus.send(
             endpoint="ExecEngine.reconcile_execution_report",
             msg=report,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Add mising _send_position_status_report method so that a position update can happen when an option is physically exercised (there's not always an order fill from IB but there's always a position update).

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
