### PR TITLE
Refine subscription to spread quotes

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -78,6 +78,7 @@ from nautilus_trader.core.datetime cimport format_iso8601
 from nautilus_trader.core.datetime cimport format_optional_iso8601
 from nautilus_trader.core.datetime cimport maybe_dt_to_unix_nanos
 from nautilus_trader.core.datetime cimport unix_nanos_to_dt
+from nautilus_trader.core.inspect import is_nautilus_class
 from nautilus_trader.core.rust.backtest cimport TimeEventAccumulatorAPI
 from nautilus_trader.core.rust.backtest cimport time_event_accumulator_advance_clock
 from nautilus_trader.core.rust.backtest cimport time_event_accumulator_drain
@@ -913,7 +914,7 @@ cdef class BacktestEngine:
 
     cpdef void _handle_data_command(self, DataCommand command):
         if not(command.data_type.type in [Bar, QuoteTick, TradeTick, OrderBookDepth10]
-               or type(command) not in [SubscribeData, UnsubscribeData, SubscribeInstruments, UnsubscribeInstruments]):
+               or type(command) in [SubscribeData, UnsubscribeData, SubscribeInstruments, UnsubscribeInstruments]):
             return
 
         if isinstance(command, SubscribeData):
@@ -1905,7 +1906,7 @@ cdef class BacktestEngine:
             self._kernel.data_engine.register_client(client)
 
     def set_default_market_data_client(self) -> None:
-        cdef ClientId client_id = ClientId("backtest_default_client")
+        cdef ClientId client_id = ClientId("BACKTEST")
         client = BacktestMarketDataClient(
             client_id=client_id,
             msgbus=self._kernel.msgbus,

--- a/nautilus_trader/common/actor.pyx
+++ b/nautilus_trader/common/actor.pyx
@@ -1283,6 +1283,7 @@ cdef class Actor(Component):
 
         # TODO during a backtest, use any ClientId for subscribing to custom data from a catalog when not using instrument_id
         if client_id is None and instrument_id is None:
+            self.log.error("`Actor.subscribe_data`: `client_id` or `instrument_id` need to be specified")
             return
 
         params = params or {}
@@ -2019,6 +2020,7 @@ cdef class Actor(Component):
 
         # TODO during a backtest, use any ClientId for subscribing to custom data from a catalog when not using instrument_id
         if client_id is None and instrument_id is None:
+            self.log.error("`Actor.unsubscribe_data`: `client_id` or `instrument_id` need to be specified")
             return
 
         cdef UnsubscribeData command = UnsubscribeData(

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -202,7 +202,7 @@ cdef class SpreadQuoteAggregator:
 
     cpdef void start_timer(self)
     cpdef void stop_timer(self)
-    cpdef void set_historical_mode(self, bint historical_mode, handler)
+    cpdef void set_historical_mode(self, bint historical_mode, handler, GreeksCalculator greeks_calculator)
     cpdef void set_running(self, bint is_running)
     cpdef void set_clock(self, Clock clock)
     cpdef void handle_quote_tick(self, QuoteTick tick)

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -143,7 +143,6 @@ cdef class DataEngine(Component):
     cpdef bint check_disconnected(self)
     cpdef set[ClientId] get_external_client_ids(self)
     cpdef bint _is_backtest_client(self, DataClient client)
-    cpdef bint is_live_mode(self)
 
 # -- REGISTRATION ---------------------------------------------------------------------------------
 

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -4035,7 +4035,7 @@ class TestTimeBarAggregator:
             clock,
         )
         aggregator.start_timer()
-        timer_name = str(bar_type.standard())
+        timer_name = f"time_bar_{bar_type.standard()}"
         composite_bar_type = bar_type.composite()
 
         bar1 = Bar(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Refine data query and subscription

This PR refines data query and subscription handling, particularly for spread instruments and backtest scenarios. It fixes several logic bugs, improves error handling, and standardizes client identification.

### Core changes

#### Data engine improvements

- Fixed logic bug in backtest engine data command handling: corrected condition from `not in` to `in` for proper subscription command filtering.

- Standardized backtest client ID: changed from `"backtest_default_client"` to `"BACKTEST"` for consistency across the codebase.

- Removed deprecated `is_live_mode()` method: eliminated unused method from `DataEngine` that was checking for backtest client presence.

- Fixed spread quote aggregator logic: corrected condition from `or` to `and not` to properly handle aggregated quotes in backtest scenarios. The aggregator now only activates when it's a backtest client and `force_aggregated_quotes` is not set.

- Renamed parameter for clarity: changed `"request_actual_quotes"` to `"force_aggregated_quotes"` to better reflect its purpose of requesting actual quotes instead of aggregated ones.

#### Aggregator enhancements

- Improved timer name generation: updated `TimeBarAggregator` to use `f"time_bar_{self.bar_type}"` format and `SpreadQuoteAggregator` to use `f"spread_quote_{self._spread_instrument_id}"` format. This ensures proper timer ordering (spread quote timers execute before time bar timers).

- Enhanced historical mode handling: improved clock management when switching between historical and live modes for both `TimeBarAggregator` and `SpreadQuoteAggregator`. Timers are now properly stopped and restarted during mode transitions.

- Added GreeksCalculator requirement: `SpreadQuoteAggregator.set_historical_mode()` now requires a `GreeksCalculator` parameter, ensuring proper greeks calculation in both historical and live modes.

#### Request handling improvements

- Fixed spread quote request handling: improved parameter passing for leg requests in spread quote tick requests. Parameters are now properly copied and cleaned before creating leg requests.

- Enhanced request routing: spread quote requests now use direct message bus routing instead of recursive request calls, improving request flow control.

#### Error handling and logging

- Added error logging in Actor: `subscribe_data()` and `unsubscribe_data()` now log errors when both `client_id` and `instrument_id` are `None`, providing better debugging information.

- Improved debug logging: added debug logs for aggregator creation in both bar and spread quote aggregator setup methods.

### Example and test updates

#### Example notebook improvements

- Reordered data requests and subscriptions: moved quote tick and bar requests before subscriptions to ensure proper data flow.

- Added new bar type subscription: added subscription to `bar_type_3` (spread ask bars) for more comprehensive data coverage.

- Improved logging configuration: updated logging to use `WARNING` level for `DataEngine` component and enabled all component logging.

- Simplified data conversion: removed try-except blocks around catalog conversion calls, relying on proper error propagation.

- Enhanced logging output: improved log messages for better debugging, including color-coded logs for different data types.

#### Test cleanup

- Removed large test class: eliminated `TestBacktestNodeWithBacktestDataIterator` class (587 lines) that was marked as skipped and causing test file bloat.

### Technical details

The changes ensure that:

- Spread quote aggregators work correctly in backtest scenarios with proper parameter handling.

- Timer execution order is predictable and correct for time-sensitive operations.

- Historical and live mode transitions are handled gracefully without timer conflicts.

- Error conditions are properly logged for easier debugging.

- Client identification is consistent across the codebase.

### Files changed

- `nautilus_trader/backtest/engine.pyx`: Fixed data command handling logic and standardized client ID.

- `nautilus_trader/common/actor.pyx`: Added error logging for invalid subscribe/unsubscribe calls.

- `nautilus_trader/data/aggregation.pxd` and `.pyx`: Enhanced aggregator timer naming and historical mode handling.

- `nautilus_trader/data/engine.pxd` and `.pyx`: Fixed spread aggregator logic, improved request handling, and removed deprecated method.

- `examples/backtest/notebooks/databento_option_greeks.py`: Improved data request ordering and logging.

- `tests/acceptance_tests/test_backtest.py`: Removed large skipped test class.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
