### PR TITLE
docs(architect_ax): mark order modification unsupported

### DIFF
--- a/docs/integrations/architect_ax.md
+++ b/docs/integrations/architect_ax.md
@@ -181,7 +181,7 @@ AX Exchange supports market and limit order types with stop triggers.
 
 | Feature            | Supported | Notes                                     |
 |--------------------|-----------|-------------------------------------------|
-| Order modification | ✓         | Price and quantity modification.          |
+| Order modification | -         | Not supported; use cancel and resubmit.   |
 | Cancel order       | ✓         | Single order cancellation.                |
 | Cancel all orders  | ✓         | Cancel all open orders for an instrument. |
 | Batch cancel       | ✓         | Cancel multiple specified orders.         |


### PR DESCRIPTION
## Summary
- update Architect AX integration docs to mark order modification as unsupported
- document cancel-and-resubmit guidance

## Architect Docs
- Place order API reference: https://docs.architect.exchange/api-reference/order-management/place-order
- Orders WebSocket API reference: https://docs.architect.exchange/api-reference/order-management/orders-ws

## Files
- `docs/integrations/architect_ax.md`

## Testing
- Docs-only change.
- Ran: `cargo test -p nautilus-architect-ax --locked`
- Result: PASS on branch `acho/ax-error-06-docs-modify-mismatch`
