### PR TITLE
Add schwab adapter

### DIFF
--- a/nautilus_trader/adapters/schwab/__init__.py
+++ b/nautilus_trader/adapters/schwab/__init__.py
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Charles Schwab brokerage adapter package.
+"""
+
+from nautilus_trader.adapters.schwab.common import SCHWAB
+from nautilus_trader.adapters.schwab.common import SCHWAB_VENUE
+
+
+__all__ = ["SCHWAB", "SCHWAB_VENUE"]
+
+try:  # Optional exports, avoid import-time failures during partial builds
+    from nautilus_trader.adapters.schwab.config import SchwabDataClientConfig
+    from nautilus_trader.adapters.schwab.config import SchwabExecClientConfig
+    from nautilus_trader.adapters.schwab.config import SchwabInstrumentProviderConfig
+    from nautilus_trader.adapters.schwab.factories import SchwabLiveDataClientFactory
+    from nautilus_trader.adapters.schwab.factories import SchwabLiveExecClientFactory
+except ImportError:  # pragma: no cover - executed on environments without compiled deps
+    pass
+else:
+    __all__ += [
+        "SchwabDataClientConfig",
+        "SchwabExecClientConfig",
+        "SchwabInstrumentProviderConfig",
+        "SchwabLiveDataClientFactory",
+        "SchwabLiveExecClientFactory",
+    ]

--- a/nautilus_trader/adapters/schwab/common.py
+++ b/nautilus_trader/adapters/schwab/common.py
@@ -1,0 +1,105 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from decimal import Decimal
+
+from nautilus_trader.model.enums import OptionKind
+from nautilus_trader.model.identifiers import Venue
+
+
+SCHWAB = "SCHWAB"
+SCHWAB_VENUE = Venue(SCHWAB)
+SCHWAB_OPTION_VENUE = Venue("OPRA")
+
+
+@dataclass(slots=True)
+class ParsedOpraSymbol:
+    """
+    Structured OPRA symbol fields.
+    """
+
+    underlying: str
+    expiration: datetime
+    option_kind: OptionKind
+    strike: Decimal
+
+
+def parse_opra_symbol(symbol: str) -> ParsedOpraSymbol:
+    """
+    Parse an OPRA symbol into its components.
+
+    Parameters
+    ----------
+    symbol : str
+        The raw OPRA symbol (e.g. ``AAPL211217C00150000``).
+
+    Returns
+    -------
+    ParsedOpraSymbol
+
+    Raises
+    ------
+    ValueError
+        If ``symbol`` does not conform to the expected OPRA format.
+
+    """
+    if len(symbol) <= 15:
+        raise ValueError(f"OPRA symbol too short: {symbol}")
+
+    underlying = symbol[:-15].strip()
+    if not underlying:
+        raise ValueError(f"OPRA symbol missing underlying: {symbol}")
+
+    date_part = symbol[-15:-9]
+    option_flag = symbol[-9]
+    strike_part = symbol[-8:]
+
+    try:
+        year = 2000 + int(date_part[0:2])
+        month = int(date_part[2:4])
+        day = int(date_part[4:6])
+    except ValueError as exc:
+        raise ValueError(f"Invalid OPRA expiration in symbol: {symbol}") from exc
+
+    try:
+        option_kind = OptionKind.CALL if option_flag.upper() == "C" else OptionKind.PUT
+    except Exception as exc:
+        raise ValueError(f"Invalid OPRA option flag in symbol: {symbol}") from exc
+
+    try:
+        strike = Decimal(int(strike_part)) / Decimal(1000)
+    except ValueError as exc:
+        raise ValueError(f"Invalid OPRA strike in symbol: {symbol}") from exc
+
+    expiration = datetime(year, month, day, tzinfo=UTC)
+    return ParsedOpraSymbol(
+        underlying=underlying,
+        expiration=expiration,
+        option_kind=option_kind,
+        strike=strike,
+    )
+
+
+__all__ = [
+    "SCHWAB",
+    "SCHWAB_OPTION_VENUE",
+    "SCHWAB_VENUE",
+    "ParsedOpraSymbol",
+    "parse_opra_symbol",
+]

--- a/nautilus_trader/adapters/schwab/config.py
+++ b/nautilus_trader/adapters/schwab/config.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from nautilus_trader.adapters.schwab.common import SCHWAB_VENUE
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LiveDataClientConfig
+from nautilus_trader.config import LiveExecClientConfig
+from nautilus_trader.config import NautilusConfig
+from nautilus_trader.config import PositiveFloat
+from nautilus_trader.config import PositiveInt
+from nautilus_trader.model.identifiers import Venue
+
+
+class SchwabClientConfig(NautilusConfig, frozen=True):
+    """
+    Connection details required to create a ``schwab-py`` client.
+    """
+
+    api_key: str | None = None
+    app_secret: str | None = None
+    callback_url: str | None = None
+    token_path: str | None = None
+
+
+class SchwabInstrumentProviderConfig(InstrumentProviderConfig, frozen=True):
+    """
+    Instrument bootstrap configuration for Schwab universes.
+    """
+
+    equity_exchange: str = "XNAS"
+    equity_currency: str = "USD"
+    equity_price_precision: int = 2
+    equity_tick_size: PositiveFloat = 0.01
+    equity_lot_size: PositiveInt = 1
+    option_exchange: str = "OPRA"
+    option_currency: str = "USD"
+    option_price_precision: int = 2
+    option_tick_size: PositiveFloat = 0.01
+    option_multiplier: PositiveFloat = 100.0
+
+
+class SchwabDataClientConfig(LiveDataClientConfig, frozen=True):
+    """
+    Configuration for :class:`SchwabDataClient` instances.
+    """
+
+    venue: Venue = SCHWAB_VENUE
+    account_id: str | None = None
+    http_client: SchwabClientConfig | None = None
+    include_pre_market: bool = False
+    bars_timestamp_on_close: bool = True
+
+
+class SchwabExecClientConfig(LiveExecClientConfig, frozen=True):
+    """
+    Configuration for :class:`SchwabExecutionClient` instances.
+    """
+
+    venue: Venue = SCHWAB_VENUE
+    account_number: str = ""
+    http_client: SchwabClientConfig | None = None
+    session: str = "NORMAL"
+    default_duration: str = "DAY"
+    default_instruction_equity_buy: str = "BUY"
+    default_instruction_equity_sell: str = "SELL"
+    default_instruction_option_buy: str = "BUY_TO_OPEN"
+    default_instruction_option_sell: str = "SELL_TO_CLOSE"
+    max_retries: PositiveInt | None = None
+    retry_delay_initial_ms: PositiveInt | None = None
+    retry_delay_max_ms: PositiveInt | None = None
+
+
+__all__ = [
+    "SchwabClientConfig",
+    "SchwabDataClientConfig",
+    "SchwabExecClientConfig",
+    "SchwabInstrumentProviderConfig",
+]

--- a/nautilus_trader/adapters/schwab/data.py
+++ b/nautilus_trader/adapters/schwab/data.py
@@ -1,0 +1,397 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import asyncio
+import copy
+import datetime as dt
+from typing import Any
+
+from msgspec import json as msgspec_json
+from schwab.streaming import StreamClient
+
+from nautilus_trader.adapters.schwab.common import SCHWAB_VENUE
+from nautilus_trader.adapters.schwab.config import SchwabDataClientConfig
+from nautilus_trader.adapters.schwab.http.client import SchwabHttpClient
+from nautilus_trader.adapters.schwab.providers import SchwabInstrumentProvider
+from nautilus_trader.adapters.schwab.websocket.client import SchwabWebSocketClient
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.core.datetime import millis_to_nanos
+from nautilus_trader.data.messages import RequestQuoteTicks
+from nautilus_trader.data.messages import RequestTradeTicks
+from nautilus_trader.data.messages import SubscribeBars
+from nautilus_trader.data.messages import SubscribeOrderBook
+from nautilus_trader.data.messages import SubscribeQuoteTicks
+from nautilus_trader.data.messages import SubscribeTradeTicks
+from nautilus_trader.data.messages import UnsubscribeBars
+from nautilus_trader.data.messages import UnsubscribeOrderBook
+from nautilus_trader.data.messages import UnsubscribeQuoteTicks
+from nautilus_trader.data.messages import UnsubscribeTradeTicks
+from nautilus_trader.live.data_client import LiveMarketDataClient
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.data import BookOrder
+from nautilus_trader.model.data import OrderBookDelta
+from nautilus_trader.model.data import OrderBookDeltas
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import BookAction
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+
+
+class SchwabDataClient(LiveMarketDataClient):
+    """
+    Schwab market data client based on ``schwab-py``.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+        http_client: SchwabHttpClient,
+        instrument_provider: SchwabInstrumentProvider,
+        config: SchwabDataClientConfig,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            loop=loop,
+            client_id=ClientId(name or f"{SCHWAB_VENUE.value}-DATA"),
+            venue=SCHWAB_VENUE,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=instrument_provider,
+        )
+
+        self._config = config
+        self._http_client = http_client
+        self._bars_timestamp_on_close = config.bars_timestamp_on_close
+        # WebSocket API
+        self._ws_client = SchwabWebSocketClient(
+            clock=clock,
+            http_client=self._http_client,
+            handler=self._handle_ws_message,
+            handler_reconnect=None,
+            loop=self._loop,
+        )
+        self._ws_handlers_map = {
+            "CHART_EQUITY": self._handle_chart_equity_message,
+            "CHART_FUTURES": self._handle_chart_futures_message,
+            "LEVELONE_EQUITIES": self._handle_level_one_equity_message,
+            "NYSE_BOOK": self._handle_level_two_message,
+            "NASDAQ_BOOK": self._handle_level_two_message,
+            "SMART_BOOK": self._handle_level_two_message,
+        }
+        self._subscribe_bar_types: dict[str, BarType] = {}
+        self._level_one_instrument_id_cache: dict[str, InstrumentId] = {}
+        self._order_book_deltas_instrument_id_cache: dict[str, InstrumentId] = {}
+        self._last_quotes: dict[InstrumentId, QuoteTick] = {}
+        self._last_trades: dict[InstrumentId, TradeTick] = {}
+
+    def _label_message(self, msg, field_enum_type):
+        if "content" in msg:
+            new_msg = copy.deepcopy(msg)
+            for idx in range(len(msg["content"])):
+                field_enum_type.relabel_message(
+                    msg["content"][idx],
+                    new_msg["content"][idx],
+                )
+            return new_msg
+        else:
+            return msg
+
+    def _handle_chart_equity_message(self, msg: dict[str, Any]) -> None:
+        labeled_msg = self._label_message(msg, StreamClient.ChartEquityFields)
+        try:
+            for data in labeled_msg["content"]:
+                # Only 1 minute bar is supported by schwab for now
+                bar_type = self._subscribe_bar_types.get(data["key"], None)
+                if bar_type is None:
+                    self._log.error(
+                        f"Cannot parse bar data: no bar_type for {msg}",
+                    )
+                    return
+                instrument_id = bar_type.instrument_id
+                instrument = self._cache.instrument(instrument_id)
+                ts_event = millis_to_nanos(data["CHART_TIME_MILLIS"])
+                if self._bars_timestamp_on_close:
+                    interval_ms = bar_type.spec.timedelta / dt.timedelta(milliseconds=1)
+                    ts_event += millis_to_nanos(interval_ms)
+                bar = Bar(
+                    bar_type=bar_type,
+                    open=Price(data["OPEN_PRICE"], instrument.price_precision),
+                    high=Price(data["HIGH_PRICE"], instrument.price_precision),
+                    low=Price(data["LOW_PRICE"], instrument.price_precision),
+                    close=Price(
+                        data["CLOSE_PRICE"],
+                        instrument.price_precision,
+                    ),
+                    volume=Quantity(data["VOLUME"], instrument.size_precision),
+                    ts_event=ts_event,
+                    ts_init=self._clock.timestamp_ns(),
+                )
+                self._handle_data(bar)
+        except Exception as e:
+            self._log.exception(f"Failed to parse bar: {msg}", e)
+
+    def _handle_chart_futures_message(self, msg: dict[str, Any]) -> None:
+        pass
+
+    def _handle_level_one_equity_message(self, msg: dict[str, Any]) -> None:
+        labeled_msg = self._label_message(
+            msg,
+            StreamClient.LevelOneEquityFields,
+        )
+        try:
+            for data in labeled_msg["content"]:
+                instrument_id = self._level_one_instrument_id_cache[data["key"]]
+                instrument = self._cache.instrument(instrument_id)
+                last_quote = self._last_quotes.get(instrument_id, None)
+                if last_quote:
+                    bid_price = data.get(
+                        "BID_PRICE",
+                        last_quote.bid_price.as_double(),
+                    )
+                    ask_price = data.get(
+                        "ASK_PRICE",
+                        last_quote.ask_price.as_double(),
+                    )
+                    bid_size = data.get(
+                        "BID_SIZE",
+                        last_quote.bid_size.as_double(),
+                    )
+                    ask_size = data.get(
+                        "ASK_SIZE",
+                        last_quote.ask_size.as_double(),
+                    )
+                else:
+                    bid_price = data["BID_PRICE"]
+                    ask_price = data["ASK_PRICE"]
+                    bid_size = data["BID_SIZE"]
+                    ask_size = data["ASK_SIZE"]
+                ts_event = data.get(
+                    "QUOTE_TIME_MILLIS",
+                    data.get("TRADE_TIME_MILLIS", None),
+                )
+                if ts_event is None:
+                    ts_event = labeled_msg["timestamp"]
+                tick = QuoteTick(
+                    instrument_id=instrument_id,
+                    bid_price=Price(bid_price, instrument.price_precision),
+                    ask_price=Price(ask_price, instrument.price_precision),
+                    bid_size=Quantity(bid_size, instrument.size_precision),
+                    ask_size=Quantity(ask_size, instrument.size_precision),
+                    ts_event=millis_to_nanos(ts_event),
+                    ts_init=self._clock.timestamp_ns(),
+                )
+                self._last_quotes[instrument_id] = tick
+                self._handle_data(tick)
+        except Exception as e:
+            self._log.exception(f"Failed to parse level one tick: {msg}", e)
+
+    def _label_book_message(self, msg: dict[str, Any]) -> None:
+        new_msg = self._label_message(msg, StreamClient.BookFields)
+
+        # Relabel bids
+        for content in new_msg["content"]:
+            if "BIDS" in content:
+                for bid in content["BIDS"]:
+                    # Relabel top-level bids
+                    StreamClient.BidFields.relabel_message(bid, bid)
+
+                    # Relabel per-exchange bids
+                    for e_bid in bid["BIDS"]:
+                        StreamClient.PerExchangeBidFields.relabel_message(
+                            e_bid,
+                            e_bid,
+                        )
+
+        # Relabel asks
+        for content in new_msg["content"]:
+            if "ASKS" in content:
+                for ask in content["ASKS"]:
+                    # Relabel top-level asks
+                    StreamClient.AskFields.relabel_message(ask, ask)
+
+                    # Relabel per-exchange bids
+                    for e_ask in ask["ASKS"]:
+                        StreamClient.PerExchangeAskFields.relabel_message(
+                            e_ask,
+                            e_ask,
+                        )
+
+        return new_msg
+
+    def _handle_level_two_message(self, msg: dict[str, Any]) -> None:
+        labeled_msg = self._label_book_message(msg)
+        try:
+            for data in labeled_msg["content"]:
+                instrument_id = self._order_book_deltas_instrument_id_cache[data["key"]]
+                instrument = self._cache.instrument(instrument_id)
+                ts_init = self._clock.timestamp_ns()
+                ts_event = millis_to_nanos(data["BOOK_TIME"])
+                deltas: list[OrderBookDelta] = []
+                deltas.append(
+                    OrderBookDelta.clear(
+                        instrument_id,
+                        0,
+                        ts_event,
+                        ts_init,
+                    ),
+                )
+                for bid in data["BIDS"]:
+                    deltas.append(
+                        OrderBookDelta(
+                            instrument_id=instrument_id,
+                            action=BookAction.ADD,
+                            order=BookOrder(
+                                side=OrderSide.BUY,
+                                price=Price(
+                                    bid["BID_PRICE"],
+                                    instrument.price_precision,
+                                ),
+                                size=Quantity.from_int(bid["NUM_BIDS"]),
+                                order_id=0,
+                            ),
+                            flags=0,
+                            sequence=0,
+                            ts_event=ts_event,
+                            ts_init=ts_init,
+                        ),
+                    )
+                for ask in data["ASKS"]:
+                    deltas.append(
+                        OrderBookDelta(
+                            instrument_id=instrument_id,
+                            action=BookAction.ADD,
+                            order=BookOrder(
+                                side=OrderSide.SELL,
+                                price=Price(
+                                    ask["ASK_PRICE"],
+                                    instrument.price_precision,
+                                ),
+                                size=Quantity.from_int(ask["NUM_ASKS"]),
+                                order_id=0,
+                            ),
+                            flags=0,
+                            sequence=0,
+                            ts_event=ts_event,
+                            ts_init=ts_init,
+                        ),
+                    )
+                snapshot = OrderBookDeltas(
+                    instrument_id=instrument_id,
+                    deltas=deltas,
+                )
+                self._handle_data(snapshot)
+        except Exception as e:
+            self._log.exception(f"Failed to parse level two tick: {msg}", e)
+
+    async def _connect(self) -> None:
+        await self._instrument_provider.initialize()
+        await self._ws_client.connect()
+        self._send_all_instruments_to_data_engine()
+
+    async def _disconnect(self) -> None:
+        self._last_quotes.clear()
+        self._last_trades.clear()
+
+    def _handle_ws_message(self, raw: bytes) -> None:
+        msg = msgspec_json.decode(raw)
+        self._log.debug(f"Received: {msg}", LogColor.BLUE)
+        if "notify" in msg:
+            for d in msg["notify"]:
+                if "heartbeat" in d:
+                    continue
+                else:
+                    if d["service"] in self._ws_handlers_map:
+                        self._ws_handlers_map[d["service"]](d)
+
+        if "data" in msg:
+            for d in msg["data"]:
+                if d["service"] in self._ws_handlers_map:
+                    self._ws_handlers_map[d["service"]](d)
+
+    async def _subscribe_quote_ticks(self, command: SubscribeQuoteTicks) -> None:
+        symbol = command.instrument_id.symbol.value
+        self._level_one_instrument_id_cache[symbol] = command.instrument_id
+        await self._ws_client.subscribe_quote_ticks(symbol)
+
+    async def _unsubscribe_quote_ticks(self, command: UnsubscribeQuoteTicks) -> None:
+        symbol = command.instrument_id.symbol.value
+        self._level_one_instrument_id_cache.pop(symbol, None)
+        await self._ws_client.unsubscribe_quote_ticks(symbol)
+
+    async def _subscribe_trade_ticks(self, command: SubscribeTradeTicks) -> None:
+        raise NotImplementedError
+
+    async def _unsubscribe_trade_ticks(self, command: UnsubscribeTradeTicks) -> None:
+        raise NotImplementedError
+
+    async def _request_quote_ticks(self, request: RequestQuoteTicks) -> None:
+        raise NotImplementedError
+
+    async def _request_trade_ticks(self, request: RequestTradeTicks) -> None:
+        raise NotImplementedError
+
+    async def _subscribe_bars(self, command: SubscribeBars) -> None:
+        symbol = command.bar_type.instrument_id.symbol.value
+        interval_str = str(command.bar_type.spec)
+        self._subscribe_bar_types[symbol] = command.bar_type
+        await self._ws_client.subscribe_klines(symbol, interval_str)
+
+    async def _unsubscribe_bars(self, command: UnsubscribeBars) -> None:
+        symbol = command.bar_type.instrument_id.symbol.value
+        interval_str = str(command.bar_type.spec)
+        self._subscribe_bar_types.pop(symbol, None)
+        await self._ws_client.unsubscribe_klines(symbol, interval_str)
+
+    async def _subscribe_order_book_deltas(self, command: SubscribeOrderBook) -> None:
+        if command.book_type != BookType.L2_MBP:
+            self._log.error(
+                "Cannot subscribe to order book deltas: " "Only L2_MBP data is supported by Schwab",
+            )
+            return
+        symbol = command.instrument_id.symbol.value
+        venue = command.instrument_id.venue.value
+        self._order_book_deltas_instrument_id_cache[symbol] = command.instrument_id
+        await self._ws_client.subscribe_order_book_deltas(symbol, venue)
+
+    async def _unsubscribe_order_book_deltas(self, command: UnsubscribeOrderBook) -> None:
+        symbol = command.instrument_id.symbol.value
+        venue = command.instrument_id.venue.value
+        self._order_book_deltas_instrument_id_cache.pop(symbol, None)
+        await self._ws_client.unsubscribe_order_book_deltas(symbol, venue)
+
+    def _send_all_instruments_to_data_engine(self) -> None:
+        instruments = self._instrument_provider.get_all().values()
+        for instrument in instruments:
+            self._handle_data(instrument)
+
+        for currency in self._instrument_provider.currencies().values():
+            self._cache.add_currency(currency)
+
+
+__all__ = ["SchwabDataClient"]

--- a/nautilus_trader/adapters/schwab/execution.py
+++ b/nautilus_trader/adapters/schwab/execution.py
@@ -1,0 +1,961 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+from schwab.orders.common import Duration as SchwabDuration
+from schwab.orders.common import EquityInstruction
+from schwab.orders.common import OrderStrategyType
+from schwab.orders.common import OrderType as SchwabOrderType
+from schwab.orders.common import PriceLinkBasis
+from schwab.orders.common import PriceLinkType
+from schwab.orders.common import Session as SchwabSession
+from schwab.orders.generic import OrderBuilder
+
+from nautilus_trader.adapters.schwab.common import SCHWAB_OPTION_VENUE
+from nautilus_trader.adapters.schwab.common import SCHWAB_VENUE
+from nautilus_trader.adapters.schwab.config import SchwabExecClientConfig
+from nautilus_trader.adapters.schwab.http.client import SchwabHttpClient
+from nautilus_trader.adapters.schwab.http.error import SchwabError
+from nautilus_trader.adapters.schwab.http.error import should_retry
+from nautilus_trader.adapters.schwab.providers import SchwabInstrumentProvider
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.core.uuid import UUID4
+from nautilus_trader.execution.messages import BatchCancelOrders
+from nautilus_trader.execution.messages import CancelAllOrders
+from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import ModifyOrder
+from nautilus_trader.execution.messages import SubmitOrder
+from nautilus_trader.execution.messages import SubmitOrderList
+from nautilus_trader.execution.reports import FillReport
+from nautilus_trader.execution.reports import OrderStatusReport
+from nautilus_trader.execution.reports import PositionStatusReport
+from nautilus_trader.live.execution_client import LiveExecutionClient
+from nautilus_trader.live.retry import RetryManagerPool
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import ContingencyType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import OrderStatus
+from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.enums import TrailingOffsetType
+from nautilus_trader.model.enums import TriggerType
+from nautilus_trader.model.identifiers import AccountId
+from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import ClientOrderId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import VenueOrderId
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import LimitOrder
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.model.orders import Order
+from nautilus_trader.model.orders import StopMarketOrder
+from nautilus_trader.model.orders import TrailingStopLimitOrder
+from nautilus_trader.model.orders import TrailingStopMarketOrder
+
+
+ORDER_TYPE_MAP = {
+    OrderType.MARKET: SchwabOrderType.MARKET,
+    OrderType.LIMIT: SchwabOrderType.LIMIT,
+    OrderType.STOP_MARKET: SchwabOrderType.STOP,
+    OrderType.STOP_LIMIT: SchwabOrderType.STOP_LIMIT,
+    OrderType.TRAILING_STOP_MARKET: SchwabOrderType.TRAILING_STOP,
+    OrderType.TRAILING_STOP_LIMIT: SchwabOrderType.TRAILING_STOP_LIMIT,
+}
+
+ORDER_TYPE_REVERSE = {value: key for key, value in ORDER_TYPE_MAP.items()}
+
+TIME_IN_FORCE_MAP = {
+    TimeInForce.DAY: SchwabDuration.DAY,
+    TimeInForce.GTC: SchwabDuration.GOOD_TILL_CANCEL,
+    TimeInForce.IOC: SchwabDuration.IMMEDIATE_OR_CANCEL,
+    TimeInForce.FOK: SchwabDuration.FILL_OR_KILL,
+}
+
+TIME_IN_FORCE_REVERSE = {value: key for key, value in TIME_IN_FORCE_MAP.items()}
+
+ORDER_ACTION_MAP = {
+    OrderSide.BUY: EquityInstruction.BUY,
+    OrderSide.SELL: EquityInstruction.SELL,
+}
+
+TRAILING_OFFSET_TYPE_MAP = {
+    TrailingOffsetType.PRICE: PriceLinkType.VALUE,
+    TrailingOffsetType.BASIS_POINTS: PriceLinkType.PERCENT,
+    TrailingOffsetType.TICKS: PriceLinkType.TICK,
+}
+
+TRAILING_OFFSET_TYPE_REVERSE = {value: key for key, value in TRAILING_OFFSET_TYPE_MAP.items()}
+
+# TODO: schwab has no specific default here, need to double check
+TRIGGER_TYPE_MAP = {
+    TriggerType.LAST_PRICE: PriceLinkBasis.LAST,
+    TriggerType.BID_ASK: PriceLinkBasis.ASK_BID,
+    TriggerType.MARK_PRICE: PriceLinkBasis.MARK,
+    TriggerType.MID_POINT: PriceLinkBasis.AVERAGE,
+    TriggerType.DEFAULT: PriceLinkBasis.LAST,
+}
+
+SCHWAB_STATUS_MAP = {
+    "ACCEPTED": OrderStatus.INITIALIZED,
+    "WORKING": OrderStatus.SUBMITTED,
+    "QUEUED": OrderStatus.SUBMITTED,
+    "PENDING_ACTIVATION": OrderStatus.SUBMITTED,
+    "FILLED": OrderStatus.FILLED,
+    "CANCELED": OrderStatus.CANCELED,
+    "REJECTED": OrderStatus.REJECTED,
+    "EXPIRED": OrderStatus.EXPIRED,
+}
+
+
+class SchwabExecutionClient(LiveExecutionClient):
+    """
+    Execution client for Schwab brokerage accounts.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+        http_client: SchwabHttpClient,
+        instrument_provider: SchwabInstrumentProvider,
+        config: SchwabExecClientConfig,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            loop=loop,
+            client_id=ClientId(name or f"{SCHWAB_VENUE.value}-EXEC"),
+            venue=SCHWAB_VENUE,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            instrument_provider=instrument_provider,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            config=config,
+        )
+
+        self._http_client = http_client
+        self._config = config
+        self._client_order_to_venue: dict[ClientOrderId, VenueOrderId] = {}
+        self._client_order_to_instrument: dict[ClientOrderId, InstrumentId] = {}
+        self._open_orders: dict[VenueOrderId, Mapping[str, Any]] = {}
+        self._account_hash: str | None = None
+
+        account_id_value = config.account_number
+        if account_id_value:
+            self._set_account_id(
+                AccountId(f"{SCHWAB_VENUE.value}-{account_id_value}"),
+            )
+        else:
+            self._set_account_id(AccountId(f"{SCHWAB_VENUE.value}-001"))
+
+        self._retry_manager_pool = RetryManagerPool[None](
+            pool_size=100,
+            max_retries=config.max_retries or 0,
+            delay_initial_ms=config.retry_delay_initial_ms or 1_000,
+            delay_max_ms=config.retry_delay_max_ms or 10_000,
+            backoff_factor=2,
+            logger=self._log,
+            exc_types=(SchwabError,),
+            retry_check=should_retry,
+        )
+
+        self._submit_order_methods = {
+            OrderType.MARKET: self._submit_market_order,
+            OrderType.LIMIT: self._submit_limit_order,
+            OrderType.STOP_MARKET: self._submit_stop_market_order,
+            OrderType.STOP_LIMIT: self._submit_stop_limit_order,
+            OrderType.TRAILING_STOP_MARKET: self._submit_trailing_stop_market_order,
+            OrderType.TRAILING_STOP_LIMIT: self._submit_trailing_stop_limit_order,
+        }
+
+    async def _connect(self) -> None:
+        await self._instrument_provider.initialize()
+        await self._update_account_state()
+
+    async def _update_account_state(self) -> None:
+        if self._account_hash is None:
+            account_hashmap = await self._http_client.get_account_numbers()
+            self._account_hash = account_hashmap[self._config.account_number]
+
+        balances, margins = await self._http_client.get_account(
+            self._account_hash,
+            self.base_currency,
+        )
+        self.generate_account_state(
+            balances=balances,
+            margins=margins,
+            reported=True,
+            ts_event=self._clock.timestamp_ns(),
+        )
+
+    async def _disconnect(self) -> None:
+        self._log.info("Schwab execution client disconnected", LogColor.BLUE)
+
+    # -- COMMAND HANDLERS -------------------------------------------------------------------------
+
+    async def _submit_order(self, command: SubmitOrder) -> None:
+        order = command.order
+        instrument = self._cache.instrument(order.instrument_id)
+
+        self.generate_order_submitted(
+            strategy_id=order.strategy_id,
+            instrument_id=order.instrument_id,
+            client_order_id=order.client_order_id,
+            ts_event=self._clock.timestamp_ns(),
+        )
+
+        retry_manager = await self._retry_manager_pool.acquire()
+        try:
+            await retry_manager.run(
+                "submit_order",
+                [order.client_order_id],
+                self._submit_order_methods[order.order_type],
+                order,
+            )
+            if not retry_manager.result:
+                self.generate_order_rejected(
+                    strategy_id=order.strategy_id,
+                    instrument_id=order.instrument_id,
+                    client_order_id=order.client_order_id,
+                    reason=retry_manager.message,
+                    ts_event=self._clock.timestamp_ns(),
+                )
+        finally:
+            await self._retry_manager_pool.release(retry_manager)
+
+    async def _submit_and_check_order(self, order: Order, order_spec: Mapping[str, Any]) -> None:
+        if order.is_post_only:
+            raise ValueError("`post_only` not supported by Schwab")
+        venue_order_id = await self._http_client.place_order(self._account_hash, order_spec)
+        if venue_order_id:
+            order_status = await self._http_client.get_order(venue_order_id, self._account_hash)
+            if order_status["status"] in ["WORKING", "PENDING_ACTIVATION"]:
+                self.generate_order_accepted(
+                    strategy_id=order.strategy_id,
+                    instrument_id=order.instrument_id,
+                    client_order_id=order.client_order_id,
+                    venue_order_id=VenueOrderId(venue_order_id),
+                    ts_event=self._clock.timestamp_ns(),
+                )
+            elif order_status["status"] == "REJECTED":
+                self.generate_order_rejected(
+                    strategy_id=order.strategy_id,
+                    instrument_id=order.instrument_id,
+                    client_order_id=order.client_order_id,
+                    reason=order_status["statusDescription"],
+                    ts_event=self._clock.timestamp_ns(),
+                )
+
+    async def _submit_limit_order(self, order: LimitOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_price(str(order.price))
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_market_order(self, order: MarketOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_stop_market_order(self, order: StopMarketOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_stop_price_link_basis(TRIGGER_TYPE_MAP[order.trigger_type])
+            .set_stop_price(str(order.trigger_price))
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_stop_limit_order(self, order: StopMarketOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_price(str(order.price))
+            .set_stop_price_link_basis(TRIGGER_TYPE_MAP[order.trigger_type])
+            .set_stop_price(str(order.trigger_price))
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_trailing_stop_market_order(self, order: TrailingStopMarketOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_activation_price(str(order.trigger_price))
+            .set_stop_price_link_basis(TRIGGER_TYPE_MAP[order.trigger_type])
+            .set_stop_price_link_type(TRAILING_OFFSET_TYPE_MAP[order.trailing_offset_type])
+            .set_stop_price_offset(float(order.trailing_offset))
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_trailing_stop_limit_order(self, order: TrailingStopLimitOrder) -> None:
+        schwab_order = (
+            OrderBuilder()
+            .set_order_type(ORDER_TYPE_MAP[order.order_type])
+            .set_session(SchwabSession.NORMAL)
+            .set_duration(TIME_IN_FORCE_MAP[order.time_in_force])
+            .set_activation_price(str(order.trigger_price))
+            .set_price(str(order.price))
+            .set_stop_price_link_basis(TRIGGER_TYPE_MAP[order.trigger_type])
+            .set_stop_price_link_type(TRAILING_OFFSET_TYPE_MAP[order.trailing_offset_type])
+            .set_stop_price_offset(float(order.trailing_offset))
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(
+                ORDER_ACTION_MAP[order.side],
+                order.instrument_id.symbol.value,
+                int(
+                    order.quantity,
+                ),
+            )
+            .build()
+        )
+        await self._submit_and_check_order(order, schwab_order)
+
+    async def _submit_order_list(self, command: SubmitOrderList) -> None:
+        self._log.warning("Order list submission not supported for Schwab")
+
+    async def _modify_order(self, command: ModifyOrder) -> None:
+        self._log.warning(
+            "Order modification not supported for Schwab, the replace_order endpoint will cancel the old order and create a new one",
+        )
+
+    async def _cancel_order(self, command: CancelOrder) -> None:
+        order: Order | None = self._cache.order(command.client_order_id)
+        if order is None:
+            self._log.error(f"{command.client_order_id!r} not found in cache")
+            return
+
+        if order.is_closed:
+            self._log.warning(
+                f"`CancelOrder` command for {command.client_order_id!r} when order already {
+                    order.status_string()
+                } (will not send to exchange)",
+            )
+            return
+
+        client_order_id = command.client_order_id.value
+        venue_order_id = (
+            str(
+                command.venue_order_id,
+            )
+            if command.venue_order_id
+            else None
+        )
+
+        if venue_order_id is None:
+            self._log.error(
+                f"Unable to cancel {
+                    command.client_order_id
+                }: missing venue order id",
+            )
+            return
+
+        retry_manager = await self._retry_manager_pool.acquire()
+        try:
+            response = await retry_manager.run(
+                "cancel_order",
+                [client_order_id, venue_order_id],
+                self._http_client.cancel_order,
+                order_id=venue_order_id,
+                account_hash=self._account_hash,
+            )
+            if not retry_manager.result:
+                self.generate_order_cancel_rejected(
+                    order.strategy_id,
+                    order.instrument_id,
+                    order.client_order_id,
+                    order.venue_order_id,
+                    retry_manager.message,
+                    self._clock.timestamp_ns(),
+                )
+
+            if response:
+                ret_code = response.status_code
+                if ret_code != 0:
+                    if ret_code == 200:
+                        self.generate_order_canceled(
+                            strategy_id=order.strategy_id,
+                            instrument_id=order.instrument_id,
+                            client_order_id=order.client_order_id,
+                            venue_order_id=order.venue_order_id,
+                            ts_event=self._clock.timestamp_ns(),
+                        )
+                    else:
+                        self.generate_order_cancel_rejected(
+                            strategy_id=order.strategy_id,
+                            instrument_id=order.instrument_id,
+                            client_order_id=order.client_order_id,
+                            venue_order_id=order.venue_order_id,
+                            reason=response.json()["message"],
+                            ts_event=self._clock.timestamp_ns(),
+                        )
+        finally:
+            await self._retry_manager_pool.release(retry_manager)
+
+    async def _batch_cancel_orders(self, command: BatchCancelOrders) -> None:
+        cancels = command.cancels if hasattr(command, "cancels") else []
+        for cancel in cancels:
+            await self._cancel_order(cancel)
+
+    async def _cancel_all_orders(self, command: CancelAllOrders) -> None:
+        open_orders: list[Order] = self._cache.orders_open(
+            instrument_id=command.instrument_id,
+            strategy_id=command.strategy_id,
+        )
+
+        # TODO: A future improvement could be to asyncio.gather all cancel tasks
+        for order in open_orders:
+            retry_manager = await self._retry_manager_pool.acquire()
+            try:
+                response = await retry_manager.run(
+                    "cancel_order",
+                    [order.client_order_id, order.venue_order_id],
+                    self._http_client.cancel_order,
+                    order_id=order.venue_order_id,
+                    account_hash=self._account_hash,
+                )
+                if not retry_manager.result:
+                    self.generate_order_cancel_rejected(
+                        order.strategy_id,
+                        order.instrument_id,
+                        order.client_order_id,
+                        order.venue_order_id,
+                        retry_manager.message,
+                        self._clock.timestamp_ns(),
+                    )
+                if response:
+                    ret_code = response.status_code
+                    if ret_code != 0:
+                        if ret_code == 200:
+                            self.generate_order_canceled(
+                                strategy_id=order.strategy_id,
+                                instrument_id=order.instrument_id,
+                                client_order_id=order.client_order_id,
+                                venue_order_id=order.venue_order_id,
+                                ts_event=self._clock.timestamp_ns(),
+                            )
+                        else:
+                            self.generate_order_cancel_rejected(
+                                strategy_id=order.strategy_id,
+                                instrument_id=order.instrument_id,
+                                client_order_id=order.client_order_id,
+                                venue_order_id=order.venue_order_id,
+                                reason=response.json()["message"],
+                                ts_event=self._clock.timestamp_ns(),
+                            )
+            finally:
+                await self._retry_manager_pool.release(retry_manager)
+
+    # -- EXECUTION REPORTS ------------------------------------------------------------------------
+
+    async def generate_order_status_report(
+        self,
+        command: GenerateOrderStatusReport,
+    ) -> OrderStatusReport | None:
+        instrument_id = command.instrument_id
+        client_order_id = command.client_order_id
+        venue_order_id = command.venue_order_id
+
+        if venue_order_id:
+            order_data = await self._http_client.get_order(venue_order_id, self._account_hash)
+
+        report = self._build_order_status_report(
+            order_data,
+            instrument_id,
+        )
+        return report
+
+    async def generate_order_status_reports(
+        self,
+        command: GenerateOrderStatusReports,
+    ) -> list[OrderStatusReport]:
+        try:
+            orders = await self._http_client.get_orders_for_account(
+                account_hash=self._account_hash,
+                from_entered_datetime=command.start,
+                to_entered_datetime=command.end,
+            )
+        except Exception as exc:
+            self._log.exception("Failed to list orders", exc)
+            return []
+
+        reports: list[OrderStatusReport] = []
+        for order_data in orders:
+            # Apply filtering from command
+            if command.instrument_id:
+                instrument_id = self._infer_instrument_id(order_data)
+                if instrument_id != command.instrument_id:
+                    continue
+
+            status = SCHWAB_STATUS_MAP.get(
+                order_data.get("status", "").upper(),
+            )
+            if command.open_only and status not in (OrderStatus.SUBMITTED, OrderStatus.ACCEPTED):
+                continue
+
+            entered_time_str = order_data.get("enteredTime")
+            if entered_time_str:
+                # Timestamps from Schwab are like '2024-02-07T18:04:59+0000'
+                entered_time = pd.to_datetime(entered_time_str).to_pydatetime()
+                if command.start and entered_time < command.start:
+                    continue
+                if command.end and entered_time > command.end:
+                    continue
+
+            venue_order_id = order_data.get("orderId", None)
+            instrument_id = self._infer_instrument_id(order_data)
+            report = self._build_order_status_report(
+                order_data,
+                instrument_id,
+            )
+            if report:
+                reports.append(report)
+        return reports
+
+    async def generate_fill_reports(
+        self,
+        command: GenerateFillReports,
+    ) -> list[FillReport]:
+        return []
+        # order_data = await self._fetch_order_snapshot(
+        #     command.client_order_id,
+        #     command.venue_order_id,
+        # )
+        # if not order_data:
+        #     return []
+        #
+        # venue_order_id = self._resolve_venue_order_id(
+        #     command.client_order_id,
+        #     command.venue_order_id,
+        # )
+        # instrument_id = (
+        #     command.instrument_id
+        #     or self._client_order_to_instrument.get(command.client_order_id)
+        #     or self._infer_instrument_id(order_data)
+        # )
+        # instrument = (
+        #     self._cache.instrument(
+        #         instrument_id,
+        #     )
+        #     if instrument_id
+        #     else None
+        # )
+        # if instrument is None:
+        #     return []
+        #
+        # fills = self._extract_fills(order_data)
+        # reports: list[FillReport] = []
+        # for fill in fills:
+        #     report = self._build_fill_report(
+        #         fill,
+        #         instrument=instrument,
+        #         instrument_id=instrument_id,
+        #         venue_order_id=venue_order_id,
+        #         client_order_id=command.client_order_id,
+        #     )
+        #     reports.append(report)
+        # return reports
+
+    async def generate_position_status_reports(
+        self,
+        command: GeneratePositionStatusReports,
+    ) -> list[PositionStatusReport]:
+        return []
+
+    # -- Helpers ---------------------------------------------------------------------------------
+
+    # def _resolve_venue_order_id(
+    #     self,
+    #     client_order_id: ClientOrderId | None,
+    #     venue_order_id: VenueOrderId | None,
+    # ) -> VenueOrderId | None:
+    #     if venue_order_id:
+    #         return venue_order_id
+    #     if client_order_id:
+    #         return self._client_order_to_venue.get(client_order_id)
+    #     return None
+    #
+    # async def _fetch_order_snapshot(
+    #     self,
+    #     client_order_id: ClientOrderId | None,
+    #     venue_order_id: VenueOrderId | None,
+    # ) -> Mapping[str, Any] | None:
+    #     resolved = self._resolve_venue_order_id(
+    #         client_order_id,
+    #         venue_order_id,
+    #     )
+    #     if resolved is None:
+    #         return None
+    #     if resolved in self._open_orders:
+    #         return self._open_orders[resolved]
+    #     try:
+    #         order_data = await self._http_client.get_order(resolved.value, self.account_id.get_id())
+    #         self._open_orders[resolved] = order_data
+    #         return order_data
+    #     except Exception as exc:
+    #         self._log.exception(f"Failed to load order {resolved.value}", exc)
+    #         return None
+
+    def _build_order_status_report(
+        self,
+        order_data: Mapping[str, Any],
+        instrument_id: InstrumentId,
+    ) -> OrderStatusReport | None:
+        order_list_id = None
+        contingency_type = ContingencyType.NO_CONTINGENCY
+        venue_order_id = VenueOrderId(str(order_data.get("orderId", "")))
+        client_order_id = self._cache.client_order_id(venue_order_id)
+        status = SCHWAB_STATUS_MAP.get(
+            order_data.get(
+                "status",
+                "",
+            ).upper(),
+            OrderStatus.ACCEPTED,
+        )
+        raw_type = str(order_data.get("orderType", "")).upper()
+        order_type_enum = ORDER_TYPE_REVERSE.get(SchwabOrderType(raw_type))
+        tif_value = str(
+            order_data.get(
+                "duration",
+                self._config.default_duration,
+            ),
+        )
+        time_in_force = TIME_IN_FORCE_REVERSE.get(
+            SchwabDuration(tif_value),
+            TimeInForce.DAY,
+        )
+        if order_type_enum in (OrderType.TRAILING_STOP_MARKET, OrderType.TRAILING_STOP_LIMIT):
+            # TODO: need to refine here
+            self._log.warning("Trailing stop orders not supported for now!")
+            return None
+            # trigger_price = Decimal(self.triggerPrice)
+            # last_price = Decimal(self.lastPriceOnCreated)
+            trailing_offset = order_data.get("priceOffset")
+            trailing_offset_type = TRAILING_OFFSET_TYPE_REVERSE.get(
+                PriceLinkType(order_data.get("priceLinkType")),
+                TrailingOffsetType.NO_TRAILING_OFFSET,
+            )
+        else:
+            trailing_offset = None
+            trailing_offset_type = TrailingOffsetType.NO_TRAILING_OFFSET
+        stop_price = order_data.get("stopPrice", None)
+        if stop_price:
+            stop_price = Price.from_str(str(stop_price))
+        stop_type = order_data.get("stopType", None)
+        if stop_type == "STANDARD":
+            stop_type = TriggerType.DEFAULT
+        elif stop_type == "LAST":
+            stop_type = TriggerType.LAST_PRICE
+        else:
+            stop_type = TriggerType.NO_TRIGGER
+
+        total_qty = float(order_data.get("quantity", 0.0))
+        filled_qty = float(order_data.get("filledQuantity", 0.0))
+        limit_price = order_data.get("price")
+        if limit_price:
+            limit_price = Price.from_str(str(limit_price))
+
+        if status == OrderStatus.FILLED:
+            avg_price = Decimal(self._parse_avg_price(order_data))
+        else:
+            avg_price = Decimal()
+
+        ts_init = self._clock.timestamp_ns()
+
+        ts_accepted = ts_init
+        entered_time_str = order_data.get("enteredTime")
+        if entered_time_str:
+            ts_accepted = int(
+                pd.to_datetime(
+                    entered_time_str,
+                ).timestamp()
+                * 1e9,
+            )
+
+        ts_last = ts_init
+        close_time_str = order_data.get("closeTime")
+        if close_time_str:
+            ts_last = int(pd.to_datetime(close_time_str).timestamp() * 1e9)
+
+        report = OrderStatusReport(
+            account_id=self.account_id,
+            instrument_id=instrument_id,
+            venue_order_id=venue_order_id,
+            client_order_id=client_order_id,
+            order_side=self._parse_order_side(order_data),
+            order_type=order_type_enum,
+            time_in_force=time_in_force,
+            order_status=status,
+            quantity=Quantity.from_str(str(total_qty)),
+            filled_qty=Quantity.from_str(str(filled_qty)),
+            avg_px=avg_price,
+            report_id=UUID4(),
+            ts_accepted=ts_accepted,
+            ts_last=ts_last,
+            ts_init=ts_init,
+            price=limit_price,
+            trigger_price=stop_price,
+            trigger_type=stop_type,
+        )
+        return report
+
+    def _parse_avg_price(self, order_data: Mapping[str, Any]) -> float:
+        # TODO: need to support options and orders that are filled in separate times
+        return order_data.get("orderActivityCollection").get("executionLegs")[0].get("price")
+
+    def _parse_order_side(self, order_data: Mapping[str, Any]) -> OrderSide:
+        legs = order_data.get("orderLegCollection")
+        if isinstance(legs, list) and legs:
+            instruction = str(legs[0].get("instruction", "")).upper()
+            if "SELL" in instruction:
+                return OrderSide.SELL
+        return OrderSide.BUY
+
+    def _extract_fills(self, order_data: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        activities = order_data.get("orderActivityCollection", [])
+        fills: list[Mapping[str, Any]] = []
+        if isinstance(activities, list):
+            for activity in activities:
+                execution_legs = (
+                    activity.get("executionLegs")
+                    if isinstance(
+                        activity,
+                        Mapping,
+                    )
+                    else None
+                )
+                if isinstance(execution_legs, list):
+                    fills.extend(
+                        [
+                            leg
+                            for leg in execution_legs
+                            if isinstance(
+                                leg,
+                                Mapping,
+                            )
+                        ],
+                    )
+        return fills
+
+    # def _build_fill_report(
+    #     self,
+    #     fill: Mapping[str, Any],
+    #     *,
+    #     instrument: Instrument,
+    #     instrument_id: InstrumentId,
+    #     venue_order_id: VenueOrderId | None,
+    #     client_order_id: ClientOrderId,
+    # ) -> FillReport:
+    #     qty = float(fill.get("quantity", 0.0))
+    #     price = float(fill.get("price", 0.0))
+    #     ts = fill.get("time")
+    #     ts_event = self._clock.timestamp_ns()
+    #     if isinstance(ts, int | float):
+    #         ts_event = self._coerce_time_number(ts)
+    #
+    #     return FillReport(
+    #         client_order_id=client_order_id,
+    #         instrument_id=instrument_id,
+    #         account_id=self.account_id,
+    #         venue_order_id=venue_order_id,
+    #         venue_position_id=None,
+    #         order_side=self._parse_order_side({"orderLegCollection": [fill]}),
+    #         trade_id=TradeId(str(fill.get("executionId", UUID4()))),
+    #         last_qty=instrument.make_qty(qty),
+    #         last_px=instrument.make_price(price),
+    #         commission=Money(
+    #             0.0,
+    #             (
+    #                 instrument.currency
+    #                 if hasattr(instrument, "currency")
+    #                 else Currency.from_str("USD")
+    #             ),
+    #         ),
+    #         liquidity_side=LiquiditySide.NO_LIQUIDITY_SIDE,
+    #         report_id=UUID4(),
+    #         ts_event=ts_event,
+    #         ts_init=ts_event,
+    #     )
+    #
+    # def _build_position_report(
+    #     self,
+    #     position: Mapping[str, Any],
+    #     ts: int,
+    #     requested_instrument: InstrumentId | None,
+    # ) -> PositionStatusReport | None:
+    #     instrument_info = (
+    #         position.get("instrument")
+    #         if isinstance(
+    #             position,
+    #             Mapping,
+    #         )
+    #         else None
+    #     )
+    #     if not isinstance(instrument_info, Mapping):
+    #         return None
+    #
+    #     symbol = instrument_info.get("symbol")
+    #     asset_type = instrument_info.get("assetType", "EQUITY")
+    #     if not symbol:
+    #         return None
+    #
+    #     instrument_id = self._instrument_id_from_symbol(symbol, asset_type)
+    #     if requested_instrument and instrument_id != requested_instrument:
+    #         return None
+    #
+    #     instrument = self._cache.instrument(instrument_id)
+    #     if instrument is None:
+    #         return None
+    #
+    #     long_qty = float(position.get("longQuantity", 0.0))
+    #     short_qty = float(position.get("shortQuantity", 0.0))
+    #     net_qty = long_qty - short_qty
+    #
+    #     if net_qty > 0:
+    #         side = PositionSide.LONG
+    #         qty = instrument.make_qty(net_qty)
+    #     elif net_qty < 0:
+    #         side = PositionSide.SHORT
+    #         qty = instrument.make_qty(abs(net_qty))
+    #     else:
+    #         side = PositionSide.FLAT
+    #         qty = instrument.make_qty(0.0)
+    #
+    #     return PositionStatusReport(
+    #         account_id=self.account_id,
+    #         instrument_id=instrument_id,
+    #         position_side=side,
+    #         quantity=qty,
+    #         report_id=UUID4(),
+    #         ts_last=ts,
+    #         ts_init=ts,
+    #     )
+
+    def _instrument_id_from_symbol(self, symbol: str, asset_type: str) -> InstrumentId:
+        venue = None
+        if asset_type.upper() == "OPTION":
+            option_exchange = SCHWAB_OPTION_VENUE.value
+            provider_config = getattr(
+                self._config.instrument_provider,
+                "option_exchange",
+                None,
+            )
+            if isinstance(provider_config, str) and provider_config:
+                option_exchange = provider_config
+            venue = option_exchange
+        else:
+            # TODO: should not be hardcoded
+            venue = "XNAS"
+        return InstrumentId.from_str(f"{symbol}.{venue}")
+
+    def _infer_instrument_id(self, order_data: Mapping[str, Any]) -> InstrumentId | None:
+        legs = order_data.get("orderLegCollection")
+        if not isinstance(legs, list) or not legs:
+            return None
+        instrument_payload = legs[0].get("instrument")
+        if not isinstance(instrument_payload, Mapping):
+            return None
+        symbol = instrument_payload.get("symbol")
+        asset_type = instrument_payload.get("assetType", "EQUITY")
+        if not symbol:
+            return None
+        return self._instrument_id_from_symbol(symbol, asset_type)
+
+    # def _coerce_time_number(self, value: float) -> int:
+    #     value_int = int(value)
+    #     if value_int > 10**18:
+    #         return value_int
+    #     if value_int > 10**12:
+    #         return value_int * 1_000_000
+    #     if value_int > 10**9:
+    #         return value_int * 1_000
+    #     return value_int * 1_000_000_000
+
+
+__all__ = ["SchwabExecutionClient"]

--- a/nautilus_trader/adapters/schwab/factories.py
+++ b/nautilus_trader/adapters/schwab/factories.py
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+
+from nautilus_trader.adapters.schwab.config import SchwabClientConfig
+from nautilus_trader.adapters.schwab.config import SchwabDataClientConfig
+from nautilus_trader.adapters.schwab.config import SchwabExecClientConfig
+from nautilus_trader.adapters.schwab.config import SchwabInstrumentProviderConfig
+from nautilus_trader.adapters.schwab.data import SchwabDataClient
+from nautilus_trader.adapters.schwab.execution import SchwabExecutionClient
+from nautilus_trader.adapters.schwab.http.client import SchwabHttpClient
+from nautilus_trader.adapters.schwab.providers import SchwabInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.live.factories import LiveDataClientFactory
+from nautilus_trader.live.factories import LiveExecClientFactory
+
+
+@lru_cache(1)
+def get_schwab_http_client(config: SchwabClientConfig) -> SchwabHttpClient:
+    return SchwabHttpClient(config)
+
+
+@lru_cache(1)
+def get_schwab_instrument_provider(
+    http_client: SchwabHttpClient,
+    clock: LiveClock,
+    config: SchwabInstrumentProviderConfig,
+) -> SchwabInstrumentProvider:
+    return SchwabInstrumentProvider(http_client, clock, config)
+
+
+class SchwabLiveDataClientFactory(LiveDataClientFactory):
+    """
+    Factory for Schwab live data clients.
+    """
+
+    @staticmethod
+    def create(  # type: ignore[override]
+        loop: asyncio.AbstractEventLoop,
+        name: str,
+        config: SchwabDataClientConfig,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+    ) -> SchwabDataClient:
+        if config.http_client is None:
+            raise ValueError("SchwabDataClientConfig.rest_client must be provided")
+
+        http_client = get_schwab_http_client(config.http_client)
+        provider = get_schwab_instrument_provider(http_client, clock, config.instrument_provider)
+        return SchwabDataClient(
+            loop=loop,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            http_client=http_client,
+            instrument_provider=provider,
+            config=config,
+            name=name,
+        )
+
+
+class SchwabLiveExecClientFactory(LiveExecClientFactory):
+    """
+    Factory for Schwab live execution clients.
+    """
+
+    @staticmethod
+    def create(  # type: ignore[override]
+        loop: asyncio.AbstractEventLoop,
+        name: str,
+        config: SchwabExecClientConfig,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+    ) -> SchwabExecutionClient:
+        if config.http_client is None:
+            raise ValueError("SchwabExecClientConfig.http_client must be provided")
+
+        http_client = get_schwab_http_client(config.http_client)
+        provider = get_schwab_instrument_provider(http_client, clock, config.instrument_provider)
+        return SchwabExecutionClient(
+            loop=loop,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            http_client=http_client,
+            instrument_provider=provider,
+            config=config,
+            name=name,
+        )
+
+
+__all__ = [
+    "SchwabLiveDataClientFactory",
+    "SchwabLiveExecClientFactory",
+]

--- a/nautilus_trader/adapters/schwab/http/client.py
+++ b/nautilus_trader/adapters/schwab/http/client.py
@@ -1,0 +1,185 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from schwab import auth as schwab_auth
+from schwab.utils import Utils
+
+from nautilus_trader.adapters.schwab.config import SchwabClientConfig
+from nautilus_trader.model.objects import AccountBalance
+from nautilus_trader.model.objects import Currency
+from nautilus_trader.model.objects import MarginBalance
+from nautilus_trader.model.objects import Money
+
+
+class SchwabHttpClientError(RuntimeError):
+    """
+    Raised when the Schwab client cannot fulfil a request.
+    """
+
+
+class SchwabHttpClient:
+    """
+    Lightweight async wrapper around ``schwab-py`` REST operations.
+    """
+
+    def __init__(
+        self,
+        config: SchwabClientConfig,
+        account_id: str | None = None,
+    ) -> None:
+        self._config = config
+        self._client = self.create_schwab_client()
+
+    async def get_account_numbers(self) -> Mapping[str, Any]:
+        response = await self._client.get_account_numbers()
+        response.raise_for_status()
+        account_hashmap = {v["accountNumber"]: v["hashValue"] for v in response.json()}
+        return account_hashmap
+
+    async def get_account(
+        self,
+        account_hash: str,
+        currency: Currency,
+    ) -> tuple[list[AccountBalance], list[MarginBalance]]:
+        response = await self._client.get_account(account_hash)
+        response.raise_for_status()
+        account_balance = response.json()
+        total = account_balance["securitiesAccount"]["currentBalances"]["liquidationValue"]
+        locked = account_balance["securitiesAccount"]["currentBalances"]["maintenanceRequirement"]
+        balances = [
+            AccountBalance(
+                total=Money(total, currency),
+                free=Money(total - locked, currency),
+                locked=Money(locked, currency),
+            ),
+        ]
+        initial_locked = account_balance["securitiesAccount"]["initialBalances"][
+            "maintenanceRequirement"
+        ]
+        margins = [
+            MarginBalance(
+                initial=Money(initial_locked, currency),
+                maintenance=Money(locked, currency),
+            ),
+        ]
+        return balances, margins
+
+    async def get_orders_for_account(
+        self,
+        account_hash: str | None,
+        from_entered_datetime=None,
+        to_entered_datetime=None,
+    ) -> list[Mapping[str, Any]]:
+        response = await self._client.get_orders_for_account(
+            account_hash,
+            from_entered_datetime=from_entered_datetime,
+            to_entered_datetime=to_entered_datetime,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # async def get_option_chain(self, symbol: str, **params: Any) -> Mapping[str, Any]:
+    #     response = await self._call_async(
+    #         ["get_option_chain", "options.get_option_chain"],
+    #         symbol,
+    #         **params,
+    #     )
+    #     return self._as_mapping(response)
+
+    async def place_order(
+        self,
+        account_hash: str | None,
+        order_spec: Mapping[str, Any],
+    ) -> str:
+        response = await self._client.place_order(account_hash, order_spec)
+        assert response.status_code == 201, response.raise_for_status()
+        order_id = Utils(self._client, account_hash).extract_order_id(response)
+        assert order_id is not None
+        return str(order_id)
+
+    async def get_order(self, order_id: str, account_hash: str | None) -> Mapping[str, Any]:
+        response = await self._client.get_order(order_id, account_hash)
+        response.raise_for_status()
+        return response.json()
+
+    async def cancel_order(self, order_id: str, account_hash: str) -> Mapping[str, Any]:
+        response = await self._client.cancel_order(order_id, account_hash)
+        response.raise_for_status()
+        return response
+
+    # async def _call_async(self, candidates: Sequence[str], *args: Any, **kwargs: Any) -> Any:
+    #     func = self._resolve_callable(candidates)
+    #     return await asyncio.to_thread(func, *args, **kwargs)
+
+    # def _resolve_callable(self, candidates: Sequence[str]):
+    #     for name in candidates:
+    #         target: Any = self._client
+    #         for attr in name.split("."):
+    #             target = getattr(target, attr, None)
+    #             if target is None:
+    #                 break
+    #         if callable(target):
+    #             return target
+    #     raise SchwabHttpClientError(
+    #         f"Client does not expose any of the expected callables: {
+    #             ', '.join(candidates)}",
+    #     )
+
+    # def _as_mapping(self, response: Any) -> Mapping[str, Any]:
+    #     if isinstance(response, Mapping):
+    #         return response
+    #     if hasattr(response, "json"):
+    #         data = response.json()
+    #         if isinstance(data, Mapping):
+    #             return data
+    #     if hasattr(response, "data") and isinstance(response.data, Mapping):
+    #         return response.data
+    #     raise SchwabHttpClientError("Response payload is not a mapping")
+
+    # def _ensure_mapping(self, value: Any) -> Mapping[str, Any]:
+    #     if isinstance(value, Mapping):
+    #         return value
+    #     raise SchwabHttpClientError("Expected mapping entry in response list")
+
+    # def _require_account_id(self, value: str | None) -> str:
+    #     account = value or self._default_account_id
+    #     if not account:
+    #         raise SchwabHttpClientError("Account ID is required")
+    #     return account
+
+    def create_schwab_client(self) -> Any:
+        """
+        Instantiate a ``schwab-py`` client using the provided configuration.
+
+        The token expires every week, for now we can only refresh the token manually.
+        Every time the token is refreshed manually, the client should be re-
+        instantiated.
+
+        """
+        http_client = schwab_auth.easy_client(
+            api_key=self._config.api_key,
+            app_secret=self._config.app_secret,
+            callback_url=self._config.callback_url,
+            token_path=self._config.token_path,
+            asyncio=True,
+        )
+        return http_client
+
+
+__all__ = ["SchwabRESTClient", "SchwabRESTClientError", "create_schwab_client"]

--- a/nautilus_trader/adapters/schwab/http/error.py
+++ b/nautilus_trader/adapters/schwab/http/error.py
@@ -1,0 +1,14 @@
+class SchwabError(Exception):
+    """
+    The base class for all Schwab specific errors.
+    """
+
+    def __init__(self, status, message, headers):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+        self.headers = headers
+
+
+def should_retry(error: BaseException) -> bool:
+    return False

--- a/nautilus_trader/adapters/schwab/providers.py
+++ b/nautilus_trader/adapters/schwab/providers.py
@@ -1,0 +1,163 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from decimal import Decimal
+
+from nautilus_trader.adapters.schwab.common import SCHWAB_OPTION_VENUE
+from nautilus_trader.adapters.schwab.common import SCHWAB_VENUE
+from nautilus_trader.adapters.schwab.common import ParsedOpraSymbol
+from nautilus_trader.adapters.schwab.common import parse_opra_symbol
+from nautilus_trader.adapters.schwab.config import SchwabInstrumentProviderConfig
+from nautilus_trader.adapters.schwab.http.client import SchwabHttpClient
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.providers import InstrumentProvider
+from nautilus_trader.model.currencies import Currency
+from nautilus_trader.model.enums import AssetClass
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments import Equity
+from nautilus_trader.model.instruments import OptionContract
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+
+
+class SchwabInstrumentProvider(InstrumentProvider):
+    """
+    Loads basic instrument metadata using the Schwab REST API.
+    """
+
+    def __init__(
+        self,
+        client: SchwabHttpClient,
+        clock: LiveClock,
+        config: SchwabInstrumentProviderConfig | None = None,
+    ) -> None:
+        config = config or SchwabInstrumentProviderConfig()
+        super().__init__(config)
+        self._client = client
+        self._clock = clock
+        self._config = config
+        self._load_ids_on_start = set(config.load_ids) if config.load_ids is not None else None
+
+    async def load_all_async(self, filters=None) -> None:
+        raise RuntimeError(
+            "requesting all instrument definitions is not currently supported, "
+            "as this would mean every instrument definition for every dataset "
+            "(potentially millions)",
+        )
+
+    async def load_ids_async(
+        self,
+        instrument_ids: list[InstrumentId],
+        filters=None,
+    ) -> None:
+        await self._load_many(instrument_ids)
+
+    async def load_async(self, instrument_id: InstrumentId, filters=None) -> None:
+        await self._load_one(instrument_id)
+
+    async def _load_many(self, instrument_ids: Sequence[InstrumentId]) -> None:
+        if not instrument_ids:
+            return
+        await asyncio.gather(*(self._load_one(instrument_id) for instrument_id in instrument_ids))
+
+    async def _load_one(self, instrument_id: InstrumentId) -> None:
+        if instrument_id.venue == SCHWAB_OPTION_VENUE:
+            option_meta = parse_opra_symbol(instrument_id.symbol.value)
+            instrument = await self._build_option(instrument_id, option_meta)
+        else:
+            instrument = await self._build_equity(instrument_id)
+
+        if instrument is None:
+            self._log.warning(f"Unable to bootstrap {instrument_id}")
+            return
+
+        self.add(instrument)
+        self._log.info(f"Loaded {instrument.id}")
+
+    async def _build_equity(self, instrument_id: InstrumentId) -> Equity | None:
+        symbol = instrument_id.symbol.value
+        ts = self._clock.timestamp_ns()
+        currency = Currency.from_str("USD")
+        self.add_currency(currency)
+        precision = 2
+        tick_size_str = self._format_decimal(0.01, precision)
+        instrument = Equity(
+            instrument_id=instrument_id,
+            raw_symbol=Symbol(symbol),
+            currency=currency,
+            price_precision=precision,
+            price_increment=Price.from_str(tick_size_str),
+            lot_size=Quantity.from_int(1),
+            ts_event=ts,
+            ts_init=ts,
+        )
+        return instrument
+
+    async def _build_option(
+        self,
+        instrument_id: InstrumentId,
+        option_meta: ParsedOpraSymbol,
+    ) -> OptionContract | None:
+        symbol = instrument_id.symbol.value
+        ts = self._clock.timestamp_ns()
+        precision = self._config.option_price_precision
+        tick_size_str = self._format_decimal(self._config.option_tick_size, precision)
+        strike_str = self._format_decimal(option_meta.strike, precision)
+
+        try:
+            expiration_ns = int(option_meta.expiration.timestamp() * 1_000_000_000)
+        except AttributeError:
+            expiration_ns = ts
+
+        currency = Currency.from_str(self._config.option_currency)
+        self.add_currency(currency)
+
+        option = OptionContract(
+            instrument_id=instrument_id,
+            raw_symbol=Symbol(symbol),
+            asset_class=AssetClass.EQUITY,
+            exchange=self._config.option_exchange,
+            currency=currency,
+            price_precision=precision,
+            price_increment=Price.from_str(tick_size_str),
+            multiplier=Quantity.from_int(int(self._config.option_multiplier)),
+            lot_size=Quantity.from_int(1),
+            underlying=option_meta.underlying,
+            option_kind=option_meta.option_kind,
+            strike_price=Price.from_str(strike_str),
+            activation_ns=ts,
+            expiration_ns=expiration_ns,
+            ts_event=ts,
+            ts_init=ts,
+        )
+        return option
+
+    def _resolve_venue(self, asset_type: str) -> Venue:
+        if asset_type.upper() == "OPTION":
+            return Venue(self._config.option_exchange or SCHWAB_OPTION_VENUE.value)
+        return Venue(self._config.equity_exchange or SCHWAB_VENUE.value)
+
+    @staticmethod
+    def _format_decimal(value: float | Decimal, precision: int) -> str:
+        quantized = Decimal(str(value)).quantize(Decimal(10) ** -precision)
+        return format(quantized, f".{precision}f")
+
+
+__all__ = ["SchwabInstrumentProvider"]

--- a/nautilus_trader/adapters/schwab/websocket/client.py
+++ b/nautilus_trader/adapters/schwab/websocket/client.py
@@ -1,0 +1,373 @@
+import asyncio
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Any
+from weakref import WeakSet
+
+from msgspec import json as msgspec_json
+from schwab.streaming import StreamClient
+from schwab.streaming import UnexpectedResponse
+
+from nautilus_trader.adapters.schwab.http.client import SchwabHttpClient
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import Logger
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.core.nautilus_pyo3 import WebSocketClient
+from nautilus_trader.core.nautilus_pyo3 import WebSocketClientError
+from nautilus_trader.core.nautilus_pyo3 import WebSocketConfig
+
+
+class SchwabWebSocketClient:
+    """
+    Provides a Schwab streaming WebSocket client.
+
+    Parameters
+    ----------
+    clock : LiveClock
+        The clock instance.
+    handler : Callable[[bytes], None]
+        The callback handler for message events.
+    handler_reconnect : Callable[..., Awaitable[None]], optional
+        The callback handler to be called on reconnect.
+    loop : asyncio.AbstractEventLoop
+        The event loop for the client.
+
+    """
+
+    def __init__(
+        self,
+        clock: LiveClock,
+        http_client: SchwabHttpClient,
+        handler: Callable[[bytes], None],
+        handler_reconnect: Callable[..., Awaitable[None]] | None,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._clock = clock
+        self._log: Logger = Logger(type(self).__name__)
+        self._http_client = http_client
+        self._handler: Callable[[bytes], None] = handler
+        self._handler_reconnect: Callable[..., Awaitable[None]] | None = handler_reconnect
+        self._loop = loop
+        self._tasks: WeakSet[asyncio.Task] = WeakSet()
+        self._client: WebSocketClient | None = None
+        self._auth_event = asyncio.Event()
+
+        self._is_authenticated = False
+        self._request_id = 0
+        self._base_url = "wss://streamer-api.schwab.com/ws"
+        self._stream_correl_id = None
+        self._stream_customer_id = None
+        self._stream_channel = None
+        self._stream_function_id = None
+        self._subscriptions: dict[str, list[str]] = {}
+        self._order_book_deltas_services = {
+            "XNAS": "NASDAQ_BOOK",
+            "XNYS": "NYSE_BOOK",
+            "SMART": "OPTIONS_BOOK",
+        }
+        self._ws_auth_timeout_secs = 5.0
+
+    # @property
+    # def subscriptions(self) -> list[str]:
+    #     return self._subscriptions
+    #
+    # def has_subscription(self, item: str) -> bool:
+    #     return item in self._subscriptions
+
+    async def _init_from_preferences(self, prefs: dict[str, Any]) -> None:
+        # Record streamer subscription keys
+        stream_info = prefs["streamerInfo"][0]
+
+        self._stream_correl_id = stream_info["schwabClientCorrelId"]
+        self._stream_customer_id = stream_info["schwabClientCustomerId"]
+        self._stream_channel = stream_info["schwabClientChannel"]
+        self._stream_function_id = stream_info["schwabClientFunctionId"]
+
+        # Initialize socket
+        self._base_url = stream_info["streamerSocketUrl"]
+
+        config = WebSocketConfig(
+            url=self._base_url,
+            handler=self._msg_handler,
+            headers=[],
+        )
+        self._client = await WebSocketClient.connect(
+            config=config,
+        )
+
+    async def connect(self) -> None:
+        """
+        Connect websocket clients to the server based on existing subscriptions.
+        """
+        # Recreate the http client in case the token is updated
+        http_client = self._http_client.create_schwab_client()
+        r = await http_client.get_user_preferences()
+        assert r.status_code == 200, r.raise_for_status()
+        r = r.json()
+        await self._init_from_preferences(r)
+        self._log.info(f"Connected to {self._base_url}", LogColor.BLUE)
+        await self._authenticate(http_client.token_metadata.token["access_token"])
+
+    async def reconnect(self) -> None:
+        """
+        Reconnect the client to the server and resubscribe to all streams.
+        """
+        await self.connect()
+        await self._subscribe_all()
+        if self._handler_reconnect:
+            await self._handler_reconnect()
+
+    async def _subscribe_all(self) -> None:
+        if "CHART_EQUITY" in self._subscriptions:
+            for symbol in self._subscriptions["CHART_EQUITY"]:
+                await self.subscribe_klines(symbol, "1-MINUTE-LAST")
+        if "LEVELONE_EQUITIES" in self._subscriptions:
+            for symbol in self._subscriptions["LEVELONE_EQUITIES"]:
+                await self.subscribe_quote_ticks(symbol)
+        if "NASDAQ_BOOK" in self._subscriptions:
+            for symbol in self._subscriptions["NASDAQ_BOOK"]:
+                await self.subscribe_order_book_deltas(symbol, "XNAS")
+        if "NYSE_BOOK" in self._subscriptions:
+            for symbol in self._subscriptions["NYSE_BOOK"]:
+                await self.subscribe_order_book_deltas(symbol, "XNYS")
+        if "OPTIONS_BOOK" in self._subscriptions:
+            for symbol in self._subscriptions["OPTIONS_BOOK"]:
+                await self.subscribe_order_book_deltas(symbol, "SMART")
+
+    async def disconnect(self) -> None:
+        pass
+
+    def _make_request(self, *, service, command, parameters):
+        request_id = self._request_id
+        self._request_id += 1
+        request = {
+            "service": service,
+            "requestid": str(request_id),
+            "command": command,
+            "SchwabClientCustomerId": self._stream_customer_id,
+            "SchwabClientCorrelId": self._stream_correl_id,
+            "parameters": parameters,
+        }
+
+        return request, request_id
+
+    async def _authenticate(self, token: str) -> None:
+        self._is_authenticated = False
+        self._auth_event.clear()
+        request_parameters = {
+            "Authorization": token,
+            "SchwabClientChannel": self._stream_channel,
+            "SchwabClientFunctionId": self._stream_function_id,
+        }
+        request, request_id = self._make_request(
+            service="ADMIN",
+            command="LOGIN",
+            parameters=request_parameters,
+        )
+        try:
+            await self._send({"requests": [request]})
+            await asyncio.wait_for(
+                self._auth_event.wait(),
+                timeout=self._ws_auth_timeout_secs,
+            )
+        except TimeoutError:
+            self._log.warning("Websocket client authentication timeout")
+            raise
+        except WebSocketClientError as e:
+            self._log.exception(
+                "Failed to send authentication request",
+                {e},
+            )
+            raise
+        except Exception as e:
+            self._log.exception(
+                "Unexpected error during websocket client authentication",
+                {e},
+            )
+            raise
+
+    def _msg_handler(self, raw: bytes) -> None:
+        """
+        Handle pushed websocket messages.
+
+        Parameters
+        ----------
+        raw : bytes
+            The received message in bytes.
+
+        """
+        msg = msgspec_json.decode(raw)
+
+        if (
+            not self._is_authenticated
+            and "response" in msg
+            and msg["response"][0]["service"] == "ADMIN"
+            and msg["response"][0]["command"] == "LOGIN"
+            and msg["response"][0]["content"]["code"] == 0
+        ):
+            # Login response
+            self._is_authenticated = True
+            self._auth_event.set()
+            self._log.info("Websocket client authenticated", LogColor.BLUE)
+            return
+
+        if "response" in msg:
+            # Sub response
+            for d in msg["response"]:
+                if d["content"]["code"] == 0:
+                    continue
+                else:
+                    raise UnexpectedResponse(
+                        msg,
+                        f"Unexpected response code during message handling: "
+                        f"{msg['response'][0]['content']['code']}, "
+                        f"msg is '{msg['response'][0]['content']['msg']}'",
+                    )
+            return
+
+        self._handler(raw)
+
+    async def _send(self, msg: dict[str, Any]) -> None:
+        await self._send_text(msgspec_json.encode(msg))
+
+    async def _send_text(self, msg: bytes) -> None:
+        if self._client is None:
+            self._log.error(f"Cannot send message {msg!r}: not connected")
+            return
+
+        self._log.debug(f"SENDING: {msg!r}")
+
+        try:
+            await self._client.send_text(msg)
+        except WebSocketClientError as e:
+            self._log.error(str(e))
+
+    def _convert_enum_iterable(self, iterable, required_enum_type):
+        if iterable is None:
+            return None
+
+        if isinstance(iterable, required_enum_type):
+            return [iterable.value]
+
+        values = []
+        for value in iterable:
+            if isinstance(value, required_enum_type):
+                values.append(value.value)
+            else:
+                values.append(value)
+        return values
+
+    async def _subscribe(self, symbol: str, service: str, command: str, field_type=None) -> None:
+        self._log.debug(f"Subscribing to {service}.{command} for {symbol}")
+        parameters = {
+            # 'keys': ','.join(symbol)
+            "keys": symbol,
+        }
+
+        if field_type is not None:
+            fields = field_type.all_fields()
+
+            fields = sorted(self._convert_enum_iterable(fields, field_type))
+            parameters["fields"] = ",".join(str(f) for f in fields)
+
+        request, request_id = self._make_request(
+            service=service,
+            command=command,
+            parameters=parameters,
+        )
+
+        await self._send(request)
+
+    ################################################################################
+    # Public
+    ################################################################################
+
+    async def subscribe_klines(self, symbol: str, interval: str) -> None:
+        if interval != "1-MINUTE-LAST":
+            raise NotImplementedError
+        service = "CHART_EQUITY"
+        command = None
+        if service not in self._subscriptions:
+            self._subscriptions[service] = [symbol]
+            command = "SUBS"
+        else:
+            if symbol in self._subscriptions[service]:
+                self._log.warning(f"Cannot subscribe {service} for '{symbol}': already subscribed")
+                return
+            self._subscriptions[service].append(symbol)
+            command = "ADD"
+        await self._subscribe(symbol, service, command, field_type=StreamClient.ChartEquityFields)
+
+    async def unsubscribe_klines(self, symbol: str, interval: str) -> None:
+        if interval != "1-MINUTE-LAST":
+            raise NotImplementedError
+        service = "CHART_EQUITY"
+        command = "UNSUBS"
+        if service not in self._subscriptions:
+            self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+            return
+        else:
+            if symbol not in self._subscriptions[service]:
+                self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+                return
+            self._subscriptions[service].remove(symbol)
+        await self._subscribe(symbol, service, command)
+
+    async def subscribe_quote_ticks(self, symbol: str) -> None:
+        service = "LEVELONE_EQUITIES"
+        command = None
+        if service not in self._subscriptions:
+            self._subscriptions[service] = [symbol]
+            command = "SUBS"
+        else:
+            if symbol in self._subscriptions[service]:
+                self._log.warning(f"Cannot subscribe {service} for '{symbol}': already subscribed")
+                return
+            self._subscriptions[service].append(symbol)
+            command = "ADD"
+        await self._subscribe(
+            symbol,
+            service,
+            command,
+            field_type=StreamClient.LevelOneEquityFields,
+        )
+
+    async def unsubscribe_quote_ticks(self, symbol: str) -> None:
+        service = "LEVELONE_EQUITIES"
+        command = "UNSUBS"
+        if service not in self._subscriptions:
+            self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+            return
+        else:
+            if symbol not in self._subscriptions[service]:
+                self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+                return
+            self._subscriptions[service].remove(symbol)
+        await self._subscribe(symbol, service, command)
+
+    async def subscribe_order_book_deltas(self, symbol: str, venue: str) -> None:
+        service = self._order_book_deltas_services[venue]
+        command = "SUBS"
+        if service not in self._subscriptions:
+            self._subscriptions[service] = [symbol]
+            command = "SUBS"
+        else:
+            if symbol in self._subscriptions[service]:
+                self._log.warning(f"Cannot subscribe {service} for '{symbol}': already subscribed")
+                return
+            self._subscriptions[service].append(symbol)
+            command = "ADD"
+        await self._subscribe(symbol, service, command, field_type=StreamClient.BookFields)
+
+    async def unsubscribe_order_book_deltas(self, symbol: str, venue: str) -> None:
+        service = self._order_book_deltas_services[venue]
+        command = "UNSUBS"
+        if service not in self._subscriptions:
+            self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+            return
+        else:
+            if symbol not in self._subscriptions[service]:
+                self._log.warning(f"Cannot unsubscribe {service} for '{symbol}': not subscribed")
+                return
+            self._subscriptions[service].remove(symbol)
+        await self._subscribe(symbol, service, command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ dydx = [
 polymarket = [
     "py-clob-client==0.25.0,<1.0.0",  # Pinned to 0.25.0 for stability
 ]
+schwab = [
+    "schwab-py==1.5.0",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->
This pull request is an attempt to add a rudimentary adapter for Charles Schwab through the Consumer APIs. It is highly adapted from the [schwab-py](https://github.com/alexgolec/schwab-py) project. Users can subscribe L1/L2 data, as well as 1 minute ohlcv through this adapter, basic trading functions are also implemented.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
