### PR TITLE
Add TotalCashValue to IB account summary info dict

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,6 +36,7 @@ This will be the final release with support for the dYdX v3 (legacy) API. Future
 - Added Polymarket `event_slug_builder` support (#3501), thanks @jsemldonado
 - Added Polymarket batch order support (#3506), thanks @loafer-19
 - Improved tearsheet with dynamic Nautilus version and refined run info table (#3396), thanks @KaulSe
+- Added `TotalCashValue` to IB account summary `info` dict to expose actual cash balance (#3567), thanks @shzhng
 
 ### Breaking Changes
 - Removed dead `subscribe_order_book_snapshots` and `unsubscribe_order_book_snapshots` methods from `LiveMarketDataClient` (were never called by the data engine)

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -226,6 +226,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         self._set_account_id(account_id)
         self._account_summary_tags = {
             "NetLiquidation",
+            "TotalCashValue",
             "FullAvailableFunds",
             "FullInitMarginReq",
             "FullMaintMarginReq",
@@ -1358,6 +1359,9 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                     margins=[margin_balance],
                     reported=True,
                     ts_event=self._clock.timestamp_ns(),
+                    info={
+                        "TotalCashValue": self._account_summary[currency]["TotalCashValue"],
+                    },
                 )
 
                 # Store all available fields to Cache (for now until permanent solution)

--- a/tests/integration_tests/adapters/interactive_brokers/resources/responses/account_values.json
+++ b/tests/integration_tests/adapters/interactive_brokers/resources/responses/account_values.json
@@ -747,5 +747,12 @@
     "value": "0.00",
     "currency": "BASE",
     "modelCode": ""
+  },
+  {
+    "account": "DU123456",
+    "tag": "TotalCashValue",
+    "value": "51463.78",
+    "currency": "AUD",
+    "modelCode": ""
   }
 ]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The IB adapter currently discards `TotalCashValue` from the account summary, making it impossible to query actual cash balance through any Nautilus construct. This adds `TotalCashValue` to the required tags and passes it through the `AccountState` `info` dict, following the same pattern Binance Futures uses for adapter-specific account fields.

Consumers can now access actual cash via `account.last_event.info["TotalCashValue"]`.

## Related Issues/PRs

Related to #3565

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Updated the `account_values.json` test fixture to include the new `TotalCashValue` tag. Existing IB execution tests pass (all currently skipped due to pre-existing flaky mock issues).