### PR TITLE
Add optional config for immediate execution with quotes

### DIFF
--- a/examples/backtest/notebooks/databento_option_greeks.py
+++ b/examples/backtest/notebooks/databento_option_greeks.py
@@ -53,12 +53,12 @@ from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import PriceType
 from nautilus_trader.model.greeks_data import GreeksData
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.identifiers import new_generic_spread_id
 from nautilus_trader.model.instruments import FuturesContract
-from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.model.tick_scheme import TieredTickScheme
 from nautilus_trader.model.tick_scheme import register_tick_scheme
@@ -155,6 +155,15 @@ spread_id2 = new_generic_spread_id(
         (future_id2, 1),  # Long ESZ4
     ],
 )
+
+
+def get_mid_price_rounded(tick, instrument, round_up=True, num_ticks=0):
+    mid_price = tick.extract_price(PriceType.MID)
+    if round_up:
+        return instrument.next_ask_price(mid_price.as_double(), num_ticks=num_ticks)
+    else:
+        return instrument.next_bid_price(mid_price.as_double(), num_ticks=num_ticks)
+
 
 # %% [markdown]
 # ## strategy
@@ -303,13 +312,31 @@ class OptionStrategy(Strategy):
         )
 
         # Submit spread order when we have spread quotes available
-        if tick.instrument_id == self.config.spread_id and not self.spread_order_submitted:
+        if (
+            tick.instrument_id == self.config.spread_id
+            and not self.spread_order_submitted
+            and tick.ts_init == 1715248980000000000
+        ):
             # Try submitting order immediately - the exchange should have processed the quote by now
-            self.submit_market_order(instrument_id=self.config.spread_id, quantity=5)
+            instrument = self.cache.instrument(tick.instrument_id)
+            mid_price_rounded = get_mid_price_rounded(
+                tick=tick,
+                instrument=instrument,
+                round_up=True,  # Round up for buy orders (more aggressive)
+            )
+            self.submit_limit_order(
+                instrument_id=self.config.spread_id,
+                price=mid_price_rounded,
+                quantity=5,
+            )
             self.spread_order_submitted = True
 
         if tick.instrument_id == self.config.spread_id2 and not self.spread_order_submitted2:
-            self.submit_market_order(instrument_id=self.config.spread_id2, quantity=5)
+            self.submit_limit_order(
+                instrument_id=self.config.spread_id2,
+                price=tick.ask_price,
+                quantity=5,
+            )
             self.spread_order_submitted2 = True
 
     def on_order_filled(self, event):
@@ -367,18 +394,18 @@ class OptionStrategy(Strategy):
             order_side=(OrderSide.BUY if quantity > 0 else OrderSide.SELL),
             quantity=Quantity.from_int(abs(quantity)),
         )
+        self.user_log(f"Submitting order: {order}")
         self.submit_order(order)
-        self.user_log(f"Order submitted: {order}")
 
     def submit_limit_order(self, instrument_id, price, quantity):
         order = self.order_factory.limit(
             instrument_id=instrument_id,
             order_side=(OrderSide.BUY if quantity > 0 else OrderSide.SELL),
             quantity=Quantity.from_int(abs(quantity)),
-            price=Price.from_str(f"{price:.2f}"),
+            price=price,
         )
+        self.user_log(f"Submitting order: {order}")
         self.submit_order(order)
-        self.user_log(f"Order submitted: {order}")
 
     def user_log(self, msg, color=LogColor.GREEN):
         self.log.warning(f"{msg}", color=color)
@@ -463,6 +490,7 @@ engine_config = BacktestEngineConfig(
     strategies=strategies,
     streaming=(streaming if not load_greeks else None),
     catalogs=catalogs,
+    # allow_immediate_quote_execution=True,
 )
 
 # BacktestRunConfig
@@ -498,12 +526,9 @@ if load_greeks:
         *data,
     ]
 
-# Configure venue with enhanced SizeAwareFillModel for realistic option execution
-# This fill model provides different execution behavior based on order size:
-# - Small orders (<=10 contracts): Good liquidity at best prices
-# - Large orders: Experience price impact with partial fills at worse prices
+# Configure venue with enhanced BestPriceFillModel for being able to execute limit orders anywhere between a bid ask
 fill_model = ImportableFillModelConfig(
-    fill_model_path="nautilus_trader.backtest.models:SizeAwareFillModel",
+    fill_model_path="nautilus_trader.backtest.models:BestPriceFillModel",
     config_path="nautilus_trader.backtest.config:FillModelConfig",
     config={},
 )

--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -331,6 +331,10 @@ class BacktestEngineConfig(NautilusKernelConfig, frozen=True):
         If logging should be bypassed.
     run_analysis : bool, default True
         If post backtest performance analysis should be run.
+    allow_immediate_quote_execution : bool, default False
+        Allows a strategy to receive quotes and pass orders before the data is
+        processed by the execution engine. Only relevant in backtesting.
+        Useful for backtests on discrete times, like every minute, hour or day.
 
     """
 
@@ -341,6 +345,7 @@ class BacktestEngineConfig(NautilusKernelConfig, frozen=True):
     risk_engine: RiskEngineConfig | None = RiskEngineConfig()
     exec_engine: ExecEngineConfig | None = ExecEngineConfig()
     run_analysis: bool = True
+    allow_immediate_quote_execution: bool = False
 
     def __post_init__(self):
         if isinstance(self.trader_id, str):

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -559,9 +559,9 @@ cdef class BacktestEngine:
             If the `reduce_only` execution instruction on orders will be honored.
         use_message_queue : bool, default True
             If an internal message queue should be used to process trading commands in sequence after
-            they have initially arrived. Setting this to False would be appropriate for real-time
-            sandbox environments, where we don't want to introduce additional latency of waiting for
-            the next data event before processing the trading command.
+            they have initially arrived. This parameter is overridden by `allow_immediate_quote_execution`
+            in the engine config: when `allow_immediate_quote_execution=True`, `use_message_queue=False`
+            automatically.
         bar_execution : bool, default True
             If bars should be processed by the matching engine(s) (and move the market).
         bar_adaptive_high_low_ordering : bool, default False
@@ -619,6 +619,10 @@ cdef class BacktestEngine:
         # Create exchange
         normalized_price_protection = price_protection_points
 
+        # Set use_message_queue based on allow_immediate_quote_execution config
+        # When immediate execution is enabled, disable message queue
+        effective_use_message_queue = use_message_queue and not self._config.allow_immediate_quote_execution
+
         exchange = SimulatedExchange(
             venue=venue,
             oms_type=oms_type,
@@ -644,7 +648,7 @@ cdef class BacktestEngine:
             use_position_ids=use_position_ids,
             use_random_ids=use_random_ids,
             use_reduce_only=use_reduce_only,
-            use_message_queue=use_message_queue,
+            use_message_queue=effective_use_message_queue,
             bar_execution=bar_execution,
             bar_adaptive_high_low_ordering=bar_adaptive_high_low_ordering,
             trade_execution=trade_execution,
@@ -721,7 +725,6 @@ cdef class BacktestEngine:
 
         # Validate instrument is correct for the venue
         cdef SimulatedExchange venue = self._venues[instrument.id.venue]
-
         if (
             isinstance(instrument, CurrencyPair)
             and venue.account_type != AccountType.MARGIN
@@ -820,10 +823,8 @@ cdef class BacktestEngine:
             )
 
         cdef str data_added_str = "data"
-
         if validate:
             first = data[0]
-
             if hasattr(first, "instrument_id"):
                 Condition.is_true(
                     first.instrument_id in self._kernel.cache.instrument_ids(),
@@ -871,7 +872,6 @@ cdef class BacktestEngine:
 
         for data_point in data:
             data_type = type(data_point)
-
             if data_type is Bar:
                 self._backtest_subscription_names.add(f"{data_point.bar_type}")
             elif data_type in (QuoteTick, TradeTick):
@@ -928,7 +928,6 @@ cdef class BacktestEngine:
     cdef void _handle_subscribe(self, SubscribeData command):
         cdef RequestData request = command.to_request(unix_nanos_to_dt(self._last_ns), unix_nanos_to_dt(self._end_ns), self._handle_data_response)
         cdef str subscription_name = request.params["subscription_name"]
-
         if subscription_name in self._data_requests or subscription_name in self._backtest_subscription_names:
             return
 
@@ -1003,9 +1002,8 @@ cdef class BacktestEngine:
         self._kernel._msgbus.request(endpoint="DataEngine.request", request=new_request)
 
     cpdef void _handle_data_response(self, DataResponse response):
-        cdef list data = response.data
         cdef str subscription_name = response.params["subscription_name"]
-
+        cdef list data = response.data
         if not data:
             self._log.debug(f"Empty data for {subscription_name}")
         else:
@@ -1015,7 +1013,6 @@ cdef class BacktestEngine:
 
     cpdef void _handle_unsubscribe(self, UnsubscribeData command):
         cdef str subscription_name = ""
-
         if command.data_type.type is Bar:
             subscription_name = f"{command.bar_type}"
         elif type(command) is UnsubscribeInstruments:
@@ -1437,7 +1434,6 @@ cdef class BacktestEngine:
                 has_data = instrument_id in self._has_data
                 missing_book_data = instrument_id not in self._has_book_data
                 book_type_has_depth = exchange.book_type > BookType.L1_MBP
-
                 if book_type_has_depth and has_data and missing_book_data:
                     raise InvalidConfiguration(
                         f"No order book data found for instrument '{instrument_id }' when `book_type` is '{book_type_to_str(exchange.book_type)}'. "
@@ -1484,14 +1480,12 @@ cdef class BacktestEngine:
             for exchange in self._venues.values():
                 exchange.initialize_account()
                 open_orders = self._kernel.cache.orders_open(venue=exchange.id)
-
                 for order in open_orders:
                     if order.is_emulated:
                         # Order should be loaded in the emulator already
                         continue
 
                     matching_engine = exchange.get_matching_engine(order.instrument_id)
-
                     if matching_engine is None:
                         self._log.error(
                             f"No matching engine for {order.instrument_id} to process {order}",
@@ -1524,7 +1518,6 @@ cdef class BacktestEngine:
         # Set starting index
         cdef uint64_t i
         self._data_len = len(self._data)
-
         if self._data_len > 0:
             for i in range(self._data_len):
                 if start_ns <= self._data[i].ts_init:
@@ -1536,6 +1529,8 @@ cdef class BacktestEngine:
         cdef uint64_t raw_handlers_count = 0
         cdef Data data = self._data_iterator.next()
         cdef CVec raw_handlers
+        cdef bint allow_immediate_quote_execution_config = self._config.allow_immediate_quote_execution
+        cdef bint allow_immediate_quote_execution = False
         try:
             while data is not None:
                 if data.ts_init > end_ns:
@@ -1547,6 +1542,10 @@ cdef class BacktestEngine:
                     self._last_ns = data.ts_init
                     raw_handlers = self._advance_time(data.ts_init)
                     raw_handlers_count = raw_handlers.len
+
+                allow_immediate_quote_execution = allow_immediate_quote_execution_config and isinstance(data, QuoteTick)
+                if allow_immediate_quote_execution:
+                    self._data_engine.process(data)
 
                 # Process data through exchange
                 if isinstance(data, Instrument):
@@ -1577,14 +1576,14 @@ cdef class BacktestEngine:
                     exchange = self._venues[data.instrument_id.venue]
                     exchange.process_instrument_status(data)
 
-                self._data_engine.process(data)
+                if not allow_immediate_quote_execution:
+                    self._data_engine.process(data)
 
                 # Process all exchange messages
                 for exchange in self._venues.values():
                     exchange.process(data.ts_init)
 
                 data = self._data_iterator.next()
-
                 if data is None or data.ts_init > self._last_ns:
                     self._process_raw_time_event_handlers(
                         raw_handlers,
@@ -1593,6 +1592,7 @@ cdef class BacktestEngine:
                     )
                     if raw_handlers.ptr != NULL:
                         vec_time_event_handlers_drop(raw_handlers)
+
                     raw_handlers_count = 0
 
                 self._iteration += 1
@@ -1624,15 +1624,15 @@ cdef class BacktestEngine:
         # that chained alerts (alert schedules another alert) are processed in
         # correct timestamp order, maintaining clock monotonicity.
         cdef list[TestClock] clocks = get_component_clocks(self._instance_id)
-        cdef TestClock clock
-        cdef TimeEventHandler_t handler
-        cdef uint64_t ts_event
-        cdef uint64_t ts_last = 0
-        cdef TimeEvent event
-        cdef PyObject *raw_callback
-        cdef object callback
-        cdef SimulatedExchange exchange
-
+        cdef:
+            TestClock clock
+            TimeEventHandler_t handler
+            uint64_t ts_event
+            uint64_t ts_last = 0
+            TimeEvent event
+            PyObject *raw_callback
+            object callback
+            SimulatedExchange exchange
         for clock in clocks:
             time_event_accumulator_advance_clock(
                 &self._accumulator,
@@ -1650,7 +1650,6 @@ cdef class BacktestEngine:
                 &self._accumulator,
                 ts_now - 1,
             )
-
             if handler.callback_ptr == NULL:
                 break
 
@@ -1698,17 +1697,17 @@ cdef class BacktestEngine:
         return empty_vec
 
     cdef void _flush_accumulator_events(self, uint64_t ts_now):
-        cdef list[TestClock] clocks = get_component_clocks(self._instance_id)
-        cdef TestClock clock
-        cdef TimeEventHandler_t handler
-        cdef uint64_t ts_event
-        cdef uint64_t ts_last = 0
-        cdef TimeEvent event
-        cdef PyObject *raw_callback
-        cdef object callback
-        cdef SimulatedExchange exchange
-
         # Advance clocks first to capture alerts scheduled during last callbacks
+        cdef list[TestClock] clocks = get_component_clocks(self._instance_id)
+        cdef:
+            TestClock clock
+            TimeEventHandler_t handler
+            uint64_t ts_event
+            uint64_t ts_last = 0
+            TimeEvent event
+            PyObject *raw_callback
+            object callback
+            SimulatedExchange exchange
         for clock in clocks:
             time_event_accumulator_advance_clock(
                 &self._accumulator,
@@ -1725,7 +1724,6 @@ cdef class BacktestEngine:
                 &self._accumulator,
                 ts_now,
             )
-
             if handler.callback_ptr == NULL:
                 break
 
@@ -1786,12 +1784,10 @@ cdef class BacktestEngine:
                 &self._accumulator,
                 ts_now,
             )
-
             if handler.callback_ptr == NULL:
                 break
 
             ts_event = handler.event.ts_event
-
             if as_of_now and ts_event > ts_now:
                 break
 
@@ -1833,7 +1829,6 @@ cdef class BacktestEngine:
             log_sysinfo(component=type(self).__name__)
 
         cdef str color = self._get_log_color_code()
-
         for exchange in self._venues.values():
             account = exchange.exec_client.get_account()
             self._log.info(f"{color}=================================================================")
@@ -1893,7 +1888,6 @@ cdef class BacktestEngine:
 
         # Get all positions for venue
         cdef list positions = []
-
         for position in self._kernel.cache.positions() + self._kernel.cache.position_snapshots():
             positions.append(position)
 
@@ -1907,13 +1901,14 @@ cdef class BacktestEngine:
             set venue_currencies
         for venue in self._venues.values():
             account = venue.exec_client.get_account()
+
             self._log.info(f"{color}=================================================================")
             self._log.info(f"{color} SimulatedVenue {venue.id}")
             self._log.info(f"{color}=================================================================")
             self._log.info(f"{repr(account)}")
             self._log.info(f"{color}-----------------------------------------------------------------")
-            unrealized_pnls: dict[Currency, Money] | None = None
 
+            unrealized_pnls: dict[Currency, Money] | None = None
             if venue.is_frozen_account:
                 self._log.warning(f"ACCOUNT FROZEN")
             else:
@@ -1939,8 +1934,8 @@ cdef class BacktestEngine:
 
                 self._log.info(f"{color}-----------------------------------------------------------------")
                 self._log.info(f"Unrealized PnLs (included in totals):")
-                unrealized_pnls = self.portfolio.unrealized_pnls(Venue(venue.id.value))
 
+                unrealized_pnls = self.portfolio.unrealized_pnls(Venue(venue.id.value))
                 if not unrealized_pnls:
                     self._log.info("None")
                 else:
@@ -1958,12 +1953,11 @@ cdef class BacktestEngine:
             # Collect all positions and currencies for venue
             venue_positions = []
             venue_currencies = set()
-
             for position in positions:
                 if position.instrument_id.venue == venue.id:
                     venue_positions.append(position)
-                    venue_currencies.add(position.quote_currency)
 
+                    venue_currencies.add(position.quote_currency)
                     if position.base_currency is not None:
                         venue_currencies.add(position.base_currency)
 
@@ -1974,8 +1968,8 @@ cdef class BacktestEngine:
             for currency in sorted(list(venue_currencies), key=lambda x: x.code):
                 self._log.info(f" PnL Statistics ({str(currency)})")
                 self._log.info(f"{color}-----------------------------------------------------------------")
-                unrealized_pnl = unrealized_pnls.get(currency) if unrealized_pnls else None
 
+                unrealized_pnl = unrealized_pnls.get(currency) if unrealized_pnls else None
                 for stat in self._kernel.portfolio.analyzer.get_stats_pnls_formatted(currency, unrealized_pnl):
                     self._log.info(stat)
 
@@ -2009,7 +2003,6 @@ cdef class BacktestEngine:
 
     def _add_market_data_client_if_not_exists(self, Venue venue) -> None:
         cdef ClientId client_id = ClientId(venue.value)
-
         if client_id not in self._kernel.data_engine.registered_clients:
             client = BacktestMarketDataClient(
                 client_id=client_id,
@@ -2179,10 +2172,8 @@ cdef class BacktestDataIterator:
         Condition.valid_string(data_name, "data_name")
 
         cdef list[Data] data
-
         try:
             data = next(data_generator)
-
             if data:
                 self._data_update_function[data_name] = data_generator
                 self._add_data(data_name, data, append_data)
@@ -2202,7 +2193,6 @@ cdef class BacktestDataIterator:
             return
 
         cdef int data_priority
-
         if data_name in self._data_priority:
             data_priority = self._data_priority[data_name]
             self.remove_data(data_name)
@@ -2368,7 +2358,6 @@ cdef class BacktestDataIterator:
     @cython.wraparound(False)
     cpdef void _push_data(self, int data_priority, int data_index):
         cdef uint64_t ts_init
-
         if data_index < self._data_len[data_priority]:
             ts_init = self._data[data_priority][data_index].ts_init
             heapq.heappush(self._heap, (ts_init, data_priority, data_index))
@@ -2377,15 +2366,12 @@ cdef class BacktestDataIterator:
 
     cpdef void _update_data(self, int data_priority):
         cdef str data_name = self._data_name[data_priority]
-
         if data_name not in self._data_update_function:
             return
 
         cdef list[Data] data
-
         try:
             data = next(self._data_update_function[data_name])
-
             if data:
                 # No need for append_data bool as it's an update
                 self._add_data(data_name, data)
@@ -2465,9 +2451,7 @@ cdef class BacktestDataIterator:
         return self
 
     def __next__(self):
-        cdef Data element
-        element = self.next()
-
+        cdef Data element = self.next()
         if element is None:
             raise StopIteration
 
@@ -2604,8 +2588,10 @@ cdef class SimulatedExchange:
         Condition.not_empty(starting_balances, "starting_balances")
         Condition.list_type(starting_balances, Money, "starting_balances")
         Condition.list_type(modules, SimulationModule, "modules", "SimulationModule")
+
         if base_currency:
             Condition.is_true(len(starting_balances) == 1, "single-currency account has multiple starting currencies")
+
         if default_leverage and default_leverage > 1 or leverages:
             Condition.is_true(account_type == AccountType.MARGIN, "leverages defined when account type is not `MARGIN`")
 
@@ -2914,7 +2900,6 @@ cdef class SimulatedExchange:
 
         """
         cdef dict books = {}
-
         cdef OrderMatchingEngine matching_engine
         for matching_engine in self._matching_engines.values():
             books[matching_engine.instrument.id] = matching_engine.get_book()
@@ -3402,10 +3387,21 @@ cdef class SimulatedExchange:
         self._log.info("Reset")
 
     cdef void _process_trading_command(self, TradingCommand command):
+        cdef:
+            OrderMatchingEngine matching_engine
+            Instrument instrument
 
-        cdef OrderMatchingEngine matching_engine = self._matching_engines.get(command.instrument_id)
+        matching_engine = self._matching_engines.get(command.instrument_id)
         if matching_engine is None:
-            raise RuntimeError(f"Cannot process command: no matching engine for {command.instrument_id}")
+            # Try to get instrument from cache and add it to the exchange
+            instrument = self.cache.instrument(command.instrument_id)
+            if instrument is not None:
+                self._log.info(f"Auto-adding instrument {command.instrument_id} to exchange (no matching engine found)")
+                self.add_instrument(instrument)
+                matching_engine = self._matching_engines.get(command.instrument_id)
+
+            if matching_engine is None:
+                raise RuntimeError(f"Cannot process command: no matching engine for {command.instrument_id}")
 
         cdef:
             Order order
@@ -3863,7 +3859,7 @@ cdef class OrderMatchingEngine:
                     f"invalid delta price precision={delta._mem.order.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
-            if delta._mem.order.size.precision != self._size_prec:
+            elif delta._mem.order.size.precision != self._size_prec:
                 raise RuntimeError(
                     f"invalid delta size precision={delta._mem.order.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
@@ -3904,7 +3900,7 @@ cdef class OrderMatchingEngine:
                         f"invalid delta price precision={delta._mem.order.price.precision} "
                         f"did not match instrument.price_precision={self._price_prec}",
                     )
-                if delta._mem.order.size.precision != self._size_prec:
+                elif delta._mem.order.size.precision != self._size_prec:
                     raise RuntimeError(
                         f"invalid delta size precision={delta._mem.order.size.precision} "
                         f"did not match instrument.size_precision={self._size_prec}",
@@ -3941,12 +3937,12 @@ cdef class OrderMatchingEngine:
         for order in depth.bids:
             if order._mem.side == OrderSide.NO_ORDER_SIDE:
                 continue  # Skip null orders
-            if order._mem.price.precision != self._price_prec:
+            elif order._mem.price.precision != self._price_prec:
                 raise RuntimeError(
                     f"invalid depth bid price precision={order._mem.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
-            if order._mem.size.precision != self._size_prec:
+            elif order._mem.size.precision != self._size_prec:
                 raise RuntimeError(
                     f"invalid depth bid size precision={order._mem.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
@@ -3955,12 +3951,12 @@ cdef class OrderMatchingEngine:
         for order in depth.asks:
             if order._mem.side == OrderSide.NO_ORDER_SIDE:
                 continue  # Skip null orders
-            if order._mem.price.precision != self._price_prec:
+            elif order._mem.price.precision != self._price_prec:
                 raise RuntimeError(
                     f"invalid depth ask price precision={order._mem.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
-            if order._mem.size.precision != self._size_prec:
+            elif order._mem.size.precision != self._size_prec:
                 raise RuntimeError(
                     f"invalid depth ask size precision={order._mem.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
@@ -3999,15 +3995,15 @@ cdef class OrderMatchingEngine:
             raise RuntimeError(
                 f"invalid {tick.bid_price.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if tick._mem.ask_price.precision != self._price_prec:
+        elif tick._mem.ask_price.precision != self._price_prec:
             raise RuntimeError(
                 f"invalid {tick.ask_price.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if tick._mem.bid_size.precision != self._size_prec:
+        elif tick._mem.bid_size.precision != self._size_prec:
             raise RuntimeError(
                 f"invalid {tick.bid_size.precision=} did not match instrument.size_precision={self._size_prec}",
             )
-        if tick._mem.ask_size.precision != self._size_prec:
+        elif tick._mem.ask_size.precision != self._size_prec:
             raise RuntimeError(
                 f"invalid {tick.ask_size.precision=} did not match instrument.size_precision={self._size_prec}",
             )
@@ -4046,7 +4042,7 @@ cdef class OrderMatchingEngine:
             raise RuntimeError(
                 f"invalid {tick.price.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if tick._mem.size.precision != self._size_prec:
+        elif tick._mem.size.precision != self._size_prec:
             raise RuntimeError(
                 f"invalid {tick.size.precision=} did not match instrument.size_precision={self._size_prec}",
             )
@@ -4068,16 +4064,19 @@ cdef class OrderMatchingEngine:
             if aggressor_side == AggressorSide.BUYER:
                 if not self._core.is_ask_initialized or price_raw > self._core.ask_raw:
                     self._core.set_ask_raw(price_raw)
+
                 if not self._core.is_bid_initialized or price_raw < self._core.bid_raw:
                     self._core.set_bid_raw(price_raw)
             elif aggressor_side == AggressorSide.SELLER:
                 if not self._core.is_bid_initialized or price_raw < self._core.bid_raw:
                     self._core.set_bid_raw(price_raw)
+
                 if not self._core.is_ask_initialized or price_raw > self._core.ask_raw:
                     self._core.set_ask_raw(price_raw)
             elif aggressor_side == AggressorSide.NO_AGGRESSOR:
                 if not self._core.is_bid_initialized or price_raw <= self._core.bid_raw:
                     self._core.set_bid_raw(price_raw)
+
                 if not self._core.is_ask_initialized or price_raw >= self._core.ask_raw:
                     self._core.set_ask_raw(price_raw)
             else:
@@ -4145,26 +4144,25 @@ cdef class OrderMatchingEngine:
             raise RuntimeError(
                 f"invalid {bar.open.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if bar._mem.high.precision != self._price_prec:
+        elif bar._mem.high.precision != self._price_prec:
             raise RuntimeError(
                 f"invalid {bar.high.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if bar._mem.low.precision != self._price_prec:
+        elif bar._mem.low.precision != self._price_prec:
             raise RuntimeError(
                 f"invalid {bar.low.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if bar._mem.close.precision != self._price_prec:
+        elif bar._mem.close.precision != self._price_prec:
             raise RuntimeError(
                 f"invalid {bar.close.precision=} did not match instrument.price_precision={self._price_prec}",
             )
-        if bar._mem.volume.precision != self._size_prec:
+        elif bar._mem.volume.precision != self._size_prec:
             raise RuntimeError(
                 f"invalid {bar.volume.precision=} did not match instrument.size_precision={self._size_prec}",
             )
 
         cdef InstrumentId instrument_id = bar_type.instrument_id
         cdef BarType execution_bar_type = self._execution_bar_types.get(instrument_id)
-
         if execution_bar_type is None:
             execution_bar_type = bar_type
             self._execution_bar_types[instrument_id] = bar_type
@@ -4172,7 +4170,6 @@ cdef class OrderMatchingEngine:
 
         if execution_bar_type != bar_type:
             bar_type_timedelta = self._execution_bar_deltas.get(bar_type)
-
             if bar_type_timedelta is None:
                 bar_type_timedelta = bar_type.spec.timedelta
                 self._execution_bar_deltas[bar_type] = bar_type_timedelta
@@ -4319,6 +4316,7 @@ cdef class OrderMatchingEngine:
                 self._log.debug(f"Updating with close {bar.close}")
 
             self._fill_at_market = False  # Market moving through prices
+
             tick._mem.price = bar._mem.close
             if close_size is not None:
                 tick._mem.size = close_size._mem
@@ -4326,6 +4324,7 @@ cdef class OrderMatchingEngine:
                 tick._mem.aggressor_side = AggressorSide.BUYER
             else:
                 tick._mem.aggressor_side = AggressorSide.SELLER
+
             tick._mem.trade_id = trade_id_new(pystr_to_cstr(self._generate_trade_id_str()))
             self._book.update_trade_tick(tick)
             self.iterate(tick.ts_init)
@@ -4334,8 +4333,7 @@ cdef class OrderMatchingEngine:
     cdef void _process_quote_ticks_from_bar(self):
         if self._last_bid_bar is None or self._last_ask_bar is None:
             return  # Wait for next bar
-
-        if self._last_bid_bar.ts_init != self._last_ask_bar.ts_init:
+        elif self._last_bid_bar.ts_init != self._last_ask_bar.ts_init:
             return  # Wait for next bar
 
         cdef QuantityRaw min_size_raw = self.instrument.size_increment._mem.raw
@@ -4415,12 +4413,15 @@ cdef class OrderMatchingEngine:
 
     cdef void _process_quote_bar_close(self, QuoteTick tick, Quantity bid_close_size = None, Quantity ask_close_size = None):
         self._fill_at_market = False  # Market moving through prices
+
         tick._mem.bid_price = self._last_bid_bar._mem.close
         tick._mem.ask_price = self._last_ask_bar._mem.close
         if bid_close_size is not None:
             tick._mem.bid_size = bid_close_size._mem
+
         if ask_close_size is not None:
             tick._mem.ask_size = ask_close_size._mem
+
         self._book.update_quote_tick(tick)
         self.iterate(tick.ts_init)
 
@@ -4436,7 +4437,6 @@ cdef class OrderMatchingEngine:
         cdef uint64_t now_ns
         if self._instrument_has_expiration:
             now_ns = self._clock.timestamp_ns()
-
             if now_ns < self.instrument.activation_ns:
                 self._generate_order_rejected(
                     order,
@@ -4471,7 +4471,6 @@ cdef class OrderMatchingEngine:
                 # Check contingent orders are still open
                 for client_order_id in order.linked_order_ids or []:
                     contingent_order = self.cache.order(client_order_id)
-
                     if contingent_order is None:
                         raise RuntimeError(f"Cannot find contingent order for {client_order_id!r}")  # pragma: no cover
 
@@ -4494,7 +4493,6 @@ cdef class OrderMatchingEngine:
         if order.has_price_c():
             # Check order price precision (must be <= instrument precision)
             price = order.price
-
             if price._mem.precision > self._price_prec:
                 self._generate_order_rejected(
                     order,
@@ -4508,7 +4506,6 @@ cdef class OrderMatchingEngine:
         if order.has_trigger_price_c():
             # Check order trigger price precision (must be <= instrument precision)
             trigger_price = order.trigger_price
-
             if trigger_price._mem.precision > self._price_prec:
                 self._generate_order_rejected(
                     order,
@@ -4522,7 +4519,6 @@ cdef class OrderMatchingEngine:
         if order.has_activation_price_c():
             # Check order activation price precision (must be <= instrument precision)
             activation_price = order.activation_price
-
             if activation_price._mem.precision > self._price_prec:
                 self._generate_order_rejected(
                     order,
@@ -4533,7 +4529,6 @@ cdef class OrderMatchingEngine:
                 return  # Invalid order
 
         cdef Position position = self.cache.position_for_order(order.client_order_id)
-
         cdef PositionId position_id
         if position is None and self.oms_type == OmsType.NETTING:
             position_id = PositionId(f"{order.instrument_id}-{order.strategy_id}")
@@ -4807,7 +4802,6 @@ cdef class OrderMatchingEngine:
             # If activation price is not given,
             # set the activation price to the last price, and activate order
             market_price = self._core.ask if order.side == OrderSide.BUY else self._core.bid
-
             if market_price is None:
                 # If there is no market price, we cannot process the order
                 raise RuntimeError(  # pragma: no cover (design-time error)
@@ -5062,7 +5056,6 @@ cdef class OrderMatchingEngine:
                 # The activation price should have been set in OrderMatchingEngine._process_trailing_stop_order()
                 # However, the implementation of the emulator bypass this step, and directly call this method through match_order().
                 market_price = self._core.ask if order.side == OrderSide.BUY else self._core.bid
-
                 if market_price is None:
                     # If there is no market price, we cannot process the order
                     raise RuntimeError(  # pragma: no cover (design-time error)
@@ -5132,6 +5125,18 @@ cdef class OrderMatchingEngine:
             if order.is_closed_c():
                 self._cached_filled_qty.pop(order.client_order_id, None)
                 continue
+
+            # Check fill model for potential matches (including off-market)
+            if (
+                self._fill_model is not None
+                and order.order_type == OrderType.LIMIT
+                and not self._core.is_limit_matched(order.side, order.price)
+            ):
+                order.liquidity_side = LiquiditySide.MAKER
+                self.fill_limit_order(order)
+                if order.is_closed_c():
+                    self._cached_filled_qty.pop(order.client_order_id, None)
+                    continue
 
             # Check expiry
             if self._support_gtd_orders:
@@ -5216,7 +5221,6 @@ cdef class OrderMatchingEngine:
 
         order.liquidity_side = LiquiditySide.TAKER
         cdef list fills = self.determine_market_fills_with_simulation(order)
-
         self.apply_fills(
             order=order,
             fills=fills,
@@ -5239,7 +5243,6 @@ cdef class OrderMatchingEngine:
         # Get current best bid/ask for simulation
         cdef Price best_bid = self._core.bid
         cdef Price best_ask = self._core.ask
-
         if best_bid is None or best_ask is None:
             return []  # No market available
 
@@ -5247,7 +5250,6 @@ cdef class OrderMatchingEngine:
         cdef OrderBook simulated_book = self._fill_model.get_orderbook_for_fill_simulation(
             self.instrument, order, best_bid, best_ask
         )
-
         if simulated_book is not None:
             # Use simulated OrderBook for fill determination
             fills = simulated_book.simulate_fills(
@@ -5260,6 +5262,7 @@ cdef class OrderMatchingEngine:
             # fall back to standard market logic to preserve expected behavior.
             if not fills:
                 return self.determine_market_price_and_volume(order)
+
             return fills
         else:
             # Fall back to standard logic
@@ -5279,7 +5282,6 @@ cdef class OrderMatchingEngine:
 
         cdef list adjusted_fills = []
         cdef QuantityRaw remaining_qty = max_qty_raw  # 0 means no limit
-
         cdef:
             Price price
             Quantity qty
@@ -5292,7 +5294,6 @@ cdef class OrderMatchingEngine:
             QuantityRaw available
             QuantityRaw adjusted_qty_raw
             Quantity adjusted_qty
-
         for fill in fills:
             if max_qty_raw > 0 and remaining_qty == 0:
                 break
@@ -5322,7 +5323,6 @@ cdef class OrderMatchingEngine:
                 continue
 
             adjusted_qty_raw = min(qty._mem.raw, available)
-
             if max_qty_raw > 0:
                 adjusted_qty_raw = min(adjusted_qty_raw, remaining_qty)
                 remaining_qty -= adjusted_qty_raw
@@ -5426,7 +5426,6 @@ cdef class OrderMatchingEngine:
             return  # Order canceled
 
         cdef list fills = self.determine_limit_fills_with_simulation(order)
-
         self.apply_fills(
             order=order,
             fills=fills,
@@ -5449,7 +5448,6 @@ cdef class OrderMatchingEngine:
         # Get current best bid/ask for simulation
         cdef Price best_bid = self._core.bid
         cdef Price best_ask = self._core.ask
-
         if best_bid is None or best_ask is None:
             return []  # No market available
 
@@ -5457,7 +5455,6 @@ cdef class OrderMatchingEngine:
         cdef OrderBook simulated_book = self._fill_model.get_orderbook_for_fill_simulation(
             self.instrument, order, best_bid, best_ask
         )
-
         if simulated_book is not None:
             # Use simulated OrderBook for fill determination
             return simulated_book.simulate_fills(
@@ -5482,14 +5479,12 @@ cdef class OrderMatchingEngine:
         Returns None if there is no quantity available to fill.
         """
         cdef QuantityRaw leaves_raw = order.quantity._mem.raw - order.filled_qty._mem.raw if order.quantity._mem.raw > order.filled_qty._mem.raw else 0
-
         if leaves_raw == 0:
             return None
 
         cdef QuantityRaw fill_raw = leaves_raw
         cdef QuantityRaw available_raw
         cdef QuantityRaw trade_size_raw
-
         if self._last_trade_size is not None:
             trade_size_raw = self._last_trade_size._mem.raw
 
@@ -5503,7 +5498,6 @@ cdef class OrderMatchingEngine:
                 return None
 
             fill_raw = min(leaves_raw, available_raw)
-
             if self._liquidity_consumption:
                 self._trade_consumption += fill_raw
 
@@ -5533,11 +5527,10 @@ cdef class OrderMatchingEngine:
         """
         Condition.is_true(order.has_price_c(), "order has no limit `price`")
 
-        cdef list fills
-
         # When liquidity consumption is enabled, we need to consider ALL crossed
         # price levels, not just enough to satisfy leaves_qty. This is because some
         # levels may be consumed and we need to fill from subsequent levels.
+        cdef list fills
         if self._liquidity_consumption:
             fills = self._book.get_all_crossed_levels(order.side, order.price, self._size_prec)
         else:
@@ -5557,10 +5550,8 @@ cdef class OrderMatchingEngine:
             bint fills_at_trade_price
             Quantity fill_qty
             tuple fill[Price, Quantity]
-
         if self._last_trade_size is not None and self._core.is_last_initialized:
             trade_price = Price.from_raw_c(self._core.last_raw, self._price_prec)
-
             fills_at_trade_price = False
             for fill in fills:
                 if fill[0] == trade_price:
@@ -5610,20 +5601,17 @@ cdef class OrderMatchingEngine:
                 self._core.set_last_raw(price._mem.raw)
 
         cdef Price last_px
-
         if fills and order.liquidity_side == LiquiditySide.MAKER:
             ########################################################################
             # Filling as MAKER
             ########################################################################
             price = order.price
-
             if order.side == OrderSide.BUY:
                 if triggered_price and price > triggered_price:
                     price = triggered_price
 
                 for fill in fills:
                     last_px = fill[0]
-
                     if last_px._mem.raw < price._mem.raw:
                         # Marketable BUY would have filled at limit
                         self._has_targets = True
@@ -5636,9 +5624,9 @@ cdef class OrderMatchingEngine:
             elif order.side == OrderSide.SELL:
                 if triggered_price and price < triggered_price:
                     price = triggered_price
+
                 for fill in fills:
                     last_px = fill[0]
-
                     if last_px._mem.raw > price._mem.raw:
                         # Marketable SELL would have filled at limit
                         self._has_targets = True
@@ -5714,7 +5702,6 @@ cdef class OrderMatchingEngine:
         cdef:
             bint initial_market_to_limit_fill = False
             Price last_fill_px = None
-
         if not fills:
             # For L1 with consumption tracking, empty fills means liquidity was consumed
             # Allow orders to slip to next level (preserves L1 exhausted book behavior)
@@ -5723,13 +5710,17 @@ cdef class OrderMatchingEngine:
                     if not self._core.is_ask_initialized:
                         if order.status_c() == OrderStatus.SUBMITTED:
                             self._generate_order_rejected(order, f"no market for {order.instrument_id}")
+
                         return
+
                     last_fill_px = Price.from_raw_c(self._core.ask_raw, self._price_prec)
                 elif order.side == OrderSide.SELL:
                     if not self._core.is_bid_initialized:
                         if order.status_c() == OrderStatus.SUBMITTED:
                             self._generate_order_rejected(order, f"no market for {order.instrument_id}")
+
                         return
+
                     last_fill_px = Price.from_raw_c(self._core.bid_raw, self._price_prec)
                 else:
                     raise ValueError(f"invalid `OrderSide`, was {order.side}")
@@ -5804,7 +5795,6 @@ cdef class OrderMatchingEngine:
 
                 # Adjust fill to honor reduce only execution (fill remaining position size only)
                 fill_qty = Quantity.from_raw_c(position.quantity._mem.raw, self._size_prec)
-
                 self._generate_order_updated(
                     order=order,
                     qty=fill_qty,
@@ -5970,7 +5960,6 @@ cdef class OrderMatchingEngine:
 
             # Get leg instrument for precision validation
             leg_instrument = self.cache.instrument(leg_instrument_id)
-
             if leg_instrument is None:
                 self._log.warning(f"Leg instrument not found in cache: {leg_instrument_id}")
                 continue
@@ -6058,7 +6047,6 @@ cdef class OrderMatchingEngine:
         # Get mid-prices for all legs
         for leg_instrument_id, ratio in leg_tuples:
             leg_quote = self.cache.quote_tick(leg_instrument_id)
-
             if leg_quote is None:
                 self._log.warning(f"No quote available for leg {leg_instrument_id}")
                 return {}
@@ -6077,14 +6065,12 @@ cdef class OrderMatchingEngine:
         # Calculate weighted sum using mid-prices for all legs except the highest
         cdef double weighted_sum = 0.0
         cdef int highest_price_ratio = 1
-
         for leg_instrument_id, ratio in leg_tuples:
             if leg_instrument_id != highest_price_leg_id:
                 weighted_sum += leg_mid_prices[leg_instrument_id] * ratio
 
                 # Get actual instrument to use its make_price method for proper tick rounding
                 leg_instrument = self.cache.instrument(leg_instrument_id)
-
                 if leg_instrument is not None:
                     leg_prices[leg_instrument_id] = leg_instrument.make_price(
                         leg_mid_prices[leg_instrument_id]
@@ -6107,7 +6093,6 @@ cdef class OrderMatchingEngine:
 
         # Get actual instrument for highest-priced leg to use its make_price method
         highest_leg_instrument = self.cache.instrument(highest_price_leg_id)
-
         if highest_leg_instrument is not None:
             leg_prices[highest_price_leg_id] = highest_leg_instrument.make_price(adjusted_price)
         else:
@@ -6235,8 +6220,7 @@ cdef class OrderMatchingEngine:
 
                 if child_order.is_closed_c():
                     continue
-
-                if child_order.is_active_local_c():
+                elif child_order.is_active_local_c():
                     continue  # Order is not on the exchange yet
 
                 if child_order.position_id is None and order.position_id is not None:
@@ -6262,8 +6246,7 @@ cdef class OrderMatchingEngine:
 
                 if oco_order.is_closed_c():
                     continue
-
-                if oco_order.is_active_local_c():
+                elif oco_order.is_active_local_c():
                     continue  # Order is not on the exchange yet
 
                 self.cancel_order(oco_order)
@@ -6325,7 +6308,6 @@ cdef class OrderMatchingEngine:
                     parent_order = self.cache.order(ro_order.parent_order_id)
 
                 target_qty = position.quantity
-
                 if parent_order is not None:
                     cached_parent_filled = self._cached_filled_qty.get(parent_order.client_order_id, parent_order.filled_qty)
 
@@ -6367,7 +6349,6 @@ cdef class OrderMatchingEngine:
         cdef PositionId position_id
         if self.oms_type == OmsType.HEDGING:
             position_id = self.cache.position_id(order.client_order_id)
-
             if position_id is not None:
                 return position_id
 
@@ -6425,7 +6406,6 @@ cdef class OrderMatchingEngine:
         # Check if order already accepted (being added back into the matching engine)
         if not order.status_c() == OrderStatus.ACCEPTED:
             self._generate_order_accepted(order, venue_order_id=self._get_venue_order_id(order))
-
             if (
                 order.order_type == OrderType.TRAILING_STOP_MARKET
                 or order.order_type == OrderType.TRAILING_STOP_LIMIT
@@ -6473,12 +6453,12 @@ cdef class OrderMatchingEngine:
                 f"invalid update qty precision {qty._mem.precision} "
                 f"when {self.instrument.id} size precision is {self._size_prec}"
             )
-        if price is not None and price._mem.precision > self._price_prec:
+        elif price is not None and price._mem.precision > self._price_prec:
             raise RuntimeError(
                 f"invalid update price precision {price._mem.precision} "
                 f"when {self.instrument.id} price precision is {self._price_prec}"
             )
-        if trigger_price is not None and trigger_price._mem.precision > self._price_prec:
+        elif trigger_price is not None and trigger_price._mem.precision > self._price_prec:
             raise RuntimeError(
                 f"invalid update trigger_price precision {trigger_price._mem.precision} "
                 f"when {self.instrument.id} price precision is {self._price_prec}"
@@ -6551,6 +6531,7 @@ cdef class OrderMatchingEngine:
         if new_leaves_raw == 0:
             if self._support_contingent_orders and order.contingency_type != ContingencyType.NO_CONTINGENCY and update_contingencies:
                 self._update_contingent_orders(order)
+
             # Pass False since we already handled contingents above
             self.cancel_order(order, cancel_contingencies=False)
             return
@@ -6598,11 +6579,11 @@ cdef class OrderMatchingEngine:
 
         cdef Quantity parent_filled_qty = self._cached_filled_qty.get(order.client_order_id, order.filled_qty)
         cdef QuantityRaw parent_leaves_raw = order.quantity._mem.raw - parent_filled_qty._mem.raw if order.quantity._mem.raw > parent_filled_qty._mem.raw else 0
-
-        cdef ClientOrderId client_order_id
-        cdef Order ouo_order
-        cdef Quantity child_filled_qty
-        cdef QuantityRaw child_leaves_raw
+        cdef:
+            ClientOrderId client_order_id
+            Order ouo_order
+            Quantity child_filled_qty
+            QuantityRaw child_leaves_raw
         for client_order_id in order.linked_order_ids or []:
             ouo_order = self.cache.order(client_order_id)
             assert ouo_order is not None, "OUO order not found"
@@ -6755,7 +6736,6 @@ cdef class OrderMatchingEngine:
             ts_event=ts_now,
             ts_init=ts_now,
         )
-
         self.msgbus.send(endpoint="ExecEngine.process", msg=event)
 
     cdef void _generate_order_canceled(self, Order order, VenueOrderId venue_order_id):

--- a/nautilus_trader/backtest/models/fill.pyx
+++ b/nautilus_trader/backtest/models/fill.pyx
@@ -20,6 +20,7 @@ from libc.stdint cimport uint64_t
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.rust.model cimport BookType
 from nautilus_trader.core.rust.model cimport OrderSide
+from nautilus_trader.core.rust.model cimport OrderType
 from nautilus_trader.model.book cimport BookOrder
 from nautilus_trader.model.book cimport OrderBook
 from nautilus_trader.model.functions cimport liquidity_side_to_str
@@ -166,6 +167,7 @@ cdef class BestPriceFillModel(FillModel):
     ):
         """
         Return OrderBook with unlimited liquidity at best prices.
+        Also allows execution inside the bid ask
         """
         cdef:
             uint64_t UNLIMITED = 1_000_000  # Large enough to fill any order
@@ -178,16 +180,36 @@ cdef class BestPriceFillModel(FillModel):
             book_type=BookType.L2_MBP,
         )
 
-        # Add unlimited volume at best prices
+        cdef Price bid_price = best_bid
+        cdef Price ask_price = best_ask
+
+        if order.order_type == OrderType.LIMIT:
+            if order.side == OrderSide.BUY:
+                # BUY order matchable if price >= bid (within or above spread)
+                if order.price >= best_ask:
+                    pass  # Aggressive: use best_ask for price improvement
+                elif order.price >= best_bid:
+                    ask_price = order.price  # Within spread: optimistic fill at order price
+                else:
+                    return None  # Passive: not matchable
+            elif order.side == OrderSide.SELL:
+                # SELL order matchable if price <= ask (within or below spread)
+                if order.price <= best_bid:
+                    pass  # Aggressive: use best_bid for price improvement
+                elif order.price <= best_ask:
+                    bid_price = order.price  # Within spread: optimistic fill at order price
+                else:
+                    return None  # Passive: not matchable
+
         bid_order = BookOrder(
             side=OrderSide.BUY,
-            price=best_bid,
+            price=bid_price,
             size=Quantity(UNLIMITED, instrument.size_precision),
             order_id=1,
         )
         ask_order = BookOrder(
             side=OrderSide.SELL,
-            price=best_ask,
+            price=ask_price,
             size=Quantity(UNLIMITED, instrument.size_precision),
             order_id=2,
         )

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -128,6 +128,7 @@ cdef class DataEngine(Component):
     cdef readonly bint _buffer_deltas
     cdef readonly bint _emit_quotes_from_book
     cdef readonly bint _emit_quotes_from_book_depths
+    cdef readonly bint _allow_immediate_quote_execution
 
     cdef readonly bint debug
     """If debug mode is active (will provide extra debug logging).\n\n:returns: `bool`"""

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -160,6 +160,10 @@ cdef class DataEngine(Component):
         The clock for the engine.
     config : DataEngineConfig, optional
         The configuration for the instance.
+    allow_immediate_quote_execution : bool, default False
+        Allows a strategy to receive quotes and pass orders before the data is
+        processed by the execution engine. Only relevant in backtesting.
+        Useful for backtests on discrete times, like every minute, hour or day.
     """
 
     def __init__(
@@ -168,6 +172,7 @@ cdef class DataEngine(Component):
         Cache cache not None,
         Clock clock not None,
         config: DataEngineConfig | None = None,
+        allow_immediate_quote_execution: bool = False,
     ) -> None:
         if config is None:
             config = DataEngineConfig()
@@ -223,6 +228,7 @@ cdef class DataEngine(Component):
         self._buffer_deltas = config.buffer_deltas
         self._emit_quotes_from_book = config.emit_quotes_from_book
         self._emit_quotes_from_book_depths = config.emit_quotes_from_book_depths
+        self._allow_immediate_quote_execution = allow_immediate_quote_execution
 
         if config.external_clients:
             self._external_clients = set(config.external_clients)
@@ -3207,8 +3213,12 @@ cdef class DataEngine(Component):
         aggregator.set_running(True)
 
     cpdef void _handle_spread_quote(self, Data quote):
-        # We send the quote to a simulated exchanged so it can be processed for execution first
-        # before being processed by the data engine, similarly to the logic in the backtest engine
+        if self._allow_immediate_quote_execution:
+            self.process(quote)
+            self._msgbus.send(endpoint=f"SimulatedExchange.spread_quote.{quote.instrument_id.venue}", msg=quote)
+            return
+
+        # Send quote to exchange first (before data engine), matching backtest engine's default logic
         self._msgbus.send(endpoint=f"SimulatedExchange.spread_quote.{quote.instrument_id.venue}", msg=quote)
         self.process(quote)
 

--- a/nautilus_trader/execution/engine.pyx
+++ b/nautilus_trader/execution/engine.pyx
@@ -279,6 +279,7 @@ cdef class ExecutionEngine(Component):
         for client in self._clients.values():
             if not client.is_connected:
                 return False
+
         return True
 
     cpdef bint check_disconnected(self):
@@ -295,6 +296,7 @@ cdef class ExecutionEngine(Component):
         for client in self._clients.values():
             if client.is_connected:
                 return False
+
         return True
 
     cpdef bint check_residuals(self):
@@ -367,10 +369,9 @@ cdef class ExecutionEngine(Component):
         """
         Condition.not_none(orders, "orders")
 
-        cdef set[ClientId] client_ids = set()
-        cdef set[Venue] venues = set()
-
         cdef:
+            set[ClientId] client_ids = set()
+            set[Venue] venues = set()
             Order order
             ClientId client_id
             Venue venue
@@ -380,10 +381,10 @@ cdef class ExecutionEngine(Component):
             client_id = self._cache.client_id(order.client_order_id)
             if client_id is None:
                 continue
+
             client_ids.add(client_id)
 
         cdef set[ExecutionClient] clients = set()
-
         for client_id in client_ids:
             clients.add(self._clients[client_id])
 
@@ -449,6 +450,7 @@ cdef class ExecutionEngine(Component):
                     f"Default execution client already registered ("
                     f"{self._default_client.id!r}); use register_default_client to override"
                 )
+
             self._default_client = client
             routing_log = " for default routing"
         # Venue-specific routing
@@ -459,6 +461,7 @@ cdef class ExecutionEngine(Component):
                     f"Execution client for venue {client.venue!r} "
                     f"already registered ({existing.id!r})"
                 )
+
             self._routing_map[client.venue] = client
 
         # Finally register in client registry
@@ -555,6 +558,7 @@ cdef class ExecutionEngine(Component):
                 raise InvalidConfiguration(
                     f"External order claim for {instrument_id} already exists for {existing}",
                 )
+
             # Register strategy to claim external orders for this instrument
             self._external_order_claims[instrument_id] = strategy.id
 
@@ -593,6 +597,7 @@ cdef class ExecutionEngine(Component):
         for venue, mapped_client in self._routing_map.items():
             if mapped_client == client:
                 to_remove.append(venue)
+
         for venue in to_remove:
             del self._routing_map[venue]
 
@@ -800,7 +805,9 @@ cdef class ExecutionEngine(Component):
             for order in self._cache.orders():
                 if order.is_closed_c() or not should_handle_own_book_order(order):
                     continue
+
                 self._add_own_book_order(order)
+
             ts_func_end = int(time.time() * 1000)
             self._log.debug(f"manage_own_order_books processing took {ts_func_end - ts_func_start}ms")
 
@@ -941,14 +948,15 @@ cdef class ExecutionEngine(Component):
             if contingent_order is None:
                 self._log.error(f"Contingency order {client_order_id!r} not found")
                 continue
-            if not contingent_order.is_quote_quantity:
+            elif not contingent_order.is_quote_quantity:
                 continue  # Already base quantity
-            if contingent_order.quantity != original_qty:
+            elif contingent_order.quantity != original_qty:
                 self._log.warning(
                     f"Contingent order quantity {contingent_order.quantity} "
                     f"was not equal to the OTO parent original quantity {original_qty} "
                     f"when setting to base quantity of {base_qty}"
                 )
+
             self._log.info(
                 f"Setting {contingent_order.instrument_id} order quote quantity "
                 f"{contingent_order.quantity} to base quantity {base_qty}",
@@ -975,6 +983,7 @@ cdef class ExecutionEngine(Component):
             topic=self._get_order_events_topic(order.strategy_id),
             msg=denied,
         )
+
         if self.snapshot_orders:
             self._create_order_state_snapshot(order)
 
@@ -985,6 +994,7 @@ cdef class ExecutionEngine(Component):
             own_book = nautilus_pyo3.OwnOrderBook(pyo3_instrument_id)
             self._cache.add_own_order_book(own_book)
             self._log.debug(f"Initialized {own_book!r}", LogColor.MAGENTA)
+
         return own_book
 
     cpdef void _add_own_book_order(self, Order order):
@@ -1014,11 +1024,11 @@ cdef class ExecutionEngine(Component):
                     f"Skipping execution command for external client {command.client_id}: {command}",
                     LogColor.MAGENTA,
                 )
+
             return
 
-        cdef ExecutionClient client = self._clients.get(command.client_id)
         cdef Venue venue
-
+        cdef ExecutionClient client = self._clients.get(command.client_id)
         if client is None:
             if isinstance(command, QueryAccount):
                 venue = Venue(command.account_id.get_issuer())
@@ -1088,6 +1098,7 @@ cdef class ExecutionEngine(Component):
             if last_px is None:
                 self._deny_order(order, f"no-price-to-convert-quote-qty {order.instrument_id}")
                 return  # Denied
+
             base_qty = instrument.calculate_base_quantity(order.quantity, last_px)
             self._set_order_base_qty(order, base_qty)
 
@@ -1103,6 +1114,7 @@ cdef class ExecutionEngine(Component):
             if not self._cache.order_exists(order.client_order_id):
                 # Cache order
                 self._cache.add_order(order, command.position_id, command.client_id)
+
                 if self.snapshot_orders:
                     self._create_order_state_snapshot(order)
 
@@ -1131,6 +1143,7 @@ cdef class ExecutionEngine(Component):
                 if last_px is None:
                     for order in command.order_list.orders:
                         self._deny_order(order, f"no-price-to-convert-quote-qty {order.instrument_id}")
+
                     return  # Denied
 
                 base_qty = instrument.calculate_base_quantity(order.quantity, last_px)
@@ -1167,13 +1180,14 @@ cdef class ExecutionEngine(Component):
     cpdef void _handle_event(self, OrderEvent event):
         if self.debug:
             self._log.debug(f"{RECV}{EVT} {event}", LogColor.MAGENTA)
+
         self.event_count += 1
 
         # Fetch Order from cache
         cdef ClientOrderId client_order_id = event.client_order_id
         cdef Order order = self._cache.order(event.client_order_id)
         if order is None:
-            self._log.warning(
+            self._log.info(
                 f"Order with {event.client_order_id!r} "
                 f"not found in the cache to apply {event}"
             )
@@ -1246,8 +1260,10 @@ cdef class ExecutionEngine(Component):
 
             oms_type = self._determine_oms_type(event)
             self._determine_position_id(event, oms_type, order)
+
             if not self._apply_event_to_order(order, event):
                 return  # Event rejected, skip downstream handling
+
             self._handle_order_fill(order, event, oms_type)
         else:
             self._apply_event_to_order(order, event)
@@ -1280,7 +1296,6 @@ cdef class ExecutionEngine(Component):
     cdef bint _is_leg_fill(self, OrderFilled fill):
         cdef str client_order_id_str = fill.client_order_id.value
         cdef str venue_order_id_str = fill.venue_order_id.value if fill.venue_order_id else ""
-
         if not ("-LEG-" in client_order_id_str or "-LEG-" in venue_order_id_str):
             return False
 
@@ -1319,7 +1334,6 @@ cdef class ExecutionEngine(Component):
 
         # Determine position ID for leg fill without requiring an order in cache
         cdef PositionId position_id
-
         if oms_type == OmsType.HEDGING:
             position_id = self._determine_hedging_position_id(fill)
         elif oms_type == OmsType.NETTING:
@@ -1341,8 +1355,8 @@ cdef class ExecutionEngine(Component):
         )
 
     cpdef OmsType _determine_oms_type(self, OrderFilled fill):
-        cdef ExecutionClient client
         # Check for strategy OMS override
+        cdef ExecutionClient client
         cdef OmsType oms_type = self._oms_overrides.get(fill.strategy_id, OmsType.UNSPECIFIED)
         if oms_type == OmsType.UNSPECIFIED:
             # Use native venue OMS
@@ -1357,7 +1371,6 @@ cdef class ExecutionEngine(Component):
     cpdef void _determine_position_id(self, OrderFilled fill, OmsType oms_type, Order order=None):
         # Fetch ID from cache
         cdef PositionId position_id = self._cache.position_id(fill.client_order_id)
-
         if self.debug:
             self._log.debug(
                 f"Determining position ID for {fill.client_order_id!r}, "
@@ -1372,6 +1385,7 @@ cdef class ExecutionEngine(Component):
                     f"cached={position_id!r}, assigned={fill.position_id!r}; "
                     "re-assigning from cache",
                 )
+
             # Assign position ID to fill
             fill.position_id = position_id
 
@@ -1419,6 +1433,7 @@ cdef class ExecutionEngine(Component):
         if fill.position_id is not None:
             if self.debug:
                 self._log.debug(f"Already had a position ID of: {fill.position_id!r}", LogColor.MAGENTA)
+
             # Already assigned
             return fill.position_id
 
@@ -1438,6 +1453,7 @@ cdef class ExecutionEngine(Component):
                 if spawned_order.position_id is not None:
                     if self.debug:
                         self._log.debug(f"Found spawned {spawned_order.position_id!r} for {fill}", LogColor.MAGENTA)
+
                     # Use position ID for execution spawn
                     return spawned_order.position_id
 
@@ -1454,7 +1470,6 @@ cdef class ExecutionEngine(Component):
 
     cdef bint _check_overfill(self, Order order, OrderFilled fill):
         cdef Quantity potential_overfill = order.calculate_overfill_c(fill.last_qty)
-
         if potential_overfill._mem.raw > 0:
             if self.allow_overfills:
                 self._log.warning(
@@ -1480,11 +1495,11 @@ cdef class ExecutionEngine(Component):
             order.apply(event)
         except InvalidStateTrigger as e:
             log_msg = f"InvalidStateTrigger: {e}, did not apply {event}"
-
             if order.status_c() == OrderStatus.ACCEPTED and isinstance(event, OrderAccepted):
                 self._log.debug(log_msg)
             else:
                 self._log.warning(log_msg)
+
             return True  # Continue processing for idempotent state transitions
         except (ValueError, KeyError) as e:
             # ValueError: Protection against invalid IDs
@@ -1499,10 +1514,11 @@ cdef class ExecutionEngine(Component):
                 )
                 self._cache.force_remove_from_own_order_book(order.client_order_id)
             else:
-                own_book = self._cache.own_order_book(order.instrument_id)
                 # Only bypass should_handle check for closed orders (to ensure cleanup)
+                own_book = self._cache.own_order_book(order.instrument_id)
                 if (own_book is not None and order.is_closed_c()) or should_handle_own_book_order(order):
                     self._cache.update_own_order_book(order)
+
             return False  # Event rejected, skip downstream handling
 
         self._cache.update_order(order)
@@ -1539,7 +1555,6 @@ cdef class ExecutionEngine(Component):
             Position position = None
             ClientOrderId client_order_id
             Order contingent_order
-
         if not instrument.is_spread():
             self._handle_position_update(instrument, fill, oms_type)
             position = self._cache.position(fill.position_id)
@@ -1569,7 +1584,6 @@ cdef class ExecutionEngine(Component):
 
     cdef void _handle_position_update(self, Instrument instrument, OrderFilled fill, OmsType oms_type):
         cdef Position position = self._cache.position(fill.position_id)
-
         if position is None or position.is_closed_c():
             self._open_position(instrument, position, fill, oms_type)
         elif self._will_flip_position(position, fill):
@@ -1617,6 +1631,7 @@ cdef class ExecutionEngine(Component):
                     f"Cannot reopen position {position.info()} (oms_type={oms_type_to_str(oms_type)}: "
                     "reopening is only valid for closed positions in NETTING mode"
                 )
+
             # Snapshot closed position if reopening (NETTING mode)
             self._cache.snapshot_position(position)
         else:  # HEDGING

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -384,11 +384,17 @@ class NautilusKernel:
                     "Try using a `LiveDataEngineConfig`.",
                 )
 
+            # Get allow_immediate_quote_execution from BacktestEngineConfig if available
+            allow_immediate_quote_execution = False
+            if hasattr(config, "allow_immediate_quote_execution"):
+                allow_immediate_quote_execution = config.allow_immediate_quote_execution
+
             self._data_engine = DataEngine(
                 msgbus=self._msgbus,
                 cache=self._cache,
                 clock=self._clock,
                 config=config.data_engine,
+                allow_immediate_quote_execution=allow_immediate_quote_execution,
             )
 
         ########################################################################

--- a/tests/unit_tests/backtest/test_fill_models.py
+++ b/tests/unit_tests/backtest/test_fill_models.py
@@ -29,6 +29,7 @@ from nautilus_trader.backtest.models import TwoTierFillModel
 from nautilus_trader.backtest.models import VolumeSensitiveFillModel
 from nautilus_trader.common.component import TestClock
 from nautilus_trader.core.rust.model import BookType
+from nautilus_trader.core.rust.model import OrderSide
 from nautilus_trader.model.book import OrderBook
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.objects import Price
@@ -100,6 +101,114 @@ class TestEnhancedFillModels:
         assert asks[0].price == best_ask
         assert bids[0].size() == 1_000_000  # UNLIMITED
         assert asks[0].size() == 1_000_000  # UNLIMITED
+
+    def test_best_price_fill_model_optimistic_matching(self):
+        """
+        Test BestPriceFillModel optimistic matching logic.
+        """
+        # Arrange
+        fill_model = BestPriceFillModel()
+        best_bid = Price.from_str("1.00000")
+        best_ask = Price.from_str("1.00010")
+
+        # 1. Buy order at best bid (matchable)
+        order_buy_at_bid = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            price=best_bid,
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_buy_at_bid,
+            best_bid,
+            best_ask,
+        )
+        assert result is not None
+        assert next(iter(result.asks())).price == best_bid  # Ask price pushed to order price
+
+        # 2. Buy order within spread (matchable)
+        order_buy_in_spread = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            price=Price.from_str("1.00005"),
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_buy_in_spread,
+            best_bid,
+            best_ask,
+        )
+        assert result is not None
+        assert next(iter(result.asks())).price == Price.from_str("1.00005")
+
+        # 2b. Buy order above best ask (marketable - should get price improvement)
+        order_buy_above_ask = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            price=Price.from_str("1.00020"),
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_buy_above_ask,
+            best_bid,
+            best_ask,
+        )
+        assert result is not None
+        assert next(iter(result.asks())).price == best_ask  # Should stay at best_ask, not 1.00020
+
+        # 3. Buy order below best bid (not matchable)
+        order_buy_below_bid = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            price=Price.from_str("0.99995"),
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_buy_below_bid,
+            best_bid,
+            best_ask,
+        )
+        assert result is None
+
+        # 4. Sell order at best ask (matchable)
+        order_sell_at_ask = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            order_side=OrderSide.SELL,
+            price=best_ask,
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_sell_at_ask,
+            best_bid,
+            best_ask,
+        )
+        assert result is not None
+        assert next(iter(result.bids())).price == best_ask  # Bid price pushed to order price
+
+        # 5. Sell order within spread (matchable)
+        order_sell_in_spread = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            order_side=OrderSide.SELL,
+            price=Price.from_str("1.00005"),
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_sell_in_spread,
+            best_bid,
+            best_ask,
+        )
+        assert result is not None
+        assert next(iter(result.bids())).price == Price.from_str("1.00005")
+
+        # 6. Sell order above best ask (not matchable)
+        order_sell_above_ask = TestExecStubs.limit_order(
+            instrument=self.instrument,
+            order_side=OrderSide.SELL,
+            price=Price.from_str("1.00015"),
+        )
+        result = fill_model.get_orderbook_for_fill_simulation(
+            self.instrument,
+            order_sell_above_ask,
+            best_bid,
+            best_ask,
+        )
+        assert result is None
 
     def test_one_tick_slippage_model_creates_slippage(self):
         """

--- a/tests/unit_tests/backtest/test_immediate_quote_execution.py
+++ b/tests/unit_tests/backtest/test_immediate_quote_execution.py
@@ -1,0 +1,353 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.engine import BacktestEngineConfig
+from nautilus_trader.backtest.models import BestPriceFillModel
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import OrderStatus
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.objects import Money
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+from nautilus_trader.trading.strategy import Strategy
+
+
+AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD", Venue("SIM"))
+
+
+class ImmediateOrderStrategy(Strategy):
+    """
+    Strategy that submits an order immediately on the first quote tick.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.instrument_id = InstrumentId.from_str("AUD/USD.SIM")
+        self.quote_count = 0
+        self.order_submitted = False
+        self.fill_timestamps = []
+        self.submit_timestamps = []
+
+    def on_start(self):
+        self.subscribe_quote_ticks(self.instrument_id)
+
+    def on_quote_tick(self, tick: QuoteTick):
+        self.quote_count += 1
+        self._log.warning(
+            f"[Strategy] on_quote_tick: Received quote tick at {tick.ts_init}, "
+            f"bid={tick.bid_price}, ask={tick.ask_price}, quote_count={self.quote_count}",
+        )
+
+        # Submit limit order on first quote tick at mid price rounded up (like in the example)
+        # With BestPriceFillModel and immediate execution enabled:
+        # - Order is submitted and accepted immediately (use_message_queue=False)
+        # - When exchange processes quote, order is already in book
+        # - iterate() matches the order on the same quote tick (mid price between bid/ask is matchable)
+        # With immediate execution disabled:
+        # - Exchange processes quote first (no order in book yet)
+        # - Order is queued (use_message_queue=True)
+        # - Queue is processed, order accepted but not immediately matchable (mid < ask)
+        # - Order only matches when next quote arrives and iterate() is called again
+        if not self.order_submitted:
+            instrument = self.cache.instrument(self.instrument_id)
+            # Calculate mid price and round up to next ask price (like in the example)
+            # The key difference is WHEN the order is accepted relative to quote processing:
+            # - With immediate execution: order accepted before exchange processes quote,
+            #   so order is in book when iterate() is called → fills on same tick
+            # - Without immediate execution: exchange processes quote first (iterate() called),
+            #   then order queued, then accepted (but iterate() already ran) → waits for next tick
+            mid_price_double = (tick.bid_price.as_double() + tick.ask_price.as_double()) / 2.0
+            # Use mid price rounded up - BestPriceFillModel allows matching at mid price during iteration
+            limit_price = instrument.next_ask_price(mid_price_double, num_ticks=0)
+
+            order = self.order_factory.limit(
+                instrument_id=self.instrument_id,
+                order_side=OrderSide.BUY,
+                quantity=Quantity.from_int(100_000),
+                price=limit_price,
+            )
+            self._log.warning(
+                f"[Strategy] on_quote_tick: Submitting order at {tick.ts_init}, "
+                f"order_id={order.client_order_id}, price={limit_price}, side={order.side}",
+            )
+            self.submit_order(order)
+            self.order_submitted = True
+            self.submit_timestamps.append(tick.ts_init)
+
+    def on_order_filled(self, event):
+        self._log.warning(
+            f"[Strategy] on_order_filled: Order filled at {event.ts_init}, "
+            f"order_id={event.client_order_id}, filled_qty={event.last_qty}, price={event.last_px}",
+        )
+        self.fill_timestamps.append(event.ts_init)
+
+
+class TestImmediateQuoteExecution:
+    """
+    Test immediate quote execution feature.
+    """
+
+    def setup(self):
+        # Common setup
+        self.instrument = AUDUSD_SIM
+        self.venue = Venue("SIM")
+
+    def _create_quotes(self, count: int = 3):
+        """
+        Create a series of quote ticks.
+        """
+        quotes = []
+        base_price = 0.70000
+        for i in range(count):
+            bid_price = base_price + (i * 0.00001)
+            ask_price = bid_price + 0.00002
+            quote = QuoteTick(
+                instrument_id=self.instrument.id,
+                bid_price=Price.from_str(f"{bid_price:.5f}"),
+                ask_price=Price.from_str(f"{ask_price:.5f}"),
+                bid_size=Quantity.from_int(1_000_000),
+                ask_size=Quantity.from_int(1_000_000),
+                ts_event=1_000_000_000_000_000_000 + (i * 1_000_000_000),  # 1 second apart
+                ts_init=1_000_000_000_000_000_000 + (i * 1_000_000_000),
+            )
+            quotes.append(quote)
+        return quotes
+
+    def test_immediate_quote_execution_enabled_fills_on_same_tick(self):
+        """
+        Test that with immediate execution enabled, orders fill on the same quote tick.
+        """
+        # Arrange
+        config = BacktestEngineConfig(
+            allow_immediate_quote_execution=True,
+        )
+        engine = BacktestEngine(config=config)
+
+        engine.add_venue(
+            venue=self.venue,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            starting_balances=[Money(1_000_000, USD)],
+            fill_model=BestPriceFillModel(),
+        )
+
+        engine.add_instrument(self.instrument)
+
+        # Create quotes with 1 minute apart (like in the example: 10:03 vs 10:04)
+        quotes = []
+        base_ts = 1_000_000_000_000_000_000
+        for i in range(2):
+            bid_price = 0.70000 + (i * 0.00001)
+            ask_price = bid_price + 0.00002
+            quote = QuoteTick(
+                instrument_id=self.instrument.id,
+                bid_price=Price.from_str(f"{bid_price:.5f}"),
+                ask_price=Price.from_str(f"{ask_price:.5f}"),
+                bid_size=Quantity.from_int(1_000_000),
+                ask_size=Quantity.from_int(1_000_000),
+                ts_event=base_ts + (i * 60_000_000_000),  # 1 minute apart
+                ts_init=base_ts + (i * 60_000_000_000),
+            )
+            quotes.append(quote)
+
+        engine.add_data(quotes)
+
+        strategy = ImmediateOrderStrategy()
+        engine.add_strategy(strategy)
+
+        # Act
+        engine.run()
+
+        # Assert
+        # Order should be filled
+        orders = list(strategy.cache.orders())
+        assert len(orders) == 1
+        order = orders[0]
+        assert order.status == OrderStatus.FILLED
+
+        # With immediate execution enabled and use_message_queue=False:
+        # - Data engine processes quote 1 first
+        # - Strategy submits order, which is immediately accepted (no queue)
+        # - Exchange processes quote 1, calls process_quote_tick → iterate(T1)
+        # - Order is in book, iterate() matches it → fill at T1
+        assert len(strategy.fill_timestamps) == 1
+        assert strategy.fill_timestamps[0] == quotes[0].ts_init, (
+            f"Expected fill on first quote tick ({quotes[0].ts_init}), "
+            f"but got {strategy.fill_timestamps[0]}"
+        )
+
+    def test_immediate_quote_execution_disabled_fills_on_next_tick(self):
+        """
+        Test that with immediate execution disabled, orders fill on the NEXT quote tick.
+        """
+        # Arrange
+        config = BacktestEngineConfig(
+            allow_immediate_quote_execution=False,
+        )
+        engine = BacktestEngine(config=config)
+
+        engine.add_venue(
+            venue=self.venue,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            starting_balances=[Money(1_000_000, USD)],
+            fill_model=BestPriceFillModel(),
+        )
+
+        engine.add_instrument(self.instrument)
+
+        # Create quotes with 1 minute apart (like in the example: 10:03 vs 10:04)
+        quotes = []
+        base_ts = 1_000_000_000_000_000_000
+        for i in range(2):
+            bid_price = 0.70000 + (i * 0.00001)
+            ask_price = bid_price + 0.00002
+            quote = QuoteTick(
+                instrument_id=self.instrument.id,
+                bid_price=Price.from_str(f"{bid_price:.5f}"),
+                ask_price=Price.from_str(f"{ask_price:.5f}"),
+                bid_size=Quantity.from_int(1_000_000),
+                ask_size=Quantity.from_int(1_000_000),
+                ts_event=base_ts + (i * 60_000_000_000),  # 1 minute apart
+                ts_init=base_ts + (i * 60_000_000_000),
+            )
+            quotes.append(quote)
+
+        engine.add_data(quotes)
+
+        strategy = ImmediateOrderStrategy()
+        engine.add_strategy(strategy)
+
+        # Act
+        engine.run()
+
+        # Assert
+        # Order should be filled
+        orders = list(strategy.cache.orders())
+        assert len(orders) == 1
+        order = orders[0]
+        assert order.status == OrderStatus.FILLED
+
+        # With immediate execution disabled and use_message_queue=True:
+        # - Exchange processes quote 1 first, calls process_quote_tick → iterate(T1)
+        #   (no order in book yet, so no match)
+        # - Data engine processes quote 1
+        # - Strategy submits order, which goes to message queue (use_message_queue=True)
+        # - exchange.process(T1) processes queue, order is accepted (but book was already updated with quote 1)
+        # - Next quote arrives (T2), exchange processes quote 2
+        # - process_quote_tick → iterate(T2) → order matches → fill at T2
+        assert len(strategy.fill_timestamps) == 1
+        assert strategy.fill_timestamps[0] == quotes[1].ts_init, (
+            f"Expected fill on second quote tick ({quotes[1].ts_init}), "
+            f"but got {strategy.fill_timestamps[0]}"
+        )
+
+        # Strategy should have received at least 1 quote tick
+        assert strategy.quote_count >= 1
+
+    def test_immediate_quote_execution_comparison_shows_timestamp_difference(self):
+        """
+        Test that demonstrates the fill timestamp difference between enabled and
+        disabled.
+        """
+        # Create quotes with 1 minute apart to clearly show the difference
+        quotes = []
+        base_ts = 1_000_000_000_000_000_000
+        for i in range(2):
+            bid_price = 0.70000 + (i * 0.00001)
+            ask_price = bid_price + 0.00002
+            quote = QuoteTick(
+                instrument_id=self.instrument.id,
+                bid_price=Price.from_str(f"{bid_price:.5f}"),
+                ask_price=Price.from_str(f"{ask_price:.5f}"),
+                bid_size=Quantity.from_int(1_000_000),
+                ask_size=Quantity.from_int(1_000_000),
+                ts_event=base_ts + (i * 60_000_000_000),  # 1 minute apart
+                ts_init=base_ts + (i * 60_000_000_000),
+            )
+            quotes.append(quote)
+
+        # Test with immediate execution enabled
+        config_enabled = BacktestEngineConfig(allow_immediate_quote_execution=True)
+        engine_enabled = BacktestEngine(config=config_enabled)
+        engine_enabled.add_venue(
+            venue=self.venue,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            starting_balances=[Money(1_000_000, USD)],
+            fill_model=BestPriceFillModel(),
+        )
+        engine_enabled.add_instrument(self.instrument)
+        engine_enabled.add_data(quotes)
+        strategy_enabled = ImmediateOrderStrategy()
+        engine_enabled.add_strategy(strategy_enabled)
+        engine_enabled.run()
+
+        # Test with immediate execution disabled
+        config_disabled = BacktestEngineConfig(allow_immediate_quote_execution=False)
+        engine_disabled = BacktestEngine(config=config_disabled)
+        engine_disabled.add_venue(
+            venue=self.venue,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            starting_balances=[Money(1_000_000, USD)],
+            fill_model=BestPriceFillModel(),
+        )
+        engine_disabled.add_instrument(self.instrument)
+        engine_disabled.add_data(quotes)
+        strategy_disabled = ImmediateOrderStrategy()
+        engine_disabled.add_strategy(strategy_disabled)
+        engine_disabled.run()
+
+        # Assert both orders are filled
+        orders_enabled = list(strategy_enabled.cache.orders())
+        orders_disabled = list(strategy_disabled.cache.orders())
+        assert len(orders_enabled) == 1
+        assert len(orders_disabled) == 1
+        assert orders_enabled[0].status == OrderStatus.FILLED
+        assert orders_disabled[0].status == OrderStatus.FILLED
+
+        # With BestPriceFillModel and limit at mid price, the difference is clear:
+        # - Enabled: Order fills on FIRST quote tick (T1) because order is in book when exchange processes quote
+        # - Disabled: Order fills on SECOND quote tick (T2) because order is queued after exchange processed T1
+        assert len(strategy_enabled.fill_timestamps) == 1
+        assert len(strategy_disabled.fill_timestamps) == 1
+
+        # Verify the timestamp difference - this is the key assertion
+        assert strategy_enabled.fill_timestamps[0] == quotes[0].ts_init, (
+            f"With immediate execution enabled, expected fill on first quote tick ({quotes[0].ts_init}), "
+            f"but got {strategy_enabled.fill_timestamps[0]}"
+        )
+        assert strategy_disabled.fill_timestamps[0] == quotes[1].ts_init, (
+            f"With immediate execution disabled, expected fill on second quote tick ({quotes[1].ts_init}), "
+            f"but got {strategy_disabled.fill_timestamps[0]}"
+        )
+
+        # The timestamps should differ by 1 minute
+        assert strategy_disabled.fill_timestamps[0] > strategy_enabled.fill_timestamps[0], (
+            f"Disabled fill timestamp ({strategy_disabled.fill_timestamps[0]}) should be greater than "
+            f"enabled fill timestamp ({strategy_enabled.fill_timestamps[0]})"
+        )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Add option for immediate execution with quotes inside bid ask spread

This PR adds a new `allow_immediate_quote_execution` configuration option to the backtest engine that enables strategies to receive quotes and submit orders before the exchange processes the quote data. This feature allows orders to be filled on the same tick in discrete-time backtests (e.g., minute, hourly, or daily data) and extends `BestPriceFillModel` to support execution within the bid-ask spread.

### Problem

In discrete-time backtests with sparse data (e.g., quotes every minute or hour), the default execution flow processes quotes through the exchange first, then notifies strategies. When a strategy submits an order in response to a quote tick, the order is queued and only processed after the exchange has already processed that quote. This means the order cannot be filled until the next quote arrives, causing a one-tick delay that may not accurately reflect realistic trading behavior where orders can be filled immediately when market conditions are favorable.

Additionally, `BestPriceFillModel` previously only matched orders at the best bid or ask prices, which prevented orders with prices inside the spread from being filled, even though such fills are realistic in many market scenarios.

### Solution

Introduced a new `allow_immediate_quote_execution` configuration flag that changes the execution order when enabled: strategies receive quotes first (through the data engine), can submit orders immediately, and these orders are then available when the exchange processes the quote. This allows orders to be filled on the same tick when the fill model determines they are matchable. The feature also extends `BestPriceFillModel` to allow execution within the bid-ask spread for limit orders.

### Implementation details

#### Backtest engine configuration

- Added `allow_immediate_quote_execution: bool` parameter to `BacktestEngineConfig` (default `False`) that controls whether strategies can receive quotes and submit orders before exchange processing.

- When `allow_immediate_quote_execution=True`, the backtest engine automatically disables the message queue (`use_message_queue=False`) to allow immediate order acceptance and processing.

- Updated `BacktestEngine.add_venue()` to compute `effective_use_message_queue` based on the config flag, ensuring that immediate execution takes precedence over the explicit `use_message_queue` parameter.

#### Data engine changes

- Added `allow_immediate_quote_execution: bool` parameter to `DataEngine.__init__()` to receive the configuration flag.

- Modified `DataEngine._handle_spread_quote()` to process quotes through the data engine first (notifying strategies) before sending to the exchange when immediate execution is enabled. This ensures strategies can submit orders that will be available when the exchange processes the quote.

- When immediate execution is disabled (default), quotes are sent to the exchange first, then processed by the data engine, maintaining backward-compatible behavior.

#### Fill model enhancements

- Extended `BestPriceFillModel.fill()` to allow execution within the bid-ask spread for limit orders.

- For BUY limit orders: if the order price is within or above the spread (`bid <= price <= ask`), the order is matchable. Orders at or above the ask are filled at the ask (aggressive), while orders within the spread are filled at the order price (optimistic).

- For SELL limit orders: if the order price is within or below the spread (`bid <= price <= ask`), the order is matchable. Orders at or below the bid are filled at the bid (aggressive), while orders within the spread are filled at the order price (optimistic).

- Orders outside the spread remain passive and are not immediately matchable, consistent with realistic market behavior.

#### Execution engine improvements

- Refactored code formatting and variable declarations for consistency and readability.

- Improved conditional logic with `elif` chains where appropriate to reduce nesting and improve code clarity.

#### Testing infrastructure

- Added comprehensive test suite `tests/unit_tests/backtest/test_immediate_quote_execution.py` (353 lines) that validates immediate execution behavior.

- Tests verify that with `allow_immediate_quote_execution=True`, orders fill on the same quote tick they are submitted.

- Tests verify that with `allow_immediate_quote_execution=False` (default), orders fill on the next quote tick, maintaining backward compatibility.

- Added comparison test that demonstrates the timestamp difference between enabled and disabled modes.

- Enhanced `tests/unit_tests/backtest/test_fill_models.py` (109 new lines) with additional tests for fill model behavior.

#### Example notebook updates

- Updated `examples/backtest/notebooks/databento_option_greeks.py` to demonstrate the new immediate execution feature (49 lines modified).

#### System kernel integration

- Updated `nautilus_trader/system/kernel.py` to pass the `allow_immediate_quote_execution` configuration to the data engine (6 lines modified).

### Benefits

- Discrete-time backtest accuracy: Enables more realistic backtesting on sparse data (minute, hourly, daily quotes) where strategies can react immediately to market data.

- Reduced execution delay: Orders can be filled on the same tick when market conditions are favorable, eliminating artificial one-tick delays.

- Spread execution support: `BestPriceFillModel` now supports execution within the bid-ask spread, providing more realistic fill behavior for limit orders.

- Backward compatibility: Default behavior remains unchanged (`allow_immediate_quote_execution=False`), ensuring existing backtests continue to work as expected.

- Configurable behavior: Users can opt-in to immediate execution when needed without affecting existing workflows.

- Comprehensive testing: New test suite ensures correct behavior and prevents regressions.

### Files changed

- `examples/backtest/notebooks/databento_option_greeks.py`: Updated example to demonstrate immediate execution feature (49 lines modified).

- `nautilus_trader/backtest/config.py`: Added `allow_immediate_quote_execution` configuration parameter (5 lines added).

- `nautilus_trader/backtest/engine.pyx`: Modified execution flow to support immediate quote execution (240 lines modified).

- `nautilus_trader/backtest/models/fill.pyx`: Extended `BestPriceFillModel` to allow execution within bid-ask spread (28 lines modified).

- `nautilus_trader/data/engine.pxd`: Added parameter declaration to data engine interface (1 line added).

- `nautilus_trader/data/engine.pyx`: Modified quote processing order when immediate execution is enabled (14 lines modified).

- `nautilus_trader/execution/engine.pyx`: Code formatting and consistency improvements (51 lines modified).

- `nautilus_trader/system/kernel.py`: Updated to pass configuration to data engine (6 lines modified).

- `tests/unit_tests/backtest/test_fill_models.py`: Added new fill model tests (109 lines added).

- `tests/unit_tests/backtest/test_immediate_quote_execution.py`: New comprehensive test suite for immediate execution feature (353 lines added).

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
