### PR TITLE
Fix Databento zero-length interval at dataset boundary

### DIFF
--- a/nautilus_trader/adapters/databento/data.py
+++ b/nautilus_trader/adapters/databento/data.py
@@ -825,7 +825,9 @@ class DatabentoDataClient(LiveMarketDataClient):
                 LogColor.BLUE,
             )
         elif start == end:
-            self._log.warning(f"Zero-length interval at dataset boundary: {start}")
+            # At dataset boundary (e.g. available_end=midnight, floor("D") gives start=end)
+            start -= pd.Timedelta(1, "ns")
+            self._log.info("Adjusted start by -1ns to create non-empty interval", LogColor.BLUE)
 
         if original_start != start or (original_end is not None and original_end != end):
             self._log.info(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

When `available_end` is exactly at midnight (e.g., `2024-01-15T00:00:00Z`) and no `start`/`end` is provided, the `_resolve_time_range_for_request` function sets `start = end.floor("D")`, which equals `end`. This results in `start == end`, causing the Databento API to return a 422 error (`start cannot be on or after end`). **This always happen when request_instruments is called on the weekend.**

The existing code only logged a warning in this case. This PR fixes it by moving `start` back by 1 nanosecond to create a valid non-empty interval, consistent with how the first branch handles the `start == end` case when `end < available_end`.

## Related Issues/PRs

None

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually in production - this fix resolves intermittent 422 errors from Databento when requesting instruments around midnight UTC.