### PR TITLE
Fix IB adapter avg_px population in order filled events

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -248,6 +248,9 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
                 handler(
                     order_ref=self._order_id_to_order_ref[order_id].order_id,
                     order_status=status,
+                    avg_fill_price=avg_fill_price,
+                    filled=filled,
+                    remaining=remaining,
                 )
 
     async def process_exec_details(


### PR DESCRIPTION
## Summary
- Fixed Interactive Brokers adapter to properly populate the `avg_px` (average fill price) field in order filled events
- Added comprehensive tests to verify the avg_px functionality

## Changes Made

### 1. **Fix avg_px population** (`nautilus_trader/adapters/interactive_brokers/`)
- Modified `client/order.py`: Updated `process_order_status` to pass `avg_fill_price`, `filled`, and `remaining` parameters to handlers
- Modified `execution.py`: 
  - Added `_order_avg_prices` dictionary to track average prices for orders
  - Updated `_on_order_status` to accept and store `avg_fill_price` from IB
  - Modified all `generate_order_filled` calls to include `avg_px` in the info dict when available

### 2. **Added comprehensive tests** (`tests/integration_tests/adapters/interactive_brokers/`)
- `test_on_order_status_with_avg_px`: Verifies avg_fill_price is stored correctly in the `_order_avg_prices` dictionary
- `test_on_exec_details_uses_stored_avg_px`: Ensures stored avg_px is used in fill events (not the execution price)
- `test_orderStatus`: Updated to verify avg_fill_price parameter passthrough
- `test_orderStatus_with_zero_avg_fill_price`: Tests edge case when avg_fill_price is 0

## Testing
- ✅ All IB adapter tests pass (except pre-existing flaky `test_process_account_id`)
- ✅ Pre-commit checks pass
- ✅ Module imports successfully

## Context
The IB adapter was not properly propagating the average fill price from Interactive Brokers' order status updates to Nautilus order filled events. This fix ensures that the `avg_px` field is correctly populated, which is important for accurate order tracking and reconciliation.

## Note on failing test
The `test_process_account_id` test that fails is a pre-existing flaky test that also fails on the develop branch and is unrelated to these changes.