### PR TITLE
Fix GreeksCalculator to use index price for index instruments

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -62,6 +62,7 @@ This will be the final release with support for the dYdX v3 (legacy) API. Future
 - Fixed remaining `F_LAST` flag checks to use proper bitmask comparison
 - Fixed `MarketIfTouchedOrder` (MIT) filling at bar extremes instead of trigger price during backtesting (#3461, #3462), thanks @HaakonFlaaronning
 - Fixed OTO child order sizing with rapid parent fills (#3435), thanks for reporting @dxwil
+- Fixed `GreeksCalculator` to use index price for index instruments
 - Fixed `ExecAlgorithm` spawn quantity accounting (will now restore quantity from denied/rejected spawned orders)
 - Fixed reconciliation `venue_order_id` indexing and validation
 - Fixed analyzer epoch timestamp from empty shell positions

--- a/nautilus_trader/model/greeks.pyx
+++ b/nautilus_trader/model/greeks.pyx
@@ -18,6 +18,7 @@ from typing import Callable
 from nautilus_trader.core.nautilus_pyo3 import black_scholes_greeks
 from nautilus_trader.core.nautilus_pyo3 import imply_vol_and_greeks
 from nautilus_trader.core.nautilus_pyo3 import refine_vol_and_greeks
+from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import InstrumentClass
 from nautilus_trader.model.enums import PriceType
 from nautilus_trader.model.greeks_data import GreeksData
@@ -284,6 +285,14 @@ cdef class GreeksCalculator:
         return greeks_data
 
     cdef object _get_price(self, InstrumentId instrument_id):
+        # Check if the instrument is an index - if so, use index price
+        instrument = self._cache.instrument(instrument_id)
+        if instrument is not None and instrument.asset_class is AssetClass.INDEX:
+            index_price = self._cache.index_price(instrument_id)
+            if index_price is not None:
+                return index_price.value
+            # If no index price, fall through to regular price lookup
+
         # Try MID price first, then LAST price as fallback
         price_obj = self._cache.price(instrument_id, PriceType.MID)
         if price_obj is None:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

When calculating Greeks for options on index underlyings, the calculator constructs the underlying instrument ID and looks up its price. For index instruments (e.g., `^SPX.XCBO`), it should use `cache.index_price()` instead of `cache.price()` since indices don't have quotes - they have index price updates.

Now `_get_price` checks if the instrument has `asset_class == INDEX` and uses the appropriate price source.

## Related Issues/PRs

Related to #3540 (IB options index underlying prefix fix)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested with live SPX options trading - Greeks calculation now correctly retrieves the underlying index price.