### PR TITLE
Improve dYdX v4 model type safety with enums and Python bindings

### DIFF
--- a/crates/adapters/dydx/src/common/enums.rs
+++ b/crates/adapters/dydx/src/common/enums.rs
@@ -575,9 +575,13 @@ pub enum DydxTradeType {
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.dydx", eq, eq_int)
 )]
 pub enum DydxTransferType {
+    /// Transfer into the account.
     TransferIn,
+    /// Transfer out of the account.
     TransferOut,
+    /// Deposit from external wallet.
     Deposit,
+    /// Withdrawal to external wallet.
     Withdrawal,
 }
 

--- a/crates/adapters/dydx/src/http/models.rs
+++ b/crates/adapters/dydx/src/http/models.rs
@@ -393,7 +393,8 @@ pub struct Order {
     /// Post-only flag.
     pub post_only: bool,
     /// Order flags (bitfield).
-    pub order_flags: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub order_flags: u32,
     /// Good-til-block (for short-term orders).
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -502,7 +503,7 @@ pub struct TransfersResponse {
 pub struct Transfer {
     /// Unique transfer ID.
     pub id: String,
-    /// Transfer type.
+    /// Transfer type (DEPOSIT, WITHDRAWAL, TRANSFER_OUT, TRANSFER_IN).
     #[serde(rename = "type")]
     pub transfer_type: DydxTransferType,
     /// Sender address.

--- a/crates/adapters/dydx/src/http/parse.rs
+++ b/crates/adapters/dydx/src/http/parse.rs
@@ -798,6 +798,34 @@ mod tests {
         assert_eq!(deposit.asset, "USDC");
         assert_eq!(deposit.amount.to_string(), "45.334703");
     }
+
+    #[rstest]
+    fn test_transfer_type_enum_serde() {
+        // Test all transfer type variants serialize/deserialize correctly
+        let test_cases = vec![
+            (DydxTransferType::Deposit, "\"DEPOSIT\""),
+            (DydxTransferType::Withdrawal, "\"WITHDRAWAL\""),
+            (DydxTransferType::TransferIn, "\"TRANSFER_IN\""),
+            (DydxTransferType::TransferOut, "\"TRANSFER_OUT\""),
+        ];
+
+        for (variant, expected_json) in test_cases {
+            // Test serialization
+            let serialized = serde_json::to_string(&variant).expect("Failed to serialize");
+            assert_eq!(
+                serialized, expected_json,
+                "Serialization failed for {variant:?}"
+            );
+
+            // Test deserialization
+            let deserialized: DydxTransferType =
+                serde_json::from_str(&serialized).expect("Failed to deserialize");
+            assert_eq!(
+                deserialized, variant,
+                "Deserialization failed for {variant:?}"
+            );
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1349,7 +1377,7 @@ mod reconciliation_tests {
             time_in_force: DydxTimeInForce::Gtt,
             reduce_only: false,
             post_only: false,
-            order_flags: "0".to_string(),
+            order_flags: 0,
             good_til_block: None,
             good_til_block_time: Some(Utc::now()),
             created_at_height: Some(1000),
@@ -1399,7 +1427,7 @@ mod reconciliation_tests {
             time_in_force: DydxTimeInForce::Gtt,
             reduce_only: true,
             post_only: false,
-            order_flags: "0".to_string(),
+            order_flags: 0,
             good_til_block: None,
             good_til_block_time: Some(Utc::now()),
             created_at_height: Some(1000),
@@ -1577,7 +1605,7 @@ mod reconciliation_tests {
             time_in_force: DydxTimeInForce::Gtt,
             reduce_only: false,
             post_only: false,
-            order_flags: "0".to_string(),
+            order_flags: 0,
             good_til_block: Some(1000),
             good_til_block_time: None,
             created_at_height: Some(900),
@@ -1624,7 +1652,7 @@ mod reconciliation_tests {
             time_in_force: DydxTimeInForce::Gtt,
             reduce_only: false,
             post_only: false,
-            order_flags: "0".to_string(),
+            order_flags: 0,
             good_til_block: Some(2000),
             good_til_block_time: None,
             created_at_height: Some(1500),

--- a/crates/adapters/dydx/src/websocket/parse.rs
+++ b/crates/adapters/dydx/src/websocket/parse.rs
@@ -142,6 +142,11 @@ fn convert_ws_order_to_http(
         .parse()
         .context("Failed to parse client_metadata")?;
 
+    let order_flags: u32 = ws_order
+        .order_flags
+        .parse()
+        .context("Failed to parse order_flags")?;
+
     // Parse optional fields
     let good_til_block = ws_order
         .good_til_block
@@ -189,7 +194,7 @@ fn convert_ws_order_to_http(
         time_in_force: ws_order.time_in_force,
         reduce_only: ws_order.reduce_only,
         post_only: ws_order.post_only,
-        order_flags: ws_order.order_flags.clone(),
+        order_flags,
         good_til_block,
         good_til_block_time,
         created_at_height: Some(created_at_height),

--- a/crates/adapters/dydx/tests/execution.rs
+++ b/crates/adapters/dydx/tests/execution.rs
@@ -176,7 +176,7 @@ fn create_test_order() -> Order {
         time_in_force: DydxTimeInForce::Gtt,
         post_only: false,
         reduce_only: false,
-        order_flags: "0".to_string(),
+        order_flags: 0,
         good_til_block: Some(12400),
         good_til_block_time: None,
         created_at_height: Some(12345),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Improve dYdX v4 adapter model correctness by replacing stringly-typed fields with enums where the wire format is known/stable, tightening naming, and keeping Rust/Python surfaces aligned via PyO3.

Key changes:
- Add `DydxTransferType` enum (+ PyO3 binding) and use it for HTTP `Transfer.transfer_type`.
- Expose `DydxCandleResolution` as a PyO3 enum and use it for WS `DydxCandle.resolution`.
- Rename WS trade field `order_type` → `trade_type` (still mapped from JSON `type` via Serde).
- Align HTTP request `order_flags` fields with current payload encoding by modeling them as `String`.

## Related Issues/PRs

- Related to #3151
- Follow-up to #3294 (merged)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Source-breaking changes for downstream Rust code consuming these adapter models:
- `Transfer.transfer_type: String` → `Transfer.transfer_type: DydxTransferType`
- `DydxCandle.resolution: String` → `DydxCandle.resolution: DydxCandleResolution`
- `PlaceOrderRequest.order_flags: u32` → `PlaceOrderRequest.order_flags: String`
- `CancelOrderRequest.order_flags: u32` → `CancelOrderRequest.order_flags: String`
- Field rename: `DydxTrade.order_type` → `DydxTrade.trade_type`

Serde wire format is unchanged for the enum/name changes (`type`/`resolution` still serialize to the same values), but `order_flags` will now serialize as a JSON string.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Updated/added tests:
- `crates/adapters/dydx/src/http/parse.rs` (transfer type enum deserialization + serde round-trip)
