### PR TITLE
Migrate IB adapter to ibapi 10.43.2

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -140,8 +140,8 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
 
         """
         self._eclient.reset()
-        self._eclient._host = self._host
-        self._eclient._port = self._port
+        self._eclient.host = self._host
+        self._eclient.port = self._port
         self._eclient.clientId = self._client_id
 
     async def _connect_socket(self) -> None:

--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -234,6 +234,7 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
     minSize: Decimal = UNSET_DECIMAL
     sizeIncrement: Decimal = UNSET_DECIMAL
     suggestedSizeIncrement: Decimal = UNSET_DECIMAL
+    minAlgoSize: Decimal = UNSET_DECIMAL
 
     # BOND values
     cusip: str = ""
@@ -273,6 +274,9 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
     )
     fundAssetType: FundAssetType = FundAssetType.NoneItem
     ineligibilityReasonList: list = None
+    eventContract1: str = ""
+    eventContractDescription1: str = ""
+    eventContractDescription2: str = ""
 
 
 def dict_to_contract_details(dict_details: dict) -> IBContractDetails:
@@ -289,7 +293,7 @@ def dict_to_contract_details(dict_details: dict) -> IBContractDetails:
 
     # Deserialize Decimal fields from strings back to Decimal objects
     # These fields are known to be Decimal type in IBContractDetails
-    decimal_fields = ["minSize", "sizeIncrement", "suggestedSizeIncrement"]
+    decimal_fields = ["minSize", "sizeIncrement", "suggestedSizeIncrement", "minAlgoSize"]
     for field in decimal_fields:
         if field in details_copy and isinstance(details_copy[field], str):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,8 @@ generate-setup-file = false
 betfair = ["betfair-parser==0.19.1"] # Pinned to 0.19.1 for stability
 ib = [
   "defusedxml>=0.7.1,<1.0.0; python_version < '3.14'",
-  "nautilus-ibapi==10.37.2; python_version < '3.14'",
+  "nautilus-ibapi==10.43.2; python_version < '3.14'",
+  "protobuf>=5.29.5; python_version < '3.14'",
 ]
 docker = ["docker>=7.1.0,<8.0.0"]
 dydx = [

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -206,6 +206,9 @@ def data_client(data_client_config, venue, event_loop, msgbus, cache, clock):
     client._client._is_ib_connected.set()
     client._client._connect = AsyncMock()
     client._client._account_ids = {"DU123456"}
+    client._client._eclient.serverVersion_ = (
+        0  # ibapi 10.43 needs serverVersion_ set for useProtoBuf()
+    )
     return client
 
 
@@ -230,6 +233,9 @@ def exec_client(exec_client_config, venue, event_loop, msgbus, cache, clock):
     client._client._is_ib_connected.set()
     client._client._connect = AsyncMock()
     client._client._account_ids = {"DU123456"}
+    client._client._eclient.serverVersion_ = (
+        0  # ibapi 10.43 needs serverVersion_ set for useProtoBuf()
+    )
     return client
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1612,11 +1612,11 @@ wheels = [
 
 [[package]]
 name = "nautilus-ibapi"
-version = "10.37.2"
+version = "10.43.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/13/bbadf2c1216533053b2d29841107ae4a6d9eabbe4cd2bf4048503ee6ed65/nautilus_ibapi-10.37.2.tar.gz", hash = "sha256:5e498f5c8d83849c38eab1930926e33cd393d730f64835cb27af657a20e5528d", size = 90528, upload-time = "2025-08-26T08:28:20.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/a7/cd2c00d99a2500a9fde23db64bbe5588e396cd13f933dd9973a6edb27fd0/nautilus_ibapi-10.43.2.tar.gz", hash = "sha256:e7d9b0c14c81f44f88815a27ac543ac93d22ead08d14cd4d3d336b31ec3f1753", size = 154445, upload-time = "2026-02-11T21:38:40.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/71/cf8cb1f9fc6a3af902939405cfadfc09f154895f6a0830a2bcc95b5a2d07/nautilus_ibapi-10.37.2-py3-none-any.whl", hash = "sha256:7c665ce6ad85c550e7c2050d0c85ee446de5b35bf2ced07532b9a12470a78a5d", size = 117567, upload-time = "2025-08-26T08:28:19.511Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/b810d53eea98bbc29c0cd6ba06ffe942bdbe22e0c09582df4a6741b119c3/nautilus_ibapi-10.43.2-py3-none-any.whl", hash = "sha256:2afa9f42bc9f662dea0938829a1261c04edc42ecabbee9b06a27d5494b1113dc", size = 325562, upload-time = "2026-02-11T21:38:38.763Z" },
 ]
 
 [[package]]
@@ -1655,6 +1655,7 @@ dydx = [
 ib = [
     { name = "defusedxml", marker = "python_full_version < '3.14'" },
     { name = "nautilus-ibapi", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
 ]
 polymarket = [
     { name = "py-clob-client" },
@@ -1707,12 +1708,13 @@ requires-dist = [
     { name = "fsspec", specifier = ">=2025.2.0,<=2026.1.0" },
     { name = "grpcio", marker = "python_full_version < '3.14' and extra == 'dydx'", specifier = "==1.68.1" },
     { name = "msgspec", specifier = ">=0.20.0,<1.0.0" },
-    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.37.2" },
+    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.43.2" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pandas", specifier = ">=2.3.3,<3.0.0" },
     { name = "plotly", marker = "extra == 'visualization'", specifier = ">=6.3.1,<7.0.0" },
     { name = "portion", specifier = ">=2.6.1" },
     { name = "protobuf", marker = "python_full_version < '3.14' and extra == 'dydx'", specifier = "==5.29.5" },
+    { name = "protobuf", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = ">=5.29.5" },
     { name = "py-clob-client", marker = "extra == 'polymarket'", specifier = ">=0.34.5,<1.0.0" },
     { name = "pyarrow", specifier = ">=22.0.0" },
     { name = "pycryptodome", marker = "python_full_version < '3.14' and extra == 'dydx'", specifier = ">=3.20.0,<4.0.0" },


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Migrate Interactive Brokers adapter to ibapi 10.43

Upgrades the IB adapter dependency from `nautilus-ibapi` 10.37.2 to 10.43.2, bringing protobuf message support, new contract/order fields, and compatibility with the latest TWS API.

### Changes

- **Dependency upgrade**: Bump `nautilus-ibapi` from 10.37.2 to 10.43.2 and add `protobuf>=5.29.5` as a required dependency for the `ib` extra, since ibapi 10.43's decoder imports protobuf-generated modules at the module level.

- **EClient attribute rename**: Update `_initialize_connection_params()` in `client/connection.py` to use `self._eclient.host` / `self._eclient.port` (public attributes) instead of the previous `self._eclient._host` / `self._eclient._port` (private attributes), matching the attribute naming change in ibapi 10.43's `EClient`.

- **New IBContractDetails fields**: Add `minAlgoSize` (Decimal), `eventContract1`, `eventContractDescription1`, and `eventContractDescription2` (str) to `IBContractDetails` in `common.py` to match the fields added to ibapi 10.43's `ContractDetails`. Also include `minAlgoSize` in the decimal deserialization list within `dict_to_contract_details`.

- **Test fixture fix**: Set `serverVersion_ = 0` on the mocked `EClient` instances in the `data_client` and `exec_client` test fixtures. ibapi 10.43 added `useProtoBuf()` guard checks to nearly all `EClient` methods, which compare `serverVersion_` against protobuf version thresholds. When `serverVersion_` is `None` (the default for an unconnected EClient), this comparison raises `TypeError`. Setting it to `0` ensures `useProtoBuf()` returns `False` in tests, preserving the legacy code path.

### Non-breaking additions available in ibapi 10.43 (for future use)

- Full protobuf message support (transparent via decoder).
- New EWrapper callbacks: `userInfo()`, `currentTimeInMillis()`.
- New Order fields: `slOrderId`, `slOrderType`, `ptOrderId`, `ptOrderType`, `whatIfType`, `submitter`, `manualOrderIndicator`.
- New Execution field: `optExerciseOrLapseType` with `OptionExerciseType` enum.
- Server versions up to `MIN_SERVER_VER_CONFIG = 219`.
- New modules: `client_utils`, `decoder_utils`, `sync_wrapper`, `ineligibility_reason`, `protobuf/`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3561

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
