### PR TITLE
Fix ParquetDataCatalog.from_uri to support Windows paths

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -215,7 +215,8 @@ class ParquetDataCatalog(BaseDataCatalog):
         """
         if "://" not in uri:
             # Assume a local path
-            uri = "file://" + uri
+            # .resolve() will return absolute path in case relative one is provided, and .as_uri() will return path that follows RFC3986
+            uri = Path(uri).resolve().as_uri()
 
         parsed = infer_storage_options(uri)
         path = parsed.pop("path")


### PR DESCRIPTION
ParquetDataCatalog.from_uri() method incorrectly handles local paths in Windows.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

ParquetDataCatalog.from_uri() method incorrectly handles local paths. It unconditionally adds "file://" prefix and then tries to use urllib.parse.urlsplit which expects URL according to RFC3986. Now, this does not work with *all* relative paths and with Windows paths.

For example:
  "../../market_data/databento/nautilus_data/catalog" will be processed incorrectly
  "E:\market_data\databento\nautilus_data\catalog" will trigger exception
  
My suggestion is always resolve relative path to full one and then convert to URI using Path(uri).as_uri()


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
