### PR TITLE
Remove redundant debug code for reconcile execution

### DIFF
--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -1845,25 +1845,6 @@ class LiveExecutionEngine(ExecutionEngine):
         reconciled_trades: set[TradeId] = set()
 
         # Reconcile all reported orders
-        total_ethusdt_fills = 0
-        for venue_order_id, order_report in mass_status.order_reports.items():
-            trades = mass_status.fill_reports.get(venue_order_id, [])
-            if (
-                order_report.instrument_id == InstrumentId.from_str("ETHUSDT-LINEAR.BYBIT")
-                and trades
-            ):
-                total_ethusdt_fills += len(trades)
-                for trade in trades:
-                    self._log.debug(
-                        f"Reconciling order {venue_order_id}: trade_id={trade.trade_id}, last_px={trade.last_px}",
-                    )
-
-        if total_ethusdt_fills > 0:
-            self._log.info(
-                f"Total ETHUSDT fills being reconciled: {total_ethusdt_fills}",
-                LogColor.BLUE,
-            )
-
         for venue_order_id, order_report in mass_status.order_reports.items():
             trades = mass_status.fill_reports.get(venue_order_id, [])
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

remove useless test code  for _reconcile_execution_mass_status() in execution_engine.py

## Related Issues/PRs

https://github.com/nautechsystems/nautilus_trader/pull/3185/files
## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)


## Docuentation

## Release notes

## Testing

