### PR TITLE
Add IB optional exchange param for spread contracts

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -334,10 +334,9 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
                 f"Requesting instrument {request.instrument_id} with specified `end` which has no effect",
             )
 
-        force_instrument_update = request.params.get("force_instrument_update", False)
         await self.instrument_provider.load_with_return_async(
             request.instrument_id,
-            force_instrument_update=force_instrument_update,
+            request.params,
         )
 
         if instrument := self.instrument_provider.find(request.instrument_id):
@@ -349,7 +348,6 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         self._handle_instrument(instrument, request.id, request.start, request.end, request.params)
 
     async def _request_instruments(self, request: RequestInstruments) -> None:
-        force_instrument_update = request.params.get("force_instrument_update", False)
         loaded_instrument_ids: list[InstrumentId] = []
 
         if "ib_contracts" in request.params:
@@ -357,7 +355,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             ib_contracts = [IBContract(**d) for d in request.params["ib_contracts"]]
             loaded_instrument_ids = await self.instrument_provider.load_ids_with_return_async(
                 ib_contracts,
-                force_instrument_update=force_instrument_update,
+                request.params,
             )
             loaded_instruments: list[Instrument] = []
 
@@ -389,7 +387,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         instrument_ids = [instrument.id for instrument in instruments]
         loaded_instrument_ids = await self.instrument_provider.load_ids_with_return_async(
             instrument_ids,
-            force_instrument_update=force_instrument_update,
+            request.params,
         )
         self._handle_instruments(
             venue=request.venue,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Allows to pass an "exchange" key to the params argument in request_instrument in order to override "SMART" as default exchange.
- Refactored the passing of params arguments to the IB instrument provider, passing params to the filters argument

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
