### PR TITLE
Fix handling of asyncio.CancelledError in execution reconciliation

### DIFF
--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -1289,7 +1289,7 @@ class LiveExecutionEngine(ExecutionEngine):
 
             # Reconcile each mass status with the execution engine
             for mass_status_or_exception in mass_status_all:
-                if isinstance(mass_status_or_exception, Exception):
+                if isinstance(mass_status_or_exception, BaseException):
                     self._log.error(f"Failed to generate mass status: {mass_status_or_exception}")
                     results.append(False)
                     continue


### PR DESCRIPTION
## Problem

The execution reconciliation crashes with `AttributeError: 'CancelledError' object has no attribute 'client_id'` when `generate_mass_status()` is cancelled during startup. This prevents the trading node from starting when reconciliation is enabled.

## Root Cause

In Python 3.8+, `asyncio.CancelledError` inherits from `BaseException` instead of `Exception` (PEP 3151). The exception check at line 1292 only catches `Exception`, so `CancelledError` passes through uncaught and crashes when the code attempts to access `mass_status.client_id`.

**Exception hierarchy:**
- `BaseException`
  - `asyncio.CancelledError` ← NOT caught by `isinstance(x, Exception)`
  - `Exception`
    - `RuntimeError`, `ValueError`, etc.

## Solution

Changed the isinstance check from `Exception` to `BaseException` to catch all exception types that can be returned by `asyncio.gather(..., return_exceptions=True)`, including `CancelledError`.

**Before:**
```python
if isinstance(mass_status_or_exception, Exception):
```

**After:**
```python
if isinstance(mass_status_or_exception, BaseException):
```

## Testing

Verified the fix works with:
- Reconciliation enabled with 7 existing positions
- StreamingConfig enabled (which previously triggered the crash)
- All engines connected successfully
- All actors reached RUNNING state
- No CancelledError occurred

## Impact

- **Severity:** High - prevented node startup when reconciliation enabled
- **Affects:** All adapters using async operations in `generate_mass_status()`
- **Fix:** Future-proof - catches any exception type from `asyncio.gather()`

Fixes crash during execution reconciliation startup.