### PR TITLE
Fix Polymarket ws user message

### DIFF
--- a/nautilus_trader/adapters/polymarket/execution.py
+++ b/nautilus_trader/adapters/polymarket/execution.py
@@ -961,6 +961,8 @@ class PolymarketExecutionClient(LiveExecutionClient):
                 )
 
             ws_message = self._decoder_user_msg.decode(raw)
+            if not isinstance(ws_message, list):
+                ws_message = [ws_message]
             for msg in ws_message:
                 if isinstance(msg, PolymarketUserOrder):
                     self._handle_ws_order_msg(msg, wait_for_ack=True)

--- a/nautilus_trader/adapters/polymarket/websocket/types.py
+++ b/nautilus_trader/adapters/polymarket/websocket/types.py
@@ -30,4 +30,6 @@ MARKET_WS_MESSAGE: Final = list[
     | PolymarketTrade
     | PolymarketTickSizeChange
 ]
-USER_WS_MESSAGE: Final = list[PolymarketUserOrder | PolymarketUserTrade]
+USER_WS_MESSAGE: Final = (
+    list[PolymarketUserOrder | PolymarketUserTrade] | PolymarketUserOrder | PolymarketUserTrade
+)

--- a/tests/integration_tests/adapters/polymarket/test_parsing.py
+++ b/tests/integration_tests/adapters/polymarket/test_parsing.py
@@ -28,6 +28,7 @@ from nautilus_trader.adapters.polymarket.schemas.book import PolymarketTickSizeC
 from nautilus_trader.adapters.polymarket.schemas.book import PolymarketTrade
 from nautilus_trader.adapters.polymarket.schemas.user import PolymarketUserOrder
 from nautilus_trader.adapters.polymarket.schemas.user import PolymarketUserTrade
+from nautilus_trader.adapters.polymarket.websocket.types import USER_WS_MESSAGE
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.enums import AggressorSide
@@ -182,6 +183,31 @@ def test_parse_order_placement() -> None:
 
     # Assert
     assert isinstance(msg, PolymarketUserOrder)
+
+
+@pytest.mark.parametrize("wrap_list", [False, True])
+def test_parse_user_ws_message(wrap_list: bool) -> None:
+    # Arrange
+    data = pkgutil.get_data(
+        "tests.integration_tests.adapters.polymarket.resources.ws_messages",
+        "order_placement.json",
+    )
+    assert data
+
+    decoder = msgspec.json.Decoder(USER_WS_MESSAGE)
+
+    if wrap_list:
+        data = b"[" + data + b"]"
+
+    # Act
+    msg = decoder.decode(data)
+
+    # Assert
+    if wrap_list:
+        assert isinstance(msg, list)
+        assert isinstance(msg[0], PolymarketUserOrder)
+    else:
+        assert isinstance(msg, PolymarketUserOrder)
 
 
 def test_parse_order_cancel() -> None:


### PR DESCRIPTION
The ws message can contain a single message (which is not wrapped in a list).

See https://docs.polymarket.com/developers/CLOB/websocket/user-channel

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

See above.

## Related Issues/PRs

N/A

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation


## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

The failing test before fix (message not wrapped in list) reproduces the error message.
However, I have not observed the fix in production yet, but I can probably let you know by tomorrow whether this does the trick.