### PR TITLE
Implement Deribit rate limiting for HTTP and WebSocket clients

### DIFF
--- a/crates/adapters/deribit/src/common/consts.rs
+++ b/crates/adapters/deribit/src/common/consts.rs
@@ -15,10 +15,11 @@
 
 //! Core constants for the Deribit adapter.
 
-use std::sync::LazyLock;
+use std::{num::NonZeroU32, sync::LazyLock};
 
 use ahash::AHashSet;
 use nautilus_model::identifiers::Venue;
+use nautilus_network::ratelimiter::quota::Quota;
 use ustr::Ustr;
 
 /// Venue identifier string.
@@ -111,3 +112,74 @@ pub static DERIBIT_RETRY_ERROR_CODES: LazyLock<AHashSet<i64>> = LazyLock::new(||
 pub fn should_retry_error_code(error_code: i64) -> bool {
     DERIBIT_RETRY_ERROR_CODES.contains(&error_code)
 }
+
+/// Default Deribit REST API rate limit: 20 requests per second sustained.
+///
+/// Deribit uses a credit-based system for non-matching engine requests:
+/// - Each request costs 500 credits
+/// - Maximum credits: 50,000
+/// - Refill rate: 10,000 credits/second (~20 sustained req/s)
+/// - Burst capacity: up to 100 requests (50,000 / 500)
+///
+/// # References
+///
+/// <https://docs.deribit.com/#rate-limits>
+pub static DERIBIT_HTTP_REST_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(20).expect("20 is non-zero"))
+        .allow_burst(NonZeroU32::new(100).expect("100 is non-zero"))
+});
+
+/// Deribit matching engine (order operations) rate limit.
+///
+/// Matching engine requests (buy, sell, edit, cancel) have separate limits:
+/// - Default burst: 20
+/// - Default rate: 5 requests/second
+///
+/// Note: Actual limits vary by account tier based on 7-day trading volume.
+pub static DERIBIT_HTTP_ORDER_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(5).expect("5 is non-zero"))
+        .allow_burst(NonZeroU32::new(20).expect("20 is non-zero"))
+});
+
+/// Conservative rate limit for account information endpoints.
+pub static DERIBIT_HTTP_ACCOUNT_QUOTA: LazyLock<Quota> =
+    LazyLock::new(|| Quota::per_second(NonZeroU32::new(5).expect("5 is non-zero")));
+
+/// Global rate limit key for Deribit HTTP requests.
+pub const DERIBIT_GLOBAL_RATE_KEY: &str = "deribit:global";
+
+/// Rate limit key for Deribit order operations (matching engine).
+pub const DERIBIT_ORDER_RATE_KEY: &str = "deribit:orders";
+
+/// Rate limit key for account information endpoints.
+pub const DERIBIT_ACCOUNT_RATE_KEY: &str = "deribit:account";
+
+/// Deribit WebSocket subscription rate limit.
+///
+/// Subscribe methods have custom rate limits:
+/// - Cost per request: 3,000 credits
+/// - Maximum credits: 30,000
+/// - Sustained rate: ~3.3 requests/second
+/// - Burst capacity: 10 requests
+///
+/// # References
+///
+/// <https://support.deribit.com/hc/en-us/articles/25944617523357-Rate-Limits>
+pub static DERIBIT_WS_SUBSCRIPTION_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(3).expect("3 is non-zero"))
+        .allow_burst(NonZeroU32::new(10).expect("10 is non-zero"))
+});
+
+/// Deribit WebSocket order rate limit: 5 requests per second with 20 burst.
+///
+/// Matching engine operations (buy, sell, edit, cancel) have stricter limits.
+pub static DERIBIT_WS_ORDER_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(5).expect("5 is non-zero"))
+        .allow_burst(NonZeroU32::new(20).expect("20 is non-zero"))
+});
+
+/// Rate limit key for WebSocket subscriptions.
+pub const DERIBIT_WS_SUBSCRIPTION_KEY: &str = "subscription";
+
+/// Rate limit key for WebSocket order operations.
+pub const DERIBIT_WS_ORDER_KEY: &str = "order";


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Implement rate limiting for Deribit HTTP and WebSocket clients using Nautilus credit-based rate limiter.

### Changes

**HTTP Client (`http/client.rs`)**
- Add rate limiter quotas for global, order, and account request categories
- Implement method classification (`is_order_method`, `is_account_method`) to route requests to appropriate rate limit buckets
- Apply rate limit keys to all HTTP requests
- Add unit tests for method classification and rate limit key assignment

**WebSocket Client (`websocket/client.rs`)**
- Configure keyed quotas for subscriptions and order operations
- Move rate limit constants to centralized `consts.rs`
- Apply separate limits for subscription vs order operations

**Constants (`common/consts.rs`)**
- Add HTTP rate limit quotas: `DERIBIT_HTTP_REST_QUOTA`, `DERIBIT_HTTP_ORDER_QUOTA`, `DERIBIT_HTTP_ACCOUNT_QUOTA`
- Add WebSocket rate limit quotas: `DERIBIT_WS_SUBSCRIPTION_QUOTA`, `DERIBIT_WS_ORDER_QUOTA`
- Add rate limit keys for request categorization

### Deribit Rate Limits

| Category | Sustained | Burst | Notes |
|----------|-----------|-------|-------|
| Non-matching engine | 20 req/s | 100 | General API requests |
| Matching engine (Tier 4) | 5 req/s | 20 | Order operations |
| Subscribe | 3 req/s | 10 | WebSocket subscriptions |

Reference: https://support.deribit.com/hc/en-us/articles/25944617523357-Rate-Limits


## Related Issues/PRs

- https://github.com/nautechsystems/nautilus_trader/issues/3269

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
