### PR TITLE
Fix historical data request race condition in DataEngine

### DIFF
--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -100,6 +100,7 @@ cdef class DataEngine(Component):
     cdef readonly dict[str, SnapshotInfo] _snapshot_info
     cdef readonly dict[UUID4, int] _query_group_n_responses
     cdef readonly dict[UUID4, list] _query_group_responses
+    cdef readonly dict[UUID4, RequestData] _query_group_requests
 
     cdef readonly dict[InstrumentId, str] _topic_cache_deltas
     cdef readonly dict[InstrumentId, str] _topic_cache_quotes
@@ -248,7 +249,7 @@ cdef class DataEngine(Component):
     cpdef void _handle_response(self, DataResponse response)
     cpdef void _handle_instruments(self, list instruments, bint update_catalog = *, bint force_update_catalog = *)
     cpdef tuple[datetime, object] _catalog_last_timestamp(self, type data_cls, identifier: str | None = *)
-    cpdef void _new_query_group(self, UUID4 correlation_id, int n_components)
+    cpdef void _new_query_group(self, RequestData request, int n_components)
     cpdef DataResponse _handle_query_group(self, DataResponse response)
     cdef DataResponse _handle_query_group_aux(self, DataResponse response)
     cpdef Instrument _modify_instrument_properties(self, Instrument instrument, dict instrument_properties)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

  Here's a breakdown of the issue:

   1. When you request historical bars that span both the catalog and the exchange, the DataEngine creates a "query group" to manage the multiple data responses (one from the catalog, and one or more from the exchange
      for the missing data).

   2. The DataEngine's _handle_query_group_aux method in nautilus_trader/data/engine.pyx is responsible for merging these responses. The problem is that the final merged DataResponse object incorrectly uses the start and
      end timestamps from the last partial response it receives.

   3. If the response from the exchange (for the more recent, missing data) arrives after the response from your local catalog, the final DataResponse will have the start and end times of only the exchange data.

   4. This incorrect time range is then used by the _handle_aggregated_bars_aux method, which causes it to only process the bars within that smaller, later time window, effectively discarding the data that was correctly
      read from your local catalog.

  Here are the changes I'll make to fix this:

   1. In nautilus_trader/data/engine.pyx, add a new dictionary _query_group_requests to the DataEngine's __init__ method to store the original requests.
   2. Modify _new_query_group to store the original RequestData object.
   3. Update _handle_query_group_aux to use the start and end from the stored original request in the final merged response.
   4. Update the _reset method to clear the new dictionary.

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
