### PR TITLE
Fix Interactive Brokers position reconciliation double-counting

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -72,6 +72,7 @@ Released on TBD (UTC).
 - Fixed Interactive Brokers partial fill state transition errors where `openOrder` callbacks after fills caused invalid `PARTIALLY_FILLED` -> `ACCEPTED` transitions, thanks @shzhng
 - Fixed Interactive Brokers OrderStatusReport filled_qty always being 0 for open orders causing reconciliation errors, thanks @shzhng
 - Fixed Interactive Brokers external order ID collision where orders placed via TWS/other clients (orderId=0) could cause fills to be attributed to wrong orders (#3465), thanks @shzhng
+- Fixed Interactive Brokers position reconciliation double-counting partial fills from open orders (#3476), thanks @shzhng
 - Fixed Kraken spot instrument fee/margin parsing where parameters were incorrectly swapped
 - Fixed Polymarket order state race condition where `PLACEMENT` events could arrive late
 - Fixed Polymarket duplicate WebSocket subscriptions (#3403), thanks for reporting @santivazq


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixed position reconciliation double-counting when open orders have partial fills for the same instrument as a position. Synthetic position orders now subtract filled quantities from open orders to avoid double-counting, which was causing incorrect internal position state during startup reconciliation.

This likely was silently failing or didn't get surfaced for a long time because open orders were getting incorrectly imported with filled_qty=0, but my PRs #3471 and #3472  fixed hardcodes and edge cases, thus subsequently surfaced this issue.

## Related Issues/PRs

Fixes #3476

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually with real IB account having positions with partially filled open orders:
- Verified reconciliation logs show correct adjusted quantities for a `SyntheticOrder` on startup (`position=-1, open_fills=4, adjusted=-5`)
- Verified no position discrepancy warnings after startup
- Verified `Execution state reconciled` success message

**Example before fix:**
- Position: -1 (from SELL 5 + BUY 4)
- Synthetic order: SELL 1 (from position -1)
- Open order: BUY 4 (partially filled)
- Result: -1 + 4 = +3 (wrong!)

**Example after fix:**
- Position: -1, open_fills: +4
- Adjusted: -1 - (+4) = -5
- Synthetic order: SELL 5
- Open order: BUY 4
- Result: -5 + 4 = -1 ✓