### PR TITLE
Fix IB tick level historical data downloading

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/historical/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/historical/client.py
@@ -460,19 +460,14 @@ class HistoricInteractiveBrokersClient:
             return None, False
 
         timestamps = [unix_nanos_to_dt(tick.ts_event) for tick in ticks]
-        min_timestamp = min(timestamps)
         max_timestamp = max(timestamps)
 
-        if min_timestamp.floor("s") == max_timestamp.floor("s"):
-            max_timestamp = max_timestamp.floor("s") + pd.Timedelta(seconds=1)
+        next_start = max_timestamp + pd.Timedelta(seconds=1)
 
-        if len(ticks) <= 50:
-            max_timestamp = max_timestamp.floor("s") + pd.Timedelta(minutes=1)
-
-        if max_timestamp >= end_date_time:
+        if next_start >= end_date_time:
             return None, False
 
-        return max_timestamp, True
+        return next_start, True
 
     async def _fetch_instruments_if_not_cached(
         self,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [X] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Background: IB only provides users with tick data of smallest interval 1s, and there is a limitation "numberOfTicks, Number of distinct data points. Max is 1000 per request".
 
As i roughly tested, IB will give all ticks within that 1s, even if it's beyond 1000, not drop them. So we can make the code simple to prevent the endless looping bug:
<img width="1679" height="1079" alt="image" src="https://github.com/user-attachments/assets/6a32e0d0-0bc4-441d-9e79-e6b8196b982f" />

I‘ve no idea how IB deals with tick data that more than 1000 ticks in 1s. There is no docs about it. The original code is designed to deal with this situation, but often leads to endless loop. 

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
