### PR TITLE
Use BTreeMap to store live timers

### DIFF
--- a/crates/common/src/live/clock.rs
+++ b/crates/common/src/live/clock.rs
@@ -15,19 +15,17 @@
 
 //! Live clock implementation using Tokio for real-time operations.
 
-use std::{
-    collections::BinaryHeap,
-    ops::Deref,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
-
-use ahash::AHashMap;
 use futures::Stream;
 use nautilus_core::{
     AtomicTime, UnixNanos, consts::NAUTILUS_PREFIX, correctness::check_predicate_true,
     time::get_atomic_clock_realtime,
+};
+use std::{
+    collections::{BTreeMap, BinaryHeap},
+    ops::Deref,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
 };
 use ustr::Ustr;
 
@@ -50,7 +48,7 @@ use crate::{
 #[derive(Debug)]
 pub struct LiveClock {
     time: &'static AtomicTime,
-    timers: AHashMap<Ustr, LiveTimer>,
+    timers: BTreeMap<Ustr, LiveTimer>,
     callbacks: CallbackRegistry,
     sender: Option<Arc<dyn TimeEventSender>>,
 }
@@ -61,14 +59,14 @@ impl LiveClock {
     pub fn new(sender: Option<Arc<dyn TimeEventSender>>) -> Self {
         Self {
             time: get_atomic_clock_realtime(),
-            timers: AHashMap::new(),
+            timers: BTreeMap::new(),
             callbacks: CallbackRegistry::new(),
             sender,
         }
     }
 
     #[must_use]
-    pub const fn get_timers(&self) -> &AHashMap<Ustr, LiveTimer> {
+    pub const fn get_timers(&self) -> &BTreeMap<Ustr, LiveTimer> {
         &self.timers
     }
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -59,3 +59,8 @@ reason = "ruint unsoundness in reciprocal functions, transitive via alloy, we do
 [[IgnoredVulns]]
 id = "GHSA-wj6h-64fc-37mp"
 reason = "ecdsa Minerva timing attack on P-256, maintainers consider sidechannel attacks out of scope, only affects optional dYdX adapter"
+
+# Rust dependencies
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0001"
+reason = "rkyv vulnerability in transitive dependency via rust_decimal 1.39.0. rust_decimal is at latest version and hasn't updated to rkyv 0.8.x yet. Will be fixed when rust_decimal updates."


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- In order to have parity with what is used for TestClock and have some control over which timer is executed first if they fire at the same time. This can be useful for example to ensure that a spread aggregator fires before a bar aggregator, based on timer names. 

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
