### PR TITLE
Fix OKX HTTP error messages missing rejection reason details

### DIFF
--- a/crates/adapters/okx/src/http/client.rs
+++ b/crates/adapters/okx/src/http/client.rs
@@ -113,6 +113,36 @@ use crate::{
 
 const OKX_SUCCESS_CODE: &str = "0";
 
+fn resolve_okx_error_message(response_body: &[u8], top_level_msg: &str) -> String {
+    let message = top_level_msg.trim();
+    if !message.is_empty() {
+        return message.to_string();
+    }
+
+    if let Ok(payload) = serde_json::from_slice::<serde_json::Value>(response_body)
+        && let Some(first_item) = payload
+            .get("data")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|items| items.first())
+    {
+        if let Some(s_msg) = first_item.get("sMsg").and_then(serde_json::Value::as_str) {
+            let s_msg = s_msg.trim();
+            if !s_msg.is_empty() {
+                return s_msg.to_string();
+            }
+        }
+
+        if let Some(s_code) = first_item.get("sCode").and_then(serde_json::Value::as_str) {
+            let s_code = s_code.trim();
+            if !s_code.is_empty() {
+                return s_code.to_string();
+            }
+        }
+    }
+
+    String::new()
+}
+
 /// Default OKX REST API rate limit: 500 requests per 2 seconds.
 ///
 /// - Sub-account order limit: 1000 requests per 2 seconds.
@@ -476,7 +506,7 @@ impl OKXRawHttpClient {
                     if okx_response.code != OKX_SUCCESS_CODE {
                         return Err(OKXHttpError::OkxError {
                             error_code: okx_response.code,
-                            message: okx_response.msg,
+                            message: resolve_okx_error_message(&resp.body, &okx_response.msg),
                         });
                     }
 
@@ -495,7 +525,7 @@ impl OKXRawHttpClient {
                     if let Ok(parsed_error) = serde_json::from_slice::<OKXResponse<T>>(&resp.body) {
                         return Err(OKXHttpError::OkxError {
                             error_code: parsed_error.code,
-                            message: parsed_error.msg,
+                            message: resolve_okx_error_message(&resp.body, &parsed_error.msg),
                         });
                     }
 

--- a/crates/adapters/okx/tests/http.rs
+++ b/crates/adapters/okx/tests/http.rs
@@ -2127,6 +2127,231 @@ async fn test_http_okx_error_response() {
 
 #[rstest]
 #[tokio::test]
+async fn test_http_okx_error_falls_back_to_s_msg_on_http_200() {
+    let router = Router::new().route(
+        "/api/v5/account/set-position-mode",
+        post(|headers: HeaderMap| async move {
+            if !has_auth_headers(&headers) {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({
+                        "code": "401",
+                        "msg": "Missing authentication headers",
+                        "data": [],
+                    })),
+                )
+                    .into_response();
+            }
+
+            Json(json!({
+                "code": "1",
+                "msg": "",
+                "data": [{
+                    "sCode": "51000",
+                    "sMsg": "Parameter triggerPx error",
+                }],
+            }))
+            .into_response()
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    wait_for_server(addr, "/api/v5/account/set-position-mode").await;
+
+    let base_url = format!("http://{addr}");
+    let client = OKXRawHttpClient::with_credentials(
+        "test_key".to_string(),
+        "test_secret".to_string(),
+        "test_passphrase".to_string(),
+        base_url,
+        Some(60),
+        None,
+        None,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
+
+    let params = SetPositionModeParamsBuilder::default()
+        .pos_mode(OKXPositionMode::LongShortMode)
+        .build()
+        .unwrap();
+    let result = client.set_position_mode(params).await;
+
+    match result {
+        Err(OKXHttpError::OkxError {
+            error_code,
+            message,
+        }) => {
+            assert_eq!(error_code, "1");
+            assert_eq!(message, "Parameter triggerPx error");
+        }
+        other => panic!("expected OkxError: {other:?}"),
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_okx_error_falls_back_to_s_msg_on_http_400() {
+    let router = Router::new().route(
+        "/api/v5/account/set-position-mode",
+        post(|headers: HeaderMap| async move {
+            if !has_auth_headers(&headers) {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({
+                        "code": "401",
+                        "msg": "Missing authentication headers",
+                        "data": [],
+                    })),
+                )
+                    .into_response();
+            }
+
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "code": "1",
+                    "msg": "",
+                    "data": [{
+                        "sCode": "51000",
+                        "sMsg": "Parameter triggerPx error",
+                    }],
+                })),
+            )
+                .into_response()
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    wait_for_server(addr, "/api/v5/account/set-position-mode").await;
+
+    let base_url = format!("http://{addr}");
+    let client = OKXRawHttpClient::with_credentials(
+        "test_key".to_string(),
+        "test_secret".to_string(),
+        "test_passphrase".to_string(),
+        base_url,
+        Some(60),
+        None,
+        None,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
+
+    let params = SetPositionModeParamsBuilder::default()
+        .pos_mode(OKXPositionMode::LongShortMode)
+        .build()
+        .unwrap();
+    let result = client.set_position_mode(params).await;
+
+    match result {
+        Err(OKXHttpError::OkxError {
+            error_code,
+            message,
+        }) => {
+            assert_eq!(error_code, "1");
+            assert_eq!(message, "Parameter triggerPx error");
+        }
+        other => panic!("expected OkxError: {other:?}"),
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_okx_error_falls_back_to_s_code_when_s_msg_empty() {
+    let router = Router::new().route(
+        "/api/v5/account/set-position-mode",
+        post(|headers: HeaderMap| async move {
+            if !has_auth_headers(&headers) {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({
+                        "code": "401",
+                        "msg": "Missing authentication headers",
+                        "data": [],
+                    })),
+                )
+                    .into_response();
+            }
+
+            Json(json!({
+                "code": "1",
+                "msg": "",
+                "data": [{
+                    "sCode": "51008",
+                    "sMsg": "",
+                }],
+            }))
+            .into_response()
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    wait_for_server(addr, "/api/v5/account/set-position-mode").await;
+
+    let base_url = format!("http://{addr}");
+    let client = OKXRawHttpClient::with_credentials(
+        "test_key".to_string(),
+        "test_secret".to_string(),
+        "test_passphrase".to_string(),
+        base_url,
+        Some(60),
+        None,
+        None,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
+
+    let params = SetPositionModeParamsBuilder::default()
+        .pos_mode(OKXPositionMode::LongShortMode)
+        .build()
+        .unwrap();
+    let result = client.set_position_mode(params).await;
+
+    match result {
+        Err(OKXHttpError::OkxError {
+            error_code,
+            message,
+        }) => {
+            assert_eq!(error_code, "1");
+            assert_eq!(message, "51008");
+        }
+        other => panic!("expected OkxError: {other:?}"),
+    }
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_http_malformed_json_response() {
     let router = Router::new().route(
         "/api/v5/public/instruments",


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This fixes OKX HTTP error handling when `msg` is empty by adding a fallback chain: `msg -> data[0].sMsg -> data[0].sCode`.
The change prevents `OrderRejected.reason` from ending up as an empty suffix (for example, `"OKX error 1: "`).
It also adds targeted regression tests for HTTP 200/400 error envelopes and the `sCode` fallback path.

## Related Issues/PRs

Closes #3576

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validated with:
- `cargo test -p nautilus-okx --test http --no-run`
- `cargo test -p nautilus-okx --test http test_http_okx_error_falls_back -- --nocapture`
