### PR TITLE
Add Interactive Brokers configurable request_timeout to clients

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -35,6 +35,7 @@ This will be the final release with support for the dYdX v3 (legacy) API. Future
 - Added Databento bulk subscription and historical request support (#3490), thanks @shzhng
 - Added Interactive Brokers subscribe index price functionality (#3514), thanks @Murph24
 - Added Interactive Brokers `TotalCashValue` to account summary `info` dict, exposing actual cash balance (#3567), thanks @shzhng
+- Added Interactive Brokers `request_timeout` config to `InteractiveBrokersExecClientConfig` and consolidated all IB request timeouts into a single configurable value, thanks @shzhng
 - Added OKX batch cancel support for conditional (algo) orders
 - Added Polymarket data loader event-level API support (#3484), thanks @jsemldonado
 - Added Polymarket `event_slug_builder` support (#3501), thanks @jsemldonado

--- a/nautilus_trader/adapters/interactive_brokers/client/account.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/account.py
@@ -163,9 +163,9 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
                 return []
 
             request.handle()
-            all_positions = await self._await_request(request, 30)
+            all_positions = await self._await_request(request, self._request_timeout)
         else:
-            all_positions = await self._await_request(request, 30)
+            all_positions = await self._await_request(request, self._request_timeout)
 
         if not all_positions:
             return []

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -95,6 +95,7 @@ class InteractiveBrokersClient(
         port: int = 7497,
         client_id: int = 1,
         fetch_all_open_orders: bool = False,
+        request_timeout: int = 60,
     ) -> None:
         super().__init__(
             clock=clock,
@@ -110,6 +111,7 @@ class InteractiveBrokersClient(
         self._port = port
         self._client_id = client_id
         self._fetch_all_open_orders = fetch_all_open_orders
+        self._request_timeout = request_timeout
 
         # TWS API
         self._eclient: EClient = EClient(

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -526,6 +526,7 @@ class BaseMixin:
     _host: str
     _port: int
     _client_id: int
+    _request_timeout: int
     _requests: Requests
     _instrument_provider: (
         Any  # InteractiveBrokersInstrumentProvider | None - Will be set by data/execution client

--- a/nautilus_trader/adapters/interactive_brokers/client/contract.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/contract.py
@@ -68,9 +68,17 @@ class InteractiveBrokersClientContractMixin(BaseMixin):
 
             request.handle()
 
-            return await self._await_request(request, 10, suppress_timeout_warning=True)
+            return await self._await_request(
+                request,
+                self._request_timeout,
+                suppress_timeout_warning=True,
+            )
         else:
-            return await self._await_request(request, 10, suppress_timeout_warning=True)
+            return await self._await_request(
+                request,
+                self._request_timeout,
+                suppress_timeout_warning=True,
+            )
 
     async def get_matching_contracts(self, pattern: str) -> list[IBContract] | None:
         """
@@ -105,7 +113,7 @@ class InteractiveBrokersClientContractMixin(BaseMixin):
 
             request.handle()
 
-            return await self._await_request(request, 20)
+            return await self._await_request(request, self._request_timeout)
         else:
             self._log.info(f"Request already exist for {request}")
             return None
@@ -146,7 +154,7 @@ class InteractiveBrokersClientContractMixin(BaseMixin):
 
             request.handle()
 
-            return await self._await_request(request, 20)
+            return await self._await_request(request, self._request_timeout)
         else:
             self._log.info(f"Request already exist for {request}")
             return None

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -148,7 +148,7 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
 
             request.handle()
 
-        all_orders: list[IBOrder] | None = await self._await_request(request, 30)
+        all_orders: list[IBOrder] | None = await self._await_request(request, self._request_timeout)
 
         if all_orders:
             orders: list[IBOrder] = [order for order in all_orders if order.account == account_id]
@@ -206,7 +206,10 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             request.handle()
 
         # Wait for execution details to be collected
-        execution_details: list[dict] | None = await self._await_request(request, 30)
+        execution_details: list[dict] | None = await self._await_request(
+            request,
+            self._request_timeout,
+        )
 
         if execution_details:
             # Filter by account if needed (in case filter didn't work perfectly)

--- a/nautilus_trader/adapters/interactive_brokers/config.py
+++ b/nautilus_trader/adapters/interactive_brokers/config.py
@@ -223,7 +223,8 @@ class InteractiveBrokersDataClientConfig(LiveDataClientConfig, frozen=True):
     connection_timeout : int, default 300
         The timeout (seconds) to wait for the client connection to be established.
     request_timeout : int, default 60
-        The timeout (seconds) to wait for a historical data response.
+        The timeout (seconds) to wait for a historical data response. Also used for
+        contract detail lookups — increase this when requesting large option chains.
 
     """
 
@@ -262,6 +263,9 @@ class InteractiveBrokersExecClientConfig(LiveExecClientConfig, frozen=True):
         The client's gateway container configuration.
     connection_timeout : int, default 300
         The timeout (seconds) to wait for the client connection to be established.
+    request_timeout : int, default 60
+        The timeout (seconds) to wait for request responses (contract details, etc.).
+        Increase this when requesting large option chains.
     fetch_all_open_orders : bool, default False
         If True, uses reqAllOpenOrders to fetch orders from all API clients and TWS GUI.
         If False, uses reqOpenOrders to fetch only orders from current client ID session.
@@ -281,5 +285,6 @@ class InteractiveBrokersExecClientConfig(LiveExecClientConfig, frozen=True):
     account_id: str | None = None
     dockerized_gateway: DockerizedIBGatewayConfig | None = None
     connection_timeout: int = 300
+    request_timeout: int = 60
     fetch_all_open_orders: bool = False
     track_option_exercise_from_position_update: bool = False

--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -111,7 +111,6 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         config: InteractiveBrokersDataClientConfig,
         name: str | None = None,
         connection_timeout: int = 300,
-        request_timeout: int = 60,
     ) -> None:
         super().__init__(
             loop=loop,
@@ -124,7 +123,6 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             config=config,
         )
         self._connection_timeout = connection_timeout
-        self._request_timeout = request_timeout
         self._client = client
         self._handle_revised_bars = config.handle_revised_bars
         self._use_regular_trading_hours = config.use_regular_trading_hours
@@ -433,7 +431,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             end_date_time=end,
             limit=request.limit,
             use_rth=self._use_regular_trading_hours,
-            timeout=self._request_timeout,
+            timeout=self._client._request_timeout,
         )
         if not ticks:
             self._log.warning(f"No quote tick data received for {request.instrument_id}")
@@ -471,7 +469,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             end_date_time=end,
             limit=request.limit,
             use_rth=self._use_regular_trading_hours,
-            timeout=self._request_timeout,
+            timeout=self._client._request_timeout,
         )
         if not ticks:
             self._log.warning(f"No trades received for {request.instrument_id}")
@@ -623,7 +621,7 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             end_date_time=request.end,
             duration=duration_str,
             use_rth=self._use_regular_trading_hours,
-            timeout=self._request_timeout,
+            timeout=self._client._request_timeout,
         )
 
         if bars:

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -54,6 +54,7 @@ def get_cached_ib_client(
     client_id: int = 1,
     dockerized_gateway: DockerizedIBGatewayConfig | None = None,
     fetch_all_open_orders: bool = False,
+    request_timeout: int = 60,
 ) -> InteractiveBrokersClient:
     """
     Retrieve or create a cached InteractiveBrokersClient using the provided key.
@@ -87,6 +88,8 @@ def get_cached_ib_client(
     fetch_all_open_orders : bool, default False
         If True, uses reqAllOpenOrders to fetch orders from all API clients and TWS GUI.
         If False, uses reqOpenOrders to fetch only orders from current client ID session.
+    request_timeout : int, default 60
+        The timeout (seconds) to wait for request responses (contract details, etc.).
 
     Returns
     -------
@@ -126,6 +129,7 @@ def get_cached_ib_client(
             port=port,
             client_id=client_id,
             fetch_all_open_orders=fetch_all_open_orders,
+            request_timeout=request_timeout,
         )
         client.start()
         IB_CLIENTS[client_key] = client
@@ -224,6 +228,7 @@ class InteractiveBrokersLiveDataClientFactory(LiveDataClientFactory):
             port=config.ibg_port,
             client_id=config.ibg_client_id,
             dockerized_gateway=config.dockerized_gateway,
+            request_timeout=config.request_timeout,
         )
 
         # Get instrument provider singleton
@@ -245,7 +250,6 @@ class InteractiveBrokersLiveDataClientFactory(LiveDataClientFactory):
             config=config,
             name=name,
             connection_timeout=config.connection_timeout,
-            request_timeout=config.request_timeout,
         )
 
         return data_client
@@ -298,6 +302,7 @@ class InteractiveBrokersLiveExecClientFactory(LiveExecClientFactory):
             client_id=config.ibg_client_id,
             dockerized_gateway=config.dockerized_gateway,
             fetch_all_open_orders=config.fetch_all_open_orders,
+            request_timeout=config.request_timeout,
         )
 
         # Get instrument provider singleton


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Consolidate all hardcoded IB request timeouts (contract details, matching contracts, option chains, positions, orders, executions) into a single configurable `request_timeout` on `InteractiveBrokersClient`. Add `request_timeout` to `InteractiveBrokersExecClientConfig` (default 60s) to match the existing field on `InteractiveBrokersDataClientConfig`. Remove the duplicate `_request_timeout` from `InteractiveBrokersDataClient` so all requests read from the shared client.

Previous hardcoded values were 10s for contract details and 20s for matching contracts/option chains, which could cause timeouts when requesting large option chains.

## Related Issues/PRs

Related to #3599

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Existing IB integration tests cover the affected code paths. The change is backwards compatible — the default timeout (60s) is equal to or greater than all previous hardcoded values.