### PR TITLE
Add `filter_sec_types` config to skip unsupported IB instrument types

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/config.py
+++ b/nautilus_trader/adapters/interactive_brokers/config.py
@@ -136,6 +136,10 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
         Example: value set to 1, InstrumentProvider will make fresh pull every day even if TradingNode is not restarted.
     pickle_path: str (default: None)
         If provided valid path, will store the ContractDetails as pickle, and use during cache_validity period.
+    filter_sec_types: FrozenSet[str], optional
+        A set of IB `secType` values which should be ignored by the provider. Any contract whose
+        `secType` matches one of these entries will be skipped with a warning before reconciliation is
+        attempted. Use this to opt out from assets that are not yet supported (for example `WAR` or `IOPT`).
 
     """
 
@@ -150,6 +154,7 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
             and self.max_expiry_days == other.max_expiry_days
             and self.build_options_chain == other.build_options_chain
             and self.build_futures_chain == other.build_futures_chain
+            and self.filter_sec_types == other.filter_sec_types
         )
 
     def __hash__(self) -> int:
@@ -170,6 +175,7 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
                 ),
                 self.cache_validity_days,
                 self.pickle_path,
+                self.filter_sec_types,
             ),
         )
 
@@ -184,6 +190,7 @@ class InteractiveBrokersInstrumentProviderConfig(InstrumentProviderConfig, froze
 
     cache_validity_days: int | None = None
     pickle_path: str | None = None
+    filter_sec_types: frozenset[str] = frozenset()
 
 
 class InteractiveBrokersDataClientConfig(LiveDataClientConfig, frozen=True):

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -76,6 +76,7 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         self._cache_validity_days = config.cache_validity_days
         self._convert_exchange_to_mic_venue = config.convert_exchange_to_mic_venue
         self._symbol_to_mic_venue = config.symbol_to_mic_venue
+        self._filter_sec_types = set(config.filter_sec_types)
         # TODO: If cache_validity_days > 0 and Catalog is provided
 
         self._client = client
@@ -96,7 +97,23 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
             self._loading = False
             self._loaded = True
 
-    async def get_instrument(self, contract: IBContract) -> Instrument:
+    def _is_filtered_sec_type(self, sec_type: str | None) -> bool:
+        return bool(sec_type and sec_type in self._filter_sec_types)
+
+    @property
+    def filter_sec_types(self) -> set[str]:
+        """
+        Return the set of filtered security types.
+        """
+        return self._filter_sec_types
+
+    async def get_instrument(self, contract: IBContract) -> Instrument | None:
+        if self._is_filtered_sec_type(contract.secType):
+            self._log.warning(
+                f"Skipping filtered {contract.secType=} for contract {contract}",
+            )
+            return None
+
         contract_id = contract.conId
         instrument_id = self.contract_id_to_instrument_id.get(contract_id)
 
@@ -121,7 +138,6 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
 
         instrument = self.find(instrument_id)
 
-        # If instrument is still None, it means loading failed
         if instrument is None:
             self._log.error(f"Failed to load instrument for contract {contract}")
             raise ValueError(f"Instrument not found for contract {contract}")
@@ -702,6 +718,14 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
 
             if not isinstance(details, IBContractDetails):
                 details = IBContractDetails(**details.__dict__)
+
+            sec_type = details.contract.secType
+
+            if self._is_filtered_sec_type(sec_type):
+                self._log.warning(
+                    f"Skipping filtered {sec_type=} for contract {details.contract}",
+                )
+                continue
 
             self._log.debug(f"Attempting to create instrument from {details}")
 


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The current IBKR adapter implementation does not support all security types.
When my account holds `Warrant` (WAR) positions, the trading node fails to start with the following error chain:

`failed to parse` -> `Failed to load instrument for contract` -> `Cannot reconcile execution state`

Implementing full support for Warrants is quite complex, and I haven’t come across any discussion about it in Issues or on Discord. It also seems that no one else has expressed interest in Warrant so far.

Therefore, I've implemented a simple fix: adding a `filter_sec_types` config parameter to explicitly filter out unsupported asset types.

This allows the system to start normally while ignoring unsupported instrument types.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

Tested in live.
