### PR TITLE
Fix Interactive Brokers historical bar processing crash

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -16,6 +16,7 @@
 import asyncio
 import functools
 import os
+import traceback
 from collections.abc import Callable
 from collections.abc import Coroutine
 from inspect import iscoroutinefunction
@@ -724,19 +725,17 @@ class InteractiveBrokersClient(
         try:
             while True:
                 handler_task = await self._msg_handler_task_queue.get()
-                await handler_task()
-                # try:
-                #     await handler_task()
-                # except Exception as e:
-                #     exc_type = type(e)
-                #     exc_traceback = e.__traceback__
-                #     stack_trace = traceback.format_exception(exc_type, e, exc_traceback)
-                #     stack_trace_str = "".join(stack_trace)
-                #     task_name = getattr(handler_task, "__name__", str(handler_task))
-                #     self._log.error(
-                #         f"Exception in message handler task '{task_name}': {e!r}\n{stack_trace_str}",
-                #     )
-                #     raise
+                try:
+                    await handler_task()
+                except Exception as e:
+                    exc_type = type(e)
+                    exc_traceback = e.__traceback__
+                    stack_trace = traceback.format_exception(exc_type, e, exc_traceback)
+                    stack_trace_str = "".join(stack_trace)
+                    task_name = getattr(handler_task, "__name__", str(handler_task))
+                    self._log.error(
+                        f"Exception in message handler task '{task_name}': {e!r}\n{stack_trace_str}",
+                    )
                 self._msg_handler_task_queue.task_done()
         except asyncio.CancelledError:
             log_msg = f"Handler task processing was cancelled. (qsize={self._msg_handler_task_queue.qsize()})."

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -1036,7 +1036,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         Return the requested historical data bars.
         """
         if request := self._requests.get(req_id=req_id):
-            bar_type = request.name[0]
+            bar_type = BarType.from_str(request.name[0])
             bar = await self._ib_bar_to_nautilus_bar(
                 bar_type=bar_type,
                 bar=bar,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

After #3616 was merged, `process_historical_data` receives `request.name[0]` as a string, but passes it to `_ib_bar_to_nautilus_bar` and `_ib_bar_to_ts_init` which expect a `BarType` object. This causes `AttributeError("'str' object has no attribute 'spec'")` on the first historical bar callback, which crashes the `_run_msg_handler_processor` loop — meaning **all subsequent IB messages are never processed**, causing cascading timeouts for positions, orders, contract details, and everything else.

This was introduced when `process_historical_data` was added/modified without converting the string to `BarType`, unlike the existing patterns in `process_realtime_bar` (line 995) and `_process_bar_data` (line 1306) which both use `BarType.from_str()`.

**Fixes:**
1. Convert `request.name[0]` via `BarType.from_str()` to match existing patterns
2. Enable exception handling in `_run_msg_handler_processor` so a single bad handler task logs the error and continues rather than killing the entire message processing loop

## Related Issues/PRs

Follow-up fix for #3616

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

N/A — bug fix for a recent change, not yet in a release.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Tested manually against IB Gateway. Before the fix, the adapter crashes immediately on the first `process_historical_data` call and all subsequent messages time out. After the fix, historical bars are processed successfully and positions/orders/contracts all reconcile correctly.