### PR TITLE
Integrate PoolFlash event in blockchain adapter

### DIFF
--- a/crates/adapters/blockchain/src/cache/mod.rs
+++ b/crates/adapters/blockchain/src/cache/mod.rs
@@ -28,7 +28,7 @@ use alloy::primitives::Address;
 use nautilus_core::UnixNanos;
 use nautilus_model::defi::{
     Block, DexType, Pool, PoolLiquidityUpdate, PoolSwap, SharedChain, SharedDex, SharedPool, Token,
-    data::PoolFeeCollect,
+    data::{PoolFeeCollect, PoolFlash},
     pool_analysis::{position::PoolPosition, snapshot::PoolSnapshot},
     tick_map::tick::Tick,
 };
@@ -551,6 +551,21 @@ impl BlockchainCache {
                     .add_pool_collects_batch(self.chain.chain_id, collects)
                     .await?;
             }
+        }
+
+        Ok(())
+    }
+
+    /// Adds a batch of pool flash events to the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if adding the flash events to the database fails.
+    pub async fn add_pool_flash_batch(&self, flash_events: &[PoolFlash]) -> anyhow::Result<()> {
+        if let Some(database) = &self.database {
+            database
+                .add_pool_flash_batch(self.chain.chain_id, flash_events)
+                .await?;
         }
 
         Ok(())

--- a/crates/adapters/blockchain/src/events/flash.rs
+++ b/crates/adapters/blockchain/src/events/flash.rs
@@ -1,0 +1,111 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use alloy::primitives::{Address, U256};
+use nautilus_core::UnixNanos;
+use nautilus_model::defi::{SharedChain, SharedDex, data::PoolFlash};
+
+/// Represents a flash loan event from liquidity pools emitted from smart contract.
+///
+/// This struct captures the essential data from a flash loan transaction on decentralized
+/// exchanges (DEXs) that support flash loans.
+#[derive(Debug, Clone)]
+pub struct FlashEvent {
+    /// The decentralized exchange where the event happened.
+    pub dex: SharedDex,
+    /// The address of the smart contract which emitted the event.
+    pub pool_address: Address,
+    /// The block number in which this flash loan transaction was included.
+    pub block_number: u64,
+    /// The unique hash identifier of the transaction containing this event.
+    pub transaction_hash: String,
+    /// The position of this transaction within the block.
+    pub transaction_index: u32,
+    /// The position of this event log within the transaction.
+    pub log_index: u32,
+    /// The address that initiated the flash loan transaction.
+    pub sender: Address,
+    /// The address that received the flash loan.
+    pub recipient: Address,
+    /// The amount of token0 borrowed.
+    pub amount0: U256,
+    /// The amount of token1 borrowed.
+    pub amount1: U256,
+    /// The amount of token0 paid back (including fees).
+    pub paid0: U256,
+    /// The amount of token1 paid back (including fees).
+    pub paid1: U256,
+}
+
+impl FlashEvent {
+    /// Creates a new [`FlashEvent`] instance with the specified parameters.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        dex: SharedDex,
+        pool_address: Address,
+        block_number: u64,
+        transaction_hash: String,
+        transaction_index: u32,
+        log_index: u32,
+        sender: Address,
+        recipient: Address,
+        amount0: U256,
+        amount1: U256,
+        paid0: U256,
+        paid1: U256,
+    ) -> Self {
+        Self {
+            dex,
+            pool_address,
+            block_number,
+            transaction_hash,
+            transaction_index,
+            log_index,
+            sender,
+            recipient,
+            amount0,
+            amount1,
+            paid0,
+            paid1,
+        }
+    }
+
+    /// Converts a flash event into a `PoolFlash`.
+    #[must_use]
+    pub fn to_pool_flash(
+        &self,
+        chain: SharedChain,
+        pool_address: Address,
+        timestamp: Option<UnixNanos>,
+    ) -> PoolFlash {
+        PoolFlash::new(
+            chain,
+            self.dex.clone(),
+            pool_address,
+            self.block_number,
+            self.transaction_hash.clone(),
+            self.transaction_index,
+            self.log_index,
+            timestamp,
+            self.sender,
+            self.recipient,
+            self.amount0,
+            self.amount1,
+            self.paid0,
+            self.paid1,
+        )
+    }
+}

--- a/crates/adapters/blockchain/src/events/mod.rs
+++ b/crates/adapters/blockchain/src/events/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod burn;
 pub mod collect;
+pub mod flash;
 pub mod initialize;
 pub mod mint;
 pub mod pool_created;

--- a/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/arbitrum/uniswap_v3.rs
@@ -37,6 +37,7 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         "Collect(address,address,int24,int24,uint128,uint128)",
     );
     dex.set_initialize_event("Initialize(uint160,int24)");
+    dex.set_flash_event("Flash(address,address,uint256,uint256,uint256,uint256)");
     let mut dex_extended = DexExtended::new(dex);
 
     dex_extended.set_pool_created_event_parsing(uniswap_v3::pool_created::parse_pool_created_event);
@@ -46,6 +47,7 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
     dex_extended.set_burn_event_parsing(uniswap_v3::burn::parse_burn_event);
     dex_extended.set_collect_event_parsing(uniswap_v3::collect::parse_collect_event);
     dex_extended.set_convert_trade_data(uniswap_v3::trade_data::convert_to_trade_data);
+    dex_extended.set_flash_event_parsing(uniswap_v3::flash::parse_flash_event);
 
     dex_extended
 });

--- a/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
+++ b/crates/adapters/blockchain/src/exchanges/ethereum/uniswap_v3.rs
@@ -20,14 +20,7 @@ use nautilus_model::defi::{
     dex::{AmmType, Dex, DexType},
 };
 
-use crate::exchanges::{
-    extended::DexExtended,
-    parsing::uniswap_v3::{
-        burn::parse_burn_event, collect::parse_collect_event, mint::parse_mint_event,
-        pool_created::parse_pool_created_event, swap::parse_swap_event,
-        trade_data::convert_to_trade_data,
-    },
-};
+use crate::exchanges::{extended::DexExtended, parsing::uniswap_v3};
 
 /// Uniswap V3 DEX on Ethereum.
 pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
@@ -44,14 +37,16 @@ pub static UNISWAP_V3: LazyLock<DexExtended> = LazyLock::new(|| {
         "Collect(address,address,int24,int24,uint128,uint128)",
     );
     dex.set_initialize_event("Initialize(uint160,int24)");
+    dex.set_flash_event("Flash(address,address,uint256,uint256,uint256,uint256)");
     let mut dex_extended = DexExtended::new(dex);
 
-    dex_extended.set_pool_created_event_parsing(parse_pool_created_event);
-    dex_extended.set_swap_event_parsing(parse_swap_event);
-    dex_extended.set_convert_trade_data(convert_to_trade_data);
-    dex_extended.set_mint_event_parsing(parse_mint_event);
-    dex_extended.set_burn_event_parsing(parse_burn_event);
-    dex_extended.set_collect_event_parsing(parse_collect_event);
+    dex_extended.set_pool_created_event_parsing(uniswap_v3::pool_created::parse_pool_created_event);
+    dex_extended.set_swap_event_parsing(uniswap_v3::swap::parse_swap_event);
+    dex_extended.set_convert_trade_data(uniswap_v3::trade_data::convert_to_trade_data);
+    dex_extended.set_mint_event_parsing(uniswap_v3::mint::parse_mint_event);
+    dex_extended.set_burn_event_parsing(uniswap_v3::burn::parse_burn_event);
+    dex_extended.set_collect_event_parsing(uniswap_v3::collect::parse_collect_event);
+    dex_extended.set_flash_event_parsing(uniswap_v3::flash::parse_flash_event);
 
     dex_extended
 });

--- a/crates/adapters/blockchain/src/exchanges/extended.rs
+++ b/crates/adapters/blockchain/src/exchanges/extended.rs
@@ -26,8 +26,8 @@ use nautilus_model::{
 };
 
 use crate::events::{
-    burn::BurnEvent, collect::CollectEvent, initialize::InitializeEvent, mint::MintEvent,
-    pool_created::PoolCreatedEvent, swap::SwapEvent,
+    burn::BurnEvent, collect::CollectEvent, flash::FlashEvent, initialize::InitializeEvent,
+    mint::MintEvent, pool_created::PoolCreatedEvent, swap::SwapEvent,
 };
 
 type ConvertTradeDataFn =
@@ -50,6 +50,8 @@ pub struct DexExtended {
     pub parse_burn_event_fn: Option<fn(SharedDex, Log) -> anyhow::Result<BurnEvent>>,
     /// Function to parse collect events.
     pub parse_collect_event_fn: Option<fn(SharedDex, Log) -> anyhow::Result<CollectEvent>>,
+    /// Function to parse flash events.
+    pub parse_flash_event_fn: Option<fn(SharedDex, Log) -> anyhow::Result<FlashEvent>>,
     /// Function to convert to trade data.
     pub convert_to_trade_data_fn: Option<ConvertTradeDataFn>,
 }
@@ -67,6 +69,7 @@ impl DexExtended {
             parse_burn_event_fn: None,
             parse_collect_event_fn: None,
             convert_to_trade_data_fn: None,
+            parse_flash_event_fn: None,
         }
     }
 
@@ -116,6 +119,14 @@ impl DexExtended {
         parse_collect_event: fn(SharedDex, Log) -> anyhow::Result<CollectEvent>,
     ) {
         self.parse_collect_event_fn = Some(parse_collect_event);
+    }
+
+    /// Sets the function used to parse flash events for this Dex.
+    pub fn set_flash_event_parsing(
+        &mut self,
+        parse_flash_event: fn(SharedDex, Log) -> anyhow::Result<FlashEvent>,
+    ) {
+        self.parse_flash_event_fn = Some(parse_flash_event);
     }
 
     /// Sets the function used to convert trade data for this Dex.

--- a/crates/adapters/blockchain/src/exchanges/parsing/uniswap_v3/flash.rs
+++ b/crates/adapters/blockchain/src/exchanges/parsing/uniswap_v3/flash.rs
@@ -1,0 +1,96 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use alloy::{dyn_abi::SolType, primitives::Address, sol};
+use hypersync_client::simple_types::Log;
+use nautilus_model::defi::SharedDex;
+
+use crate::{
+    events::flash::FlashEvent,
+    hypersync::helpers::{
+        extract_address_from_topic, extract_block_number, extract_log_index,
+        extract_transaction_hash, extract_transaction_index, validate_event_signature_hash,
+    },
+};
+
+// Placeholder hash - will be calculated properly later
+const FLASH_EVENT_SIGNATURE_HASH: &str =
+    "bdbdb71d7860376ba52b25a5028beea23581364a40522f6bcfb86bb1f2dca633";
+
+// Define sol macro for easier parsing of Flash event data
+// event Flash(address indexed sender, address indexed recipient, uint256 amount0, uint256 amount1, uint256 paid0, uint256 paid1)
+sol! {
+    struct FlashEventData {
+        uint256 amount0;
+        uint256 amount1;
+        uint256 paid0;
+        uint256 paid1;
+    }
+}
+
+/// Parses a flash event from a Uniswap V3 log.
+///
+/// # Errors
+///
+/// Returns an error if the log parsing fails or if the event data is invalid.
+///
+/// # Panics
+///
+/// Panics if the contract address is not set in the log.
+pub fn parse_flash_event(dex: SharedDex, log: Log) -> anyhow::Result<FlashEvent> {
+    validate_event_signature_hash("FlashEvent", FLASH_EVENT_SIGNATURE_HASH, &log)?;
+
+    let sender = extract_address_from_topic(&log, 1, "sender")?;
+    let recipient = extract_address_from_topic(&log, 2, "recipient")?;
+
+    if let Some(data) = &log.data {
+        let data_bytes = data.as_ref();
+
+        // Validate if data contains 4 parameters of 32 bytes each
+        if data_bytes.len() < 4 * 32 {
+            anyhow::bail!("Flash event data is too short");
+        }
+
+        // Decode the data using the FlashEventData struct
+        let decoded = match <FlashEventData as SolType>::abi_decode(data_bytes) {
+            Ok(decoded) => decoded,
+            Err(e) => anyhow::bail!("Failed to decode flash event data: {e}"),
+        };
+
+        let pool_address = Address::from_slice(
+            log.address
+                .clone()
+                .expect("Contract address should be set in logs")
+                .as_ref(),
+        );
+
+        Ok(FlashEvent::new(
+            dex,
+            pool_address,
+            extract_block_number(&log)?,
+            extract_transaction_hash(&log)?,
+            extract_transaction_index(&log)?,
+            extract_log_index(&log)?,
+            sender,
+            recipient,
+            decoded.amount0,
+            decoded.amount1,
+            decoded.paid0,
+            decoded.paid1,
+        ))
+    } else {
+        anyhow::bail!("Missing data in flash event log");
+    }
+}

--- a/crates/adapters/blockchain/src/exchanges/parsing/uniswap_v3/mod.rs
+++ b/crates/adapters/blockchain/src/exchanges/parsing/uniswap_v3/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod burn;
 pub mod collect;
+pub mod flash;
 pub mod initialize;
 pub mod mint;
 pub mod pool_created;

--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -228,6 +228,15 @@ pub fn get_defi_collect_topic(instrument_id: InstrumentId) -> MStr<Topic> {
         .get_defi_pool_collect_topic(instrument_id)
 }
 
+#[cfg(feature = "defi")]
+#[must_use]
+pub fn get_defi_flash_topic(instrument_id: InstrumentId) -> MStr<Topic> {
+    get_message_bus()
+        .borrow_mut()
+        .switchboard
+        .get_defi_pool_flash_topic(instrument_id)
+}
+
 /// Represents a switchboard of built-in messaging endpoint names.
 #[derive(Clone, Debug)]
 pub struct MessagingSwitchboard {
@@ -260,6 +269,8 @@ pub struct MessagingSwitchboard {
     defi_pool_liquidity_topics: AHashMap<InstrumentId, MStr<Topic>>,
     #[cfg(feature = "defi")]
     defi_pool_collect_topics: AHashMap<InstrumentId, MStr<Topic>>,
+    #[cfg(feature = "defi")]
+    defi_pool_flash_topics: AHashMap<InstrumentId, MStr<Topic>>,
 }
 
 impl Default for MessagingSwitchboard {
@@ -295,6 +306,8 @@ impl Default for MessagingSwitchboard {
             defi_pool_liquidity_topics: AHashMap::new(),
             #[cfg(feature = "defi")]
             defi_pool_collect_topics: AHashMap::new(),
+            #[cfg(feature = "defi")]
+            defi_pool_flash_topics: AHashMap::new(),
         }
     }
 }
@@ -588,6 +601,15 @@ impl MessagingSwitchboard {
             .defi_pool_collect_topics
             .entry(instrument_id)
             .or_insert_with(|| format!("data.defi.pool_collect.{instrument_id}").into())
+    }
+
+    #[cfg(feature = "defi")]
+    #[must_use]
+    pub fn get_defi_pool_flash_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
+        *self
+            .defi_pool_flash_topics
+            .entry(instrument_id)
+            .or_insert_with(|| format!("data.defi.pool_flash.{instrument_id}").into())
     }
 }
 

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -795,6 +795,10 @@ impl DataEngine {
                 let topic = switchboard::get_defi_collect_topic(collect.instrument_id());
                 msgbus::publish(topic, &collect as &dyn Any);
             }
+            DefiData::PoolFlash(flash) => {
+                let topic = switchboard::get_defi_flash_topic(flash.instrument_id());
+                msgbus::publish(topic, &flash as &dyn Any);
+            }
         }
     }
 

--- a/crates/model/src/defi/data/flash.rs
+++ b/crates/model/src/defi/data/flash.rs
@@ -1,0 +1,125 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::Display;
+
+use alloy_primitives::{Address, U256};
+use nautilus_core::UnixNanos;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    defi::{Pool, SharedChain, SharedDex},
+    identifiers::InstrumentId,
+};
+
+/// Represents a flash loan event from a Uniswap V3 pool.
+///
+/// Flash loans allow users to borrow tokens without collateral as long as they are returned
+/// within the same transaction. Fees are paid on the borrowed amount, which are added to
+/// the pool's fee growth accumulators.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.model")
+)]
+pub struct PoolFlash {
+    /// The blockchain network where the flash loan occurred.
+    pub chain: SharedChain,
+    /// The decentralized exchange where the flash loan was executed.
+    pub dex: SharedDex,
+    /// The blockchain address of the pool smart contract.
+    pub pool_address: Address,
+    /// The blockchain block number at which the flash loan was executed.
+    pub block: u64,
+    /// The unique hash identifier of the blockchain transaction containing the flash loan.
+    pub transaction_hash: String,
+    /// The index position of the transaction within the block.
+    pub transaction_index: u32,
+    /// The index position of the flash loan event log within the transaction.
+    pub log_index: u32,
+    /// The UNIX timestamp (nanoseconds) when the event occurred.
+    pub ts_event: Option<UnixNanos>,
+    /// The blockchain address of the user or contract that initiated the flash loan.
+    pub sender: Address,
+    /// The blockchain address that received the flash loan.
+    pub recipient: Address,
+    /// The amount of token0 borrowed.
+    pub amount0: U256,
+    /// The amount of token1 borrowed.
+    pub amount1: U256,
+    /// The amount of token0 paid back (including fees).
+    pub paid0: U256,
+    /// The amount of token1 paid back (including fees).
+    pub paid1: U256,
+}
+
+impl PoolFlash {
+    /// Creates a new [`PoolFlash`] instance with the specified parameters.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        chain: SharedChain,
+        dex: SharedDex,
+        pool_address: Address,
+        block_number: u64,
+        transaction_hash: String,
+        transaction_index: u32,
+        log_index: u32,
+        ts_event: Option<UnixNanos>,
+        sender: Address,
+        recipient: Address,
+        amount0: U256,
+        amount1: U256,
+        paid0: U256,
+        paid1: U256,
+    ) -> Self {
+        Self {
+            chain,
+            dex,
+            pool_address,
+            block: block_number,
+            transaction_hash,
+            transaction_index,
+            log_index,
+            ts_event,
+            sender,
+            recipient,
+            amount0,
+            amount1,
+            paid0,
+            paid1,
+        }
+    }
+
+    /// Returns the instrument ID for this pool's trading pair.
+    pub fn instrument_id(&self) -> InstrumentId {
+        Pool::create_instrument_id(self.chain.name, &self.dex, &self.pool_address)
+    }
+}
+
+impl Display for PoolFlash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PoolFlash(instrument={}, recipient={}, amount0={}, amount1={}, paid1={}, paid2={})",
+            self.instrument_id(),
+            self.recipient,
+            self.amount0,
+            self.amount1,
+            self.paid0,
+            self.paid1,
+        )
+    }
+}

--- a/crates/model/src/defi/data/mod.rs
+++ b/crates/model/src/defi/data/mod.rs
@@ -26,6 +26,7 @@ use crate::{defi::Pool, identifiers::InstrumentId};
 
 pub mod block;
 pub mod collect;
+pub mod flash;
 pub mod liquidity;
 pub mod swap;
 pub mod transaction;
@@ -33,6 +34,7 @@ pub mod transaction;
 // Re-exports
 pub use block::Block;
 pub use collect::PoolFeeCollect;
+pub use flash::PoolFlash;
 pub use liquidity::{PoolLiquidityUpdate, PoolLiquidityUpdateType};
 pub use swap::PoolSwap;
 pub use transaction::Transaction;
@@ -42,6 +44,7 @@ pub enum DexPoolData {
     Swap(PoolSwap),
     LiquidityUpdate(PoolLiquidityUpdate),
     FeeCollect(PoolFeeCollect),
+    Flash(PoolFlash),
 }
 
 /// Represents DeFi-specific data events in a decentralized exchange ecosystem.
@@ -62,6 +65,8 @@ pub enum DefiData {
     PoolLiquidityUpdate(PoolLiquidityUpdate),
     /// A fee collection event from a DEX pool position.
     PoolFeeCollect(PoolFeeCollect),
+    /// A flash event
+    PoolFlash(PoolFlash),
 }
 
 impl DefiData {
@@ -78,6 +83,7 @@ impl DefiData {
             Self::PoolLiquidityUpdate(update) => update.instrument_id(),
             Self::PoolFeeCollect(collect) => collect.instrument_id(),
             Self::Pool(pool) => pool.instrument_id,
+            Self::PoolFlash(flash) => flash.instrument_id(),
         }
     }
 }
@@ -90,6 +96,7 @@ impl Display for DefiData {
             Self::PoolSwap(s) => write!(f, "{s}"),
             Self::PoolLiquidityUpdate(u) => write!(f, "{u}"),
             Self::PoolFeeCollect(c) => write!(f, "{c}"),
+            Self::PoolFlash(p) => write!(f, "{p}"),
         }
     }
 }

--- a/crates/model/src/defi/dex.rs
+++ b/crates/model/src/defi/dex.rs
@@ -126,6 +126,8 @@ pub struct Dex {
     pub burn_created_event: Cow<'static, str>,
     /// The event signature or identifier used to detect collect fee events.
     pub collect_created_event: Cow<'static, str>,
+    // Optional Flash event signature emitted when flash loan occurs.
+    pub flash_created_event: Option<Cow<'static, str>>,
     /// The type of automated market maker (AMM) algorithm used by this DEX.
     pub amm_type: AmmType,
     /// Collection of liquidity pools managed by this DEX.
@@ -193,6 +195,7 @@ impl Dex {
             mint_created_event: encoded_mint_event.into(),
             burn_created_event: encoded_burn_event.into(),
             collect_created_event: encoded_collect_event.into(),
+            flash_created_event: None,
             amm_type,
             pairs: vec![],
         }
@@ -203,6 +206,7 @@ impl Dex {
         format!("{}:{}", self.chain.name, self.name)
     }
 
+    /// Sets the pool initialization event signature by hashing and encoding the provided event string.
     pub fn set_initialize_event(&mut self, event: &str) {
         let initialize_event_hash = keccak256(event.as_bytes());
         let encoded_initialized_event = format!(
@@ -210,6 +214,16 @@ impl Dex {
             encoded_hash = hex::encode(initialize_event_hash)
         );
         self.initialize_event = Some(encoded_initialized_event.into());
+    }
+
+    /// Sets the flash loan event signature by hashing and encoding the provided event string.
+    pub fn set_flash_event(&mut self, event: &str) {
+        let flash_event_hash = keccak256(event.as_bytes());
+        let encoded_flash_event = format!(
+            "0x{encoded_hash}",
+            encoded_hash = hex::encode(flash_event_hash)
+        );
+        self.flash_created_event = Some(encoded_flash_event.into());
     }
 }
 

--- a/crates/model/src/defi/pool_analysis/snapshot.rs
+++ b/crates/model/src/defi/pool_analysis/snapshot.rs
@@ -135,6 +135,8 @@ pub struct PoolAnalytics {
     pub total_burns: u64,
     /// Total number of fee collection events processed.
     pub total_fee_collects: u64,
+    /// Total number of flash events processed.
+    pub total_flashes: u64,
     /// Time spent processing swap events (debug builds only).
     #[cfg(debug_assertions)]
     pub swap_processing_time: std::time::Duration,
@@ -160,6 +162,7 @@ impl Default for PoolAnalytics {
             total_mints: 0,
             total_burns: 0,
             total_fee_collects: 0,
+            total_flashes: 0,
             #[cfg(debug_assertions)]
             swap_processing_time: std::time::Duration::ZERO,
             #[cfg(debug_assertions)]

--- a/schema/sql/tables.sql
+++ b/schema/sql/tables.sql
@@ -412,6 +412,26 @@ CREATE TABLE IF NOT EXISTS "pool_collect_event" (
 CREATE INDEX IF NOT EXISTS idx_pool_collect_event_lookup
     ON pool_collect_event(chain_id, pool_address, block, transaction_index, log_index);
 
+CREATE TABLE IF NOT EXISTS "pool_flash_event" (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL REFERENCES chain(chain_id) ON DELETE CASCADE,
+    pool_address TEXT NOT NULL,
+    block BIGINT NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    transaction_index INTEGER NOT NULL,
+    log_index INTEGER NOT NULL,
+    sender TEXT NOT NULL,
+    recipient TEXT NOT NULL,
+    amount0 U256 NOT NULL,
+    amount1 U256 NOT NULL,
+    paid0 U256 NOT NULL,
+    paid1 U256 NOT NULL,
+    FOREIGN KEY (chain_id, pool_address) REFERENCES pool(chain_id, address),
+--     FOREIGN KEY (chain_id, block) REFERENCES block(chain_id, number),  // TODO temporarily disabled not to be blocked by full block sync
+    UNIQUE(chain_id, transaction_hash, log_index)
+);
+CREATE INDEX IF NOT EXISTS idx_pool_flash_event_lookup
+    ON pool_flash_event(chain_id, pool_address, block, transaction_index, log_index);
 
 CREATE TABLE IF NOT EXISTS "pool_snapshot" (
     chain_id INTEGER NOT NULL REFERENCES chain(chain_id) ON DELETE CASCADE,
@@ -432,9 +452,10 @@ CREATE TABLE IF NOT EXISTS "pool_snapshot" (
     total_amount1_deposited U256 NOT NULL,
     total_amount0_collected U256 NOT NULL,
     total_amount1_collected U256 NOT NULL,
-    total_swaps INTEGER NOT NULL,
-    total_mints INTEGER NOT NULL,
-    total_burns INTEGER NOT NULL,
+    total_swaps INTEGER NOT NULL DEFAULT 0,
+    total_mints INTEGER NOT NULL DEFAULT 0,
+    total_burns INTEGER NOT NULL DEFAULT 0,
+    total_flashes INTEGER NOT NULL DEFAULT 0,
     total_fee_collects INTEGER NOT NULL,
     is_valid BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary
  
- Full `Flash` event integration across the blockchain adapter with a new PSQL table defined `pool_flash_event` and all the corresponding queries
- Integrated with the pool events syncing pipeline and `PoolProfiler` processing and execution
- added `PoolFlash` into the defi domain model

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

