### PR TITLE
Convert LatencyModel to trait with StaticLatencyModel impl

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -135,7 +135,7 @@ impl BacktestEngine {
         modules: Vec<Box<dyn SimulationModule>>,
         fill_model: FillModel,
         fee_model: FeeModelAny,
-        latency_model: Option<LatencyModel>,
+        latency_model: Option<Box<dyn LatencyModel>>,
         routing: Option<bool>,
         reject_stop_orders: Option<bool>,
         support_gtd_orders: Option<bool>,

--- a/crates/execution/src/models/latency.rs
+++ b/crates/execution/src/models/latency.rs
@@ -13,26 +13,57 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use nautilus_core::UnixNanos;
 
-/// Provides latency modeling for order processing operations.
+/// Trait for latency models used in backtesting.
+///
+/// Latency models simulate network delays for order operations during backtesting.
+/// Implementations can provide static or dynamic (jittered) latency values.
+pub trait LatencyModel: Debug {
+    /// Returns the latency for order insertion operations.
+    fn get_insert_latency(&self) -> UnixNanos;
+
+    /// Returns the latency for order update/modify operations.
+    fn get_update_latency(&self) -> UnixNanos;
+
+    /// Returns the latency for order delete/cancel operations.
+    fn get_delete_latency(&self) -> UnixNanos;
+
+    /// Returns the base latency component.
+    fn get_base_latency(&self) -> UnixNanos;
+}
+
+/// Static latency model with fixed latency values.
 ///
 /// Models the latency for different order operations including base network latency
 /// and specific operation latencies for insert, update, and delete operations.
-#[derive(Debug)]
-pub struct LatencyModel {
-    pub base_latency_nanos: UnixNanos,
-    pub insert_latency_nanos: UnixNanos,
-    pub update_latency_nanos: UnixNanos,
-    pub delete_latency_nanos: UnixNanos,
+///
+/// The base latency is automatically added to each operation latency, matching
+/// Python's behavior. For example, if `base_latency_nanos = 100ms` and
+/// `insert_latency_nanos = 200ms`, the effective insert latency will be 300ms.
+#[derive(Debug, Clone)]
+pub struct StaticLatencyModel {
+    base_latency_nanos: UnixNanos,
+    insert_latency_nanos: UnixNanos,
+    update_latency_nanos: UnixNanos,
+    delete_latency_nanos: UnixNanos,
 }
 
-impl LatencyModel {
-    /// Creates a new [`LatencyModel`] instance.
+impl StaticLatencyModel {
+    /// Creates a new [`StaticLatencyModel`] instance.
+    ///
+    /// The base latency is added to each operation latency to get the effective latency.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_latency_nanos` - Base network latency added to all operations
+    /// * `insert_latency_nanos` - Additional latency for order insertion
+    /// * `update_latency_nanos` - Additional latency for order updates
+    /// * `delete_latency_nanos` - Additional latency for order cancellation
     #[must_use]
-    pub const fn new(
+    pub fn new(
         base_latency_nanos: UnixNanos,
         insert_latency_nanos: UnixNanos,
         update_latency_nanos: UnixNanos,
@@ -40,15 +71,62 @@ impl LatencyModel {
     ) -> Self {
         Self {
             base_latency_nanos,
-            insert_latency_nanos,
-            update_latency_nanos,
-            delete_latency_nanos,
+            insert_latency_nanos: UnixNanos::from(
+                base_latency_nanos.as_u64() + insert_latency_nanos.as_u64(),
+            ),
+            update_latency_nanos: UnixNanos::from(
+                base_latency_nanos.as_u64() + update_latency_nanos.as_u64(),
+            ),
+            delete_latency_nanos: UnixNanos::from(
+                base_latency_nanos.as_u64() + delete_latency_nanos.as_u64(),
+            ),
         }
     }
 }
 
-impl Display for LatencyModel {
+impl LatencyModel for StaticLatencyModel {
+    fn get_insert_latency(&self) -> UnixNanos {
+        self.insert_latency_nanos
+    }
+
+    fn get_update_latency(&self) -> UnixNanos {
+        self.update_latency_nanos
+    }
+
+    fn get_delete_latency(&self) -> UnixNanos {
+        self.delete_latency_nanos
+    }
+
+    fn get_base_latency(&self) -> UnixNanos {
+        self.base_latency_nanos
+    }
+}
+
+impl Display for StaticLatencyModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "LatencyModel()")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_static_latency_model() {
+        let model = StaticLatencyModel::new(
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(2_000_000),
+            UnixNanos::from(3_000_000),
+            UnixNanos::from(4_000_000),
+        );
+
+        // Base is added to each operation latency
+        assert_eq!(model.get_insert_latency().as_u64(), 3_000_000);
+        assert_eq!(model.get_update_latency().as_u64(), 4_000_000);
+        assert_eq!(model.get_delete_latency().as_u64(), 5_000_000);
+        assert_eq!(model.get_base_latency().as_u64(), 1_000_000);
     }
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Introduce LatencyModel trait with methods for getting latencies
- Rename LatencyModel struct to StaticLatencyModel
- Update StaticLatencyModel to add base_latency to operation latencies
- Change latency_model field to Box<dyn LatencyModel> for trait object
- Update set_latency_model to accept boxed trait object
- Replace direct field access with trait method calls
- Update tests to use StaticLatencyModel and fix expected values
- Add unit tests for StaticLatencyModel behavior

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
