### PR TITLE
Use filesystem in catalog for isfile and isdir

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -2251,7 +2251,7 @@ class ParquetDataCatalog(BaseDataCatalog):
         feather_dir = Path(self.path) / subdirectory / instance_id
 
         if self.fs.isdir(feather_dir / table_name):
-            feather_files = sorted(self.fs.glob(feather_dir / table_name / "*.feather"))
+            feather_files = sorted(self.fs.glob(str(feather_dir / table_name / "*.feather")))
         else:
             feather_files = sorted(self.fs.glob(f"{table_name}_*.feather"))
 


### PR DESCRIPTION
## Summary

Use catalog filesystem instead of `Path`, which only works when `self.fs = file`

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic