### PR TITLE
Add Databento support for conversion of OPRA venues

### DIFF
--- a/crates/adapters/databento/src/loader.rs
+++ b/crates/adapters/databento/src/loader.rs
@@ -41,6 +41,32 @@ use super::{
 };
 use crate::{decode::decode_instrument_def_msg, symbology::MetadataCache};
 
+/// Applies default venue-to-dataset mappings for consolidated Databento feeds.
+/// GLBX.MDP3 covers CME Globex exchange MICs; OPRA.PILLAR covers OPRA option venues.
+fn apply_default_venue_dataset_mappings(venue_dataset_map: &mut IndexMap<Venue, Dataset>) {
+    let glbx = Dataset::from("GLBX.MDP3");
+    for venue in [
+        Venue::CBCM(),
+        Venue::GLBX(),
+        Venue::NYUM(),
+        Venue::XCBT(),
+        Venue::XCEC(),
+        Venue::XCME(),
+        Venue::XFXS(),
+        Venue::XNYM(),
+    ] {
+        _ = venue_dataset_map.insert(venue, glbx);
+    }
+
+    let opra = Dataset::from("OPRA.PILLAR");
+    for venue_code in [
+        "AMXO", "XBOX", "XCBO", "EMLD", "EDGO", "GMNI", "XISX", "MCRY", "XMIO", "ARCO", "OPRA",
+        "MPRL", "XNDQ", "XBXO", "C2OX", "XPHL", "BATO", "MXOP", "SPHR",
+    ] {
+        _ = venue_dataset_map.insert(Venue::from(venue_code), opra);
+    }
+}
+
 /// A Nautilus data loader for Databento Binary Encoding (DBN) format data.
 ///
 /// # Supported Schemas
@@ -137,17 +163,7 @@ impl DatabentoDataLoader {
         }
 
         self.venue_dataset_map = venue_dataset_map;
-
-        // Insert CME Globex exchanges
-        let glbx = Dataset::from("GLBX.MDP3");
-        self.venue_dataset_map.insert(Venue::CBCM(), glbx);
-        self.venue_dataset_map.insert(Venue::GLBX(), glbx);
-        self.venue_dataset_map.insert(Venue::NYUM(), glbx);
-        self.venue_dataset_map.insert(Venue::XCBT(), glbx);
-        self.venue_dataset_map.insert(Venue::XCEC(), glbx);
-        self.venue_dataset_map.insert(Venue::XCME(), glbx);
-        self.venue_dataset_map.insert(Venue::XFXS(), glbx);
-        self.venue_dataset_map.insert(Venue::XNYM(), glbx);
+        apply_default_venue_dataset_mappings(&mut self.venue_dataset_map);
 
         self.publisher_venue_map = publishers
             .into_iter()
@@ -808,6 +824,17 @@ mod tests {
 
         let result = loader.get_dataset_for_venue(&venue).unwrap();
         assert_eq!(*result, dataset);
+    }
+
+    #[rstest]
+    fn test_default_venue_dataset_mappings(loader: DatabentoDataLoader) {
+        let xcme = Venue::XCME();
+        let result = loader.get_dataset_for_venue(&xcme).unwrap();
+        assert_eq!(*result, Ustr::from("GLBX.MDP3"));
+
+        let xcbo = Venue::from("XCBO");
+        let result = loader.get_dataset_for_venue(&xcbo).unwrap();
+        assert_eq!(*result, Ustr::from("OPRA.PILLAR"));
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

# PR Summary: Databento venue-to-dataset config as code

## Overview

Generalize the hardcoded GLBX venue-to-dataset mapping in the Databento loader by adding OPRA and exposing both in a single in-code function. Venues like XCME map to the GLBX.MDP3 dataset and OPRA venues (e.g. XCBO) map to OPRA.PILLAR, so both work out of the box for live and historical data without user config.

## Changes

- **Rust loader ([crates/adapters/databento/src/loader.rs](nautilus_trader/crates/adapters/databento/src/loader.rs))**
  - Added `apply_default_venue_dataset_mappings()` which inserts default venue → dataset entries for:
    - **GLBX.MDP3:** CBCM, GLBX, NYUM, XCBT, XCEC, XCME, XFXS, XNYM (CME Globex).
    - **OPRA.PILLAR:** AMXO, XBOX, XCBO, EMLD, EDGO, GMNI, XISX, MCRY, XMIO, ARCO, OPRA, MPRL, XNDQ, XBXO, C2OX, XPHL, BATO, MXOP, SPHR.
  - Replaced the previous inline GLBX block in `load_publishers()` with a call to this function.
- **Tests**
  - Added `test_default_venue_dataset_mappings` asserting XCME → GLBX.MDP3 and XCBO → OPRA.PILLAR.
- **Config**
  - No new config options. Existing `venue_dataset_map` in `DatabentoDataClientConfig` still overrides or extends these defaults via `set_dataset_for_venue` in the Python loader.

## How the two directions work

Databento integration uses two separate mappings; both are required for correct behaviour and only one was extended in this PR.

### Direction 1: Venue → Dataset (which feed to use)

- **Purpose:** When the user (or system) refers to a Nautilus venue (e.g. XCBO, XCME), we need to know which Databento *dataset* to request or subscribe to.
- **Mechanism:** `venue_dataset_map` on the loader (and in config). Implemented by building the map from [publishers.json](nautilus_trader/nautilus_trader/adapters/databento/publishers.json) and then applying `apply_default_venue_dataset_mappings()` so that:
  - CME exchange MICs (XCME, XCBT, etc.) map to **GLBX.MDP3** even though publishers.json only lists GLBX as a venue for that dataset.
  - All OPRA option venues map to **OPRA.PILLAR** for consistency and so any OPRA venue resolves without relying on iteration order in publishers.
- **Used by:** Subscription and request handling in the data client (Python and Rust): e.g. `get_dataset_for_venue(instrument_id.venue)` to choose the dataset for historical or live requests.
- **Scope of this PR:** This is the direction that was generalized (GLBX + OPRA defaults in one function).

### Direction 2: Publisher / feed → Venue (which venue to put on incoming data)

- **Purpose:** When a message arrives from Databento, we need to assign a Nautilus *venue* to the instrument or data (e.g. so an option shows as XCBO or OPRA).
- **Mechanism:** `publisher_venue_map` built from [publishers.json](nautilus_trader/nautilus_trader/adapters/databento/publishers.json): each publisher entry has a `venue` field (e.g. publisher_id 22 → `"XCBO"`). The loader and live/historical clients use this map (and, when enabled, exchange codes) to set the venue on decoded instruments and data.
- **Used by:** Instrument definition decoding and live feed handling (e.g. resolving publisher_id or exchange from the message to a `Venue`).
- **Scope of this PR:** No changes. This direction was already correct; publishers.json already lists all OPRA venues with their MICs.

## Summary

- **Venue → dataset:** Handled by `venue_dataset_map`; this PR adds default GLBX and OPRA groupings in code so both directions (request by venue and labelling of incoming data) work for XCME/GLBX and for OPRA venues without extra config.
- **Publisher → venue:** Handled by `publisher_venue_map` from publishers.json; unchanged and sufficient for assigning venues to incoming OPRA/GLBX data.
- **Live and historical:** Both use the same loader and the same maps, so the new defaults apply everywhere.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3451

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
