### PR TITLE
Reset BarAggregator state to avoid live data conflict when requesting historical data

### DIFF
--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -312,6 +312,9 @@ cdef class BarAggregator:
         self.is_running = False # is_running means that an aggregator receives data from the message bus
 
     def start_batch_update(self, handler: Callable[[Bar], None], uint64_t time_ns) -> None:
+        self._builder.reset()
+        self._builder.ts_last = 0
+        self._builder._last_close = None
         self._batch_mode = True
         self._handler_backup = self._handler
         self._handler = handler


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This bug happens when subscribe_bars() and request_aggregated_bars() are called at the same time. Since the DataEngine utilize the same aggregator for live and historical data, if the request_aggregated_bars() take time longer than a new live bar arrives, the aggregator would store ts_last/_last_close from the live bar, which prevents the historical data to be correctly aggregated.
This fix resets the aggregator's state at the beginning of a historical batch (start_batch_update) erases the "poisoned" state from the live feed, ensuring the historical data can be processed correctly.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
