### PR TITLE
Add fs_rust_storage_options to Python catalog

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -212,6 +212,8 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
         The `fsspec` filesystem protocol for the catalog.
     catalog_fs_storage_options : dict, optional
         The `fsspec` storage options.
+    catalog_fs_rust_storage_options : dict, optional
+        The `fsspec` storage options for the Rust backend.
     instrument_id : InstrumentId | str, optional
         The instrument ID for the data configuration.
     start_time : str or int, optional
@@ -242,6 +244,7 @@ class BacktestDataConfig(NautilusConfig, frozen=True):
     data_cls: str
     catalog_fs_protocol: str | None = None
     catalog_fs_storage_options: dict | None = None
+    catalog_fs_rust_storage_options: dict | None = None
     instrument_id: InstrumentId | None = None
     start_time: str | int | None = None
     end_time: str | int | None = None

--- a/nautilus_trader/backtest/node.py
+++ b/nautilus_trader/backtest/node.py
@@ -666,6 +666,7 @@ class BacktestNode:
             path=config.catalog_path,
             fs_protocol=config.catalog_fs_protocol,
             fs_storage_options=config.catalog_fs_storage_options,
+            fs_rust_storage_options=config.catalog_fs_rust_storage_options,
         )
 
     def _load_engine_data(self, engine: BacktestEngine, result: CatalogDataResult) -> None:

--- a/nautilus_trader/persistence/config.py
+++ b/nautilus_trader/persistence/config.py
@@ -36,6 +36,8 @@ class StreamingConfig(NautilusConfig, frozen=True):
         The `fsspec` filesystem protocol for the catalog.
     fs_storage_options : dict, optional
         The `fsspec` storage options.
+    fs_rust_storage_options : dict, optional
+        The `fsspec` storage options for the Rust backend.
     flush_interval_ms : int, optional
         The flush interval (milliseconds) for writing chunks.
     replace_existing: bool, default False
@@ -59,6 +61,7 @@ class StreamingConfig(NautilusConfig, frozen=True):
     catalog_path: str
     fs_protocol: str | None = None
     fs_storage_options: dict | None = None
+    fs_rust_storage_options: dict | None = None
     flush_interval_ms: int | None = None
     replace_existing: bool = False
     include_types: list[type] | None = None
@@ -79,6 +82,7 @@ class StreamingConfig(NautilusConfig, frozen=True):
             path=self.catalog_path,
             fs_protocol=self.fs_protocol,
             fs_storage_options=self.fs_storage_options,
+            fs_rust_storage_options=self.fs_rust_storage_options,
         )
 
 
@@ -94,10 +98,13 @@ class DataCatalogConfig(NautilusConfig, frozen=True):
         The fsspec file system protocol for the data catalog.
     fs_storage_options : dict, optional
         The fsspec storage options for the data catalog.
+    fs_rust_storage_options : dict, optional
+        The fsspec storage options for the Rust backend.
 
     """
 
     path: str
     fs_protocol: str | None = None
     fs_storage_options: dict | None = None
+    fs_rust_storage_options: dict | None = None
     name: str | None = None

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -507,6 +507,7 @@ class NautilusKernel:
                     path=catalog_config.path,
                     fs_protocol=catalog_config.fs_protocol,
                     fs_storage_options=catalog_config.fs_storage_options,
+                    fs_rust_storage_options=catalog_config.fs_rust_storage_options,
                 )
                 used_catalog_name = catalog_config.name
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Allows to have rust specific parameters for querying with the rust catalog as they can be different in name from Python parameters. Thanks to @Johnkhk  for the suggestion.

Also updated BacktestDataConfig, DataCatalogConfig and StreamingConfig accordingly as well as code using them.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
