### PR TITLE
Add Binance listenKeyExpired event handling

### DIFF
--- a/nautilus_trader/adapters/binance/spot/enums.py
+++ b/nautilus_trader/adapters/binance/spot/enums.py
@@ -99,6 +99,7 @@ class BinanceSpotEventType(Enum):
     balanceUpdate = "balanceUpdate"
     executionReport = "executionReport"
     listStatus = "listStatus"
+    listenKeyExpired = "listenKeyExpired"
 
 
 class BinanceSpotEnumParser(BinanceEnumParser):

--- a/nautilus_trader/adapters/binance/spot/execution.py
+++ b/nautilus_trader/adapters/binance/spot/execution.py
@@ -124,6 +124,7 @@ class BinanceSpotExecutionClient(BinanceCommonExecutionClient):
             BinanceSpotEventType.executionReport: self._handle_execution_report,
             BinanceSpotEventType.listStatus: self._handle_list_status,
             BinanceSpotEventType.balanceUpdate: self._handle_balance_update,
+            BinanceSpotEventType.listenKeyExpired: self._handle_listen_key_expired,
         }
 
         # Websocket spot schema decoders
@@ -259,3 +260,6 @@ class BinanceSpotExecutionClient(BinanceCommonExecutionClient):
 
     def _handle_balance_update(self, raw: bytes) -> None:
         self.create_task(self._update_account_state())
+
+    def _handle_listen_key_expired(self, raw: bytes) -> None:
+        self._log.warning("Listen key expired")


### PR DESCRIPTION
## Summary

- Add `listenKeyExpired` enum value to `BinanceSpotEventType`
- Add `_handle_listen_key_expired()` handler that logs a warning
- Matches the existing implementation in the Binance Futures adapter

## Test plan

- [x] Tested on Binance Spot testnet with live trading
- [x] Confirmed clean `[WARN] Listen key expired` log instead of `ValidationError` traceback
- [x] Verified order execution flow continues working after the event

Closes #3386