### PR TITLE
Refine requests and aggregators

### DIFF
--- a/examples/backtest/notebooks/databento_test_request_bars.py
+++ b/examples/backtest/notebooks/databento_test_request_bars.py
@@ -259,16 +259,14 @@ class TestHistoricalAggStrategy(Strategy):
     def on_historical_data(self, data):
         if type(data) is Bar:
             self.user_log(
-                f"historical bar ts_init = {unix_nanos_to_iso8601(data.ts_init)}, {data.ts_init}",
+                f"historical bar: {data}, ts_init = {unix_nanos_to_iso8601(data.ts_init)}",
             )
-            self.user_log(data)
 
             # self.user_log(f"{self.external_sma.value=}, {self.external_sma.initialized=}")
             # self.user_log(f"{self.composite_sma.value=}, {self.composite_sma.initialized=}")
 
     def on_bar(self, bar):
-        self.user_log(f"bar ts_init = {unix_nanos_to_iso8601(bar.ts_init)}, {bar.ts_init}")
-        self.user_log(bar)
+        self.user_log(f"bar: {bar}, ts_init = {unix_nanos_to_iso8601(bar.ts_init)}")
 
         # self.user_log(f"{self.external_sma.value=}, {self.external_sma.initialized=}")
         # self.user_log(f"{self.composite_sma.value=}, {self.composite_sma.initialized=}")

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -228,6 +228,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_instrument(
         self,
@@ -239,6 +240,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_instruments(
         self,
@@ -250,6 +252,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_order_book_snapshot(
         self,
@@ -259,6 +262,7 @@ cdef class Actor(Component):
         callback=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_order_book_depth(
         self,
@@ -272,6 +276,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_quote_ticks(
         self,
@@ -284,6 +289,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_trade_ticks(
         self,
@@ -296,6 +302,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_bars(
         self,
@@ -308,6 +315,7 @@ cdef class Actor(Component):
         bint update_catalog=*,
         dict[str, object] params=*,
         bint join_request=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_aggregated_bars(
         self,
@@ -321,6 +329,7 @@ cdef class Actor(Component):
         bint update_subscriptions=*,
         bint update_catalog=*,
         dict[str, object] params=*,
+        UUID4 request_id=*,
     )
     cpdef UUID4 request_join(
         self,
@@ -331,6 +340,7 @@ cdef class Actor(Component):
         Venue venue=*,
         callback=*,
         dict[str, object] params=*,
+        UUID4 request_id=*,
     )
     cpdef bint is_pending_request(self, UUID4 request_id)
     cpdef bint has_pending_requests(self)

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -204,6 +204,7 @@ cdef class SpreadQuoteAggregator:
     cpdef void stop_timer(self)
     cpdef void set_historical_mode(self, bint historical_mode, handler)
     cpdef void set_running(self, bint is_running)
+    cpdef void set_clock(self, Clock clock)
     cpdef void handle_quote_tick(self, QuoteTick tick)
 
     cdef void _process_historical_events(self, uint64_t ts_init)

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -1762,6 +1762,9 @@ cdef class SpreadQuoteAggregator:
     cpdef void set_running(self, bint is_running):
         self.is_running = is_running
 
+    cpdef void set_clock(self, Clock clock):
+        self._clock = clock
+
     cpdef void start_timer(self):
         if self._update_interval_seconds is None:
             return

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -113,6 +113,7 @@ cdef class DataEngine(Component):
     cdef readonly dict[UUID4, UUID4] _parent_long_request_id
     cdef readonly dict[UUID4, UUID4] _parent_join_request_id
     cdef readonly dict[UUID4, UUID4] _parent_request_id
+    cdef readonly bint _disable_historical_cache
 
     cdef TopicCache _topic_cache
 
@@ -297,7 +298,7 @@ cdef class DataEngine(Component):
 
     cpdef void _start_spread_quote_aggregator(self, MarketDataClient client, SubscribeQuoteTicks command)
     cpdef void _subscribe_spread_quote_aggregator(self, MarketDataClient client, SubscribeQuoteTicks command)
-    cpdef void _create_spread_quote_aggregator(self, InstrumentId spread_instrument_id, dict params, bint historical = *, UUID4 request_id = *)
+    cpdef void _create_spread_quote_aggregator(self, InstrumentId spread_instrument_id, dict params, UUID4 request_id = *)
     cpdef void _setup_spread_quote_aggregator(self, InstrumentId spread_instrument_id, bint historical = *, UUID4 request_id = *)
     cpdef void _handle_spread_quote(self, Data quote)
     cpdef void _stop_spread_quote_aggregator(self, MarketDataClient client, UnsubscribeQuoteTicks command)

--- a/nautilus_trader/test_kit/mocks/data.py
+++ b/nautilus_trader/test_kit/mocks/data.py
@@ -27,6 +27,9 @@ from nautilus_trader.data.messages import RequestInstruments
 from nautilus_trader.data.messages import RequestOrderBookDepth
 from nautilus_trader.data.messages import RequestQuoteTicks
 from nautilus_trader.data.messages import RequestTradeTicks
+from nautilus_trader.data.messages import SubscribeBars
+from nautilus_trader.data.messages import SubscribeQuoteTicks
+from nautilus_trader.data.messages import SubscribeTradeTicks
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import OrderBookDepth10
 from nautilus_trader.model.data import QuoteTick
@@ -141,6 +144,18 @@ class MockMarketDataClient(MarketDataClient):
             request.end,
             request.params,
         )
+
+    def subscribe_quote_ticks(self, command: SubscribeQuoteTicks) -> None:
+        """Subscribe to quote ticks - mock implementation that just tracks the subscription."""
+        self._add_subscription_quote_ticks(command.instrument_id)
+
+    def subscribe_trade_ticks(self, command: SubscribeTradeTicks) -> None:
+        """Subscribe to trade ticks - mock implementation that just tracks the subscription."""
+        self._add_subscription_trade_ticks(command.instrument_id)
+
+    def subscribe_bars(self, command: SubscribeBars) -> None:
+        """Subscribe to bars - mock implementation that just tracks the subscription."""
+        self._add_subscription_bars(command.bar_type)
 
 
 _AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Refine requests and aggregators

This PR introduces several enhancements to the request system and aggregator management, improving flexibility and control over data requests and historical data caching.

### Request ID customization

All request methods in the `Actor` class now accept an optional `request_id` parameter, allowing callers to specify a custom UUID for tracking requests instead of always generating a new one.

- Added `request_id` parameter to all request methods:
  - `request_data`
  - `request_instrument`
  - `request_instruments`
  - `request_order_book_snapshot`
  - `request_order_book_depth`
  - `request_quote_ticks`
  - `request_trade_ticks`
  - `request_bars`
  - `request_aggregated_bars`
  - `request_join`

- When `request_id` is provided, it is used directly; otherwise, a new UUID is generated as before.
- This is useful in a backtesting context where request ids are returned after a request has completed as the execution is completely synchronous.

### Historical cache control

Added the ability to disable historical data caching when processing historical data responses.

- Introduced `_disable_historical_cache` flag in `DataEngine` to control cache behavior.
- Cache updates are conditionally skipped for historical data when `disable_historical_cache=True` is set in response parameters.
- Applies to all historical data types: instruments, quote ticks, trade ticks, mark prices, index prices, and funding rates.
- Enables more efficient memory usage when processing large historical datasets where caching is not needed.
- Allows to avoid polluting the cache when a live subscription is ongoing and requesting historical data.

### Aggregator improvements

Refactored aggregator lifecycle management with improved handling of historical and live mode transitions.

- **Bar aggregators:**
  - Improved setup logic to detect and reuse aggregators already in historical mode.
  - Better handling of aggregator disposal and cleanup.
  - Enhanced timer management for historical vs live modes.
  - Improved error messages with clearer variable naming.

- **Spread quote aggregators:**
  - Added `set_clock` method to `SpreadQuoteAggregator` for clock management.
  - Simplified aggregator creation by removing historical mode parameter from `_create_spread_quote_aggregator`.
  - Improved setup logic to detect and reuse aggregators already in historical mode.
  - Better timer management for historical processing.

- **Request handling:**
  - Reordered request processing to handle `RequestJoin` after other request types.
  - Improved handling of aggregated bar requests with better lifecycle management.

### Testing

- Added comprehensive test for historical cache disabling functionality.
- Updated existing tests to reflect new request ID parameter behavior.
- Removed obsolete test for `update_subscriptions` behavior that is no longer applicable.

### Code quality

- Improved variable naming consistency (using `bar_type` and `request_id` instead of `bar_type_key` and `request_id_key`).
- Better error messages with more descriptive context.
- Cleaner separation of concerns in aggregator setup and disposal logic.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
