### PR TITLE
 Refactor Deribit WS client to standard Nautilus method names

### DIFF
--- a/nautilus_trader/adapters/deribit/execution.py
+++ b/nautilus_trader/adapters/deribit/execution.py
@@ -301,32 +301,20 @@ class DeribitExecutionClient(LiveExecutionClient):
                 ts_event=self._clock.timestamp_ns(),
             )
 
-            if order.side == OrderSide.BUY:
-                await self._ws_client.buy(
-                    quantity=pyo3_quantity,
-                    order_type=pyo3_order_type,
-                    client_order_id=pyo3_client_order_id,
-                    trader_id=pyo3_trader_id,
-                    strategy_id=pyo3_strategy_id,
-                    instrument_id=pyo3_instrument_id,
-                    price=pyo3_price,
-                    time_in_force=time_in_force_str,
-                    post_only=order.is_post_only,
-                    reduce_only=order.is_reduce_only,
-                )
-            else:  # SELL
-                await self._ws_client.sell(
-                    quantity=pyo3_quantity,
-                    order_type=pyo3_order_type,
-                    client_order_id=pyo3_client_order_id,
-                    trader_id=pyo3_trader_id,
-                    strategy_id=pyo3_strategy_id,
-                    instrument_id=pyo3_instrument_id,
-                    price=pyo3_price,
-                    time_in_force=time_in_force_str,
-                    post_only=order.is_post_only,
-                    reduce_only=order.is_reduce_only,
-                )
+            pyo3_order_side = nautilus_pyo3.OrderSide.from_str(order.side.name)
+            await self._ws_client.submit_order(
+                order_side=pyo3_order_side,
+                quantity=pyo3_quantity,
+                order_type=pyo3_order_type,
+                client_order_id=pyo3_client_order_id,
+                trader_id=pyo3_trader_id,
+                strategy_id=pyo3_strategy_id,
+                instrument_id=pyo3_instrument_id,
+                price=pyo3_price,
+                time_in_force=time_in_force_str,
+                post_only=order.is_post_only,
+                reduce_only=order.is_reduce_only,
+            )
         except Exception as e:
             self._log.error(f"Failed to submit order: {e}")
             self.generate_order_rejected(
@@ -392,33 +380,20 @@ class DeribitExecutionClient(LiveExecutionClient):
                     f"({order.side.name} {order.quantity} @ {order.price})",
                 )
 
-                # Call appropriate WebSocket method based on side
-                if order.side == OrderSide.BUY:
-                    await self._ws_client.buy(
-                        quantity=pyo3_quantity,
-                        order_type=pyo3_order_type,
-                        client_order_id=pyo3_client_order_id,
-                        trader_id=pyo3_trader_id,
-                        strategy_id=pyo3_strategy_id,
-                        instrument_id=pyo3_instrument_id,
-                        price=pyo3_price,
-                        time_in_force=time_in_force_str,
-                        post_only=order.is_post_only,
-                        reduce_only=order.is_reduce_only,
-                    )
-                else:  # SELL
-                    await self._ws_client.sell(
-                        quantity=pyo3_quantity,
-                        order_type=pyo3_order_type,
-                        client_order_id=pyo3_client_order_id,
-                        trader_id=pyo3_trader_id,
-                        strategy_id=pyo3_strategy_id,
-                        instrument_id=pyo3_instrument_id,
-                        price=pyo3_price,
-                        time_in_force=time_in_force_str,
-                        post_only=order.is_post_only,
-                        reduce_only=order.is_reduce_only,
-                    )
+                pyo3_order_side = nautilus_pyo3.OrderSide.from_str(order.side.name)
+                await self._ws_client.submit_order(
+                    order_side=pyo3_order_side,
+                    quantity=pyo3_quantity,
+                    order_type=pyo3_order_type,
+                    client_order_id=pyo3_client_order_id,
+                    trader_id=pyo3_trader_id,
+                    strategy_id=pyo3_strategy_id,
+                    instrument_id=pyo3_instrument_id,
+                    price=pyo3_price,
+                    time_in_force=time_in_force_str,
+                    post_only=order.is_post_only,
+                    reduce_only=order.is_reduce_only,
+                )
             except Exception as e:
                 self._log.error(f"Failed to submit order from list: {e}")
                 self.generate_order_rejected(
@@ -475,7 +450,7 @@ class DeribitExecutionClient(LiveExecutionClient):
                 f"to price={price} qty={quantity}",
             )
 
-            await self._ws_client.edit(
+            await self._ws_client.modify_order(
                 order_id=order.venue_order_id.value,
                 quantity=pyo3_quantity,
                 price=pyo3_price,
@@ -533,7 +508,7 @@ class DeribitExecutionClient(LiveExecutionClient):
                 f"Canceling order {order.client_order_id} (venue: {order.venue_order_id})",
             )
 
-            await self._ws_client.cancel(
+            await self._ws_client.cancel_order(
                 order_id=order.venue_order_id.value,
                 client_order_id=pyo3_client_order_id,
                 trader_id=pyo3_trader_id,
@@ -566,7 +541,7 @@ class DeribitExecutionClient(LiveExecutionClient):
                 f"Cancelling all orders for instrument {command.instrument_id}",
             )
 
-            await self._ws_client.cancel_all_by_instrument(
+            await self._ws_client.cancel_all_orders(
                 instrument_id=pyo3_instrument_id,
                 order_type=None,  # Cancel all order types
             )
@@ -623,7 +598,7 @@ class DeribitExecutionClient(LiveExecutionClient):
                     f"Batch cancel: {order.client_order_id} (venue: {order.venue_order_id})",
                 )
 
-                await self._ws_client.cancel(
+                await self._ws_client.cancel_order(
                     order_id=order.venue_order_id.value,
                     client_order_id=pyo3_client_order_id,
                     trader_id=pyo3_trader_id,
@@ -667,7 +642,7 @@ class DeribitExecutionClient(LiveExecutionClient):
                 f"Querying order {order.client_order_id} (venue: {order.venue_order_id})",
             )
 
-            await self._ws_client.get_order_state(
+            await self._ws_client.query_order(
                 order_id=order.venue_order_id.value,
                 client_order_id=pyo3_client_order_id,
                 trader_id=pyo3_trader_id,

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -1319,6 +1319,9 @@ class OrderSide(Enum):
     BUY = "BUY"
     SELL = "SELL"
 
+    @classmethod
+    def from_str(cls, value: str) -> OrderSide: ...
+
 class OrderStatus(Enum):
     INITIALIZED = "INITIALIZED"
     DENIED = "DENIED"
@@ -7058,8 +7061,9 @@ class DeribitWebSocketClient:
         instrument_id: InstrumentId,
         resolution: str,
     ) -> None: ...
-    async def buy(
+    async def submit_order(
         self,
+        order_side: OrderSide,
         quantity: Quantity,
         order_type: OrderType,
         client_order_id: ClientOrderId,
@@ -7073,22 +7077,7 @@ class DeribitWebSocketClient:
         trigger_price: Price | None = None,
         trigger: str | None = None,
     ) -> None: ...
-    async def sell(
-        self,
-        quantity: Quantity,
-        order_type: OrderType,
-        client_order_id: ClientOrderId,
-        trader_id: TraderId,
-        strategy_id: StrategyId,
-        instrument_id: InstrumentId,
-        price: Price | None = None,
-        time_in_force: str | None = None,
-        post_only: bool = False,
-        reduce_only: bool = False,
-        trigger_price: Price | None = None,
-        trigger: str | None = None,
-    ) -> None: ...
-    async def edit(
+    async def modify_order(
         self,
         order_id: str,
         quantity: Quantity,
@@ -7098,7 +7087,7 @@ class DeribitWebSocketClient:
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
     ) -> None: ...
-    async def cancel(
+    async def cancel_order(
         self,
         order_id: str,
         client_order_id: ClientOrderId,
@@ -7106,12 +7095,12 @@ class DeribitWebSocketClient:
         strategy_id: StrategyId,
         instrument_id: InstrumentId,
     ) -> None: ...
-    async def cancel_all_by_instrument(
+    async def cancel_all_orders(
         self,
         instrument_id: InstrumentId,
         order_type: str | None = None,
     ) -> None: ...
-    async def get_order_state(
+    async def query_order(
         self,
         order_id: str,
         client_order_id: ClientOrderId,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The Deribit adapter was previously exposing API-specific method names (`buy`, `sell`, `edit`, `cancel`, `get_order_state`, `cancel_all_by_instrument`) at the outer client level. This deviated from the standard Nautilus adapter pattern where outer clients expose unified domain methods, and API-specific naming remains an internal implementation detail.

### Changes
**Method renames across all layers (Rust client, Python bindings, execution clients):**
- `buy()` + `sell()` → `submit_order(order_side, ...)` - Consolidated into single method with order side parameter
- `edit()` → `modify_order()`
- `cancel()` → `cancel_order()`
- `cancel_all_by_instrument()` → `cancel_all_orders()`
- `get_order_state()` → `query_order()`

### Why this matters
This aligns the Deribit adapter with the standard pattern used by other Nautilus adapters in `crates/adapters/`. The internal routing to Deribit's `private/buy`, `private/sell`, `private/edit` JSON-RPC methods is preserved - only the public interface changes to match Nautilus conventions.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
