### PR TITLE
Fix handling of asyncio.CancelledError in execution reconciliation

### DIFF
--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -1289,7 +1289,7 @@ class LiveExecutionEngine(ExecutionEngine):
 
             # Reconcile each mass status with the execution engine
             for mass_status_or_exception in mass_status_all:
-                if isinstance(mass_status_or_exception, Exception):
+                if isinstance(mass_status_or_exception, BaseException):
                     self._log.error(f"Failed to generate mass status: {mass_status_or_exception}")
                     results.append(False)
                     continue


### PR DESCRIPTION
## Description

Fixes a crash during execution reconciliation startup when `asyncio.CancelledError` is returned from `generate_mass_status()`. The crash prevents the trading node from starting when reconciliation is enabled.

## Problem

The execution reconciliation crashes with:
```
AttributeError: 'CancelledError' object has no attribute 'client_id'
```

This occurs in `LiveExecEngine.reconcile_execution_state()` at line 1292-1295.

## Root Cause

In Python 3.8+, `asyncio.CancelledError` was changed to inherit from `BaseException` instead of `Exception` ([PEP 3151](https://peps.python.org/pep-3151/), [Python 3.8 release notes](https://docs.python.org/3/whatsnew/3.8.html#asyncio)).

The exception hierarchy:
- `BaseException`
  - `asyncio.CancelledError` ← NOT caught by `isinstance(x, Exception)`
  - `Exception`
    - `RuntimeError`, `ValueError`, etc.

The exception check at line 1292 only catches `Exception`:
```python
if isinstance(mass_status_or_exception, Exception):
```

When `generate_mass_status()` is cancelled, the `CancelledError` passes through this check and the code attempts to access `mass_status.client_id`, causing the crash.

## Solution

Changed the isinstance check from `Exception` to `BaseException` to catch all exception types that can be returned by `asyncio.gather(..., return_exceptions=True)`:

```python
if isinstance(mass_status_or_exception, BaseException):
```

This is more future-proof and handles any exception type that might be raised during mass status generation.

## Testing

Verified the fix resolves the issue with:
- ✅ Reconciliation enabled with 7 existing positions from IB Gateway
- ✅ StreamingConfig enabled (which previously triggered the crash)
- ✅ All engines connected successfully
- ✅ All actors reached RUNNING state
- ✅ No CancelledError crash occurred
- ✅ Reconciliation completed: "Initialized 7 open positions"

### Reproduction Environment
- **OS:** Linux (WSL2, Ubuntu 24.04)
- **Python:** 3.11.13
- **NautilusTrader:** 1.221.0 (develop branch, commit 806f1f8fc)
- **Adapter:** Interactive Brokers
- **Configuration:** Reconciliation + StreamingConfig both enabled

## Impact

- **Severity:** High - prevents node startup when reconciliation is enabled
- **Affects:** All adapters that use async operations in `generate_mass_status()`
- **Workaround (before fix):** Disable reconciliation, losing important safety features
- **Fix:** One-line change, fully backward compatible

## Related Issues

This appears to be a new issue not previously reported. Similar reconciliation issues have been filed (#1789, #1154, #3054, #3042) but none address the `CancelledError` inheritance problem.

## Checklist

- [x] Code follows project style guidelines
- [x] Changes have been tested with live adapter (Interactive Brokers)
- [x] Fix is minimal and focused on the specific issue
- [x] Commit message follows conventional commits format
- [x] Change is backward compatible

## References

- [PEP 3151 - Reworking the OS and IO exception hierarchy](https://peps.python.org/pep-3151/)
- [Python 3.8 What's New - asyncio.CancelledError](https://docs.python.org/3/whatsnow/3.8.html#asyncio)
- [asyncio.gather() documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather)