### PR TITLE
Upgrade IB adapter to ibapi 10.37.2

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/account.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/account.py
@@ -203,8 +203,12 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
 
         """
         self._account_ids = {a for a in accounts_list.split(",") if a}
-        self._log.debug(f"Managed accounts set: {self._account_ids}")
+        self._log.debug(
+            f"Managed accounts set: {self._account_ids}, next_valid_order_id: {self._next_valid_order_id}",
+        )
 
+        # Set connection flag if we have next valid order id
+        # Accounts may be empty in some cases, but nextValidId is required
         if self._next_valid_order_id >= 0 and not self._is_ib_connected.is_set():
             self._log.debug("`_is_ib_connected` set by `managedAccounts`", LogColor.BLUE)
             self._is_ib_connected.set()

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -25,7 +25,7 @@ from typing import NamedTuple
 
 import msgspec
 from ibapi.client import EClient
-from ibapi.commission_report import CommissionReport
+from ibapi.commission_and_fees_report import CommissionAndFeesReport
 from ibapi.common import BarData
 from ibapi.execution import Execution
 
@@ -540,7 +540,7 @@ class BaseMixin:
     _next_valid_order_id: int
     _exec_id_details: dict[
         str,
-        dict[str, Execution | (CommissionReport | str)],
+        dict[str, Execution | (CommissionAndFeesReport | str)],
     ]
 
 

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -24,6 +24,7 @@ from ibapi.const import NO_VALID_ID
 from ibapi.errors import CONNECT_FAIL
 from ibapi.server_versions import MAX_CLIENT_VER
 from ibapi.server_versions import MIN_CLIENT_VER
+from ibapi.utils import currentTimeMillis
 
 from nautilus_trader.adapters.interactive_brokers.client.common import BaseMixin
 from nautilus_trader.common.enums import LogColor
@@ -70,17 +71,32 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         except ConnectionError:
             self._log.error("Connection failed")
             if self._eclient.wrapper:
-                self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
+                self._eclient.wrapper.error(
+                    NO_VALID_ID,
+                    currentTimeMillis(),
+                    CONNECT_FAIL.code(),
+                    CONNECT_FAIL.msg(),
+                )
         except TimeoutError:
             self._log.warning("Connection timeout")
             if self._eclient.wrapper:
-                self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
+                self._eclient.wrapper.error(
+                    NO_VALID_ID,
+                    currentTimeMillis(),
+                    CONNECT_FAIL.code(),
+                    CONNECT_FAIL.msg(),
+                )
         except asyncio.CancelledError:
             self._log.info("Connection cancelled")
         except Exception as e:
             self._log.exception("Connection failed", e)
             if self._eclient.wrapper:
-                self._eclient.wrapper.error(NO_VALID_ID, CONNECT_FAIL.code(), CONNECT_FAIL.msg())
+                self._eclient.wrapper.error(
+                    NO_VALID_ID,
+                    currentTimeMillis(),
+                    CONNECT_FAIL.code(),
+                    CONNECT_FAIL.msg(),
+                )
 
     def _msgspec_decoding_hook(self, byte_data: bytes) -> str:
         """
@@ -163,7 +179,7 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
         if self._eclient.connectOptions:
             v100version += f" {self._eclient.connectOptions}"
 
-        msg = comm.make_msg(v100version)
+        msg = comm.make_initial_msg(v100version)
         msg2 = str.encode(v100prefix, "ascii") + msg
         await asyncio.to_thread(functools.partial(self._eclient.conn.sendMsg, msg2))
 

--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -73,6 +73,7 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
         self,
         *,
         req_id: int,
+        error_time: int,
         error_code: int,
         error_string: str,
         advanced_order_reject_json: str = "",
@@ -86,6 +87,8 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
         ----------
         req_id : int
             The request ID associated with the error.
+        error_time : int
+            The timestamp when the error occurred.
         error_code : int
             The error code.
         error_string : str

--- a/nautilus_trader/adapters/interactive_brokers/client/wrapper.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/wrapper.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from functools import partial
 from typing import TYPE_CHECKING
 
-from ibapi.commission_report import CommissionReport
+from ibapi.commission_and_fees_report import CommissionAndFeesReport
 from ibapi.common import BarData
 from ibapi.common import FaDataType
 from ibapi.common import HistogramData
@@ -82,6 +82,7 @@ class InteractiveBrokersEWrapper(EWrapper):
     def error(
         self,
         reqId: TickerId,
+        errorTime: int,
         errorCode: int,
         errorString: str,
         advancedOrderRejectJson="",
@@ -94,6 +95,7 @@ class InteractiveBrokersEWrapper(EWrapper):
         task = partial(
             self._client.process_error,
             req_id=reqId,
+            error_time=errorTime,
             error_code=errorCode,
             error_string=errorString,
             advanced_order_reject_json=advancedOrderRejectJson,
@@ -789,7 +791,7 @@ class InteractiveBrokersEWrapper(EWrapper):
         """
         self.logAnswer(current_fn_name(), vars())
 
-    def commissionReport(self, commissionReport: CommissionReport) -> None:
+    def commissionAndFeesReport(self, commissionAndFeesReport: CommissionAndFeesReport) -> None:
         """
         Trigger this callback in the following scenarios:
 
@@ -800,7 +802,7 @@ class InteractiveBrokersEWrapper(EWrapper):
         self.logAnswer(current_fn_name(), vars())
         task = partial(
             self._client.process_commission_report,
-            commission_report=commissionReport,
+            commission_report=commissionAndFeesReport,
         )
         self._client.submit_to_msg_handler_queue(task)
 
@@ -1317,7 +1319,7 @@ class InteractiveBrokersEWrapper(EWrapper):
         """
         self.logAnswer(current_fn_name(), vars())
 
-    def orderBound(self, reqId: int, apiClientId: int, apiOrderId: int) -> None:
+    def orderBound(self, permId: int, clientId: int, orderId: int) -> None:
         """
         Return the orderBound notification.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ generate-setup-file = false
 betfair = ["betfair-parser==0.18.0"] # Pinned to 0.18.0 for stability
 ib = [
   "defusedxml>=0.7.1,<1.0.0; python_version < '3.14'",
-  "nautilus-ibapi==10.30.1; python_version < '3.14'",
+  "nautilus-ibapi==10.37.2; python_version < '3.14'",
 ]
 docker = ["docker>=7.1.0,<8.0.0"]
 dydx = [

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
@@ -61,11 +61,13 @@ async def test_connect_fail(ib_client):
 
     await ib_client._connect()
 
-    ib_client._eclient.wrapper.error.assert_called_with(
-        NO_VALID_ID,
-        CONNECT_FAIL.code(),
-        CONNECT_FAIL.msg(),
-    )
+    # Check that error was called with correct parameters (allowing any timestamp)
+    ib_client._eclient.wrapper.error.assert_called()
+    call_args = ib_client._eclient.wrapper.error.call_args[0]
+    assert call_args[0] == NO_VALID_ID
+    assert isinstance(call_args[1], int)  # errorTime should be an integer timestamp
+    assert call_args[2] == CONNECT_FAIL.code()
+    assert call_args[3] == CONNECT_FAIL.msg()
     ib_client._handle_reconnect.assert_not_awaited()
 
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
@@ -25,6 +25,7 @@ async def test_ib_is_ready_by_notification_1101(ib_client):
     # Act
     await ib_client.process_error(
         req_id=-1,
+        error_time=0,
         error_code=1101,
         error_string="Connectivity between IB and Trader Workstation has been restored",
     )
@@ -41,6 +42,7 @@ async def test_ib_is_ready_by_notification_1102(ib_client):
     # Act
     await ib_client.process_error(
         req_id=-1,
+        error_time=0,
         error_code=1102,
         error_string="Connectivity between IB and Trader Workstation has been restored",
     )
@@ -59,6 +61,7 @@ async def test_ib_is_not_ready_by_error_10182(ib_client):
     # Act
     await ib_client.process_error(
         req_id=req_id,
+        error_time=0,
         error_code=10182,
         error_string="Failed to request live updates (disconnected).",
     )

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 import msgspec
 import pandas as pd
 import pytz
-from ibapi.commission_report import CommissionReport
+from ibapi.commission_and_fees_report import CommissionAndFeesReport
 from ibapi.common import UNSET_DECIMAL
 from ibapi.common import BarData
 from ibapi.contract import Contract  # We use this for the expected response from IB
@@ -774,16 +774,16 @@ class IBTestExecStubs:
         return set_attributes(Execution(), params)
 
     @staticmethod
-    def commission() -> CommissionReport:
+    def commission() -> CommissionAndFeesReport:
         params = {
             "execId": "0000e0d5.6596b0d2.01.01",
-            "commission": 1.0,
+            "commissionAndFees": 1.0,
             "currency": "USD",
             "realizedPNL": 0.0,
             "yield_": 0.0,
             "yieldRedemptionDate": 0,
         }
-        return set_attributes(CommissionReport(), params)
+        return set_attributes(CommissionAndFeesReport(), params)
 
 
 def filter_out_options(instrument) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -1594,11 +1594,11 @@ wheels = [
 
 [[package]]
 name = "nautilus-ibapi"
-version = "10.30.1"
+version = "10.37.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/06/88ffe792be8b2d8b39cde54739fe9c05a8a82254f07e459a43044fae8863/nautilus_ibapi-10.30.1.tar.gz", hash = "sha256:eaad889d37d35e317eaf6a70afa656c79cd3267e4eee7fc883d097ea9ef6445f", size = 68623, upload-time = "2025-03-07T22:28:14.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/13/bbadf2c1216533053b2d29841107ae4a6d9eabbe4cd2bf4048503ee6ed65/nautilus_ibapi-10.37.2.tar.gz", hash = "sha256:5e498f5c8d83849c38eab1930926e33cd393d730f64835cb27af657a20e5528d", size = 90528, upload-time = "2025-08-26T08:28:20.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/cf/0ac25403435030814e8c60ef20d476acdc27140738f871c8d7f944e033e7/nautilus_ibapi-10.30.1-py3-none-any.whl", hash = "sha256:2aa0df654de46b469962f504541c388a099486c3e9aa5edb55a40e849ca00ed8", size = 77554, upload-time = "2025-03-07T22:28:13.295Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/71/cf8cb1f9fc6a3af902939405cfadfc09f154895f6a0830a2bcc95b5a2d07/nautilus_ibapi-10.37.2-py3-none-any.whl", hash = "sha256:7c665ce6ad85c550e7c2050d0c85ee446de5b35bf2ced07532b9a12470a78a5d", size = 117567, upload-time = "2025-08-26T08:28:19.511Z" },
 ]
 
 [[package]]
@@ -1689,7 +1689,7 @@ requires-dist = [
     { name = "fsspec", specifier = ">=2025.2.0,<=2026.1.0" },
     { name = "grpcio", marker = "python_full_version < '3.14' and extra == 'dydx'", specifier = "==1.68.1" },
     { name = "msgspec", specifier = ">=0.20.0,<1.0.0" },
-    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.30.1" },
+    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.37.2" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pandas", specifier = ">=2.2.3,<3.0.0" },
     { name = "plotly", marker = "extra == 'visualization'", specifier = ">=6.3.1,<7.0.0" },


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Summary

Migrated the Interactive Brokers adapter from `ibapi` 10.30.1 to 10.37.2, adding support for Protobuf message encoding and updating API calls to match the new version's interface changes. This migration ensures compatibility with newer TWS/Gateway versions while maintaining backward compatibility with older servers.

* **Updated dependency**: Upgraded `nautilus-ibapi` from 10.30.1 to 10.37.2 in `pyproject.toml`.

* **Protobuf message support**: Added support for Protobuf-encoded messages used by newer TWS API versions, with automatic detection and routing to the appropriate decoder.

* **API interface updates**: Updated method signatures and imports to match the new API version, including `CommissionReport` → `CommissionAndFeesReport` and addition of `error_time` parameter to error callbacks.

* **Connection improvements**: Enhanced connection logic to use `nextValidId` as the primary indicator of successful connection instead of relying solely on account data.

* **Message processing**: Refactored message processing to handle both Protobuf and standard encoding formats based on server version capabilities.

* **Test updates**: Simplified and updated test files to align with the new API structure.

## Problem

* **API version mismatch**: The adapter was using an older version of the IB API (10.30.1) which lacked support for newer features and Protobuf encoding used by modern TWS/Gateway versions.

* **Missing Protobuf support**: Newer TWS API versions use Protobuf encoding for more efficient communication, but the adapter only supported the legacy text-based encoding.

* **API interface changes**: The newer API version introduced breaking changes including renamed classes (`CommissionReport` → `CommissionAndFeesReport`) and additional required parameters (`error_time` in error callbacks).

* **Connection detection logic**: The previous implementation relied on account data availability to determine connection status, which could be unreliable if accounts arrived late or were empty.

## Solution

* **Dependency upgrade**: Updated `nautilus-ibapi` dependency to 10.37.2 in `pyproject.toml` and regenerated `uv.lock`.

* **Dual encoding support**: Implemented message processing that detects the server version and routes messages to either the Protobuf decoder (`processProtoBuf`) or the standard decoder (`interpret`) based on `MIN_SERVER_VER_PROTOBUF`.

* **Message ID extraction**: Added logic to extract message IDs from both Protobuf and standard message formats, handling the different header structures appropriately.

* **API compatibility updates**:
  * Replaced `CommissionReport` with `CommissionAndFeesReport` throughout the codebase.
  * Added `error_time` parameter to all `error()` callback invocations.
  * Updated connection initialization to use `comm.make_initial_msg()` instead of `comm.make_msg()`.
  * Updated `process_error()` method signature to include `error_time` parameter.

* **Improved connection detection**: Changed connection readiness logic to use `nextValidId` as the primary indicator, since it's a more reliable signal that the server is ready to accept orders.

* **Error handling**: Updated error processing to include timestamps using `currentTimeMillis()` when invoking error callbacks during connection failures.

## Test plan

* **Integration tests**: Run `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/` to verify all adapter functionality works with the new API version.

* **Client tests**: Verify client connection, account management, and error handling in `tests/integration_tests/adapters/interactive_brokers/client/`.

* **Backward compatibility**: Test with both older TWS/Gateway versions (using standard encoding) and newer versions (using Protobuf encoding) to ensure compatibility.

## Files changed

* `pyproject.toml`

* `uv.lock`

* `nautilus_trader/adapters/interactive_brokers/client/account.py`

* `nautilus_trader/adapters/interactive_brokers/client/client.py`

* `nautilus_trader/adapters/interactive_brokers/client/common.py`

* `nautilus_trader/adapters/interactive_brokers/client/connection.py`

* `nautilus_trader/adapters/interactive_brokers/client/error.py`

* `nautilus_trader/adapters/interactive_brokers/client/order.py`

* `nautilus_trader/adapters/interactive_brokers/client/wrapper.py`

* `nautilus_trader/adapters/interactive_brokers/execution.py`

* `tests/integration_tests/adapters/interactive_brokers/client/test_client_account.py`

* `tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py`

* `tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py`

* `tests/integration_tests/adapters/interactive_brokers/test_kit.py`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
