### PR TITLE
Fix BinanceSymbol COIN-M perpetual symbol conversion

### DIFF
--- a/nautilus_trader/adapters/binance/common/symbol.py
+++ b/nautilus_trader/adapters/binance/common/symbol.py
@@ -35,10 +35,31 @@ class BinanceSymbol(str):
         PyCondition.valid_string(symbol, "symbol")
 
         # Format the string on construction to be Binance compatible
-        return super().__new__(
-            cls,
-            symbol.upper().replace(" ", "").replace("/", "").replace("-PERP", ""),
-        )
+        formatted = symbol.upper().replace(" ", "").replace("/", "")
+
+        # Convert Nautilus format back to Binance format for perpetual symbols.
+        # COIN-M (inverse): BTCUSD-PERP → BTCUSD_PERP (Binance uses underscore)
+        # USDT-M (linear):  BTCUSDT-PERP → BTCUSDT (Binance has no suffix)
+        if formatted.endswith("-PERP"):
+            base = formatted[:-5]
+            # Detect Linear (stablecoin-quoted) symbols.
+            # Must avoid false positives where COIN-M {BASE}USD overlaps with
+            # stablecoin names: e.g. BNBUSD matches "BUSD", DOTUSD matches "TUSD".
+            # Fix: after removing the stablecoin suffix, require ≥3 chars remaining
+            # (all Binance crypto tickers are ≥3 chars). This ensures BNBUSD is
+            # treated as BNB+USD (COIN-M) not BN+BUSD (Linear).
+            _LINEAR_QUOTES = ("USDT", "BUSD", "TUSD", "FDUSD", "USDC", "DAI")
+            is_linear = False
+            for quote in _LINEAR_QUOTES:
+                if base.endswith(quote) and len(base) > len(quote) + 2:
+                    is_linear = True
+                    break
+            if is_linear:
+                formatted = base
+            else:
+                formatted = base + "_PERP"
+
+        return super().__new__(cls, formatted)
 
     def parse_as_nautilus(self, account_type: BinanceAccountType) -> str:
         if account_type.is_spot_or_margin:

--- a/tests/integration_tests/adapters/binance/test_core_functions.py
+++ b/tests/integration_tests/adapters/binance/test_core_functions.py
@@ -31,6 +31,45 @@ class TestBinanceCoreFunctions:
         # Assert
         assert result == "ETHUSDT"
 
+    @pytest.mark.parametrize(
+        ("symbol", "expected"),
+        [
+            # Linear (USDT-M) perpetuals: strip -PERP suffix
+            ("BTCUSDT-PERP", "BTCUSDT"),
+            ("ETHUSDT-PERP", "ETHUSDT"),
+            ("BNBUSDT-PERP", "BNBUSDT"),
+            ("BTCBUSD-PERP", "BTCBUSD"),
+            # COIN-M (inverse) perpetuals: replace -PERP with _PERP
+            ("BTCUSD-PERP", "BTCUSD_PERP"),
+            ("ETHUSD-PERP", "ETHUSD_PERP"),
+            ("BNBUSD-PERP", "BNBUSD_PERP"),
+            ("LINKUSD-PERP", "LINKUSD_PERP"),
+            ("DOTUSD-PERP", "DOTUSD_PERP"),
+            # Spot / no -PERP suffix: pass through
+            ("BTCUSDT", "BTCUSDT"),
+            ("ETHUSDT", "ETHUSDT"),
+        ],
+    )
+    def test_format_symbol_perp_variants(self, symbol, expected):
+        assert BinanceSymbol(symbol) == expected
+
+    @pytest.mark.parametrize(
+        ("symbol", "account_type", "expected"),
+        [
+            # COIN-M perpetuals round-trip
+            ("BTCUSD_PERP", BinanceAccountType.COIN_FUTURES, "BTCUSD-PERP"),
+            ("BNBUSD_PERP", BinanceAccountType.COIN_FUTURES, "BNBUSD-PERP"),
+            # Linear perpetuals round-trip
+            ("BTCUSDT", BinanceAccountType.USDT_FUTURES, "BTCUSDT-PERP"),
+            ("ETHUSDT", BinanceAccountType.USDT_FUTURES, "ETHUSDT-PERP"),
+            # Spot: no suffix added
+            ("BTCUSDT", BinanceAccountType.SPOT, "BTCUSDT"),
+        ],
+    )
+    def test_parse_as_nautilus(self, symbol, account_type, expected):
+        result = BinanceSymbol(symbol).parse_as_nautilus(account_type)
+        assert result == expected
+
     def test_convert_symbols_list_to_json_array(self):
         # Arrange
         symbols = ["BTCUSDT", "ETHUSDT-PERP", " XRDUSDT"]


### PR DESCRIPTION
## Bug

`BinanceSymbol` strips the `-PERP` suffix from **all** symbols, producing bare symbols like `BTCUSD` instead of the Binance COIN-M format `BTCUSD_PERP`. This causes `Invalid symbol` errors (code -1121) when querying any COIN-M `/dapi/v1/` endpoint.

**Affected symbols**: All COIN-M (inverse) perpetuals — `BTCUSD_PERP`, `ETHUSD_PERP`, `BNBUSD_PERP`, `LINKUSD_PERP`, etc.

### Before (broken)

```
BinanceSymbol("BTCUSD-PERP")  → "BTCUSD"      # ✗ should be BTCUSD_PERP
BinanceSymbol("BNBUSD-PERP")  → "BNBUSD"      # ✗ should be BNBUSD_PERP
```

### After (fixed)

```
BinanceSymbol("BTCUSD-PERP")  → "BTCUSD_PERP" # ✓ COIN-M format
BinanceSymbol("BNBUSD-PERP")  → "BNBUSD_PERP" # ✓ COIN-M format
BinanceSymbol("BTCUSDT-PERP") → "BTCUSDT"     # ✓ Linear (unchanged)
```

## Fix

The fix distinguishes between Linear (USDT-M) and COIN-M (inverse) perpetuals:

- **Linear**: symbol ends with a stablecoin quote (`USDT`, `BUSD`, `USDC`, etc.) → strip `-PERP`
- **COIN-M**: symbol ends with `USD` (no stablecoin match) → replace `-PERP` with `_PERP`

A minimum-base-length guard (`len(base) > len(quote) + 2`) prevents false positives where COIN-M `{BASE}USD` overlaps stablecoin names (e.g. `BNBUSD` ends with `BUSD`, `DOTUSD` ends with `TUSD`). Since all Binance crypto tickers are ≥3 characters, this safely distinguishes `BNB+USD` from `BN+BUSD`.

## Tests

Added parametrized tests covering:
- Linear perpetuals: `BTCUSDT-PERP`, `ETHUSDT-PERP`, `BNBUSDT-PERP`, `BTCBUSD-PERP`
- COIN-M perpetuals: `BTCUSD-PERP`, `ETHUSD-PERP`, `BNBUSD-PERP`, `LINKUSD-PERP`, `DOTUSD-PERP`
- `parse_as_nautilus` round-trip for both COIN-M and Linear

Closes #3640