### PR TITLE
Fix missing raise and divide-by-zero guards

### DIFF
--- a/nautilus_trader/indicators/momentum.pyx
+++ b/nautilus_trader/indicators/momentum.pyx
@@ -627,7 +627,10 @@ cdef class CommodityChannelIndex(Indicator):
             mean=self._ma.value,
         )
         if self._ma.initialized:
-            self.value = (typical_price - self._ma.value) / (self.scalar * self._mad)
+            if self._mad > 0:
+                self.value = (typical_price - self._ma.value) / (self.scalar * self._mad)
+            else:
+                self.value = 0.0
 
         # Initialization logic
         if not self.initialized:
@@ -816,8 +819,10 @@ cdef class RelativeVolatilityIndex(Indicator):
                 self._pos_ma.update_raw(0)
                 self._neg_ma.update_raw(0)
 
-            self.value = self.scalar * self._pos_ma.value
-            self.value = self.value / (self._pos_ma.value + self._neg_ma.value)
+            if self._pos_ma.value + self._neg_ma.value == 0.0:
+                self.value = 0.0
+            else:
+                self.value = self.scalar * self._pos_ma.value / (self._pos_ma.value + self._neg_ma.value)
 
 
         self._previous_close = close

--- a/nautilus_trader/model/instruments/base.pyx
+++ b/nautilus_trader/model/instruments/base.pyx
@@ -872,6 +872,6 @@ cpdef list[Instrument] instruments_from_pyo3(list pyo3_instruments):
         elif isinstance(pyo3_instrument, nautilus_pyo3.OptionSpread):
             instruments.append(OptionSpread.from_pyo3_c(pyo3_instrument))
         else:
-            RuntimeError(f"Instrument {pyo3_instrument} not supported")
+            raise RuntimeError(f"Instrument {pyo3_instrument} not supported")
 
     return instruments

--- a/tests/unit_tests/indicators/test_cci.py
+++ b/tests/unit_tests/indicators/test_cci.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-import numpy as np
-
 from nautilus_trader.indicators import CommodityChannelIndex
 from nautilus_trader.test_kit.providers import TestInstrumentProvider
 from nautilus_trader.test_kit.stubs.data import TestDataStubs
@@ -47,7 +45,7 @@ class TestCommodityChannelIndex:
         assert self.cci.has_inputs
         assert self.cci.scalar == 0.015
         assert self.cci._mad == 0
-        assert np.isnan(self.cci.value)
+        assert self.cci.value == 0
 
     def test_value_with_one_input(self):
         self.cci.update_raw(0.18000, 0.01001, 0.13810)


### PR DESCRIPTION
Fixes #3593

## Changes

### 1. Missing `raise` before `RuntimeError` — `instruments/base.pyx:875`
`instruments_from_pyo3` constructs the exception but never raises it, silently dropping unsupported instrument types.

```python
# Before
RuntimeError(f"Instrument {pyo3_instrument} not supported")
# After
raise RuntimeError(f"Instrument {pyo3_instrument} not supported")
```

### 2. CCI divide-by-zero — `indicators/momentum.pyx:630`
When all prices in the window are identical, MAD is 0, causing `ZeroDivisionError`.

```python
# Before
self.value = (typical_price - self._ma.value) / (self.scalar * self._mad)
# After
if self._mad > 0:
    self.value = (typical_price - self._ma.value) / (self.scalar * self._mad)
else:
    self.value = 0.0
```

### 3. RVI divide-by-zero — `indicators/momentum.pyx:819-820`
When both pos/neg MAs are 0 (constant prices → zero std dev), the divisor is 0. Guard follows the same pattern used by `ChandeMomentumOscillator` (lines 300-306).

```python
# Before
self.value = self.scalar * self._pos_ma.value
self.value = self.value / (self._pos_ma.value + self._neg_ma.value)
# After
if self._pos_ma.value + self._neg_ma.value == 0.0:
    self.value = 0.0
else:
    self.value = self.scalar * self._pos_ma.value / (self._pos_ma.value + self._neg_ma.value)
```

### 4. Test update — `test_cci.py`
Updated `test_handle_bar_updates_indicator` to expect `0` instead of `NaN` when MAD is zero (consistent with the existing `test_value_with_one_input` which already asserts `value == 0` for the same condition). Removed unused `numpy` import.