### PR TITLE
Add consolidated schema support in Databento historical client

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -97,6 +97,7 @@ This release adds support for Python 3.14 with the following limitations:
 - Fixed Binance Futures Algo Order API for conditional orders (#3287), thanks for reporting @KaizynX
 - Fixed Bybit historical bars requests partial (unclosed) bar filtering
 - Fixed `BybitHttpClient` type stub pyi signatures (#3238), thanks @sunlei
+- Fixed Databento historical client to support consolidated schemas (`cmbp-1`, `cbbo-1s`, `cbbo-1m`) in quote requests
 - Fixed Databento MBO data decoding when `PRICE_UNDEF` appears with non-zero precision
 - Fixed Databento Arrow serialization for `PRICE_UNDEF` (#3183), thanks for reporting @marloncalvo
 - Fixed Databento quote decoding with undefined bid/ask prices

--- a/crates/adapters/databento/src/historical.rs
+++ b/crates/adapters/databento/src/historical.rs
@@ -234,8 +234,15 @@ impl DatabentoHistoricalClient {
         let dbn_schema = dbn::Schema::from_str(&schema)?;
 
         match dbn_schema {
-            dbn::Schema::Mbp1 | dbn::Schema::Bbo1S | dbn::Schema::Bbo1M => (),
-            _ => anyhow::bail!("Invalid schema. Must be one of: mbp-1, bbo-1s, bbo-1m"),
+            dbn::Schema::Mbp1
+            | dbn::Schema::Bbo1S
+            | dbn::Schema::Bbo1M
+            | dbn::Schema::Cmbp1
+            | dbn::Schema::Cbbo1S
+            | dbn::Schema::Cbbo1M => (),
+            _ => anyhow::bail!(
+                "Invalid schema. Must be one of: mbp-1, bbo-1s, bbo-1m, cmbp-1, cbbo-1s, cbbo-1m"
+            ),
         }
 
         let range_params = GetRangeParams::builder()
@@ -290,7 +297,7 @@ impl DatabentoHistoricalClient {
         };
 
         match dbn_schema {
-            dbn::Schema::Mbp1 => {
+            dbn::Schema::Mbp1 | dbn::Schema::Cmbp1 => {
                 while let Ok(Some(msg)) = decoder.decode_record::<dbn::Mbp1Msg>().await {
                     process_record(dbn::RecordRef::from(msg))?;
                 }
@@ -302,6 +309,11 @@ impl DatabentoHistoricalClient {
             }
             dbn::Schema::Bbo1S => {
                 while let Ok(Some(msg)) = decoder.decode_record::<dbn::Bbo1SMsg>().await {
+                    process_record(dbn::RecordRef::from(msg))?;
+                }
+            }
+            dbn::Schema::Cbbo1S | dbn::Schema::Cbbo1M => {
+                while let Ok(Some(msg)) = decoder.decode_record::<dbn::CbboMsg>().await {
                     process_record(dbn::RecordRef::from(msg))?;
                 }
             }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Add support for consolidated book schemas in the Databento historical client `get_range_quotes` method:
- `cmbp-1` (consolidated MBP-1)
- `cbbo-1s` (consolidated BBO 1-second)
- `cbbo-1m` (consolidated BBO 1-minute)

These consolidated schemas use `CbboMsg` for decoding instead of `Bbo1SMsg`/`Bbo1MMsg`.

## Related Issues/PRs

<!-- None -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually by requesting historical data with consolidated schemas.