### PR TITLE
Rename Deribit instrument kind enum to product type

### DIFF
--- a/crates/adapters/deribit/examples/node_data_tester.rs
+++ b/crates/adapters/deribit/examples/node_data_tester.rs
@@ -20,7 +20,7 @@
 use nautilus_common::enums::Environment;
 use nautilus_deribit::{
     config::DeribitDataClientConfig, factories::DeribitDataClientFactory,
-    http::models::DeribitInstrumentKind,
+    http::models::DeribitProductType,
 };
 use nautilus_live::node::LiveNode;
 use nautilus_model::{
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let deribit_config = DeribitDataClientConfig {
         api_key: None,    // Will use 'DERIBIT_API_KEY' env var
         api_secret: None, // Will use 'DERIBIT_API_SECRET' env var
-        instrument_kinds: vec![DeribitInstrumentKind::Future],
+        product_types: vec![DeribitProductType::Future],
         use_testnet: false,
         ..Default::default()
     };

--- a/crates/adapters/deribit/examples/node_exec_tester.rs
+++ b/crates/adapters/deribit/examples/node_exec_tester.rs
@@ -28,7 +28,7 @@ use nautilus_common::enums::Environment;
 use nautilus_deribit::{
     config::{DeribitDataClientConfig, DeribitExecClientConfig},
     factories::{DeribitDataClientFactory, DeribitExecutionClientFactory},
-    http::models::DeribitInstrumentKind,
+    http::models::DeribitProductType,
 };
 use nautilus_live::node::LiveNode;
 use nautilus_model::{
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_config = DeribitDataClientConfig {
         api_key: None,    // Will use env var
         api_secret: None, // Will use env var
-        instrument_kinds: vec![DeribitInstrumentKind::Future],
+        product_types: vec![DeribitProductType::Future],
         use_testnet,
         ..Default::default()
     };
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         account_id,
         api_key: None,    // Will use env var
         api_secret: None, // Will use env var
-        instrument_kinds: vec![DeribitInstrumentKind::Future],
+        product_types: vec![DeribitProductType::Future],
         use_testnet,
         ..Default::default()
     };

--- a/crates/adapters/deribit/src/common/enums.rs
+++ b/crates/adapters/deribit/src/common/enums.rs
@@ -21,7 +21,7 @@ use nautilus_model::enums::TimeInForce;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumIter, EnumString};
 
-/// Deribit instrument kind/type.
+/// Deribit product type.
 #[derive(
     Clone,
     Copy,
@@ -42,7 +42,7 @@ use strum::{AsRefStr, Display as StrumDisplay, EnumIter, EnumString};
     feature = "python",
     pyo3::pyclass(eq, eq_int, module = "nautilus_trader.core.nautilus_pyo3.deribit")
 )]
-pub enum DeribitInstrumentKind {
+pub enum DeribitProductType {
     /// Future contract
     Future,
     /// Option contract

--- a/crates/adapters/deribit/src/common/parse.rs
+++ b/crates/adapters/deribit/src/common/parse.rs
@@ -41,7 +41,7 @@ use rust_decimal::Decimal;
 use crate::{
     common::{
         consts::DERIBIT_VENUE,
-        enums::{DeribitInstrumentKind, DeribitOptionType},
+        enums::{DeribitOptionType, DeribitProductType},
     },
     http::models::{
         DeribitAccountSummary, DeribitInstrument, DeribitOrderBook, DeribitPublicTrade,
@@ -131,10 +131,8 @@ pub fn parse_deribit_instrument_any(
     ts_event: UnixNanos,
 ) -> anyhow::Result<Option<InstrumentAny>> {
     match instrument.kind {
-        DeribitInstrumentKind::Spot => {
-            parse_spot_instrument(instrument, ts_init, ts_event).map(Some)
-        }
-        DeribitInstrumentKind::Future => {
+        DeribitProductType::Spot => parse_spot_instrument(instrument, ts_init, ts_event).map(Some),
+        DeribitProductType::Future => {
             // Check if it's a perpetual
             if instrument.instrument_name.as_str().contains("PERPETUAL") {
                 parse_perpetual_instrument(instrument, ts_init, ts_event).map(Some)
@@ -142,10 +140,10 @@ pub fn parse_deribit_instrument_any(
                 parse_future_instrument(instrument, ts_init, ts_event).map(Some)
             }
         }
-        DeribitInstrumentKind::Option => {
+        DeribitProductType::Option => {
             parse_option_instrument(instrument, ts_init, ts_event).map(Some)
         }
-        DeribitInstrumentKind::FutureCombo | DeribitInstrumentKind::OptionCombo => {
+        DeribitProductType::FutureCombo | DeribitProductType::OptionCombo => {
             log::debug!(
                 "Skipping combo instrument: {} (kind={:?})",
                 instrument.instrument_name,

--- a/crates/adapters/deribit/src/config.rs
+++ b/crates/adapters/deribit/src/config.rs
@@ -19,7 +19,7 @@ use nautilus_model::identifiers::{AccountId, TraderId};
 
 use crate::{
     common::urls::{get_http_base_url, get_ws_url},
-    http::models::DeribitInstrumentKind,
+    http::models::DeribitProductType,
 };
 
 /// Configuration for the Deribit data client.
@@ -29,8 +29,8 @@ pub struct DeribitDataClientConfig {
     pub api_key: Option<String>,
     /// Optional API secret for authenticated endpoints.
     pub api_secret: Option<String>,
-    /// Instrument kinds to load (e.g., Future, Option, Spot).
-    pub instrument_kinds: Vec<DeribitInstrumentKind>,
+    /// Product types to load (e.g., Future, Option, Spot).
+    pub product_types: Vec<DeribitProductType>,
     /// Optional override for the HTTP base URL.
     pub base_url_http: Option<String>,
     /// Optional override for the WebSocket URL.
@@ -56,7 +56,7 @@ impl Default for DeribitDataClientConfig {
         Self {
             api_key: None,
             api_secret: None,
-            instrument_kinds: vec![DeribitInstrumentKind::Future],
+            product_types: vec![DeribitProductType::Future],
             base_url_http: None,
             base_url_ws: None,
             use_testnet: false,
@@ -119,8 +119,8 @@ pub struct DeribitExecClientConfig {
     pub api_key: Option<String>,
     /// Optional API secret for authenticated endpoints.
     pub api_secret: Option<String>,
-    /// Instrument kinds to load (e.g., Future, Option, Spot).
-    pub instrument_kinds: Vec<DeribitInstrumentKind>,
+    /// Product types to load (e.g., Future, Option, Spot).
+    pub product_types: Vec<DeribitProductType>,
     /// Optional override for the HTTP base URL.
     pub base_url_http: Option<String>,
     /// Optional override for the WebSocket URL.
@@ -144,7 +144,7 @@ impl Default for DeribitExecClientConfig {
             account_id: AccountId::from("DERIBIT-001"),
             api_key: None,
             api_secret: None,
-            instrument_kinds: vec![DeribitInstrumentKind::Future],
+            product_types: vec![DeribitProductType::Future],
             base_url_http: None,
             base_url_ws: None,
             use_testnet: false,
@@ -208,7 +208,7 @@ mod tests {
     fn test_default_config() {
         let config = DeribitDataClientConfig::default();
         assert!(!config.use_testnet);
-        assert_eq!(config.instrument_kinds.len(), 1);
+        assert_eq!(config.product_types.len(), 1);
         assert_eq!(config.http_timeout_secs, Some(60));
     }
 

--- a/crates/adapters/deribit/src/data/mod.rs
+++ b/crates/adapters/deribit/src/data/mod.rs
@@ -66,7 +66,7 @@ use crate::{
     config::DeribitDataClientConfig,
     http::{
         client::DeribitHttpClient,
-        models::{DeribitCurrency, DeribitInstrumentKind},
+        models::{DeribitCurrency, DeribitProductType},
     },
     websocket::{
         auth::DERIBIT_DATA_SESSION_NAME, client::DeribitWebSocketClient,
@@ -357,15 +357,15 @@ impl DataClient for DeribitDataClient {
             return Ok(());
         }
 
-        // Fetch instruments for each configured instrument kind
-        let instrument_kinds = if self.config.instrument_kinds.is_empty() {
-            vec![DeribitInstrumentKind::Future]
+        // Fetch instruments for each configured product type
+        let product_types = if self.config.product_types.is_empty() {
+            vec![DeribitProductType::Future]
         } else {
-            self.config.instrument_kinds.clone()
+            self.config.product_types.clone()
         };
 
         let mut all_instruments = Vec::new();
-        for kind in &instrument_kinds {
+        for kind in &product_types {
             let fetched = self
                 .http_client
                 .request_instruments(DeribitCurrency::ANY, Some(*kind))
@@ -1172,16 +1172,16 @@ impl DataClient for DeribitDataClient {
         let clock = self.clock;
         let venue = *DERIBIT_VENUE;
 
-        // Get instrument kinds from config, default to Future if empty
-        let instrument_kinds = if self.config.instrument_kinds.is_empty() {
-            vec![crate::http::models::DeribitInstrumentKind::Future]
+        // Get product types from config, default to Future if empty
+        let product_types = if self.config.product_types.is_empty() {
+            vec![crate::http::models::DeribitProductType::Future]
         } else {
-            self.config.instrument_kinds.clone()
+            self.config.product_types.clone()
         };
 
         get_runtime().spawn(async move {
             let mut all_instruments = Vec::new();
-            for kind in &instrument_kinds {
+            for kind in &product_types {
                 log::debug!("Requesting instruments for currency=ANY, kind={kind:?}");
 
                 match http_client

--- a/crates/adapters/deribit/src/execution/mod.rs
+++ b/crates/adapters/deribit/src/execution/mod.rs
@@ -393,11 +393,11 @@ impl ExecutionClient for DeribitExecutionClient {
         self.core.set_started();
 
         log::info!(
-            "Started: client_id={}, account_id={}, account_type={:?}, instrument_kinds={:?}, use_testnet={}",
+            "Started: client_id={}, account_id={}, account_type={:?}, product_types={:?}, use_testnet={}",
             self.core.client_id,
             self.core.account_id,
             self.core.account_type,
-            self.config.instrument_kinds,
+            self.config.product_types,
             self.config.use_testnet
         );
         Ok(())
@@ -430,7 +430,7 @@ impl ExecutionClient for DeribitExecutionClient {
 
         // Fetch and cache instruments in both HTTP client and WebSocket client
         if !self.core.instruments_initialized() {
-            for kind in &self.config.instrument_kinds {
+            for kind in &self.config.product_types {
                 let instruments = self
                     .http_client
                     .request_instruments(DeribitCurrency::ANY, Some(*kind))

--- a/crates/adapters/deribit/src/factories.rs
+++ b/crates/adapters/deribit/src/factories.rs
@@ -173,7 +173,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::http::models::DeribitInstrumentKind;
+    use crate::http::models::DeribitProductType;
 
     fn setup_test_env() {
         // Initialize data event sender for tests
@@ -197,7 +197,7 @@ mod tests {
     #[rstest]
     fn test_deribit_data_client_config_implements_client_config() {
         let config = DeribitDataClientConfig {
-            instrument_kinds: vec![DeribitInstrumentKind::Future],
+            product_types: vec![DeribitProductType::Future],
             ..Default::default()
         };
 
@@ -215,7 +215,7 @@ mod tests {
 
         let factory = DeribitDataClientFactory::new();
         let config = DeribitDataClientConfig {
-            instrument_kinds: vec![DeribitInstrumentKind::Future],
+            product_types: vec![DeribitProductType::Future],
             use_testnet: true,
             ..Default::default()
         };

--- a/crates/adapters/deribit/src/http/client.rs
+++ b/crates/adapters/deribit/src/http/client.rs
@@ -50,7 +50,7 @@ use super::{
     error::DeribitHttpError,
     models::{
         DeribitAccountSummariesResponse, DeribitCurrency, DeribitInstrument, DeribitJsonRpcRequest,
-        DeribitJsonRpcResponse, DeribitPosition, DeribitUserTradesResponse,
+        DeribitJsonRpcResponse, DeribitPosition, DeribitProductType, DeribitUserTradesResponse,
     },
     query::{
         GetAccountSummariesParams, GetInstrumentParams, GetInstrumentsParams,
@@ -851,7 +851,7 @@ impl DeribitHttpClient {
     pub async fn request_instruments(
         &self,
         currency: DeribitCurrency,
-        kind: Option<super::models::DeribitInstrumentKind>,
+        kind: Option<DeribitProductType>,
     ) -> anyhow::Result<Vec<InstrumentAny>> {
         // Build parameters
         let params = if let Some(k) = kind {

--- a/crates/adapters/deribit/src/http/models.rs
+++ b/crates/adapters/deribit/src/http/models.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
 pub use crate::common::{
-    enums::{DeribitCurrency, DeribitInstrumentKind, DeribitOptionType},
+    enums::{DeribitCurrency, DeribitOptionType, DeribitProductType},
     rpc::{DeribitJsonRpcError, DeribitJsonRpcRequest, DeribitJsonRpcResponse},
 };
 
@@ -68,8 +68,8 @@ pub struct DeribitInstrument {
     pub instrument_type: Option<String>,
     /// Indicates if the instrument can currently be traded
     pub is_active: bool,
-    /// Instrument kind: "future", "option", "spot", "future_combo", "option_combo"
-    pub kind: DeribitInstrumentKind,
+    /// Product type: "future", "option", "spot", "future_combo", "option_combo"
+    pub kind: DeribitProductType,
     /// Maker commission for instrument
     #[serde(deserialize_with = "deserialize_decimal")]
     pub maker_commission: Decimal,
@@ -590,8 +590,8 @@ pub struct DeribitPosition {
         deserialize_with = "nautilus_core::serialization::deserialize_decimal"
     )]
     pub total_profit_loss: Decimal,
-    /// Instrument kind: future, option, spot, etc.
-    pub kind: DeribitInstrumentKind,
+    /// Product type: future, option, spot, etc.
+    pub kind: DeribitProductType,
     /// Position size in currency units (for currency-quoted positions)
     #[serde(
         default,

--- a/crates/adapters/deribit/src/http/query.rs
+++ b/crates/adapters/deribit/src/http/query.rs
@@ -18,7 +18,7 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use super::models::{DeribitCurrency, DeribitInstrumentKind};
+use super::models::{DeribitCurrency, DeribitProductType};
 
 /// Query parameters for `/public/get_instruments` endpoint.
 #[derive(Clone, Debug, Deserialize, Serialize, Builder)]
@@ -26,10 +26,10 @@ use super::models::{DeribitCurrency, DeribitInstrumentKind};
 pub struct GetInstrumentsParams {
     /// Currency filter
     pub currency: DeribitCurrency,
-    /// Optional instrument kind filter
+    /// Optional product type filter
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub kind: Option<DeribitInstrumentKind>,
+    pub kind: Option<DeribitProductType>,
     /// Whether to include expired instruments
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
@@ -53,9 +53,9 @@ impl GetInstrumentsParams {
         }
     }
 
-    /// Creates parameters for a specific currency and kind.
+    /// Creates parameters for a specific currency and product type.
     #[must_use]
-    pub fn with_kind(currency: DeribitCurrency, kind: DeribitInstrumentKind) -> Self {
+    pub fn with_kind(currency: DeribitCurrency, kind: DeribitProductType) -> Self {
         Self {
             currency,
             kind: Some(kind),
@@ -298,10 +298,10 @@ impl GetOrderHistoryByInstrumentParams {
 pub struct GetOrderHistoryByCurrencyParams {
     /// Currency filter
     pub currency: DeribitCurrency,
-    /// Optional instrument kind filter
+    /// Optional product type filter
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub kind: Option<DeribitInstrumentKind>,
+    pub kind: Option<DeribitProductType>,
     /// Number of requested items, default - 20, maximum - 10000
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
@@ -387,10 +387,10 @@ pub struct GetUserTradesByCurrencyAndTimeParams {
     pub start_timestamp: i64,
     /// End timestamp in milliseconds since UNIX epoch
     pub end_timestamp: i64,
-    /// Optional instrument kind filter
+    /// Optional product type filter
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub kind: Option<DeribitInstrumentKind>,
+    pub kind: Option<DeribitProductType>,
     /// Number of requested items, default - 10, maximum - 1000
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
@@ -424,10 +424,10 @@ impl GetUserTradesByCurrencyAndTimeParams {
 pub struct GetPositionsParams {
     /// Currency filter
     pub currency: DeribitCurrency,
-    /// Optional instrument kind filter
+    /// Optional product type filter
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub kind: Option<DeribitInstrumentKind>,
+    pub kind: Option<DeribitProductType>,
 }
 
 impl GetPositionsParams {

--- a/crates/adapters/deribit/src/python/enums.rs
+++ b/crates/adapters/deribit/src/python/enums.rs
@@ -22,7 +22,7 @@ use pyo3::{PyTypeInfo, prelude::*, types::PyType};
 use strum::IntoEnumIterator;
 
 use crate::{
-    common::enums::{DeribitCurrency, DeribitInstrumentKind},
+    common::enums::{DeribitCurrency, DeribitProductType},
     websocket::enums::DeribitUpdateInterval,
 };
 
@@ -108,7 +108,7 @@ impl DeribitCurrency {
 }
 
 #[pymethods]
-impl DeribitInstrumentKind {
+impl DeribitProductType {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Self> {
         let t = Self::type_object(py);
@@ -122,7 +122,7 @@ impl DeribitInstrumentKind {
     fn __repr__(&self) -> String {
         format!(
             "<{}.{}: '{}'>",
-            stringify!(DeribitInstrumentKind),
+            stringify!(DeribitProductType),
             self.name(),
             self.value(),
         )

--- a/crates/adapters/deribit/src/python/http.rs
+++ b/crates/adapters/deribit/src/python/http.rs
@@ -27,7 +27,7 @@ use pyo3::{conversion::IntoPyObjectExt, prelude::*, types::PyList};
 use crate::http::{
     client::DeribitHttpClient,
     error::DeribitHttpError,
-    models::{DeribitCurrency, DeribitInstrumentKind},
+    models::{DeribitCurrency, DeribitProductType},
 };
 
 #[pymethods]
@@ -116,7 +116,7 @@ impl DeribitHttpClient {
         &self,
         py: Python<'py>,
         currency: DeribitCurrency,
-        kind: Option<DeribitInstrumentKind>,
+        kind: Option<DeribitProductType>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.clone();
 

--- a/crates/adapters/deribit/src/python/mod.rs
+++ b/crates/adapters/deribit/src/python/mod.rs
@@ -32,7 +32,7 @@ pub fn deribit(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<super::http::client::DeribitHttpClient>()?;
     m.add_class::<super::websocket::client::DeribitWebSocketClient>()?;
     m.add_class::<crate::common::enums::DeribitCurrency>()?;
-    m.add_class::<crate::common::enums::DeribitInstrumentKind>()?;
+    m.add_class::<crate::common::enums::DeribitProductType>()?;
     m.add_class::<crate::websocket::enums::DeribitUpdateInterval>()?;
     m.add_function(wrap_pyfunction!(urls::py_get_deribit_http_base_url, m)?)?;
     m.add_function(wrap_pyfunction!(urls::py_get_deribit_ws_url, m)?)?;

--- a/crates/adapters/deribit/tests/http_public.rs
+++ b/crates/adapters/deribit/tests/http_public.rs
@@ -28,7 +28,7 @@ use nautilus_common::testing::wait_until_async;
 use nautilus_deribit::http::{
     client::DeribitRawHttpClient,
     error::DeribitHttpError,
-    models::{DeribitCurrency, DeribitInstrumentKind},
+    models::{DeribitCurrency, DeribitProductType},
     query::{
         GetInstrumentParams, GetInstrumentsParams, GetLastTradesByInstrumentAndTimeParams,
         GetOrderBookParams, GetTradingViewChartDataParams,
@@ -425,7 +425,7 @@ async fn test_get_instrument_success() {
     assert_eq!(instrument.tick_size, dec!(0.5));
     assert_eq!(instrument.min_trade_amount, dec!(10.0));
     assert!(instrument.is_active);
-    assert_eq!(instrument.kind, DeribitInstrumentKind::Future);
+    assert_eq!(instrument.kind, DeribitProductType::Future);
 
     assert_eq!(
         *state
@@ -538,23 +538,23 @@ async fn test_get_instruments_success() {
 
     let perpetual = &instruments[0];
     assert_eq!(perpetual.instrument_name.as_str(), "BTC-PERPETUAL");
-    assert_eq!(perpetual.kind, DeribitInstrumentKind::Future);
+    assert_eq!(perpetual.kind, DeribitProductType::Future);
     assert_eq!(perpetual.base_currency.as_str(), "BTC");
     assert!(perpetual.is_active);
 
     let future = &instruments[1];
     assert_eq!(future.instrument_name.as_str(), "BTC-27DEC24");
-    assert_eq!(future.kind, DeribitInstrumentKind::Future);
+    assert_eq!(future.kind, DeribitProductType::Future);
     assert_eq!(future.expiration_timestamp, Some(1735300800000));
 
     let option = &instruments[2];
     assert_eq!(option.instrument_name.as_str(), "BTC-27DEC24-100000-C");
-    assert_eq!(option.kind, DeribitInstrumentKind::Option);
+    assert_eq!(option.kind, DeribitProductType::Option);
     assert_eq!(option.strike, Some(dec!(100000.0)));
 
     let combo = &instruments[3];
     assert_eq!(combo.instrument_name.as_str(), "BTC-COMBO-1");
-    assert_eq!(combo.kind, DeribitInstrumentKind::FutureCombo);
+    assert_eq!(combo.kind, DeribitProductType::FutureCombo);
 
     assert_eq!(
         *state
@@ -583,8 +583,7 @@ async fn test_get_instruments_with_kind_filter() {
     )
     .unwrap();
 
-    let params =
-        GetInstrumentsParams::with_kind(DeribitCurrency::BTC, DeribitInstrumentKind::Option);
+    let params = GetInstrumentsParams::with_kind(DeribitCurrency::BTC, DeribitProductType::Option);
     let result = client.get_instruments(params).await;
 
     assert!(result.is_ok(), "Request should succeed");
@@ -595,7 +594,7 @@ async fn test_get_instruments_with_kind_filter() {
 
     let option = &instruments[0];
     assert_eq!(option.instrument_name.as_str(), "BTC-27DEC24-100000-C");
-    assert_eq!(option.kind, DeribitInstrumentKind::Option);
+    assert_eq!(option.kind, DeribitProductType::Option);
 }
 
 #[tokio::test]

--- a/examples/live/deribit/deribit_data_tester.py
+++ b/examples/live/deribit/deribit_data_tester.py
@@ -41,7 +41,7 @@ from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.config import LiveExecEngineConfig
 from nautilus_trader.config import LoggingConfig
 from nautilus_trader.config import TradingNodeConfig
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.live.node import TradingNode
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.identifiers import InstrumentId
@@ -57,10 +57,10 @@ from nautilus_trader.test_kit.strategies.tester_data import DataTesterConfig
 # Use testnet by default for safety
 USE_TESTNET = bool(os.getenv("USE_TESTNET", "true").lower() == "true")
 
-# Optional: Filter by instrument kinds
-instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = (
-    DeribitInstrumentKind.FUTURE,
-    # DeribitInstrumentKind.OPTION,  # Uncomment to include options (many instruments!)
+# Optional: Filter by product types
+product_types: tuple[DeribitProductType, ...] | None = (
+    DeribitProductType.FUTURE,
+    # DeribitProductType.OPTION,  # Uncomment to include options (many instruments!)
 )
 
 # Define instruments to subscribe to
@@ -87,7 +87,7 @@ config_node = TradingNodeConfig(
         DERIBIT: DeribitDataClientConfig(
             api_key=None,  # Will use env var: DERIBIT_TESTNET_API_KEY or DERIBIT_API_KEY
             api_secret=None,  # Will use env var: DERIBIT_TESTNET_API_SECRET or DERIBIT_API_SECRET
-            instrument_kinds=instrument_kinds,
+            product_types=product_types,
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
             ),

--- a/examples/live/deribit/deribit_exec_tester.py
+++ b/examples/live/deribit/deribit_exec_tester.py
@@ -46,7 +46,7 @@ from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.config import LiveExecEngineConfig
 from nautilus_trader.config import LoggingConfig
 from nautilus_trader.config import TradingNodeConfig
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.live.node import TradingNode
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import TraderId
@@ -61,8 +61,8 @@ from nautilus_trader.test_kit.strategies.tester_exec import ExecTesterConfig
 # Use testnet by default for safety
 USE_TESTNET = os.getenv("USE_TESTNET", "true").lower() != "false"
 
-# Optional: Filter by instrument kinds
-instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = (DeribitInstrumentKind.FUTURE,)
+# Optional: Filter by product types
+product_types: tuple[DeribitProductType, ...] | None = (DeribitProductType.FUTURE,)
 
 # Define instrument to test with
 instrument_id = InstrumentId.from_str(f"BTC-PERPETUAL.{DERIBIT}")
@@ -90,7 +90,7 @@ config_node = TradingNodeConfig(
         DERIBIT: DeribitDataClientConfig(
             api_key=None,  # Will use env var
             api_secret=None,  # Will use env var
-            instrument_kinds=instrument_kinds,
+            product_types=product_types,
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
             ),
@@ -102,7 +102,7 @@ config_node = TradingNodeConfig(
         DERIBIT: DeribitExecClientConfig(
             api_key=None,  # Will use env var
             api_secret=None,  # Will use env var
-            instrument_kinds=instrument_kinds,
+            product_types=product_types,
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
             ),

--- a/nautilus_trader/adapters/deribit/__init__.py
+++ b/nautilus_trader/adapters/deribit/__init__.py
@@ -37,7 +37,7 @@ from nautilus_trader.adapters.deribit.factories import get_cached_deribit_instru
 from nautilus_trader.adapters.deribit.providers import DeribitInstrumentProvider
 from nautilus_trader.core.nautilus_pyo3 import DeribitCurrency
 from nautilus_trader.core.nautilus_pyo3 import DeribitHttpClient
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.core.nautilus_pyo3 import DeribitUpdateInterval
 from nautilus_trader.core.nautilus_pyo3 import DeribitWebSocketClient
 
@@ -52,10 +52,10 @@ __all__ = [
     "DeribitExecClientConfig",
     "DeribitExecutionClient",
     "DeribitHttpClient",
-    "DeribitInstrumentKind",
     "DeribitInstrumentProvider",
     "DeribitLiveDataClientFactory",
     "DeribitLiveExecClientFactory",
+    "DeribitProductType",
     "DeribitUpdateInterval",
     "DeribitWebSocketClient",
     "get_cached_deribit_http_client",

--- a/nautilus_trader/adapters/deribit/config.py
+++ b/nautilus_trader/adapters/deribit/config.py
@@ -16,7 +16,7 @@
 from nautilus_trader.common.config import PositiveInt
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 
 
 class DeribitDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -33,8 +33,8 @@ class DeribitDataClientConfig(LiveDataClientConfig, frozen=True):
         The Deribit API secret key.
         If ``None`` then will source the `DERIBIT_API_SECRET` or `DERIBIT_TESTNET_API_SECRET`
         environment variable based on `is_testnet`.
-    instrument_kinds : tuple[DeribitInstrumentKind, ...], optional
-        The Deribit instrument kinds to load.
+    product_types : tuple[DeribitProductType, ...], optional
+        The Deribit product types to load.
         If None, all instrument kinds are loaded for all currencies.
     base_url_http : str, optional
         The base URL for Deribit's HTTP API.
@@ -59,7 +59,7 @@ class DeribitDataClientConfig(LiveDataClientConfig, frozen=True):
 
     api_key: str | None = None
     api_secret: str | None = None
-    instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = None
+    product_types: tuple[DeribitProductType, ...] | None = None
     base_url_http: str | None = None
     base_url_ws: str | None = None
     is_testnet: bool = False
@@ -84,8 +84,8 @@ class DeribitExecClientConfig(LiveExecClientConfig, frozen=True):
         The Deribit API secret key.
         If ``None`` then will source the `DERIBIT_API_SECRET` or `DERIBIT_TESTNET_API_SECRET`
         environment variable based on `is_testnet`.
-    instrument_kinds : tuple[DeribitInstrumentKind, ...], optional
-        The Deribit instrument kinds to load.
+    product_types : tuple[DeribitProductType, ...], optional
+        The Deribit product types to load.
         If None, defaults to Future.
     base_url_http : str, optional
         The base URL for Deribit's HTTP API.
@@ -108,7 +108,7 @@ class DeribitExecClientConfig(LiveExecClientConfig, frozen=True):
 
     api_key: str | None = None
     api_secret: str | None = None
-    instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = None
+    product_types: tuple[DeribitProductType, ...] | None = None
     base_url_http: str | None = None
     base_url_ws: str | None = None
     is_testnet: bool = False

--- a/nautilus_trader/adapters/deribit/data.py
+++ b/nautilus_trader/adapters/deribit/data.py
@@ -201,13 +201,11 @@ class DeribitDataClient(LiveMarketDataClient):
 
         self._instrument_provider: DeribitInstrumentProvider = instrument_provider
 
-        instrument_kinds = (
-            [k.name for k in config.instrument_kinds] if config.instrument_kinds else None
-        )
+        product_types = [k.name for k in config.product_types] if config.product_types else None
 
         # Configuration
         self._config = config
-        self._log.info(f"config.instrument_kinds={instrument_kinds}", LogColor.BLUE)
+        self._log.info(f"config.product_types={product_types}", LogColor.BLUE)
         self._log.info(f"{config.is_testnet=}", LogColor.BLUE)
         self._log.info(f"{config.http_timeout_secs=}", LogColor.BLUE)
         self._log.info(f"{config.max_retries=}", LogColor.BLUE)
@@ -727,7 +725,7 @@ class DeribitDataClient(LiveMarketDataClient):
     async def _fetch_instruments_for_currency(
         self,
         currency: nautilus_pyo3.DeribitCurrency,
-        kind: nautilus_pyo3.DeribitInstrumentKind | None = None,
+        kind: nautilus_pyo3.DeribitProductType | None = None,
     ) -> list[Instrument]:
         try:
             pyo3_instruments = await self._http_client.request_instruments(currency, kind)
@@ -755,16 +753,16 @@ class DeribitDataClient(LiveMarketDataClient):
 
         all_instruments: list[Instrument] = []
 
-        instrument_kinds = self._config.instrument_kinds
+        product_types = self._config.product_types
 
-        if instrument_kinds:
-            for kind in instrument_kinds:
+        if product_types:
+            for kind in product_types:
                 instruments = await self._fetch_instruments_for_currency(DeribitCurrency.ANY, kind)
                 all_instruments.extend(instruments)
         else:
             instruments = await self._fetch_instruments_for_currency(
                 DeribitCurrency.ANY,
-                nautilus_pyo3.DeribitInstrumentKind.FUTURE,
+                nautilus_pyo3.DeribitProductType.FUTURE,
             )
             all_instruments.extend(instruments)
 

--- a/nautilus_trader/adapters/deribit/execution.py
+++ b/nautilus_trader/adapters/deribit/execution.py
@@ -114,10 +114,10 @@ class DeribitExecutionClient(LiveExecutionClient):
 
         # Configuration
         self._config = config
-        instrument_kinds = (
-            [i.name.upper() for i in config.instrument_kinds] if config.instrument_kinds else None
+        product_types = (
+            [i.name.upper() for i in config.product_types] if config.product_types else None
         )
-        self._log.info(f"config.instrument_kinds={instrument_kinds}", LogColor.BLUE)
+        self._log.info(f"config.product_types={product_types}", LogColor.BLUE)
         self._log.info(f"{config.is_testnet=}", LogColor.BLUE)
         self._log.info(f"{config.http_timeout_secs=}", LogColor.BLUE)
         self._log.info(f"{config.max_retries=}", LogColor.BLUE)

--- a/nautilus_trader/adapters/deribit/factories.py
+++ b/nautilus_trader/adapters/deribit/factories.py
@@ -26,7 +26,7 @@ from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import MessageBus
 from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.core import nautilus_pyo3
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.live.factories import LiveDataClientFactory
 from nautilus_trader.live.factories import LiveExecClientFactory
 
@@ -86,7 +86,7 @@ def get_cached_deribit_http_client(
 @lru_cache(1)
 def get_cached_deribit_instrument_provider(
     client: nautilus_pyo3.DeribitHttpClient,
-    instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = None,
+    product_types: tuple[DeribitProductType, ...] | None = None,
     config: InstrumentProviderConfig | None = None,
 ) -> DeribitInstrumentProvider:
     """
@@ -98,8 +98,8 @@ def get_cached_deribit_instrument_provider(
     ----------
     client : DeribitHttpClient
         The Deribit HTTP client.
-    instrument_kinds : tuple[DeribitInstrumentKind, ...], optional
-        The instrument kinds to load.
+    product_types : tuple[DeribitProductType, ...], optional
+        The product types to load.
     config : InstrumentProviderConfig, optional
         The instrument provider configuration, by default None.
 
@@ -110,7 +110,7 @@ def get_cached_deribit_instrument_provider(
     """
     return DeribitInstrumentProvider(
         client=client,
-        instrument_kinds=instrument_kinds,
+        product_types=product_types,
         config=config,
     )
 
@@ -164,7 +164,7 @@ class DeribitLiveDataClientFactory(LiveDataClientFactory):
         )
         provider = get_cached_deribit_instrument_provider(
             client=client,
-            instrument_kinds=config.instrument_kinds,
+            product_types=config.product_types,
             config=config.instrument_provider,
         )
         return DeribitDataClient(
@@ -229,7 +229,7 @@ class DeribitLiveExecClientFactory(LiveExecClientFactory):
 
         provider = get_cached_deribit_instrument_provider(
             client=http_client,
-            instrument_kinds=config.instrument_kinds,
+            product_types=config.product_types,
             config=config.instrument_provider,
         )
         return DeribitExecutionClient(

--- a/nautilus_trader/adapters/deribit/providers.py
+++ b/nautilus_trader/adapters/deribit/providers.py
@@ -21,7 +21,7 @@ from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.nautilus_pyo3 import DeribitCurrency
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.instruments import instruments_from_pyo3
 
@@ -34,8 +34,8 @@ class DeribitInstrumentProvider(InstrumentProvider):
     ----------
     client : nautilus_pyo3.DeribitHttpClient
         The Deribit HTTP client.
-    instrument_kinds : tuple[DeribitInstrumentKind, ...], optional
-        The instrument kinds to load.
+    product_types : tuple[DeribitProductType, ...], optional
+        The product types to load.
     config : InstrumentProviderConfig, optional
         The instrument provider configuration, by default None.
 
@@ -44,27 +44,27 @@ class DeribitInstrumentProvider(InstrumentProvider):
     def __init__(
         self,
         client: nautilus_pyo3.DeribitHttpClient,
-        instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = None,
+        product_types: tuple[DeribitProductType, ...] | None = None,
         config: InstrumentProviderConfig | None = None,
     ) -> None:
         super().__init__(config=config)
         self._client = client
-        self._instrument_kinds = instrument_kinds
+        self._product_types = product_types
         self._log_warnings = config.log_warnings if config else True
 
         self._instruments_pyo3: list[nautilus_pyo3.Instrument] = []
 
     @property
-    def instrument_kinds(self) -> tuple[DeribitInstrumentKind, ...] | None:
+    def product_types(self) -> tuple[DeribitProductType, ...] | None:
         """
-        Return the Deribit instrument kinds configured for the provider.
+        Return the Deribit product types configured for the provider.
 
         Returns
         -------
-        tuple[DeribitInstrumentKind, ...] | None
+        tuple[DeribitProductType, ...] | None
 
         """
-        return self._instrument_kinds
+        return self._product_types
 
     def instruments_pyo3(self) -> list[Any]:
         """
@@ -82,9 +82,9 @@ class DeribitInstrumentProvider(InstrumentProvider):
         self._log.info(f"Loading all instruments{filters_str}")
 
         all_pyo3_instruments = []
-        if self._instrument_kinds:
+        if self._product_types:
             # Load each instrument kind separately
-            for kind in self._instrument_kinds:
+            for kind in self._product_types:
                 pyo3_instruments = await self._client.request_instruments(
                     DeribitCurrency.ANY,
                     kind,
@@ -123,8 +123,8 @@ class DeribitInstrumentProvider(InstrumentProvider):
             PyCondition.equal(instrument_id.venue, DERIBIT_VENUE, "instrument_id.venue", "DERIBIT")
 
         all_pyo3_instruments = []
-        if self._instrument_kinds:
-            for kind in self._instrument_kinds:
+        if self._product_types:
+            for kind in self._product_types:
                 pyo3_instruments = await self._client.request_instruments(
                     DeribitCurrency.ANY,
                     kind,

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -6885,7 +6885,7 @@ class DeribitHttpClient:
     async def request_instruments(
         self,
         currency: DeribitCurrency,
-        kind: DeribitInstrumentKind | None = None,
+        kind: DeribitProductType | None = None,
     ) -> list[Instrument]: ...
     async def request_instrument(self, instrument_id: InstrumentId) -> Instrument: ...
     async def request_trades(
@@ -7105,7 +7105,7 @@ class DeribitCurrency(Enum):
     EURR = "EURR"
     ANY = "ANY"
 
-class DeribitInstrumentKind(Enum):
+class DeribitProductType(Enum):
     FUTURE = "FUTURE"
     OPTION = "OPTION"
     SPOT = "SPOT"

--- a/tests/integration_tests/adapters/deribit/conftest.py
+++ b/tests/integration_tests/adapters/deribit/conftest.py
@@ -29,7 +29,7 @@ from nautilus_trader.common.component import Logger
 from nautilus_trader.common.component import MessageBus
 from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.core import nautilus_pyo3
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.model.currencies import BTC
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.identifiers import InstrumentId
@@ -94,7 +94,7 @@ def mock_instrument_provider(mock_http_client):
     """
     provider = MagicMock(spec=DeribitInstrumentProvider)
     provider._client = mock_http_client
-    provider.instrument_kinds = (DeribitInstrumentKind.FUTURE,)
+    provider.product_types = (DeribitProductType.FUTURE,)
     provider.initialize = AsyncMock()
     provider.instruments_pyo3.return_value = []
     provider.get_all.return_value = {}
@@ -174,7 +174,7 @@ def data_client_builder(
     Provide a factory for creating DeribitDataClient instances.
     """
 
-    def _builder(instrument_kinds: tuple[DeribitInstrumentKind, ...] | None = None):
+    def _builder(product_types: tuple[DeribitProductType, ...] | None = None):
         msgbus = MessageBus(
             trader_id=TestIdStubs.trader_id(),
             clock=live_clock,
@@ -183,7 +183,7 @@ def data_client_builder(
         cache = Cache(database=cache_db)
 
         config = DeribitDataClientConfig(
-            instrument_kinds=instrument_kinds or (DeribitInstrumentKind.FUTURE,),
+            product_types=product_types or (DeribitProductType.FUTURE,),
             instrument_provider=InstrumentProviderConfig(load_all=True),
             is_testnet=True,
             http_timeout_secs=30,

--- a/tests/integration_tests/adapters/deribit/test_data.py
+++ b/tests/integration_tests/adapters/deribit/test_data.py
@@ -21,7 +21,7 @@ import pytest
 
 from nautilus_trader.adapters.deribit.constants import DERIBIT_VENUE
 from nautilus_trader.core import nautilus_pyo3
-from nautilus_trader.core.nautilus_pyo3 import DeribitInstrumentKind
+from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.data.engine import DataEngine
 from nautilus_trader.data.messages import RequestInstrument
@@ -241,16 +241,16 @@ class TestDeribitDataClient:
             await client._disconnect()
 
     @pytest.mark.asyncio
-    async def test_subscribe_multiple_instrument_kinds(
+    async def test_subscribe_multiple_product_types(
         self,
         data_client_builder,
         instrument,
     ) -> None:
         # Arrange
         client = data_client_builder(
-            instrument_kinds=(
-                DeribitInstrumentKind.FUTURE,
-                DeribitInstrumentKind.OPTION,
+            product_types=(
+                DeribitProductType.FUTURE,
+                DeribitProductType.OPTION,
             ),
         )
         client._instrument_provider.get_all.return_value = {
@@ -262,9 +262,9 @@ class TestDeribitDataClient:
 
         try:
             # Assert
-            assert client._config.instrument_kinds == (
-                DeribitInstrumentKind.FUTURE,
-                DeribitInstrumentKind.OPTION,
+            assert client._config.product_types == (
+                DeribitProductType.FUTURE,
+                DeribitProductType.OPTION,
             )
         finally:
             await client._disconnect()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Renames `DeribitInstrumentKind` to `DeribitProductType` across both Rust and Python codebases to align with the naming convention used by other adapters (Binance, Bybit, Kraken) which all use `[AdapterName]ProductType`.

## Changes

### Rust (16 files)
- Renamed enum `DeribitInstrumentKind` → `DeribitProductType` in `common/enums.rs`
- Renamed config field `instrument_kinds` → `product_types` in `config.rs`
- Updated all imports, type references, and pattern matching across:
  - `python/enums.rs`, `python/mod.rs`, `python/http.rs`
  - `http/models.rs`, `http/query.rs`, `http/client.rs`
  - `data/mod.rs`, `common/parse.rs`, `execution/mod.rs`
  - `factories.rs`, `tests/http_public.rs`
  - `examples/node_data_tester.rs`, `examples/node_exec_tester.rs`

### Python (11 files)
- Updated adapters: `__init__.py`, `config.py`, `factories.py`, `providers.py`, `data.py`, `execution.py`
- Updated type stubs: `nautilus_pyo3.pyi`
- Updated tests: `test_data.py`, `conftest.py`
- Updated examples: `deribit_data_tester.py`, `deribit_exec_tester.py`

## Breaking Changes
- `DeribitInstrumentKind` renamed to `DeribitProductType`
- Config field `instrument_kinds` renamed to `product_types`

## Wire Format
No change - serde serialization uses `snake_case` so JSON values remain `"future"`, `"option"`, etc.


## Related Issues/PRs

- https://github.com/nautechsystems/nautilus_trader/issues/3269

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

