### PR TITLE
Add fallback to default order book for custom fill model

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -5022,12 +5022,17 @@ cdef class OrderMatchingEngine:
 
         if simulated_book is not None:
             # Use simulated OrderBook for fill determination
-            return simulated_book.simulate_fills(
+            fills = simulated_book.simulate_fills(
                 order,
                 price_prec=self.instrument.price_precision,
                 size_prec=self.instrument.size_precision,
                 is_aggressive=True,
             )
+            # If simulation produced no fills (e.g., custom model removed best levels),
+            # fall back to standard market logic to preserve expected behavior.
+            if not fills:
+                return self.determine_market_price_and_volume(order)
+            return fills
         else:
             # Fall back to standard logic
             return self.determine_market_price_and_volume(order)


### PR DESCRIPTION
fix(backtest): fallback to standard market fills when simulated book yields no fills

When using custom FillModel implementations like OneTickSlippageFillModel that
create simulated OrderBooks without liquidity at best bid/ask prices, market
orders would fail to fill entirely. This change adds a fallback mechanism that
reverts to the standard market fill logic when the simulated book produces no
fills, ensuring market orders always execute while still allowing custom models
to apply their intended slippage behavior when liquidity is available.

Fixes issue where OneTickSlippageFillModel prevented market order fills when
the simulated book contained no orders at best bid/ask prices (zero quantity
BookOrders), causing strategies to fail unexpectedly in backtesting.

- Modified determine_market_fills_with_simulation() in backtest engine
- Added fallback to determine_market_price_and_volume() when simulated fills empty
- Preserves existing behavior for models that provide liquidity
- No breaking changes to public API