### PR TITLE
Fix IB historical bars resubscription failure after connection loss

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -147,6 +147,7 @@ class InteractiveBrokersClient(
             {}
         )  # Track timeout tasks for each bar type
         self._subscription_tick_data: dict[int, dict] = {}  # Store tick data by req_id
+        self._subscription_start_times: dict[int, int] = {}  # Store start_ns for bar filtering
 
         # OrderMixin
         self._exec_id_details: dict[

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -442,7 +442,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         """
         name = str(bar_type)
         now = self._clock.timestamp_ns()
-        start = params.get("start_ns")
+        start = params.pop("start_ns", None)
 
         if start is not None:
             # start_time = pd.Timestamp(start)

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -76,6 +76,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
 
     # Instance variables that will be available when mixed into InteractiveBrokersClient
     _subscription_tick_data: dict[int, dict[int, Any]]
+    _subscription_start_times: dict[int, int]  # reqId -> start_ns (for bar filtering)
 
     _order_books: ClassVar[dict[int, dict[str, dict[int, IBKRBookLevel]]]] = {}
     """
@@ -462,8 +463,11 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             contract=contract,
             use_rth=use_rth,
             handle_revised_bars=handle_revised_bars,
-            start=start,
+            params=params,
         )
+
+        # Store start time separately for bar filtering (not part of resubscription handle)
+        self._subscription_start_times[subscription.req_id] = start
 
         bar_size_setting: str = bar_spec_to_bar_size(bar_type.spec)
         self._eclient.reqHistoricalData(
@@ -490,6 +494,12 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
 
         """
         name = str(bar_type)
+
+        # Clean up stored start time before unsubscribing
+        subscription = self._subscriptions.get(name=name)
+        if subscription:
+            self._subscription_start_times.pop(subscription.req_id, None)
+
         await self._unsubscribe(name, self._eclient.cancelHistoricalData)
 
     async def get_historical_bars(
@@ -893,9 +903,8 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             if bar:
                 request.result.append(bar)
         elif subscription := self._subscriptions.get(req_id=req_id):
-            start = None
-            if isinstance(subscription.handle, functools.partial):
-                start = subscription.handle.keywords.get("start")
+            # Get start time from stored subscription start times
+            start = self._subscription_start_times.get(req_id)
 
             bar = await self._process_bar_data(
                 bar_type_str=str(subscription.name),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes a critical bug introduced in PR #2870 where historical bar subscriptions fail to resubscribe after IB Gateway disconnects/reconnects due to a parameter
signature mismatch. The fix stores start timestamps separately from the resubscription handle to prevent `TypeError` during automatic resubscription, restoring
proper data flow after connection loss.

## Related Issues/PRs

Fixes #3001 
Related to #2870

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A - This is a bug fix that restores intended behavior without changing the public API.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No documentation changes required (code-only fix).

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

Will add after review.

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

---

## Technical Details

**Problem:**
- PR #2870 passes `start` as a separate kwarg to `_subscribe()` instead of within `params`
- Creates `functools.partial` with `start=<value>` in kwargs
- On resubscription, the partial calls `subscribe_historical_bars(start=...)`
- Method signature only accepts `params` dict → `TypeError`
- Resubscription silently fails, causing data starvation

**Solution:**
- Store start times in separate `_subscription_start_times` dict (keyed by `req_id`)
- Pass full `params` dict to `_subscribe()` instead of individual `start` kwarg
- Retrieve `start` from stored dict when filtering bars (line 907)
- Clean up stored start time on unsubscribe

**Affected versions:** 1.220.0, 1.221.0+
**Last working version:** 1.219.0
