### PR TITLE
architect_ax: cache instrument in ws_data demo before subscriptions

### DIFF
--- a/crates/adapters/architect_ax/bin/ws_data.rs
+++ b/crates/adapters/architect_ax/bin/ws_data.rs
@@ -34,9 +34,11 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use nautilus_architect_ax::{
     common::enums::AxEnvironment,
-    http::client::AxRawHttpClient,
+    http::{client::AxRawHttpClient, parse::parse_perp_instrument},
     websocket::{NautilusDataWsMessage, data::AxMdWebSocketClient},
 };
+use nautilus_core::time::get_atomic_clock_realtime;
+use rust_decimal::Decimal;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -73,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    match http_client.get_instruments().await {
+    let instruments_response = match http_client.get_instruments().await {
         Ok(response) => {
             log::info!(
                 "Connectivity OK - got {} instruments",
@@ -82,12 +84,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(first) = response.instruments.first() {
                 log::debug!("First instrument: {:?}", first.symbol);
             }
+            response
         }
         Err(e) => {
             log::error!("Connectivity test failed: {e:?}");
             return Err(format!("Connectivity test failed: {e:?}").into());
         }
-    }
+    };
 
     log::info!(
         "Authenticating via HTTP to {}/authenticate ...",
@@ -110,11 +113,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(30),
     );
 
+    let test_symbol = "EURUSD-PERP";
+    let ts_init = get_atomic_clock_realtime().get_time_ns();
+    let maybe_instrument = instruments_response
+        .instruments
+        .iter()
+        .find(|inst| inst.symbol.as_str() == test_symbol)
+        .ok_or_else(|| format!("Instrument {test_symbol} not found in /instruments response"))?;
+
+    let instrument = parse_perp_instrument(
+        maybe_instrument,
+        Decimal::ZERO,
+        Decimal::ZERO,
+        ts_init,
+        ts_init,
+    )
+    .map_err(|e| format!("Failed to parse instrument {test_symbol}: {e}"))?;
+    client.cache_instrument(instrument);
+    log::info!("Cached instrument {test_symbol} for WebSocket parsing");
+
     log::info!("Establishing WebSocket connection...");
     client.connect().await?;
     log::info!("Connected");
 
-    let test_symbol = "EURUSD-PERP";
     log::info!("Subscribing to {test_symbol} quotes and trades...");
     client.subscribe_quotes(test_symbol).await?;
     client.subscribe_trades(test_symbol).await?;


### PR DESCRIPTION
## Summary
- parse and cache instrument metadata from `/instruments` before WS subscriptions in demo binary
- avoid parse failures from missing instrument cache during message handling

## Architect Docs
- Market data WebSocket API (subscription/message formats): https://docs.architect.exchange/api-reference/marketdata/md-ws

## Files
- `crates/adapters/architect_ax/bin/ws_data.rs`

## Testing
- Manual demo flow change.
- Ran: `cargo test -p nautilus-architect-ax --locked`
- Result: PASS on branch `acho/ax-error-07-ws-data-instrument-cache`
