### PR TITLE
Fix instrument cache race condition during Rust LiveNode startup

### DIFF
--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -206,6 +206,18 @@ impl AsyncRunner {
         self.channels
     }
 
+    /// Drains all pending data events from the channel and processes them.
+    pub fn drain_pending_data_events(&mut self) {
+        let mut count = 0;
+        while let Ok(evt) = self.channels.data_evt_rx.try_recv() {
+            Self::handle_data_event(evt);
+            count += 1;
+        }
+        if count > 0 {
+            log::debug!("Drained {count} pending data events");
+        }
+    }
+
     /// Runs the async runner event loop.
     ///
     /// This method processes data events, time events, execution events, and signal events in an async loop.

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -580,12 +580,19 @@ impl NautilusKernel {
         }
         log::info!("Clients started");
 
+        self.ts_started = Some(self.clock.borrow().timestamp_ns());
+        log::info!("Started");
+    }
+
+    /// Starts the trader (strategies and actors).
+    ///
+    /// This should be called after clients are connected and instruments are cached.
+    pub fn start_trader(&mut self) {
+        log::info!("Starting trader...");
         if let Err(e) = self.trader.start() {
             log::error!("Error starting trader: {e:?}");
         }
-
-        self.ts_started = Some(self.clock.borrow().timestamp_ns());
-        log::info!("Started");
+        log::info!("Trader started");
     }
 
     /// Stops the trader and its registered components.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix startup race condition where instruments weren't in cache when strategies started, causing `on_start()` to fail with "Instrument not found in cache" errors.

### Problem

When a strategy's `on_start()` method tried to access instruments from the cache, they weren't there yet. This happened because:

1. During `connect_clients()`, the data client fetches instruments and sends them to a channel via `DataEvent::Instrument`
2. These events were queued but not processed into the shared cache
3. `start_trader()` was called before the events were processed
4. Strategy's `on_start()` tried to get instrument from cache → **FAIL**

**Timeline (before fix):**
```
12:09:14.408812  Cached instruments (sent to channel)
12:09:14.619928  All engine clients connected
12:09:14.619930  Starting trader...          ← Too early!
12:09:14.620106  ERROR - Instrument not found in cache
12:09:14.741671  Events finally processed    ← Too late!
```

### Solution

Ensure all pending data events that we can receive during the `connect` method are processed into the cache **before** starting the trader/strategies.

## Why This Approach?

### Rust vs Python Architecture

Python's data clients have direct access to `self._cache` and can add instruments synchronously during connect:

```python
# nautilus_trader/adapters/deribit/data.py:289-294
def _send_all_instruments_to_data_engine(self) -> None:
    for currency in self._instrument_provider.currencies().values():
        self._cache.add_currency(currency)

    for instrument in self._instrument_provider.get_all().values():
        self._handle_data(instrument)  # Processed immediately by event loop
```

Rust data clients use channels (`data_sender`) and don't have direct cache access. Events are processed asynchronously by the event loop, creating a timing gap.

### Alignment with Python Kernel

The startup ordering now matches [`NautilusKernel.start_async()`](https://github.com/nautechsystems/nautilus_trader/blob/develop/nautilus_trader/system/kernel.py#L997-L1033):

```python
# nautilus_trader/system/kernel.py:997-1033
async def start_async(self) -> None:
    self._register_executor()
    self._start_engines()
    self._connect_clients()

    if not await self._await_engines_connected():
        return

    # Reconciliation happens BEFORE trader.start()
    if self.exec_engine.reconciliation:
        if not await self._await_execution_reconciliation():
            return

    self._emulator.start()
    self._initialize_portfolio()

    if not await self._await_portfolio_initialization():
        return

    self._trader.start()  # Strategies start AFTER reconciliation
```

### Startup Sequence (both `start()` and `run()`)

```
1. start_async()              # Start engines, initialize trader
2. connect_clients()          # Async network connections
3. await_engines_connected()
4. drain_pending_events()     # Process instrument data events ← NEW
5. reconciliation()           # Align with venue state
6. start_trader()             # Start strategies ← MOVED AFTER DRAIN
7. set_state(Running)         # ← MOVED AFTER START_TRADER
```



## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
