### PR TITLE
Add is_limit_fillable callback to MatchingCore

### DIFF
--- a/examples/backtest/notebooks/databento_option_greeks.py
+++ b/examples/backtest/notebooks/databento_option_greeks.py
@@ -30,7 +30,6 @@ from nautilus_trader.analysis import TearsheetConfig
 from nautilus_trader.analysis import TearsheetEquityChart
 from nautilus_trader.analysis import TearsheetStatsTableChart
 from nautilus_trader.analysis.tearsheet import create_bars_with_fills
-from nautilus_trader.analysis.tearsheet import create_tearsheet
 from nautilus_trader.backtest.config import MarginModelConfig
 from nautilus_trader.backtest.node import BacktestNode
 from nautilus_trader.common.enums import LogColor
@@ -589,11 +588,11 @@ tearsheet_config = TearsheetConfig(
     theme="nautilus_dark",
 )
 
-create_tearsheet(
-    engine,
-    config=tearsheet_config,
-    output_path="tearsheet_with_bars_fills.html",
-)
+# create_tearsheet(
+#     engine,
+#     config=tearsheet_config,
+#     output_path="tearsheet_with_bars_fills.html",
+# )
 
 # %%
 node.dispose()

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -430,6 +430,15 @@ cdef class OrderMatchingEngine:
 
     cpdef void reset(self)
     cpdef void set_fill_model(self, FillModel fill_model)
+    cpdef bint custom_is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef void update_instrument(self, Instrument instrument)
 
 # -- QUERIES --------------------------------------------------------------------------------------

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -3892,6 +3892,7 @@ cdef class OrderMatchingEngine:
             fill_market_order=self.fill_market_order,
             fill_limit_order=self.fill_limit_order,
         )
+        self._core.set_is_limit_fillable_callback(None if type(fill_model) is FillModel else self.custom_is_limit_fillable)
         self._price_prec = instrument.price_precision
         self._size_prec = instrument.size_precision
 
@@ -3977,8 +3978,23 @@ cdef class OrderMatchingEngine:
         Condition.not_none(fill_model, "fill_model")
 
         self._fill_model = fill_model
+        self._core.set_is_limit_fillable_callback(None if type(fill_model) is FillModel else self.custom_is_limit_fillable)
 
         self._log.debug(f"Changed `FillModel` to {self._fill_model}")
+
+    cpdef bint custom_is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        # Delegates to the fill model when a custom (non-default) fill model is used.
+        return self._fill_model.is_limit_fillable(
+            side, price, bid_raw, ask_raw, is_bid_initialized, is_ask_initialized
+        )
 
     cpdef void update_instrument(self, Instrument instrument):
         """

--- a/nautilus_trader/backtest/models/fill.pxd
+++ b/nautilus_trader/backtest/models/fill.pxd
@@ -15,6 +15,8 @@
 
 from libc.stdint cimport uint64_t
 
+from nautilus_trader.core.rust.model cimport OrderSide
+from nautilus_trader.core.rust.model cimport PriceRaw
 from nautilus_trader.model.book cimport BookOrder
 from nautilus_trader.model.book cimport OrderBook
 from nautilus_trader.model.instruments.base cimport Instrument
@@ -30,6 +32,15 @@ cdef class FillModel:
 
     cpdef bint is_limit_filled(self)
     cpdef bint is_slipped(self)
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -42,6 +53,15 @@ cdef class FillModel:
 
 
 cdef class BestPriceFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -62,6 +82,15 @@ cdef class OneTickSlippageFillModel(FillModel):
 
 
 cdef class TwoTierFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -72,6 +101,15 @@ cdef class TwoTierFillModel(FillModel):
 
 
 cdef class ProbabilisticFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -82,6 +120,15 @@ cdef class ProbabilisticFillModel(FillModel):
 
 
 cdef class SizeAwareFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -92,6 +139,15 @@ cdef class SizeAwareFillModel(FillModel):
 
 
 cdef class LimitOrderPartialFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -102,6 +158,15 @@ cdef class LimitOrderPartialFillModel(FillModel):
 
 
 cdef class ThreeTierFillModel(FillModel):
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -116,6 +181,15 @@ cdef class MarketHoursFillModel(FillModel):
 
     cpdef bint is_low_liquidity_period(self)
     cpdef void set_low_liquidity_period(self, bint is_low_liquidity)
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -129,6 +203,15 @@ cdef class VolumeSensitiveFillModel(FillModel):
     cdef double _recent_volume
 
     cpdef void set_recent_volume(self, double volume)
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -141,6 +224,15 @@ cdef class VolumeSensitiveFillModel(FillModel):
 cdef class CompetitionAwareFillModel(FillModel):
     cdef double liquidity_factor
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    )
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,

--- a/nautilus_trader/backtest/models/fill.pyx
+++ b/nautilus_trader/backtest/models/fill.pyx
@@ -21,6 +21,7 @@ from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.rust.model cimport BookType
 from nautilus_trader.core.rust.model cimport OrderSide
 from nautilus_trader.core.rust.model cimport OrderType
+from nautilus_trader.core.rust.model cimport PriceRaw
 from nautilus_trader.model.book cimport BookOrder
 from nautilus_trader.model.book cimport OrderBook
 from nautilus_trader.model.functions cimport liquidity_side_to_str
@@ -101,6 +102,18 @@ cdef class FillModel:
         """
         return self._event_success(self.prob_slippage)
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        # Default: only marketable is fillable; no extra callback logic.
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -157,6 +170,26 @@ cdef class BestPriceFillModel(FillModel):
     immediately at the best available price. Ideal for testing basic strategy logic.
 
     """
+
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        # Limit order is fillable when priced at or inside the bid-ask spread.
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
 
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
@@ -280,6 +313,26 @@ cdef class TwoTierFillModel(FillModel):
     of basic market impact for small to medium orders.
     """
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        # Limit fillable when at or inside spread (liquidity at best in simulated book).
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -350,6 +403,25 @@ cdef class ProbabilisticFillModel(FillModel):
 
     """
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -415,6 +487,25 @@ cdef class SizeAwareFillModel(FillModel):
     impact with partial fills at worse prices.
 
     """
+
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
 
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
@@ -512,6 +603,25 @@ cdef class LimitOrderPartialFillModel(FillModel):
 
     """
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -582,6 +692,25 @@ cdef class ThreeTierFillModel(FillModel):
     - 20 contracts 2 ticks worse
 
     """
+
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
 
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
@@ -695,6 +824,25 @@ cdef class MarketHoursFillModel(FillModel):
         """
         self._is_low_liquidity = is_low_liquidity
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -776,6 +924,25 @@ cdef class VolumeSensitiveFillModel(FillModel):
         """
         self._recent_volume = volume
 
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
+
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,
         Instrument instrument,
@@ -856,6 +1023,25 @@ cdef class CompetitionAwareFillModel(FillModel):
     ):
         super().__init__(prob_fill_on_limit, prob_slippage, random_seed)
         self.liquidity_factor = liquidity_factor
+
+    cpdef bint is_limit_fillable(
+        self,
+        OrderSide side,
+        Price price,
+        PriceRaw bid_raw,
+        PriceRaw ask_raw,
+        bint is_bid_initialized,
+        bint is_ask_initialized,
+    ):
+        if price is None:
+            return False
+
+        if side == OrderSide.BUY:
+            return is_bid_initialized and price._mem.raw >= bid_raw
+        elif side == OrderSide.SELL:
+            return is_ask_initialized and price._mem.raw <= ask_raw
+
+        return False
 
     cpdef OrderBook get_orderbook_for_fill_simulation(
         self,

--- a/nautilus_trader/execution/matching_core.pxd
+++ b/nautilus_trader/execution/matching_core.pxd
@@ -40,6 +40,7 @@ cdef class MatchingCore:
     cdef object _trigger_stop_order
     cdef object _fill_market_order
     cdef object _fill_limit_order
+    cdef object _is_limit_fillable
 
     cdef dict _orders
     cdef list _orders_bid
@@ -78,6 +79,7 @@ cdef class MatchingCore:
     cpdef void match_trailing_stop_market_order(self, Order order)
     cpdef void match_trailing_stop_limit_order(self, Order order, bint initial)
     cpdef bint is_limit_marketable(self, OrderSide side, Price price)
+    cpdef void set_is_limit_fillable_callback(self, object callback)
     cpdef bint is_limit_fillable(self, OrderSide side, Price price)
     cpdef bint is_stop_triggered(self, OrderSide side, Price trigger_price)
     cpdef bint is_touch_triggered(self, OrderSide side, Price trigger_price)

--- a/nautilus_trader/execution/matching_core.pyx
+++ b/nautilus_trader/execution/matching_core.pyx
@@ -70,6 +70,7 @@ cdef class MatchingCore:
         self._trigger_stop_order = trigger_stop_order
         self._fill_market_order = fill_market_order
         self._fill_limit_order = fill_limit_order
+        self._is_limit_fillable = None
 
         # Orders
         self._orders: dict[ClientOrderId, Order] = {}
@@ -364,8 +365,19 @@ cdef class MatchingCore:
         if order.is_activated:
             self.match_stop_market_order(order)
 
+    cpdef void set_is_limit_fillable_callback(self, object callback):
+        self._is_limit_fillable = callback
+
     cpdef bint is_limit_fillable(self, OrderSide side, Price price):
-        return self.is_limit_marketable(side, price)
+        return (self.is_limit_marketable(side, price)
+                or self._is_limit_fillable is not None and self._is_limit_fillable(
+            side,
+            price,
+            self.bid_raw,
+            self.ask_raw,
+            self.is_bid_initialized,
+            self.is_ask_initialized,
+        ))
 
     cpdef bint is_limit_marketable(self, OrderSide side, Price price):
         # True when order would take liquidity (crosses the spread). Used for post-only rejection.
@@ -374,10 +386,12 @@ cdef class MatchingCore:
         if side == OrderSide.BUY:
             if not self.is_ask_initialized:
                 return False  # No market
+
             return self.ask_raw <= price._mem.raw
         elif side == OrderSide.SELL:
             if not self.is_bid_initialized:
                 return False  # No market
+
             return self.bid_raw >= price._mem.raw
         else:
             raise ValueError(f"invalid `OrderSide`, was {side}")  # pragma: no cover (design-time error)

--- a/tests/unit_tests/backtest/test_immediate_quote_execution.py
+++ b/tests/unit_tests/backtest/test_immediate_quote_execution.py
@@ -56,11 +56,15 @@ class ImmediateOrderStrategy(Strategy):
         self.quote_count += 1
 
         if not self.order_submitted:
+            instrument = self.cache.instrument(self.instrument_id)
+            mid_price_double = (tick.bid_price.as_double() + tick.ask_price.as_double()) / 2.0
+            limit_price = instrument.next_ask_price(mid_price_double, num_ticks=0)
+
             order = self.order_factory.limit(
                 instrument_id=self.instrument_id,
                 order_side=OrderSide.BUY,
                 quantity=Quantity.from_int(100_000),
-                price=tick.ask_price,
+                price=limit_price,
             )
             self.submit_order(order)
             self.order_submitted = True
@@ -92,11 +96,14 @@ class DeltaHedgeOnFillStrategy(Strategy):
 
     def on_quote_tick(self, tick: QuoteTick):
         if not self.first_order_submitted:
+            instrument = self.cache.instrument(self.instrument_id)
+            mid = (tick.bid_price.as_double() + tick.ask_price.as_double()) / 2.0
+            price = instrument.next_ask_price(mid, num_ticks=0)
             order = self.order_factory.limit(
                 instrument_id=self.instrument_id,
                 order_side=OrderSide.BUY,
                 quantity=Quantity.from_int(100_000),
-                price=tick.ask_price,
+                price=price,
             )
             self.submit_order(order)
             self.first_order_submitted = True


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Limit order fillability in the matching core is now customisable per fill model. When the default `FillModel` is used, behaviour is unchanged (only marketable limits are fillable). When a custom fill model is used, the core can treat limit orders at or inside the spread as fillable so that models that provide simulated liquidity at best bid/ask behave correctly.

## Changes

### Matching core

- **[matching_core.pyx](nautilus_trader/nautilus_trader/execution/matching_core.pyx)**  
  - Added optional callback `_is_limit_fillable`, initialised to `None` in `__init__`.  
  - Added `set_is_limit_fillable_callback(object callback)` to set or clear the callback.  
  - `is_limit_fillable(side, price)` now returns `is_limit_marketable(side, price) or (callback is set and callback(side, price, bid_raw, ask_raw, is_bid_initialized, is_ask_initialized))`.  
  - The callback receives current book state so fill models can implement inside-spread logic without holding book state.

- **[matching_core.pxd](nautilus_trader/nautilus_trader/execution/matching_core.pxd)**  
  - Declared `_is_limit_fillable` and `set_is_limit_fillable_callback`.

### Backtest engine

- **[engine.pyx](nautilus_trader/nautilus_trader/backtest/engine.pyx)**  
  - In `OrderMatchingEngine.__init__`, after creating the core: set callback to `None` when `type(fill_model) is FillModel`, otherwise to `self.custom_is_limit_fillable`.  
  - In `OrderMatchingEngine.set_fill_model`, apply the same rule after updating `_fill_model`.  
  - Added `custom_is_limit_fillable(side, price, bid_raw, ask_raw, is_bid_initialized, is_ask_initialized)` which delegates to `self._fill_model.is_limit_fillable(...)`.  
  - The engine method is passed to the core as the callback so the core does not hold a reference to the fill model; when the fill model is changed via `set_fill_model`, the same callback continues to use the new model.

- **[engine.pxd](nautilus_trader/nautilus_trader/backtest/engine.pxd)**  
  - Declared `custom_is_limit_fillable`.

### Fill models

- **[fill.pyx](nautilus_trader/nautilus_trader/backtest/models/fill.pyx)**  
  - **FillModel:** Added `is_limit_fillable(self, side, price, bid_raw, ask_raw, is_bid_initialized, is_ask_initialized)` returning `False` (default: only marketable is fillable).  
  - **BestPriceFillModel:** Overrode `is_limit_fillable` with inside-spread logic: fillable when BUY and `price >= bid_raw` (with bid initialised) or SELL and `price <= ask_raw` (with ask initialised). Marketable is not re-checked here; the core already does `is_limit_marketable` first.  
  - **TwoTierFillModel, ProbabilisticFillModel, SizeAwareFillModel, LimitOrderPartialFillModel, ThreeTierFillModel, MarketHoursFillModel, VolumeSensitiveFillModel, CompetitionAwareFillModel:** Same `is_limit_fillable` override (at or inside spread), since each provides liquidity at best bid/ask in `get_orderbook_for_fill_simulation`.  
  - **OneTickSlippageFillModel:** No override; it only has liquidity one tick away from best, so limit orders at touch are not fillable in that model.

- **[fill.pxd](nautilus_trader/nautilus_trader/backtest/models/fill.pxd)**  
  - Declared `is_limit_fillable` on `FillModel` and on each subclass that overrides it.  
  - Added `OrderSide` import for the new method signature.

### Tests

- **[test_immediate_quote_execution.py](tests/unit_tests/backtest/test_immediate_quote_execution.py)**  
  - Reverted strategy logic to the pre-9c28292e behaviour: limit price is derived from mid (e.g. `instrument.next_ask_price(mid, num_ticks=0)`) in `ImmediateOrderStrategy` and `DeltaHedgeOnFillStrategy`.  
  - Venue already uses `BestPriceFillModel()`, so limit orders at or inside the spread are fillable and the tests pass.

## Design notes

- The callback receives `(side, price, bid_raw, ask_raw, is_bid_initialized, is_ask_initialized)` so fill models can implement “inside spread” without holding book state; the core supplies current best bid/ask and flags.  
- Only the default `FillModel` (exact type) leaves the callback unset; any subclass gets the callback so custom models can override `is_limit_fillable`.  
- The emulator does not use a backtest fill model; its `MatchingCore` keeps `_is_limit_fillable` as `None`, so behaviour remains “fillable iff marketable”.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
