### PR TITLE
Fix nautilus CLI macOS compatibility with regex unicode-perl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ redis = { version = "0.32.5", features = [
   "tls-rustls",
   "tls-rustls-webpki-roots",
 ] }
-regex = { version = "1.11.2", default-features = false, features = ["std", "perf"] }
+regex = { version = "1.11.2", default-features = false, features = ["std", "perf", "unicode-perl"] }
 reqwest = { version = "0.12.23", default-features = false, features = [
   "blocking",
   "rustls-tls",


### PR DESCRIPTION
## Summary

Adds `unicode-perl` feature to the regex crate dependency to fix compilation and runtime issues on macOS when running `nautilus database init` command.

## Problem

The `nautilus database init` command fails on macOS with regex pattern compilation errors due to missing Unicode Perl compatibility features in the regex crate.

## Solution

- Added `unicode-perl` feature to the regex dependency in `Cargo.toml`
- This enables Perl-compatible Unicode regex support required for proper pattern matching on macOS systems
- Maintains compatibility with existing regex usage while fixing macOS-specific issues

## Testing

- [x] Verified `cargo build` succeeds with new dependency
- [x] Pre-commit hooks pass
- [x] Confirmed `nautilus database init` command runs without regex compilation errors on macOS

## Dependencies

This change only adds a feature flag to the existing regex dependency and does not introduce new dependencies.

## Compatibility

This change is backward compatible and only enhances regex functionality without breaking existing behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings