### PR TITLE
Fix serialization of IBContractDetails

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -299,4 +299,55 @@ def dict_to_contract_details(dict_details: dict) -> IBContractDetails:
         ]
         details_copy["secIdList"] = tag_values
 
+    # Deserialize Decimal fields from strings back to Decimal objects
+    # These fields are known to be Decimal type in IBContractDetails
+    decimal_fields = ["minSize", "sizeIncrement", "suggestedSizeIncrement"]
+    for field in decimal_fields:
+        if field in details_copy and isinstance(details_copy[field], str):
+            try:
+                decimal_value = Decimal(details_copy[field])
+
+                # Check if this is the UNSET_DECIMAL value
+                if decimal_value == UNSET_DECIMAL:
+                    details_copy[field] = UNSET_DECIMAL
+                else:
+                    details_copy[field] = decimal_value
+            except (ValueError, TypeError):
+                # If conversion fails, keep the original value
+                pass
+
+    # Deserialize Enum fields from their values back to Enum members
+    # These fields are known to be Enum type in IBContractDetails
+    if "fundDistributionPolicyIndicator" in details_copy:
+        details_copy["fundDistributionPolicyIndicator"] = _deserialize_enum_from_value(
+            FundDistributionPolicyIndicator,
+            details_copy["fundDistributionPolicyIndicator"],
+        )
+
+    if "fundAssetType" in details_copy:
+        details_copy["fundAssetType"] = _deserialize_enum_from_value(
+            FundAssetType,
+            details_copy["fundAssetType"],
+        )
+
     return IBContractDetails(**details_copy)
+
+
+def _deserialize_enum_from_value(enum_class, value):
+    """
+    Convert an enum value (tuple or string) back to the enum member.
+    """
+    if value is None:
+        return None
+
+    # If already an enum member, return as-is
+    if isinstance(value, enum_class):
+        return value
+
+    # Try to find enum member by matching value
+    for member in enum_class:
+        if member.value == value:
+            return member
+
+    # If not found, return the original value (might be invalid)
+    return value


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

IBContractDetails are stored as dict in the info field of instruments and there was a bug when trying to serialise a Decimal field. Also added code to serialise and deserialise Enums properly used in IBContractDetails.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
