### PR TITLE
Improve backtest data iteration by sorting data using ts_event instead of ts_init

### DIFF
--- a/crates/backtest/src/data_iterator.rs
+++ b/crates/backtest/src/data_iterator.rs
@@ -20,9 +20,9 @@ use std::collections::BinaryHeap;
 
 use ahash::AHashMap;
 use nautilus_core::UnixNanos;
-use nautilus_model::data::{Data, HasTsInit};
+use nautilus_model::data::{Data, HasTsEvent};
 
-/// Internal convenience struct to keep heap entries ordered by `(ts_init, priority)`.
+/// Internal convenience struct to keep heap entries ordered by `(ts_event, priority)`.
 #[derive(Debug, Eq, PartialEq)]
 struct HeapEntry {
     ts: UnixNanos,
@@ -81,8 +81,8 @@ impl BacktestDataIterator {
             return;
         }
 
-        // Ensure sorted by ts_init
-        data.sort_by_key(HasTsInit::ts_init);
+        // Ensure sorted by ts_event (when the event occurred at the exchange)
+        data.sort_by_key(HasTsEvent::ts_event);
 
         let priority = if let Some(p) = self.priorities.get(name) {
             // Replace existing stream – remove previous traces then re-insert below.
@@ -157,7 +157,7 @@ impl BacktestDataIterator {
         self.indices.insert(entry.priority, next_index);
         if next_index < stream_vec.len() {
             self.heap.push(HeapEntry {
-                ts: stream_vec[next_index].ts_init(),
+                ts: stream_vec[next_index].ts_event(),
                 priority: entry.priority,
                 index: next_index,
             });
@@ -194,7 +194,7 @@ impl BacktestDataIterator {
             let idx = *self.indices.get(&priority).unwrap_or(&0);
             if idx < vec.len() {
                 self.heap.push(HeapEntry {
-                    ts: vec[idx].ts_init(),
+                    ts: vec[idx].ts_event(),
                     priority,
                     index: idx,
                 });
@@ -232,8 +232,8 @@ mod tests {
         let mut it = BacktestDataIterator::new();
         let stream = vec![quote("BTC-PERP.BINANCE", 1), quote("BTC-PERP.BINANCE", 3)];
         it.add_data("main", stream, true);
-        assert_eq!(it.next().unwrap().ts_init(), UnixNanos::from(1));
-        assert_eq!(it.next().unwrap().ts_init(), UnixNanos::from(3));
+        assert_eq!(it.next().unwrap().ts_event(), UnixNanos::from(1));
+        assert_eq!(it.next().unwrap().ts_event(), UnixNanos::from(3));
         assert!(it.next().is_none());
     }
 
@@ -245,7 +245,7 @@ mod tests {
 
         let mut ts = Vec::new();
         while let Some(d) = it.next() {
-            ts.push(d.ts_init());
+            ts.push(d.ts_event());
         }
         assert_eq!(
             ts,

--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -33,7 +33,7 @@ use nautilus_core::{UUID4, UnixNanos};
 use nautilus_data::client::DataClientAdapter;
 use nautilus_execution::models::{fee::FeeModelAny, fill::FillModel, latency::LatencyModel};
 use nautilus_model::{
-    data::{Data, HasTsInit},
+    data::{Data, HasTsEvent},
     enums::{AccountType, BookType, OmsType},
     identifiers::{AccountId, ClientId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
@@ -288,10 +288,12 @@ impl BacktestEngine {
             return;
         }
 
-        // If requested, sort by ts_init so internal stream is monotonic.
+        // If requested, sort by ts_event so internal stream is monotonic.
+        // We use ts_event (when the event occurred at the exchange) rather than ts_init
+        // (when the data was ingested) to ensure proper chronological ordering for backtesting.
         let mut to_add = data;
         if sort {
-            to_add.sort_by_key(HasTsInit::ts_init);
+            to_add.sort_by_key(HasTsEvent::ts_event);
         }
 
         // Instrument & book tracking using Data helpers
@@ -317,7 +319,7 @@ impl BacktestEngine {
         if sort {
             // VecDeque cannot be sorted directly; convert to Vec for sorting, then back.
             let mut vec: Vec<Data> = self.data.drain(..).collect();
-            vec.sort_by_key(HasTsInit::ts_init);
+            vec.sort_by_key(HasTsEvent::ts_event);
             self.data = vec.into();
         }
 

--- a/crates/model/src/data/mod.rs
+++ b/crates/model/src/data/mod.rs
@@ -148,6 +148,31 @@ impl Data {
     }
 }
 
+/// Marker trait for types that carry an event timestamp.
+///
+/// `ts_event` is the moment (UNIX nanoseconds) when the event occurred at the venue/exchange.
+/// This is the authoritative timestamp for ordering events chronologically.
+pub trait HasTsEvent {
+    /// Returns the UNIX timestamp (nanoseconds) when the event occurred.
+    fn ts_event(&self) -> UnixNanos;
+}
+
+impl HasTsEvent for Data {
+    fn ts_event(&self) -> UnixNanos {
+        match self {
+            Self::Delta(d) => d.ts_event,
+            Self::Deltas(d) => d.ts_event,
+            Self::Depth10(d) => d.ts_event,
+            Self::Quote(q) => q.ts_event,
+            Self::Trade(t) => t.ts_event,
+            Self::Bar(b) => b.ts_event,
+            Self::MarkPriceUpdate(p) => p.ts_event,
+            Self::IndexPriceUpdate(p) => p.ts_event,
+            Self::InstrumentClose(c) => c.ts_event,
+        }
+    }
+}
+
 /// Marker trait for types that carry a creation timestamp.
 ///
 /// `ts_init` is the moment (UNIX nanoseconds) when this value was first generated or


### PR DESCRIPTION
I've added a `HasTsEvent` trait to the `Data` enum and updated the backtest engine to sort data by `ts_event` instead of `ts_init`.

### Rationale
- `ts_event` represents when the event occurred at the exchange/venue
- `ts_init` represents when the data was ingested by Nautilus
- For backtesting, we want to process events in the order they occurred at the exchange, not when they were ingested
- This ensures proper chronological ordering for realistic backtesting

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
