### PR TITLE
Add trigger type check to set market price correctly

### DIFF
--- a/nautilus_trader/execution/emulator.pyx
+++ b/nautilus_trader/execution/emulator.pyx
@@ -927,13 +927,16 @@ cdef class OrderEmulator(Actor):
                 # NOTE
                 # The activation price should have been set in OrderMatchingEngine._process_trailing_stop_order()
                 # However, the implementation of the emulator bypass this step, and directly call this method through match_order().
-                market_price = ask if order.side == OrderSide.BUY else bid
+                if order.trigger_type == TriggerType.LAST_PRICE or order.trigger_type == TriggerType.MARK_PRICE:
+                    market_price = last
+                else:
+                    market_price = ask if order.side == OrderSide.BUY else bid
                 if market_price is None:
                     # If there is no market price, we cannot process the order
                     raise RuntimeError(  # pragma: no cover (design-time error)
                         f"cannot process trailing stop, "
-                        f"no BID or ASK price for {order.instrument_id} "
-                        f"(add quotes or use bars)",
+                        f"no market price for {order.instrument_id} "
+                        f"(add trades or quotes)",
                     )
                 order.set_activated_c(market_price)
             elif matching_core.is_touch_triggered(order.side, order.activation_price):

--- a/tests/unit_tests/execution/test_emulator.py
+++ b/tests/unit_tests/execution/test_emulator.py
@@ -948,6 +948,43 @@ class TestOrderEmulatorWithSingleOrders:
         assert order not in self.cache.orders_emulated()
 
     @pytest.mark.parametrize(
+        ("order_side", "expected_trigger_price"),
+        [
+            [OrderSide.BUY, ETHUSDT_PERP_BINANCE.make_price(5_075)],
+            [OrderSide.SELL, ETHUSDT_PERP_BINANCE.make_price(5_055)],
+        ],
+    )
+    def test_submit_trailing_stop_market_order_last_price_trigger_activates_from_trade_tick(
+        self,
+        order_side: OrderSide,
+        expected_trigger_price: Price,
+    ) -> None:
+        # Arrange: Provide only trade tick (no quotes)
+        tick = TestDataStubs.trade_tick(
+            instrument=ETHUSDT_PERP_BINANCE,
+            price=5_065.0,
+        )
+        self.data_engine.process(tick)
+
+        # Act: Submit trailing stop with LAST_PRICE trigger
+        order = self.strategy.order_factory.trailing_stop_market(
+            instrument_id=ETHUSDT_PERP_BINANCE.id,
+            order_side=order_side,
+            quantity=Quantity.from_int(10),
+            trigger_type=TriggerType.LAST_PRICE,
+            trailing_offset=Decimal(10),
+            trailing_offset_type=TrailingOffsetType.PRICE,
+            emulation_trigger=TriggerType.LAST_PRICE,
+        )
+        self.strategy.submit_order(order)
+
+        # Assert: Order activated using last price, trigger price set
+        order = self.cache.order(order.client_order_id)
+        assert order.order_type == OrderType.TRAILING_STOP_MARKET
+        assert order.is_emulated
+        assert order.trigger_price == expected_trigger_price
+
+    @pytest.mark.parametrize(
         ("order_side", "price", "expected_trigger_price"),
         [
             [


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix `_trail_stop_order()` activation step to respect `order.trigger_type`. For `LAST_PRICE`/`MARK_PRICE` orders, activation now uses `last` instead of `ask`/`bid`, consistent with `TrailingStopCalculator.calculate()`. Error messages are now trigger-type-aware.

## Related Issues/PRs

Closes #3629

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_submit_trailing_stop_market_order_last_price_trigger_activates_from_trade_tick` (parametrized BUY/SELL) to `tests/unit_tests/execution/test_emulator.py`. Verifies that an emulated trailing stop with `TriggerType.LAST_PRICE` activates correctly from trade tick data alone (no quotes).
