### PR TITLE
Add configurable bulk read batch size for Redis cache

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@ Released on TBD (UTC).
 This will be the final release with support for the dYdX v3 (legacy) API. Future releases will only support dYdX v4 (Cosmos-based).
 
 ### Enhancements
+- Added `bulk_read_batch_size` option to `CacheConfig` for batched Redis bulk reads, thanks @shzhng
 - Added sandbox execution adapter in Rust
 - Added multi-account execution support (#3194), thanks @faysou
 - Added `manage_stop` config option to `StrategyConfig` for automatic market exit on stop

--- a/crates/common/src/cache/config.rs
+++ b/crates/common/src/cache/config.rs
@@ -33,6 +33,9 @@ pub struct CacheConfig {
     pub timestamps_as_iso8601: bool,
     /// The buffer interval (milliseconds) between pipelined/batched transactions.
     pub buffer_interval_ms: Option<usize>,
+    /// The batch size for bulk read operations (e.g., MGET).
+    /// If set, bulk reads will be batched into chunks of this size.
+    pub bulk_read_batch_size: Option<usize>,
     /// If a 'trader-' prefix is used for keys.
     pub use_trader_prefix: bool,
     /// If the trader's instance ID is used for keys.
@@ -57,6 +60,7 @@ impl Default for CacheConfig {
             encoding: SerializationEncoding::MsgPack,
             timestamps_as_iso8601: false,
             buffer_interval_ms: None,
+            bulk_read_batch_size: None,
             use_trader_prefix: true,
             use_instance_id: false,
             flush_on_start: false,
@@ -77,6 +81,7 @@ impl CacheConfig {
         encoding: SerializationEncoding,
         timestamps_as_iso8601: bool,
         buffer_interval_ms: Option<usize>,
+        bulk_read_batch_size: Option<usize>,
         use_trader_prefix: bool,
         use_instance_id: bool,
         flush_on_start: bool,
@@ -90,6 +95,7 @@ impl CacheConfig {
             encoding,
             timestamps_as_iso8601,
             buffer_interval_ms,
+            bulk_read_batch_size,
             use_trader_prefix,
             use_instance_id,
             flush_on_start,

--- a/crates/infrastructure/src/redis/cache.rs
+++ b/crates/infrastructure/src/redis/cache.rs
@@ -136,6 +136,7 @@ pub struct RedisCacheDatabase {
     pub trader_id: TraderId,
     pub trader_key: String,
     pub encoding: SerializationEncoding,
+    pub bulk_read_batch_size: Option<usize>,
     tx: tokio::sync::mpsc::UnboundedSender<DatabaseCommand>,
     handle: tokio::task::JoinHandle<()>,
 }
@@ -175,6 +176,7 @@ impl RedisCacheDatabase {
         let trader_key = get_trader_key(trader_id, instance_id, &config);
         let trader_key_clone = trader_key.clone();
         let encoding = config.encoding;
+        let bulk_read_batch_size = config.bulk_read_batch_size;
 
         let handle = get_runtime().spawn(async move {
             if let Err(e) = process_commands(rx, trader_key_clone, config.clone()).await {
@@ -187,6 +189,7 @@ impl RedisCacheDatabase {
             trader_id,
             trader_key,
             encoding,
+            bulk_read_batch_size,
             tx,
             handle,
         })
@@ -254,7 +257,12 @@ impl RedisCacheDatabase {
     ///
     /// Returns an error if the underlying Redis read operation fails.
     pub async fn read_bulk(&mut self, keys: &[String]) -> anyhow::Result<Vec<Option<Bytes>>> {
-        DatabaseQueries::read_bulk(&self.con, keys).await
+        match self.bulk_read_batch_size {
+            Some(batch_size) => {
+                DatabaseQueries::read_bulk_batched(&self.con, keys, batch_size).await
+            }
+            None => DatabaseQueries::read_bulk(&self.con, keys).await,
+        }
     }
 
     /// Sends an insert command for `key` with optional `payload` to Redis via the background task.

--- a/crates/infrastructure/src/redis/queries.rs
+++ b/crates/infrastructure/src/redis/queries.rs
@@ -157,17 +157,46 @@ impl DatabaseQueries {
 
         let mut con = con.clone();
 
-        // Use MGET to fetch all keys in a single network operation
         let results: Vec<Option<Vec<u8>>> =
             redis::cmd("MGET").arg(keys).query_async(&mut con).await?;
 
-        // Convert Vec<u8> to Bytes
         let bytes_results: Vec<Option<Bytes>> = results
             .into_iter()
             .map(|opt| opt.map(Bytes::from))
             .collect();
 
         Ok(bytes_results)
+    }
+
+    /// Bulk reads multiple keys from Redis using MGET, batched into chunks.
+    ///
+    /// Keys are batched into chunks of `batch_size` to avoid exceeding Redis
+    /// request size limits on some providers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying Redis MGET operation fails.
+    pub async fn read_bulk_batched(
+        con: &ConnectionManager,
+        keys: &[String],
+        batch_size: usize,
+    ) -> anyhow::Result<Vec<Option<Bytes>>> {
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut all_results: Vec<Option<Bytes>> = Vec::with_capacity(keys.len());
+
+        for chunk in keys.chunks(batch_size) {
+            let mut con = con.clone();
+
+            let results: Vec<Option<Vec<u8>>> =
+                redis::cmd("MGET").arg(chunk).query_async(&mut con).await?;
+
+            all_results.extend(results.into_iter().map(|opt| opt.map(Bytes::from)));
+        }
+
+        Ok(all_results)
     }
 
     /// Reads raw byte payloads for `key` under `trader_key` from Redis.

--- a/crates/infrastructure/tests/test_redis_queries.rs
+++ b/crates/infrastructure/tests/test_redis_queries.rs
@@ -393,6 +393,33 @@ mod serial_tests {
     }
 
     #[tokio::test]
+    async fn test_read_bulk_batched() {
+        let mut con = get_redis_connection().await;
+
+        // Clean state
+        let _: () = redis::cmd("FLUSHDB").query_async(&mut con).await.unwrap();
+
+        // Set up test data - more keys than batch size
+        let num_keys = 25;
+        let batch_size = 10;
+        let keys: Vec<String> = (0..num_keys).map(|i| format!("test:batched:{i}")).collect();
+        let values: Vec<Vec<u8>> = (0..num_keys).map(|i| format!("value_{i}").into_bytes()).collect();
+
+        for (key, value) in keys.iter().zip(values.iter()) {
+            let _: () = con.set(key, value).await.unwrap();
+        }
+
+        let result = DatabaseQueries::read_bulk_batched(&con, &keys, batch_size)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), num_keys);
+        for (i, bytes_opt) in result.iter().enumerate() {
+            assert_eq!(*bytes_opt, Some(Bytes::from(values[i].clone())));
+        }
+    }
+
+    #[tokio::test]
     async fn test_scan_keys_with_special_characters() {
         let mut con = get_redis_connection().await;
 

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -108,6 +108,7 @@ cache_config = CacheConfig(
     encoding: str = "msgpack",               # Data encoding format ('msgpack' or 'json')
     timestamps_as_iso8601: bool = False,     # Store timestamps as ISO8601 strings
     buffer_interval_ms: int | None = None,   # Buffer interval for batch operations
+    bulk_read_batch_size: int | None = None, # Batch size for bulk reads (e.g., MGET)
     use_trader_prefix: bool = True,          # Use trader prefix in keys
     use_instance_id: bool = False,           # Include instance ID in keys
     flush_on_start: bool = False,            # Clear database on startup

--- a/nautilus_trader/cache/config.py
+++ b/nautilus_trader/cache/config.py
@@ -40,6 +40,11 @@ class CacheConfig(NautilusConfig, frozen=True):
         The buffer interval (milliseconds) between pipelined/batched transactions.
         The recommended range if using buffered pipelining is [10, 1000] milliseconds,
         with a good compromise being 100 milliseconds.
+    bulk_read_batch_size : PositiveInt, optional
+        The batch size for bulk read operations (e.g., MGET). If set, bulk reads
+        will be batched into chunks of this size to avoid exceeding request size
+        limits on some Redis providers. If `None`, all keys are fetched in a
+        single operation.
     use_trader_prefix : bool, default True
         If a 'trader-' prefix is used for keys.
     use_instance_id : bool, default False
@@ -60,6 +65,7 @@ class CacheConfig(NautilusConfig, frozen=True):
     timestamps_as_iso8601: bool = False
     persist_account_events: bool = True
     buffer_interval_ms: PositiveInt | None = None
+    bulk_read_batch_size: PositiveInt | None = None
     use_trader_prefix: bool = True
     use_instance_id: bool = False
     flush_on_start: bool = False


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds a new `bulk_read_batch_size` option to `CacheConfig` that enables batching of MGET operations during Redis cache loading. Some Redis providers (e.g., managed Redis services) have request size limits that can be exceeded when loading large numbers of cached items (such as thousands of option instruments). This change allows users to configure batched bulk reads to work around these limits.

The feature is **opt-in**: when `bulk_read_batch_size` is `None` (the default), behavior is unchanged and all keys are fetched in a single MGET operation. When set to a value (e.g., `1000`), bulk reads are chunked into batches of that size.

## Related Issues/PRs

None

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A - This is a fully backwards-compatible, opt-in feature.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_read_bulk_batched` test in `test_redis_queries.rs` to verify the batched bulk read functionality works correctly across batch boundaries.