### PR TITLE
architect_ax: reject cancel when venue order id is unknown

### DIFF
--- a/crates/adapters/architect_ax/src/websocket/orders/client.rs
+++ b/crates/adapters/architect_ax/src/websocket/orders/client.rs
@@ -653,7 +653,7 @@ impl AxOrdersWebSocketClient {
 
     /// Cancels an order via WebSocket.
     ///
-    /// Uses `venue_order_id` if available, otherwise falls back to `client_order_id`.
+    /// Requires a known `venue_order_id`.
     ///
     /// # Errors
     ///
@@ -663,8 +663,13 @@ impl AxOrdersWebSocketClient {
         client_order_id: ClientOrderId,
         venue_order_id: Option<VenueOrderId>,
     ) -> AxOrdersWsResult<i64> {
-        let order_id =
-            venue_order_id.map_or_else(|| client_order_id.to_string(), |v| v.to_string());
+        let order_id = venue_order_id
+            .map(|v| v.to_string())
+            .ok_or_else(|| {
+                AxOrdersWsClientError::ClientError(format!(
+                    "Cannot cancel order {client_order_id}: missing venue_order_id"
+                ))
+            })?;
 
         let request_id = self.next_request_id();
 
@@ -753,5 +758,67 @@ impl AxOrdersWebSocketClient {
         guard
             .send(cmd)
             .map_err(|e| AxOrdersWsClientError::ChannelError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cancel_order_rejects_without_venue_order_id() {
+        let client = AxOrdersWebSocketClient::new(
+            "wss://example.com/orders/ws".to_string(),
+            AccountId::from("AX-001"),
+            TraderId::from("TRADER-001"),
+            Some(30),
+        );
+        let client_order_id = ClientOrderId::from("CID-123");
+
+        let result = client.cancel_order(client_order_id, None).await;
+
+        assert!(matches!(
+            result,
+            Err(AxOrdersWsClientError::ClientError(msg))
+            if msg.contains("missing venue_order_id")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_order_sends_known_venue_order_id() {
+        let mut client = AxOrdersWebSocketClient::new(
+            "wss://example.com/orders/ws".to_string(),
+            AccountId::from("AX-001"),
+            TraderId::from("TRADER-001"),
+            Some(30),
+        );
+
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
+        client.cmd_tx = Arc::new(RwLock::new(cmd_tx));
+
+        let client_order_id = ClientOrderId::from("CID-456");
+        let venue_order_id = VenueOrderId::from("V-ORDER-789");
+
+        let request_id = client
+            .cancel_order(client_order_id, Some(venue_order_id))
+            .await
+            .unwrap();
+
+        assert_eq!(request_id, 1);
+        let cmd = cmd_rx.recv().await.unwrap();
+        match cmd {
+            HandlerCommand::CancelOrder {
+                request_id,
+                order_id,
+            } => {
+                assert_eq!(request_id, 1);
+                assert_eq!(order_id, "V-ORDER-789");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- remove cancel fallback that sent client order IDs as venue `oid`
- return deterministic client-side error when `venue_order_id` is missing
- keep cancel requests wire-safe by sending only known venue order IDs

## Architect Docs
- Orders WebSocket API (cancel request expects venue order id `oid`): https://docs.architect.exchange/api-reference/order-management/orders-ws

## Files
- `crates/adapters/architect_ax/src/websocket/orders/client.rs`

## Testing
- Added tests for missing-venue-id rejection and positive cancel command path.
- Ran: `cargo test -p nautilus-architect-ax --locked`
- Result: PASS on branch `acho/ax-error-03-cancel-unknown-oid`
