### PR TITLE
Add Kraken spot order placement via REST and WebSocket

### DIFF
--- a/crates/adapters/kraken/Cargo.toml
+++ b/crates/adapters/kraken/Cargo.toml
@@ -106,3 +106,11 @@ path = "bin/http_spot_public.rs"
 [[bin]]
 name = "kraken-ws-spot-data"
 path = "bin/ws_spot_data.rs"
+
+[[bin]]
+name = "kraken-spot-order-rest"
+path = "bin/spot_order_rest.rs"
+
+[[bin]]
+name = "kraken-spot-order-ws"
+path = "bin/spot_order_ws.rs"

--- a/crates/adapters/kraken/bin/futures-demo.rs
+++ b/crates/adapters/kraken/bin/futures-demo.rs
@@ -13,274 +13,55 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! Demonstration of Kraken adapter HTTP client capabilities.
+//! Demonstration binary for testing Kraken Futures HTTP client endpoints.
 //!
-//! Tests both Spot and Futures endpoints with public and authenticated methods.
-//!
-//! Usage:
+//! Run with:
 //! ```bash
-//! # Test public endpoints only
-//! cargo run -p nautilus-kraken --bin kraken-demo
+//! cargo run -p nautilus-kraken --bin futures-demo
+//! ```
 //!
-//! # Test Futures demo environment (includes order placement tests)
-//! export KRAKEN_TESTNET_API_KEY=your_demo_key
-//! export KRAKEN_TESTNET_API_SECRET=your_demo_secret
-//! cargo run -p nautilus-kraken --bin kraken-demo
+//! For authenticated endpoints, set environment variables:
+//! ```bash
+//! export KRAKEN_TESTNET_API_KEY=your_key
+//! export KRAKEN_TESTNET_API_SECRET=your_secret
+//! cargo run -p nautilus-kraken --bin futures-demo
 //! ```
 
 use std::env;
 
 use nautilus_kraken::{
-    common::enums::{KrakenEnvironment, KrakenFuturesOrderType, KrakenOrderSide},
-    http::{
-        futures::{client::KrakenFuturesRawHttpClient, query::KrakenFuturesSendOrderParamsBuilder},
-        spot::client::KrakenSpotRawHttpClient,
-    },
+    common::enums::KrakenEnvironment, http::futures::client::KrakenFuturesRawHttpClient,
 };
 use tracing::level_filters::LevelFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_max_level(LevelFilter::INFO)
+        .with_max_level(LevelFilter::DEBUG)
         .init();
 
-    // Detect testnet credentials
-    let has_testnet_creds = env::var("KRAKEN_TESTNET_API_KEY").is_ok();
+    println!("=== Kraken Futures HTTP Client Demo ===\n");
 
-    if has_testnet_creds {
-        tracing::info!("=== Kraken Adapter Demo (TESTNET) ===");
-        tracing::info!("Using KRAKEN_TESTNET_API_KEY and KRAKEN_TESTNET_API_SECRET");
+    test_public_endpoints().await?;
+
+    let api_key = env::var("KRAKEN_TESTNET_API_KEY").ok();
+    let api_secret = env::var("KRAKEN_TESTNET_API_SECRET").ok();
+
+    if let (Some(key), Some(secret)) = (api_key, api_secret) {
+        println!("\n=== Testing Authenticated Endpoints ===");
+        test_authenticated_endpoints(&key, &secret).await?;
     } else {
-        tracing::info!("=== Kraken Adapter Demo ===");
-        tracing::info!("No credentials detected - running public endpoints only");
-    }
-
-    test_spot_public().await?;
-    test_futures_public(has_testnet_creds).await?;
-    test_futures_authenticated(has_testnet_creds).await?;
-
-    // Run order placement tests if testnet credentials are available
-    if has_testnet_creds {
-        test_futures_order_placement(has_testnet_creds).await?;
-    }
-
-    tracing::info!("=== Demo Complete ===");
-
-    Ok(())
-}
-
-async fn test_spot_public() -> anyhow::Result<()> {
-    tracing::info!("=== Spot Public Endpoints ===");
-
-    let client = KrakenSpotRawHttpClient::default();
-
-    match client.get_server_time().await {
-        Ok(response) => {
-            tracing::info!("Server time: {} ({})", response.unixtime, response.rfc1123);
-        }
-        Err(e) => {
-            tracing::error!("Failed to get server time: {e}");
-            return Err(e.into());
-        }
-    }
-
-    match client.get_system_status().await {
-        Ok(response) => {
-            tracing::info!("System status: {:?}", response.status);
-        }
-        Err(e) => {
-            tracing::error!("Failed to get system status: {e}");
-            return Err(e.into());
-        }
-    }
-
-    match client
-        .get_asset_pairs(Some(vec!["XBTUSDT".to_string()]))
-        .await
-    {
-        Ok(pairs) => {
-            tracing::info!("Found {} asset pair(s)", pairs.len());
-        }
-        Err(e) => {
-            tracing::error!("Failed to get asset pairs: {e}");
-            return Err(e.into());
-        }
-    }
-
-    match client.get_ticker(vec!["XBTUSDT".to_string()]).await {
-        Ok(tickers) => {
-            if let Some((symbol, ticker)) = tickers.iter().next()
-                && let Some(last) = ticker.last.first()
-            {
-                tracing::info!("Ticker {symbol}: last={last}");
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to get ticker: {e}");
-            return Err(e.into());
-        }
+        println!(
+            "\n[SKIP] Set KRAKEN_TESTNET_API_KEY and KRAKEN_TESTNET_API_SECRET to test authenticated endpoints"
+        );
     }
 
     Ok(())
 }
 
-async fn test_futures_public(testnet: bool) -> anyhow::Result<()> {
-    tracing::info!("=== Futures Public Endpoints ===");
-
-    let environment = if testnet {
-        KrakenEnvironment::Testnet
-    } else {
-        KrakenEnvironment::Mainnet
-    };
-
-    let client = KrakenFuturesRawHttpClient::new(environment, None, None, None, None, None, None)?;
-
-    match client.get_instruments().await {
-        Ok(instruments) => {
-            tracing::info!("Found {} instrument(s)", instruments.instruments.len());
-            if let Some(instrument) = instruments.instruments.first() {
-                tracing::info!(
-                    "Sample instrument: {} (type: {})",
-                    instrument.symbol,
-                    instrument.instrument_type
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to get instruments: {e}");
-            return Err(e.into());
-        }
-    }
-
-    match client.get_tickers().await {
-        Ok(response) => {
-            tracing::info!("Found {} ticker(s)", response.tickers.len());
-            if let Some(ticker) = response.tickers.first() {
-                if let Some(last) = ticker.last {
-                    tracing::info!("Sample ticker: {} (last={})", ticker.symbol, last);
-                } else {
-                    tracing::info!(
-                        "Sample ticker: {} (last price not available)",
-                        ticker.symbol
-                    );
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!("Failed to get tickers (may not be available in demo environment): {e}");
-        }
-    }
-
-    Ok(())
-}
-
-async fn test_futures_authenticated(testnet: bool) -> anyhow::Result<()> {
-    tracing::info!("=== Futures Authenticated Endpoints ===");
-
-    let environment = if testnet {
-        KrakenEnvironment::Testnet
-    } else {
-        KrakenEnvironment::Mainnet
-    };
-
-    let (api_key_var, api_secret_var) = if testnet {
-        ("KRAKEN_TESTNET_API_KEY", "KRAKEN_TESTNET_API_SECRET")
-    } else {
-        ("KRAKEN_FUTURES_API_KEY", "KRAKEN_FUTURES_API_SECRET")
-    };
-
-    let api_key = env::var(api_key_var).ok();
-    let api_secret = env::var(api_secret_var).ok();
-
-    let client = match (api_key, api_secret) {
-        (Some(key), Some(secret)) => KrakenFuturesRawHttpClient::with_credentials(
-            key,
-            secret,
-            environment,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?,
-        _ => {
-            tracing::warn!("No credentials found - skipping authenticated tests");
-            return Ok(());
-        }
-    };
-
-    match client.get_open_orders().await {
-        Ok(response) => {
-            tracing::info!("Open orders: {}", response.open_orders.len());
-        }
-        Err(e) => {
-            tracing::error!("Failed to get open orders: {e}");
-        }
-    }
-
-    match client.get_open_positions().await {
-        Ok(response) => {
-            tracing::info!("Open positions: {}", response.open_positions.len());
-            for pos in response.open_positions.iter().take(3) {
-                tracing::info!(
-                    "  Position: {} {:?} size={}",
-                    pos.symbol,
-                    pos.side,
-                    pos.size
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to get open positions: {e}");
-        }
-    }
-
-    match client.get_fills(None).await {
-        Ok(response) => {
-            tracing::info!("Recent fills: {}", response.fills.len());
-            for fill in response.fills.iter().take(3) {
-                tracing::info!(
-                    "  Fill: {} {:?} price={} size={}",
-                    fill.symbol,
-                    fill.side,
-                    fill.price,
-                    fill.size
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to get fills: {e}");
-        }
-    }
-
-    Ok(())
-}
-
-async fn test_futures_order_placement(testnet: bool) -> anyhow::Result<()> {
-    tracing::info!("=== Futures Order Placement Tests ===");
-
-    let environment = if testnet {
-        KrakenEnvironment::Testnet
-    } else {
-        KrakenEnvironment::Mainnet
-    };
-
-    let (api_key_var, api_secret_var) = if testnet {
-        ("KRAKEN_TESTNET_API_KEY", "KRAKEN_TESTNET_API_SECRET")
-    } else {
-        ("KRAKEN_FUTURES_API_KEY", "KRAKEN_FUTURES_API_SECRET")
-    };
-
-    let api_key = env::var(api_key_var).map_err(|_| anyhow::anyhow!("Missing {}", api_key_var))?;
-    let api_secret =
-        env::var(api_secret_var).map_err(|_| anyhow::anyhow!("Missing {}", api_secret_var))?;
-
-    let client = KrakenFuturesRawHttpClient::with_credentials(
-        api_key,
-        api_secret,
-        environment,
+async fn test_public_endpoints() -> anyhow::Result<()> {
+    let client = KrakenFuturesRawHttpClient::new(
+        KrakenEnvironment::Testnet,
         None,
         None,
         None,
@@ -289,202 +70,91 @@ async fn test_futures_order_placement(testnet: bool) -> anyhow::Result<()> {
         None,
     )?;
 
-    let current_price: f64 = 95000.0;
-    tracing::info!("Using reference PI_XBTUSD price: {}", current_price);
-
-    tracing::info!("Test 1: LIMIT order (post-only, far from market)");
-    let limit_price = (current_price * 0.5).round();
-    let params = KrakenFuturesSendOrderParamsBuilder::default()
-        .symbol("PI_XBTUSD".to_string())
-        .side(KrakenOrderSide::Buy)
-        .order_type(KrakenFuturesOrderType::Post)
-        .size("1".to_string())
-        .limit_price(limit_price.to_string())
-        .cli_ord_id(format!("limit_{}", chrono::Utc::now().timestamp()))
-        .build()?;
-
-    let order_response = client.send_order_params(&params).await?;
-    tracing::info!("LIMIT order result: {:?}", order_response.result);
-
-    let mut limit_order_id = None;
-    if let Some(send_status) = &order_response.send_status {
-        tracing::info!("Order status: {}", send_status.status);
-        if let Some(order_id) = &send_status.order_id {
-            tracing::info!("Order ID: {}", order_id);
-            limit_order_id = Some(order_id.clone());
+    println!("1. Testing GET /derivatives/api/v3/instruments");
+    match client.get_instruments().await {
+        Ok(response) => {
+            println!("   [OK] Found {} instruments", response.instruments.len());
+            if let Some(inst) = response.instruments.first() {
+                println!("   [OK] Sample: {} ({})", inst.symbol, inst.instrument_type);
+            }
         }
-    } else {
-        tracing::error!("Order placement failed. Error: {:?}", order_response.error);
-        tracing::warn!("This may indicate:");
-        tracing::warn!("  1. API keys lack trading permissions");
-        tracing::warn!("  2. Demo account needs additional setup");
-        tracing::warn!("  3. Credentials are expired or invalid");
-        tracing::warn!("Note: Read operations (get_open_orders, etc.) worked successfully");
-        return Ok(());
-    }
-
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    if let Some(order_id) = limit_order_id {
-        tracing::info!("Test 2: Cancel LIMIT order");
-        let cancel_response = client.cancel_order(Some(order_id.clone()), None).await?;
-        tracing::info!("Cancel status: {}", cancel_response.cancel_status.status);
-    }
-
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    tracing::info!("Test 3: STOP_MARKET order (stop-loss, far from market)");
-    let stop_price = (current_price * 0.6).round();
-    let params = KrakenFuturesSendOrderParamsBuilder::default()
-        .symbol("PI_XBTUSD".to_string())
-        .side(KrakenOrderSide::Sell)
-        .order_type(KrakenFuturesOrderType::Stop)
-        .size("1".to_string())
-        .stop_price(stop_price.to_string())
-        .cli_ord_id(format!("stop_{}", chrono::Utc::now().timestamp()))
-        .build()?;
-
-    let stop_order_response = client.send_order_params(&params).await?;
-    let mut stop_order_id = None;
-    if let Some(send_status) = &stop_order_response.send_status {
-        tracing::info!("STOP order status: {}", send_status.status);
-        if let Some(order_id) = &send_status.order_id {
-            tracing::info!("STOP Order ID: {}", order_id);
-            stop_order_id = Some(order_id.clone());
+        Err(e) => {
+            println!("   [ERROR] {e}");
+            return Err(e.into());
         }
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    tracing::info!("Test 4: STOP_LIMIT order (stop-loss with limit, far from market)");
-    let stop_limit_trigger = (current_price * 0.65).round();
-    let stop_limit_price = (current_price * 0.64).round();
-    let params = KrakenFuturesSendOrderParamsBuilder::default()
-        .symbol("PI_XBTUSD".to_string())
-        .side(KrakenOrderSide::Sell)
-        .order_type(KrakenFuturesOrderType::Stop)
-        .size("1".to_string())
-        .stop_price(stop_limit_trigger.to_string())
-        .limit_price(stop_limit_price.to_string())
-        .cli_ord_id(format!("stop_limit_{}", chrono::Utc::now().timestamp()))
-        .build()?;
-
-    let stop_limit_response = client.send_order_params(&params).await?;
-    let mut stop_limit_order_id = None;
-    if let Some(send_status) = &stop_limit_response.send_status {
-        tracing::info!("STOP_LIMIT order status: {}", send_status.status);
-        if let Some(order_id) = &send_status.order_id {
-            tracing::info!("STOP_LIMIT Order ID: {}", order_id);
-            stop_limit_order_id = Some(order_id.clone());
+    println!("\n2. Testing GET /derivatives/api/v3/tickers");
+    match client.get_tickers().await {
+        Ok(response) => {
+            println!("   [OK] Found {} tickers", response.tickers.len());
+            if let Some(ticker) = response.tickers.first()
+                && let Some(last) = ticker.last
+            {
+                println!("   [OK] Sample: {} (last={})", ticker.symbol, last);
+            }
+        }
+        Err(e) => {
+            println!("   [WARN] {e}");
         }
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    println!("\n[SUCCESS] Public endpoint tests passed!");
+    Ok(())
+}
 
-    tracing::info!("Test 5: MARKET_IF_TOUCHED order (take-profit, above market)");
-    let take_profit_price = (current_price * 1.5).round();
-    let params = KrakenFuturesSendOrderParamsBuilder::default()
-        .symbol("PI_XBTUSD".to_string())
-        .side(KrakenOrderSide::Sell)
-        .order_type(KrakenFuturesOrderType::TakeProfit)
-        .size("1".to_string())
-        .stop_price(take_profit_price.to_string())
-        .cli_ord_id(format!("tp_{}", chrono::Utc::now().timestamp()))
-        .build()?;
+async fn test_authenticated_endpoints(api_key: &str, api_secret: &str) -> anyhow::Result<()> {
+    let client = KrakenFuturesRawHttpClient::with_credentials(
+        api_key.to_string(),
+        api_secret.to_string(),
+        KrakenEnvironment::Testnet,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
 
-    let tp_order_response = client.send_order_params(&params).await?;
-    let mut tp_order_id = None;
-    if let Some(send_status) = &tp_order_response.send_status {
-        tracing::info!("TAKE_PROFIT order status: {}", send_status.status);
-        if let Some(order_id) = &send_status.order_id {
-            tracing::info!("TAKE_PROFIT Order ID: {}", order_id);
-            tp_order_id = Some(order_id.clone());
+    println!("\n1. Testing GET /derivatives/api/v3/openorders");
+    match client.get_open_orders().await {
+        Ok(response) => {
+            println!("   [OK] Open orders: {}", response.open_orders.len());
+        }
+        Err(e) => {
+            println!("   [WARN] {e}");
         }
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    tracing::info!("Test 6: MARKET order (small size to open position)");
-    let params = KrakenFuturesSendOrderParamsBuilder::default()
-        .symbol("PI_XBTUSD".to_string())
-        .side(KrakenOrderSide::Buy)
-        .order_type(KrakenFuturesOrderType::Market)
-        .size("1".to_string())
-        .cli_ord_id(format!("market_{}", chrono::Utc::now().timestamp()))
-        .build()?;
-
-    let market_response = client.send_order_params(&params).await?;
-    if let Some(send_status) = &market_response.send_status {
-        tracing::info!("MARKET order status: {}", send_status.status);
-        if let Some(order_id) = &send_status.order_id {
-            tracing::info!("MARKET Order ID: {}", order_id);
+    println!("\n2. Testing GET /derivatives/api/v3/openpositions");
+    match client.get_open_positions().await {
+        Ok(response) => {
+            println!("   [OK] Open positions: {}", response.open_positions.len());
+            for pos in response.open_positions.iter().take(3) {
+                println!("   - {} {:?} size={}", pos.symbol, pos.side, pos.size);
+            }
+        }
+        Err(e) => {
+            println!("   [WARN] {e}");
         }
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-    let positions = client.get_open_positions().await?;
-    tracing::info!(
-        "Open positions after MARKET order: {}",
-        positions.open_positions.len()
-    );
-
-    if !positions.open_positions.is_empty() {
-        tracing::info!("Test 7: Close position with MARKET order (reduce_only)");
-        let params = KrakenFuturesSendOrderParamsBuilder::default()
-            .symbol("PI_XBTUSD".to_string())
-            .side(KrakenOrderSide::Sell)
-            .order_type(KrakenFuturesOrderType::Market)
-            .size("1".to_string())
-            .reduce_only(true)
-            .cli_ord_id(format!("close_{}", chrono::Utc::now().timestamp()))
-            .build()?;
-
-        let close_response = client.send_order_params(&params).await?;
-        if let Some(send_status) = &close_response.send_status {
-            tracing::info!("CLOSE order status: {}", send_status.status);
+    println!("\n3. Testing GET /derivatives/api/v3/fills");
+    match client.get_fills(None).await {
+        Ok(response) => {
+            println!("   [OK] Recent fills: {}", response.fills.len());
+            for fill in response.fills.iter().take(3) {
+                println!(
+                    "   - {} {:?} price={} size={}",
+                    fill.symbol, fill.side, fill.price, fill.size
+                );
+            }
         }
-
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-        let positions_after = client.get_open_positions().await?;
-        tracing::info!(
-            "Open positions after close: {}",
-            positions_after.open_positions.len()
-        );
-    } else {
-        tracing::warn!("No position opened by MARKET order - skipping close test");
+        Err(e) => {
+            println!("   [WARN] {e}");
+        }
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    if let Some(order_id) = stop_order_id {
-        tracing::info!("Cancelling STOP order");
-        let _ = client.cancel_order(Some(order_id), None).await;
-    }
-
-    if let Some(order_id) = stop_limit_order_id {
-        tracing::info!("Cancelling STOP_LIMIT order");
-        let _ = client.cancel_order(Some(order_id), None).await;
-    }
-
-    if let Some(order_id) = tp_order_id {
-        tracing::info!("Cancelling TAKE_PROFIT order");
-        let _ = client.cancel_order(Some(order_id), None).await;
-    }
-
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-    let open_orders = client.get_open_orders().await?;
-    tracing::info!("Remaining open orders: {}", open_orders.open_orders.len());
-
-    let final_positions = client.get_open_positions().await?;
-    tracing::info!(
-        "Final open positions: {}",
-        final_positions.open_positions.len()
-    );
-
-    tracing::info!("All order type tests complete");
-
+    println!("\n[SUCCESS] Authenticated endpoint tests completed!");
     Ok(())
 }

--- a/crates/adapters/kraken/bin/spot_order_rest.rs
+++ b/crates/adapters/kraken/bin/spot_order_rest.rs
@@ -1,0 +1,544 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Kraken Spot REST API order type testing.
+//!
+//! Tests all supported order types:
+//! 1. Market order (buy and sell)
+//! 2. Limit order (with post-only)
+//! 3. Stop-loss order
+//! 4. Stop-loss-limit order
+//! 5. Take-profit order
+//! 6. Take-profit-limit order
+//!
+//! # Environment Variables
+//!
+//! - `KRAKEN_SPOT_API_KEY`: Your Kraken Spot API key
+//! - `KRAKEN_SPOT_API_SECRET`: Your Kraken Spot API secret
+
+use nautilus_kraken::{
+    common::{
+        consts::NAUTILUS_KRAKEN_BROKER_ID,
+        enums::{KrakenEnvironment, KrakenOrderSide, KrakenOrderType},
+    },
+    http::spot::{
+        client::KrakenSpotRawHttpClient,
+        query::{KrakenSpotAddOrderParamsBuilder, KrakenSpotCancelOrderParamsBuilder},
+    },
+};
+
+// Test configuration constants
+const PAIR: &str = "ATOMUSDC";
+const QTY: &str = "0.5";
+const DEFAULT_PRICE: f64 = 5.0;
+
+// Price calculation multipliers
+const LIMIT_BUY_MULTIPLIER: f64 = 0.95; // 5% below market
+const LIMIT_SELL_MULTIPLIER: f64 = 1.05; // 5% above market
+const STOP_LOSS_MULTIPLIER: f64 = 0.90; // 10% below market
+const TAKE_PROFIT_MULTIPLIER: f64 = 1.10; // 10% above market
+const SECONDARY_PRICE_MULTIPLIER: f64 = 0.99; // 1% below trigger for limit orders
+
+// Timing constants (seconds)
+const SHORT_WAIT: u64 = 1;
+const LONG_WAIT: u64 = 2;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .finish(),
+    )?;
+
+    tracing::info!("Kraken Spot REST API - Order Type Testing");
+    tracing::info!("==========================================");
+
+    let api_key = std::env::var("KRAKEN_SPOT_API_KEY")
+        .map_err(|_| anyhow::anyhow!("KRAKEN_SPOT_API_KEY not set"))?;
+    let api_secret = std::env::var("KRAKEN_SPOT_API_SECRET")
+        .map_err(|_| anyhow::anyhow!("KRAKEN_SPOT_API_SECRET not set"))?;
+
+    let client = KrakenSpotRawHttpClient::with_credentials(
+        api_key,
+        api_secret,
+        KrakenEnvironment::Mainnet,
+        None,
+        Some(60),
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    // Cancel all open orders first
+    tracing::info!("\n[SETUP] Canceling all open orders...");
+    let _ = client.cancel_all_orders().await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Get current ticker for reference prices
+    let ticker = client.get_ticker(vec![PAIR.to_string()]).await?;
+    let current_price = ticker
+        .values()
+        .next()
+        .and_then(|t| t.last.first())
+        .and_then(|p| p.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_PRICE);
+    tracing::info!("Current {} price: ${:.4}", PAIR, current_price);
+
+    // Calculate prices for limit/stop orders
+    let limit_buy_price = current_price * LIMIT_BUY_MULTIPLIER;
+    let limit_sell_price = current_price * LIMIT_SELL_MULTIPLIER;
+    let stop_loss_trigger = current_price * STOP_LOSS_MULTIPLIER;
+    let take_profit_trigger = current_price * TAKE_PROFIT_MULTIPLIER;
+
+    // =========================================================================
+    // TEST 1: Market Order (BUY)
+    // =========================================================================
+    tracing::info!("\n[TEST 1] MARKET BUY Order");
+    tracing::info!("  Pair: {}, Qty: {}", PAIR, QTY);
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+        }
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 2: Market Order (SELL) - close position
+    // =========================================================================
+    tracing::info!("\n[TEST 2] MARKET SELL Order");
+    tracing::info!("  Pair: {}, Qty: {}", PAIR, QTY);
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+        }
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 3: Limit Order (BUY) with post-only
+    // =========================================================================
+    tracing::info!("\n[TEST 3] LIMIT BUY Order (post-only)");
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Price: ${:.4}",
+        PAIR,
+        QTY,
+        limit_buy_price
+    );
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Limit)
+        .volume(QTY)
+        .price(format!("{:.4}", limit_buy_price))
+        .oflags("post") // post-only
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let limit_order_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel the limit order
+    if let Some(order_id) = &limit_order_id {
+        tracing::info!("  Canceling limit order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+    }
+
+    // =========================================================================
+    // TEST 4: Limit Order (SELL)
+    // =========================================================================
+    tracing::info!("\n[TEST 4] LIMIT SELL Order");
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Price: ${:.4}",
+        PAIR,
+        QTY,
+        limit_sell_price
+    );
+
+    // First buy some to sell
+    let buy_params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+    let _ = client.add_order(&buy_params).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::Limit)
+        .volume(QTY)
+        .price(format!("{:.4}", limit_sell_price))
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let limit_sell_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel and sell at market
+    if let Some(order_id) = &limit_sell_id {
+        tracing::info!("  Canceling limit sell order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+        // Sell at market
+        let sell_params = KrakenSpotAddOrderParamsBuilder::default()
+            .pair(PAIR)
+            .side(KrakenOrderSide::Sell)
+            .order_type(KrakenOrderType::Market)
+            .volume(QTY)
+            .broker(NAUTILUS_KRAKEN_BROKER_ID)
+            .build()?;
+        let _ = client.add_order(&sell_params).await;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 5: Stop-Loss Order
+    // =========================================================================
+    tracing::info!("\n[TEST 5] STOP-LOSS Order");
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Trigger: ${:.4}",
+        PAIR,
+        QTY,
+        stop_loss_trigger
+    );
+
+    // Buy first so we have something to stop-loss
+    let buy_params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+    let _ = client.add_order(&buy_params).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::StopLoss)
+        .volume(QTY)
+        .price(format!("{:.4}", stop_loss_trigger)) // trigger price
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let stop_loss_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel and sell at market
+    if let Some(order_id) = &stop_loss_id {
+        tracing::info!("  Canceling stop-loss order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+        let sell_params = KrakenSpotAddOrderParamsBuilder::default()
+            .pair(PAIR)
+            .side(KrakenOrderSide::Sell)
+            .order_type(KrakenOrderType::Market)
+            .volume(QTY)
+            .broker(NAUTILUS_KRAKEN_BROKER_ID)
+            .build()?;
+        let _ = client.add_order(&sell_params).await;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 6: Stop-Loss-Limit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 6] STOP-LOSS-LIMIT Order");
+    let stop_limit_price = stop_loss_trigger * SECONDARY_PRICE_MULTIPLIER;
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Trigger: ${:.4}, Limit: ${:.4}",
+        PAIR,
+        QTY,
+        stop_loss_trigger,
+        stop_limit_price
+    );
+
+    // Buy first
+    let buy_params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+    let _ = client.add_order(&buy_params).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::StopLossLimit)
+        .volume(QTY)
+        .price(format!("{:.4}", stop_loss_trigger)) // trigger price
+        .price2(format!("{:.4}", stop_limit_price)) // limit price
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let stop_loss_limit_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel and sell at market
+    if let Some(order_id) = &stop_loss_limit_id {
+        tracing::info!("  Canceling stop-loss-limit order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+        let sell_params = KrakenSpotAddOrderParamsBuilder::default()
+            .pair(PAIR)
+            .side(KrakenOrderSide::Sell)
+            .order_type(KrakenOrderType::Market)
+            .volume(QTY)
+            .broker(NAUTILUS_KRAKEN_BROKER_ID)
+            .build()?;
+        let _ = client.add_order(&sell_params).await;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 7: Take-Profit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 7] TAKE-PROFIT Order");
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Trigger: ${:.4}",
+        PAIR,
+        QTY,
+        take_profit_trigger
+    );
+
+    // Buy first
+    let buy_params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+    let _ = client.add_order(&buy_params).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::TakeProfit)
+        .volume(QTY)
+        .price(format!("{:.4}", take_profit_trigger)) // trigger price
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let take_profit_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel and sell at market
+    if let Some(order_id) = &take_profit_id {
+        tracing::info!("  Canceling take-profit order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+        let sell_params = KrakenSpotAddOrderParamsBuilder::default()
+            .pair(PAIR)
+            .side(KrakenOrderSide::Sell)
+            .order_type(KrakenOrderType::Market)
+            .volume(QTY)
+            .broker(NAUTILUS_KRAKEN_BROKER_ID)
+            .build()?;
+        let _ = client.add_order(&sell_params).await;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    // =========================================================================
+    // TEST 8: Take-Profit-Limit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 8] TAKE-PROFIT-LIMIT Order");
+    let tp_limit_price = take_profit_trigger * SECONDARY_PRICE_MULTIPLIER;
+    tracing::info!(
+        "  Pair: {}, Qty: {}, Trigger: ${:.4}, Limit: ${:.4}",
+        PAIR,
+        QTY,
+        take_profit_trigger,
+        tp_limit_price
+    );
+
+    // Buy first
+    let buy_params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Buy)
+        .order_type(KrakenOrderType::Market)
+        .volume(QTY)
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+    let _ = client.add_order(&buy_params).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(LONG_WAIT)).await;
+
+    let params = KrakenSpotAddOrderParamsBuilder::default()
+        .pair(PAIR)
+        .side(KrakenOrderSide::Sell)
+        .order_type(KrakenOrderType::TakeProfitLimit)
+        .volume(QTY)
+        .price(format!("{:.4}", take_profit_trigger)) // trigger price
+        .price2(format!("{:.4}", tp_limit_price)) // limit price
+        .broker(NAUTILUS_KRAKEN_BROKER_ID)
+        .build()?;
+
+    let tp_limit_id = match client.add_order(&params).await {
+        Ok(resp) => {
+            tracing::info!("  SUCCESS: {:?}", resp.txid);
+            if let Some(d) = &resp.descr {
+                tracing::info!("  Description: {:?}", d.order);
+            }
+            resp.txid.first().cloned()
+        }
+        Err(e) => {
+            tracing::error!("  FAILED: {}", e);
+            None
+        }
+    };
+    tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+
+    // Cancel and sell at market
+    if let Some(order_id) = &tp_limit_id {
+        tracing::info!("  Canceling take-profit-limit order: {}", order_id);
+        let cancel_params = KrakenSpotCancelOrderParamsBuilder::default()
+            .txid(order_id.clone())
+            .build()?;
+        let _ = client.cancel_order(&cancel_params).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(SHORT_WAIT)).await;
+        let sell_params = KrakenSpotAddOrderParamsBuilder::default()
+            .pair(PAIR)
+            .side(KrakenOrderSide::Sell)
+            .order_type(KrakenOrderType::Market)
+            .volume(QTY)
+            .broker(NAUTILUS_KRAKEN_BROKER_ID)
+            .build()?;
+        let _ = client.add_order(&sell_params).await;
+    }
+
+    // Final cleanup
+    tracing::info!("\n[CLEANUP] Canceling any remaining orders...");
+    let _ = client.cancel_all_orders().await;
+
+    tracing::info!("\n==========================================");
+    tracing::info!("REST API Order Type Testing Complete!");
+    tracing::info!(
+        "Tested: Market, Limit, Stop-Loss, Stop-Loss-Limit, Take-Profit, Take-Profit-Limit"
+    );
+
+    Ok(())
+}

--- a/crates/adapters/kraken/bin/spot_order_ws.rs
+++ b/crates/adapters/kraken/bin/spot_order_ws.rs
@@ -1,0 +1,543 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Kraken Spot WebSocket API order type testing.
+//!
+//! Tests all supported order types via WebSocket:
+//! 1. Market order (buy and sell)
+//! 2. Limit order (with post-only)
+//! 3. Stop-loss order
+//! 4. Stop-loss-limit order
+//! 5. Take-profit order
+//! 6. Take-profit-limit order
+//! 7. IOC (Immediate-Or-Cancel) order
+//! 8. FOK (Fill-Or-Kill) order - requires special account permissions
+//!
+//! Note: WebSocket API does NOT support broker_id (only REST API does)
+//! Note: FOK time-in-force requires Kraken Pro or institutional account permissions
+//!
+//! # Environment Variables
+//!
+//! - `KRAKEN_SPOT_API_KEY`: Your Kraken Spot API key
+//! - `KRAKEN_SPOT_API_SECRET`: Your Kraken Spot API secret
+
+use nautilus_kraken::{
+    common::{consts::KRAKEN_SPOT_WS_PRIVATE_URL, enums::KrakenEnvironment},
+    config::KrakenDataClientConfig,
+    http::spot::client::KrakenSpotRawHttpClient,
+    websocket::spot_v2::client::KrakenSpotWebSocketClient,
+};
+use nautilus_model::identifiers::AccountId;
+use tokio_util::sync::CancellationToken;
+
+// Test configuration constants
+const SYMBOL: &str = "ATOM/USDC"; // WebSocket symbol format
+const PAIR: &str = "ATOMUSDC"; // REST API pair format
+const QTY: f64 = 0.5;
+const ACCOUNT_ID: &str = "KRAKEN-001";
+
+// Price calculation multipliers
+const LIMIT_BUY_MULTIPLIER: f64 = 0.95; // 5% below market
+const LIMIT_SELL_MULTIPLIER: f64 = 1.05; // 5% above market
+const STOP_LOSS_MULTIPLIER: f64 = 0.90; // 10% below market
+const TAKE_PROFIT_MULTIPLIER: f64 = 1.10; // 10% above market
+const SECONDARY_PRICE_MULTIPLIER: f64 = 0.99; // 1% below trigger for limit orders
+
+// Timing constants
+const WAIT_DURATION_SECS: u64 = 2;
+const WS_CONNECT_TIMEOUT_SECS: f64 = 10.0;
+const DEFAULT_PRICE: f64 = 5.0;
+const PRICE_DECIMALS: f64 = 10000.0; // 4 decimal places
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .finish(),
+    )?;
+
+    tracing::info!("Kraken Spot WebSocket API - Order Type Testing");
+    tracing::info!("===============================================");
+
+    let api_key = std::env::var("KRAKEN_SPOT_API_KEY")
+        .map_err(|_| anyhow::anyhow!("KRAKEN_SPOT_API_KEY not set"))?;
+    let api_secret = std::env::var("KRAKEN_SPOT_API_SECRET")
+        .map_err(|_| anyhow::anyhow!("KRAKEN_SPOT_API_SECRET not set"))?;
+
+    // Create REST client for ticker and cancel operations
+    let rest_client = KrakenSpotRawHttpClient::with_credentials(
+        api_key.clone(),
+        api_secret.clone(),
+        KrakenEnvironment::Mainnet,
+        None,
+        Some(60),
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    // Cancel all open orders first via REST
+    tracing::info!("\n[SETUP] Canceling all open orders via REST...");
+    let _ = rest_client.cancel_all_orders().await;
+
+    // Get current ticker for reference prices
+    let ticker = rest_client.get_ticker(vec![PAIR.to_string()]).await?;
+    let current_price = ticker
+        .values()
+        .next()
+        .and_then(|t| t.last.first())
+        .and_then(|p| p.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_PRICE);
+    tracing::info!("Current {} price: ${:.4}", SYMBOL, current_price);
+
+    // Helper to round to 4 decimal places (ATOM/USDC precision)
+    fn round_price(price: f64) -> f64 {
+        (price * PRICE_DECIMALS).round() / PRICE_DECIMALS
+    }
+
+    // Calculate prices for limit/stop orders (rounded to 4 decimals)
+    let limit_buy_price = round_price(current_price * LIMIT_BUY_MULTIPLIER);
+    let limit_sell_price = round_price(current_price * LIMIT_SELL_MULTIPLIER);
+    let stop_loss_trigger = round_price(current_price * STOP_LOSS_MULTIPLIER);
+    let take_profit_trigger = round_price(current_price * TAKE_PROFIT_MULTIPLIER);
+
+    // Create WebSocket client
+    let ws_config = KrakenDataClientConfig {
+        environment: KrakenEnvironment::Mainnet,
+        api_key: Some(api_key),
+        api_secret: Some(api_secret),
+        ws_public_url: Some(KRAKEN_SPOT_WS_PRIVATE_URL.to_string()),
+        ..Default::default()
+    };
+
+    let token = CancellationToken::new();
+    let mut ws_client = KrakenSpotWebSocketClient::new(ws_config, token.clone());
+
+    // Connect and authenticate
+    tracing::info!("\n[SETUP] Connecting WebSocket...");
+    ws_client.connect().await?;
+    ws_client.wait_until_active(WS_CONNECT_TIMEOUT_SECS).await?;
+    ws_client.authenticate().await?;
+    ws_client.set_account_id(AccountId::new(ACCOUNT_ID));
+    ws_client.subscribe_executions(true, true).await?;
+    tracing::info!("WebSocket connected and authenticated");
+
+    // Helper to wait for order processing
+    async fn wait_short() {
+        tokio::time::sleep(tokio::time::Duration::from_secs(WAIT_DURATION_SECS)).await;
+    }
+
+    // =========================================================================
+    // TEST 1: Market Order (BUY)
+    // =========================================================================
+    tracing::info!("\n[TEST 1] MARKET BUY Order via WebSocket");
+    tracing::info!("  Symbol: {}, Qty: {}", SYMBOL, QTY);
+
+    match ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 2: Market Order (SELL)
+    // =========================================================================
+    tracing::info!("\n[TEST 2] MARKET SELL Order via WebSocket");
+    tracing::info!("  Symbol: {}, Qty: {}", SYMBOL, QTY);
+
+    match ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 3: Limit Order (BUY) with post-only
+    // =========================================================================
+    tracing::info!("\n[TEST 3] LIMIT BUY Order (post-only) via WebSocket");
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Price: ${:.4}",
+        SYMBOL,
+        QTY,
+        limit_buy_price
+    );
+
+    match ws_client
+        .add_order(
+            "limit",
+            "buy",
+            QTY,
+            SYMBOL,
+            Some(limit_buy_price),
+            None,                             // no trigger
+            None,                             // no trigger reference
+            Some("testlimitbuy".to_string()), // cl_ord_id (no hyphens)
+            Some("gtc".to_string()),          // time_in_force
+            Some(true),                       // post-only
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel limit order via REST
+    tracing::info!("  Canceling limit orders via REST...");
+    let _ = rest_client.cancel_all_orders().await;
+
+    // =========================================================================
+    // TEST 4: Limit Order (SELL)
+    // =========================================================================
+    tracing::info!("\n[TEST 4] LIMIT SELL Order via WebSocket");
+
+    // Buy first via WS
+    let _ = ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Price: ${:.4}",
+        SYMBOL,
+        QTY,
+        limit_sell_price
+    );
+
+    match ws_client
+        .add_order(
+            "limit",
+            "sell",
+            QTY,
+            SYMBOL,
+            Some(limit_sell_price),
+            None,
+            None,
+            Some("testlimitsell".to_string()),
+            Some("gtc".to_string()),
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel and close position
+    let _ = rest_client.cancel_all_orders().await;
+    let _ = ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 5: Stop-Loss Order
+    // =========================================================================
+    tracing::info!("\n[TEST 5] STOP-LOSS Order via WebSocket");
+
+    // Buy first
+    let _ = ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Trigger: ${:.4}",
+        SYMBOL,
+        QTY,
+        stop_loss_trigger
+    );
+
+    match ws_client
+        .add_order(
+            "stop-loss",
+            "sell",
+            QTY,
+            SYMBOL,
+            None,                    // no limit price for pure stop-loss
+            Some(stop_loss_trigger), // trigger price
+            Some("last"),            // trigger reference
+            Some("teststoploss".to_string()),
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel and close
+    let _ = rest_client.cancel_all_orders().await;
+    let _ = ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 6: Stop-Loss-Limit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 6] STOP-LOSS-LIMIT Order via WebSocket");
+
+    // Buy first
+    let _ = ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    let stop_limit_price = round_price(stop_loss_trigger * SECONDARY_PRICE_MULTIPLIER);
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Trigger: ${:.4}, Limit: ${:.4}",
+        SYMBOL,
+        QTY,
+        stop_loss_trigger,
+        stop_limit_price
+    );
+
+    match ws_client
+        .add_order(
+            "stop-loss-limit",
+            "sell",
+            QTY,
+            SYMBOL,
+            Some(stop_limit_price),  // limit price
+            Some(stop_loss_trigger), // trigger price
+            Some("last"),            // trigger reference
+            Some("teststoplosslimit".to_string()),
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel and close
+    let _ = rest_client.cancel_all_orders().await;
+    let _ = ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 7: Take-Profit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 7] TAKE-PROFIT Order via WebSocket");
+
+    // Buy first
+    let _ = ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Trigger: ${:.4}",
+        SYMBOL,
+        QTY,
+        take_profit_trigger
+    );
+
+    match ws_client
+        .add_order(
+            "take-profit",
+            "sell",
+            QTY,
+            SYMBOL,
+            None,                      // no limit price
+            Some(take_profit_trigger), // trigger price
+            Some("last"),              // trigger reference
+            Some("testtakeprofit".to_string()),
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel and close
+    let _ = rest_client.cancel_all_orders().await;
+    let _ = ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 8: Take-Profit-Limit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 8] TAKE-PROFIT-LIMIT Order via WebSocket");
+
+    // Buy first
+    let _ = ws_client
+        .add_order(
+            "market", "buy", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    let tp_limit_price = round_price(take_profit_trigger * SECONDARY_PRICE_MULTIPLIER);
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Trigger: ${:.4}, Limit: ${:.4}",
+        SYMBOL,
+        QTY,
+        take_profit_trigger,
+        tp_limit_price
+    );
+
+    match ws_client
+        .add_order(
+            "take-profit-limit",
+            "sell",
+            QTY,
+            SYMBOL,
+            Some(tp_limit_price),                 // limit price
+            Some(take_profit_trigger),            // trigger price
+            Some("last"),                         // trigger reference
+            Some("testtprofitlimit".to_string()), // cl_ord_id max 18 chars
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // Cancel and close
+    let _ = rest_client.cancel_all_orders().await;
+    let _ = ws_client
+        .add_order(
+            "market", "sell", QTY, SYMBOL, None, None, None, None, None, None,
+        )
+        .await;
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 9: IOC (Immediate-Or-Cancel) Limit Order
+    // =========================================================================
+    tracing::info!("\n[TEST 9] IOC LIMIT BUY Order via WebSocket");
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Price: ${:.4}, TIF: IOC",
+        SYMBOL,
+        QTY,
+        limit_buy_price
+    );
+
+    match ws_client
+        .add_order(
+            "limit",
+            "buy",
+            QTY,
+            SYMBOL,
+            Some(limit_buy_price),
+            None,
+            None,
+            Some("testioc".to_string()),
+            Some("ioc".to_string()), // immediate-or-cancel
+            None,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!("  Order submitted successfully (should cancel if not filled)"),
+        Err(e) => tracing::error!("  FAILED: {}", e),
+    }
+    wait_short().await;
+
+    // =========================================================================
+    // TEST 10: FOK (Fill-Or-Kill) Limit Order
+    // Note: FOK requires special account permissions on Kraken
+    // =========================================================================
+    tracing::info!("\n[TEST 10] FOK LIMIT BUY Order via WebSocket");
+    tracing::info!(
+        "  Symbol: {}, Qty: {}, Price: ${:.4}, TIF: FOK",
+        SYMBOL,
+        QTY,
+        limit_buy_price
+    );
+    tracing::info!("  Note: FOK may require special account permissions");
+
+    match ws_client
+        .add_order(
+            "limit",
+            "buy",
+            QTY,
+            SYMBOL,
+            Some(limit_buy_price),
+            None,
+            None,
+            Some("testfok".to_string()),
+            Some("fok".to_string()), // fill-or-kill
+            None,
+        )
+        .await
+    {
+        Ok(()) => {
+            tracing::info!("  Order submitted successfully (should cancel if not fully filled)")
+        }
+        Err(e) => tracing::warn!("  Expected: FOK requires account permission: {}", e),
+    }
+    wait_short().await;
+
+    // Final cleanup
+    tracing::info!("\n[CLEANUP] Canceling any remaining orders...");
+    let _ = rest_client.cancel_all_orders().await;
+
+    // Disconnect WebSocket
+    tracing::info!("Disconnecting WebSocket...");
+    ws_client.disconnect().await?;
+
+    tracing::info!("\n===============================================");
+    tracing::info!("WebSocket API Order Type Testing Complete!");
+    tracing::info!(
+        "Tested: Market, Limit, Stop-Loss, Stop-Loss-Limit, Take-Profit, Take-Profit-Limit, IOC, FOK"
+    );
+
+    Ok(())
+}

--- a/crates/adapters/kraken/src/http/spot/client.rs
+++ b/crates/adapters/kraken/src/http/spot/client.rs
@@ -1253,6 +1253,10 @@ impl KrakenSpotHttpClient {
     ///
     /// Returns the venue order ID on success. WebSocket handles all execution events.
     ///
+    /// # References
+    /// - <https://docs.kraken.com/api/docs/rest-api/add-order>
+    /// - <https://github.com/krakenfx/api-go/blob/main/pkg/spot/rest.go> (AddOrder)
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -1297,23 +1301,29 @@ impl KrakenSpotHttpClient {
             _ => anyhow::bail!("Unsupported order type: {order_type:?}"),
         };
 
-        // Build oflags based on time in force and order options
-        let mut oflags = Vec::new();
-
-        match time_in_force {
-            TimeInForce::Gtc => {} // Default, no flag needed
+        // Map time in force to Kraken API format
+        // Note: timeinforce only applies to limit orders, not market orders
+        let kraken_tif = match time_in_force {
+            TimeInForce::Gtc => None, // Default, no need to send
             TimeInForce::Ioc => {
-                oflags.push("ioc");
+                // IOC only applies to limit-type orders
+                if matches!(kraken_order_type, KrakenOrderType::Market) {
+                    None // Market orders are implicitly IOC
+                } else {
+                    Some("IOC")
+                }
             }
             TimeInForce::Fok => {
-                anyhow::bail!("FOK time in force not supported by Kraken Spot API");
+                anyhow::bail!("FOK time in force requires Kraken Pro account");
             }
             TimeInForce::Gtd => {
                 anyhow::bail!("GTD time in force requires expire_time parameter");
             }
             _ => anyhow::bail!("Unsupported time in force: {time_in_force:?}"),
-        }
+        };
 
+        // Build oflags for order options (post-only)
+        let mut oflags = Vec::new();
         if post_only {
             oflags.push("post");
         }
@@ -1322,9 +1332,19 @@ impl KrakenSpotHttpClient {
             tracing::warn!("reduce_only is not supported by Kraken Spot API, ignoring");
         }
 
+        // Truncate client_order_id to max 18 chars (Kraken limit for free text format)
+        let cl_ord_id = {
+            let id_str = client_order_id.to_string();
+            if id_str.len() > 18 {
+                id_str[..18].to_string()
+            } else {
+                id_str
+            }
+        };
+
         let mut builder = KrakenSpotAddOrderParamsBuilder::default();
         builder
-            .cl_ord_id(client_order_id.to_string())
+            .cl_ord_id(cl_ord_id)
             .broker(NAUTILUS_KRAKEN_BROKER_ID)
             .pair(raw_symbol)
             .side(kraken_side)
@@ -1333,6 +1353,10 @@ impl KrakenSpotHttpClient {
 
         if let Some(price) = price {
             builder.price(price.to_string());
+        }
+
+        if let Some(tif) = kraken_tif {
+            builder.timeinforce(tif);
         }
 
         if !oflags.is_empty() {

--- a/crates/adapters/kraken/src/http/spot/query.rs
+++ b/crates/adapters/kraken/src/http/spot/query.rs
@@ -25,6 +25,7 @@ use crate::common::enums::{KrakenOrderSide, KrakenOrderType};
 ///
 /// # References
 /// - <https://docs.kraken.com/api/docs/rest-api/add-order>
+/// - <https://github.com/krakenfx/api-go/blob/main/pkg/spot/rest.go> (AddOrderRequest)
 #[derive(Clone, Debug, Serialize, Deserialize, Builder)]
 #[builder(setter(into, strip_option), build_fn(validate = "Self::validate"))]
 pub struct KrakenSpotAddOrderParams {
@@ -52,12 +53,19 @@ pub struct KrakenSpotAddOrderParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price2: Option<String>,
 
-    /// Client order ID (must be UUID format).
+    /// Client order ID (free text, max 18 chars).
+    /// See: <https://docs.kraken.com/api/docs/rest-api/add-order#request> (cl_ord_id)
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cl_ord_id: Option<String>,
 
-    /// Order flags (comma-separated: post, ioc, fcib, fciq, nompp, viqc).
+    /// Time in force: "GTC" (default), "IOC", "GTD".
+    /// See: <https://github.com/krakenfx/api-go/blob/main/pkg/spot/rest.go> (TimeInForce)
+    #[builder(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeinforce: Option<String>,
+
+    /// Order flags (comma-separated: post, fcib, fciq, nompp, viqc).
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oflags: Option<String>,

--- a/crates/adapters/kraken/src/python/http_futures.rs
+++ b/crates/adapters/kraken/src/python/http_futures.rs
@@ -15,16 +15,14 @@
 
 //! Python bindings for the Kraken Futures HTTP client.
 
-use chrono::{DateTime, Utc};
 use nautilus_core::python::{to_pyruntime_err, to_pyvalue_err};
 use nautilus_model::{
-    data::BarType,
     enums::{OrderSide, OrderType, TimeInForce},
     identifiers::{AccountId, ClientOrderId, InstrumentId, VenueOrderId},
     python::instruments::{instrument_any_to_pyobject, pyobject_to_instrument_any},
     types::{Price, Quantity},
 };
-use pyo3::{conversion::IntoPyObjectExt, prelude::*, types::PyList};
+use pyo3::{prelude::*, types::PyList};
 
 use crate::{common::enums::KrakenEnvironment, http::KrakenFuturesHttpClient};
 
@@ -133,35 +131,6 @@ impl KrakenFuturesHttpClient {
         })
     }
 
-    #[pyo3(name = "request_trades")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None))]
-    fn py_request_trades<'py>(
-        &self,
-        py: Python<'py>,
-        instrument_id: InstrumentId,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        limit: Option<u64>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let trades = client
-                .request_trades(instrument_id, start, end, limit)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Python::attach(|py| {
-                let py_trades: PyResult<Vec<_>> = trades
-                    .into_iter()
-                    .map(|trade| trade.into_py_any(py))
-                    .collect();
-                let pylist = PyList::new(py, py_trades?).unwrap().into_any().unbind();
-                Ok(pylist)
-            })
-        })
-    }
-
     #[pyo3(name = "request_mark_price")]
     fn py_request_mark_price<'py>(
         &self,
@@ -177,137 +146,6 @@ impl KrakenFuturesHttpClient {
                 .map_err(to_pyruntime_err)?;
 
             Ok(mark_price)
-        })
-    }
-
-    #[pyo3(name = "request_index_price")]
-    fn py_request_index_price<'py>(
-        &self,
-        py: Python<'py>,
-        instrument_id: InstrumentId,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let index_price = client
-                .request_index_price(instrument_id)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Ok(index_price)
-        })
-    }
-
-    #[pyo3(name = "request_bars")]
-    #[pyo3(signature = (bar_type, start=None, end=None, limit=None))]
-    fn py_request_bars<'py>(
-        &self,
-        py: Python<'py>,
-        bar_type: BarType,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        limit: Option<u64>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let bars = client
-                .request_bars(bar_type, start, end, limit)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Python::attach(|py| {
-                let py_bars: PyResult<Vec<_>> =
-                    bars.into_iter().map(|bar| bar.into_py_any(py)).collect();
-                let pylist = PyList::new(py, py_bars?).unwrap().into_any().unbind();
-                Ok(pylist)
-            })
-        })
-    }
-
-    #[pyo3(name = "request_order_status_reports")]
-    #[pyo3(signature = (account_id, instrument_id=None, start=None, end=None, open_only=false))]
-    fn py_request_order_status_reports<'py>(
-        &self,
-        py: Python<'py>,
-        account_id: AccountId,
-        instrument_id: Option<InstrumentId>,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        open_only: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let reports = client
-                .request_order_status_reports(account_id, instrument_id, start, end, open_only)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Python::attach(|py| {
-                let py_reports: PyResult<Vec<_>> = reports
-                    .into_iter()
-                    .map(|report| report.into_py_any(py))
-                    .collect();
-                let pylist = PyList::new(py, py_reports?).unwrap().into_any().unbind();
-                Ok(pylist)
-            })
-        })
-    }
-
-    #[pyo3(name = "request_fill_reports")]
-    #[pyo3(signature = (account_id, instrument_id=None, start=None, end=None))]
-    fn py_request_fill_reports<'py>(
-        &self,
-        py: Python<'py>,
-        account_id: AccountId,
-        instrument_id: Option<InstrumentId>,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let reports = client
-                .request_fill_reports(account_id, instrument_id, start, end)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Python::attach(|py| {
-                let py_reports: PyResult<Vec<_>> = reports
-                    .into_iter()
-                    .map(|report| report.into_py_any(py))
-                    .collect();
-                let pylist = PyList::new(py, py_reports?).unwrap().into_any().unbind();
-                Ok(pylist)
-            })
-        })
-    }
-
-    #[pyo3(name = "request_position_status_reports")]
-    #[pyo3(signature = (account_id, instrument_id=None))]
-    fn py_request_position_status_reports<'py>(
-        &self,
-        py: Python<'py>,
-        account_id: AccountId,
-        instrument_id: Option<InstrumentId>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.clone();
-
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let reports = client
-                .request_position_status_reports(account_id, instrument_id)
-                .await
-                .map_err(to_pyruntime_err)?;
-
-            Python::attach(|py| {
-                let py_reports: PyResult<Vec<_>> = reports
-                    .into_iter()
-                    .map(|report| report.into_py_any(py))
-                    .collect();
-                let pylist = PyList::new(py, py_reports?).unwrap().into_any().unbind();
-                Ok(pylist)
-            })
         })
     }
 

--- a/crates/adapters/kraken/src/python/websocket_spot.rs
+++ b/crates/adapters/kraken/src/python/websocket_spot.rs
@@ -438,6 +438,72 @@ impl KrakenSpotWebSocketClient {
             Ok(())
         })
     }
+
+    /// Submit an order via WebSocket.
+    ///
+    /// Note: WebSocket API does NOT support broker_id (only REST API does).
+    /// For conditional orders (stop-loss, take-profit), provide trigger_price and trigger_reference.
+    ///
+    /// Parameters
+    /// ----------
+    /// order_type : str
+    ///     Order type: "market", "limit", "stop-loss", "stop-loss-limit", "take-profit", "take-profit-limit"
+    /// side : str
+    ///     Order side: "buy" or "sell"
+    /// order_qty : float
+    ///     Order quantity
+    /// symbol : str
+    ///     Trading symbol (e.g., "ATOM/USDC")
+    /// limit_price : float, optional
+    ///     Limit price for limit orders
+    /// trigger_price : float, optional
+    ///     Trigger price for conditional orders
+    /// trigger_reference : str, optional
+    ///     Trigger reference: "last" (default), "index"
+    /// cl_ord_id : str, optional
+    ///     Client order ID (max 18 chars for free text format)
+    /// time_in_force : str, optional
+    ///     Time in force: "gtc" (default), "ioc", "fok"
+    /// post_only : bool, optional
+    ///     Post-only flag for limit orders
+    #[pyo3(name = "add_order")]
+    #[pyo3(signature = (order_type, side, order_qty, symbol, limit_price=None, trigger_price=None, trigger_reference=None, cl_ord_id=None, time_in_force=None, post_only=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn py_add_order<'py>(
+        &self,
+        py: Python<'py>,
+        order_type: String,
+        side: String,
+        order_qty: f64,
+        symbol: String,
+        limit_price: Option<f64>,
+        trigger_price: Option<f64>,
+        trigger_reference: Option<String>,
+        cl_ord_id: Option<String>,
+        time_in_force: Option<String>,
+        post_only: Option<bool>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .add_order(
+                    &order_type,
+                    &side,
+                    order_qty,
+                    &symbol,
+                    limit_price,
+                    trigger_price,
+                    trigger_reference.as_deref(),
+                    cl_ord_id,
+                    time_in_force,
+                    post_only,
+                )
+                .await
+                .map_err(to_pyruntime_err)?;
+            Ok(())
+        })
+    }
 }
 
 pub fn call_python(py: Python, callback: &Py<PyAny>, py_obj: Py<PyAny>) {

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -604,6 +604,85 @@ impl KrakenSpotWebSocketClient {
         Ok(())
     }
 
+    /// Place an order via WebSocket.
+    ///
+    /// Requires authentication - call `authenticate()` first.
+    /// Note: WebSocket API does not support broker_id (only REST API does).
+    ///
+    /// For conditional orders (stop-loss, take-profit), provide trigger_price and trigger_reference.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add_order(
+        &self,
+        order_type: &str,
+        side: &str,
+        order_qty: f64,
+        symbol: &str,
+        limit_price: Option<f64>,
+        trigger_price: Option<f64>,
+        trigger_reference: Option<&str>,
+        cl_ord_id: Option<String>,
+        time_in_force: Option<String>,
+        post_only: Option<bool>,
+    ) -> Result<(), KrakenWsError> {
+        let req_id = self.get_next_req_id().await;
+
+        let token = self.auth_token.read().await.clone().ok_or_else(|| {
+            KrakenWsError::AuthenticationError(
+                "Authentication token required for add_order. Call authenticate() first"
+                    .to_string(),
+            )
+        })?;
+
+        let triggers = trigger_price.map(|price| super::messages::KrakenWsOrderTriggers {
+            reference: trigger_reference.unwrap_or("last").to_string(),
+            price,
+            price_type: None,
+        });
+
+        let request = super::messages::KrakenWsAddOrderRequest::new(
+            super::messages::KrakenWsAddOrderParams {
+                order_type: order_type.to_string(),
+                side: side.to_string(),
+                order_qty,
+                symbol: symbol.to_string(),
+                limit_price,
+                triggers,
+                cl_ord_id,
+                time_in_force,
+                post_only,
+                reduce_only: None,
+                order_userref: None,
+                display_qty: None,
+                fee_preference: None,
+                oflags: None,
+            },
+            Some(req_id),
+        );
+
+        // Inject token into params
+        let mut request_value =
+            serde_json::to_value(&request).map_err(|e| KrakenWsError::JsonError(e.to_string()))?;
+
+        if let Some(params) = request_value.get_mut("params") {
+            params["token"] = serde_json::Value::String(token);
+        }
+
+        let payload = serde_json::to_string(&request_value)
+            .map_err(|e| KrakenWsError::JsonError(e.to_string()))?;
+
+        tracing::trace!("Sending add_order: {payload}");
+
+        self.cmd_tx
+            .read()
+            .await
+            .send(SpotHandlerCommand::SendText { payload })
+            .map_err(|e| {
+                KrakenWsError::ConnectionError(format!("Failed to send add_order request: {e}"))
+            })?;
+
+        Ok(())
+    }
+
     /// Unsubscribe from order book updates for the given instrument.
     ///
     /// Note: Will only actually unsubscribe if quotes are not also subscribed.

--- a/crates/adapters/kraken/src/websocket/spot_v2/enums.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/enums.rs
@@ -43,6 +43,15 @@ pub enum KrakenWsMethod {
     Unsubscribe,
     Ping,
     Pong,
+    #[serde(rename = "add_order")]
+    #[strum(serialize = "add_order")]
+    AddOrder,
+    #[serde(rename = "cancel_order")]
+    #[strum(serialize = "cancel_order")]
+    CancelOrder,
+    #[serde(rename = "cancel_all")]
+    #[strum(serialize = "cancel_all")]
+    CancelAll,
 }
 
 #[derive(

--- a/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
@@ -301,12 +301,30 @@ impl SpotFeedHandler {
                         KrakenWsResponse::Pong(pong) => {
                             tracing::trace!(req_id = ?pong.req_id, "Received pong");
                         }
+                        KrakenWsResponse::AddOrder(add_order) => {
+                            if add_order.success {
+                                if let Some(result) = &add_order.result {
+                                    tracing::info!(
+                                        order_id = %result.order_id,
+                                        cl_ord_id = ?result.cl_ord_id,
+                                        req_id = ?add_order.req_id,
+                                        "Order submitted successfully via WebSocket"
+                                    );
+                                }
+                            } else {
+                                tracing::warn!(
+                                    error = ?add_order.error,
+                                    req_id = ?add_order.req_id,
+                                    "Order submission failed via WebSocket"
+                                );
+                            }
+                        }
                         KrakenWsResponse::Other => {
                             tracing::debug!("Received unknown subscription response");
                         }
                     }
                 } else {
-                    tracing::debug!("Received subscription response (failed to parse details)");
+                    tracing::debug!(raw = ?text, "Received subscription response (failed to parse details)");
                 }
                 return None;
             }

--- a/crates/adapters/kraken/src/websocket/spot_v2/messages.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/messages.rs
@@ -73,6 +73,8 @@ pub enum KrakenWsResponse {
     Subscribe(KrakenWsSubscribeResponse),
     #[serde(rename = "unsubscribe")]
     Unsubscribe(KrakenWsUnsubscribeResponse),
+    #[serde(rename = "add_order")]
+    AddOrder(KrakenWsAddOrderResponse),
     #[serde(other)]
     Other,
 }
@@ -260,6 +262,125 @@ pub struct KrakenWsFee {
     pub asset: String,
     /// Fee quantity.
     pub qty: f64,
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Order Request/Response Types
+////////////////////////////////////////////////////////////////////////////////
+
+/// Trigger parameters for conditional orders (stop-loss, take-profit).
+#[derive(Debug, Clone, Serialize)]
+pub struct KrakenWsOrderTriggers {
+    /// Trigger reference: "index" or "last".
+    pub reference: String,
+    /// Trigger price.
+    pub price: f64,
+    /// Price type: "static" (default) or "pct" for percentage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_type: Option<String>,
+}
+
+/// WebSocket add_order request parameters.
+#[derive(Debug, Clone, Serialize)]
+pub struct KrakenWsAddOrderParams {
+    /// Order type: "market", "limit", "stop-loss", "take-profit", "stop-loss-limit", "take-profit-limit".
+    pub order_type: String,
+    /// Order side: "buy" or "sell".
+    pub side: String,
+    /// Order quantity in base currency.
+    pub order_qty: f64,
+    /// Trading pair symbol (e.g., "ATOM/USDC").
+    pub symbol: String,
+    /// Limit price (required for limit orders and limit variants of stop/take-profit).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_price: Option<f64>,
+    /// Trigger parameters for conditional orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggers: Option<KrakenWsOrderTriggers>,
+    /// Client order ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Time in force: "gtc", "ioc", "gtd".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in_force: Option<String>,
+    /// Post-only flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    /// Reduce-only flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// Order user reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_userref: Option<i64>,
+    /// Display quantity for iceberg orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_qty: Option<f64>,
+    /// Fee preference: "base" or "quote".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_preference: Option<String>,
+    /// Order flags.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oflags: Option<Vec<String>>,
+}
+
+/// WebSocket add_order request.
+#[derive(Debug, Clone, Serialize)]
+pub struct KrakenWsAddOrderRequest {
+    /// Method name.
+    pub method: String,
+    /// Request parameters.
+    pub params: KrakenWsAddOrderParams,
+    /// Request ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_id: Option<u64>,
+}
+
+impl KrakenWsAddOrderRequest {
+    pub fn new(params: KrakenWsAddOrderParams, req_id: Option<u64>) -> Self {
+        Self {
+            method: "add_order".to_string(),
+            params,
+            req_id,
+        }
+    }
+}
+
+/// WebSocket add_order response result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsAddOrderResult {
+    /// Order ID assigned by Kraken.
+    pub order_id: String,
+    /// Client order ID (echoed back).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Order user reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_userref: Option<i64>,
+    /// Warnings if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
+}
+
+/// WebSocket add_order response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsAddOrderResponse {
+    /// Request ID (echoed back).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_id: Option<u64>,
+    /// Success flag.
+    pub success: bool,
+    /// Result on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<KrakenWsAddOrderResult>,
+    /// Error message on failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Time in (ISO 8601).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in: Option<String>,
+    /// Time out (ISO 8601).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_out: Option<String>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/examples/live/kraken/kraken_futures_demo.py
+++ b/examples/live/kraken/kraken_futures_demo.py
@@ -14,32 +14,24 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 """
-Kraken Futures Demo - Comprehensive testing of the Kraken Futures adapter.
+Kraken Futures order placement demo.
 
-This demo tests:
-1. Public endpoints (instruments, trades, mark/index prices, bars)
-2. Authenticated endpoints (open orders, positions, fills)
-3. Order placement (LIMIT, STOP_MARKET, STOP_LIMIT, MARKET_IF_TOUCHED, MARKET execution, position close)
+Demonstrates order placement for various order types on Kraken Futures testnet.
 
-Environment Variables (Testnet/Demo):
+Environment Variables:
     KRAKEN_TESTNET_API_KEY: Your Kraken demo API key
     KRAKEN_TESTNET_API_SECRET: Your Kraken demo API secret
 
 Usage:
-    # Public endpoints only (no credentials)
-    python kraken_futures_demo.py
-
-    # Full testnet tests with order placement
     export KRAKEN_TESTNET_API_KEY="your_key"
     export KRAKEN_TESTNET_API_SECRET="your_secret"
     python kraken_futures_demo.py
+
 """
 
 import asyncio
 import os
-from datetime import UTC
 from datetime import datetime
-from datetime import timedelta
 
 from nautilus_trader.core.nautilus_pyo3 import AccountId
 from nautilus_trader.core.nautilus_pyo3 import ClientOrderId
@@ -50,174 +42,32 @@ from nautilus_trader.core.nautilus_pyo3 import OrderType
 from nautilus_trader.core.nautilus_pyo3 import Price
 from nautilus_trader.core.nautilus_pyo3 import Quantity
 from nautilus_trader.core.nautilus_pyo3 import TimeInForce
+from nautilus_trader.core.nautilus_pyo3 import VenueOrderId
 
 
-def get_testnet_credentials():
+async def run_order_tests(client: KrakenFuturesHttpClient, account_id: AccountId) -> None:
     """
-    Check for testnet credentials in environment.
+    Test order placement with various order types.
     """
-    api_key = os.environ.get("KRAKEN_TESTNET_API_KEY")
-    api_secret = os.environ.get("KRAKEN_TESTNET_API_SECRET")
-
-    if api_key and api_secret:
-        return api_key, api_secret
-    return None, None
-
-
-async def test_futures_public(client: KrakenFuturesHttpClient):
-    """
-    Test Futures public endpoints.
-    """
-    print("\n=== Testing Futures Public Endpoints ===")
-
-    # Test 1: Request instruments
-    print("\n[1/5] Requesting instruments...")
-    try:
-        instruments = await client.request_instruments()
-        print(f"[OK] Found {len(instruments)} instruments")
-        if instruments:
-            sample = instruments[0]
-            # Cache all instruments for later use
-            for inst in instruments:
-                client.cache_instrument(inst)
-            print(f"  Sample: {sample.id}")
-    except Exception as e:
-        print(f"[ERROR] Instruments request failed: {e}")
-        return
-
-    # Use PI_XBTUSD for remaining tests
     instrument_id = InstrumentId.from_str("PI_XBTUSD.KRAKEN")
+    placed_order_ids: list[VenueOrderId] = []
+    results = {"passed": 0, "failed": 0}
 
-    # Test 2: Request trades
-    print("\n[2/5] Requesting recent trades for PI_XBTUSD...")
+    instruments = await client.request_instruments()
+    for inst in instruments:
+        client.cache_instrument(inst)
+
+    mark_price = float(await client.request_mark_price(instrument_id))
+    print(f"Reference price: {mark_price}")
+
+    # Test 1: LIMIT order (post-only)
+    print("\n[1] LIMIT order (post-only, 50% below market)...")
     try:
-        end = datetime.now(UTC)
-        start = end - timedelta(minutes=5)
-        trades = await client.request_trades(instrument_id, start, end, limit=10)
-        print(f"[OK] Received {len(trades)} trades")
-        if trades:
-            latest = trades[-1]
-            print(f"  Latest: {latest.price} @ {latest.size} ({latest.aggressor_side})")
-    except Exception as e:
-        print(f"[ERROR] Trades request failed: {e}")
-
-    # Test 3: Request mark price
-    print("\n[3/5] Requesting mark price for PI_XBTUSD...")
-    mark_price = None
-    try:
-        mark_price = await client.request_mark_price(instrument_id)
-        print(f"[OK] Mark price: {mark_price}")
-    except Exception:
-        print("[WARN] Mark price unavailable in testnet")
-
-    # Test 4: Request index price
-    print("\n[4/5] Requesting index price for PI_XBTUSD...")
-    try:
-        index_price = await client.request_index_price(instrument_id)
-        print(f"[OK] Index price: {index_price}")
-    except Exception:
-        print("[WARN] Index price unavailable in testnet")
-
-    # Test 5: Request bars
-    print("\n[5/5] Requesting 1-minute bars for PI_XBTUSD...")
-    try:
-        from nautilus_trader.model.data import BarType as NautilusBarType
-        bar_type = NautilusBarType.from_str("PI_XBTUSD.KRAKEN-1-MINUTE-LAST-EXTERNAL")
-        end = datetime.now(UTC)
-        start = end - timedelta(hours=1)
-        bars = await client.request_bars(bar_type, start, end, limit=10)
-        print(f"[OK] Received {len(bars)} bars")
-        if bars:
-            bar = bars[-1]
-            print(f"  Latest: O={bar.open} H={bar.high} L={bar.low} C={bar.close} V={bar.volume}")
-    except Exception:
-        print("[WARN] Bars unavailable in testnet")
-
-    # Return mark price or latest trade price for order placement tests
-    return mark_price or (trades[-1].price if trades else None)
-
-
-async def test_futures_authenticated(client: KrakenFuturesHttpClient, account_id: AccountId):
-    """
-    Test Futures authenticated endpoints.
-    """
-    print("\n=== Testing Futures Authenticated Endpoints ===")
-
-    # Test 1: Request open orders
-    print("\n[1/3] Requesting open orders...")
-    try:
-        orders = await client.request_order_status_reports(
-            account_id=account_id,
-            open_only=True,
-        )
-        print(f"[OK] Found {len(orders)} open orders")
-        if orders:
-            for order in orders[:3]:  # Show first 3
-                print(f"  Order: {order.venue_order_id} {order.order_side} {order.quantity} @ {order.price or 'MARKET'}")
-    except Exception as e:
-        print(f"[ERROR] Open orders request failed: {e}")
-        return
-
-    # Test 2: Request positions
-    print("\n[2/3] Requesting open positions...")
-    try:
-        positions = await client.request_position_status_reports(account_id=account_id)
-        print(f"[OK] Found {len(positions)} positions")
-        if positions:
-            for pos in positions:
-                print(f"  Position: {pos.instrument_id} size={pos.quantity}")
-    except Exception as e:
-        print(f"[ERROR] Positions request failed: {e}")
-
-    # Test 3: Request recent fills
-    print("\n[3/3] Requesting recent fills...")
-    try:
-        end = datetime.now(UTC)
-        start = end - timedelta(hours=24)
-        fills = await client.request_fill_reports(
-            account_id=account_id,
-            start=start,
-            end=end,
-        )
-        print(f"[OK] Found {len(fills)} fills in last 24 hours")
-        if fills:
-            for fill in fills[:3]:  # Show first 3
-                print(f"  Fill: {fill.venue_order_id} {fill.order_side} {fill.last_qty} @ {fill.last_px}")
-    except Exception as e:
-        print(f"[ERROR] Fills request failed: {e}")
-
-
-async def test_futures_order_placement(  # noqa: C901
-    client: KrakenFuturesHttpClient,
-    account_id: AccountId,
-    reference_price,
-):
-    """
-    Test order placement with all required order types.
-    """
-    print("\n=== Testing Order Placement ===")
-
-    instrument_id = InstrumentId.from_str("PI_XBTUSD.KRAKEN")
-    placed_order_ids = []
-
-    # Use provided reference price
-    if not reference_price:
-        print("[ERROR] No reference price available, skipping order placement tests")
-        return
-
-    mark_price = float(reference_price)
-    print(f"\nUsing reference price: {mark_price}")
-
-    # Test 1: LIMIT order (Post-only, far from market)
-    print("\n[Test 1/8] Placing LIMIT order (post-only, 50% of market price)...")
-    try:
-        limit_price = float(mark_price) * 0.50  # 50% below market
-        client_order_id = ClientOrderId(f"test-limit-{int(datetime.now().timestamp())}")
-
+        limit_price = mark_price * 0.50
         report = await client.submit_order(
             account_id=account_id,
             instrument_id=instrument_id,
-            client_order_id=client_order_id,
+            client_order_id=ClientOrderId(f"limit-{int(datetime.now().timestamp())}"),
             order_side=OrderSide.BUY,
             order_type=OrderType.LIMIT,
             quantity=Quantity.from_int(1),
@@ -225,283 +75,120 @@ async def test_futures_order_placement(  # noqa: C901
             price=Price.from_str(f"{limit_price:.2f}"),
             post_only=True,
         )
-
-        venue_order_id = report.venue_order_id
-        print(f"[OK] LIMIT order placed: {venue_order_id}")
-        print(f"  Price: {limit_price:.2f}, Status: {report.order_status}")
-        placed_order_ids.append(venue_order_id)
-
+        print(f"    Order: {report.venue_order_id}, Status: {report.order_status}")
+        placed_order_ids.append(report.venue_order_id)
+        results["passed"] += 1
     except Exception as e:
-        error_msg = str(e)
-        if "502" in error_msg:
-            print("[WARN] LIMIT order skipped (testnet API returned 502 - infrastructure issue)")
-        else:
-            print(f"[ERROR] LIMIT order failed: {e}")
+        print(f"    FAILED: {e}")
+        results["failed"] += 1
 
-    # Test 2: Cancel the LIMIT order
-    print("\n[Test 2/8] Cancelling LIMIT order...")
+    # Test 2: Cancel order
+    print("\n[2] Cancel LIMIT order...")
     try:
         if placed_order_ids:
             report = await client.cancel_order(
                 account_id=account_id,
                 instrument_id=instrument_id,
-                venue_order_id=placed_order_ids[0],
+                venue_order_id=placed_order_ids.pop(),
             )
-            print(f"[OK] Cancel status: {report.order_status}")
-            placed_order_ids.pop(0)
+            print(f"    Status: {report.order_status}")
+            results["passed"] += 1
+        else:
+            print("    SKIPPED: No order to cancel")
     except Exception as e:
-        print(f"[ERROR] Cancel failed: {e}")
+        print(f"    FAILED: {e}")
+        results["failed"] += 1
 
-    await asyncio.sleep(2)  # Longer delay to avoid rate limiting
-
-    # Test 3: STOP_MARKET order (stop-loss trigger)
-    print("\n[Test 3/8] Placing STOP_MARKET order (trigger at 60% of market)...")
+    # Test 3: STOP_MARKET order
+    print("\n[3] STOP_MARKET order (trigger at 60% of market)...")
     try:
-        stop_price = float(mark_price) * 0.60  # 60% of market (stop-loss)
-        client_order_id = ClientOrderId(f"test-stop-{int(datetime.now().timestamp())}")
-
+        stop_price = mark_price * 0.60
         report = await client.submit_order(
             account_id=account_id,
             instrument_id=instrument_id,
-            client_order_id=client_order_id,
+            client_order_id=ClientOrderId(f"stop-{int(datetime.now().timestamp())}"),
             order_side=OrderSide.SELL,
             order_type=OrderType.STOP_MARKET,
             quantity=Quantity.from_int(1),
             time_in_force=TimeInForce.GTC,
             trigger_price=Price.from_str(f"{stop_price:.2f}"),
         )
-
-        venue_order_id = report.venue_order_id
-        print(f"[OK] STOP_MARKET order placed: {venue_order_id}")
-        print(f"  Trigger: {stop_price:.2f}, Status: {report.order_status}")
-        placed_order_ids.append(venue_order_id)
-
+        print(f"    Order: {report.venue_order_id}, Status: {report.order_status}")
+        placed_order_ids.append(report.venue_order_id)
+        results["passed"] += 1
     except Exception as e:
-        error_msg = str(e)
-        if "502" in error_msg:
-            print("[WARN] STOP_MARKET order skipped (testnet API returned 502 - infrastructure issue)")
-        else:
-            print(f"[ERROR] STOP_MARKET order failed: {e}")
+        print(f"    FAILED: {e}")
+        results["failed"] += 1
 
-    await asyncio.sleep(2)  # Longer delay to avoid rate limiting
-
-    # Test 4: STOP_LIMIT order (stop-loss with limit price)
-    print("\n[Test 4/8] Placing STOP_LIMIT order (trigger at 65% with limit at 64%)...")
+    # Test 4: STOP_LIMIT order
+    print("\n[4] STOP_LIMIT order (trigger at 65%, limit at 64%)...")
     try:
-        stop_trigger = float(mark_price) * 0.65  # 65% of market
-        stop_limit = float(mark_price) * 0.64   # 64% of market
-        client_order_id = ClientOrderId(f"test-stop-limit-{int(datetime.now().timestamp())}")
-
+        stop_trigger = mark_price * 0.65
+        stop_limit = mark_price * 0.64
         report = await client.submit_order(
             account_id=account_id,
             instrument_id=instrument_id,
-            client_order_id=client_order_id,
+            client_order_id=ClientOrderId(f"stop-limit-{int(datetime.now().timestamp())}"),
             order_side=OrderSide.SELL,
             order_type=OrderType.STOP_LIMIT,
             quantity=Quantity.from_int(1),
             time_in_force=TimeInForce.GTC,
-            price=Price.from_str(f"{stop_limit:.2f}"),  # Limit price
-            trigger_price=Price.from_str(f"{stop_trigger:.2f}"),  # Stop trigger
+            price=Price.from_str(f"{stop_limit:.2f}"),
+            trigger_price=Price.from_str(f"{stop_trigger:.2f}"),
         )
-
-        venue_order_id = report.venue_order_id
-        print(f"[OK] STOP_LIMIT order placed: {venue_order_id}")
-        print(f"  Trigger: {stop_trigger:.2f}, Limit: {stop_limit:.2f}, Status: {report.order_status}")
-        placed_order_ids.append(venue_order_id)
-
+        print(f"    Order: {report.venue_order_id}, Status: {report.order_status}")
+        placed_order_ids.append(report.venue_order_id)
+        results["passed"] += 1
     except Exception as e:
-        error_msg = str(e)
-        if "502" in error_msg:
-            print("[WARN] STOP_LIMIT order skipped (testnet API returned 502 - infrastructure issue)")
-        else:
-            print(f"[ERROR] STOP_LIMIT order failed: {e}")
+        print(f"    FAILED: {e}")
+        results["failed"] += 1
 
-    await asyncio.sleep(2)  # Longer delay to avoid rate limiting
-
-    # Test 5: MARKET_IF_TOUCHED order (take-profit trigger)
-    print("\n[Test 5/8] Placing MARKET_IF_TOUCHED order (trigger at 150% of market)...")
+    # Test 5: MARKET order
+    print("\n[5] MARKET order...")
     try:
-        profit_price = float(mark_price) * 1.50  # 150% of market (take-profit)
-        # Add a limit price slightly above trigger for take-profit orders
-        limit_price = profit_price * 1.01  # 1% above trigger
-        client_order_id = ClientOrderId(f"test-profit-{int(datetime.now().timestamp())}")
-
         report = await client.submit_order(
             account_id=account_id,
             instrument_id=instrument_id,
-            client_order_id=client_order_id,
-            order_side=OrderSide.SELL,
-            order_type=OrderType.MARKET_IF_TOUCHED,
-            quantity=Quantity.from_int(1),
-            time_in_force=TimeInForce.GTC,
-            price=Price.from_str(f"{limit_price:.2f}"),  # Limit price for execution
-            trigger_price=Price.from_str(f"{profit_price:.2f}"),  # Trigger price
-        )
-
-        venue_order_id = report.venue_order_id
-        print(f"[OK] MARKET_IF_TOUCHED order placed: {venue_order_id}")
-        print(f"  Trigger: {profit_price:.2f}, Limit: {limit_price:.2f}, Status: {report.order_status}")
-        placed_order_ids.append(venue_order_id)
-
-    except Exception as e:
-        print(f"[WARN] MARKET_IF_TOUCHED order skipped (testnet API limitation): {str(e)[:60]}")
-
-    await asyncio.sleep(1)
-
-    # Test 6: MARKET order (immediate execution)
-    print("\n[Test 6/8] Placing MARKET order (immediate execution)...")
-    try:
-        client_order_id = ClientOrderId(f"test-market-{int(datetime.now().timestamp())}")
-
-        report = await client.submit_order(
-            account_id=account_id,
-            instrument_id=instrument_id,
-            client_order_id=client_order_id,
+            client_order_id=ClientOrderId(f"market-{int(datetime.now().timestamp())}"),
             order_side=OrderSide.BUY,
             order_type=OrderType.MARKET,
             quantity=Quantity.from_int(1),
             time_in_force=TimeInForce.IOC,
         )
-
-        print("[OK] MARKET order executed")
-        print(f"  Status: {report.order_status}, Filled: {report.filled_qty}")
-
+        print(f"    Status: {report.order_status}, Filled: {report.filled_qty}")
+        results["passed"] += 1
     except Exception as e:
-        print(f"[ERROR] MARKET order failed: {e}")
+        print(f"    FAILED: {e}")
+        results["failed"] += 1
 
-    await asyncio.sleep(1)
-
-    # Test 7: Close position with reduce_only MARKET order
-    print("\n[Test 7/8] Closing position with reduce_only MARKET order...")
-    try:
-        # Check if we have an open position
-        positions = await client.request_position_status_reports(
-            account_id=account_id,
-            instrument_id=instrument_id,
-        )
-
-        if positions:
-            pos = positions[0]
-            print(f"  Current position size: {pos.quantity}")
-
-            # Close with opposite side based on quantity sign
-            position_qty = pos.quantity.as_double()
-            close_side = OrderSide.SELL if position_qty > 0 else OrderSide.BUY
-            client_order_id = ClientOrderId(f"test-close-{int(datetime.now().timestamp())}")
-
-            report = await client.submit_order(
-                account_id=account_id,
-                instrument_id=instrument_id,
-                client_order_id=client_order_id,
-                order_side=close_side,
-                order_type=OrderType.MARKET,
-                quantity=Quantity.from_str(str(abs(pos.quantity.as_double()))),
-                time_in_force=TimeInForce.IOC,
-                reduce_only=True,
-            )
-
-            print("[OK] Position close order executed")
-            print(f"  Status: {report.order_status}, Filled: {report.filled_qty}")
-        else:
-            print("  No position to close")
-
-    except Exception as e:
-        print(f"[ERROR] Position close failed: {e}")
-
-    # Cleanup: Cancel any remaining open orders
+    # Cleanup: Cancel any remaining orders
     if placed_order_ids:
-        print(f"\n[Cleanup] Cancelling {len(placed_order_ids)} remaining orders...")
+        print(f"\n[Cleanup] Cancelling {len(placed_order_ids)} orders...")
         try:
-            cancelled_count = await client.cancel_all_orders(instrument_id=instrument_id)
-            print(f"[OK] Cancelled {cancelled_count} orders")
+            cancelled = await client.cancel_all_orders(instrument_id=instrument_id)
+            print(f"    Cancelled: {cancelled}")
         except Exception as e:
-            print(f"[ERROR] Cleanup failed: {e}")
+            print(f"    Cleanup failed: {e}")
 
-    # Final status check
-    print("\n[Final Status] Checking open orders and positions...")
-    try:
-        orders = await client.request_order_status_reports(
-            account_id=account_id,
-            open_only=True,
-        )
-        positions = await client.request_position_status_reports(account_id=account_id)
-        print(f"  Open orders: {len(orders)}")
-        print(f"  Open positions: {len(positions)}")
-    except Exception as e:
-        print(f"[ERROR] Status check failed: {e}")
-
-    # Test 8: IOC (Immediate-or-Cancel) LIMIT order
-    print("\n[Test 8/8] Placing IOC LIMIT order (immediate-or-cancel)...")
-    try:
-        ioc_price = float(mark_price) * 0.55  # 55% below market (unlikely to fill)
-        client_order_id = ClientOrderId(f"test-ioc-{int(datetime.now().timestamp())}")
-
-        report = await client.submit_order(
-            account_id=account_id,
-            instrument_id=instrument_id,
-            client_order_id=client_order_id,
-            order_side=OrderSide.BUY,
-            order_type=OrderType.LIMIT,
-            quantity=Quantity.from_int(1),
-            time_in_force=TimeInForce.IOC,  # IOC time in force
-            price=Price.from_str(f"{ioc_price:.2f}"),
-        )
-
-        print("[OK] IOC LIMIT order executed")
-        print(f"  Price: {ioc_price:.2f}, Status: {report.order_status}")
-        # IOC orders auto-cancel if not filled, no need to track
-
-    except Exception as e:
-        error_msg = str(e)
-        if "502" in error_msg:
-            print("[WARN] IOC LIMIT order skipped (testnet API returned 502 - infrastructure issue)")
-        else:
-            print(f"[ERROR] IOC LIMIT order failed: {e}")
-
-    print("\nAll order type tests complete!")
+    print(f"\nResults: {results['passed']} passed, {results['failed']} failed")
 
 
 async def main():
-    """
-    Run the main demo entry point.
-    """
-    print("=== Kraken Futures Adapter Demo (TESTNET) ===\n")
+    api_key = os.environ.get("KRAKEN_TESTNET_API_KEY")
+    api_secret = os.environ.get("KRAKEN_TESTNET_API_SECRET")
 
-    # Check for testnet credentials
-    api_key, api_secret = get_testnet_credentials()
+    if not api_key or not api_secret:
+        print("Set KRAKEN_TESTNET_API_KEY and KRAKEN_TESTNET_API_SECRET")
+        return
 
-    if api_key and api_secret:
-        print(f"Using KRAKEN_TESTNET_API_KEY: {api_key[:8]}...")
-        print(f"Using KRAKEN_TESTNET_API_SECRET: {api_secret[:8]}...\n")
+    client = KrakenFuturesHttpClient(
+        api_key=api_key,
+        api_secret=api_secret,
+        testnet=True,
+    )
 
-        # Create authenticated client
-        client = KrakenFuturesHttpClient(
-            api_key=api_key,
-            api_secret=api_secret,
-            testnet=True,
-        )
-
-        # Test public endpoints and get reference price
-        reference_price = await test_futures_public(client)
-
-        # Test authenticated endpoints
-        account_id = AccountId("KRAKEN-001")
-        await test_futures_authenticated(client, account_id)
-
-        # Test order placement
-        await test_futures_order_placement(client, account_id, reference_price)
-
-    else:
-        print("No testnet credentials found")
-        print("Running public endpoint tests only...\n")
-
-        # Create public client
-        client = KrakenFuturesHttpClient(testnet=True)
-
-        # Test public endpoints only
-        await test_futures_public(client)
-
-    print("\n=== Demo Complete ===")
+    account_id = AccountId("KRAKEN-001")
+    await run_order_tests(client, account_id)
 
 
 if __name__ == "__main__":

--- a/examples/live/kraken/kraken_spot_rest.py
+++ b/examples/live/kraken/kraken_spot_rest.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Kraken Spot REST API order placement.
+
+Places orders for various order types on Kraken Spot mainnet via REST API.
+
+Order Types Tested:
+    1. Market order (buy and sell)
+    2. Limit order (with post-only)
+    3. IOC (Immediate-Or-Cancel) limit order
+
+Environment Variables:
+    KRAKEN_SPOT_API_KEY: Your Kraken Spot API key
+    KRAKEN_SPOT_API_SECRET: Your Kraken Spot API secret
+
+Usage:
+    export KRAKEN_SPOT_API_KEY="your_key"
+    export KRAKEN_SPOT_API_SECRET="your_secret"
+    python kraken_spot_rest.py
+
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+from nautilus_trader.core.nautilus_pyo3 import AccountId
+from nautilus_trader.core.nautilus_pyo3 import ClientOrderId
+from nautilus_trader.core.nautilus_pyo3 import InstrumentId
+from nautilus_trader.core.nautilus_pyo3 import KrakenSpotHttpClient
+from nautilus_trader.core.nautilus_pyo3 import OrderSide
+from nautilus_trader.core.nautilus_pyo3 import OrderType
+from nautilus_trader.core.nautilus_pyo3 import Price
+from nautilus_trader.core.nautilus_pyo3 import Quantity
+from nautilus_trader.core.nautilus_pyo3 import TimeInForce
+from nautilus_trader.core.nautilus_pyo3 import VenueOrderId
+
+
+# -----------------------------------------------------------------------------
+# Configuration Constants
+# -----------------------------------------------------------------------------
+SYMBOL = "ATOM/USDC"
+INSTRUMENT_ID_STR = "ATOM/USDC.KRAKEN"
+QTY = "0.5"
+ACCOUNT_ID_STR = "KRAKEN-001"
+
+# Price multipliers
+LIMIT_BUY_MULTIPLIER = 0.95   # 5% below market
+LIMIT_SELL_MULTIPLIER = 1.05  # 5% above market
+
+# Timing
+SHORT_WAIT = 1  # seconds
+LONG_WAIT = 2   # seconds
+
+
+async def submit_market_order(
+    client: KrakenSpotHttpClient,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    side: OrderSide,
+    prefix: str,
+) -> None:
+    """
+    Submit a market order and print result.
+    """
+    client_order_id = ClientOrderId(f"{prefix}-{int(datetime.now().timestamp())}")
+    try:
+        venue_order_id = await client.submit_order(
+            account_id=account_id,
+            instrument_id=instrument_id,
+            client_order_id=client_order_id,
+            order_side=side,
+            order_type=OrderType.MARKET,
+            quantity=Quantity.from_str(QTY),
+            time_in_force=TimeInForce.IOC,
+        )
+        print(f"    SUCCESS: {venue_order_id}")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+
+
+async def submit_limit_order(
+    client: KrakenSpotHttpClient,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    side: OrderSide,
+    price: float,
+    prefix: str,
+    time_in_force: TimeInForce = TimeInForce.GTC,
+    post_only: bool = False,
+) -> VenueOrderId | None:
+    """
+    Submit a limit order and return venue order ID on success.
+    """
+    client_order_id = ClientOrderId(f"{prefix}-{int(datetime.now().timestamp())}")
+    try:
+        venue_order_id = await client.submit_order(
+            account_id=account_id,
+            instrument_id=instrument_id,
+            client_order_id=client_order_id,
+            order_side=side,
+            order_type=OrderType.LIMIT,
+            quantity=Quantity.from_str(QTY),
+            time_in_force=time_in_force,
+            price=Price.from_str(f"{price:.4f}"),
+            post_only=post_only,
+        )
+        print(f"    SUCCESS: {venue_order_id}")
+        return venue_order_id
+    except Exception as e:
+        print(f"    FAILED: {e}")
+        return None
+
+
+async def run_order_tests(client: KrakenSpotHttpClient, account_id: AccountId) -> None:
+    """
+    Test order placement with various order types via REST API.
+    """
+    instrument_id = InstrumentId.from_str(INSTRUMENT_ID_STR)
+
+    print("\n[SETUP] Loading instruments...")
+    instruments = await client.request_instruments()
+    for inst in instruments:
+        client.cache_instrument(inst)
+    print(f"    Loaded {len(instruments)} instruments")
+
+    reference_price = 7.50
+    print(f"    Reference price: ${reference_price:.4f}")
+
+    print("\n[SETUP] Canceling all open orders...")
+    cancelled = await client.cancel_all_orders()
+    print(f"    Cancelled: {cancelled}")
+    await asyncio.sleep(SHORT_WAIT)
+
+    # TEST 1: MARKET BUY
+    print(f"\n[TEST 1] MARKET BUY Order\n    Symbol: {SYMBOL}, Qty: {QTY}")
+    await submit_market_order(client, account_id, instrument_id, OrderSide.BUY, "market-buy")
+    await asyncio.sleep(LONG_WAIT)
+
+    # TEST 2: MARKET SELL
+    print(f"\n[TEST 2] MARKET SELL Order\n    Symbol: {SYMBOL}, Qty: {QTY}")
+    await submit_market_order(client, account_id, instrument_id, OrderSide.SELL, "market-sell")
+    await asyncio.sleep(LONG_WAIT)
+
+    # TEST 3: LIMIT BUY (post-only)
+    limit_buy_price = reference_price * LIMIT_BUY_MULTIPLIER
+    print(f"\n[TEST 3] LIMIT BUY Order (post-only)\n    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${limit_buy_price:.4f}")
+    venue_id = await submit_limit_order(client, account_id, instrument_id, OrderSide.BUY, limit_buy_price, "limit-buy", post_only=True)
+    await asyncio.sleep(SHORT_WAIT)
+    if venue_id:
+        print("    Canceling limit order...")
+        try:
+            report = await client.cancel_order(account_id=account_id, instrument_id=instrument_id, venue_order_id=venue_id)
+            print(f"    Cancelled: {report.order_status}")
+        except Exception as e:
+            print(f"    Cancel failed: {e}")
+    await asyncio.sleep(SHORT_WAIT)
+
+    # TEST 4: LIMIT SELL
+    print("\n[TEST 4] LIMIT SELL Order\n    Buying position first...")
+    await submit_market_order(client, account_id, instrument_id, OrderSide.BUY, "pre-buy")
+    await asyncio.sleep(LONG_WAIT)
+    limit_sell_price = reference_price * LIMIT_SELL_MULTIPLIER
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${limit_sell_price:.4f}")
+    venue_id = await submit_limit_order(client, account_id, instrument_id, OrderSide.SELL, limit_sell_price, "limit-sell")
+    await asyncio.sleep(SHORT_WAIT)
+    if venue_id:
+        print("    Canceling limit sell order...")
+        try:
+            await client.cancel_order(account_id=account_id, instrument_id=instrument_id, venue_order_id=venue_id)
+        except Exception as e:
+            print(f"    Cancel failed: {e}")
+    print("    Closing position at market...")
+    await submit_market_order(client, account_id, instrument_id, OrderSide.SELL, "close")
+    await asyncio.sleep(LONG_WAIT)
+
+    # TEST 5: IOC LIMIT BUY
+    ioc_price = reference_price * LIMIT_BUY_MULTIPLIER
+    print(f"\n[TEST 5] IOC LIMIT BUY Order\n    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${ioc_price:.4f}")
+    print("    Note: Should cancel immediately if not filled")
+    await submit_limit_order(client, account_id, instrument_id, OrderSide.BUY, ioc_price, "ioc", time_in_force=TimeInForce.IOC)
+    await asyncio.sleep(SHORT_WAIT)
+
+    # Cleanup
+    print("\n[CLEANUP] Canceling any remaining orders...")
+    cancelled = await client.cancel_all_orders()
+    print(f"    Cancelled: {cancelled}")
+
+    print("\n" + "=" * 50)
+    print("REST API Order Type Testing Complete!")
+    print("Tested: Market (Buy/Sell), Limit (Buy/Sell, post-only), IOC")
+    print("=" * 50)
+
+
+async def main() -> None:
+    api_key = os.environ.get("KRAKEN_SPOT_API_KEY")
+    api_secret = os.environ.get("KRAKEN_SPOT_API_SECRET")
+
+    if not api_key or not api_secret:
+        print("Error: Set KRAKEN_SPOT_API_KEY and KRAKEN_SPOT_API_SECRET environment variables")
+        return
+
+    print("Kraken Spot REST API - Order Type Testing")
+    print("=" * 50)
+
+    client = KrakenSpotHttpClient(
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+
+    account_id = AccountId(ACCOUNT_ID_STR)
+    await run_order_tests(client, account_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/live/kraken/kraken_spot_ws.py
+++ b/examples/live/kraken/kraken_spot_ws.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Kraken Spot WebSocket API order placement.
+
+Places orders via WebSocket add_order method on mainnet.
+Uses REST only for instrument loading and cancel_all_orders cleanup.
+
+Order Types Tested:
+    1. Market order (buy and sell)
+    2. Limit order (with post-only)
+    3. IOC (Immediate-Or-Cancel) limit order
+
+Environment Variables:
+    KRAKEN_SPOT_API_KEY: Your Kraken Spot API key
+    KRAKEN_SPOT_API_SECRET: Your Kraken Spot API secret
+
+Usage:
+    export KRAKEN_SPOT_API_KEY="your_key"
+    export KRAKEN_SPOT_API_SECRET="your_secret"
+    python kraken_spot_ws.py
+
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+from nautilus_trader.core.nautilus_pyo3 import AccountId
+from nautilus_trader.core.nautilus_pyo3 import InstrumentId
+from nautilus_trader.core.nautilus_pyo3 import KrakenEnvironment
+from nautilus_trader.core.nautilus_pyo3 import KrakenSpotHttpClient
+from nautilus_trader.core.nautilus_pyo3 import KrakenSpotWebSocketClient
+
+
+# -----------------------------------------------------------------------------
+# Configuration Constants
+# -----------------------------------------------------------------------------
+SYMBOL = "ATOM/USDC"
+INSTRUMENT_ID_STR = "ATOM/USDC.KRAKEN"
+QTY = 0.5
+ACCOUNT_ID_STR = "KRAKEN-001"
+
+# Price multipliers
+LIMIT_BUY_MULTIPLIER = 0.95   # 5% below market
+LIMIT_SELL_MULTIPLIER = 1.05  # 5% above market
+
+# Timing
+SHORT_WAIT = 1   # seconds
+LONG_WAIT = 2    # seconds
+WS_TIMEOUT = 10.0  # seconds
+
+# Reference price for ATOM/USDC
+REFERENCE_PRICE = 7.50
+
+
+def gen_cl_ord_id(prefix: str) -> str:
+    """
+    Generate a client order ID (max 18 chars for Kraken).
+    """
+    ts = int(datetime.now().timestamp()) % 100000
+    return f"{prefix}{ts}"
+
+
+def round_price(price: float, decimals: int = 4) -> float:
+    """
+    Round price to specified decimal places.
+    """
+    return round(price, decimals)
+
+
+def handle_ws_message(msg: object) -> None:
+    """
+    Handle WebSocket messages (execution reports, etc.).
+    """
+    print(f"    [WS] Received: {type(msg).__name__}")
+
+
+async def run_order_tests(
+    rest_client: KrakenSpotHttpClient,
+    ws_client: KrakenSpotWebSocketClient,
+    account_id: AccountId,
+) -> None:
+    """
+    Test order placement via WebSocket add_order method.
+    """
+    instrument_id = InstrumentId.from_str(INSTRUMENT_ID_STR)
+
+    # Load instruments via REST and cache in both clients
+    print("\n[SETUP] Loading instruments...")
+    instruments = await rest_client.request_instruments()
+    for inst in instruments:
+        rest_client.cache_instrument(inst)
+        ws_client.cache_instrument(inst)
+    print(f"    Loaded {len(instruments)} instruments")
+
+    # Connect WebSocket
+    print("\n[SETUP] Connecting WebSocket...")
+    await ws_client.connect(instruments, handle_ws_message)
+    await ws_client.wait_until_active(timeout_secs=WS_TIMEOUT)
+    print(f"    Connected to {ws_client.url}")
+
+    # Authenticate for private channels
+    print("    Authenticating...")
+    await ws_client.authenticate()
+    ws_client.set_account_id(account_id)
+
+    # Subscribe to executions
+    print("    Subscribing to executions...")
+    await ws_client.subscribe_executions(snap_orders=True, snap_trades=True)
+    print("    WebSocket ready for order placement")
+
+    print(f"    Reference price: ${REFERENCE_PRICE:.4f}")
+
+    # Cancel all open orders first via REST
+    print("\n[SETUP] Canceling all open orders via REST...")
+    cancelled = await rest_client.cancel_all_orders()
+    print(f"    Cancelled: {cancelled}")
+
+    await asyncio.sleep(SHORT_WAIT)
+
+    # =========================================================================
+    # TEST 1: MARKET order (BUY) via WebSocket
+    # =========================================================================
+    print("\n[TEST 1] MARKET BUY Order (via WebSocket add_order)")
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}")
+
+    cl_ord_id = gen_cl_ord_id("ws-mkt-b-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="market",
+            side="buy",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            cl_ord_id=cl_ord_id,
+        )
+        print(f"    SUCCESS: cl_ord_id={cl_ord_id}")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+
+    await asyncio.sleep(LONG_WAIT)
+
+    # =========================================================================
+    # TEST 2: MARKET order (SELL) via WebSocket - close position
+    # =========================================================================
+    print("\n[TEST 2] MARKET SELL Order (via WebSocket add_order)")
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}")
+
+    cl_ord_id = gen_cl_ord_id("ws-mkt-s-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="market",
+            side="sell",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            cl_ord_id=cl_ord_id,
+        )
+        print(f"    SUCCESS: cl_ord_id={cl_ord_id}")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+
+    await asyncio.sleep(LONG_WAIT)
+
+    # =========================================================================
+    # TEST 3: LIMIT order (BUY) with post-only via WebSocket
+    # =========================================================================
+    limit_buy_price = round_price(REFERENCE_PRICE * LIMIT_BUY_MULTIPLIER)
+    print("\n[TEST 3] LIMIT BUY Order (post-only, via WebSocket)")
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${limit_buy_price:.4f}")
+
+    cl_ord_id = gen_cl_ord_id("ws-lmt-b-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="limit",
+            side="buy",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            limit_price=limit_buy_price,
+            cl_ord_id=cl_ord_id,
+            time_in_force="gtc",
+            post_only=True,
+        )
+        print(f"    SUCCESS: cl_ord_id={cl_ord_id}")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+
+    await asyncio.sleep(SHORT_WAIT)
+
+    # Cancel via REST
+    print("    Canceling limit order via REST...")
+    cancelled = await rest_client.cancel_all_orders()
+    print(f"    Cancelled: {cancelled}")
+
+    await asyncio.sleep(SHORT_WAIT)
+
+    # =========================================================================
+    # TEST 4: LIMIT order (SELL) via WebSocket
+    # =========================================================================
+    print("\n[TEST 4] LIMIT SELL Order (via WebSocket)")
+    print("    Buying position first...")
+
+    cl_ord_id = gen_cl_ord_id("ws-pre-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="market",
+            side="buy",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            cl_ord_id=cl_ord_id,
+        )
+    except Exception as e:
+        print(f"    Pre-buy failed: {e}")
+
+    await asyncio.sleep(LONG_WAIT)
+
+    limit_sell_price = round_price(REFERENCE_PRICE * LIMIT_SELL_MULTIPLIER)
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${limit_sell_price:.4f}")
+
+    cl_ord_id = gen_cl_ord_id("ws-lmt-s-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="limit",
+            side="sell",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            limit_price=limit_sell_price,
+            cl_ord_id=cl_ord_id,
+            time_in_force="gtc",
+        )
+        print(f"    SUCCESS: cl_ord_id={cl_ord_id}")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+
+    await asyncio.sleep(SHORT_WAIT)
+
+    # Cancel and close position
+    print("    Canceling limit sell order via REST...")
+    await rest_client.cancel_all_orders()
+
+    # Close at market
+    print("    Closing position at market...")
+    cl_ord_id = gen_cl_ord_id("ws-cls-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="market",
+            side="sell",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            cl_ord_id=cl_ord_id,
+        )
+    except Exception as e:
+        print(f"    Close failed: {e}")
+
+    await asyncio.sleep(LONG_WAIT)
+
+    # =========================================================================
+    # TEST 5: IOC LIMIT order via WebSocket
+    # =========================================================================
+    ioc_price = round_price(REFERENCE_PRICE * LIMIT_BUY_MULTIPLIER)
+    print("\n[TEST 5] IOC LIMIT BUY Order (via WebSocket)")
+    print(f"    Symbol: {SYMBOL}, Qty: {QTY}, Price: ${ioc_price:.4f}")
+    print("    Note: Should cancel immediately if not filled")
+
+    cl_ord_id = gen_cl_ord_id("ws-ioc-")
+    ws_client.cache_client_order(cl_ord_id, instrument_id)
+
+    try:
+        await ws_client.add_order(
+            order_type="limit",
+            side="buy",
+            order_qty=QTY,
+            symbol=SYMBOL,
+            limit_price=ioc_price,
+            cl_ord_id=cl_ord_id,
+            time_in_force="ioc",
+        )
+        print(f"    SUCCESS: cl_ord_id={cl_ord_id}")
+    except Exception as e:
+        print(f"    FAILED (expected if not filled): {e}")
+
+    await asyncio.sleep(SHORT_WAIT)
+
+    # =========================================================================
+    # Cleanup
+    # =========================================================================
+    print("\n[CLEANUP] Canceling any remaining orders...")
+    cancelled = await rest_client.cancel_all_orders()
+    print(f"    Cancelled: {cancelled}")
+
+    print("\n[CLEANUP] Disconnecting WebSocket...")
+    await ws_client.disconnect()
+    print("    Disconnected")
+
+    print("\n" + "=" * 60)
+    print("WebSocket add_order Testing Complete!")
+    print("Tested: Market (Buy/Sell), Limit (Buy/Sell, post-only), IOC")
+    print("All orders placed via WebSocket add_order method")
+    print("=" * 60)
+
+
+async def main() -> None:
+    api_key = os.environ.get("KRAKEN_SPOT_API_KEY")
+    api_secret = os.environ.get("KRAKEN_SPOT_API_SECRET")
+
+    if not api_key or not api_secret:
+        print("Error: Set KRAKEN_SPOT_API_KEY and KRAKEN_SPOT_API_SECRET environment variables")
+        return
+
+    print("Kraken Spot WebSocket API - Order Type Testing")
+    print("=" * 60)
+    print("Orders placed via WebSocket add_order method")
+    print("REST used only for instrument loading and cancel_all")
+    print("=" * 60)
+
+    # Create REST client for instrument loading and cancel_all
+    rest_client = KrakenSpotHttpClient(
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+
+    # Create WebSocket client for order placement
+    ws_client = KrakenSpotWebSocketClient(
+        environment=KrakenEnvironment.MAINNET,
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+
+    account_id = AccountId(ACCOUNT_ID_STR)
+    await run_order_tests(rest_client, ws_client, account_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -8117,6 +8117,19 @@ class KrakenSpotWebSocketClient:
     async def unsubscribe_trades(self, instrument_id: InstrumentId) -> None: ...
     async def unsubscribe_bars(self, bar_type: BarType) -> None: ...
     async def send_ping(self) -> None: ...
+    async def add_order(
+        self,
+        order_type: str,
+        side: str,
+        order_qty: float,
+        symbol: str,
+        limit_price: float | None = None,
+        trigger_price: float | None = None,
+        trigger_reference: str | None = None,
+        cl_ord_id: str | None = None,
+        time_in_force: str | None = None,
+        post_only: bool | None = None,
+    ) -> None: ...
 
 class KrakenFuturesWebSocketClient:
     def __init__(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Add Kraken spot order placement support via REST and WebSocket APIs. Implements `submit_order` on `KrakenSpotHttpClient` and exposes `add_order` on `KrakenSpotWebSocketClient` to Python, supporting Market, Limit, and IOC order types with proper `timeinforce` and `cl_ord_id` handling per Kraken API specs.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Tested via Rust binaries (`kraken-spot-order-rest`, `kraken-spot-order-ws`) and Python examples (`kraken_spot_rest.py`, `kraken_spot_ws.py`) against Kraken mainnet. All order types (Market Buy/Sell, Limit Buy/Sell with post-only, IOC Limit) pass successfully.