### PR TITLE
Fix reconciliation timing - process instruments before reconciliation

### DIFF
--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -613,7 +613,8 @@ impl LiveNode {
         pending.drain();
 
         if engines_connected {
-            // Now start trader - instruments are in cache after drain()
+            // Run reconciliation now that instruments are in cache and start trader
+            self.perform_startup_reconciliation().await?;
             self.kernel.start_trader();
         } else {
             log::error!("Not starting trader: engine client(s) not connected");
@@ -716,6 +717,7 @@ impl LiveNode {
     }
 
     /// Returns `true` if all engines connected successfully, `false` otherwise.
+    /// Note: Does NOT run reconciliation - that happens after pending events are drained.
     async fn complete_startup(&mut self) -> anyhow::Result<bool> {
         self.kernel.connect_clients().await;
 
@@ -723,7 +725,6 @@ impl LiveNode {
             return Ok(false);
         }
 
-        self.perform_startup_reconciliation().await?;
         Ok(true)
     }
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Reconciliation was failing to find instruments in cache, causing orders to be skipped:

```
Instrument NOT found in cache: ETH_USDC-PERPETUAL.DERIBIT | Cache has 0 instruments
```

### Root Cause

`complete_startup()` included reconciliation, but `pending.drain()` (which processes instrument events) happened after it returned:

**BEFORE (broken):**
```
┌────────────────────────────────────────┐     ┌───────────────┐
│ complete_startup()                     │     │               │
│  ├── connect (sends instruments)       │────►│ pending.drain │
│  ├── await connections                 │     │ (too late!)   │
│  └── reconciliation (cache empty!) ❌  │     │               │
└────────────────────────────────────────┘     └───────────────┘
```

**AFTER (fixed):**
```
┌───────────────────────────────────┐  ┌───────────────┐  ┌───────────────┐
│ complete_startup()                │  │               │  │               │
│  ├── connect (instruments queued) │─►│ pending.drain │─►│ reconciliation│
│  └── await connections            │  │ (cache filled)│  │ (cache ready!)│
└───────────────────────────────────┘  └───────────────┘  └───────────────┘
```

### Changes

**crates/live/src/node.rs:**
- Removed `perform_startup_reconciliation()` from `complete_startup()`
- Moved reconciliation to after `pending.drain()` so instruments are in cache first

```rust
// Before
complete_startup() → pending.drain() → start_trader()

// After  
complete_startup() → pending.drain() → reconciliation → start_trader()
```

## Test plan

- [ ] Verify reconciliation finds instruments in cache
- [ ] Confirm orders are processed correctly after startup




## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
