### PR TITLE
Fix Binance Spot WebSocket subscription acknowledgment parsing

### DIFF
--- a/nautilus_trader/adapters/binance/spot/execution.py
+++ b/nautilus_trader/adapters/binance/spot/execution.py
@@ -239,6 +239,9 @@ class BinanceSpotExecutionClient(BinanceCommonExecutionClient):
     def _handle_user_ws_message(self, raw: bytes) -> None:
         try:
             wrapper = self._decoder_spot_user_msg_wrapper.decode(raw)
+            if not wrapper.stream or not wrapper.data:
+                return  # Control message response
+
             self._spot_user_ws_handlers[wrapper.data.e](raw)
         except Exception as e:
             self._log.exception(f"Error on handling {raw!r}", e)

--- a/nautilus_trader/adapters/binance/spot/schemas/user.py
+++ b/nautilus_trader/adapters/binance/spot/schemas/user.py
@@ -62,8 +62,8 @@ class BinanceSpotUserMsgWrapper(msgspec.Struct, frozen=True):
     Provides a wrapper for execution WebSocket messages from Binance.
     """
 
-    stream: str
-    data: BinanceSpotUserMsgData
+    data: BinanceSpotUserMsgData | None = None
+    stream: str | None = None
 
 
 class BinanceSpotBalance(msgspec.Struct, frozen=True):


### PR DESCRIPTION
## Summary

Fixes the Binance Spot adapter crashing when receiving WebSocket subscription acknowledgment messages (`{"result":null,"id":0}`).

## Changes

- Makes `stream` and `data` fields optional in `BinanceSpotUserMsgWrapper` (matching the Futures adapter)
- Adds guard check in `_handle_user_ws_message` to skip control messages

## Context

The Futures adapter was fixed in commit `cb53edd57` ("Fix BinanceWebSocketClient reconnects", Oct 2023) but the same fix was never applied to Spot. This PR applies the identical fix pattern.

## Testing

Tested locally against Binance Spot testnet - subscription acknowledgments are now properly skipped and real-time bar data flows correctly.

Closes #3381