### PR TITLE
Update loaders.py to only parse index if parse_dates is True.

### DIFF
--- a/nautilus_trader/persistence/loaders.py
+++ b/nautilus_trader/persistence/loaders.py
@@ -66,7 +66,8 @@ class CSVTickDataLoader:
             parse_dates=parse_dates,
             **kwargs,
         )
-        df.index = pd.to_datetime(df.index, format=datetime_format)
+        if parse_dates:
+            df.index = pd.to_datetime(df.index, format=datetime_format)
         return df
 
 
@@ -107,7 +108,8 @@ class CSVBarDataLoader:
             parse_dates=parse_dates,
             **kwargs,
         )
-        df.index = pd.to_datetime(df.index, format="mixed")
+        if parse_dates:
+            df.index = pd.to_datetime(df.index, format="mixed")
         return df
 
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix loaders in loaders.py always parsing index dates.

## Related Issues/PRs

Closes #3130

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
