### PR TITLE
Add Bybit start/end time filtering for order status reports

### DIFF
--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -2788,12 +2788,15 @@ impl BybitHttpClient {
     /// - Credentials are missing.
     /// - The request fails.
     /// - The API returns an error.
+    #[allow(clippy::too_many_arguments)]
     pub async fn request_order_status_reports(
         &self,
         account_id: AccountId,
         product_type: BybitProductType,
         instrument_id: Option<InstrumentId>,
         open_only: bool,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
         limit: Option<u32>,
     ) -> anyhow::Result<Vec<OrderStatusReport>> {
         // Extract symbol parameter from instrument_id if provided
@@ -2966,6 +2969,12 @@ impl BybitHttpClient {
                     }
                     if let Some(coin) = settle_coin.clone() {
                         history_params.settle_coin(coin);
+                    }
+                    if let Some(start) = start {
+                        history_params.start_time(start.timestamp_millis());
+                    }
+                    if let Some(end) = end {
+                        history_params.end_time(end.timestamp_millis());
                     }
                     history_params.limit(page_limit as u32);
                     if let Some(c) = cursor {

--- a/crates/adapters/bybit/src/python/http.rs
+++ b/crates/adapters/bybit/src/python/http.rs
@@ -574,7 +574,8 @@ impl BybitHttpClient {
     }
 
     #[pyo3(name = "request_order_status_reports")]
-    #[pyo3(signature = (account_id, product_type, instrument_id=None, open_only=false, limit=None))]
+    #[pyo3(signature = (account_id, product_type, instrument_id=None, open_only=false, start=None, end=None, limit=None))]
+    #[allow(clippy::too_many_arguments)]
     fn py_request_order_status_reports<'py>(
         &self,
         py: Python<'py>,
@@ -582,6 +583,8 @@ impl BybitHttpClient {
         product_type: BybitProductType,
         instrument_id: Option<InstrumentId>,
         open_only: bool,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
         limit: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.clone();
@@ -593,6 +596,8 @@ impl BybitHttpClient {
                     product_type,
                     instrument_id,
                     open_only,
+                    start,
+                    end,
                     limit,
                 )
                 .await

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -1235,6 +1235,8 @@ async fn test_request_order_status_reports_calls_both_endpoints() {
             BybitProductType::Linear,
             None,    // No specific instrument - will query both USDT and USDC
             false,   // open_only=false triggers dual endpoint call
+            None,    // start
+            None,    // end
             Some(3), // Limit to 3 to keep test focused on deduplication logic
         )
         .await
@@ -1295,7 +1297,9 @@ async fn test_request_order_status_reports_requires_settle_coin_for_linear() {
             BybitProductType::Linear,
             None, // No symbol - requires settleCoin
             true, // open_only=true
-            None,
+            None, // start
+            None, // end
+            None, // limit
         )
         .await;
 
@@ -1342,7 +1346,9 @@ async fn test_order_deduplication_by_order_id() {
             BybitProductType::Linear,
             Some(instrument_id), // Specify instrument to avoid settle coin iteration
             false,               // This will query both realtime and history endpoints
-            None,
+            None,                // start
+            None,                // end
+            None,                // limit
         )
         .await
         .unwrap();
@@ -1390,7 +1396,15 @@ async fn test_request_order_status_reports_linear_queries_all_settle_coins() {
     let account_id = AccountId::from("BYBIT-UNIFIED");
 
     let _reports = client
-        .request_order_status_reports(account_id, BybitProductType::Linear, None, true, None)
+        .request_order_status_reports(
+            account_id,
+            BybitProductType::Linear,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -1448,7 +1462,15 @@ async fn test_request_order_status_reports_respects_limit_across_settle_coins() 
     // Test data has 2 orders per settle coin
     // With limit=3: expect 2 from USDT, 1 from USDC
     let reports = client
-        .request_order_status_reports(account_id, BybitProductType::Linear, None, true, Some(3))
+        .request_order_status_reports(
+            account_id,
+            BybitProductType::Linear,
+            None,
+            true,
+            None,
+            None,
+            Some(3),
+        )
         .await
         .unwrap();
 
@@ -1500,7 +1522,15 @@ async fn test_request_order_status_reports_stops_before_next_coin() {
 
     // Test data has 2 orders, limit=1 should stop after USDT
     let reports = client
-        .request_order_status_reports(account_id, BybitProductType::Linear, None, true, Some(1))
+        .request_order_status_reports(
+            account_id,
+            BybitProductType::Linear,
+            None,
+            true,
+            None,
+            None,
+            Some(1),
+        )
         .await
         .unwrap();
 
@@ -1556,7 +1586,15 @@ async fn test_request_order_status_reports_combines_orders_from_each_settle_coin
     let account_id = AccountId::from("BYBIT-UNIFIED");
 
     let reports = client
-        .request_order_status_reports(account_id, BybitProductType::Linear, None, true, None)
+        .request_order_status_reports(
+            account_id,
+            BybitProductType::Linear,
+            None,
+            true,
+            None,
+            None,
+            None,
+        )
         .await
         .unwrap();
 

--- a/nautilus_trader/adapters/bybit/execution.py
+++ b/nautilus_trader/adapters/bybit/execution.py
@@ -390,6 +390,8 @@ class BybitExecutionClient(LiveExecutionClient):
                     product_type=product_type,
                     instrument_id=pyo3_instrument_id,
                     open_only=command.open_only,
+                    start=ensure_pydatetime_utc(command.start),
+                    end=ensure_pydatetime_utc(command.end),
                 )
                 pyo3_reports.extend(response)
 

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -5885,6 +5885,8 @@ class BybitHttpClient:
         product_type: BybitProductType,
         instrument_id: InstrumentId | None = None,
         open_only: bool = False,
+        start: dt.datetime | None = None,
+        end: dt.datetime | None = None,
         limit: int | None = None,
     ) -> list[OrderStatusReport]: ...
     async def request_fill_reports(


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds `start` and `end` time range parameters to Bybit's `request_order_status_reports` method, enabling proper time-based filtering during reconciliation. This fixes the issue where `reconciliation_lookback_mins` configuration was ignored, causing HFT strategies to query all historical orders on startup.

- Bybit adapter's `reconciliation_lookback_mins` configuration had no effect
- Startup reconciliation always queried **all** historical orders regardless of configuration

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
