### PR TITLE
[DRAFT] Add Interactive Brokers support for externally placed & filled order execution while running

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,6 +28,7 @@ Released on TBD (UTC).
 - Improved TLS cert loading and socket suffix validation
 
 ### Fixes
+- Fixed Interactive Brokers external order reconciliation (orders placed via TWS or other clients)
 - Fixed matching engine liquidity consumption using cumulative book quantity
 - Fixed matching engine trade execution fills discarded with `liquidity_consumption`
 - Fixed remaining `F_LAST` flag checks to use proper bitmask comparison

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -166,7 +166,7 @@ class InteractiveBrokersClient(
             str,
             dict[str, Execution | (CommissionAndFeesReport | str)],
         ] = {}
-        self._order_id_to_order_ref: dict[int, AccountOrderRef] = {}
+        self._order_id_to_order_ref: dict[int | str, AccountOrderRef] = {}
         self._next_valid_order_id: int = -1
 
         # Instrument provider (set by data/execution clients during connection)

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -534,7 +534,7 @@ class BaseMixin:
     # MarketData
     _bar_type_to_last_bar: dict[str, BarData | None]
     _bar_timeout_tasks: dict[str, Any]  # asyncio.Task
-    _order_id_to_order_ref: dict[int, AccountOrderRef]
+    _order_id_to_order_ref: dict[int | str, AccountOrderRef]
 
     # Order
     _next_valid_order_id: int

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -275,16 +275,19 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             request.result.append(order)
 
             # Validate and add reverse mapping, if not exists
-            if order_ref := self._order_id_to_order_ref.get(order.orderId):
+            # Use permId as key for external orders (orderId=0) since permId is unique
+            # and persistent across sessions/clients
+            order_key = order.orderId if order.orderId != 0 else f"PERM-{order.permId}"
+            if order_ref := self._order_id_to_order_ref.get(order_key):
                 if not (
                     order_ref.account_id == order.account and order_ref.order_id == order.orderRef
                 ):
                     self._log.warning(
-                        f"Discrepancy found in order, expected {order_ref}, "
-                        f"was (account={order.account}, order_id={order.orderRef}",
+                        f"Discrepancy found in order (ib_order_id={order.orderId}, permId={order.permId}), "
+                        f"expected {order_ref}, was (account={order.account}, order_id={order.orderRef})",
                     )
             else:
-                self._order_id_to_order_ref[order.orderId] = AccountOrderRef(
+                self._order_id_to_order_ref[order_key] = AccountOrderRef(
                     account_id=order.account,
                     order_id=order.orderRef,
                 )

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -240,6 +240,9 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # Track average fill prices for orders
         self._order_avg_prices: dict[ClientOrderId, Price] = {}
 
+        # Track external execIds processed in real-time to avoid duplicate processing during reconciliation
+        self._processed_external_exec_ids: set[str] = set()
+
     @property
     def instrument_provider(self) -> InteractiveBrokersInstrumentProvider:
         return self._instrument_provider  # type: ignore
@@ -391,10 +394,17 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             order_type = mapped_order_type_info
             time_in_force = ib_to_nautilus_time_in_force[ib_order.tif]
 
+        # Use permId for external orders (orderId=0) since it's unique across sessions
+        venue_order_id = (
+            VenueOrderId(f"PERM-{ib_order.permId}")
+            if ib_order.orderId == 0
+            else VenueOrderId(str(ib_order.orderId))
+        )
+
         order_status = OrderStatusReport(
             account_id=self.account_id,
             instrument_id=instrument.id,
-            venue_order_id=VenueOrderId(str(ib_order.orderId)),
+            venue_order_id=venue_order_id,
             order_side=ib_to_nautilus_order_side[ib_order.action],
             order_type=order_type,
             time_in_force=time_in_force,
@@ -513,6 +523,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
     ) -> list[FillReport]:
         self._log.debug("Requesting FillReports...")
         reports: list[FillReport] = []
+        # Track external orders (orderId=0) by permId to generate synthetic OrderStatusReports
+        external_orders: dict[int, dict] = {}  # permId -> {instrument, execution, side, qty, price}
 
         try:
             # Create execution filter based on command parameters
@@ -579,6 +591,39 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                     )
                     continue
 
+                # Track external orders for synthetic OrderStatusReport generation
+                if execution.orderId == 0 and execution.permId != 0:
+                    # Skip if already processed in real-time
+                    if execution.execId in self._processed_external_exec_ids:
+                        self._log.debug(
+                            f"Skipping already-processed external execution: {execution.execId}",
+                        )
+                        continue
+
+                    perm_id = execution.permId
+                    order_side = OrderSide[ORDER_SIDE_TO_ORDER_ACTION[execution.side]]
+                    price_magnifier = self.instrument_provider.get_price_magnifier(instrument.id)
+                    exec_price = ib_price_to_nautilus_price(execution.price, price_magnifier)
+
+                    if perm_id not in external_orders:
+                        external_orders[perm_id] = {
+                            "instrument": instrument,
+                            "order_side": order_side,
+                            "total_qty": Decimal(str(execution.shares)),
+                            "avg_price": exec_price,
+                            "ts_event": timestring_to_timestamp(execution.time).value,
+                        }
+                    else:
+                        # Aggregate fills for the same order
+                        existing = external_orders[perm_id]
+                        existing["total_qty"] += Decimal(str(execution.shares))
+                        # Use cumQty's avgPrice if available, otherwise keep first price
+                        if hasattr(execution, "avgPrice") and execution.avgPrice > 0:
+                            existing["avg_price"] = ib_price_to_nautilus_price(
+                                execution.avgPrice,
+                                price_magnifier,
+                            )
+
                 # Convert IB execution to Nautilus FillReport
                 try:
                     fill_report = self._create_fill_report(
@@ -595,6 +640,19 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                         f"Failed to create fill report for execution {execution.execId}: {e}",
                     )
                     continue
+
+            # Generate and send synthetic OrderStatusReports for external orders
+            # These must be processed before FillReports so the execution engine can find the orders
+            for perm_id, order_data in external_orders.items():
+                self._send_synthetic_external_order_report(
+                    perm_id=perm_id,
+                    instrument=order_data["instrument"],
+                    order_side=order_data["order_side"],
+                    quantity=order_data["total_qty"],
+                    avg_price=order_data["avg_price"],
+                    ts_event=order_data["ts_event"],
+                    ts_init=ts_init,
+                )
 
             self._log_report_receipt(len(reports), "FillReport", LogLevel.INFO, "Generated")
 
@@ -627,9 +685,16 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             # Remove the order ID suffix that IB adds
             order_ref = execution.orderRef.rsplit(":", 1)[0]
             client_order_id = ClientOrderId(order_ref)
+        elif execution.orderId == 0 and execution.permId != 0:
+            # External order - use synthetic client order ID matching the synthetic order
+            client_order_id = ClientOrderId(f"EXTERNAL-{execution.permId}")
 
         # Create venue order ID
-        venue_order_id = VenueOrderId(str(execution.orderId))
+        # For external orders (orderId=0), use permId as the unique identifier
+        if execution.orderId == 0 and execution.permId != 0:
+            venue_order_id = VenueOrderId(f"PERM-{execution.permId}")
+        else:
+            venue_order_id = VenueOrderId(str(execution.orderId))
 
         # Create trade ID
         trade_id = TradeId(execution.execId)
@@ -669,6 +734,59 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             client_order_id=client_order_id,
             venue_position_id=None,  # IB doesn't provide position ID in executions
         )
+
+    def _send_synthetic_external_order_report(
+        self,
+        perm_id: int,
+        instrument,
+        order_side: OrderSide,
+        quantity: Decimal,
+        avg_price: Decimal,
+        ts_event: int,
+        ts_init: int,
+    ) -> None:
+        """
+        Create and send a synthetic OrderStatusReport for an external order.
+
+        External orders are those placed outside NautilusTrader (e.g., via TWS or
+        another client). They have orderId=0 and are identified by their permId.
+
+        """
+        venue_order_id = VenueOrderId(f"PERM-{perm_id}")
+        client_order_id = ClientOrderId(f"EXTERNAL-{perm_id}")
+
+        qty = Quantity(quantity, precision=instrument.size_precision)
+        price = Price(avg_price, precision=instrument.price_precision)
+
+        # Note: order_type and time_in_force are not available from IB Execution data
+        # (only from the Order object which we don't have for external orders).
+        # Using MARKET/FOK as defaults for consistency with generate_fill_reports.
+        # Since the order is already filled, these values only affect record-keeping.
+        report = OrderStatusReport(
+            account_id=self.account_id,
+            instrument_id=instrument.id,
+            venue_order_id=venue_order_id,
+            order_side=order_side,
+            order_type=OrderType.MARKET,
+            time_in_force=TimeInForce.FOK,
+            order_status=OrderStatus.FILLED,
+            quantity=qty,
+            filled_qty=qty,
+            avg_px=price,
+            report_id=UUID4(),
+            ts_accepted=ts_event,
+            ts_last=ts_event,
+            ts_init=ts_init,
+            client_order_id=client_order_id,
+        )
+
+        self._log.info(
+            f"Generated synthetic OrderStatusReport for external order: "
+            f"permId={perm_id}, instrument={instrument.id}, side={order_side.name}, "
+            f"qty={qty}, avg_px={price}",
+        )
+
+        self._send_order_status_report(report)
 
     async def generate_position_status_reports(
         self,
@@ -1531,8 +1649,20 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         commission_report: CommissionAndFeesReport,
         contract: IBContract,
     ) -> None:
-        if not execution.orderRef:
+        # Check for external order (no orderRef, but has permId)
+        is_external_order = (
+            not execution.orderRef and execution.orderId == 0 and execution.permId != 0
+        )
+
+        if not execution.orderRef and not is_external_order:
             self._log.warning(f"ClientOrderId not available, execution={execution.__dict__}")
+            return
+
+        if is_external_order:
+            # Handle external order asynchronously
+            self.create_task(
+                self._handle_external_execution(execution, commission_report, contract),
+            )
             return
 
         client_order_id = ClientOrderId(order_ref)
@@ -1542,8 +1672,22 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         nautilus_order = self._find_order_for_execution(client_order_id, venue_order_id)
 
         if not nautilus_order:
-            # Order not found - execution engine will handle this during reconciliation
-            # Log and return early to avoid processing incomplete execution details
+            # Order not found in cache. If orderId=0, this is likely an order from a
+            # previous Nautilus session (same clientId but different session), so treat
+            # it as an external order. This ensures fills are processed in real-time
+            # rather than waiting for periodic reconciliation.
+            if execution.orderId == 0 and execution.permId != 0:
+                self._log.info(
+                    f"Order {order_ref} not found in cache but orderId=0. "
+                    f"Treating as external order (previous session). permId={execution.permId}",
+                )
+                self.create_task(
+                    self._handle_external_execution(execution, commission_report, contract),
+                )
+                return
+
+            # Order not found and has valid orderId - execution engine will handle
+            # this during reconciliation
             self._log.debug(
                 f"Order not found in cache for execution (order_ref={order_ref}, "
                 f"venue_order_id={venue_order_id}, execId={execution.execId}). "
@@ -1630,6 +1774,72 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                     return order
 
         return None
+
+    async def _handle_external_execution(
+        self,
+        execution: Execution,
+        commission_report: CommissionAndFeesReport,
+        contract: IBContract,
+    ) -> None:
+        """
+        Handle execution from an external order (placed outside NautilusTrader).
+
+        Creates a synthetic order report followed by a fill event for the execution.
+
+        """
+        # Skip if already processed (IB can send duplicate execution callbacks)
+        if execution.execId in self._processed_external_exec_ids:
+            self._log.debug(
+                f"Skipping already-processed external execution: {execution.execId}",
+            )
+            return
+
+        perm_id = execution.permId
+
+        self._log.info(
+            f"Handling external execution: permId={perm_id}, "
+            f"execId={execution.execId}, shares={execution.shares}, price={execution.price}",
+        )
+
+        # Get the instrument for this contract
+        instrument = await self.instrument_provider.get_instrument(contract)
+        if not instrument:
+            self._log.error(
+                f"Cannot process external execution: instrument not found for contract {contract}",
+            )
+            return
+
+        # Determine order side from execution
+        order_side = OrderSide[ORDER_SIDE_TO_ORDER_ACTION[execution.side]]
+
+        # Get timestamps
+        ts_event = timestring_to_timestamp(execution.time).value
+        ts_init = self._clock.timestamp_ns()
+
+        # Convert execution price using price magnifier
+        price_magnifier = self.instrument_provider.get_price_magnifier(instrument.id)
+        converted_price = ib_price_to_nautilus_price(execution.price, price_magnifier)
+
+        # Send synthetic OrderStatusReport for this external order
+        self._send_synthetic_external_order_report(
+            perm_id=perm_id,
+            instrument=instrument,
+            order_side=order_side,
+            quantity=Decimal(execution.shares),
+            avg_price=Decimal(converted_price),
+            ts_event=ts_event,
+            ts_init=ts_init,
+        )
+
+        # Track this execId to prevent duplicate processing
+        self._processed_external_exec_ids.add(execution.execId)
+
+        # Note: We don't call generate_order_filled here because the execution engine
+        # automatically infers a fill when it sees the OrderStatusReport transition
+        # from unfilled to filled state.
+
+        # Update position tracking
+        self._update_position_tracking_from_execution(contract, execution)
 
     def _handle_spread_execution(
         self,


### PR DESCRIPTION
## Pull Request

NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

### Summary

External orders placed outside NautilusTrader (e.g., via TWS or another IB API client) have `orderId=0` and no `orderRef`, but include a unique `permId`. Previously, these orders were dropped during reconciliation, causing position discrepancies. This PR uses `permId` as the unique identifier for external orders to enable proper reconciliation.

### Related Issues/PRs

- Issue #3465 (orderId=0 discrepancy warning)

### Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

### Breaking change details (if applicable)

N/A

### Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

### Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

### Testing

Ensure new or changed logic is covered by tests.

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually with real IB Gateway by placing orders through TWS and verifying NautilusTrader correctly reconciles the positions.

---

## Details

### Background: IB Order IDs

Interactive Brokers uses two different order identifiers:

1. **`orderId`**: Session-specific, assigned when placing an order. Only valid for orders placed by the current API session.
2. **`permId`**: Permanent ID assigned by IB servers, unique and persistent across all sessions/clients.

When using `reqAllOpenOrders()` (required to see orders from TWS GUI or other clients), IB returns `orderId=0` for orders not placed by the current session. This includes:
- Orders placed via TWS GUI
- Orders placed by other IB API clients
- Orders placed by previous sessions of the same `clientId` (after gateway restart)

### Problem

When orders are placed through TWS or another IB API client (not NautilusTrader), the execution details show:

- `orderId: 0` (not a valid order ID)
- `orderRef: ''` (empty string)  
- `permId: 277757119` (unique permanent ID)

This caused several issues:

1. **Discrepancy warnings** during order status updates:
   ```
   Discrepancy found in order, expected AccountOrderRef(...), was (account=..., order_id=)
   ```
   Because all external orders used `orderId=0` as the mapping key, they collided.

2. **Fill processing failures**:
   ```
   ClientOrderId not available, execution={...}
   FillReport received before OrderStatusReport for VenueOrderId('0')
   ```

3. **Position discrepancies**:
   ```
   Position discrepancy detected for SGOV.ARCX: cached_qty=0 (flat), venue_qty=9900
   ```

4. **Duplicate fill processing**: IB can send the same execution multiple times (real-time callbacks + reconciliation queries), causing overfill errors.

### Solution

Use `permId` as the unique identifier for external orders throughout:

**1. Order ID Mapping** (`client/order.py`, `client/client.py`, `client/common.py`):
- Use `PERM-{permId}` as the key in `_order_id_to_order_ref` for external orders
- Changed type annotation from `dict[int, ...]` to `dict[int | str, ...]`

**2. VenueOrderId** (`execution.py`):
- Use `VenueOrderId(f"PERM-{permId}")` for external orders in `OrderStatusReport`

**3. Real-time External Execution Handling** (`execution.py`):
- New `_handle_external_execution` async method for processing external fills in real-time
- Generates synthetic `OrderStatusReport` which triggers the execution engine to infer the fill
- No manual `generate_order_filled` call needed - the execution engine handles it automatically

**4. Duplicate Prevention** (`execution.py`):
- Track processed `execId`s in `_processed_external_exec_ids` set
- Skip already-processed executions in both real-time and reconciliation paths
- Check at the start of `_handle_external_execution` before any processing

**5. Reconciliation** (`execution.py`):
- Generate synthetic `OrderStatusReport`s before `FillReport`s so the execution engine can find the orders
- Aggregate fills by `permId` to compute correct total quantities

### Changes Summary

| File | Change |
|------|--------|
| `client/client.py` | Type annotation `dict[int \| str, ...]` for order mapping |
| `client/common.py` | Type annotation `dict[int \| str, ...]` for order mapping |
| `client/order.py` | Use `PERM-{permId}` key for external orders, improved warning message |
| `execution.py` | External order handling, duplicate prevention, permId-based VenueOrderId |

### Testing

Tested manually with real IB Gateway:
1. Place orders through TWS GUI while NautilusTrader is running
2. Verify fills are processed correctly without duplicates
3. Restart NautilusTrader and verify reconciliation finds existing external positions
4. Verify no discrepancy warnings for external orders
