### PR TITLE
Add theme support to bars_with_fills chart

### DIFF
--- a/examples/backtest/notebooks/databento_option_greeks.py
+++ b/examples/backtest/notebooks/databento_option_greeks.py
@@ -13,42 +13,6 @@
 #     name: python3
 # ---
 
-# %%
-from nautilus_trader.common.component import TestClock
-
-
-clock = TestClock()
-
-# %%
-clock.set_time(10)
-
-
-# %%
-def f(x):
-    print("toto")
-
-
-# %%
-import pandas as pd  # noqa: E402
-
-
-# %%
-clock.set_timer(
-    name="toto",
-    interval=pd.Timedelta(seconds=1),
-    callback=f,
-    start_time=pd.Timestamp(10),
-    stop_time=None,   # Run indefinitely
-    allow_past=True,  # Allow past start times
-    fire_immediately=True,
-)
-
-# %%
-clock.advance_time(2e9, set_time=True)
-
-# %%
-clock.next_time_ns("toto")
-
 # %% [markdown]
 # ## imports
 
@@ -56,49 +20,49 @@ clock.next_time_ns("toto")
 # Note: Use the jupytext python extension to be able to open this python file in jupyter as a notebook
 
 # %%
-import numpy as np  # noqa: E402
+import numpy as np
 
-from nautilus_trader.adapters.databento.data_utils import data_path  # noqa: E402
-from nautilus_trader.adapters.databento.data_utils import databento_data  # noqa: E402
-from nautilus_trader.adapters.databento.data_utils import load_catalog  # noqa: E402
-from nautilus_trader.analysis.config import TearsheetConfig  # noqa: E402
-from nautilus_trader.analysis.tearsheet import create_bars_with_fills  # noqa: E402
-from nautilus_trader.analysis.tearsheet import create_tearsheet  # noqa: E402
-from nautilus_trader.backtest.config import MarginModelConfig  # noqa: E402
-from nautilus_trader.backtest.node import BacktestNode  # noqa: E402
-from nautilus_trader.backtest.option_exercise import OptionExerciseConfig  # noqa: E402
-from nautilus_trader.backtest.option_exercise import OptionExerciseModule  # noqa: E402
-from nautilus_trader.common.enums import LogColor  # noqa: E402
-from nautilus_trader.config import BacktestDataConfig  # noqa: E402
-from nautilus_trader.config import BacktestEngineConfig  # noqa: E402
-from nautilus_trader.config import BacktestRunConfig  # noqa: E402
-from nautilus_trader.config import BacktestVenueConfig  # noqa: E402
-from nautilus_trader.config import ImportableActorConfig  # noqa: E402
-from nautilus_trader.config import ImportableFillModelConfig  # noqa: E402
-from nautilus_trader.config import ImportableStrategyConfig  # noqa: E402
-from nautilus_trader.config import LoggingConfig  # noqa: E402
-from nautilus_trader.config import StrategyConfig  # noqa: E402
-from nautilus_trader.config import StreamingConfig  # noqa: E402
-from nautilus_trader.core.datetime import time_object_to_dt  # noqa: E402
-from nautilus_trader.core.datetime import unix_nanos_to_iso8601  # noqa: E402
-from nautilus_trader.model.data import Bar  # noqa: E402
-from nautilus_trader.model.data import BarType  # noqa: E402
-from nautilus_trader.model.data import DataType  # noqa: E402
-from nautilus_trader.model.data import QuoteTick  # noqa: E402
-from nautilus_trader.model.enums import OrderSide  # noqa: E402
-from nautilus_trader.model.greeks_data import GreeksData  # noqa: E402
-from nautilus_trader.model.identifiers import InstrumentId  # noqa: E402
-from nautilus_trader.model.identifiers import Venue  # noqa: E402
-from nautilus_trader.model.identifiers import new_generic_spread_id  # noqa: E402
-from nautilus_trader.model.instruments import FuturesContract  # noqa: E402
-from nautilus_trader.model.objects import Price  # noqa: E402
-from nautilus_trader.model.objects import Quantity  # noqa: E402
-from nautilus_trader.model.tick_scheme import TieredTickScheme  # noqa: E402
-from nautilus_trader.model.tick_scheme import register_tick_scheme  # noqa: E402
-from nautilus_trader.persistence.config import DataCatalogConfig  # noqa: E402
-from nautilus_trader.persistence.loaders import InterestRateProvider  # noqa: E402
-from nautilus_trader.persistence.loaders import InterestRateProviderConfig  # noqa: E402
-from nautilus_trader.trading.strategy import Strategy  # noqa: E402
+from nautilus_trader.adapters.databento.data_utils import data_path
+from nautilus_trader.adapters.databento.data_utils import databento_data
+from nautilus_trader.adapters.databento.data_utils import load_catalog
+from nautilus_trader.analysis.config import TearsheetConfig
+from nautilus_trader.analysis.tearsheet import create_bars_with_fills
+from nautilus_trader.analysis.tearsheet import create_tearsheet
+from nautilus_trader.backtest.config import MarginModelConfig
+from nautilus_trader.backtest.node import BacktestNode
+from nautilus_trader.backtest.option_exercise import OptionExerciseConfig
+from nautilus_trader.backtest.option_exercise import OptionExerciseModule
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import BacktestDataConfig
+from nautilus_trader.config import BacktestEngineConfig
+from nautilus_trader.config import BacktestRunConfig
+from nautilus_trader.config import BacktestVenueConfig
+from nautilus_trader.config import ImportableActorConfig
+from nautilus_trader.config import ImportableFillModelConfig
+from nautilus_trader.config import ImportableStrategyConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.config import StreamingConfig
+from nautilus_trader.core.datetime import time_object_to_dt
+from nautilus_trader.core.datetime import unix_nanos_to_iso8601
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.data import DataType
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.greeks_data import GreeksData
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import new_generic_spread_id
+from nautilus_trader.model.instruments import FuturesContract
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.tick_scheme import TieredTickScheme
+from nautilus_trader.model.tick_scheme import register_tick_scheme
+from nautilus_trader.persistence.config import DataCatalogConfig
+from nautilus_trader.persistence.loaders import InterestRateProvider
+from nautilus_trader.persistence.loaders import InterestRateProviderConfig
+from nautilus_trader.trading.strategy import Strategy
 
 
 # %%
@@ -593,6 +557,7 @@ fig = create_bars_with_fills(
     engine=engine,
     bar_type=bar_type,
     title=f"{future_symbols[0]} - Price Bars with Order Fills",
+    theme="nautilus_dark",
 )
 fig
 
@@ -605,6 +570,7 @@ tearsheet_config = TearsheetConfig(
             "bar_type": f"{future_symbols[0]}.XCME-1-MINUTE-LAST-EXTERNAL",
         },
     },
+    theme="nautilus_dark",
 )
 
 create_tearsheet(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Add theme support to bars_with_fills chart

### Summary

This PR adds theme support to the `create_bars_with_fills` function and its internal renderer `_render_bars_with_fills`, enabling consistent styling with the rest of the visualization system. The chart now respects the tearsheet theme configuration and supports all built-in themes (`plotly_white`, `plotly_dark`, `nautilus`, `nautilus_dark`) as well as custom themes.

### Changes

#### Standalone function enhancements

- Added `theme` parameter to `create_bars_with_fills` with default value `"plotly_white"` for backward compatibility.
- Added `output_path` parameter to `create_bars_with_fills` for consistency with other standalone chart functions.
- Integrated theme system: the function now uses `get_theme()` and `_normalize_theme_config()` to apply theme styling.
- Replaced hardcoded `template="plotly_white"` with dynamic `template=theme_config["template"]` in layout updates.

#### Renderer improvements

- Updated `_render_bars_with_fills` to accept `theme_config` parameter with fallback to `plotly_white` theme.
- Replaced hardcoded fill marker colors with theme-based colors:
  - Buy fills now use `theme_config["colors"]["positive"]`.
  - Sell fills now use `theme_config["colors"]["negative"]`.
- Added `_hex_to_rgba()` conversion for theme colors with 70% opacity to maintain visual consistency.
- Made `create_bars_with_fills` pass `theme_config` to `_render_bars_with_fills` to ensure theme colors are applied in standalone usage.

### Benefits

- **Visual consistency**: The chart now matches the tearsheet theme when included in tearsheets, and supports theme selection when used standalone.
- **Backward compatibility**: All changes maintain default behavior (`plotly_white` theme) when no theme is specified.
- **Code reuse**: The same renderer function handles theme logic for both standalone and tearsheet contexts.
- **Design alignment**: Follows the same pattern as other chart functions like `create_drawdown_chart` that accept theme parameters.

### Testing

- Existing tests remain compatible as they don't specify theme parameters (defaults to `plotly_white`).
- The function signature changes are backward compatible (new parameters have defaults).
- Theme colors are automatically applied when the chart is included in tearsheets via `TearsheetConfig`.

### Example usage

```python
# Standalone usage with custom theme
fig = create_bars_with_fills(
    engine=engine,
    bar_type=bar_type,
    title="ES Futures - Entry/Exit Analysis",
    theme="nautilus_dark",
    output_path="chart.html",
)

# Tearsheet usage (theme automatically applied from TearsheetConfig)
config = TearsheetConfig(
    charts=["bars_with_fills"],
    theme="nautilus_dark",
)
create_tearsheet(engine, config=config)
```


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3327

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
