### PR TITLE
Refactor streaming writer to support per-bar-type persistence

### DIFF
--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1604,7 +1604,7 @@ cdef class DataEngine(Component):
 
                 data = catalog.bars(
                     instrument_ids=[str(bar_type.instrument_id)],
-                    bar_type=str(bar_type),
+                    bar_types=[str(bar_type)],
                     start=ts_start,
                     end=ts_end,
                 )

--- a/nautilus_trader/portfolio/portfolio.pyx
+++ b/nautilus_trader/portfolio/portfolio.pyx
@@ -1556,10 +1556,8 @@ cdef class Portfolio(PortfolioFacade):
             instrument_id=instrument_id,
         )
 
-        cdef:
-            Order o
-
         # Initialize initial (order) margin
+        cdef Order o
         cdef bint result_init = self._accounts.update_orders(
             account=account,
             instrument=instrument,

--- a/nautilus_trader/serialization/arrow/serializer.py
+++ b/nautilus_trader/serialization/arrow/serializer.py
@@ -125,6 +125,7 @@ class ArrowSerializer:
     def _unpack_container_objects(data_cls: type, data: list[Any]) -> list[Data]:
         if data_cls == OrderBookDeltas:
             return [delta for deltas in data for delta in deltas.deltas]
+
         return data
 
     @staticmethod
@@ -208,6 +209,7 @@ class ArrowSerializer:
     ) -> pa.RecordBatch:
         if isinstance(data, CustomData):
             data = data.data
+
         data_cls = data_cls or type(data)
         if data_cls is None:
             raise RuntimeError("`cls` was `None` when a value was expected")
@@ -223,6 +225,7 @@ class ArrowSerializer:
 
         batch = delegate(data)
         assert isinstance(batch, pa.RecordBatch)
+
         return batch
 
     @staticmethod
@@ -252,7 +255,9 @@ class ArrowSerializer:
         """
         if data_cls in RUST_SERIALIZERS or data_cls.__name__ in RUST_STR_SERIALIZERS:
             return ArrowSerializer.rust_defined_to_record_batch(data, data_cls=data_cls)
+
         batches = [ArrowSerializer.serialize(obj, data_cls) for obj in data]
+
         return pa.Table.from_batches(batches, schema=batches[0].schema)
 
     @staticmethod
@@ -282,6 +287,7 @@ class ArrowSerializer:
             if data_cls in RUST_SERIALIZERS:
                 if isinstance(batch, pa.RecordBatch):
                     batch = pa.Table.from_batches([batch])
+
                 return ArrowSerializer._deserialize_rust(data_cls=data_cls, table=batch)
             raise TypeError(
                 f"Cannot deserialize object `{data_cls}`. Register a "
@@ -309,6 +315,7 @@ class ArrowSerializer:
 
         wrangler = Wrangler.from_schema(table.schema)
         ticks = wrangler.from_arrow(table)
+
         return ticks
 
 
@@ -316,7 +323,9 @@ def make_dict_serializer(schema: pa.Schema) -> Callable[[list[Data | Event]], pa
     def inner(data: list[Data | Event]) -> pa.RecordBatch:
         if not isinstance(data, list):
             data = [data]
+
         dicts = [d.to_dict(d) for d in data]
+
         return dicts_to_record_batch(dicts, schema=schema)
 
     return inner

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -447,3 +447,183 @@ class TestPersistenceStreaming:
             "TradeTick": 179,
         }
         assert counts == expected
+
+    def test_feather_writer_per_bar_type(
+        self,
+        catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        from nautilus_trader.cache.cache import Cache
+        from nautilus_trader.common.component import TestClock
+        from nautilus_trader.model.data import Bar
+        from nautilus_trader.persistence.writer import StreamingFeatherWriter
+        from nautilus_trader.test_kit.providers import TestInstrumentProvider
+        from nautilus_trader.test_kit.stubs.data import TestDataStubs
+
+        self.catalog = catalog_betfair
+
+        # Create test infrastructure
+        clock = TestClock()
+        cache = Cache()
+        instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD")
+        cache.add_instrument(instrument)
+
+        # Create writer with Bar in include_types
+        writer = StreamingFeatherWriter(
+            path=f"{self.catalog.path}/backtest/test_instance",
+            cache=cache,
+            clock=clock,
+            fs_protocol="file",
+            include_types=[Bar],
+        )
+
+        # Create bars with different bar types
+        bar1 = TestDataStubs.bar_5decimal(ts_event=1000, ts_init=1000)
+        bar2 = TestDataStubs.bar_5decimal_5min_bid()
+
+        # Act - write bars
+        writer.write(bar1)
+        writer.write(bar2)
+        writer.close()
+
+        # Assert - check that bars were written to per-bar-type subdirectories
+        bar_dir = f"{self.catalog.path}/backtest/test_instance/bar"
+
+        # Verify directory structure exists
+        assert self.catalog.fs.isdir(bar_dir)
+
+        # Verify subdirectories for each bar type exist
+        subdirs = [d for d in self.catalog.fs.glob(f"{bar_dir}/*") if self.catalog.fs.isdir(d)]
+        assert len(subdirs) == 2  # One for each bar type
+
+        # Verify feather files exist in subdirectories
+        feather_files = list(self.catalog.fs.glob(f"{bar_dir}/**/*.feather"))
+        assert len(feather_files) == 2  # One file per bar type
+
+    def test_convert_stream_to_data_with_identifiers(
+        self,
+        catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        from nautilus_trader.cache.cache import Cache
+        from nautilus_trader.common.component import TestClock
+        from nautilus_trader.model.data import Bar
+        from nautilus_trader.persistence.writer import StreamingFeatherWriter
+        from nautilus_trader.test_kit.providers import TestInstrumentProvider
+        from nautilus_trader.test_kit.stubs.data import TestDataStubs
+
+        self.catalog = catalog_betfair
+
+        # Create test infrastructure
+        clock = TestClock()
+        cache = Cache()
+        instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD")
+        cache.add_instrument(instrument)
+
+        # Create writer
+        instance_id = "test_instance_identifiers"
+        writer = StreamingFeatherWriter(
+            path=f"{self.catalog.path}/backtest/{instance_id}",
+            cache=cache,
+            clock=clock,
+            fs_protocol="file",
+            include_types=[Bar],
+        )
+
+        # Create bars with different bar types (1-MINUTE and 5-MINUTE)
+        bar1 = TestDataStubs.bar_5decimal(ts_event=1000, ts_init=1000)
+        bar2 = TestDataStubs.bar_5decimal_5min_bid()
+
+        # Write bars
+        writer.write(bar1)
+        writer.write(bar2)
+        writer.close()
+
+        # Act - convert only bars with "5-MINUTE" in their identifier
+        self.catalog.convert_stream_to_data(
+            instance_id,
+            Bar,
+            identifiers=["5-MINUTE"],
+        )
+
+        # Assert - verify only 5-MINUTE bars were written to catalog
+        # Query all bars from catalog
+        all_bars = self.catalog.bars()
+        assert len(all_bars) == 1
+
+        # Verify the bar is a 5-MINUTE bar
+        assert "5-MINUTE" in str(all_bars[0].bar_type)
+
+    def test_convert_stream_to_data_internal_to_external(
+        self,
+        catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange
+        from nautilus_trader.cache.cache import Cache
+        from nautilus_trader.common.component import TestClock
+        from nautilus_trader.model.data import Bar
+        from nautilus_trader.model.data import BarSpecification
+        from nautilus_trader.model.data import BarType
+        from nautilus_trader.model.enums import AggregationSource
+        from nautilus_trader.model.enums import BarAggregation
+        from nautilus_trader.model.enums import PriceType
+        from nautilus_trader.model.objects import Price
+        from nautilus_trader.model.objects import Quantity
+        from nautilus_trader.persistence.writer import StreamingFeatherWriter
+        from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+        self.catalog = catalog_betfair
+
+        # Create test infrastructure
+        clock = TestClock()
+        cache = Cache()
+        instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD")
+        cache.add_instrument(instrument)
+
+        # Create writer
+        instance_id = "test_instance_internal"
+        writer = StreamingFeatherWriter(
+            path=f"{self.catalog.path}/backtest/{instance_id}",
+            cache=cache,
+            clock=clock,
+            fs_protocol="file",
+            include_types=[Bar],
+        )
+
+        # Create a bar with INTERNAL aggregation source
+        bar_spec = BarSpecification(1, BarAggregation.MINUTE, PriceType.BID)
+        bar_type_internal = BarType(
+            instrument.id,
+            bar_spec,
+            AggregationSource.INTERNAL,
+        )
+
+        bar = Bar(
+            bar_type=bar_type_internal,
+            open=Price.from_str("1.00002"),
+            high=Price.from_str("1.00004"),
+            low=Price.from_str("1.00001"),
+            close=Price.from_str("1.00003"),
+            volume=Quantity.from_int(1_000_000),
+            ts_event=1000,
+            ts_init=1000,
+        )
+
+        # Write bar
+        writer.write(bar)
+        writer.close()
+
+        # Act - convert stream to data (should convert INTERNAL to EXTERNAL)
+        self.catalog.convert_stream_to_data(
+            instance_id,
+            Bar,
+        )
+
+        # Assert - verify bars were converted to EXTERNAL
+        # Load all bars from catalog
+        bars = self.catalog.bars()
+        assert len(bars) == 1
+
+        # Check that the bar has EXTERNAL aggregation source
+        assert bars[0].bar_type.aggregation_source == AggregationSource.EXTERNAL
+        assert str(bars[0].bar_type).endswith("-EXTERNAL")


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Refactor streaming writer to support per-bar-type persistence and improve catalog conversion

### Overview

This PR refactors the streaming writer infrastructure to properly handle per-bar-type file organization and enhances the catalog's ability to convert streamed data back to parquet format. The changes enable better organization of streamed data and support for converting internal bars to external bars during catalog conversion.

### Key changes

**Streaming writer improvements:**
- Refactored `StreamingFeatherWriter` to support per-bar-type file organization for `Bar` data, similar to existing per-instrument organization for ticks and order book data.
- Consolidated file rotation logic into unified `_rotate_identifier_file()` method that handles both per-instrument and per-bar-type cases.
- Renamed `_create_instrument_writer()` to `_create_identifier_writer()` to better reflect its dual purpose (instrument_id and bar_type).
- Fixed writer creation logic to properly handle custom data types with and without instrument_id attributes.
- Improved file size tracking to use appropriate keys (tuples for per-identifier data, strings for regular data).
- Changed logger attribute from `self.logger` to `self.log` for consistency with codebase conventions.

**Catalog conversion enhancements:**
- Added `identifiers` parameter to `convert_stream_to_data()` to allow filtering by specific instrument_ids or bar_types.
- Added `convert_bar_type_to_external` parameter to `_handle_table_nautilus()` to convert INTERNAL bar types to EXTERNAL during deserialization.
- Refactored `convert_stream_to_data()` to handle both subdirectory-organized files (per-instrument/per-bar-type) and flat files.
- Improved feather file discovery to properly handle nested directory structures.
- Data is now written incrementally per feather file rather than loading all data into memory first.

**Data engine fix:**
- Fixed `bars()` catalog query to use `bar_types` parameter (list) instead of `bar_type` (string).

**Example updates:**
- Updated `databento_option_greeks.py` example to demonstrate streaming both `GreeksData` and `Bar` data.
- Added subscription to 2-MINUTE bars with INTERNAL aggregation for demonstration.
- Enhanced catalog conversion to include both greeks and bars with identifier filtering.

**Minor improvements:**
- Cleaned up code formatting and removed debug print statements.
- Simplified `_extract_sql_safe_filename()` implementation.
- Added proper handling of custom data types in writer creation.

### Testing

**New tests added:**
- `test_feather_writer_per_bar_type`: Tests per-bar-type file organization with separate subdirectories for different bar types.
- `test_convert_stream_to_data_with_identifiers`: Tests filtering by identifiers when converting stream data to catalog.
- `test_convert_stream_to_data_internal_to_external`: Tests conversion of INTERNAL bar types to EXTERNAL during catalog conversion.

**Test results:**
- All 14 tests in `test_streaming.py` pass successfully.
- Example notebook demonstrates end-to-end workflow of streaming and converting bars and greeks data.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Tested all functionalities in databento_option_greeks.py (updated)
