### PR TITLE
Fix Bybit historical requests to use ts_event as ts_init

### DIFF
--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -557,7 +557,7 @@ pub fn parse_option_instrument(
 pub fn parse_trade_tick(
     trade: &BybitTrade,
     instrument: &InstrumentAny,
-    ts_init: UnixNanos,
+    ts_init: Option<UnixNanos>,
 ) -> anyhow::Result<TradeTick> {
     let price =
         parse_price_with_precision(&trade.price, instrument.price_precision(), "trade.price")?;
@@ -567,6 +567,7 @@ pub fn parse_trade_tick(
     let trade_id = TradeId::new_checked(trade.exec_id.as_str())
         .context("invalid exec_id in Bybit trade payload")?;
     let ts_event = parse_millis_timestamp(&trade.time, "trade.time")?;
+    let ts_init = ts_init.unwrap_or(ts_event);
 
     TradeTick::new_checked(
         instrument.id(),
@@ -601,9 +602,10 @@ pub fn parse_funding_rate(
 pub fn parse_orderbook(
     result: &BybitOrderbookResult,
     instrument: &InstrumentAny,
-    ts_init: UnixNanos,
+    ts_init: Option<UnixNanos>,
 ) -> anyhow::Result<OrderBookDeltas> {
     let ts_event = parse_millis_i64(result.ts, "orderbook.timestamp")?;
+    let ts_init = ts_init.unwrap_or(ts_event);
 
     let instrument_id = instrument.id();
     let price_precision = instrument.price_precision();
@@ -682,7 +684,7 @@ pub fn parse_kline_bar(
     instrument: &InstrumentAny,
     bar_type: BarType,
     timestamp_on_close: bool,
-    ts_init: UnixNanos,
+    ts_init: Option<UnixNanos>,
 ) -> anyhow::Result<Bar> {
     let price_precision = instrument.price_precision();
     let size_precision = instrument.size_precision();
@@ -708,7 +710,7 @@ pub fn parse_kline_bar(
             .context("bar timestamp overflowed when adjusting to close time")?;
         ts_event = UnixNanos::from(updated);
     }
-    let ts_init = if ts_init.is_zero() { ts_event } else { ts_init };
+    let ts_init = ts_init.unwrap_or(ts_event);
 
     Bar::new_checked(bar_type, open, high, low, close, volume, ts_event, ts_init)
         .context("failed to construct Bar from Bybit kline entry")
@@ -1330,7 +1332,7 @@ mod tests {
         let response: BybitTradesResponse = serde_json::from_str(&json).unwrap();
         let trade = &response.result.list[0];
 
-        let tick = parse_trade_tick(trade, &instrument, TS).unwrap();
+        let tick = parse_trade_tick(trade, &instrument, Some(TS)).unwrap();
 
         assert_eq!(tick.instrument_id, instrument.id());
         assert_eq!(tick.price, instrument.make_price(27450.50));
@@ -1356,7 +1358,7 @@ mod tests {
             AggregationSource::External,
         );
 
-        let bar = parse_kline_bar(kline, &instrument, bar_type, false, TS).unwrap();
+        let bar = parse_kline_bar(kline, &instrument, bar_type, false, Some(TS)).unwrap();
 
         assert_eq!(bar.bar_type.to_string(), bar_type.to_string());
         assert_eq!(bar.open, instrument.make_price(27450.0));

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -2998,11 +2998,10 @@ impl BybitHttpClient {
         let params = params_builder.build().map_err(|e| anyhow::anyhow!(e))?;
         let response = self.inner.get_recent_trades(&params).await?;
 
-        let ts_init = self.generate_ts_init();
         let mut trades = Vec::new();
 
         for trade in response.result.list {
-            if let Ok(trade_tick) = parse_trade_tick(&trade, &instrument, ts_init) {
+            if let Ok(trade_tick) = parse_trade_tick(&trade, &instrument, None) {
                 trades.push(trade_tick);
             }
         }
@@ -3188,8 +3187,7 @@ impl BybitHttpClient {
         let params = params_builder.build().map_err(|e| anyhow::anyhow!(e))?;
         let response = self.inner.get_orderbook(&params).await?;
 
-        let ts_init = self.generate_ts_init();
-        let deltas = parse_orderbook(&response.result, &instrument, ts_init)?;
+        let deltas = parse_orderbook(&response.result, &instrument, None)?;
 
         Ok(deltas)
     }
@@ -3282,7 +3280,6 @@ impl BybitHttpClient {
                 break;
             }
 
-            let ts_init = self.generate_ts_init();
             let mut page_bars = Vec::with_capacity(klines_with_ts.len());
 
             let mut earliest_ts: Option<i64> = None;
@@ -3300,7 +3297,7 @@ impl BybitHttpClient {
 
                 if !seen_timestamps.contains(start_time)
                     && let Ok(bar) =
-                        parse_kline_bar(kline, &instrument, bar_type, timestamp_on_close, ts_init)
+                        parse_kline_bar(kline, &instrument, bar_type, timestamp_on_close, None)
                 {
                     page_bars.push(bar);
                     seen_timestamps.insert(*start_time);


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

According to the discussion in #3491, historical data should be tagged with ts_event for ts_init in the adapters. This PR does so for the Bybit adapter. What I noticed though is that all adapters that I briefly looked at (bitmex, deribit, kraken, okx) all generate ts_init for historical data, instead of tagging with ts_event (so someone will need to take care of those as well). 

## Related Issues/PRs

Partial fix for #3491

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore


## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic