### PR TITLE
Fix Interactive Brokers partial fill order status issues

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -65,6 +65,8 @@ Released on TBD (UTC).
 - Fixed Interactive Brokers venue determination when primaryExchange is empty (#3452), thanks @shzhng
 - Fixed Interactive Brokers option symbol parsing to preserve OCC format with space padding (#3452), thanks @shzhng
 - Fixed Interactive Brokers minor bugs with options (#3452), thanks @shzhng
+- Fixed Interactive Brokers partial fill state transition errors where openOrder callbacks after fills caused invalid PARTIALLY_FILLED -> ACCEPTED transitions, thanks @shzhng
+- Fixed Interactive Brokers OrderStatusReport filled_qty always being 0 for open orders causing reconciliation errors, thanks @shzhng
 - Fixed Kraken spot instrument fee/margin parsing where parameters were incorrectly swapped
 - Fixed Polymarket order state race condition where `PLACEMENT` events could arrive late
 - Fixed Polymarket duplicate WebSocket subscriptions (#3403), thanks for reporting @santivazq


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes two bugs in the Interactive Brokers adapter that caused errors during partial fill scenarios:
1. Invalid state transitions (`PARTIALLY_FILLED -> ACCEPTED`) when IB sends `openOrder` callbacks after partial fills
2. `OrderStatusReport.filled_qty` always being 0 for open orders, causing reconciliation errors ("report.filled_qty 0 < order.filled_qty N")

## Related Issues/PRs

<!-- No specific issue, discovered during live trading -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

The bugs were discovered during live trading with partially filled limit orders. The fixes are defensive checks that prevent invalid state machine transitions and ensure computed values are used instead of hardcoded zeros.