### PR TITLE
Fix typo in OrderBook.simulate_fills error message

### DIFF
--- a/nautilus_trader/model/book.pyx
+++ b/nautilus_trader/model/book.pyx
@@ -629,7 +629,7 @@ cdef class OrderBook(Data):
             raise RuntimeError(
                 f"Invalid size precision for order leaves quantity {order.leaves_qty._mem.precision} "
                 f"when instrument size precision is {size_prec}. "
-                f"Check order quantity precision matches the {order.instrument.id} instrument"
+                f"Check order quantity precision matches the {order.instrument_id} instrument"
             )
 
         cdef Price order_price


### PR DESCRIPTION
## Description

Fixes a typo in the precision validation error message in `OrderBook.simulate_fills()`.

The error message references `order.instrument.id`, but `Order` objects have `instrument_id` attribute, not `instrument`. This causes an `AttributeError` when the precision validation fails, masking the actual helpful error message.

## Changes

- `nautilus_trader/model/book.pyx` line 632: `order.instrument.id` → `order.instrument_id`

## Before

When order precision doesn't match instrument precision:
```
AttributeError: 'nautilus_trader.model.orders.market.MarketOrder' object 
has no attribute 'instrument'. Did you mean: 'instrument_id'?
```

## After

```
RuntimeError: Invalid size precision for order leaves quantity 0 
when instrument size precision is 8. 
Check order quantity precision matches the BTCUSDT.BINANCE instrument
```

## Note

To avoid triggering this error in the first place, ensure order quantities are created using the instrument's size precision (e.g., via `instrument.make_qty()` or using `instrument.size_precision`).

## Related

Introduced in 791b73b5 ("Add additional precision validations for simulated fills")