### PR TITLE
Refine rust bar aggregators

### DIFF
--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -16,6 +16,7 @@
 //! Real-time and static `Clock` implementations.
 
 use std::{
+    any::Any,
     collections::{BTreeMap, BinaryHeap, HashMap},
     fmt::Debug,
     ops::Deref,
@@ -49,7 +50,7 @@ use crate::{
 /// # Notes
 ///
 /// An active timer is one which has not expired (`timer.is_expired == False`).
-pub trait Clock: Debug {
+pub trait Clock: Debug + Any {
     /// Returns the current date and time as a timezone-aware `DateTime<UTC>`.
     fn utc_now(&self) -> DateTime<Utc> {
         DateTime::from_timestamp_nanos(self.timestamp_ns().as_i64())
@@ -227,6 +228,17 @@ pub trait Clock: Debug {
 
     /// Resets the clock by clearing it's internal state.
     fn reset(&mut self);
+}
+
+impl dyn Clock {
+    /// Returns a reference to this clock as `Any` for downcasting.
+    pub fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    /// Returns a mutable reference to this clock as `Any` for downcasting.
+    pub fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }
 
 /// A static test clock.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Explanation: Weak References and Timer Callbacks

### The Problem: Circular References

The aggregator is stored in the data engine as:
```rust
Rc<RefCell<Box<dyn BarAggregator>>>
```

When setting up a timer, we need to:
1. Register a callback with the clock that calls `build_bar` on the aggregator
2. Avoid creating a circular reference that prevents cleanup

### Why Weak References?

If we used a strong `Rc` reference in the callback:
```rust
// BAD: Creates circular reference
let aggregator_rc = aggregator.clone(); // Strong reference
let callback = Rc::new(move |event| {
    aggregator_rc.borrow_mut().build_bar(event); // Aggregator holds callback, callback holds aggregator
});
```

This creates a cycle:
- `aggregator` (Rc) → holds `callback` (Rc)
- `callback` (Rc) → holds `aggregator` (Rc)

Neither can be dropped, causing a memory leak.

### The Solution: Weak References

A `Weak<T>` is a non-owning reference that doesn't prevent the value from being dropped:

```rust
// GOOD: Weak reference breaks the cycle
let aggregator_weak = Rc::downgrade(&aggregator); // Weak reference
let callback = Rc::new(move |event| {
    if let Some(agg) = aggregator_weak.upgrade() { // Try to get strong reference
        agg.borrow_mut().build_bar(event);
    }
    // If aggregator was dropped, upgrade() returns None - safe!
});
```

### How It Works in Our Code

**1. In the Data Engine (Non-Historical Mode):**

```rust
aggregator.borrow_mut().set_clock(self.clock.clone());
aggregator
    .borrow_mut()
    .start_timer(Some(aggregator.clone()));
```

The data engine passes the `Rc` to `start_timer`, which creates a weak reference internally.

**2. In `start_timer_internal`:**

```rust
// Create callback that calls build_bar through the weak reference
let aggregator_weak = if let Some(rc) = aggregator_rc {
    // Store weak reference for future use (e.g., in build_bar for month/year)
    let weak = Rc::downgrade(&rc);
    self.aggregator_weak = Some(weak.clone());
    weak
} else {
    // Use existing weak reference (for historical mode where it was set earlier)
    self.aggregator_weak
        .as_ref()
        .expect("Aggregator weak reference must be set before calling start_timer()")
        .clone()
};

let callback = TimeEventCallback::Rust(Rc::new(move |event: TimeEvent| {
    if let Some(agg) = aggregator_weak.upgrade() {
        agg.borrow_mut().build_bar(event);
    }
}));
```

**3. Historical Mode:**

```rust
// Set weak reference for historical mode (start_timer called later from preprocess_historical_events)
// Store weak reference so start_timer can use it when called later
let aggregator_weak = Rc::downgrade(aggregator);
aggregator.borrow_mut().set_aggregator_weak(aggregator_weak);
```

In historical mode, the weak reference is set early, and `start_timer` is called later (from `preprocess_historical_events`) with `None`, so it uses the stored weak reference.

### Key Benefits

1. **No memory leaks**: The aggregator can be dropped even if the callback still exists
2. **Safe cleanup**: If the aggregator is dropped, `upgrade()` returns `None` and the callback does nothing
3. **Flexible lifecycle**: The callback can outlive the aggregator without issues

### The Flow

```
Data Engine
    ↓ (creates Rc<RefCell<Box<dyn BarAggregator>>>)
    ↓ (calls start_timer with Rc)
TimeBarAggregator::start_timer_internal
    ↓ (creates Weak from Rc)
    ↓ (stores Weak in self.aggregator_weak)
    ↓ (creates callback using Weak)
Clock::set_timer_ns
    ↓ (stores callback)
    ↓ (timer fires → callback called)
Callback
    ↓ (upgrades Weak to Rc)
    ↓ (calls build_bar if aggregator still exists)
```

This pattern is common in Rust when you need callbacks that don't create ownership cycles.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
