### PR TITLE
Add support for configurable Multicall calls per RPC request

### DIFF
--- a/crates/adapters/blockchain/bin/node_test.rs
+++ b/crates/adapters/blockchain/bin/node_test.rs
@@ -68,6 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec![DexType::UniswapV3],
         http_rpc_url,
         None, // RPC requests per second
+        None, // Multicall calls per RPC request
         Some(wss_rpc_url),
         true, // Use HyperSync for live data
         // Some(from_block), // from_block

--- a/crates/adapters/blockchain/src/config.rs
+++ b/crates/adapters/blockchain/src/config.rs
@@ -63,6 +63,8 @@ pub struct BlockchainDataClientConfig {
     pub http_rpc_url: String,
     /// The maximum number of RPC requests allowed per second.
     pub rpc_requests_per_second: Option<u32>,
+    /// The maximum number of Multicall calls per one RPC request.
+    pub multicall_calls_per_rpc_request: u32,
     /// The WebSocket secure URL for the blockchain RPC endpoint.
     pub wss_rpc_url: Option<String>,
     /// The block from which to sync historical data.
@@ -82,6 +84,7 @@ impl BlockchainDataClientConfig {
         dex_ids: Vec<DexType>,
         http_rpc_url: String,
         rpc_requests_per_second: Option<u32>,
+        multicall_calls_per_rpc_request: Option<u32>,
         wss_rpc_url: Option<String>,
         use_hypersync_for_live_data: bool,
         from_block: Option<u64>,
@@ -94,6 +97,7 @@ impl BlockchainDataClientConfig {
             use_hypersync_for_live_data,
             http_rpc_url,
             rpc_requests_per_second,
+            multicall_calls_per_rpc_request: multicall_calls_per_rpc_request.unwrap_or(100),
             wss_rpc_url,
             from_block,
             pool_filters: pools_filters.unwrap_or_default(),

--- a/crates/adapters/blockchain/src/data/core.rs
+++ b/crates/adapters/blockchain/src/data/core.rs
@@ -841,7 +841,8 @@ impl BlockchainDataClientCore {
 
         tokio::pin!(pools_stream);
 
-        const TOKEN_BATCH_SIZE: usize = 100;
+        // Get the token batch by diving max multicall calls by 3, as each token will yield 3 calls (name, decimals, symbol).
+        let token_batch_size = (self.config.multicall_calls_per_rpc_request / 3) as usize;
         const POOL_BATCH_SIZE: usize = 1000;
         let mut token_buffer: HashSet<Address> = HashSet::new();
         let mut pool_buffer: Vec<PoolCreatedEvent> = Vec::new();
@@ -874,7 +875,7 @@ impl BlockchainDataClientCore {
             // Buffer the pool for later processing
             pool_buffer.push(pool);
 
-            if token_buffer.len() >= TOKEN_BATCH_SIZE || pool_buffer.len() >= POOL_BATCH_SIZE {
+            if token_buffer.len() >= token_batch_size || pool_buffer.len() >= POOL_BATCH_SIZE {
                 self.flush_tokens_and_process_pools(
                     &mut token_buffer,
                     &mut pool_buffer,

--- a/crates/adapters/blockchain/src/factories.rs
+++ b/crates/adapters/blockchain/src/factories.rs
@@ -104,6 +104,7 @@ mod tests {
             "https://eth-mainnet.example.com".to_string(),
             None,
             None,
+            None,
             false,
             None,
             None,

--- a/crates/adapters/blockchain/src/python/config.rs
+++ b/crates/adapters/blockchain/src/python/config.rs
@@ -38,12 +38,13 @@ impl BlockchainDataClientConfig {
     /// Creates a new `BlockchainDataClientConfig` instance.
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None))]
+    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, multicall_calls_per_rpc_request=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None))]
     fn py_new(
         chain: &Chain,
         dex_ids: Vec<DexType>,
         http_rpc_url: String,
         rpc_requests_per_second: Option<u32>,
+        multicall_calls_per_rpc_request: Option<u32>,
         wss_rpc_url: Option<String>,
         use_hypersync_for_live_data: bool,
         from_block: Option<u64>,
@@ -55,6 +56,7 @@ impl BlockchainDataClientConfig {
             dex_ids,
             http_rpc_url,
             rpc_requests_per_second,
+            multicall_calls_per_rpc_request,
             wss_rpc_url,
             use_hypersync_for_live_data,
             from_block,

--- a/crates/cli/src/blockchain/analyze.rs
+++ b/crates/cli/src/blockchain/analyze.rs
@@ -39,6 +39,7 @@ pub async fn run_analyze_pool(
     rpc_url: Option<String>,
     database: DatabaseConfig,
     reset: bool,
+    multicall_calls_per_rpc_request: Option<u32>,
 ) -> anyhow::Result<()> {
     let chain = Chain::from_chain_name(&chain)
         .ok_or_else(|| anyhow::anyhow!("Invalid chain name: {}", chain))?;
@@ -85,6 +86,7 @@ pub async fn run_analyze_pool(
         vec![dex_type],
         rpc_http_url,
         None,
+        multicall_calls_per_rpc_request,
         None,
         true,
         None,

--- a/crates/cli/src/blockchain/mod.rs
+++ b/crates/cli/src/blockchain/mod.rs
@@ -45,7 +45,18 @@ pub async fn run_blockchain_command(opt: BlockchainOpt) -> anyhow::Result<()> {
             rpc_url,
             database,
             reset,
-        } => run_sync_dex(chain, dex, rpc_url, database, reset).await,
+            multicall_calls_per_rpc_request,
+        } => {
+            run_sync_dex(
+                chain,
+                dex,
+                rpc_url,
+                database,
+                reset,
+                multicall_calls_per_rpc_request,
+            )
+            .await
+        }
         BlockchainCommand::AnalyzePool {
             chain,
             dex,
@@ -55,9 +66,18 @@ pub async fn run_blockchain_command(opt: BlockchainOpt) -> anyhow::Result<()> {
             rpc_url,
             reset,
             database,
+            multicall_calls_per_rpc_request,
         } => {
             run_analyze_pool(
-                chain, dex, address, from_block, to_block, rpc_url, database, reset,
+                chain,
+                dex,
+                address,
+                from_block,
+                to_block,
+                rpc_url,
+                database,
+                reset,
+                multicall_calls_per_rpc_request,
             )
             .await
         }

--- a/crates/cli/src/blockchain/sync.rs
+++ b/crates/cli/src/blockchain/sync.rs
@@ -31,6 +31,7 @@ pub async fn run_sync_dex(
     rpc_url: Option<String>,
     database: DatabaseConfig,
     reset: bool,
+    multicall_calls_per_rpc_request: Option<u32>,
 ) -> anyhow::Result<()> {
     let chain = Chain::from_chain_name(&chain)
         .ok_or_else(|| anyhow::anyhow!("Invalid chain name: {}", chain))?;
@@ -69,6 +70,7 @@ pub async fn run_sync_dex(
         vec![dex_type],
         rpc_http_url,
         None,
+        multicall_calls_per_rpc_request,
         None,
         true,
         None,
@@ -114,6 +116,7 @@ pub async fn run_sync_blocks(
         chain.clone(),
         vec![],
         "".to_string(), // we dont need to http rpc url for block syncing
+        None,
         None,
         None,
         true,

--- a/crates/cli/src/opt.rs
+++ b/crates/cli/src/opt.rs
@@ -118,6 +118,9 @@ pub enum BlockchainCommand {
         /// Reset sync progress and start from the beginning, ignoring last synced block
         #[arg(long)]
         reset: bool,
+        /// Maximum number of Multicall calls per RPC request (optional, defaults to 100)
+        #[arg(long)]
+        multicall_calls_per_rpc_request: Option<u32>,
         /// Database configuration options
         #[clap(flatten)]
         database: DatabaseConfig,
@@ -145,6 +148,9 @@ pub enum BlockchainCommand {
         /// Reset sync progress and start from the beginning, ignoring last synced block
         #[arg(long)]
         reset: bool,
+        /// Maximum number of Multicall calls per RPC request (optional, defaults to 100)
+        #[arg(long)]
+        multicall_calls_per_rpc_request: Option<u32>,
         /// Database configuration options
         #[clap(flatten)]
         database: DatabaseConfig,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- adds `multicall_calls_per_rpc_request` param in the Blockchain data client config to limit number of multicall calls per create per RPC request

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
