### PR TITLE
Fix Interactive Brokers synthetic position order reconciliation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -211,6 +211,7 @@ This release adds support for Python 3.14 with the following limitations:
 - Fixed Databento quote decoding with undefined bid/ask prices
 - Fixed Interactive Brokers quote tick subscriptions to use tick-by-tick data (#3135), thanks for reporting @genliusrocks
 - Fixed Interactive Brokers serialization of `IBContractDetails` (#3181), thanks @faysou
+- Fixed Interactive Brokers synthetic position order reconciliation causing filled_qty mismatch errors during periodic consistency checks
 - Fixed Interactive Brokers parsing of invalid prices (#3246), thanks @faysou
 - Fixed OKX pre-open instrument parsing and standardize enum usage (#3134), thanks for reporting @3wtz
 - Fixed OKX `request_bars` pagination halting prematurely in Range mode (#3145), thanks for reporting @3wtz


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixed a bug where the IB execution client's `generate_order_status_reports` method was generating synthetic filled orders from positions during periodic consistency checks (when `open_only=True`), causing `filled_qty` mismatch errors when position quantities changed due to partial fills on exit orders.

## Related Issues/PRs

None

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Problem

The IB adapter creates synthetic "filled" `OrderStatusReport` objects from open positions to establish position state during startup reconciliation. These synthetic orders use the **instrument ID** as both `client_order_id` and `venue_order_id`.

**The bug occurs under these specific conditions:**

1. **At startup**: A position exists at IB (e.g., -6 contracts). The adapter creates a synthetic filled SELL order with `client_order_id=<instrument_id>` and `filled_qty=6` to represent this position.

2. **An exit order exists**: There's also a real open BUY exit order at IB (e.g., to close the -6 position). This order is imported correctly with proper IB-assigned IDs (`client_order_id=O-...`, `venue_order_id=102`).

3. **Partial fills occur**: The exit order gets partial fills over time, reducing the position (e.g., from -6 to -1).

4. **Periodic consistency check runs**: The execution engine calls `generate_order_status_reports` with `open_only=True`. The IB adapter **incorrectly** regenerates synthetic orders from the **current** position state, creating a new synthetic order with the **same** `client_order_id=<instrument_id>` but `filled_qty=1` (current position).

5. **Mismatch detected**: The cached synthetic order has `filled_qty=6` (from startup), but the new report says `filled_qty=1`, triggering the error:
   ```
   report.filled_qty 1 < order.filled_qty 6, this could potentially be caused by duplicate fills or corrupted cached state
   ```

## Solution

When `command.open_only=True` (periodic consistency checks), skip generating synthetic filled orders from positions. These synthetic orders:
- Are FILLED (closed) orders, so they shouldn't appear in "open only" queries semantically
- Were already created at startup - no need to regenerate them
- May have stale `filled_qty` values that conflict with the cached state

This also fixes a secondary bug where the method would return early (`if not positions: return []`) without fetching actual open orders from IB.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually by running live trading with the fix applied - the periodic consistency check errors no longer occur when exit orders are partially filled.