### PR TITLE
Fix spurious tick size warnings for IB index subscriptions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -62,7 +62,6 @@ This will be the final release with support for the dYdX v3 (legacy) API. Future
 - Fixed remaining `F_LAST` flag checks to use proper bitmask comparison
 - Fixed `MarketIfTouchedOrder` (MIT) filling at bar extremes instead of trigger price during backtesting (#3461, #3462), thanks @HaakonFlaaronning
 - Fixed OTO child order sizing with rapid parent fills (#3435), thanks for reporting @dxwil
-- Fixed spurious tick size warnings for Interactive Brokers index subscriptions
 - Fixed `ExecAlgorithm` spawn quantity accounting (will now restore quantity from denied/rejected spawned orders)
 - Fixed reconciliation `venue_order_id` indexing and validation
 - Fixed analyzer epoch timestamp from empty shell positions


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Suppresses invalid tick size warnings for Interactive Brokers index subscriptions. Index instruments have no volume data, so IB sends invalid/placeholder size values which triggered spurious warnings. This was introduced in #3514 when index price subscriptions were added.

## Related Issues/PRs

Related to #3514

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually with live IB connection - warnings no longer appear for index subscriptions.