### PR TITLE
Fix IBKR account balance calculation

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1140,9 +1140,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
             if self._account_summary_tags - set(self._account_summary[currency].keys()) == set():
                 self._log.info(f"{self._account_summary}", LogColor.GREEN)
-                locked = self._account_summary[currency]["FullMaintMarginReq"]
                 total = self._account_summary[currency]["NetLiquidation"]
-                free = self._account_summary[currency].get("FullAvailableFunds", total - locked)
+                free = self._account_summary[currency]["FullAvailableFunds"]
+                locked = total - free
+
                 account_balance = AccountBalance(
                     total=Money(total, Currency.from_str(currency)),
                     free=Money(free, Currency.from_str(currency)),


### PR DESCRIPTION
## Summary

After #3052, the IBKR live environment could not start, showing the error:
> Error on '_run_msg_handler_processor': ValueError('`total` (28121.16 USD) - `locked` (9.39 USD) != `free` (28108.33 USD)').  

The calculation of `locked` in IBKR is quite complex. However, since the API provides clear values for `NetLiquidation` and `FullAvailableFunds`, we switched to computing `locked` as `total - free`.

## Related Issues/PRs

Related to #3052

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

Tested in live.