### PR TITLE
Fix Polymarket websocket client cancellation on concurrent subscriptions

### DIFF
--- a/nautilus_trader/adapters/polymarket/data.py
+++ b/nautilus_trader/adapters/polymarket/data.py
@@ -12,9 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
-
 import asyncio
-from collections.abc import Coroutine
 from typing import Any
 
 import msgspec


### PR DESCRIPTION
…ll except the last one.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Added thread-safe support for multiple concurrent Polymarket websocket connect tasks, fixing the situation where only the last one would prevail, and all preceding ones would get cancelled when adding a new one.

## Type of change

<!-- Select all that apply. -->

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

It's hard to reproduce possible race conditions, but I tested the common path and it now connects all created tasks instead just the last one.