### PR TITLE
Add Ichimoku Cloud indicator

### DIFF
--- a/crates/indicators/src/momentum/ichimoku.rs
+++ b/crates/indicators/src/momentum/ichimoku.rs
@@ -1,0 +1,329 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Ichimoku Cloud (Kinko Hyo) indicator.
+
+use std::fmt::Display;
+
+use arraydeque::{ArrayDeque, Wrapping};
+use nautilus_model::data::Bar;
+
+use crate::indicator::Indicator;
+
+const MAX_PERIOD: usize = 128;
+const MAX_DISPLACEMENT: usize = 64;
+
+#[repr(C)]
+#[derive(Debug)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.indicators")
+)]
+pub struct IchimokuCloud {
+    pub tenkan_period: usize,
+    pub kijun_period: usize,
+    pub senkou_period: usize,
+    pub displacement: usize,
+    pub tenkan_sen: f64,
+    pub kijun_sen: f64,
+    pub senkou_span_a: f64,
+    pub senkou_span_b: f64,
+    pub chikou_span: f64,
+    pub initialized: bool,
+    has_inputs: bool,
+    highs: ArrayDeque<f64, MAX_PERIOD, Wrapping>,
+    lows: ArrayDeque<f64, MAX_PERIOD, Wrapping>,
+    senkou_a: ArrayDeque<f64, MAX_DISPLACEMENT, Wrapping>,
+    senkou_b: ArrayDeque<f64, MAX_DISPLACEMENT, Wrapping>,
+    chikou: ArrayDeque<f64, MAX_DISPLACEMENT, Wrapping>,
+}
+
+impl Display for IchimokuCloud {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}({},{},{},{})",
+            self.name(),
+            self.tenkan_period,
+            self.kijun_period,
+            self.senkou_period,
+            self.displacement,
+        )
+    }
+}
+
+impl Indicator for IchimokuCloud {
+    fn name(&self) -> String {
+        stringify!(IchimokuCloud).to_string()
+    }
+
+    fn has_inputs(&self) -> bool {
+        self.has_inputs
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    fn handle_bar(&mut self, bar: &Bar) {
+        self.update_raw((&bar.high).into(), (&bar.low).into(), (&bar.close).into());
+    }
+
+    fn reset(&mut self) {
+        self.highs.clear();
+        self.lows.clear();
+        self.senkou_a.clear();
+        self.senkou_b.clear();
+        self.chikou.clear();
+        self.tenkan_sen = 0.0;
+        self.kijun_sen = 0.0;
+        self.senkou_span_a = 0.0;
+        self.senkou_span_b = 0.0;
+        self.chikou_span = 0.0;
+        self.has_inputs = false;
+        self.initialized = false;
+    }
+}
+
+impl IchimokuCloud {
+    /// Creates a new [`IchimokuCloud`] instance with standard periods (9, 26, 52, 26).
+    ///
+    /// # Panics
+    ///
+    /// Panics if periods are invalid: `tenkan_period` and others must be positive,
+    /// `kijun_period >= tenkan_period`, `senkou_period >= kijun_period`,
+    /// and all within allowed maximums.
+    #[must_use]
+    pub fn new(
+        tenkan_period: usize,
+        kijun_period: usize,
+        senkou_period: usize,
+        displacement: usize,
+    ) -> Self {
+        assert!(
+            tenkan_period > 0 && tenkan_period <= MAX_PERIOD,
+            "IchimokuCloud: tenkan_period must be in 1..={MAX_PERIOD}"
+        );
+        assert!(
+            kijun_period > 0 && kijun_period <= MAX_PERIOD,
+            "IchimokuCloud: kijun_period must be in 1..={MAX_PERIOD}"
+        );
+        assert!(
+            senkou_period > 0 && senkou_period <= MAX_PERIOD,
+            "IchimokuCloud: senkou_period must be in 1..={MAX_PERIOD}"
+        );
+        assert!(
+            displacement > 0 && displacement <= MAX_DISPLACEMENT,
+            "IchimokuCloud: displacement must be in 1..={MAX_DISPLACEMENT}"
+        );
+        assert!(
+            kijun_period >= tenkan_period,
+            "IchimokuCloud: kijun_period must be >= tenkan_period"
+        );
+        assert!(
+            senkou_period >= kijun_period,
+            "IchimokuCloud: senkou_period must be >= kijun_period"
+        );
+
+        Self {
+            tenkan_period,
+            kijun_period,
+            senkou_period,
+            displacement,
+            tenkan_sen: 0.0,
+            kijun_sen: 0.0,
+            senkou_span_a: 0.0,
+            senkou_span_b: 0.0,
+            chikou_span: 0.0,
+            initialized: false,
+            has_inputs: false,
+            highs: ArrayDeque::new(),
+            lows: ArrayDeque::new(),
+            senkou_a: ArrayDeque::new(),
+            senkou_b: ArrayDeque::new(),
+            chikou: ArrayDeque::new(),
+        }
+    }
+
+    /// Updates the indicator with OHLC values.
+    pub fn update_raw(&mut self, high: f64, low: f64, close: f64) {
+        let _ = self.highs.push_back(high);
+        let _ = self.lows.push_back(low);
+
+        if !self.initialized {
+            self.has_inputs = true;
+            let n = self.highs.len();
+            if n >= self.tenkan_period && n >= self.kijun_period && n >= self.senkou_period {
+                self.initialized = true;
+            }
+        }
+
+        self.tenkan_sen = Self::midpoint_over(&self.highs, &self.lows, self.tenkan_period);
+        self.kijun_sen = Self::midpoint_over(&self.highs, &self.lows, self.kijun_period);
+        let mid52 = Self::midpoint_over(&self.highs, &self.lows, self.senkou_period);
+
+        if self.initialized {
+            if self.senkou_a.len() == self.displacement {
+                self.senkou_span_a = self.senkou_a.pop_front().unwrap_or(0.0);
+            }
+            let _ = self
+                .senkou_a
+                .push_back((self.tenkan_sen + self.kijun_sen) / 2.0);
+
+            if self.senkou_b.len() == self.displacement {
+                self.senkou_span_b = self.senkou_b.pop_front().unwrap_or(0.0);
+            }
+            let _ = self.senkou_b.push_back(mid52);
+
+            if self.chikou.len() == self.displacement {
+                self.chikou_span = self.chikou.pop_front().unwrap_or(0.0);
+            }
+            let _ = self.chikou.push_back(close);
+        }
+    }
+
+    fn midpoint_over(
+        highs: &ArrayDeque<f64, MAX_PERIOD, Wrapping>,
+        lows: &ArrayDeque<f64, MAX_PERIOD, Wrapping>,
+        period: usize,
+    ) -> f64 {
+        if highs.len() < period || lows.len() < period {
+            return 0.0;
+        }
+        let high_max = highs
+            .iter()
+            .rev()
+            .take(period)
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max);
+        let low_min = lows
+            .iter()
+            .rev()
+            .take(period)
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        (high_max + low_min) / 2.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+
+    use super::*;
+    use crate::indicator::Indicator;
+
+    #[fixture]
+    fn ich_default() -> IchimokuCloud {
+        IchimokuCloud::new(9, 26, 52, 26)
+    }
+
+    #[rstest]
+    fn test_name(ich_default: IchimokuCloud) {
+        assert_eq!(ich_default.name(), "IchimokuCloud");
+    }
+
+    #[rstest]
+    fn test_display(ich_default: IchimokuCloud) {
+        assert_eq!(format!("{ich_default}"), "IchimokuCloud(9,26,52,26)");
+    }
+
+    #[rstest]
+    fn test_initialized_without_inputs(ich_default: IchimokuCloud) {
+        assert!(!ich_default.initialized());
+        assert!(!ich_default.has_inputs());
+    }
+
+    #[rstest]
+    fn test_tenkan_after_nine_bars(mut ich_default: IchimokuCloud) {
+        for _ in 0..9 {
+            ich_default.update_raw(12.0, 8.0, 10.0);
+        }
+        assert_eq!(ich_default.tenkan_sen, 10.0);
+    }
+
+    #[rstest]
+    fn test_kijun_after_twenty_six_bars(mut ich_default: IchimokuCloud) {
+        for _ in 0..26 {
+            ich_default.update_raw(12.0, 8.0, 10.0);
+        }
+        assert_eq!(ich_default.kijun_sen, 10.0);
+    }
+
+    #[rstest]
+    fn test_initialized_after_fifty_two_bars(mut ich_default: IchimokuCloud) {
+        for _ in 0..52 {
+            ich_default.update_raw(10.0, 8.0, 9.0);
+        }
+        assert!(ich_default.initialized());
+    }
+
+    #[rstest]
+    fn test_senkou_chikou_after_displacement_bars(mut ich_default: IchimokuCloud) {
+        for _ in 0..(52 + 26) {
+            ich_default.update_raw(12.0, 8.0, 10.0);
+        }
+        assert_eq!(ich_default.senkou_span_a, 10.0);
+        assert_eq!(ich_default.senkou_span_b, 10.0);
+        assert_eq!(ich_default.chikou_span, 10.0);
+    }
+
+    #[rstest]
+    fn test_reset(mut ich_default: IchimokuCloud) {
+        for _ in 0..20 {
+            ich_default.update_raw(10.0, 8.0, 9.0);
+        }
+        ich_default.reset();
+        assert!(!ich_default.initialized());
+        assert_eq!(ich_default.tenkan_sen, 0.0);
+        assert_eq!(ich_default.kijun_sen, 0.0);
+        assert_eq!(ich_default.senkou_span_a, 0.0);
+        assert_eq!(ich_default.senkou_span_b, 0.0);
+        assert_eq!(ich_default.chikou_span, 0.0);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "kijun_period must be >= tenkan_period")]
+    fn test_new_panics_invalid_kijun() {
+        let _ = IchimokuCloud::new(9, 5, 52, 26);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "senkou_period must be >= kijun_period")]
+    fn test_new_panics_invalid_senkou() {
+        let _ = IchimokuCloud::new(9, 26, 20, 26);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "displacement must be in 1..=")]
+    fn test_new_panics_invalid_displacement() {
+        let _ = IchimokuCloud::new(9, 26, 52, 0);
+    }
+
+    #[rstest]
+    fn test_custom_periods_initialization() {
+        let mut ich = IchimokuCloud::new(5, 10, 20, 10);
+        assert_eq!(ich.tenkan_period, 5);
+        assert_eq!(ich.kijun_period, 10);
+        assert_eq!(ich.senkou_period, 20);
+        assert_eq!(ich.displacement, 10);
+        for _ in 0..20 {
+            ich.update_raw(1.0, 1.0, 1.0);
+        }
+        assert!(ich.initialized());
+        assert_eq!(ich.tenkan_sen, 1.0);
+        assert_eq!(ich.kijun_sen, 1.0);
+    }
+}

--- a/crates/indicators/src/momentum/mod.rs
+++ b/crates/indicators/src/momentum/mod.rs
@@ -22,6 +22,7 @@ pub mod bias;
 pub mod cci;
 pub mod cmo;
 pub mod dm;
+pub mod ichimoku;
 pub mod kvo;
 pub mod macd;
 pub mod obv;

--- a/crates/indicators/src/python/mod.rs
+++ b/crates/indicators/src/python/mod.rs
@@ -58,6 +58,7 @@ pub fn indicators(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::momentum::vhf::VerticalHorizontalFilter>()?;
     m.add_class::<crate::momentum::kvo::KlingerVolumeOscillator>()?;
     m.add_class::<crate::momentum::dm::DirectionalMovement>()?;
+    m.add_class::<crate::momentum::ichimoku::IchimokuCloud>()?;
     m.add_class::<crate::momentum::amat::ArcherMovingAveragesTrends>()?;
     m.add_class::<crate::momentum::swings::Swings>()?;
     m.add_class::<crate::momentum::bb::BollingerBands>()?;

--- a/crates/indicators/src/python/momentum/ichimoku.rs
+++ b/crates/indicators/src/python/momentum/ichimoku.rs
@@ -1,0 +1,125 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_model::data::Bar;
+use pyo3::prelude::*;
+
+use crate::{indicator::Indicator, momentum::ichimoku::IchimokuCloud};
+
+#[pymethods]
+impl IchimokuCloud {
+    #[new]
+    #[pyo3(signature = (tenkan_period=9, kijun_period=26, senkou_period=52, displacement=26))]
+    #[must_use]
+    pub fn py_new(
+        tenkan_period: usize,
+        kijun_period: usize,
+        senkou_period: usize,
+        displacement: usize,
+    ) -> Self {
+        Self::new(tenkan_period, kijun_period, senkou_period, displacement)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self}")
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[getter]
+    #[pyo3(name = "tenkan_period")]
+    const fn py_tenkan_period(&self) -> usize {
+        self.tenkan_period
+    }
+
+    #[getter]
+    #[pyo3(name = "kijun_period")]
+    const fn py_kijun_period(&self) -> usize {
+        self.kijun_period
+    }
+
+    #[getter]
+    #[pyo3(name = "senkou_period")]
+    const fn py_senkou_period(&self) -> usize {
+        self.senkou_period
+    }
+
+    #[getter]
+    #[pyo3(name = "displacement")]
+    const fn py_displacement(&self) -> usize {
+        self.displacement
+    }
+
+    #[getter]
+    #[pyo3(name = "has_inputs")]
+    fn py_has_inputs(&self) -> bool {
+        self.has_inputs()
+    }
+
+    #[getter]
+    #[pyo3(name = "tenkan_sen")]
+    const fn py_tenkan_sen(&self) -> f64 {
+        self.tenkan_sen
+    }
+
+    #[getter]
+    #[pyo3(name = "kijun_sen")]
+    const fn py_kijun_sen(&self) -> f64 {
+        self.kijun_sen
+    }
+
+    #[getter]
+    #[pyo3(name = "senkou_span_a")]
+    const fn py_senkou_span_a(&self) -> f64 {
+        self.senkou_span_a
+    }
+
+    #[getter]
+    #[pyo3(name = "senkou_span_b")]
+    const fn py_senkou_span_b(&self) -> f64 {
+        self.senkou_span_b
+    }
+
+    #[getter]
+    #[pyo3(name = "chikou_span")]
+    const fn py_chikou_span(&self) -> f64 {
+        self.chikou_span
+    }
+
+    #[getter]
+    #[pyo3(name = "initialized")]
+    const fn py_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    #[pyo3(name = "update_raw")]
+    fn py_update_raw(&mut self, high: f64, low: f64, close: f64) {
+        self.update_raw(high, low, close);
+    }
+
+    #[pyo3(name = "handle_bar")]
+    fn py_handle_bar(&mut self, bar: &Bar) {
+        self.handle_bar(bar);
+    }
+
+    #[pyo3(name = "reset")]
+    fn py_reset(&mut self) {
+        self.reset();
+    }
+}

--- a/crates/indicators/src/python/momentum/mod.rs
+++ b/crates/indicators/src/python/momentum/mod.rs
@@ -20,6 +20,7 @@ pub mod bias;
 pub mod cci;
 pub mod cmo;
 pub mod dm;
+pub mod ichimoku;
 pub mod kvo;
 pub mod macd;
 pub mod obv;

--- a/nautilus_trader/indicators/__init__.py
+++ b/nautilus_trader/indicators/__init__.py
@@ -53,6 +53,7 @@ from nautilus_trader.indicators.trend import ArcherMovingAveragesTrends
 from nautilus_trader.indicators.trend import AroonOscillator
 from nautilus_trader.indicators.trend import Bias
 from nautilus_trader.indicators.trend import DirectionalMovement
+from nautilus_trader.indicators.trend import IchimokuCloud
 from nautilus_trader.indicators.trend import LinearRegression
 from nautilus_trader.indicators.trend import MovingAverageConvergenceDivergence
 from nautilus_trader.indicators.trend import Swings
@@ -90,6 +91,7 @@ __all__ = [
     "FuzzyCandle",
     "FuzzyCandlesticks",
     "HullMovingAverage",
+    "IchimokuCloud",
     "Indicator",
     "KeltnerChannel",
     "KeltnerPosition",

--- a/nautilus_trader/indicators/trend.pxd
+++ b/nautilus_trader/indicators/trend.pxd
@@ -80,6 +80,30 @@ cdef class MovingAverageConvergenceDivergence(Indicator):
     cpdef void update_raw(self, double value)
 
 
+cdef class IchimokuCloud(Indicator):
+    cdef object _highs_9
+    cdef object _lows_9
+    cdef object _highs_26
+    cdef object _lows_26
+    cdef object _highs_52
+    cdef object _lows_52
+    cdef object _senkou_a
+    cdef object _senkou_b
+    cdef object _chikou
+
+    cdef readonly int tenkan_period
+    cdef readonly int kijun_period
+    cdef readonly int senkou_period
+    cdef readonly int displacement
+    cdef readonly double tenkan_sen
+    cdef readonly double kijun_sen
+    cdef readonly double senkou_span_a
+    cdef readonly double senkou_span_b
+    cdef readonly double chikou_span
+
+    cpdef void update_raw(self, double high, double low, double close)
+
+
 cdef class LinearRegression(Indicator):
     cdef object _inputs
 

--- a/nautilus_trader/indicators/trend.pyx
+++ b/nautilus_trader/indicators/trend.pyx
@@ -468,6 +468,146 @@ cdef class MovingAverageConvergenceDivergence(Indicator):
         self.value = 0
 
 
+cdef class IchimokuCloud(Indicator):
+    """
+    Ichimoku Cloud (Kinko Hyo) with five components.
+
+    - Tenkan-sen (Conversion Line): (tenkan_period high + tenkan_period low) / 2.
+    - Kijun-sen (Base Line): (kijun_period high + kijun_period low) / 2.
+    - Senkou Span A (Leading Span A): (Tenkan + Kijun) / 2, displaced forward by displacement.
+    - Senkou Span B (Leading Span B): (senkou_period high + senkou_period low) / 2, displaced forward by displacement.
+    - Chikou Span (Lagging Span): Close displaced backward by displacement.
+
+    Parameters
+    ----------
+    tenkan_period : int
+        Period for Tenkan-sen (default 9).
+    kijun_period : int
+        Period for Kijun-sen (default 26).
+    senkou_period : int
+        Period for Senkou Span B (default 52).
+    displacement : int
+        Displacement for leading/lagging spans (default 26).
+
+    Raises
+    ------
+    ValueError
+        If any period or displacement is not positive.
+    ValueError
+        If senkou_period is not >= kijun_period or kijun_period is not >= tenkan_period.
+    """
+
+    def __init__(
+        self,
+        int tenkan_period=9,
+        int kijun_period=26,
+        int senkou_period=52,
+        int displacement=26,
+    ):
+        Condition.positive_int(tenkan_period, "tenkan_period")
+        Condition.positive_int(kijun_period, "kijun_period")
+        Condition.positive_int(senkou_period, "senkou_period")
+        Condition.positive_int(displacement, "displacement")
+        Condition.is_true(
+            kijun_period >= tenkan_period,
+            "kijun_period was < tenkan_period",
+        )
+        Condition.is_true(
+            senkou_period >= kijun_period,
+            "senkou_period was < kijun_period",
+        )
+        super().__init__(params=[tenkan_period, kijun_period, senkou_period, displacement])
+
+        self.tenkan_period = tenkan_period
+        self.kijun_period = kijun_period
+        self.senkou_period = senkou_period
+        self.displacement = displacement
+
+        self._highs_9 = deque(maxlen=tenkan_period)
+        self._lows_9 = deque(maxlen=tenkan_period)
+        self._highs_26 = deque(maxlen=kijun_period)
+        self._lows_26 = deque(maxlen=kijun_period)
+        self._highs_52 = deque(maxlen=senkou_period)
+        self._lows_52 = deque(maxlen=senkou_period)
+        self._senkou_a = deque(maxlen=displacement)
+        self._senkou_b = deque(maxlen=displacement)
+        self._chikou = deque(maxlen=displacement)
+
+        self.tenkan_sen = 0.0
+        self.kijun_sen = 0.0
+        self.senkou_span_a = 0.0
+        self.senkou_span_b = 0.0
+        self.chikou_span = 0.0
+
+    cpdef void handle_bar(self, Bar bar):
+        Condition.not_none(bar, "bar")
+        self.update_raw(
+            bar.high.as_double(),
+            bar.low.as_double(),
+            bar.close.as_double(),
+        )
+
+    cpdef void update_raw(self, double high, double low, double close):
+        self._highs_9.append(high)
+        self._lows_9.append(low)
+        self._highs_26.append(high)
+        self._lows_26.append(low)
+        self._highs_52.append(high)
+        self._lows_52.append(low)
+
+        if not self.initialized:
+            self._set_has_inputs(True)
+
+            if (
+                len(self._highs_9) >= self.tenkan_period
+                and len(self._highs_26) >= self.kijun_period
+                and len(self._highs_52) >= self.senkou_period
+            ):
+                self._set_initialized(True)
+
+        if len(self._highs_9) >= self.tenkan_period:
+            self.tenkan_sen = (max(self._highs_9) + min(self._lows_9)) / 2.0
+
+        if len(self._highs_26) >= self.kijun_period:
+            self.kijun_sen = (max(self._highs_26) + min(self._lows_26)) / 2.0
+
+        cdef double mid52 = 0.0
+        if len(self._highs_52) >= self.senkou_period:
+            mid52 = (max(self._highs_52) + min(self._lows_52)) / 2.0
+
+        if self.initialized:
+            if len(self._senkou_a) == self.displacement:
+                self.senkou_span_a = self._senkou_a[0]
+
+            self._senkou_a.append((self.tenkan_sen + self.kijun_sen) / 2.0)
+
+            if len(self._senkou_b) == self.displacement:
+                self.senkou_span_b = self._senkou_b[0]
+
+            self._senkou_b.append(mid52)
+
+            if len(self._chikou) == self.displacement:
+                self.chikou_span = self._chikou[0]
+
+            self._chikou.append(close)
+
+    cpdef void _reset(self):
+        self._highs_9.clear()
+        self._lows_9.clear()
+        self._highs_26.clear()
+        self._lows_26.clear()
+        self._highs_52.clear()
+        self._lows_52.clear()
+        self._senkou_a.clear()
+        self._senkou_b.clear()
+        self._chikou.clear()
+        self.tenkan_sen = 0.0
+        self.kijun_sen = 0.0
+        self.senkou_span_a = 0.0
+        self.senkou_span_b = 0.0
+        self.chikou_span = 0.0
+
+
 cdef class LinearRegression(Indicator):
     """
     An indicator that calculates a simple linear regression.

--- a/tests/unit_tests/indicators/test_ichimoku.py
+++ b/tests/unit_tests/indicators/test_ichimoku.py
@@ -1,0 +1,129 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+
+from nautilus_trader.indicators import IchimokuCloud
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+from nautilus_trader.test_kit.stubs.data import TestDataStubs
+
+
+AUDUSD_SIM = TestInstrumentProvider.default_fx_ccy("AUD/USD")
+
+
+class TestIchimokuCloud:
+    def setup(self):
+        self.ich = IchimokuCloud(9, 26, 52, 26)
+
+    def test_name_returns_expected_string(self):
+        assert self.ich.name == "IchimokuCloud"
+
+    def test_str_repr_returns_expected_string(self):
+        assert str(self.ich) == "IchimokuCloud(9, 26, 52, 26)"
+        assert repr(self.ich) == "IchimokuCloud(9, 26, 52, 26)"
+
+    def test_parameters_after_instantiation(self):
+        assert self.ich.tenkan_period == 9
+        assert self.ich.kijun_period == 26
+        assert self.ich.senkou_period == 52
+        assert self.ich.displacement == 26
+        assert self.ich.tenkan_sen == 0.0
+        assert self.ich.kijun_sen == 0.0
+        assert self.ich.senkou_span_a == 0.0
+        assert self.ich.senkou_span_b == 0.0
+        assert self.ich.chikou_span == 0.0
+
+    def test_initialized_without_inputs_returns_false(self):
+        assert self.ich.initialized is False
+
+    def test_has_inputs_after_one_bar_returns_true(self):
+        self.ich.update_raw(11.0, 9.0, 10.0)
+        assert self.ich.has_inputs is True
+        assert self.ich.tenkan_sen == 0.0
+        assert self.ich.kijun_sen == 0.0
+
+    def test_value_with_one_input_returns_expected_value(self):
+        self.ich.update_raw(11.0, 9.0, 10.0)
+        assert self.ich.tenkan_sen == 0.0
+        assert self.ich.kijun_sen == 0.0
+        assert self.ich.senkou_span_a == 0.0
+        assert self.ich.senkou_span_b == 0.0
+        assert self.ich.chikou_span == 0.0
+
+    def test_initialized_after_required_inputs_returns_true(self):
+        for _ in range(52):
+            self.ich.update_raw(10.0, 8.0, 9.0)
+        assert self.ich.initialized is True
+
+    def test_tenkan_sen_after_nine_bars_returns_midpoint(self):
+        for _ in range(9):
+            self.ich.update_raw(12.0, 8.0, 10.0)
+        assert self.ich.tenkan_sen == 10.0
+
+    def test_kijun_sen_after_twenty_six_bars_returns_midpoint(self):
+        for _ in range(26):
+            self.ich.update_raw(12.0, 8.0, 10.0)
+        assert self.ich.kijun_sen == 10.0
+
+    def test_senkou_and_chikou_after_displacement_bars_returns_expected(self):
+        for _ in range(52 + 26):
+            self.ich.update_raw(12.0, 8.0, 10.0)
+        assert self.ich.senkou_span_a == 10.0
+        assert self.ich.senkou_span_b == 10.0
+        assert self.ich.chikou_span == 10.0
+
+    def test_handle_bar_updates_indicator(self):
+        indicator = IchimokuCloud(9, 26, 52, 26)
+        bar = TestDataStubs.bar_5decimal()
+        indicator.handle_bar(bar)
+        assert indicator.has_inputs
+
+    def test_handle_bar_nine_times_returns_expected_tenkan_sen(self):
+        indicator = IchimokuCloud(9, 26, 52, 26)
+        bar = TestDataStubs.bar_5decimal()
+        for _ in range(9):
+            indicator.handle_bar(bar)
+        assert indicator.tenkan_sen == 1.000025
+
+    def test_reset_returns_to_fresh_state(self):
+        for _ in range(20):
+            self.ich.update_raw(10.0, 8.0, 9.0)
+        self.ich.reset()
+        assert self.ich.initialized is False
+        assert self.ich.tenkan_sen == 0.0
+        assert self.ich.kijun_sen == 0.0
+        assert self.ich.senkou_span_a == 0.0
+        assert self.ich.senkou_span_b == 0.0
+        assert self.ich.chikou_span == 0.0
+
+    def test_custom_periods_initialization(self):
+        ich = IchimokuCloud(tenkan_period=5, kijun_period=10, senkou_period=20, displacement=10)
+        assert ich.tenkan_period == 5
+        assert ich.kijun_period == 10
+        assert ich.senkou_period == 20
+        assert ich.displacement == 10
+        for _ in range(20):
+            ich.update_raw(1.0, 1.0, 1.0)
+        assert ich.initialized is True
+        assert ich.tenkan_sen == 1.0
+        assert ich.kijun_sen == 1.0
+
+    def test_invalid_periods_raises(self):
+        with pytest.raises(ValueError):
+            IchimokuCloud(9, 5, 52, 26)
+        with pytest.raises(ValueError):
+            IchimokuCloud(9, 26, 20, 26)
+        with pytest.raises(ValueError):
+            IchimokuCloud(9, 26, 52, 0)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

# Pull request summary: Ichimoku Cloud indicator

## Overview

Adds the Ichimoku Cloud (Kinko Hyo) indicator to Nautilus with five components (Tenkan-sen, Kijun-sen, Senkou Span A, Senkou Span B, Chikou Span), implemented in both Cython and Rust, with configurable periods and full unit tests in both codebases.

## Changes

### Cython indicator (Python API)

- **New indicator:** `IchimokuCloud` in `nautilus_trader/indicators/trend.pyx` and `trend.pxd`.
- Subclasses `Indicator`; exposes five readonly attributes: `tenkan_sen`, `kijun_sen`, `senkou_span_a`, `senkou_span_b`, `chikou_span`.
- Default periods: `tenkan_period=9`, `kijun_period=26`, `senkou_period=52`, `displacement=26`.
- Implements `handle_bar` and `update_raw(high, low, close)`; uses deques for rolling high/low (9, 26, 52) and displacement buffers (26) for leading/lagging spans.
- Validation: `tenkan_period <= kijun_period <= senkou_period`, all positive; `displacement` positive.
- Exported from `nautilus_trader.indicators` in `indicators/__init__.py`.

### Rust indicator (momentum module)

- **New module:** `crates/indicators/src/momentum/ichimoku.rs` implementing `IchimokuCloud`.
- Same formulas and semantics as Cython: single high/low buffer (capacity 128), last N values used for tenkan/kijun/senkou midpoints; displacement buffers (capacity 64) for Senkou A/B and Chikou.
- Implements `Indicator` (`name`, `has_inputs`, `initialized`, `handle_bar`, `reset`); panics in `new()` for invalid or out-of-range periods.
- Python bindings in `crates/indicators/src/python/momentum/ichimoku.rs` (PyO3) with constructor defaults and getters for all five components and `update_raw` / `handle_bar` / `reset`.
- Registered in `crates/indicators/src/python/mod.rs` under the Momentum section (no separate trend module).

### Tests

- **Python:** `tests/unit_tests/indicators/test_ichimoku.py` (15 tests): name, str/repr, parameters, initialized/has_inputs, one-bar and one-input values, tenkan after 9 bars, kijun after 26 bars, senkou/chikou after 52+26 bars, `handle_bar`, `handle_bar` nine times with exact tenkan (1.000025), reset, custom periods, invalid periods (ValueError).
- **Rust:** Unit tests in `momentum/ichimoku.rs` (12 tests): same scenarios plus panic tests for invalid kijun, senkou, and displacement; custom-period initialization.
- Tests aligned between Python and Rust so both implementations stay in sync.

## Design notes

- **Multi-value indicator pattern:** Ichimoku follows the same pattern as BollingerBands and DonchianChannel: one `Indicator` subclass with multiple readonly numeric attributes rather than a single `value`.
- **Placement in Rust:** Ichimoku lives in the existing `momentum` module rather than a new `trend` module, consistent with other trend-style indicators (e.g. MACD, Aroon) in the crate.
- **Five components:** The standard Ichimoku definition uses these five components; default periods (9, 26, 52, 26) are configurable for different timeframes.

## Files touched

| Area | Files |
|------|--------|
| Cython | `nautilus_trader/indicators/trend.pxd`, `trend.pyx`, `indicators/__init__.py` |
| Rust core | `crates/indicators/src/momentum/mod.rs`, `momentum/ichimoku.rs` |
| Rust Python | `crates/indicators/src/python/momentum/mod.rs`, `python/momentum/ichimoku.rs`, `python/mod.rs` |
| Tests | `tests/unit_tests/indicators/test_ichimoku.py` |

## How to verify

- **Rust:** `cargo test -p nautilus-indicators momentum::ichimoku`
- **Python:** `uv run --no-sync pytest tests/unit_tests/indicators/test_ichimoku.py -v`
- **Build:** `make build-debug` (if Cython/Rust changed).


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
