### PR TITLE
Fix Interactive Brokers `fetch_all_open_orders` in client cache key preventing connection sharing

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -48,6 +48,7 @@ Released on TBD (UTC).
 - Fixed Databento zero-length interval at dataset boundary (#3429), thanks @shzhng
 - Fixed Deribit auth token refresh race condition (#3402), thanks @filipmacek
 - Fixed Deribit race condition between response and subscription (#3436), thanks @filipmacek
+- Fixed Interactive Brokers `fetch_all_open_orders` in client cache key preventing connection sharing (#3441)
 - Fixed Polymarket order state race condition where PLACEMENT events could arrive late
 - Fixed Polymarket duplicate WebSocket subscriptions (#3403), thanks for reporting @santivazq
 

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -114,7 +114,7 @@ def get_cached_ib_client(
         )
         PyCondition.not_none(port, "Please provide the `port` for the IB TWS or Gateway.")
 
-    client_key: tuple = (host, port, client_id, fetch_all_open_orders)
+    client_key: tuple = (host, port, client_id)
 
     if client_key not in IB_CLIENTS:
         client = InteractiveBrokersClient(
@@ -129,6 +129,11 @@ def get_cached_ib_client(
         )
         client.start()
         IB_CLIENTS[client_key] = client
+    elif fetch_all_open_orders:
+        # Upgrade existing client to fetch all open orders if requested
+        # This handles the case where data client is created first (without the flag)
+        # and exec client is created later (with the flag)
+        IB_CLIENTS[client_key]._fetch_all_open_orders = True
 
     return IB_CLIENTS[client_key]
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The `fetch_all_open_orders` flag was included in the IB client cache key, which prevented data and exec clients from sharing the same IB connection when using different values for this flag. This caused two connections to be created with the same client ID, which IB rejects.

## Problem

In `get_cached_interactive_brokers_client()`, the client cache key included `fetch_all_open_orders`:

```python
client_key: tuple = (host, port, client_id, fetch_all_open_orders)
```

This causes issues when using both data and exec clients:

1. `InteractiveBrokersDataClientConfig` doesn't have a `fetch_all_open_orders` option, so data clients always pass `False`
2. `InteractiveBrokersExecClientConfig` can set `fetch_all_open_orders=True` for order reconciliation
3. Data clients are typically created before exec clients (based on config dict ordering)
4. When the data client is created first with `fetch_all_open_orders=False`, it creates a cached client with key `(host, port, client_id, False)`
5. When the exec client is created later with `fetch_all_open_orders=True`, it looks for key `(host, port, client_id, True)` which doesn't exist
6. A second IB connection is created with the same `client_id`, which IB rejects

## Solution

1. Remove `fetch_all_open_orders` from the cache key since connection sharing shouldn't depend on this flag
2. Add logic to upgrade an existing client's `_fetch_all_open_orders` flag to `True` if a later request needs it

```python
client_key: tuple = (host, port, client_id)

if client_key not in IB_CLIENTS:
    client = InteractiveBrokersClient(...)
    client.start()
    IB_CLIENTS[client_key] = client
elif fetch_all_open_orders:
    # Upgrade existing client to fetch all open orders if requested
    # This handles the case where data client is created first (without the flag)
    # and exec client is created later (with the flag)
    IB_CLIENTS[client_key]._fetch_all_open_orders = True
```

The upgrade logic ensures that if the exec client needs `fetch_all_open_orders=True`, the shared client will have that capability even if it was originally created by the data client with `False`.

## Related Issues/PRs

Closes #3439

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

The existing test suite covers client caching behavior. Tested manually with hybrid Databento+IB setup where data client is created first and exec client second.