### PR TITLE
Refine memory management for PyCapsule

### DIFF
--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -89,9 +89,9 @@ impl DataType {
 /// Rust data structure.
 #[must_use]
 pub fn data_to_pycapsule(py: Python, data: Data) -> Py<PyAny> {
-    // Register a destructor which simply drops the `Data` value once the
-    // capsule is released by Python.
-    let capsule = PyCapsule::new_with_destructor(py, data, None, |_, _| {})
+    // Register a destructor which drops the `Data` value when the capsule is
+    // released by Python. The destructor receives ownership of the value.
+    let capsule = PyCapsule::new_with_destructor(py, data, None, |data, _| drop(data))
         .expect("Error creating `PyCapsule`");
     capsule.into_any().unbind()
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Refine memory management in databento adapter

### Summary

Fixes the destructor for the `PyCapsule` created in `data_to_pycapsule` so that the Rust `Data` value is explicitly dropped when Python releases the capsule, preventing memory leaks when passing data from adapters (including databento) into the Python runtime.

### Changes

- **`crates/model/src/python/data/mod.rs`**
  - Updated the destructor passed to `PyCapsule::new_with_destructor` from `|_, _| {}` to `|data, _| drop(data)`.
  - The previous destructor ignored its arguments and did nothing, so the encapsulated `Data` was never freed when the capsule was released.
  - The new destructor receives ownership of the `Data` value and calls `drop(data)`, ensuring correct cleanup.
  - Adjusted the inline comment to state that the destructor receives ownership of the value and drops it when the capsule is released by Python.

### Rationale

`data_to_pycapsule` is used by multiple adapters (databento, binance, bybit, deribit, kraken, hyperliquid, okx, tardis, dydx, coinbase_intx, bitmex) to pass Rust `Data` into Python. When Python no longer holds a reference to the capsule, the destructor is invoked. Without explicitly dropping the `Data` in that destructor, the memory was not reclaimed. This change aligns behaviour with Rust ownership and ensures no leak for each capsule created.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
