### PR TITLE
Fix Deribit trades parsing for combo_trade_id field

### DIFF
--- a/crates/adapters/deribit/src/websocket/messages.rs
+++ b/crates/adapters/deribit/src/websocket/messages.rs
@@ -164,7 +164,7 @@ pub struct DeribitTradeMsg {
     /// Liquidation indicator.
     pub liquidation: Option<String>,
     /// Combo trade ID (if part of combo).
-    pub combo_trade_id: Option<i64>,
+    pub combo_trade_id: Option<String>,
     /// Block trade ID.
     pub block_trade_id: Option<String>,
     /// Combo ID.

--- a/crates/adapters/deribit/test_data/ws_trades.json
+++ b/crates/adapters/deribit/test_data/ws_trades.json
@@ -1,34 +1,35 @@
 {
-  "jsonrpc":"2.0",
-  "method":"subscription",
-  "params":{
-    "channel":"trades.BTC-PERPETUAL.100ms",
-    "data":[
+  "jsonrpc": "2.0",
+  "method": "subscription",
+  "params": {
+    "channel": "trades.BTC-PERPETUAL.100ms",
+    "data": [
       {
-        "timestamp":1765531356452,
-        "price":92294.5,
-        "amount":10.0,
-        "direction":"sell",
-        "index_price":92276.75,
-        "instrument_name":"BTC-PERPETUAL",
-        "trade_seq":271252854,
-        "mark_price":92287.11,
-        "tick_direction":2,
-        "contracts":1.0,
-        "trade_id":"403691824"
+        "timestamp": 1765531356452,
+        "price": 92294.5,
+        "amount": 10.0,
+        "direction": "sell",
+        "index_price": 92276.75,
+        "instrument_name": "BTC-PERPETUAL",
+        "trade_seq": 271252854,
+        "mark_price": 92287.11,
+        "tick_direction": 2,
+        "contracts": 1.0,
+        "combo_trade_id": "43",
+        "trade_id": "403691824"
       },
       {
-        "timestamp":1765531356452,
-        "price":92288.5,
-        "amount":750.0,
-        "direction":"sell",
-        "index_price":92276.75,
-        "instrument_name":"BTC-PERPETUAL",
-        "trade_seq":271252855,
-        "mark_price":92287.11,
-        "tick_direction":2,
-        "contracts":75.0,
-        "trade_id":"403691825"
+        "timestamp": 1765531356452,
+        "price": 92288.5,
+        "amount": 750.0,
+        "direction": "sell",
+        "index_price": 92276.75,
+        "instrument_name": "BTC-PERPETUAL",
+        "trade_seq": 271252855,
+        "mark_price": 92287.11,
+        "tick_direction": 2,
+        "contracts": 75.0,
+        "trade_id": "403691825"
       }
     ]
   }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The combo_trade_id field for trades could not be parsed resulting in dropped trades.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Modified the data fixture and manual testing.
