### PR TITLE
Fix Interactive Brokers reconciliation error when account has no positions

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -439,9 +439,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # periodic checks causes filled_qty mismatches because the position may have
         # changed due to partial fills on exit orders.
         if not command.open_only:
-            positions: list[IBPosition] = await self._client.get_positions(
+            positions: list[IBPosition] | None = await self._client.get_positions(
                 self.account_id.get_id(),
             )
+
+            if not positions:
+                positions = []
 
             ts_init = self._clock.timestamp_ns()
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Handle `None` return from `get_positions()` when account has no open positions, preventing `TypeError: 'NoneType' object is not iterable` during execution state reconciliation.

## Related Issues/PRs

Fixes regression introduced in #3443

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually with IB account that has no open positions.