### PR TITLE
Refine conversion of feather files to parquet

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -2469,13 +2469,130 @@ class ParquetDataCatalog(BaseDataCatalog):
             if feather_table is None:
                 continue
 
-            file_data = self._handle_table_nautilus(
-                feather_table,
-                data_cls,
-                convert_bar_type_to_external=True,
+            self._convert_feather_table_to_parquet(
+                feather_table=feather_table,
+                feather_path=feather_file.path,
+                data_cls=data_cls,
+                used_catalog=used_catalog,
                 use_ts_event_for_ts_init=use_ts_event_for_ts_init,
             )
-            used_catalog.write_data(file_data)
+
+    def _convert_feather_table_to_parquet(
+        self,
+        feather_table: pa.Table,
+        feather_path: str,
+        data_cls: type,
+        used_catalog: ParquetDataCatalog,
+        use_ts_event_for_ts_init: bool = False,
+    ) -> None:
+        # Apply table-only transforms (no deserialization).
+        table = self._apply_stream_conversion_transforms(
+            feather_table,
+            use_ts_event_for_ts_init=use_ts_event_for_ts_init,
+            convert_bar_type_to_external=True,
+        )
+        if table is None or len(table) == 0:
+            return
+
+        identifier = self._identifier_from_table_or_path(table, data_cls, feather_path)
+        start = int(pa.compute.min(table["ts_init"]).as_py())
+        end = int(pa.compute.max(table["ts_init"]).as_py())
+
+        directory = used_catalog._make_path(data_cls=data_cls, identifier=identifier)
+        used_catalog.fs.mkdirs(directory, exist_ok=True)
+        filename = _timestamps_to_filename(start, end)
+        parquet_file = f"{directory}/{filename}"
+
+        if used_catalog.fs.exists(parquet_file):
+            print(f"File {parquet_file} already exists, skipping write")
+            return
+
+        current_intervals = used_catalog._get_directory_intervals(directory)
+        new_intervals = [*current_intervals, (start, end)]
+        if not _are_intervals_disjoint(new_intervals):
+            raise ValueError(
+                f"Writing file {filename} with interval ({start}, {end}) would create "
+                f"non-disjoint intervals. Existing intervals: {current_intervals}",
+            )
+
+        pq.write_table(
+            table,
+            where=parquet_file,
+            filesystem=used_catalog.fs,
+            row_group_size=used_catalog.max_rows_per_group,
+        )
+
+    @staticmethod
+    def _apply_stream_conversion_transforms(
+        table: pa.Table,
+        use_ts_event_for_ts_init: bool = False,
+        convert_bar_type_to_external: bool = False,
+    ) -> pa.Table:
+        if use_ts_event_for_ts_init:
+            schema = table.schema
+            column_names = schema.names
+            if "ts_event" not in column_names or "ts_init" not in column_names:
+                raise ValueError(
+                    "Both 'ts_event' and 'ts_init' columns must exist in the table "
+                    "to use 'use_ts_event_for_ts_init' option",
+                )
+
+            ts_event_idx = column_names.index("ts_event")
+            ts_init_idx = column_names.index("ts_init")
+            new_arrays = list(table.columns)
+            new_arrays[ts_init_idx] = new_arrays[ts_event_idx]
+            table = pa.Table.from_arrays(new_arrays, schema=schema)
+
+        if convert_bar_type_to_external and table.schema.metadata:
+            metadata = dict(table.schema.metadata)
+            if b"bar_type" in metadata:
+                bar_type_str = metadata[b"bar_type"].decode()
+                if bar_type_str.endswith("-INTERNAL"):
+                    metadata[b"bar_type"] = bar_type_str.replace(
+                        "-INTERNAL",
+                        "-EXTERNAL",
+                    ).encode()
+
+            table = table.replace_schema_metadata(metadata)
+
+        # Enforce ts_init non-decreasing for non-empty tables
+        if len(table) > 0:
+            if "ts_init" not in table.schema.names:
+                raise ValueError(
+                    "Table has no 'ts_init' column; cannot enforce monotonicity",
+                )
+
+            if len(table) > 1:
+                sort_indices = pa.compute.sort_indices(
+                    table,
+                    sort_keys=[("ts_init", "ascending")],
+                )
+                identity = pa.array(range(len(table)), type=pa.uint64())
+                if not sort_indices.equals(identity):
+                    table = table.take(sort_indices)
+
+        return table
+
+    @staticmethod
+    def _identifier_from_table_or_path(
+        table: pa.Table,
+        data_cls: type,
+        feather_path: str,
+    ) -> str | None:
+        metadata = table.schema.metadata or {}
+        if b"bar_type" in metadata:
+            return metadata[b"bar_type"].decode()
+
+        if b"instrument_id" in metadata:
+            return metadata[b"instrument_id"].decode()
+
+        # Fallback: per-instrument feather layout .../data_name/identifier/file.feather
+        parts = feather_path.rstrip("/").split("/")
+        data_name = class_to_filename(data_cls)
+        if len(parts) >= 3 and parts[-3] == data_name:
+            return parts[-2]
+
+        return None
 
     def _read_feather_file(
         self,
@@ -2501,40 +2618,11 @@ class ParquetDataCatalog(BaseDataCatalog):
         if isinstance(table, pd.DataFrame):
             table = pa.Table.from_pandas(table)
 
-        # Replace ts_init column with ts_event if requested
-        if use_ts_event_for_ts_init:
-            schema = table.schema
-            column_names = schema.names
-
-            if "ts_event" not in column_names or "ts_init" not in column_names:
-                raise ValueError(
-                    "Both 'ts_event' and 'ts_init' columns must exist in the table "
-                    "to use 'use_ts_event_for_ts_init' option",
-                )
-
-            ts_event_idx = column_names.index("ts_event")
-            ts_init_idx = column_names.index("ts_init")
-
-            # Create new arrays with ts_init replaced by ts_event
-            new_arrays = list(table.columns)
-            new_arrays[ts_init_idx] = new_arrays[ts_event_idx]
-
-            # Create new table with updated arrays
-            table = pa.Table.from_arrays(new_arrays, schema=schema)
-
-        # Convert metadata from INTERNAL to EXTERNAL if requested
-        if convert_bar_type_to_external and table.schema.metadata:
-            metadata = dict(table.schema.metadata)
-
-            # Convert bar_type metadata (for Bar data)
-            if b"bar_type" in metadata:
-                bar_type_str = metadata[b"bar_type"].decode()
-
-                if bar_type_str.endswith("-INTERNAL"):
-                    metadata[b"bar_type"] = bar_type_str.replace("-INTERNAL", "-EXTERNAL").encode()
-
-            # Replace schema with updated metadata (shallow copy)
-            table = table.replace_schema_metadata(metadata)
+        table = ParquetDataCatalog._apply_stream_conversion_transforms(
+            table,
+            use_ts_event_for_ts_init=use_ts_event_for_ts_init,
+            convert_bar_type_to_external=convert_bar_type_to_external,
+        )
 
         data = ArrowSerializer.deserialize(data_cls=data_cls, batch=table)
         if len(data) == 0:

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -456,7 +456,7 @@ class StreamingFeatherWriter:
 
         self.log.info(f"Created writer for table '{table_name}'")
 
-    def _extract_obj_metadata(
+    def _extract_obj_metadata(  # noqa: C901
         self,
         obj: TradeTick
         | QuoteTick
@@ -466,6 +466,7 @@ class StreamingFeatherWriter:
         | FundingRateUpdate
         | object,
     ) -> dict[bytes, bytes]:
+        # Derive instrument_id and (when possible) precision from the object to match catalog/Rust metadata.
         if isinstance(obj, Bar):
             instrument_id = obj.bar_type.instrument_id
         elif hasattr(obj, "instrument_id"):
@@ -475,20 +476,70 @@ class StreamingFeatherWriter:
                 f"Object of type '{type(obj).__name__}' does not have an instrument_id attribute",
             )
 
-        instrument = self.cache.instrument(instrument_id)
         metadata = {b"instrument_id": instrument_id.value.encode()}
 
         if isinstance(obj, Bar):
             metadata.update(
                 {
                     b"bar_type": str(obj.bar_type).encode(),
-                    b"price_precision": str(instrument.price_precision).encode(),
-                    b"size_precision": str(instrument.size_precision).encode(),
+                    b"price_precision": str(obj.open.precision).encode(),
+                    b"size_precision": str(obj.volume.precision).encode(),
                 },
             )
+        elif isinstance(obj, QuoteTick):
+            metadata.update(
+                {
+                    b"price_precision": str(obj.bid_price.precision).encode(),
+                    b"size_precision": str(obj.bid_size.precision).encode(),
+                },
+            )
+        elif isinstance(obj, TradeTick):
+            metadata.update(
+                {
+                    b"price_precision": str(obj.price.precision).encode(),
+                    b"size_precision": str(obj.size.precision).encode(),
+                },
+            )
+        elif isinstance(obj, OrderBookDelta):
+            metadata.update(
+                {
+                    b"price_precision": str(obj.order.price.precision).encode(),
+                    b"size_precision": str(obj.order.size.precision).encode(),
+                },
+            )
+        elif isinstance(obj, OrderBookDepth10):
+            if obj.bids:
+                first_bid = obj.bids[0]
+                metadata.update(
+                    {
+                        b"price_precision": str(first_bid.price.precision).encode(),
+                        b"size_precision": str(first_bid.size.precision).encode(),
+                    },
+                )
+            else:
+                instrument = self.cache.instrument(instrument_id)
+                if instrument is None:
+                    raise ValueError(
+                        f"Cannot determine precision for OrderBookDepth10 with empty bids: "
+                        f"instrument '{instrument_id}' not found in cache",
+                    )
+                metadata.update(
+                    {
+                        b"price_precision": str(instrument.price_precision).encode(),
+                        b"size_precision": str(instrument.size_precision).encode(),
+                    },
+                )
         elif isinstance(obj, FundingRateUpdate):
+            # FundingRateUpdate only has instrument_id in Rust metadata; no precision.
             pass
         else:
+            # Fallback for custom or legacy types: use cache
+            instrument = self.cache.instrument(instrument_id)
+            if instrument is None:
+                raise ValueError(
+                    f"Cannot determine precision for type '{type(obj).__name__}': "
+                    f"instrument '{instrument_id}' not found in cache",
+                )
             metadata.update(
                 {
                     b"price_precision": str(instrument.price_precision).encode(),

--- a/tests/unit_tests/persistence/test_streaming.py
+++ b/tests/unit_tests/persistence/test_streaming.py
@@ -16,6 +16,9 @@
 import copy
 from collections import Counter
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from nautilus_trader.backtest.node import BacktestNode
 from nautilus_trader.backtest.results import BacktestResult
 from nautilus_trader.cache.cache import Cache
@@ -747,3 +750,72 @@ class TestPersistenceStreaming:
         # Original values were: ts_event=3_000_000_000, ts_init=3_300_000_000
         assert trade_ticks[2].ts_event == 3_000_000_000
         assert trade_ticks[2].ts_init == trade_ticks[2].ts_event
+
+    def test_convert_stream_to_data_preserves_feather_schema_in_parquet(
+        self,
+        catalog_betfair: ParquetDataCatalog,
+    ) -> None:
+        # Arrange: write bar to feather then convert to parquet (direct table write).
+        self.catalog = catalog_betfair
+        clock = TestClock()
+        cache = Cache()
+        instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD")
+        cache.add_instrument(instrument)
+
+        instance_id = "test_instance_schema_match"
+        writer = StreamingFeatherWriter(
+            path=f"{self.catalog.path}/backtest/{instance_id}",
+            cache=cache,
+            clock=clock,
+            fs_protocol="file",
+            include_types=[Bar],
+        )
+
+        bar_spec = BarSpecification(1, BarAggregation.MINUTE, PriceType.BID)
+        bar_type_internal = BarType(
+            instrument.id,
+            bar_spec,
+            AggregationSource.INTERNAL,
+        )
+        bar = Bar(
+            bar_type=bar_type_internal,
+            open=Price.from_str("1.00002"),
+            high=Price.from_str("1.00004"),
+            low=Price.from_str("1.00001"),
+            close=Price.from_str("1.00003"),
+            volume=Quantity.from_int(1_000_000),
+            ts_event=1000,
+            ts_init=1000,
+        )
+        writer.write(bar)
+        writer.close()
+
+        feather_files = list(
+            self.catalog.fs.glob(
+                f"{self.catalog.path}/backtest/{instance_id}/bar/**/*.feather",
+            ),
+        )
+        assert len(feather_files) >= 1
+        feather_path = feather_files[0]
+
+        with self.catalog.fs.open(feather_path) as f:
+            feather_table = pa.ipc.open_stream(f).read_all()
+        transformed_feather_table = ParquetDataCatalog._apply_stream_conversion_transforms(
+            feather_table,
+            use_ts_event_for_ts_init=False,
+            convert_bar_type_to_external=True,
+        )
+
+        self.catalog.convert_stream_to_data(instance_id, Bar)
+
+        parquet_files = list(
+            self.catalog.fs.glob(f"{self.catalog.path}/data/bar/**/*.parquet"),
+        )
+        assert len(parquet_files) >= 1
+        with self.catalog.fs.open(parquet_files[0]) as f:
+            parquet_table = pq.read_table(f)
+
+        assert parquet_table.schema.equals(
+            transformed_feather_table.schema,
+            check_metadata=True,
+        )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Summary

- **Feather-to-parquet conversion:** Converts streamed feather files to parquet by writing directly from the in-memory Arrow table instead of deserializing to Nautilus objects and calling `write_data`. A new `_convert_feather_table_to_parquet` applies table-only transforms (ts_init, bar type externalization), derives identifier and time range from the table, enforces disjoint intervals, and writes parquet with the catalog’s row group size.
- **Table-only transforms:** `_apply_stream_conversion_transforms` centralizes stream conversion (e.g. `use_ts_event_for_ts_init`, `convert_bar_type_to_external`). `_identifier_from_table_or_path` derives the catalog identifier from table metadata (bar_type, instrument_id) or from the per-instrument path layout.
- **Feather metadata:** `StreamingFeatherWriter` now sets `price_precision` and `size_precision` from the written object (Bar, QuoteTick, TradeTick, OrderBookDelta, OrderBookDepth10) when available, so metadata matches the data and aligns with catalog/Rust. Falls back to the instrument cache for OrderBookDepth10 when there are no bids and for other types; FundingRateUpdate is unchanged (no precision in metadata).

## Test plan

- New unit test `test_convert_stream_to_data_preserves_feather_schema_in_parquet`: writes a bar to feather, runs `convert_stream_to_data`, and asserts the resulting parquet schema and metadata match the transformed feather table.
- Rely on existing persistence/streaming tests and CI.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
