### PR TITLE
Refine closing of streaming writer

### DIFF
--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -1438,4 +1438,4 @@ class NautilusKernel:
 
     def _flush_writer(self) -> None:
         if self._writer is not None:
-            self._writer.flush()
+            self._writer.close()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Fix potential data loss in writers during shutdown

This PR fixes a potential data loss issue where in-memory buffered data in `StreamingFeatherWriter` may not be uploaded to S3 during service restarts. The fix ensures all buffered data is properly flushed and uploaded before the process exits.

### Problem

When writing feather files to S3 via fsspec/s3fs, data is buffered in memory and only uploaded to S3 when the buffer size exceeds 50MB (default `blocksize`). During shutdown, `_flush_writer()` was calling `flush()`, which does not force upload of buffers smaller than 50MB. This could result in data loss if:

- The process exits before `__del__` runs.
- There are circular references preventing garbage collection.
- The process is killed with SIGKILL (OOM, systemd timeout).

### Solution

Changed `_flush_writer()` to call `close()` instead of `flush()` during shutdown. The `close()` method ensures all remaining buffered data is uploaded to S3 regardless of buffer size by calling `flush(force=True)` internally, then properly closing all file handles.

### Implementation details

#### Core change

- Modified `_flush_writer()` in `nautilus_trader/system/kernel.py` to call `self._writer.close()` instead of `self._writer.flush()`.

- This change only affects the shutdown path (`stop()` and `stop_async()` methods), ensuring it's safe to close writers since the application is terminating.

- The periodic flush mechanism (every ~10 seconds during normal operation) remains completely unchanged and unaffected.

#### Safety considerations

- `close()` is idempotent: safe to call multiple times if `dispose()` is later called.

- `_flush_writer()` is only called from terminal shutdown operations, so closing writers does not require reinitialization.

- The `StreamingFeatherWriter.close()` method internally calls `flush()` first, then closes all writers and file handles, ensuring all data is uploaded.

### Benefits

- Prevents data loss: all in-memory buffered data is guaranteed to be uploaded to S3 before process exit.

- Minimal code change: single line modification with low risk of introducing bugs.

- No performance impact: change only affects shutdown path, normal operation remains unchanged.

- Reliable shutdown: eliminates dependency on `__del__` destructor which is not guaranteed to run.

### Files changed

- `nautilus_trader/system/kernel.py`: changed `_flush_writer()` to call `close()` instead of `flush()`.

### References

- Fixes issue #3391: Potential data loss in writers.
- Solution A from the issue analysis: change shutdown flush to use `close()`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
