### PR TITLE
Fix active liquidity calculation Pool profiler simulation

### DIFF
--- a/crates/model/src/defi/pool_analysis/profiler.rs
+++ b/crates/model/src/defi/pool_analysis/profiler.rs
@@ -443,7 +443,7 @@ impl PoolProfiler {
             let swap_step_result = compute_swap_step(
                 current_sqrt_price,
                 sqrt_price_target,
-                self.get_active_liquidity(),
+                current_active_liquidity,
                 amount_specified_remaining,
                 fee_tier,
             )?;
@@ -479,9 +479,9 @@ impl PoolProfiler {
             lp_fee += step_fee_amount;
 
             // Update global fee tracker
-            if self.tick_map.liquidity > 0 {
+            if current_active_liquidity > 0 {
                 let fee_growth_delta =
-                    FullMath::mul_div(step_fee_amount, Q128, U256::from(self.tick_map.liquidity))?;
+                    FullMath::mul_div(step_fee_amount, Q128, U256::from(current_active_liquidity))?;
                 current_fee_growth_global += fee_growth_delta;
             }
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

I've discovered that when running `analyze-pool` command on some Arbitrum pools, I would get errors logs from failed invariants here https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/model/src/defi/pool_analysis/profiler.rs#L272 where we check that our simulation-calculated tick is the same as the tick from the Swap event.
```
2025-11-08T14:45:35.765Z INFO  [nautilus_blockchain::data::core] Successfully synced Dex 'UniswapV3' Pool 'RAIN/WETH-100.Arbitrum:UniswapV3' up to block 398,123,900
2025-11-08T14:45:35.765Z INFO  [nautilus_model::defi::pool_analysis::profiler] Initializing pool profiler with tick -139514 and price sqrt ratio 74049653664017522035127093
2025-11-08T14:45:36.338Z ERROR [nautilus_model::defi::pool_analysis::profiler] Inconsistency in swap processing: Current tick mismatch: simulated -139764, event -139759 on block 391702274
2025-11-08T14:45:36.338Z ERROR [nautilus_model::defi::pool_analysis::profiler] Inconsistency in swap processing: Current tick mismatch: simulated -139764, event -139760 on block 391702633
2025-11-08T14:45:36.340Z ERROR [nautilus_model::defi::pool_analysis::profiler] Inconsistency in swap processing: Current tick mismatch: simulated -139764, event -139759 on block 391704673
```
After some investigation, I've concluded that active liquidity is used from `self.tick_map.liquidity`, which is not updated after https://github.com/nautechsystems/nautilus_trader/pull/3123 refactoring, where we made `simulate_swap_through_ticks` non-mutating.
We track this information in the `current_active_liquidity` variable, which should be used as input in the next swap step and fee calculations.


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
