### PR TITLE
Add passthrough_bar_type to TimeBarAggregator

### DIFF
--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -113,6 +113,7 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef uint64_t _batch_open_ns
     cdef uint64_t _batch_next_close_ns
     cdef object _time_bars_origin_offset
+    cdef bint _passthrough_bar_type
 
     cdef readonly timedelta interval
     """The aggregators time interval.\n\n:returns: `timedelta`"""
@@ -121,10 +122,10 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef readonly uint64_t next_close_ns
     """The aggregators next closing time.\n\n:returns: `uint64_t`"""
 
+    cpdef void start(self)
     cpdef void stop(self)
     cdef timedelta _get_interval(self)
     cdef uint64_t _get_interval_ns(self)
-    cpdef void _set_build_timer(self)
     cdef void _batch_pre_update(self, uint64_t time_ns)
     cdef void _batch_post_update(self, uint64_t time_ns)
     cpdef void _build_bar(self, TimeEvent event)

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -730,6 +730,7 @@ cdef class TimeBarAggregator(BarAggregator):
         bint build_with_no_updates = True,
         object time_bars_origin_offset: pd.Timedelta | pd.DateOffset = None,
         int bar_build_delay = 0,
+        bint passthrough_bar_type: bool = False,
     ) -> None:
         super().__init__(
             instrument=instrument,
@@ -752,6 +753,7 @@ cdef class TimeBarAggregator(BarAggregator):
         self._build_with_no_updates = build_with_no_updates
         self._bar_build_delay = bar_build_delay
         self._time_bars_origin_offset = time_bars_origin_offset or 0
+        self._passthrough_bar_type = passthrough_bar_type
 
         if type(self._time_bars_origin_offset) is int:
             self._time_bars_origin_offset = pd.Timedelta(self._time_bars_origin_offset)
@@ -763,11 +765,8 @@ cdef class TimeBarAggregator(BarAggregator):
 
         self.interval = self._get_interval()
         self.interval_ns = self._get_interval_ns()
-        self._set_build_timer()
-        self.next_close_ns = self._clock.next_time_ns(self._timer_name)
-
-        cdef datetime now = self._clock.utc_now()
-        self._stored_open_ns = dt_to_unix_nanos(self.get_start_time(now))
+        self.next_close_ns = 0
+        self._stored_open_ns = 0
         self._stored_close_ns = 0
 
     def __str__(self):
@@ -875,11 +874,15 @@ cdef class TimeBarAggregator(BarAggregator):
                 f"Aggregation not time based, was {bar_aggregation_to_str(aggregation)}",
             )
 
-    cpdef void _set_build_timer(self):
+    cpdef void start(self):
         cdef int step = self.bar_type.spec.step
         self._timer_name = str(self.bar_type)
         cdef datetime now = self._clock.utc_now()
         cdef datetime start_time = self.get_start_time(now)
+
+        # Initialize stored open time based on current time
+        self._stored_open_ns = dt_to_unix_nanos(start_time)
+        self._stored_close_ns = 0
 
         # Consider near-boundary starts within a small tolerance as on-boundary
         cdef uint64_t now_ns = dt_to_unix_nanos(now)
@@ -906,6 +909,7 @@ cdef class TimeBarAggregator(BarAggregator):
                 stop_time=None,
                 callback=self._build_bar,
             )
+            self.next_close_ns = self._clock.next_time_ns(self._timer_name)
         else:
             # The monthly alert time is defined iteratively at each alert time as there is no regular interval
             alert_time = start_time + pd.DateOffset(months=step)
@@ -916,6 +920,7 @@ cdef class TimeBarAggregator(BarAggregator):
                 callback=self._build_bar,
                 override=True,
             )
+            self.next_close_ns = dt_to_unix_nanos(alert_time)
 
         self._log.debug(f"Started timer {self._timer_name}")
 
@@ -1029,6 +1034,22 @@ cdef class TimeBarAggregator(BarAggregator):
             self._batch_post_update(ts_event)
 
     cdef void _apply_update_bar(self, Bar bar, Quantity volume, uint64_t ts_init):
+        cdef Bar passthrough_bar
+
+        if self._passthrough_bar_type:
+            passthrough_bar = Bar(
+                bar_type=self.bar_type,
+                open=bar.open,
+                high=bar.high,
+                low=bar.low,
+                close=bar.close,
+                volume=bar.volume,
+                ts_event=bar.ts_event,
+                ts_init=bar.ts_init,
+            )
+            self._handler(passthrough_bar)
+            return
+
         if self._batch_next_close_ns != 0:
             self._batch_pre_update(ts_init)
 

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -2390,6 +2390,9 @@ cdef class DataEngine(Component):
         if aggregator is None:
             aggregator = self._create_bar_aggregator(instrument, command.bar_type, command.params)
 
+        if isinstance(aggregator, TimeBarAggregator):
+            aggregator.start()
+
         # Set if awaiting initial partial bar
         aggregator.set_await_partial(command.await_partial)
 
@@ -2457,6 +2460,14 @@ cdef class DataEngine(Component):
             if bar_type.is_composite() and bar_type.composite().is_internally_aggregated() and bar_build_delay == 0:
                 bar_build_delay = 15  # Default for composite bars when config is 0
 
+            passthrough_bar_type = False
+
+            if bar_type.is_composite():
+                standard_bar_type = bar_type.standard()
+                composite_bar_type = bar_type.composite()
+                passthrough_bar_type = (standard_bar_type.spec.step == composite_bar_type.spec.step
+                                        and standard_bar_type.spec.aggregation == composite_bar_type.spec.aggregation)
+
             aggregator = TimeBarAggregator(
                 instrument=instrument,
                 bar_type=bar_type,
@@ -2468,6 +2479,7 @@ cdef class DataEngine(Component):
                 build_with_no_updates=self._time_bars_build_with_no_updates,
                 time_bars_origin_offset=time_bars_origin_offset,
                 bar_build_delay=bar_build_delay,
+                passthrough_bar_type=passthrough_bar_type,
             )
         elif bar_type.spec.aggregation == BarAggregation.TICK:
             aggregator = TickBarAggregator(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Allows to pass through bars of the form "BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL" through the TimeBarAggregator with minimal processing
- Add extra step to start timer of time bar aggregator by calling start method

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
