### PR TITLE
Make spread quote aggregation opt-in

### DIFF
--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -895,7 +895,6 @@ data_config = BacktestDataConfig(
     instrument_id=InstrumentId.from_str("BTC/USD.COINBASE"),
     start_time="2024-01-01T09:30:00Z",
     end_time="2024-01-01T16:00:00Z",
-    filter_expr="side == 'BUY'",  # Only buy-side deltas
 )
 ```
 

--- a/examples/backtest/notebooks/databento_option_greeks.py
+++ b/examples/backtest/notebooks/databento_option_greeks.py
@@ -186,6 +186,8 @@ class OptionStrategy(Strategy):
         self.spread_order_submitted2 = False
 
     def on_start(self):
+        self.default_data_params = {"aggregate_spread_quotes":True}
+
         self.user_log("Strategy on_start called")
         self.bar_type = BarType.from_str(f"{self.config.future_id}-1-MINUTE-LAST-EXTERNAL")
 
@@ -216,13 +218,14 @@ class OptionStrategy(Strategy):
         )
 
         self.user_log(f"Requesting quote ticks for spread {self.config.spread_id2} from {start_time}")
-        self.request_quote_ticks(self.config.spread_id2, start=time_object_to_dt(start_time))
+        self.request_quote_ticks(self.config.spread_id2, start=time_object_to_dt(start_time), params=self.default_data_params)
 
         self.user_log(f"Requesting bars for spread {self.bar_type_3} from {start_time}")
         self.request_aggregated_bars(
             [self.bar_type_3],
             start=time_object_to_dt(start_time),
             update_subscriptions=True,
+            params=self.default_data_params,
         )
 
         # Subscribe to various data
@@ -232,8 +235,8 @@ class OptionStrategy(Strategy):
         self.subscribe_bars(self.bar_type)
         self.subscribe_quote_ticks(self.config.future_id)
         self.subscribe_quote_ticks(self.config.future_id2)
-        self.subscribe_quote_ticks(self.config.spread_id)
-        self.subscribe_quote_ticks(self.config.spread_id2)
+        self.subscribe_quote_ticks(self.config.spread_id, params=self.default_data_params)
+        self.subscribe_quote_ticks(self.config.spread_id2, params=self.default_data_params)
         self.subscribe_bars(self.bar_type_2)
         self.subscribe_bars(self.bar_type_3)
 
@@ -353,11 +356,14 @@ class OptionStrategy(Strategy):
 
     def on_stop(self):
         self.unsubscribe_bars(self.bar_type)
+        self.unsubscribe_bars(self.bar_type_2)
+        self.unsubscribe_bars(self.bar_type_3)
         self.unsubscribe_quote_ticks(self.config.option_id)
         self.unsubscribe_quote_ticks(self.config.option_id2)
         self.unsubscribe_data(DataType(GreeksData), instrument_id=self.config.option_id)
         self.unsubscribe_data(DataType(GreeksData), instrument_id=self.config.option_id2)
-        self.unsubscribe_quote_ticks(self.config.spread_id)
+        self.unsubscribe_quote_ticks(self.config.spread_id, params=self.default_data_params)
+        self.unsubscribe_quote_ticks(self.config.spread_id2, params=self.default_data_params)
 
 
 # %% [markdown]

--- a/nautilus_trader/common/actor.pxd
+++ b/nautilus_trader/common/actor.pxd
@@ -184,7 +184,7 @@ cdef class Actor(Component):
         ClientId client_id=*,
         dict[str, object] params=*,
     )
-    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, bint update_catalog=*, dict[str, object] params=*)
+    cpdef void subscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, bint update_catalog=*, bint aggregate_spread_quotes=*, dict[str, object] params=*)
     cpdef void subscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*, bint update_catalog=*, dict[str, object] params=*)
     cpdef void subscribe_mark_prices(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
     cpdef void subscribe_index_prices(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
@@ -200,7 +200,7 @@ cdef class Actor(Component):
     cpdef void unsubscribe_order_book_deltas(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
     cpdef void unsubscribe_order_book_depth(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
     cpdef void unsubscribe_order_book_at_interval(self, InstrumentId instrument_id, int interval_ms=*, ClientId client_id=*, dict[str, object] params=*)
-    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
+    cpdef void unsubscribe_quote_ticks(self, InstrumentId instrument_id, ClientId client_id=*, bint aggregate_spread_quotes=*, dict[str, object] params=*)
     cpdef void unsubscribe_trade_ticks(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
     cpdef void unsubscribe_mark_prices(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
     cpdef void unsubscribe_index_prices(self, InstrumentId instrument_id, ClientId client_id=*, dict[str, object] params=*)
@@ -226,9 +226,9 @@ cdef class Actor(Component):
         int limit=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_instrument(
         self,
@@ -238,9 +238,9 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_instruments(
         self,
@@ -250,9 +250,9 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_order_book_snapshot(
         self,
@@ -260,9 +260,9 @@ cdef class Actor(Component):
         int limit=*,
         ClientId client_id=*,
         callback=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_order_book_depth(
         self,
@@ -274,9 +274,9 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_quote_ticks(
         self,
@@ -287,9 +287,10 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
+        bint aggregate_spread_quotes=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_trade_ticks(
         self,
@@ -300,9 +301,9 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_bars(
         self,
@@ -313,9 +314,9 @@ cdef class Actor(Component):
         ClientId client_id=*,
         callback=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
         bint join_request=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_aggregated_bars(
         self,
@@ -328,8 +329,9 @@ cdef class Actor(Component):
         bint include_external_data=*,
         bint update_subscriptions=*,
         bint update_catalog=*,
-        dict[str, object] params=*,
+        bint aggregate_spread_quotes=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef UUID4 request_join(
         self,
@@ -339,8 +341,8 @@ cdef class Actor(Component):
         ClientId client_id=*,
         Venue venue=*,
         callback=*,
-        dict[str, object] params=*,
         UUID4 request_id=*,
+        dict[str, object] params=*,
     )
     cpdef bint is_pending_request(self, UUID4 request_id)
     cpdef bint has_pending_requests(self)

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -175,6 +175,7 @@ cdef class SpreadQuoteAggregator:
     cdef readonly list _legs
     cdef readonly GreeksCalculator _greeks_calculator
     cdef readonly object _update_interval_seconds
+    cdef readonly int _quote_build_delay
     cdef readonly str _timer_name
     cdef readonly list _leg_ids
     cdef readonly int _n_legs

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -114,6 +114,7 @@ cdef class DataEngine(Component):
     cdef readonly dict[UUID4, UUID4] _parent_join_request_id
     cdef readonly dict[UUID4, UUID4] _parent_request_id
     cdef readonly bint _disable_historical_cache
+    cdef readonly dict[UUID4, dict[str, Any]] _bar_types_params
 
     cdef TopicCache _topic_cache
 

--- a/nautilus_trader/trading/strategy.pyx
+++ b/nautilus_trader/trading/strategy.pyx
@@ -809,6 +809,10 @@ cdef class Strategy(Actor):
 
         self.cache.add_order(order, position_id, client_id)
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef SubmitOrder command = SubmitOrder(
             trader_id=self.trader_id,
             strategy_id=self.id,
@@ -817,7 +821,7 @@ cdef class Strategy(Actor):
             ts_init=self.clock.timestamp_ns(),
             position_id=position_id,
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
 
         if self.manage_gtd_expiry and order.time_in_force == TimeInForce.GTD:
@@ -908,6 +912,10 @@ cdef class Strategy(Actor):
         for order in order_list.orders:
             self.cache.add_order(order, position_id, client_id)
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef SubmitOrderList command = SubmitOrderList(
             trader_id=self.trader_id,
             strategy_id=self.id,
@@ -916,7 +924,7 @@ cdef class Strategy(Actor):
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
 
         if self.manage_gtd_expiry:
@@ -990,13 +998,17 @@ cdef class Strategy(Actor):
         Condition.is_true(self.trader_id is not None, "The strategy has not been registered")
         Condition.not_none(order, "order")
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef ModifyOrder command = self._create_modify_order(
             order=order,
             quantity=quantity,
             price=price,
             trigger_price=trigger_price,
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
         if command is None:
             return
@@ -1027,10 +1039,14 @@ cdef class Strategy(Actor):
         Condition.is_true(self.trader_id is not None, "The strategy has not been registered")
         Condition.not_none(order, "order")
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef CancelOrder command = self._create_cancel_order(
             order=order,
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
         if command is None:
             return
@@ -1111,6 +1127,10 @@ cdef class Strategy(Actor):
             self._log.warning("Cannot send `BatchCancelOrders`, no valid cancel commands")
             return
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef command = BatchCancelOrders(
             trader_id=self.trader_id,
             strategy_id=self.id,
@@ -1119,7 +1139,7 @@ cdef class Strategy(Actor):
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
 
         self._manager.send_exec_command(command)
@@ -1214,6 +1234,10 @@ cdef class Strategy(Actor):
                 if order.strategy_id == self.id and not order.is_closed_c():
                     self.cancel_order(order)
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef CancelAllOrders command
 
         if open_count > 0:
@@ -1225,7 +1249,7 @@ cdef class Strategy(Actor):
                 command_id=UUID4(),
                 ts_init=self.clock.timestamp_ns(),
                 client_id=client_id,
-                params=params,
+                params=used_params,
             )
             self._manager.send_exec_command(command)
 
@@ -1238,7 +1262,7 @@ cdef class Strategy(Actor):
                 command_id=UUID4(),
                 ts_init=self.clock.timestamp_ns(),
                 client_id=client_id,
-                params=params,
+                params=used_params,
             )
             self._manager.send_emulator_command(command)
 
@@ -1303,7 +1327,11 @@ cdef class Strategy(Actor):
             tags=tags,
         )
 
-        self.submit_order(order, position_id=position.id, client_id=client_id, params=params)
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
+        self.submit_order(order, position_id=position.id, client_id=client_id, params=used_params)
 
     cpdef void close_all_positions(
         self,
@@ -1363,6 +1391,10 @@ cdef class Strategy(Actor):
             f"Closing {count} open{position_side_str} position{'' if count == 1 else 's'}",
         )
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef Position position
         for position in positions_open:
             self.close_position(
@@ -1372,7 +1404,7 @@ cdef class Strategy(Actor):
                 time_in_force,
                 reduce_only,
                 quote_quantity,
-                params,
+                used_params,
             )
 
     cpdef void query_account(self, AccountId account_id, ClientId client_id = None, dict[str, object] params = None):
@@ -1395,13 +1427,17 @@ cdef class Strategy(Actor):
         """
         Condition.is_true(self.trader_id is not None, "The strategy has not been registered")
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef QueryAccount command = QueryAccount(
             trader_id=self.trader_id,
             account_id=account_id,
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
 
         self._manager.send_exec_command(command)
@@ -1429,6 +1465,10 @@ cdef class Strategy(Actor):
         Condition.is_true(self.trader_id is not None, "The strategy has not been registered")
         Condition.not_none(order, "order")
 
+        cdef dict[str, object] used_params = {}
+        if params:
+            used_params.update(params)
+
         cdef QueryOrder command = QueryOrder(
             trader_id=self.trader_id,
             strategy_id=self.id,
@@ -1438,7 +1478,7 @@ cdef class Strategy(Actor):
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
             client_id=client_id,
-            params=params,
+            params=used_params,
         )
 
         self._manager.send_exec_command(command)

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -4812,6 +4812,7 @@ class TestDataEngine:
             instrument_id=spread_instrument_id,
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
+            params={"aggregate_spread_quotes": True},
         )
 
         # Act
@@ -4909,6 +4910,7 @@ class TestDataEngine:
             instrument_id=spread_instrument_id,
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
+            params={"aggregate_spread_quotes": True},
         )
         self.data_engine.execute(subscribe)
 
@@ -4923,6 +4925,7 @@ class TestDataEngine:
             instrument_id=spread_instrument_id,
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
+            params={"aggregate_spread_quotes": True},
         )
         self.data_engine.execute(unsubscribe)
 
@@ -5022,6 +5025,7 @@ class TestDataEngine:
             instrument_id=spread_instrument_id,
             command_id=UUID4(),
             ts_init=self.clock.timestamp_ns(),
+            params={"aggregate_spread_quotes": True},
         )
         self.data_engine.execute(subscribe)
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Make spread quote aggregation opt-in

This PR changes spread quote aggregation from automatic (based on client type) to explicit opt-in via the `aggregate_spread_quotes` parameter. It also introduces default parameter dictionaries for both data subscriptions and execution commands, improving flexibility and reducing boilerplate.

### Core changes

#### Spread quote aggregation control

- Changed aggregation logic: spread quote aggregation now requires explicit opt-in via the `aggregate_spread_quotes` parameter instead of being automatically enabled for backtest clients.

- Added `aggregate_spread_quotes` parameter: new boolean parameter added to `subscribe_quote_ticks()`, `unsubscribe_quote_ticks()`, and `request_quote_ticks()` methods in the `Actor` class. When `True`, activates spread quote aggregation from leg quotes for spread instruments.

- Simplified data engine logic: removed dependency on client type checking (`_is_backtest_client()`) for spread aggregator activation. The aggregator now activates based solely on the `aggregate_spread_quotes` parameter value.

#### Parameter ordering standardization

- Reordered method signatures: moved `params` parameter to the end of all request method signatures for consistency. This affects `request_instrument()`, `request_instruments()`, `request_order_book_snapshot()`, `request_order_book_depth()`, `request_quote_ticks()`, `request_trade_ticks()`, `request_bars()`, `request_aggregated_bars()`, and `request_join()`.

- Improved API consistency: all data-related methods now follow a consistent parameter ordering pattern, making the API more predictable and easier to use.

### Implementation details

#### Actor class enhancements

- Parameter handling: all subscription, unsubscribe, and request methods now use a `used_params` dictionary that merges `default_data_params` with method-specific parameters in the correct order (defaults first, then method params).

- Code organization: moved `_validate_datetime_range()` method to the end of the class for better code organization.

#### Strategy class enhancements

- Execution parameter merging: all execution methods (`submit_order()`, `submit_order_list()`, `modify_order()`, `cancel_order()`, `batch_cancel_orders()`, `cancel_all_orders()`, `close_position()`, `close_all_positions()`, `query_account()`, `query_order()`) now merge `default_execution_params` with method-specific parameters.

#### Data engine changes

- Simplified aggregator activation: `_handle_subscribe_quote_ticks()` and `_handle_unsubscribe_quote_ticks()` now check `command.params.get("aggregate_spread_quotes", False)` instead of client type and `force_aggregated_quotes` parameter.

- Request handling: `_handle_request()` now checks `request.params.get("aggregate_spread_quotes", False)` for `RequestQuoteTicks` instead of checking `force_aggregated_quotes`.

#### parse_filters_expr

- Improve `parse_filters_expr` to allow all operators supported by pyarrow Expression.
- Tested it works with an example in `test_backtest.py`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
