### PR TITLE
Fix Tardis deltas snapshot boundaries with CLEAR

### DIFF
--- a/crates/adapters/tardis/src/csv/stream.rs
+++ b/crates/adapters/tardis/src/csv/stream.rs
@@ -508,8 +508,8 @@ impl Iterator for BatchedDeltasStreamIterator {
         }
 
         self.buffer.clear();
-        if let Some(Err(err)) = self.fill_pending_batches() {
-            return Some(Err(err));
+        if let Some(Err(e)) = self.fill_pending_batches() {
+            return Some(Err(e));
         }
 
         if self.pending_batches.is_empty() {
@@ -1614,7 +1614,7 @@ binance-futures,BTCUSDT,1640995301000000,1640995301100000,false,bid,50099.0,1.0"
         // Should have 2 CLEAR deltas: initial snapshot + mid-day snapshot
         assert_eq!(
             clear_count, 2,
-            "Expected 2 CLEAR deltas (initial + mid-day snapshot), got {clear_count}"
+            "Expected 2 CLEAR deltas (initial + mid-day snapshot), found {clear_count}"
         );
 
         // Verify CLEAR positions:
@@ -2235,7 +2235,7 @@ binance-futures,BTCUSDT,1640995301000000,1640995301100000,false,bid,50099.0,1.0"
         // Should have 2 CLEAR deltas: initial snapshot + mid-day snapshot
         assert_eq!(
             clear_count, 2,
-            "Expected 2 CLEAR deltas (initial + mid-day snapshot), got {clear_count}"
+            "Expected 2 CLEAR deltas (initial + mid-day snapshot), found {clear_count}"
         );
 
         // Verify CLEAR positions:
@@ -2271,7 +2271,7 @@ binance-futures,BTCUSDT,1640995301000000,1640995301100000,false,bid,50099.0,1.0"
         // Should have 2 CLEAR deltas: initial snapshot + mid-day snapshot
         assert_eq!(
             clear_count, 2,
-            "Expected 2 CLEAR deltas (initial + mid-day snapshot), got {clear_count}"
+            "Expected 2 CLEAR deltas (initial + mid-day snapshot), found {clear_count}"
         );
 
         assert_eq!(deltas[0].action, BookAction::Clear);
@@ -2287,7 +2287,7 @@ binance-futures,BTCUSDT,1640995301000000,1640995301100000,false,bid,50099.0,1.0"
         // 0=CLEAR, 1=Add, 2=Add, 3=Update, 4=Update, 5=Delete, 6=CLEAR
         assert_eq!(
             second_clear_idx, 6,
-            "Second CLEAR should be at index 6, got {second_clear_idx}"
+            "Second CLEAR should be at index 6, found {second_clear_idx}"
         );
 
         // CLEAR deltas should NOT have F_LAST when followed by same-timestamp deltas


### PR DESCRIPTION
# Pull Request

## Summary

Updated Tardis CSV delta streaming to always emit a synthetic CLEAR at snapshot boundaries (including batched/Python paths) and to count CLEAR events toward the `limit`. 

## Related Issues/PRs

https://github.com/nautechsystems/nautilus_trader/issues/3529

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added/updated stream tests in `crates/adapters/tardis/src/csv/stream.rs` to cover CLEAR insertion on snapshot boundaries, limit counting (including CLEAR), and `F_LAST` flag behavior for both chunked and limited streaming. 
