### PR TITLE
Refactor risk engine initialization with shallow clone for portfolio

### DIFF
--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -142,6 +142,20 @@ impl Portfolio {
         }
     }
 
+    /// Creates a shallow clone of the Portfolio that shares the same internal state.
+    ///
+    /// This is useful when multiple components need to reference the same Portfolio
+    /// without creating duplicate msgbus handler registrations.
+    #[must_use]
+    pub fn clone_shallow(&self) -> Self {
+        Self {
+            clock: self.clock.clone(),
+            cache: self.cache.clone(),
+            inner: self.inner.clone(),
+            config: self.config.clone(),
+        }
+    }
+
     fn register_message_handlers(
         cache: Rc<RefCell<Cache>>,
         clock: Rc<RefCell<dyn Clock>>,

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -144,7 +144,7 @@ impl NautilusKernel {
 
         let risk_engine = RiskEngine::new(
             config.risk_engine().unwrap_or_default(),
-            Portfolio::new(cache.clone(), clock.clone(), config.portfolio()),
+            portfolio.borrow().clone_shallow(),
             clock.clone(),
             cache.clone(),
         );


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The `RiskEngine` should **NOT** create its own `Portfolio`. It should share the same `Portfolio` instance that the kernel creates. The `RiskEngine` uses the portfolio to check net positions (e.g., `is_net_long`, `is_net_short`) for trading state validation, and it needs to see the same position state as the rest of the system.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
