### PR TITLE
Fix consolidation name clash for an overlapping edge case

### DIFF
--- a/crates/persistence/src/parquet.rs
+++ b/crates/persistence/src/parquet.rs
@@ -198,7 +198,9 @@ pub async fn combine_parquet_files_from_object_store(
 
     // Remove the merged files
     for path in &file_paths {
-        object_store.delete(path).await?;
+        if path != new_file_path {
+            object_store.delete(path).await?;
+        }
     }
 
     Ok(())

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -654,7 +654,8 @@ class ParquetDataCatalog(BaseDataCatalog):
         pq.write_table(combined_table, where=new_file)
 
         for file in file_list:
-            self.fs.rm(file)
+            if file != new_file:
+                self.fs.rm(file)
 
     def consolidate_catalog_by_period(
         self,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix for an edge case when after consolidation the file name clashes with one of the original file names

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [X] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
