### PR TITLE
Fix OKX fee rate sign handling causing backtest errors

### DIFF
--- a/crates/adapters/okx/src/common/parse.rs
+++ b/crates/adapters/okx/src/common/parse.rs
@@ -1296,6 +1296,8 @@ pub fn parse_instrument_any(
     taker_fee: Option<Decimal>,
     ts_init: UnixNanos,
 ) -> anyhow::Result<Option<InstrumentAny>> {
+    let maker_fee = maker_fee.map(|v| -v);
+    let taker_fee = taker_fee.map(|v| -v);
     match instrument.inst_type {
         OKXInstrumentType::Spot => parse_spot_instrument(
             instrument,


### PR DESCRIPTION
The OKX adapter previously failed to handle the sign convention of fee rates, leading to incorrect fee calculations during backtesting.

As per OKX docs (https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-fee-rates): "The fee rate like maker and taker: positive number, which means the rate of rebate; negative number, which means the rate of commission."

This change negates the fetched maker and taker fees to align with the system's expected format for fee calculation.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
