### PR TITLE
Remove tick validation in collect processing for pool profiler

### DIFF
--- a/crates/model/src/defi/pool_analysis/profiler.rs
+++ b/crates/model/src/defi/pool_analysis/profiler.rs
@@ -830,25 +830,23 @@ impl PoolProfiler {
     /// Updates position state when accumulated fees are collected. Finds the
     /// position and delegates fee collection to the position object.
     ///
+    /// Note: Tick validation is intentionally skipped to match Uniswap V3 behavior.
+    /// Invalid positions have no fees to collect, so they're silently ignored.
+    ///
     /// # Errors
     ///
     /// This function returns an error if:
     /// - Pool is not initialized.
-    /// - Tick range is invalid.
-    /// - Position does not exist.
     fn process_collect(&mut self, collect: &PoolFeeCollect) -> anyhow::Result<()> {
         self.check_if_initialized();
-        self.validate_ticks(collect.tick_lower, collect.tick_upper)?;
 
         let position_key =
             PoolPosition::get_position_key(&collect.owner, collect.tick_lower, collect.tick_upper);
         if let Some(position) = self.positions.get_mut(&position_key) {
             position.collect_fees(collect.amount0, collect.amount1);
-
-            Ok(())
-        } else {
-            anyhow::bail!("Position {} not found", position_key)
         }
+
+        Ok(())
     }
 
     /// Updates position state and tick maps when liquidity changes.


### PR DESCRIPTION
# Pull Request

 This change aligns `PoolProfiler::process_collect` with Uniswap V3's actual behavior by removing tick validation for collect events.

  ### Problem

  The profiler was validating ticks in `process_collect`, causing it to fail on legitimate on-chain collect events with invalid or edge-case tick values (e.g., `tick_lower == tick_upper`). This validation doesn't exist in Uniswap V3's collect function
  because invalid positions never accumulate fees to collect.

  **Example transaction that caused the error:**
  https://arbiscan.io/tx/0x9d8d8511ea136be6758bf7cdfb71e18297ebfc54273552c7c4ddf2c8e40387e2#eventlog#31

  **Error logs:**
```
2025-10-01T14:22:43.640Z INFO  [nautilus_cli::blockchain::analyze] Profiling pool events from database...
2025-10-01T14:22:55.636Z ERROR [nautilus] Error executing Nautilus CLI: Invalid tick range: 0 >= 0
```

  ### Solution

  - Removed `validate_ticks()` call from `process_collect`
  - Changed behavior to silently return `Ok(())` when position doesn't exist (instead of throwing error)
  - Updated documentation to explain why tick validation is intentionally skipped
  - Added test case verifying collect with invalid ticks doesn't panic and leaves valid positions unchanged

  ### Why This Is Correct

  In Uniswap V3, the `collect` function doesn't validate tick ranges because:
  1. Positions with invalid ticks can never accumulate fees
  2. The function safely returns zero fees for non-existent positions
  3. Validation adds unnecessary overhead for a non-issue

  This change makes the profiler more resilient when processing real-world blockchain data that may contain edge cases.



## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


