### PR TITLE
[InteractiveBrokers] Fix fetching historical bar data for futures using raw symbology

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/historical/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/historical/client.py
@@ -180,7 +180,7 @@ class HistoricInteractiveBrokersClient:
 
         return list(self._data_client.instrument_provider._instruments.values())
 
-    async def request_bars(
+    async def request_bars(  # noqa: C901
         self,
         bar_specifications: list[str],
         end_date_time: datetime.datetime,
@@ -253,42 +253,48 @@ class HistoricInteractiveBrokersClient:
         if not contracts and not instrument_ids:
             raise ValueError("Either contracts or instrument_ids must be provided")
 
+        contract_instrument_pairs = []
+
         # Convert instrument_id strings or InstrumentId objects to IBContracts
-        contracts.extend(
-            [
-                await self._data_client.instrument_provider.instrument_id_to_ib_contract(
-                    InstrumentId.from_str(instrument_id)
-                    if isinstance(instrument_id, str)
-                    else instrument_id,
-                )
-                for instrument_id in instrument_ids
-            ],
-        )
+        for instrument_id in instrument_ids:
+            contract = await self._data_client.instrument_provider.instrument_id_to_ib_contract(
+                InstrumentId.from_str(instrument_id)
+                if isinstance(instrument_id, str)
+                else instrument_id,
+            )
+            contract_instrument_pairs.append((instrument_id, contract))
+
+        # Convert IBContract objects to instrument_ids
+        for contract in contracts:
+            venue = self._data_client.instrument_provider.determine_venue_from_contract(
+                contract,
+            )
+            instrument_id = ib_contract_to_instrument_id(
+                contract,
+                venue,
+                self._instrument_provider_config.symbology_method,
+            )
+            contract_instrument_pairs.append((instrument_id, contract))
 
         # Ensure instruments are fetched and cached
-        await self._fetch_instruments_if_not_cached(contracts)
+        await self._fetch_instruments_if_not_cached(
+            contracts=[contract for _, contract in contract_instrument_pairs],
+        )
         data: list[Bar] = []
 
-        for contract in contracts:
+        for instrument_id, contract in contract_instrument_pairs:
             for bar_spec in bar_specifications:
-                venue = self._data_client.instrument_provider.determine_venue_from_contract(
-                    contract,
-                )
-                instrument_id = ib_contract_to_instrument_id(
-                    contract,
-                    venue,
-                    self._instrument_provider_config.symbology_method,
-                )
                 bar_type = BarType(
                     instrument_id,
                     BarSpecification.from_str(bar_spec),
                     AggregationSource.EXTERNAL,
                 )
-
                 bars = await self._data_client.get_historical_bars_chunked(
                     bar_type=bar_type,
                     contract=contract,
-                    start_date_time=start_date_time,
+                    start_date_time=pd.Timestamp(start_date_time)
+                    if start_date_time is not None
+                    else None,
                     end_date_time=end_date_time,
                     duration=duration,
                     use_rth=use_rth,

--- a/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/instruments.py
@@ -1168,7 +1168,10 @@ def instrument_id_to_ib_contract(
             contract_details_map,
         )
     elif symbology_method == SymbologyMethod.IB_RAW:
-        return instrument_id_to_ib_contract_raw_symbology(instrument_id)
+        return instrument_id_to_ib_contract_raw_symbology(
+            instrument_id,
+            contract_details_map=contract_details_map,
+        )
     else:
         raise NotImplementedError(f"{symbology_method} not implemented")
 
@@ -1308,7 +1311,10 @@ def instrument_id_to_bag_contract(
         raise ValueError(f"Failed to create BAG contract from spread {instrument_id}: {e}")
 
 
-def instrument_id_to_ib_contract_raw_symbology(instrument_id: InstrumentId) -> IBContract:
+def instrument_id_to_ib_contract_raw_symbology(
+    instrument_id: InstrumentId,
+    contract_details_map: dict[InstrumentId, IBContractDetails] | None = None,
+) -> IBContract:
     local_symbol, security_type = instrument_id.symbol.value.rsplit("=", 1)
     exchange = instrument_id.venue.value.replace("/", ".")
 
@@ -1336,6 +1342,30 @@ def instrument_id_to_ib_contract_raw_symbology(instrument_id: InstrumentId) -> I
             secType=security_type,
             exchange=exchange,
             localSymbol=local_symbol,
+        )
+    elif security_type == "FUT":
+        if contract_details_map is None:
+            raise ValueError(
+                "Unable to build IBContract for futures security: contract_details_map is None.",
+            )
+
+        contract_details = contract_details_map[instrument_id]
+
+        if contract_details.contract is None:
+            raise ValueError(f"Failed to find contract details for instrument {instrument_id}")
+
+        currency = contract_details.contract.currency
+        multiplier = contract_details.contract.multiplier
+        lastTradeDateOrContractMonth = contract_details.contractMonth
+        symbol = contract_details.contract.symbol
+
+        return IBContract(
+            secType=security_type,
+            exchange=exchange,
+            currency=currency,
+            multiplier=multiplier,
+            symbol=symbol,
+            lastTradeDateOrContractMonth=lastTradeDateOrContractMonth,
         )
     else:
         return IBContract(


### PR DESCRIPTION
# Pull Request

## Summary

Fix fetching historical bar data for future chains when using raw symbology for the Interactive Brokers adapter. The instrument ID was regenerated with the wrong symbol. As a consequence, when building the Bars, the instrument could not be found in the Cache.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

- [x] Bug fix (non-breaking)

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Manual testing.
