### PR TITLE
Fix IBKR adapter crash due to excessive tick size values

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -870,11 +870,11 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             converted_ask_price = ib_price_to_nautilus_price(ask_price, price_magnifier)
 
             # Cap sizes to prevent overflow (IBKR sometimes sends invalid huge values)
-            SAFE_MAX_SIZE = Decimal("2000000000")  # 2 Billion cap
+            SAFE_MAX_SIZE = Decimal(2000000000)  # 2 Billion cap
             if bid_size > SAFE_MAX_SIZE:
-               bid_size = SAFE_MAX_SIZE
+                bid_size = SAFE_MAX_SIZE
             if ask_size > SAFE_MAX_SIZE:
-               ask_size = SAFE_MAX_SIZE
+                ask_size = SAFE_MAX_SIZE
 
             quote_tick = QuoteTick(
                 instrument_id=instrument_id,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The Interactive Brokers API occasionally emits ticks with extremely large size values (e.g., 1e38 or MAX_INT) during illiquid periods or pre-market or untradable indices such as SPX. These values exceed Nautilus's QUANTITY_MAX, causing a ValueError in instrument.make_qty() which crashes the InteractiveBrokersClient message loop.

**I set it to an arbitrary but reasonable number(2 Billion) as safe bid/ask size. Feel free to change to a different number that is more appropriate for all instruments/brokers.**

## Related Issues/PRs

None

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic


