### PR TITLE
Fix Interactive Brokers contract details parsing

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -308,7 +308,9 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
         the constructor sees it — hence this is a classmethod rather than __post_init__.
 
         """
-        contract_details.contract = IBContract(**contract_details.contract.__dict__)
+        if not isinstance(contract_details.contract, IBContract):
+            contract_details.contract = IBContract(**contract_details.contract.__dict__)
+
         d = contract_details.__dict__.copy()
         if "underConid" in d:
             if not d.get("underConId"):


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix parsing contract details for Interactive Brokers

Some contracts are already parsed (don't know why). Then accessing `contract_details.contract.__dict__` throws an AttributeError.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

Manual testing. Odd issue.