### PR TITLE
Improve JSON-RPC non-standard rate limit error handling

### DIFF
--- a/crates/model/src/defi/rpc.rs
+++ b/crates/model/src/defi/rpc.rs
@@ -49,15 +49,19 @@ pub struct RpcNodeHttpResponse<T>
 where
     T: DeserializeOwned,
 {
-    /// JSON-RPC version identifier.
-    pub jsonrpc: String,
-    /// Request identifier returned by the server.
-    pub id: u64,
+    /// JSON-RPC version identifier (optional for non-standard error responses like rate limits).
+    pub jsonrpc: Option<String>,
+    /// Request identifier returned by the server (optional for non-standard error responses).
+    pub id: Option<u64>,
     /// Deserialized result.
     #[serde(bound(deserialize = ""))]
     pub result: Option<T>,
     /// Error information if the request failed.
     pub error: Option<RpcError>,
+    /// Error code (for non-standard rate limit responses).
+    pub code: Option<i32>,
+    /// Error message (for non-standard rate limit responses).
+    pub message: Option<String>,
 }
 
 /// JSON-RPC error structure.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

 **Problem:** When RPC providers like Infura hit rate limits, they return a non-standard error response that doesn't follow the JSON-RPC specification. Instead of the expected format with `jsonrpc`, `id`, and `error` fields, Infura returns:

```
2025-11-27T07:55:15.669Z ERROR [nautilus] Error executing Nautilus CLI: Failed to sync pools: Failed to parse eth call response: missing field `jsonrpc` at line 1 column 90
Raw response: {"code":-32005,"message":"Too Many Requests","data":{"see":"https://infura.io/dashboard"}}
```

This caused a parsing error because jsonrpc and id were required fields:
Error: Failed to parse eth call response: missing field `jsonrpc` at line 1 column 90


**Solution:**  Make the response struct flexible enough to handle both standard JSON-RPC responses and non-standard rate limit errors.
After the proposed change, we don't seea  parsing error but rather correct ERROR log: 

```
2025-11-27T08:12:10.477Z ERROR [nautilus] Error executing Nautilus CLI: Failed to sync pools: RPC provider error -32005: Too Many Requests
```




## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


