### PR TITLE
Fix IBKR adapter bars request

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -534,7 +534,6 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             self._handle_bars(
                 request.bar_type,
                 bars,
-                bars[0],
                 request.id,
                 request.start,
                 request.end,


### PR DESCRIPTION

## Summary

Fix IBKR adapter bars request `TypeError: _handle_bars() takes exactly 6 positional arguments (7 given)`

## Related Issues/PRs

#3020

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore