### PR TITLE
Add Binance accurate commission rates per symbol

### DIFF
--- a/nautilus_trader/adapters/binance/futures/providers.py
+++ b/nautilus_trader/adapters/binance/futures/providers.py
@@ -153,22 +153,22 @@ class BinanceFuturesInstrumentProvider(InstrumentProvider):
         account_info = await self._http_account.query_futures_account_info(recv_window=str(5000))
         fee_rates = self._fee_rates[account_info.feeTier]
 
-        for symbol_info in exchange_info.symbols:  
-            try:  
-                # Priority API query for accurate, symbol-specific fee rates  
-                fee = await self._http_wallet.query_futures_commission_rate(  
-                    symbol=symbol_info.symbol,  
-                    recv_window=str(5000),  
-                )  
-            except Exception as e:  
-                # If API call fails, fall back to hardcoded table  
-                self._log.warning(f"Failed to query commission rate for {symbol_info.symbol}: {e}.Falling back to fee tier table.")  
-                account_info = await self._http_account.query_futures_account_info(recv_window=str(5000))  
-                fee_rates = self._fee_rates.get(account_info.feeTier, self._fee_rates[0])  
-                fee = BinanceFuturesCommissionRate(  
-                    symbol=symbol_info.symbol,  
-                    makerCommissionRate=fee_rates.maker,  
-                    takerCommissionRate=fee_rates.taker,  
+        for symbol_info in exchange_info.symbols:
+            try:
+                # Priority API query for accurate, symbol-specific fee rates
+                fee = await self._http_wallet.query_futures_commission_rate(
+                    symbol=symbol_info.symbol,
+                    recv_window=str(5000),
+                )
+            except Exception as e:
+                # If API call fails, fall back to hardcoded table
+                self._log.warning(f"Failed to query commission rate for {symbol_info.symbol}: {e}.Falling back to fee tier table.")
+                account_info = await self._http_account.query_futures_account_info(recv_window=str(5000))
+                fee_rates = self._fee_rates.get(account_info.feeTier, self._fee_rates[0])
+                fee = BinanceFuturesCommissionRate(
+                    symbol=symbol_info.symbol,
+                    makerCommissionRate=fee_rates.maker,
+                    takerCommissionRate=fee_rates.taker,
                 )
             self._parse_instrument(
                 symbol_info=symbol_info,
@@ -205,13 +205,13 @@ class BinanceFuturesInstrumentProvider(InstrumentProvider):
         position_risk_resp = await self._http_account.query_futures_position_risk()
         position_risk = {risk.symbol: risk for risk in position_risk_resp}
         for symbol in symbols:
-            try:  
-                fee = await self._http_wallet.query_futures_commission_rate(  
-                    symbol=symbol,  
-                    recv_window=str(5000),  
+            try:
+                fee = await self._http_wallet.query_futures_commission_rate(
+                    symbol=symbol,
+                    recv_window=str(5000),
                 )
-            except Exception as e:  
-                self._log.warning(f"Failed to load commission rate for {symbol}: {e}")  
+            except Exception as e:
+                self._log.warning(f"Failed to load commission rate for {symbol}: {e}")
                 fee = BinanceFuturesCommissionRate(
                     symbol=symbol,
                     makerCommissionRate=fee_rates.maker,
@@ -241,13 +241,13 @@ class BinanceFuturesInstrumentProvider(InstrumentProvider):
 
         account_info = await self._http_account.query_futures_account_info(recv_window=str(5000))
         fee_rates = self._fee_rates[account_info.feeTier]
-        try:  
-            fee = await self._http_wallet.query_futures_commission_rate(  
-                symbol=symbol,  
-                recv_window=str(5000),  
+        try:
+            fee = await self._http_wallet.query_futures_commission_rate(
+                symbol=symbol,
+                recv_window=str(5000),
             )
-        except Exception as e:  
-            self._log.warning(f"Failed to load commission rate for {symbol}: {e}")  
+        except Exception as e:
+            self._log.warning(f"Failed to load commission rate for {symbol}: {e}")
             fee = BinanceFuturesCommissionRate(
                 symbol=symbol,
                 makerCommissionRate=fee_rates.maker,


### PR DESCRIPTION
…rate),directly query from binance

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [yes] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary
Change: nautilus_trader/nautilus_trader/adapters/binance/futures/providers.py function load_all_async() and load_ids_async() to ensure get commission fee rate directly from binance (if failed fall back to hardcoded table).
Because the old fee rate table doesn't include market maker account fee rate which is negative for maker order.

## Related Issues/PRs

Missing tier for market maker fee rate in Binance Adapter #3207

## Type of change

<!-- Select all that apply. -->

- [yes] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [no] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [no] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
