### PR TITLE
Refine processing of gaps in aggregated historical bars

### DIFF
--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -159,12 +159,14 @@ cdef class TimeBarAggregator(BarAggregator):
     cdef int _bar_build_delay
     cdef object _time_bars_origin_offset
     cdef list _historical_events
+    cdef object _historical_event_at_ts_init
 
     cpdef void set_clock(self, Clock clock)
     cdef uint64_t _get_interval_ns(self)
     cpdef void start_timer(self)
     cpdef void stop_timer(self)
-    cdef void _process_historical_events(self, uint64_t ts_init)
+    cdef void _pre_process_historical_events(self, uint64_t ts_init)
+    cdef void _post_process_historical_events(self)
     cpdef void _build_bar(self, TimeEvent event)
 
 

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -3983,7 +3983,7 @@ class TestDataEngine:
             Price.from_str("5528.75"),
             Price.from_str("5528.50"),
             Price.from_str("5528.75"),
-            Quantity.from_int(5777),
+            Quantity.from_int(5806),
             1719878400000000000,
             1719878400000000000,
         )
@@ -4101,10 +4101,10 @@ class TestDataEngine:
         expected_last_1_minute_bar = Bar(
             BarType.from_str("ESU4.GLBX-1-MINUTE-LAST-INTERNAL"),
             Price.from_str("5528.50"),
-            Price.from_str("5529.00"),
+            Price.from_str("5528.75"),
             Price.from_str("5528.50"),
-            Price.from_str("5529.00"),
-            Quantity.from_int(31),
+            Price.from_str("5528.75"),
+            Quantity.from_int(23),
             1719878400000000000,
             1719878400000000000,
         )
@@ -4112,10 +4112,10 @@ class TestDataEngine:
         expected_last_2_minute_bar = Bar(
             BarType.from_str("ESU4.GLBX-2-MINUTE-LAST-INTERNAL"),
             Price.from_str("5528.75"),
-            Price.from_str("5529.00"),
+            Price.from_str("5528.75"),
             Price.from_str("5528.50"),
-            Price.from_str("5529.00"),
-            Quantity.from_int(50),
+            Price.from_str("5528.75"),
+            Quantity.from_int(41),
             1719878400000000000,
             1719878400000000000,
         )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Prevent building bars for timer events that fire before the last data update we've processed. This could happen when there are gaps in a time series with historical data (market closed, first new data gets built with a timer close to the close before the gap).

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Tested with bug reproduction here https://gist.github.com/flatlander-upup/cac706b7a5f5a14e7b4245d74d808210

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
