### PR TITLE
Continue implementing Deribit data client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,6 +5790,7 @@ dependencies = [
  "anyhow",
  "aws-lc-rs",
  "axum",
+ "chrono",
  "hex",
  "log",
  "nautilus-common",

--- a/crates/adapters/deribit/src/data/mod.rs
+++ b/crates/adapters/deribit/src/data/mod.rs
@@ -32,10 +32,10 @@ use nautilus_common::{
             RequestInstruments, RequestTrades, SubscribeBars, SubscribeBookDeltas,
             SubscribeBookDepth10, SubscribeBookSnapshots, SubscribeFundingRates,
             SubscribeIndexPrices, SubscribeInstrument, SubscribeInstruments, SubscribeMarkPrices,
-            SubscribeQuotes, SubscribeTrades, UnsubscribeBars, UnsubscribeBookDeltas,
-            UnsubscribeBookDepth10, UnsubscribeBookSnapshots, UnsubscribeFundingRates,
-            UnsubscribeIndexPrices, UnsubscribeInstrument, UnsubscribeInstruments,
-            UnsubscribeMarkPrices, UnsubscribeQuotes, UnsubscribeTrades,
+            SubscribeQuotes, SubscribeTrades, TradesResponse, UnsubscribeBars,
+            UnsubscribeBookDeltas, UnsubscribeBookDepth10, UnsubscribeBookSnapshots,
+            UnsubscribeFundingRates, UnsubscribeIndexPrices, UnsubscribeInstrument,
+            UnsubscribeInstruments, UnsubscribeMarkPrices, UnsubscribeQuotes, UnsubscribeTrades,
         },
     },
 };
@@ -469,8 +469,46 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn request_trades(&self, _request: &RequestTrades) -> anyhow::Result<()> {
-        todo!("Implement request_trades");
+    fn request_trades(&self, request: &RequestTrades) -> anyhow::Result<()> {
+        let http_client = self.http_client.clone();
+        let sender = self.data_sender.clone();
+        let instrument_id = request.instrument_id;
+        let start = request.start;
+        let end = request.end;
+        let limit = request.limit.map(|n| n.get() as u32);
+        let request_id = request.request_id;
+        let client_id = request.client_id.unwrap_or(self.client_id);
+        let params = request.params.clone();
+        let clock = self.clock;
+        let start_nanos = datetime_to_unix_nanos(start);
+        let end_nanos = datetime_to_unix_nanos(end);
+
+        get_runtime().spawn(async move {
+            match http_client
+                .request_trades(instrument_id, start, end, limit)
+                .await
+                .context("failed to request trades from Deribit")
+            {
+                Ok(trades) => {
+                    let response = DataResponse::Trades(TradesResponse::new(
+                        request_id,
+                        client_id,
+                        instrument_id,
+                        trades,
+                        start_nanos,
+                        end_nanos,
+                        clock.get_time_ns(),
+                        params,
+                    ));
+                    if let Err(e) = sender.send(DataEvent::Response(response)) {
+                        tracing::error!("Failed to send trades response: {e}");
+                    }
+                }
+                Err(e) => tracing::error!("Trades request failed for {}: {:?}", instrument_id, e),
+            }
+        });
+
+        Ok(())
     }
 
     fn request_bars(&self, _request: &RequestBars) -> anyhow::Result<()> {

--- a/crates/adapters/deribit/src/http/models.rs
+++ b/crates/adapters/deribit/src/http/models.rs
@@ -450,3 +450,67 @@ pub struct DeribitAccountSummaryExtended {
     #[serde(default)]
     pub block_rfq_self_match_prevention: Option<bool>,
 }
+
+/// Deribit public trade data from the market data API.
+///
+/// Represents a single trade returned by `/public/get_last_trades_by_instrument_and_time`
+/// and other trade-related endpoints.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeribitPublicTrade {
+    /// Trade amount. For perpetual and inverse futures the amount is in USD units.
+    /// For options and linear futures it is the underlying base currency coin.
+    pub amount: f64,
+    /// Trade size in contract units (optional, may be absent in historical trades).
+    #[serde(default)]
+    pub contracts: Option<f64>,
+    /// Direction of the trade: "buy" or "sell"
+    pub direction: String,
+    /// Index Price at the moment of trade.
+    pub index_price: f64,
+    /// Unique instrument identifier.
+    pub instrument_name: String,
+    /// Option implied volatility for the price (Option only).
+    #[serde(default)]
+    pub iv: Option<f64>,
+    /// Optional field (only for trades caused by liquidation).
+    #[serde(default)]
+    pub liquidation: Option<String>,
+    /// Mark Price at the moment of trade.
+    pub mark_price: f64,
+    /// Price in base currency.
+    pub price: f64,
+    /// Direction of the "tick" (0 = Plus Tick, 1 = Zero-Plus Tick, 2 = Minus Tick, 3 = Zero-Minus Tick).
+    pub tick_direction: i32,
+    /// The timestamp of the trade (milliseconds since the UNIX epoch).
+    pub timestamp: i64,
+    /// Unique (per currency) trade identifier.
+    pub trade_id: String,
+    /// The sequence number of the trade within instrument.
+    pub trade_seq: i64,
+    /// Block trade id - when trade was part of a block trade.
+    #[serde(default)]
+    pub block_trade_id: Option<String>,
+    /// Block trade leg count - when trade was part of a block trade.
+    #[serde(default)]
+    pub block_trade_leg_count: Option<i32>,
+    /// ID of the Block RFQ - when trade was part of the Block RFQ.
+    #[serde(default)]
+    pub block_rfq_id: Option<i64>,
+    /// Optional field containing combo instrument name if the trade is a combo trade.
+    #[serde(default)]
+    pub combo_id: Option<String>,
+    /// Optional field containing combo trade identifier if the trade is a combo trade.
+    #[serde(default)]
+    pub combo_trade_id: Option<f64>,
+}
+
+/// Response wrapper for trades endpoints.
+///
+/// Contains the trades array and pagination information.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeribitTradesResponse {
+    /// Whether there are more trades available.
+    pub has_more: bool,
+    /// Array of trade objects.
+    pub trades: Vec<DeribitPublicTrade>,
+}

--- a/crates/adapters/deribit/src/http/query.rs
+++ b/crates/adapters/deribit/src/http/query.rs
@@ -92,3 +92,43 @@ impl GetAccountSummariesParams {
         }
     }
 }
+
+/// Query parameters for `/public/get_last_trades_by_instrument_and_time` endpoint.
+#[derive(Clone, Debug, Deserialize, Serialize, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct GetLastTradesByInstrumentAndTimeParams {
+    /// Instrument name (e.g., "BTC-PERPETUAL")
+    pub instrument_name: String,
+    /// The earliest timestamp to return result from (milliseconds since the UNIX epoch)
+    pub start_timestamp: i64,
+    /// The most recent timestamp to return result from (milliseconds since the UNIX epoch)
+    pub end_timestamp: i64,
+    /// Number of requested items, default - 10, maximum - 1000
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub count: Option<u32>,
+    /// Direction of results sorting: "asc", "desc", or "default"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub sorting: Option<String>,
+}
+
+impl GetLastTradesByInstrumentAndTimeParams {
+    /// Creates a new instance with the required parameters.
+    #[must_use]
+    pub fn new(
+        instrument_name: impl Into<String>,
+        start_timestamp: i64,
+        end_timestamp: i64,
+        count: Option<u32>,
+        sorting: Option<String>,
+    ) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            start_timestamp,
+            end_timestamp,
+            count,
+            sorting,
+        }
+    }
+}

--- a/crates/adapters/deribit/test_data/http_get_last_trades.json
+++ b/crates/adapters/deribit/test_data/http_get_last_trades.json
@@ -1,0 +1,143 @@
+{
+  "id": 2,
+  "jsonrpc": "2.0",
+  "result": {
+    "has_more": true,
+    "trades": [
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2967.73,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.01,
+        "price": 2968.3,
+        "tick_direction": 0,
+        "timestamp": 1766332040636,
+        "trade_id": "ETH-284830839",
+        "trade_seq": 203024587
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2967.63,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2967.91,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332047406,
+        "trade_id": "ETH-284830843",
+        "trade_seq": 203024588
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2967.63,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2967.91,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332047588,
+        "trade_id": "ETH-284830844",
+        "trade_seq": 203024589
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2967.64,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2967.93,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332053559,
+        "trade_id": "ETH-284830845",
+        "trade_seq": 203024590
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2967.93,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.25,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332059546,
+        "trade_id": "ETH-284830846",
+        "trade_seq": 203024591
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2968.03,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.36,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332065501,
+        "trade_id": "ETH-284830847",
+        "trade_seq": 203024592
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2968.02,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.35,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332071115,
+        "trade_id": "ETH-284830848",
+        "trade_seq": 203024593
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2968.02,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.35,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332077402,
+        "trade_id": "ETH-284830849",
+        "trade_seq": 203024594
+      },
+      {
+        "amount": 1.0,
+        "contracts": 1.0,
+        "direction": "sell",
+        "index_price": 2968.02,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.35,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332079917,
+        "trade_id": "ETH-284830853",
+        "trade_seq": 203024595
+      },
+      {
+        "amount": 106.0,
+        "contracts": 106.0,
+        "direction": "buy",
+        "index_price": 2968.02,
+        "instrument_name": "ETH-PERPETUAL",
+        "mark_price": 2968.35,
+        "price": 2968.3,
+        "tick_direction": 1,
+        "timestamp": 1766332079917,
+        "trade_id": "ETH-284830854",
+        "trade_seq": 203024596
+      }
+    ]
+  },
+  "testnet": false,
+  "usDiff": 384,
+  "usIn": 1766335632425192,
+  "usOut": 1766335632425576
+}

--- a/crates/testkit/Cargo.toml
+++ b/crates/testkit/Cargo.toml
@@ -49,6 +49,7 @@ nautilus-trading = { workspace = true }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 aws-lc-rs = { workspace = true }
+chrono = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }

--- a/nautilus_trader/adapters/deribit/data.py
+++ b/nautilus_trader/adapters/deribit/data.py
@@ -26,9 +26,11 @@ from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.common.secure import mask_api_key
 from nautilus_trader.core import nautilus_pyo3
+from nautilus_trader.core.datetime import ensure_pydatetime_utc
 from nautilus_trader.core.nautilus_pyo3 import DeribitCurrency
 from nautilus_trader.data.messages import RequestInstrument
 from nautilus_trader.data.messages import RequestInstruments
+from nautilus_trader.data.messages import RequestTradeTicks
 from nautilus_trader.data.messages import SubscribeOrderBook
 from nautilus_trader.data.messages import SubscribeQuoteTicks
 from nautilus_trader.data.messages import SubscribeTradeTicks
@@ -38,6 +40,7 @@ from nautilus_trader.data.messages import UnsubscribeTradeTicks
 from nautilus_trader.live.cancellation import DEFAULT_FUTURE_CANCELLATION_TIMEOUT
 from nautilus_trader.live.cancellation import cancel_tasks_with_timeout
 from nautilus_trader.live.data_client import LiveMarketDataClient
+from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.data import capsule_to_data
 from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.enums import book_type_to_str
@@ -288,13 +291,41 @@ class DeribitDataClient(LiveMarketDataClient):
         else:
             instruments = await self._fetch_instruments_for_currency(
                 DeribitCurrency.ANY,
-                nautilus_pyo3.DeribitInstrumentKind.Future,
+                nautilus_pyo3.DeribitInstrumentKind.FUTURE,
             )
             all_instruments.extend(instruments)
 
         self._handle_instruments(
             request.venue,
             all_instruments,
+            request.id,
+            request.start,
+            request.end,
+            request.params,
+        )
+
+    async def _request_trade_ticks(self, request: RequestTradeTicks) -> None:
+        pyo3_instrument_id = nautilus_pyo3.InstrumentId.from_str(request.instrument_id.value)
+
+        try:
+            pyo3_trades = await self._http_client.request_trades(
+                instrument_id=pyo3_instrument_id,
+                start=ensure_pydatetime_utc(request.start),
+                end=ensure_pydatetime_utc(request.end),
+                limit=request.limit or None,
+            )
+        except Exception as e:
+            self._log.exception(
+                f"Failed to request trades for {request.instrument_id}",
+                e,
+            )
+            return
+
+        trades = TradeTick.from_pyo3_list(pyo3_trades)
+
+        self._handle_trade_ticks(
+            request.instrument_id,
+            trades,
             request.id,
             request.start,
             request.end,

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -6859,6 +6859,13 @@ class DeribitHttpClient:
         kind: DeribitInstrumentKind | None = None,
     ) -> list[Instrument]: ...
     async def request_instrument(self, instrument_id: InstrumentId) -> Instrument: ...
+    async def request_trades(
+        self,
+        instrument_id: InstrumentId,
+        start: dt.datetime | None = None,
+        end: dt.datetime | None = None,
+        limit: int | None = None,
+    ) -> list[TradeTick]: ...
     async def request_account_state(self, account_id: AccountId) -> AccountState: ...
 
 class DeribitWebSocketClient:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR continues the implementation of the Deribit data client by adding request functionality for instruments and trade ticks. These changes enable fetching historical market data through the Deribit HTTP API.

### Changes

#### Instrument Requests (`request_instruments`)
- Implement `request_instruments` in `DeribitDataClient` to fetch all instruments by kind
- Iterate over configured `instrument_kinds` (defaults to `Future` if not specified)
- Use `DeribitCurrency::ANY` to fetch instruments across all currencies
- Cache fetched instruments in the client's instrument store
- Send `InstrumentsResponse` via data channel after collection
- Add warnings when `start`/`end` parameters are specified (not supported by Deribit)

#### Trade Tick Requests (`request_trades`)
- Implement `request_trades` in `DeribitDataClient` with async HTTP fetching
- Add `get_last_trades_by_instrument_and_time` HTTP endpoint in `DeribitRawHttpClient`
- New query parameters struct `GetLastTradesByInstrumentAndTimeParams` with:
  - `instrument_name`, `start_timestamp`, `end_timestamp`
  - Optional `count` (max 1000) and `sorting` direction
- Add `DeribitPublicTrade` model with full trade data fields:
  - `amount`, `price`, `direction`, `trade_id`, `timestamp`
  - Optional fields: `iv`, `liquidation`, `combo_id`, `block_trade_id`
- Add `DeribitTradesResponse` wrapper with `has_more` pagination flag
- Implement `parse_trade_tick` parser converting Deribit trades to Nautilus `TradeTick`:
  - Maps `direction` ("buy"/"sell") to `AggressorSide`
  - Converts millisecond timestamps to `UnixNanos`
  - Uses cached instrument precisions (fallback to 8 decimals)
- Add `request_trades` helper in `DeribitHttpClient` with time range handling

#### Python Bindings
- Expose `request_trades` method in Python HTTP client (`python/http.rs`)
- Add Python type stub in `nautilus_pyo3.pyi`
- Update `DeribitDataClient.request_trade_ticks` to call Rust implementation

#### Testing
- Add test fixture `http_get_last_trades.json` with 10 sample ETH-PERPETUAL trades
- Add unit tests for `parse_trade_tick` covering buy/sell directions
- Add integration tests in `http_public.rs` for trade tick requests
- Extend `DataClientTester` in testkit with trade request validation
- Add `chrono` dependency to testkit for timestamp handling

## Related Issues/PRs

- https://github.com/nautechsystems/nautilus_trader/issues/3269

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

