### PR TITLE
architect_ax: serialize MD WebSocket request ids as rid

### DIFF
--- a/crates/adapters/architect_ax/src/websocket/messages.rs
+++ b/crates/adapters/architect_ax/src/websocket/messages.rs
@@ -99,6 +99,7 @@ pub enum NautilusExecWsMessage {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxMdSubscribe {
     /// Client request ID for correlation.
+    #[serde(rename = "rid")]
     pub request_id: i64,
     /// Request type (always "subscribe").
     #[serde(rename = "type")]
@@ -116,6 +117,7 @@ pub struct AxMdSubscribe {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxMdUnsubscribe {
     /// Client request ID for correlation.
+    #[serde(rename = "rid")]
     pub request_id: i64,
     /// Request type (always "unsubscribe").
     #[serde(rename = "type")]
@@ -131,6 +133,7 @@ pub struct AxMdUnsubscribe {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxMdSubscribeCandles {
     /// Client request ID for correlation.
+    #[serde(rename = "rid")]
     pub request_id: i64,
     /// Request type (always "subscribe_candles").
     #[serde(rename = "type")]
@@ -148,6 +151,7 @@ pub struct AxMdSubscribeCandles {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxMdUnsubscribeCandles {
     /// Client request ID for correlation.
+    #[serde(rename = "rid")]
     pub request_id: i64,
     /// Request type (always "unsubscribe_candles").
     #[serde(rename = "type")]
@@ -984,7 +988,8 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["request_id"], 2);
+        assert_eq!(parsed["rid"], 2);
+        assert!(parsed.get("request_id").is_none());
         assert_eq!(parsed["type"], "subscribe");
         assert_eq!(parsed["symbol"], "BTCUSD-PERP");
         assert_eq!(parsed["level"], "LEVEL_2");
@@ -1000,7 +1005,8 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["request_id"], 3);
+        assert_eq!(parsed["rid"], 3);
+        assert!(parsed.get("request_id").is_none());
         assert_eq!(parsed["type"], "unsubscribe");
         assert_eq!(parsed["symbol"], "BTCUSD-PERP");
     }
@@ -1016,7 +1022,8 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["request_id"], 4);
+        assert_eq!(parsed["rid"], 4);
+        assert!(parsed.get("request_id").is_none());
         assert_eq!(parsed["type"], "subscribe_candles");
         assert_eq!(parsed["symbol"], "BTCUSD-PERP");
         assert_eq!(parsed["width"], "1m");
@@ -1033,7 +1040,8 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["request_id"], 5);
+        assert_eq!(parsed["rid"], 5);
+        assert!(parsed.get("request_id").is_none());
         assert_eq!(parsed["type"], "unsubscribe_candles");
         assert_eq!(parsed["symbol"], "BTCUSD-PERP");
         assert_eq!(parsed["width"], "1m");


### PR DESCRIPTION
## Summary
- serialize outbound market-data request IDs as `rid` instead of `request_id`
- update serialization tests to assert `rid`
- assert `request_id` key is absent in serialized payloads

## Architect Docs
- Market data WebSocket API (request/response correlation field format): https://docs.architect.exchange/api-reference/marketdata/md-ws

## Files
- `crates/adapters/architect_ax/src/websocket/messages.rs`

## Testing
- Updated message serialization unit tests.
- Ran: `cargo test -p nautilus-architect-ax --locked`
- Result: PASS on branch `acho/ax-error-02-md-rid`
