### PR TITLE
Fix busy loop in blockchain client

### DIFF
--- a/crates/adapters/blockchain/src/data/client.rs
+++ b/crates/adapters/blockchain/src/data/client.rs
@@ -316,36 +316,34 @@ impl BlockchainDataClient {
                         }
                     }
                     msg = async {
-                        if let Some(ref mut rpc_client) = core_client.rpc_client {
-                            Some(rpc_client.next_rpc_message().await)
-                        } else {
-                            None
+                        match core_client.rpc_client {
+                            Some(ref mut rpc_client) => rpc_client.next_rpc_message().await,
+                            None => std::future::pending().await,  // Never resolves
                         }
                     } => {
-                        if let Some(msg) = msg {
-                            match msg {
-                                Ok(BlockchainMessage::Block(block)) => {
-                                    let data = DataEvent::DeFi(DefiData::Block(block));
-                                    core_client.send_data(data);
-                                },
-                                Ok(BlockchainMessage::SwapEvent(_)) => {
-                                    tracing::warn!("RPC swap events are not yet supported");
-                                }
-                                Ok(BlockchainMessage::MintEvent(_)) => {
-                                    tracing::warn!("RPC mint events are not yet supported");
-                                }
-                                Ok(BlockchainMessage::BurnEvent(_)) => {
-                                    tracing::warn!("RPC burn events are not yet supported");
-                                }
-                                Ok(BlockchainMessage::CollectEvent(_)) => {
-                                    tracing::warn!("RPC collect events are not yet supported")
-                                }
-                                Ok(BlockchainMessage::FlashEvent(_)) => {
-                                    tracing::warn!("RPC flash events are not yet supported")
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error processing RPC message: {e}");
-                                }
+                        // This branch only fires when we actually receive a message
+                        match msg {
+                            Ok(BlockchainMessage::Block(block)) => {
+                                let data = DataEvent::DeFi(DefiData::Block(block));
+                                core_client.send_data(data);
+                            },
+                            Ok(BlockchainMessage::SwapEvent(_)) => {
+                                tracing::warn!("RPC swap events are not yet supported");
+                            }
+                            Ok(BlockchainMessage::MintEvent(_)) => {
+                                tracing::warn!("RPC mint events are not yet supported");
+                            }
+                            Ok(BlockchainMessage::BurnEvent(_)) => {
+                                tracing::warn!("RPC burn events are not yet supported");
+                            }
+                            Ok(BlockchainMessage::CollectEvent(_)) => {
+                                tracing::warn!("RPC collect events are not yet supported")
+                            }
+                            Ok(BlockchainMessage::FlashEvent(_)) => {
+                                tracing::warn!("RPC flash events are not yet supported")
+                            }
+                            Err(e) => {
+                                tracing::error!("Error processing RPC message: {e}");
                             }
                         }
                     }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

  Fixes a critical busy loop in the blockchain data client that caused 100% CPU usage and prevented graceful shutdown via Ctrl+C.
 
### Problem

  The blockchain client's processing task had a select branch for RPC messages that immediately returned `None` when `rpc_client` was not configured:

  ```rust
  msg = async {
      if let Some(ref mut rpc_client) = core_client.rpc_client {
          Some(rpc_client.next_rpc_message().await)
      } else {
          None  // Returns Poll::Ready(None) immediately
      }
  } => { ... }
```

  When rpc_client is None (e.g., when using HyperSync), this async block completes instantly without any await points, causing the select to pick this branch on every iteration. This created a tight busy loop that consumed 100% CPU and starved the Tokio runtime, preventing signal handlers and other tasks from running.

 ### Solution

  Replace the immediately-ready None with `std::future::pending().await`:
```rust
  msg = async {
      match core_client.rpc_client {
          Some(ref mut rpc_client) => rpc_client.next_rpc_message().await,
          None => std::future::pending().await,  // Never resolves
      }
  } => { ... }
```

It works because `std::future::pending()` creates a future that always returns `Poll::Pending`, effectively disabling this select branch when RPC is not configured. This allows the task to properly yield and other branches to be polled fairly.


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


