### PR TITLE
Prefer sccache for faster builds when available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ CARGO_INCREMENTAL ?= 0
 export RUSTC_WRAPPER
 export CARGO_INCREMENTAL
 endif
+
 export CC
 export CXX
 


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Prefer sccache for faster builds when available.
- Some dependencies in the project currently require compilation with clang, so clang is set as the default compiler in the Makefile, otherwise it will throw errors:
```
  × Failed to build `ed25519-blake2b==1.4.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stdout]
      UPDATING build/lib.linux-x86_64-cpython-312/ed25519_blake2b/_version.py
      set build/lib.linux-x86_64-cpython-312/ed25519_blake2b/_version.py to '1.4.1'

      [stderr]
      cc: error: unrecognized command-line option ‘-fdebug-default-version=4’
      error: command '/usr/bin/cc' failed with exit code 1

      hint: This usually indicates a problem with the package or the build environment.
  help: `ed25519-blake2b` (v1.4.1) was included because `nautilus-trader[dydx]` (v1.222.0) depends on `bip-utils` (v2.10.0) which depends on `ed25519-blake2b`
DEBUG Released lock at `/root/code/nautilus_trader/.venv/.lock`
DEBUG Released lock at `/root/.cache/uv/.lock`
make: *** [Makefile:90: install-debug] Error 1
```

## Type of change

- [x] Bug fix (non-breaking)
- [x] Improvement (non-breaking)