### PR TITLE
Add log_components_only option to Logger

### DIFF
--- a/crates/common/src/ffi/logging.rs
+++ b/crates/common/src/ffi/logging.rs
@@ -97,6 +97,7 @@ pub unsafe extern "C" fn logging_init(
     is_colored: u8,
     is_bypassed: u8,
     print_config: u8,
+    log_components_only: u8,
     max_file_size: u64,
     max_backup_count: u32,
 ) -> LogGuard_API {
@@ -112,6 +113,7 @@ pub unsafe extern "C" fn logging_init(
         component_levels,
         u8_as_bool(is_colored),
         u8_as_bool(print_config),
+        u8_as_bool(log_components_only),
     );
 
     // Configure file rotation if max_file_size > 0

--- a/crates/common/src/python/logging.rs
+++ b/crates/common/src/python/logging.rs
@@ -101,7 +101,7 @@ pub fn py_init_tracing() -> PyResult<()> {
 #[pyfunction]
 #[pyo3(name = "init_logging")]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (trader_id, instance_id, level_stdout, level_file=None, component_levels=None, directory=None, file_name=None, file_format=None, file_rotate=None, is_colored=None, is_bypassed=None, print_config=None))]
+#[pyo3(signature = (trader_id, instance_id, level_stdout, level_file=None, component_levels=None, directory=None, file_name=None, file_format=None, file_rotate=None, is_colored=None, is_bypassed=None, print_config=None, log_components_only=None))]
 pub fn py_init_logging(
     trader_id: TraderId,
     instance_id: UUID4,
@@ -115,6 +115,7 @@ pub fn py_init_logging(
     is_colored: Option<bool>,
     is_bypassed: Option<bool>,
     print_config: Option<bool>,
+    log_components_only: Option<bool>,
 ) -> PyResult<LogGuard> {
     let level_file = level_file.map_or(LevelFilter::Off, map_log_level_to_filter);
 
@@ -124,6 +125,7 @@ pub fn py_init_logging(
         parse_component_levels(component_levels),
         is_colored.unwrap_or(true),
         print_config.unwrap_or(false),
+        log_components_only.unwrap_or(false),
     );
 
     let file_config = FileWriterConfig::new(directory, file_name, file_format, file_rotate);

--- a/examples/backtest/notebooks/databento_option_greeks.py
+++ b/examples/backtest/notebooks/databento_option_greeks.py
@@ -321,16 +321,17 @@ streaming = StreamingConfig(
 )
 
 logging = LoggingConfig(
-    log_level="WARNING",
+    log_level="WARNING",  # "DEBUG"
     log_level_file="WARNING",
     log_directory=".",
     log_file_name="databento_option_greeks",
     log_file_format=None,  # "json" or None
-    # log_component_levels={"SpreadQuoteAggregator": "WARNING"},
+    # log_component_levels={"SpreadQuoteAggregator": "DEBUG"},
     bypass_logging=False,
     print_config=False,
     use_pyo3=False,
     clear_log_file=True,
+    # log_components_only=True,
 )
 
 catalogs = [

--- a/nautilus_trader/common/component.pxd
+++ b/nautilus_trader/common/component.pxd
@@ -169,6 +169,7 @@ cpdef LogGuard init_logging(
     bint colors=*,
     bint bypass=*,
     bint print_config=*,
+    bint log_components_only=*,
     uint64_t max_file_size=*,
     uint32_t max_backup_count=*,
 )

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -1218,6 +1218,7 @@ cpdef LogGuard init_logging(
     bint colors = True,
     bint bypass = False,
     bint print_config = False,
+    bint log_components_only = False,
     uint64_t max_file_size = 0,
     uint32_t max_backup_count = 5,
 ):
@@ -1298,6 +1299,7 @@ cpdef LogGuard init_logging(
         colors,
         bypass,
         print_config,
+        log_components_only,
         max_file_size,
         max_backup_count,
     )

--- a/nautilus_trader/common/config.py
+++ b/nautilus_trader/common/config.py
@@ -575,6 +575,10 @@ class LoggingConfig(NautilusConfig, frozen=True):
     clear_log_file : bool, default False
         If the log file name should be cleared before being used (e.g. for testing).
         Only applies if `log_file_name` is not ``None``.
+    log_components_only : bool, default False
+        If only components with explicit component-level filters should be logged.
+        When enabled, only log messages from components that have been explicitly
+        configured in `log_component_levels` will be output.
 
     """
 
@@ -591,6 +595,7 @@ class LoggingConfig(NautilusConfig, frozen=True):
     print_config: bool = False
     use_pyo3: bool = False
     clear_log_file: bool = False
+    log_components_only: bool = False
 
 
 class ImportableFactoryConfig(NautilusConfig, frozen=True):

--- a/nautilus_trader/core/includes/common.h
+++ b/nautilus_trader/core/includes/common.h
@@ -604,6 +604,7 @@ struct LogGuard_API logging_init(TraderId_t trader_id,
                                  uint8_t is_colored,
                                  uint8_t is_bypassed,
                                  uint8_t print_config,
+                                 uint8_t log_components_only,
                                  uint64_t max_file_size,
                                  uint32_t max_backup_count);
 

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -99,6 +99,7 @@ def init_logging(
     is_colored: bool | None = None,
     is_bypassed: bool | None = None,
     print_config: bool | None = None,
+    log_components_only: bool | None = None,
 ) -> LogGuard: ...
 
 def log_header(

--- a/nautilus_trader/core/rust/common.pxd
+++ b/nautilus_trader/core/rust/common.pxd
@@ -446,6 +446,7 @@ cdef extern from "../includes/common.h":
                               uint8_t is_colored,
                               uint8_t is_bypassed,
                               uint8_t print_config,
+                              uint8_t log_components_only,
                               uint64_t max_file_size,
                               uint32_t max_backup_count);
 

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -213,6 +213,7 @@ class NautilusKernel:
                         is_colored=logging.log_colors,
                         is_bypassed=logging.bypass_logging,
                         print_config=logging.print_config,
+                        log_components_only=logging.log_components_only,
                     )
                     nautilus_pyo3.log_header(
                         trader_id=nautilus_pyo3.TraderId(self._trader_id.value),
@@ -239,6 +240,7 @@ class NautilusKernel:
                         colors=logging.log_colors,
                         bypass=logging.bypass_logging,
                         print_config=logging.print_config,
+                        log_components_only=logging.log_components_only,
                         max_file_size=logging.log_file_max_size or 0,
                         max_backup_count=logging.log_file_max_backup_count,
                     )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

```python
"""
log_components_only : bool, default False
        If only components with explicit component-level filters should be logged.
        When enabled, only log messages from components that have been explicitly
        configured in `log_component_levels` will be output.
"""
```

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Tested that the feature works in databento_option_greeks.py, setting log_components_only to True, the log level to DEBUG and the component level for a component to DEBUG
