### PR TITLE
Allow separate aggregators for historical data

### DIFF
--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -94,8 +94,8 @@ cdef class DataEngine(Component):
     cdef readonly dict[ClientId, DataClient] _clients
     cdef readonly dict[Venue, DataClient] _routing_map
     cdef readonly dict _order_book_intervals
-    cdef readonly dict[BarType, BarAggregator] _bar_aggregators
-    cdef readonly dict[InstrumentId, SpreadQuoteAggregator] _spread_quote_aggregators
+    cdef readonly dict[tuple, BarAggregator] _bar_aggregators
+    cdef readonly dict[tuple, SpreadQuoteAggregator] _spread_quote_aggregators
     cdef readonly dict[InstrumentId, list] _spread_quote_aggregator_handlers
     cdef readonly dict[InstrumentId, list[SyntheticInstrument]] _synthetic_quote_feeds
     cdef readonly dict[InstrumentId, list[SyntheticInstrument]] _synthetic_trade_feeds
@@ -280,25 +280,28 @@ cdef class DataEngine(Component):
 
 # -- INTERNAL - Bar Aggregators --------------------------------------------------------------------
 
+    cdef tuple _get_bar_aggregator_key(self, BarType bar_type, UUID4 request_id = *)
+    cdef tuple _get_spread_quote_aggregator_key(self, InstrumentId spread_instrument_id, UUID4 request_id = *)
+    cdef list _get_bar_types_from_aggregators(self)
     cpdef void _init_historical_aggregators(self, RequestData request)
     cpdef void _start_bar_aggregator(self, MarketDataClient client, SubscribeBars command)
-    cpdef BarAggregator _create_bar_aggregator(self, BarType bar_type, dict params)
-    cpdef void _setup_bar_aggregator(self, BarType bar_type, bint historical = *)
+    cpdef BarAggregator _create_bar_aggregator(self, BarType bar_type, dict params, UUID4 request_id = *)
+    cpdef void _setup_bar_aggregator(self, BarType bar_type, bint historical = *, UUID4 request_id = *)
     cpdef void _subscribe_bar_aggregator(self, MarketDataClient client, SubscribeBars command)
-    cpdef void _handle_aggregated_bars(self, DataResponse response)
+    cpdef void _finalize_aggregated_bars_request(self, DataResponse response)
     cpdef void _stop_bar_aggregator(self, MarketDataClient client, UnsubscribeBars command)
-    cpdef void _dispose_bar_aggregator(self, BarType bar_type, bint historical = *)
+    cpdef void _dispose_bar_aggregator(self, BarType bar_type, bint historical = *, UUID4 request_id = *)
     cpdef void _unsubscribe_bar_aggregator(self, MarketDataClient client, UnsubscribeBars command)
 
 # -- INTERNAL - Spread Quote Aggregators ----------------------------------------------------------
 
     cpdef void _start_spread_quote_aggregator(self, MarketDataClient client, SubscribeQuoteTicks command)
     cpdef void _subscribe_spread_quote_aggregator(self, MarketDataClient client, SubscribeQuoteTicks command)
-    cpdef void _create_spread_quote_aggregator(self, InstrumentId spread_instrument_id, dict params, bint historical = *)
-    cpdef void _setup_spread_quote_aggregator(self, InstrumentId spread_instrument_id, bint historical = *)
+    cpdef void _create_spread_quote_aggregator(self, InstrumentId spread_instrument_id, dict params, bint historical = *, UUID4 request_id = *)
+    cpdef void _setup_spread_quote_aggregator(self, InstrumentId spread_instrument_id, bint historical = *, UUID4 request_id = *)
     cpdef void _handle_spread_quote(self, Data quote)
     cpdef void _stop_spread_quote_aggregator(self, MarketDataClient client, UnsubscribeQuoteTicks command)
-    cpdef void _dispose_spread_quote_aggregator(self, InstrumentId spread_instrument_id, bint historical=*)
+    cpdef void _dispose_spread_quote_aggregator(self, InstrumentId spread_instrument_id, bint historical=*, UUID4 request_id = *)
     cpdef void _unsubscribe_spread_quote_aggregator(self, MarketDataClient client, UnsubscribeQuoteTicks command)
 
 cdef class SnapshotInfo:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Allow separate aggregators for historical data

This PR implements separate aggregator instances for historical data requests and live subscriptions, preventing historical data from polluting live aggregators when requesting aggregated bars or spread quotes for the same bar type or instrument.

## Summary

Previously, when requesting historical aggregated bars or spread quotes for a bar type or instrument that already had an active subscription, both the subscription and request would share the same aggregator instance. This caused historical data to interfere with live aggregation, leading to incorrect bar generation for active subscriptions.

## Changes

### Core implementation

- Changed aggregator storage from `dict[BarType, BarAggregator]` and `dict[InstrumentId, SpreadQuoteAggregator]` to `dict[tuple, BarAggregator]` and `dict[tuple, SpreadQuoteAggregator]` using tuple keys of the form `(bar_type, request_id)` or `(instrument_id, request_id)` where `request_id` can be `None` for subscription aggregators.

- Introduced key generation methods:
  - `_get_bar_aggregator_key()` - returns `(BarType, UUID4 | None)` tuple for bar aggregator keys.
  - `_get_spread_quote_aggregator_key()` - returns `(InstrumentId, UUID4 | None)` tuple for spread quote aggregator keys.

- Updated all aggregator lifecycle methods to accept optional `request_id` parameter:
  - `_create_bar_aggregator()`, `_setup_bar_aggregator()`, `_dispose_bar_aggregator()`.
  - `_create_spread_quote_aggregator()`, `_setup_spread_quote_aggregator()`, `_dispose_spread_quote_aggregator()`.

- Modified `_init_historical_aggregators()` to create aggregators with request-scoped keys, ensuring historical aggregators are isolated from subscription aggregators.

- Refactored `_finalize_aggregated_bars_request()` (renamed from `_handle_aggregated_bars()`) to properly dispose of request-specific aggregators when `update_subscriptions=False`.

- Added `_get_bar_types_from_aggregators()` helper method to extract bar types from aggregator tuple keys, filtering for subscription aggregators (where `request_id is None`).

### Request handling improvements

- Moved request registration earlier in the request handling flow to ensure request is available when initializing historical aggregators.

- Prevented sub-requests from creating aggregators by removing `bar_types` parameter from sub-request params in `_handle_long_request()`.

- Improved request finalization to use `_handle_response()` instead of direct message bus response, ensuring proper response handling flow.

### Testing

- Added comprehensive test `test_request_aggregated_bars_does_not_pollute_subscription_aggregator()` that verifies:
  - Historical data requests do not interfere with active subscriptions.
  - Subscription aggregators produce identical bars whether or not a historical request is made concurrently.
  - Historical bars are properly isolated in their own aggregator instances.

## Design decisions

The key design decision was to use tuple-based keys `(bar_type, request_id)` or `(instrument_id, request_id)` instead of string concatenation or composite key objects. This approach:

- Provides type-safe key composition using native Python/Cython tuple support.
- Maintains clear separation between request-scoped aggregators (with request ID) and subscription aggregators (with `None` request ID).
- Simplifies key generation and comparison logic compared to string-based approaches.
- Leverages built-in tuple hashing for efficient dictionary lookups.

When `update_subscriptions=True`, aggregators use subscription keys `(bar_type, None)` or `(instrument_id, None)` to allow reuse of the subscription aggregator. When `update_subscriptions=False`, aggregators use request-scoped keys `(bar_type, request_id)` or `(instrument_id, request_id)` to ensure complete isolation.

## Files changed

- `nautilus_trader/data/engine.pxd` - Updated dictionary type annotations and method signatures to use tuple keys and include optional `request_id` parameters.
- `nautilus_trader/data/engine.pyx` - Implemented tuple-based aggregator key management, removed string separator constant, and updated all aggregator lifecycle methods and logging statements to work with tuple keys.
- `tests/unit_tests/data/test_engine.py` - Added comprehensive test for aggregator isolation behavior.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
