### PR TITLE
Continue Hyperliquid adapter scaffolding and examples

### DIFF
--- a/crates/adapters/bitmex/README.md
+++ b/crates/adapters/bitmex/README.md
@@ -8,7 +8,7 @@
 
 [NautilusTrader](http://nautilustrader.io) adapter for the [BitMEX](https://bitmex.com) cryptocurrency exchange.
 
-The `nautilus-bitmex` crate provides strongly-typed client bindings (HTTP & WebSocket), data
+The `nautilus-bitmex` crate provides client bindings (HTTP & WebSocket), data
 models and helper utilities that wrap the official **BitMEX API**.
 
 The official BitMEX API reference can be found at <https://www.bitmex.com/app/apiOverview>.

--- a/crates/adapters/hyperliquid/README.md
+++ b/crates/adapters/hyperliquid/README.md
@@ -8,7 +8,7 @@
 
 [NautilusTrader](http://nautilustrader.io) adapter for the [Hyperliquid](https://hyperliquid.gitbook.io/hyperliquid-docs) decentralized exchange.
 
-The `nautilus-hyperliquid` crate provides strongly-typed client bindings (HTTP & WebSocket), data
+The `nautilus-hyperliquid` crate provides client bindings (HTTP & WebSocket), data
 models and helper utilities that wrap the official **Hyperliquid API**.
 
 ## Platform

--- a/crates/adapters/hyperliquid/README.md
+++ b/crates/adapters/hyperliquid/README.md
@@ -8,8 +8,8 @@
 
 [NautilusTrader](http://nautilustrader.io) adapter for the [Hyperliquid](https://hyperliquid.gitbook.io/hyperliquid-docs) decentralized exchange.
 
-The `nautilus-hyperliquid` crate provides integration with the Hyperliquid API for
-trading perpetual futures on a decentralized exchange.
+The `nautilus-hyperliquid` crate provides strongly-typed client bindings (HTTP & WebSocket), data
+models and helper utilities that wrap the official **Hyperliquid API**.
 
 ## Platform
 

--- a/crates/adapters/hyperliquid/bin/http-private.rs
+++ b/crates/adapters/hyperliquid/bin/http-private.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::env;
+
 use nautilus_hyperliquid::http::client::HyperliquidHttpClient;
 use tracing::level_filters::LevelFilter;
 
@@ -22,8 +24,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_level(LevelFilter::INFO)
         .init();
 
+    let args: Vec<String> = env::args().collect();
+    let testnet = args.get(1).is_some_and(|s| s == "testnet");
+
+    tracing::info!("Starting Hyperliquid HTTP private example");
+    tracing::info!("Testnet: {testnet}");
+
     // Try to create authenticated client from environment
-    let client = match HyperliquidHttpClient::from_env() {
+    let client = match HyperliquidHttpClient::from_env(testnet) {
         Ok(client) => client,
         Err(_) => {
             tracing::warn!(

--- a/crates/adapters/hyperliquid/bin/http-private.rs
+++ b/crates/adapters/hyperliquid/bin/http-private.rs
@@ -28,11 +28,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let testnet = args.get(1).is_some_and(|s| s == "testnet");
 
     tracing::info!("Starting Hyperliquid HTTP private example");
-    tracing::info!("Testnet: {testnet}");
+    if testnet {
+        tracing::info!(
+            "Testnet parameter provided - set HYPERLIQUID_NETWORK=testnet environment variable"
+        );
+    }
 
     // Try to create authenticated client from environment
-    let client = match HyperliquidHttpClient::from_env(testnet) {
-        Ok(client) => client,
+    let client = match HyperliquidHttpClient::from_env() {
+        Ok(client) => {
+            tracing::info!("Testnet mode: {}", client.is_testnet());
+            client
+        }
         Err(_) => {
             tracing::warn!(
                 "No credentials found in environment (HYPERLIQUID_PK). Skipping authenticated examples."

--- a/crates/adapters/hyperliquid/bin/http-public.rs
+++ b/crates/adapters/hyperliquid/bin/http-public.rs
@@ -13,9 +13,9 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use nautilus_hyperliquid::{
-    common::consts::HyperliquidNetwork, http::client::HyperliquidHttpClient,
-};
+use std::env;
+
+use nautilus_hyperliquid::http::client::HyperliquidHttpClient;
 use tracing::level_filters::LevelFilter;
 
 #[tokio::main]
@@ -24,8 +24,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_level(LevelFilter::INFO)
         .init();
 
-    let network = HyperliquidNetwork::from_env();
-    let client = HyperliquidHttpClient::new(network, Some(60));
+    let args: Vec<String> = env::args().collect();
+    let testnet = args.get(1).is_some_and(|s| s == "testnet");
+
+    tracing::info!("Starting Hyperliquid HTTP public example");
+    tracing::info!("Testnet: {testnet}");
+
+    let client = HyperliquidHttpClient::new(testnet, Some(60));
 
     // Fetch metadata
     let meta = client.info_meta().await?;

--- a/crates/adapters/hyperliquid/bin/ws-exec.rs
+++ b/crates/adapters/hyperliquid/bin/ws-exec.rs
@@ -13,12 +13,9 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::time::Duration;
+use std::{env, time::Duration};
 
-use nautilus_hyperliquid::{
-    common::consts::{HyperliquidNetwork, ws_url},
-    websocket::client::HyperliquidWebSocketClient,
-};
+use nautilus_hyperliquid::{common::consts::ws_url, websocket::client::HyperliquidWebSocketClient};
 use tokio::{pin, signal};
 use tracing::level_filters::LevelFilter;
 
@@ -28,11 +25,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_level(LevelFilter::TRACE)
         .init();
 
-    tracing::info!("Starting Hyperliquid WebSocket execution example");
+    let args: Vec<String> = env::args().collect();
+    let testnet = args.get(1).is_some_and(|s| s == "testnet");
 
-    // Determine network and get WebSocket URL
-    let network = HyperliquidNetwork::from_env();
-    let ws_url = ws_url(network);
+    tracing::info!("Starting Hyperliquid WebSocket execution example");
+    tracing::info!("Testnet: {testnet}");
+
+    let ws_url = ws_url(testnet);
+    tracing::info!("WebSocket URL: {ws_url}");
 
     let mut client = HyperliquidWebSocketClient::connect(ws_url).await?;
     tracing::info!("Connected to Hyperliquid WebSocket");

--- a/crates/adapters/hyperliquid/bin/ws-post.rs
+++ b/crates/adapters/hyperliquid/bin/ws-post.rs
@@ -15,10 +15,10 @@
 
 //! Minimal WS post example: info (l2Book) and a stubbed order action.
 
-use std::time::Duration;
+use std::{env, time::Duration};
 
 use nautilus_hyperliquid::{
-    common::consts::{HyperliquidNetwork, ws_url},
+    common::consts::ws_url,
     websocket::{
         client::HyperliquidWebSocketClient,
         messages::{ActionPayload, ActionRequest, SignatureData, TimeInForceRequest},
@@ -31,15 +31,17 @@ use tracing_subscriber::{EnvFilter, fmt};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Structured logging with env-controlled filter (e.g. RUST_LOG=debug)
-    let env = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     fmt()
-        .with_env_filter(env)
+        .with_env_filter(env_filter)
         .with_max_level(LevelFilter::INFO)
         .init();
 
-    let network = HyperliquidNetwork::from_env();
-    let ws_url = ws_url(network);
-    info!(component = "ws_post", %ws_url, ?network, "connecting");
+    let args: Vec<String> = env::args().collect();
+    let testnet = args.get(1).is_some_and(|s| s == "testnet");
+    let ws_url = ws_url(testnet);
+
+    info!(component = "ws_post", %ws_url, ?testnet, "connecting");
     let mut client = HyperliquidWebSocketClient::connect(ws_url).await?;
     info!(component = "ws_post", "websocket connected");
 

--- a/crates/adapters/hyperliquid/src/common/consts.rs
+++ b/crates/adapters/hyperliquid/src/common/consts.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{env, sync::LazyLock, time::Duration};
+use std::{sync::LazyLock, time::Duration};
 
 use nautilus_model::identifiers::Venue;
 use ustr::Ustr;
@@ -21,29 +21,6 @@ use ustr::Ustr;
 pub const HYPERLIQUID: &str = "HYPERLIQUID";
 pub static HYPERLIQUID_VENUE: LazyLock<Venue> =
     LazyLock::new(|| Venue::new(Ustr::from(HYPERLIQUID)));
-
-/// Represents the network configuration for Hyperliquid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HyperliquidNetwork {
-    Mainnet,
-    Testnet,
-}
-
-impl HyperliquidNetwork {
-    /// Loads network from environment variable `HYPERLIQUID_NET`.
-    ///
-    /// Defaults to `Mainnet` if not set or invalid.
-    pub fn from_env() -> Self {
-        match env::var("HYPERLIQUID_NET")
-            .unwrap_or_else(|_| "mainnet".to_string())
-            .to_lowercase()
-            .as_str()
-        {
-            "testnet" | "test" => HyperliquidNetwork::Testnet,
-            _ => HyperliquidNetwork::Mainnet,
-        }
-    }
-}
 
 // Mainnet URLs
 pub const HYPERLIQUID_WS_URL: &str = "wss://api.hyperliquid.xyz/ws";
@@ -56,26 +33,29 @@ pub const HYPERLIQUID_TESTNET_INFO_URL: &str = "https://api.hyperliquid-testnet.
 pub const HYPERLIQUID_TESTNET_EXCHANGE_URL: &str = "https://api.hyperliquid-testnet.xyz/exchange";
 
 /// Gets WebSocket URL for the specified network.
-pub fn ws_url(network: HyperliquidNetwork) -> &'static str {
-    match network {
-        HyperliquidNetwork::Mainnet => HYPERLIQUID_WS_URL,
-        HyperliquidNetwork::Testnet => HYPERLIQUID_TESTNET_WS_URL,
+pub fn ws_url(is_testnet: bool) -> &'static str {
+    if is_testnet {
+        HYPERLIQUID_TESTNET_WS_URL
+    } else {
+        HYPERLIQUID_WS_URL
     }
 }
 
 /// Gets info API URL for the specified network.
-pub fn info_url(network: HyperliquidNetwork) -> &'static str {
-    match network {
-        HyperliquidNetwork::Mainnet => HYPERLIQUID_INFO_URL,
-        HyperliquidNetwork::Testnet => HYPERLIQUID_TESTNET_INFO_URL,
+pub fn info_url(is_testnet: bool) -> &'static str {
+    if is_testnet {
+        HYPERLIQUID_TESTNET_INFO_URL
+    } else {
+        HYPERLIQUID_INFO_URL
     }
 }
 
 /// Gets exchange API URL for the specified network.
-pub fn exchange_url(network: HyperliquidNetwork) -> &'static str {
-    match network {
-        HyperliquidNetwork::Mainnet => HYPERLIQUID_EXCHANGE_URL,
-        HyperliquidNetwork::Testnet => HYPERLIQUID_TESTNET_EXCHANGE_URL,
+pub fn exchange_url(is_testnet: bool) -> &'static str {
+    if is_testnet {
+        HYPERLIQUID_TESTNET_EXCHANGE_URL
+    } else {
+        HYPERLIQUID_EXCHANGE_URL
     }
 }
 
@@ -100,50 +80,21 @@ mod tests {
     use super::*;
 
     #[rstest]
-    fn test_network_variants() {
-        assert_eq!(HyperliquidNetwork::Mainnet, HyperliquidNetwork::Mainnet);
-        assert_eq!(HyperliquidNetwork::Testnet, HyperliquidNetwork::Testnet);
-        assert_ne!(HyperliquidNetwork::Mainnet, HyperliquidNetwork::Testnet);
-    }
-
-    #[rstest]
-    fn test_network_from_env_handles_default() {
-        let network = HyperliquidNetwork::from_env();
-
-        assert!(matches!(
-            network,
-            HyperliquidNetwork::Mainnet | HyperliquidNetwork::Testnet
-        ));
-    }
-
-    #[rstest]
     fn test_ws_url() {
-        assert_eq!(ws_url(HyperliquidNetwork::Mainnet), HYPERLIQUID_WS_URL);
-        assert_eq!(
-            ws_url(HyperliquidNetwork::Testnet),
-            HYPERLIQUID_TESTNET_WS_URL
-        );
+        assert_eq!(ws_url(false), HYPERLIQUID_WS_URL);
+        assert_eq!(ws_url(true), HYPERLIQUID_TESTNET_WS_URL);
     }
 
     #[rstest]
     fn test_info_url() {
-        assert_eq!(info_url(HyperliquidNetwork::Mainnet), HYPERLIQUID_INFO_URL);
-        assert_eq!(
-            info_url(HyperliquidNetwork::Testnet),
-            HYPERLIQUID_TESTNET_INFO_URL
-        );
+        assert_eq!(info_url(false), HYPERLIQUID_INFO_URL);
+        assert_eq!(info_url(true), HYPERLIQUID_TESTNET_INFO_URL);
     }
 
     #[rstest]
     fn test_exchange_url() {
-        assert_eq!(
-            exchange_url(HyperliquidNetwork::Mainnet),
-            HYPERLIQUID_EXCHANGE_URL
-        );
-        assert_eq!(
-            exchange_url(HyperliquidNetwork::Testnet),
-            HYPERLIQUID_TESTNET_EXCHANGE_URL
-        );
+        assert_eq!(exchange_url(false), HYPERLIQUID_EXCHANGE_URL);
+        assert_eq!(exchange_url(true), HYPERLIQUID_TESTNET_EXCHANGE_URL);
     }
 
     #[rstest]

--- a/crates/adapters/hyperliquid/src/common/credential.rs
+++ b/crates/adapters/hyperliquid/src/common/credential.rs
@@ -18,10 +18,7 @@ use std::{env, fmt, fs, path::Path};
 use serde::Deserialize;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::{
-    common::consts::HyperliquidNetwork,
-    http::error::{Error, Result},
-};
+use crate::http::error::{Error, Result};
 
 /// Represents a secure wrapper for EVM private key with zeroization on drop.
 #[derive(Clone, ZeroizeOnDrop)]
@@ -151,7 +148,7 @@ impl fmt::Display for VaultAddress {
 pub struct Secrets {
     pub private_key: EvmPrivateKey,
     pub vault_address: Option<VaultAddress>,
-    pub network: HyperliquidNetwork,
+    pub is_testnet: bool,
 }
 
 impl fmt::Debug for Secrets {
@@ -159,7 +156,7 @@ impl fmt::Debug for Secrets {
         f.debug_struct("Secrets")
             .field("private_key", &self.private_key)
             .field("vault_address", &self.vault_address)
-            .field("network", &self.network)
+            .field("is_testnet", &self.is_testnet)
             .finish()
     }
 }
@@ -170,8 +167,7 @@ impl Secrets {
     /// Expected environment variables:
     /// - `HYPERLIQUID_PK`: EVM private key (required)
     /// - `HYPERLIQUID_VAULT`: Vault address (optional)
-    /// - `HYPERLIQUID_NET`: Network (optional, defaults to mainnet)
-    pub fn from_env() -> Result<Self> {
+    pub fn from_env(is_testnet: bool) -> Result<Self> {
         let private_key_str = env::var("HYPERLIQUID_PK")
             .map_err(|_| Error::bad_request("HYPERLIQUID_PK environment variable not set"))?;
 
@@ -182,12 +178,10 @@ impl Secrets {
             _ => None,
         };
 
-        let network = HyperliquidNetwork::from_env();
-
         Ok(Self {
             private_key,
             vault_address,
-            network,
+            is_testnet,
         })
     }
 
@@ -234,15 +228,12 @@ impl Secrets {
             None => None,
         };
 
-        let network = match raw.network.as_deref() {
-            Some("testnet") | Some("test") => HyperliquidNetwork::Testnet,
-            _ => HyperliquidNetwork::Mainnet,
-        };
+        let is_testnet = matches!(raw.network.as_deref(), Some("testnet") | Some("test"));
 
         Ok(Self {
             private_key,
             vault_address,
-            network,
+            is_testnet,
         })
     }
 }
@@ -356,7 +347,7 @@ mod tests {
         assert_eq!(secrets.private_key.as_hex(), TEST_PRIVATE_KEY);
         assert!(secrets.vault_address.is_some());
         assert_eq!(secrets.vault_address.unwrap().to_hex(), TEST_VAULT_ADDRESS);
-        assert_eq!(secrets.network, HyperliquidNetwork::Testnet);
+        assert!(secrets.is_testnet);
     }
 
     #[rstest]
@@ -371,7 +362,7 @@ mod tests {
         let secrets = Secrets::from_json(&json).unwrap();
         assert_eq!(secrets.private_key.as_hex(), TEST_PRIVATE_KEY);
         assert!(secrets.vault_address.is_none());
-        assert_eq!(secrets.network, HyperliquidNetwork::Mainnet);
+        assert!(!secrets.is_testnet);
     }
 
     #[rstest]
@@ -405,7 +396,7 @@ mod tests {
         // HYPERLIQUID_NET=testnet
 
         // For now, just test the error case when variables are not set
-        match Secrets::from_env() {
+        match Secrets::from_env(false) {
             Err(e) => {
                 assert!(
                     e.to_string().contains("HYPERLIQUID_PK missing")

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -131,9 +131,9 @@ impl HyperliquidHttpClient {
     ///
     /// Returns [`Error::Auth`] if required environment variables
     /// are not set.
-    pub fn from_env(is_testnet: bool) -> Result<Self> {
-        let secrets = Secrets::from_env(is_testnet)
-            .map_err(|_| Error::auth("missing credentials in environment"))?;
+    pub fn from_env() -> Result<Self> {
+        let secrets =
+            Secrets::from_env().map_err(|_| Error::auth("missing credentials in environment"))?;
         Ok(Self::with_credentials(&secrets, None))
     }
 

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -34,7 +34,7 @@ use serde_json::Value;
 
 use crate::{
     common::{
-        consts::{HyperliquidNetwork, exchange_url, info_url},
+        consts::{exchange_url, info_url},
         credential::{Secrets, VaultAddress},
     },
     http::{
@@ -62,8 +62,7 @@ pub static HYPERLIQUID_REST_QUOTA: LazyLock<Quota> =
 #[derive(Debug)]
 pub struct HyperliquidHttpClient {
     client: HttpClient,
-    #[allow(dead_code)] // May be used for future network-specific logic
-    network: HyperliquidNetwork,
+    is_testnet: bool,
     base_info: String,
     base_exchange: String,
     signer: Option<HyperliquidEip712Signer>,
@@ -73,7 +72,7 @@ pub struct HyperliquidHttpClient {
 
 impl Default for HyperliquidHttpClient {
     fn default() -> Self {
-        Self::new(HyperliquidNetwork::Testnet, None)
+        Self::new(true, None) // Default to testnet
     }
 }
 
@@ -84,7 +83,7 @@ impl HyperliquidHttpClient {
     /// This version of the client has **no credentials**, so it can only
     /// call publicly accessible endpoints.
     #[must_use]
-    pub fn new(network: HyperliquidNetwork, timeout_secs: Option<u64>) -> Self {
+    pub fn new(is_testnet: bool, timeout_secs: Option<u64>) -> Self {
         Self {
             client: HttpClient::new(
                 Self::default_headers(),
@@ -93,9 +92,9 @@ impl HyperliquidHttpClient {
                 Some(*HYPERLIQUID_REST_QUOTA),
                 timeout_secs,
             ),
-            network,
-            base_info: info_url(network).to_string(),
-            base_exchange: exchange_url(network).to_string(),
+            is_testnet,
+            base_info: info_url(is_testnet).to_string(),
+            base_exchange: exchange_url(is_testnet).to_string(),
             signer: None,
             nonce_manager: None,
             vault_address: None,
@@ -117,9 +116,9 @@ impl HyperliquidHttpClient {
                 Some(*HYPERLIQUID_REST_QUOTA),
                 timeout_secs,
             ),
-            network: secrets.network,
-            base_info: info_url(secrets.network).to_string(),
-            base_exchange: exchange_url(secrets.network).to_string(),
+            is_testnet: secrets.is_testnet,
+            base_info: info_url(secrets.is_testnet).to_string(),
+            base_exchange: exchange_url(secrets.is_testnet).to_string(),
             signer: Some(signer),
             nonce_manager: Some(nonce_manager),
             vault_address: secrets.vault_address,
@@ -132,15 +131,24 @@ impl HyperliquidHttpClient {
     ///
     /// Returns [`Error::Auth`] if required environment variables
     /// are not set.
-    pub fn from_env() -> Result<Self> {
-        let secrets =
-            Secrets::from_env().map_err(|_| Error::auth("missing credentials in environment"))?;
+    pub fn from_env(is_testnet: bool) -> Result<Self> {
+        let secrets = Secrets::from_env(is_testnet)
+            .map_err(|_| Error::auth("missing credentials in environment"))?;
         Ok(Self::with_credentials(&secrets, None))
+    }
+
+    /// Returns whether this client is configured for testnet.
+    #[must_use]
+    pub fn is_testnet(&self) -> bool {
+        self.is_testnet
     }
 
     /// Builds the default headers to include with each request (e.g., `User-Agent`).
     fn default_headers() -> HashMap<String, String> {
-        HashMap::from([(USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string())])
+        HashMap::from([
+            (USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+        ])
     }
 
     // ---------------- INFO ENDPOINTS --------------------------------------------

--- a/crates/adapters/okx/README.md
+++ b/crates/adapters/okx/README.md
@@ -6,7 +6,7 @@
 ![license](https://img.shields.io/github/license/nautechsystems/nautilus_trader?color=blue)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/NautilusTrader)
 
-The `nautilus-okx` crate provides strongly-typed client bindings (HTTP & WebSocket), data
+The `nautilus-okx` crate provides client bindings (HTTP & WebSocket), data
 models and helper utilities that wrap the official **OKX v5 API**.
 
 The official OKX API reference can be found at <https://www.okx.com/docs-v5/en/>.

--- a/crates/adapters/okx/src/lib.rs
+++ b/crates/adapters/okx/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! [NautilusTrader](http://nautilustrader.io) adapter for the [OKX](https://www.okx.com) cryptocurrency exchange.
 //!
-//! The `nautilus-okx` crate provides strongly-typed client bindings (HTTP & WebSocket), data
+//! The `nautilus-okx` crate provides client bindings (HTTP & WebSocket), data
 //! models and helper utilities that wrap the official **OKX v5 API**.
 //!
 //! The official OKX API reference can be found at <https://www.okx.com/docs-v5/en/>.

--- a/examples/live/hyperliquid/hyperliquid_data_tester.py
+++ b/examples/live/hyperliquid/hyperliquid_data_tester.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.adapters.hyperliquid import HYPERLIQUID
+from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidLiveDataClientFactory
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LiveExecEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.test_kit.strategies.tester_data import DataTester
+from nautilus_trader.test_kit.strategies.tester_data import DataTesterConfig
+
+
+# *** THIS IS A TEST STRATEGY WITH NO ALPHA ADVANTAGE WHATSOEVER. ***
+# *** IT IS NOT INTENDED TO BE USED TO TRADE LIVE WITH REAL MONEY. ***
+
+# *** THIS INTEGRATION IS STILL UNDER CONSTRUCTION. ***
+# *** CONSIDER IT TO BE IN AN UNSTABLE BETA PHASE AND EXERCISE CAUTION. ***
+
+if __name__ == "__main__":
+    # Configure the trading node
+    config_node = TradingNodeConfig(
+        trader_id=TraderId("TESTER-001"),
+        logging=LoggingConfig(log_level="INFO"),
+        exec_engine=LiveExecEngineConfig(
+            reconciliation=True,
+            reconciliation_lookback_mins=1440,
+        ),
+        data_clients={
+            HYPERLIQUID: HyperliquidDataClientConfig(
+                instrument_provider=InstrumentProviderConfig(load_all=True),
+                testnet=True,  # Set to False for mainnet
+            ),
+        },
+        timeout_connection=20.0,
+        timeout_reconciliation=10.0,
+        timeout_portfolio=10.0,
+        timeout_disconnection=10.0,
+        timeout_post_stop=5.0,
+    )
+
+    # Instantiate the node with a configuration
+    node = TradingNode(config=config_node)
+
+    # Configure your strategy
+    strat_config = DataTesterConfig(
+        instrument_ids=[InstrumentId.from_str("ETH-USD.HYPERLIQUID")],
+        subscribe_trades=True,
+        subscribe_bars=True,
+        book_type=BookType.L2_MBP,
+    )
+    # Instantiate your strategy
+    strategy = DataTester(config=strat_config)
+
+    # Add your actors and modules
+    node.trader.add_actor(strategy)
+
+    # Register your client factories with the node (can take user-defined factories)
+    node.add_data_client_factory(HYPERLIQUID, HyperliquidLiveDataClientFactory)
+    node.build()
+
+    # Stop and dispose of the node with SIGINT/CTRL+C
+    if __name__ == "__main__":
+        try:
+            node.run()
+        finally:
+            node.dispose()

--- a/examples/live/hyperliquid/hyperliquid_exec_tester.py
+++ b/examples/live/hyperliquid/hyperliquid_exec_tester.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from decimal import Decimal
+
+from nautilus_trader.adapters.hyperliquid import HYPERLIQUID
+from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidLiveDataClientFactory
+from nautilus_trader.adapters.hyperliquid import HyperliquidLiveExecClientFactory
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LiveExecEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.test_kit.strategies.tester_exec import ExecTester
+from nautilus_trader.test_kit.strategies.tester_exec import ExecTesterConfig
+
+
+# *** THIS IS A TEST STRATEGY WITH NO ALPHA ADVANTAGE WHATSOEVER. ***
+# *** IT IS NOT INTENDED TO BE USED TO TRADE LIVE WITH REAL MONEY. ***
+
+# *** THIS INTEGRATION IS STILL UNDER CONSTRUCTION. ***
+# *** CONSIDER IT TO BE IN AN UNSTABLE BETA PHASE AND EXERCISE CAUTION. ***
+
+if __name__ == "__main__":
+    # You must set your Hyperliquid API credentials through environment variables:
+    # - HYPERLIQUID_WALLET_ADDRESS
+    # - HYPERLIQUID_PRIVATE_KEY
+
+    # Configure the trading node
+    config_node = TradingNodeConfig(
+        trader_id=TraderId("TESTER-001"),
+        logging=LoggingConfig(log_level="INFO"),
+        exec_engine=LiveExecEngineConfig(
+            reconciliation=True,
+            reconciliation_lookback_mins=1440,
+        ),
+        data_clients={
+            HYPERLIQUID: HyperliquidDataClientConfig(
+                instrument_provider=InstrumentProviderConfig(load_all=True),
+                testnet=True,  # Set to False for mainnet
+            ),
+        },
+        exec_clients={
+            HYPERLIQUID: HyperliquidExecClientConfig(
+                testnet=True,  # Set to False for mainnet
+            ),
+        },
+        timeout_connection=20.0,
+        timeout_reconciliation=10.0,
+        timeout_portfolio=10.0,
+        timeout_disconnection=10.0,
+        timeout_post_stop=5.0,
+    )
+
+    # Instantiate the node with a configuration
+    node = TradingNode(config=config_node)
+
+    # Configure your strategy
+    strat_config = ExecTesterConfig(
+        instrument_id=InstrumentId.from_str("ETH-USD.HYPERLIQUID"),
+        order_qty=Decimal("0.01"),  # Small test order
+        open_position_time_in_force=TimeInForce.GTC,
+        manage_gtd_expiry=False,
+    )
+    # Instantiate your strategy
+    strategy = ExecTester(config=strat_config)
+
+    # Add your strategies and modules
+    node.trader.add_strategy(strategy)
+
+    # Register your client factories with the node (can take user-defined factories)
+    node.add_data_client_factory(HYPERLIQUID, HyperliquidLiveDataClientFactory)
+    node.add_exec_client_factory(HYPERLIQUID, HyperliquidLiveExecClientFactory)
+    node.build()
+
+    # Stop and dispose of the node with SIGINT/CTRL+C
+    if __name__ == "__main__":
+        try:
+            node.run()
+        finally:
+            node.dispose()

--- a/nautilus_trader/adapters/hyperliquid/__init__.py
+++ b/nautilus_trader/adapters/hyperliquid/__init__.py
@@ -16,20 +16,30 @@
 Hyperliquid blockchain integration adapter.
 
 This subpackage provides an instrument provider, data and execution clients,
-configurations, and constants for connecting to and interacting with Hyperliquids's API.
+configurations, and constants for connecting to and interacting with Hyperliquid's API.
 
 For convenience, the most commonly used symbols are re-exported at the
 subpackage's top level, so downstream code can simply import from
 ``nautilus_trader.adapters.hyperliquid``.
 
 """
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidExecClientConfig
 from nautilus_trader.adapters.hyperliquid.constants import HYPERLIQUID
 from nautilus_trader.adapters.hyperliquid.constants import HYPERLIQUID_CLIENT_ID
 from nautilus_trader.adapters.hyperliquid.constants import HYPERLIQUID_VENUE
+from nautilus_trader.adapters.hyperliquid.factories import HyperliquidLiveDataClientFactory
+from nautilus_trader.adapters.hyperliquid.factories import HyperliquidLiveExecClientFactory
+from nautilus_trader.adapters.hyperliquid.providers import HyperliquidInstrumentProvider
 
 
 __all__ = [
     "HYPERLIQUID",
     "HYPERLIQUID_CLIENT_ID",
     "HYPERLIQUID_VENUE",
+    "HyperliquidDataClientConfig",
+    "HyperliquidExecClientConfig",
+    "HyperliquidInstrumentProvider",
+    "HyperliquidLiveDataClientFactory",
+    "HyperliquidLiveExecClientFactory",
 ]

--- a/nautilus_trader/adapters/hyperliquid/config.py
+++ b/nautilus_trader/adapters/hyperliquid/config.py
@@ -12,3 +12,76 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from nautilus_trader.common.config import PositiveInt
+from nautilus_trader.config import LiveDataClientConfig
+from nautilus_trader.config import LiveExecClientConfig
+
+
+class HyperliquidDataClientConfig(LiveDataClientConfig, frozen=True):
+    """
+    Configuration for ``HyperliquidDataClient`` instances.
+
+    Parameters
+    ----------
+    base_url_http : str, optional
+        The HTTP client custom endpoint override.
+    base_url_ws : str, optional
+        The WebSocket client custom endpoint override.
+    testnet : bool, default False
+        If the client is connecting to the Hyperliquid testnet API.
+    http_timeout_secs : PositiveInt, default 10
+        The timeout (seconds) for HTTP requests.
+
+    """
+
+    base_url_http: str | None = None
+    base_url_ws: str | None = None
+    testnet: bool = False
+    http_timeout_secs: PositiveInt = 10
+
+
+class HyperliquidExecClientConfig(LiveExecClientConfig, frozen=True):
+    """
+    Configuration for ``HyperliquidExecutionClient`` instances.
+
+    Parameters
+    ----------
+    private_key : str, optional
+        The Hyperliquid EVM private key.
+        If ``None`` then will source the `HYPERLIQUID_PK` environment variable.
+    vault_address : str, optional
+        The vault address for vault trading.
+        If ``None`` then will source the `HYPERLIQUID_VAULT` environment variable.
+    base_url_http : str, optional
+        The HTTP client custom endpoint override.
+    base_url_ws : str, optional
+        The WebSocket client custom endpoint override.
+    testnet : bool, default False
+        If the client is connecting to the Hyperliquid testnet API.
+    max_retries : PositiveInt, optional
+        The maximum number of times a submit, cancel or modify order request will be retried.
+    retry_delay_initial_ms : PositiveInt, optional
+        The initial delay (milliseconds) between retries. Short delays with frequent retries may result in account bans.
+    retry_delay_max_ms : PositiveInt, optional
+        The maximum delay (milliseconds) between retries.
+    http_timeout_secs : PositiveInt, default 10
+        The timeout (seconds) for HTTP requests.
+
+    Warnings
+    --------
+    A short `retry_delay` with frequent retries may result in account bans.
+
+    """
+
+    private_key: str | None = None
+    vault_address: str | None = None
+    base_url_http: str | None = None
+    base_url_ws: str | None = None
+    testnet: bool = False
+    max_retries: PositiveInt | None = None
+    retry_delay_initial_ms: PositiveInt | None = None
+    retry_delay_max_ms: PositiveInt | None = None
+    http_timeout_secs: PositiveInt = 10

--- a/nautilus_trader/adapters/hyperliquid/constants.py
+++ b/nautilus_trader/adapters/hyperliquid/constants.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from __future__ import annotations
+
 from typing import Final
 
 from nautilus_trader.model.identifiers import ClientId

--- a/nautilus_trader/adapters/hyperliquid/data.py
+++ b/nautilus_trader/adapters/hyperliquid/data.py
@@ -12,3 +12,350 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid.constants import HYPERLIQUID_VENUE
+from nautilus_trader.adapters.hyperliquid.providers import HyperliquidInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.data.messages import RequestBars
+from nautilus_trader.data.messages import RequestInstrument
+from nautilus_trader.data.messages import RequestInstruments
+from nautilus_trader.data.messages import RequestQuoteTicks
+from nautilus_trader.data.messages import RequestTradeTicks
+from nautilus_trader.data.messages import SubscribeBars
+from nautilus_trader.data.messages import SubscribeInstrument
+from nautilus_trader.data.messages import SubscribeInstruments
+from nautilus_trader.data.messages import SubscribeOrderBook
+from nautilus_trader.data.messages import SubscribeQuoteTicks
+from nautilus_trader.data.messages import SubscribeTradeTicks
+from nautilus_trader.data.messages import UnsubscribeBars
+from nautilus_trader.data.messages import UnsubscribeInstrument
+from nautilus_trader.data.messages import UnsubscribeInstruments
+from nautilus_trader.data.messages import UnsubscribeOrderBook
+from nautilus_trader.data.messages import UnsubscribeQuoteTicks
+from nautilus_trader.data.messages import UnsubscribeTradeTicks
+from nautilus_trader.live.data_client import LiveMarketDataClient
+from nautilus_trader.model.identifiers import ClientId
+
+
+class HyperliquidDataClient(LiveMarketDataClient):
+    """
+    Provides a data client for the Hyperliquid decentralized exchange.
+
+    Parameters
+    ----------
+    loop : asyncio.AbstractEventLoop
+        The event loop for the client.
+    client : Any
+        The Hyperliquid HTTP client (to be implemented).
+    msgbus : MessageBus
+        The message bus for the client.
+    cache : Cache
+        The cache for the client.
+    clock : LiveClock
+        The clock for the client.
+    instrument_provider : HyperliquidInstrumentProvider
+        The instrument provider.
+    config : HyperliquidDataClientConfig
+        The configuration for the client.
+    name : str, optional
+        The custom client ID.
+
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        client: Any,  # TODO: Replace with actual HyperliquidHttpClient when available
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+        instrument_provider: HyperliquidInstrumentProvider,
+        config: HyperliquidDataClientConfig,
+        name: str | None,
+    ) -> None:
+        super().__init__(
+            loop=loop,
+            client_id=ClientId(name or HYPERLIQUID_VENUE.value),
+            venue=HYPERLIQUID_VENUE,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=instrument_provider,
+        )
+
+        # Configuration
+        self._config = config
+        self._client = client
+
+        # Log configuration details
+        self._log.info(f"config.testnet={config.testnet}", LogColor.BLUE)
+        self._log.info(f"config.http_timeout_secs={config.http_timeout_secs}", LogColor.BLUE)
+
+        # Placeholder for WebSocket connections
+        self._ws_connection = None
+
+        self._log.info("Hyperliquid data client initialized")
+
+    # -- SUBSCRIPTIONS ---------------------------------------------------------------------------------
+
+    async def _subscribe_order_book(self, request: SubscribeOrderBook) -> None:
+        """
+        Subscribe to an order book.
+
+        Parameters
+        ----------
+        request : SubscribeOrderBook
+            The request to subscribe to the order book.
+
+        """
+        self._log.warning(
+            f"Order book subscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _subscribe_quote_ticks(self, request: SubscribeQuoteTicks) -> None:
+        """
+        Subscribe to quote ticks.
+
+        Parameters
+        ----------
+        request : SubscribeQuoteTicks
+            The request to subscribe to quote ticks.
+
+        """
+        self._log.warning(
+            f"Quote ticks subscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _subscribe_trade_ticks(self, request: SubscribeTradeTicks) -> None:
+        """
+        Subscribe to trade ticks.
+
+        Parameters
+        ----------
+        request : SubscribeTradeTicks
+            The request to subscribe to trade ticks.
+
+        """
+        self._log.warning(
+            f"Trade ticks subscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _subscribe_bars(self, request: SubscribeBars) -> None:
+        """
+        Subscribe to bars.
+
+        Parameters
+        ----------
+        request : SubscribeBars
+            The request to subscribe to bars.
+
+        """
+        self._log.warning(f"Bars subscription not yet implemented for {request.instrument_id}")
+
+    async def _subscribe_instrument(self, request: SubscribeInstrument) -> None:
+        """
+        Subscribe to an instrument.
+
+        Parameters
+        ----------
+        request : SubscribeInstrument
+            The request to subscribe to the instrument.
+
+        """
+        self._log.warning(
+            f"Instrument subscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _subscribe_instruments(self, request: SubscribeInstruments) -> None:
+        """
+        Subscribe to instruments.
+
+        Parameters
+        ----------
+        request : SubscribeInstruments
+            The request to subscribe to instruments.
+
+        """
+        self._log.warning("Instruments subscription not yet implemented")
+
+    # -- UNSUBSCRIPTIONS ---------------------------------------------------------------------------
+
+    async def _unsubscribe_order_book(self, request: UnsubscribeOrderBook) -> None:
+        """
+        Unsubscribe from an order book.
+
+        Parameters
+        ----------
+        request : UnsubscribeOrderBook
+            The request to unsubscribe from the order book.
+
+        """
+        self._log.warning(
+            f"Order book unsubscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _unsubscribe_quote_ticks(self, request: UnsubscribeQuoteTicks) -> None:
+        """
+        Unsubscribe from quote ticks.
+
+        Parameters
+        ----------
+        request : UnsubscribeQuoteTicks
+            The request to unsubscribe from quote ticks.
+
+        """
+        self._log.warning(
+            f"Quote ticks unsubscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _unsubscribe_trade_ticks(self, request: UnsubscribeTradeTicks) -> None:
+        """
+        Unsubscribe from trade ticks.
+
+        Parameters
+        ----------
+        request : UnsubscribeTradeTicks
+            The request to unsubscribe from trade ticks.
+
+        """
+        self._log.warning(
+            f"Trade ticks unsubscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _unsubscribe_bars(self, request: UnsubscribeBars) -> None:
+        """
+        Unsubscribe from bars.
+
+        Parameters
+        ----------
+        request : UnsubscribeBars
+            The request to unsubscribe from bars.
+
+        """
+        self._log.warning(f"Bars unsubscription not yet implemented for {request.instrument_id}")
+
+    async def _unsubscribe_instrument(self, request: UnsubscribeInstrument) -> None:
+        """
+        Unsubscribe from an instrument.
+
+        Parameters
+        ----------
+        request : UnsubscribeInstrument
+            The request to unsubscribe from the instrument.
+
+        """
+        self._log.warning(
+            f"Instrument unsubscription not yet implemented for {request.instrument_id}",
+        )
+
+    async def _unsubscribe_instruments(self, request: UnsubscribeInstruments) -> None:
+        """
+        Unsubscribe from instruments.
+
+        Parameters
+        ----------
+        request : UnsubscribeInstruments
+            The request to unsubscribe from instruments.
+
+        """
+        self._log.warning("Instruments unsubscription not yet implemented")
+
+    # -- REQUESTS -----------------------------------------------------------------------------------
+
+    async def _request_instrument(self, request: RequestInstrument) -> None:
+        """
+        Request an instrument.
+
+        Parameters
+        ----------
+        request : RequestInstrument
+            The request for the instrument.
+
+        """
+        self._log.warning(f"Instrument request not yet implemented for {request.instrument_id}")
+
+    async def _request_instruments(self, request: RequestInstruments) -> None:
+        """
+        Request instruments.
+
+        Parameters
+        ----------
+        request : RequestInstruments
+            The request for instruments.
+
+        """
+        self._log.warning("Instruments request not yet implemented")
+
+    async def _request_quote_ticks(self, request: RequestQuoteTicks) -> None:
+        """
+        Request quote ticks.
+
+        Parameters
+        ----------
+        request : RequestQuoteTicks
+            The request for quote ticks.
+
+        """
+        self._log.warning(f"Quote ticks request not yet implemented for {request.instrument_id}")
+
+    async def _request_trade_ticks(self, request: RequestTradeTicks) -> None:
+        """
+        Request trade ticks.
+
+        Parameters
+        ----------
+        request : RequestTradeTicks
+            The request for trade ticks.
+
+        """
+        self._log.warning(f"Trade ticks request not yet implemented for {request.instrument_id}")
+
+    async def _request_bars(self, request: RequestBars) -> None:
+        """
+        Request bars.
+
+        Parameters
+        ----------
+        request : RequestBars
+            The request for bars.
+
+        """
+        self._log.warning(f"Bars request not yet implemented for {request.instrument_id}")
+
+    # -- TASKS --------------------------------------------------------------------------------------
+
+    async def _connect(self) -> None:
+        """
+        Connect the client.
+        """
+        self._log.info("Connecting to Hyperliquid...", LogColor.BLUE)
+
+        # TODO: Implement actual connection logic when HyperliquidHttpClient is available
+        self._log.warning("Hyperliquid connection logic not yet implemented")
+
+        # Simulate connection for now
+        await asyncio.sleep(0.1)
+        self._log.info("Hyperliquid connection established (placeholder)", LogColor.GREEN)
+
+    async def _disconnect(self) -> None:
+        """
+        Disconnect the client.
+        """
+        self._log.info("Disconnecting from Hyperliquid...", LogColor.BLUE)
+
+        # TODO: Implement actual disconnection logic
+        if self._ws_connection:
+            # Close WebSocket connections
+            pass
+
+        await asyncio.sleep(0.1)
+        self._log.info("Hyperliquid disconnection completed", LogColor.GREEN)

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -12,3 +12,290 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid.constants import HYPERLIQUID_VENUE
+from nautilus_trader.adapters.hyperliquid.providers import HyperliquidInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.execution.messages import BatchCancelOrders
+from nautilus_trader.execution.messages import CancelAllOrders
+from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
+from nautilus_trader.execution.messages import ModifyOrder
+from nautilus_trader.execution.messages import QueryOrder
+from nautilus_trader.execution.messages import SubmitOrder
+from nautilus_trader.execution.messages import SubmitOrderList
+from nautilus_trader.execution.reports import OrderStatusReport
+from nautilus_trader.execution.reports import PositionStatusReport
+from nautilus_trader.live.execution_client import LiveExecutionClient
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import AccountId
+from nautilus_trader.model.identifiers import ClientId
+
+
+if TYPE_CHECKING:
+    pass  # TODO: Add imports when HyperliquidHttpClient is available
+
+
+class HyperliquidExecutionClient(LiveExecutionClient):
+    """
+    Provides an execution client for the Hyperliquid decentralized exchange.
+
+    Parameters
+    ----------
+    loop : asyncio.AbstractEventLoop
+        The event loop for the client.
+    client : Any
+        The Hyperliquid HTTP client (to be implemented).
+    msgbus : MessageBus
+        The message bus for the client.
+    cache : Cache
+        The cache for the client.
+    clock : LiveClock
+        The clock for the client.
+    instrument_provider : HyperliquidInstrumentProvider
+        The instrument provider.
+    config : HyperliquidExecClientConfig
+        The configuration for the client.
+    name : str, optional
+        The custom client ID.
+
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        client: Any,  # TODO: Replace with actual HyperliquidHttpClient when available
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+        instrument_provider: HyperliquidInstrumentProvider,
+        config: HyperliquidExecClientConfig,
+        name: str | None,
+    ) -> None:
+        super().__init__(
+            loop=loop,
+            client_id=ClientId(name or HYPERLIQUID_VENUE.value),
+            venue=HYPERLIQUID_VENUE,
+            oms_type=OmsType.NETTING,  # Set to NETTING like BitMEX
+            account_type=AccountType.MARGIN,  # Set to MARGIN like BitMEX
+            base_currency=None,  # TODO: Set base currency when available
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=instrument_provider,
+        )
+
+        # Configuration
+        self._config = config
+        self._client = client
+
+        # Log configuration details
+        self._log.info(f"config.testnet={config.testnet}", LogColor.BLUE)
+        self._log.info(f"config.http_timeout_secs={config.http_timeout_secs}", LogColor.BLUE)
+
+        # Set initial account ID
+        account_id = AccountId(f"{HYPERLIQUID_VENUE.value}-001")  # Placeholder account ID
+        self._set_account_id(account_id)
+
+        # Placeholder for WebSocket connections
+        self._ws_connection = None
+
+        self._log.info("Hyperliquid execution client initialized")
+
+    # -- COMMANDS -----------------------------------------------------------------------------------
+
+    async def _submit_order(self, command: SubmitOrder) -> None:
+        """
+        Submit an order.
+
+        Parameters
+        ----------
+        command : SubmitOrder
+            The command to submit the order.
+
+        """
+        self._log.warning(f"Order submission not yet implemented for {command.order}")
+
+    async def _submit_order_list(self, command: SubmitOrderList) -> None:
+        """
+        Submit an order list.
+
+        Parameters
+        ----------
+        command : SubmitOrderList
+            The command to submit the order list.
+
+        """
+        self._log.warning(f"Order list submission not yet implemented for {command.order_list}")
+
+    async def _modify_order(self, command: ModifyOrder) -> None:
+        """
+        Modify an order.
+
+        Parameters
+        ----------
+        command : ModifyOrder
+            The command to modify the order.
+
+        """
+        self._log.warning(f"Order modification not yet implemented for {command.order}")
+
+    # -- REPORTS ------------------------------------------------------------------------------------
+
+    async def generate_order_status_report(
+        self,
+        command: GenerateOrderStatusReport,
+    ) -> OrderStatusReport | None:
+        """
+        Generate an `OrderStatusReport` for the given order.
+
+        Parameters
+        ----------
+        command : GenerateOrderStatusReport
+            The command to generate the order status report.
+
+        Returns
+        -------
+        OrderStatusReport or None
+
+        """
+        self._log.warning(
+            f"Order status report generation not yet implemented for {command.client_order_id}",
+        )
+        return None
+
+    async def generate_order_status_reports(
+        self,
+        command: GenerateOrderStatusReports,
+    ) -> list[OrderStatusReport]:
+        """
+        Generate a list of `OrderStatusReport`s with optional query filters.
+
+        Parameters
+        ----------
+        command : GenerateOrderStatusReports
+            The command to generate the order status reports.
+
+        Returns
+        -------
+        list[OrderStatusReport]
+
+        """
+        self._log.warning("Order status reports generation not yet implemented")
+        return []
+
+    async def generate_position_status_reports(
+        self,
+        command: GeneratePositionStatusReports,
+    ) -> list[PositionStatusReport]:
+        """
+        Generate a list of `PositionStatusReport`s with optional query filters.
+
+        Parameters
+        ----------
+        command : GeneratePositionStatusReports
+            The command to generate the position status reports.
+
+        Returns
+        -------
+        list[PositionStatusReport]
+
+        """
+        self._log.warning("Position status reports generation not yet implemented")
+        return []
+
+    # -- QUERIES ------------------------------------------------------------------------------------
+
+    async def _cancel_order(self, command: CancelOrder) -> None:
+        """
+        Cancel an order.
+
+        Parameters
+        ----------
+        command : CancelOrder
+            The command to cancel the order.
+
+        """
+        self._log.warning(f"Order cancellation not yet implemented for {command.client_order_id}")
+
+    async def _cancel_all_orders(self, command: CancelAllOrders) -> None:
+        """
+        Cancel all orders.
+
+        Parameters
+        ----------
+        command : CancelAllOrders
+            The command to cancel all orders.
+
+        """
+        instrument_id_str = command.instrument_id or "all instruments"
+        self._log.warning(f"Cancel all orders not yet implemented for {instrument_id_str}")
+
+    async def _batch_cancel_orders(self, command: BatchCancelOrders) -> None:
+        """
+        Batch cancel orders.
+
+        Parameters
+        ----------
+        command : BatchCancelOrders
+            The command to batch cancel orders.
+
+        """
+        self._log.warning(
+            f"Batch cancel orders not yet implemented for {len(command.cancel_list)} orders",
+        )
+
+    # -- QUERIES ------------------------------------------------------------------------------------
+
+    async def _query_order(self, command: QueryOrder) -> None:
+        """
+        Query an order.
+
+        Parameters
+        ----------
+        command : QueryOrder
+            The command to query the order.
+
+        """
+        self._log.warning(f"Order query not yet implemented for {command.client_order_id}")
+
+    # -- TASKS --------------------------------------------------------------------------------------
+
+    async def _connect(self) -> None:
+        """
+        Connect the client.
+        """
+        self._log.info("Connecting to Hyperliquid execution...", LogColor.BLUE)
+
+        # TODO: Implement actual connection logic when HyperliquidHttpClient is available
+        self._log.warning("Hyperliquid execution connection logic not yet implemented")
+
+        # Simulate connection for now
+        await asyncio.sleep(0.1)
+        self._log.info("Hyperliquid execution connection established (placeholder)", LogColor.GREEN)
+
+    async def _disconnect(self) -> None:
+        """
+        Disconnect the client.
+        """
+        self._log.info("Disconnecting from Hyperliquid execution...", LogColor.BLUE)
+
+        # TODO: Implement actual disconnection logic
+        if self._ws_connection:
+            # Close WebSocket connections
+            pass
+
+        await asyncio.sleep(0.1)
+        self._log.info("Hyperliquid execution disconnection completed", LogColor.GREEN)

--- a/nautilus_trader/adapters/hyperliquid/factories.py
+++ b/nautilus_trader/adapters/hyperliquid/factories.py
@@ -12,3 +12,219 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid.config import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid.data import HyperliquidDataClient
+from nautilus_trader.adapters.hyperliquid.execution import HyperliquidExecutionClient
+from nautilus_trader.adapters.hyperliquid.providers import HyperliquidInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.live.factories import LiveDataClientFactory
+from nautilus_trader.live.factories import LiveExecClientFactory
+
+
+if TYPE_CHECKING:
+    pass  # TODO: Add imports for actual HyperliquidHttpClient when available
+
+
+@lru_cache(1)
+def get_cached_hyperliquid_http_client(
+    private_key: str | None = None,
+    vault_address: str | None = None,
+    base_url: str | None = None,
+    timeout_secs: int = 10,
+    testnet: bool = False,
+) -> Any:  # TODO: Replace with actual HyperliquidHttpClient when available
+    """
+    Cache and return a Hyperliquid HTTP client with the given parameters.
+
+    If a cached client with matching parameters already exists, the cached client will be returned.
+
+    Parameters
+    ----------
+    private_key : str, optional
+        The EVM private key for the client.
+    vault_address : str, optional
+        The vault address for vault trading.
+    base_url : str, optional
+        The base URL for the API endpoints.
+    timeout_secs : int, default 10
+        The timeout (seconds) for HTTP requests to Hyperliquid.
+    testnet : bool, default False
+        If the client is connecting to the testnet API.
+
+    Returns
+    -------
+    Any
+        Placeholder for HyperliquidHttpClient
+
+    """
+
+    # TODO: Implement actual HyperliquidHttpClient instantiation
+    # This is a placeholder that returns a mock client
+    class MockHyperliquidHttpClient:
+        def __init__(self, **kwargs):
+            self.params = kwargs
+
+    return MockHyperliquidHttpClient(
+        private_key=private_key,
+        vault_address=vault_address,
+        base_url=base_url,
+        timeout_secs=timeout_secs,
+        testnet=testnet,
+    )
+
+
+@lru_cache(1)
+def get_cached_hyperliquid_instrument_provider(
+    client: Any,  # TODO: Replace with actual HyperliquidHttpClient when available
+    config: InstrumentProviderConfig | None = None,
+) -> HyperliquidInstrumentProvider:
+    """
+    Cache and return a Hyperliquid instrument provider.
+
+    If a cached provider already exists, then that provider will be returned.
+
+    Parameters
+    ----------
+    client : Any
+        The Hyperliquid HTTP client (placeholder).
+    config : InstrumentProviderConfig, optional
+        The instrument provider configuration, by default None.
+
+    Returns
+    -------
+    HyperliquidInstrumentProvider
+
+    """
+    return HyperliquidInstrumentProvider(
+        client=client,
+        config=config,
+    )
+
+
+class HyperliquidLiveDataClientFactory(LiveDataClientFactory):
+    """
+    Provides a Hyperliquid live data client factory.
+    """
+
+    @staticmethod
+    def create(  # type: ignore
+        loop: asyncio.AbstractEventLoop,
+        name: str,
+        config: HyperliquidDataClientConfig,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+    ) -> HyperliquidDataClient:
+        """
+        Create a new Hyperliquid data client.
+
+        Parameters
+        ----------
+        loop : asyncio.AbstractEventLoop
+            The event loop for the client.
+        name : str
+            The custom client ID.
+        config : HyperliquidDataClientConfig
+            The client configuration.
+        msgbus : MessageBus
+            The message bus for the client.
+        cache : Cache
+            The cache for the client.
+        clock: LiveClock
+            The clock for the instrument provider.
+
+        Returns
+        -------
+        HyperliquidDataClient
+
+        """
+        client = get_cached_hyperliquid_http_client(
+            base_url=config.base_url_http,
+            timeout_secs=config.http_timeout_secs,
+            testnet=config.testnet,
+        )
+        provider = get_cached_hyperliquid_instrument_provider(
+            client=client,
+            config=config.instrument_provider,
+        )
+        return HyperliquidDataClient(
+            loop=loop,
+            client=client,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=provider,
+            config=config,
+            name=name,
+        )
+
+
+class HyperliquidLiveExecClientFactory(LiveExecClientFactory):
+    """
+    Provides a Hyperliquid live execution client factory.
+    """
+
+    @staticmethod
+    def create(  # type: ignore
+        loop: asyncio.AbstractEventLoop,
+        name: str,
+        config: HyperliquidExecClientConfig,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+    ) -> HyperliquidExecutionClient:
+        """
+        Create a new Hyperliquid execution client.
+
+        Parameters
+        ----------
+        loop : asyncio.AbstractEventLoop
+            The event loop for the client.
+        name : str
+            The custom client ID.
+        config : HyperliquidExecClientConfig
+            The client configuration.
+        msgbus : MessageBus
+            The message bus for the client.
+        cache : Cache
+            The cache for the client.
+        clock : LiveClock
+            The clock for the client.
+
+        Returns
+        -------
+        HyperliquidExecutionClient
+
+        """
+        client = get_cached_hyperliquid_http_client(
+            private_key=config.private_key,
+            vault_address=config.vault_address,
+            base_url=config.base_url_http,
+            timeout_secs=config.http_timeout_secs,
+            testnet=config.testnet,
+        )
+        provider = get_cached_hyperliquid_instrument_provider(
+            client=client,
+            config=config.instrument_provider,
+        )
+        return HyperliquidExecutionClient(
+            loop=loop,
+            client=client,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=provider,
+            config=config,
+            name=name,
+        )

--- a/nautilus_trader/adapters/hyperliquid/providers.py
+++ b/nautilus_trader/adapters/hyperliquid/providers.py
@@ -12,3 +12,87 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nautilus_trader.common.providers import InstrumentProvider
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.core.correctness import PyCondition
+from nautilus_trader.model.identifiers import InstrumentId
+
+
+if TYPE_CHECKING:
+    pass  # TODO: Add imports for actual HyperliquidHttpClient when available
+
+
+class HyperliquidInstrumentProvider(InstrumentProvider):
+    """
+    Provides Nautilus instrument definitions from Hyperliquid.
+
+    Parameters
+    ----------
+    client : Any
+        The Hyperliquid HTTP client (to be implemented).
+    config : InstrumentProviderConfig, optional
+        The instrument provider configuration, by default None.
+
+    """
+
+    def __init__(
+        self,
+        client: Any | None = None,  # TODO: Replace with actual HyperliquidHttpClient when available
+        config: InstrumentProviderConfig | None = None,
+    ) -> None:
+        super().__init__(config=config)
+        self._client = client
+        self._log_warnings = config.log_warnings if config else True
+
+        self._instruments_pyo3: list[Any] = []
+
+    def instruments_pyo3(self) -> list[Any]:
+        """
+        Return all Hyperliquid PyO3 instrument definitions held by the provider.
+
+        Returns
+        -------
+        list[Any]
+
+        """
+        return self._instruments_pyo3
+
+    async def load_all_async(self, filters: dict | None = None) -> None:
+        filters_str = "..." if not filters else f" with filters {filters}..."
+        self._log.info(f"Loading all instruments{filters_str}")
+
+        # TODO: Implement actual API call when HyperliquidHttpClient is available
+        # For now, we'll create a placeholder implementation
+        self._log.warning("Hyperliquid instrument loading not yet implemented - using placeholder")
+
+        # When the actual client is available, this should be:
+        # pyo3_instruments = await self._client.request_instruments()
+        # self._instruments_pyo3 = pyo3_instruments
+        # instruments = instruments_from_pyo3(pyo3_instruments)
+        # for instrument in instruments:
+        #     self.add(instrument=instrument)
+
+        self._log.info("Loaded 0 instruments (placeholder)")
+
+    async def load_ids_async(
+        self,
+        instrument_ids: list[InstrumentId],
+        filters: dict | None = None,
+    ) -> None:
+        if not instrument_ids:
+            self._log.warning("No instrument IDs given for loading")
+            return
+
+        PyCondition.not_none(instrument_ids, "instrument_ids")
+
+        self._log.info(f"Loading instruments {instrument_ids}...")
+
+        # TODO: Implement actual API call when HyperliquidHttpClient is available
+        self._log.warning("Hyperliquid specific instrument loading not yet implemented")
+
+        self._log.info("Loaded 0 specific instruments (placeholder)")


### PR DESCRIPTION
Introduce initial Hyperliquid adapter (configs, constants, providers, factories, placeholder data/execution clients), switch network selection to a simple testnet boolean and update URL helpers, Secrets, and HttpClient plus Rust bins to accept it; add live data/exec examples; small README and formatting fixes.
