### PR TITLE
Fix Binance algo order cancellation parsing

### DIFF
--- a/crates/adapters/binance/src/futures/http/client.rs
+++ b/crates/adapters/binance/src/futures/http/client.rs
@@ -1789,7 +1789,7 @@ impl BinanceFuturesHttpClient {
         };
 
         let response = self.raw.cancel_algo_order(&params).await?;
-        if response.code == 200 {
+        if response.code.parse::<i32>().unwrap_or(0) == 200 {
             Ok(())
         } else {
             anyhow::bail!(
@@ -1817,7 +1817,7 @@ impl BinanceFuturesHttpClient {
         };
 
         let response = self.raw.cancel_all_orders(&params).await?;
-        if response.code == 200 {
+        if response.code.parse::<i32>().unwrap_or(0) == 200 {
             Ok(vec![])
         } else {
             anyhow::bail!("Cancel all orders failed: {}", response.msg);
@@ -1838,7 +1838,7 @@ impl BinanceFuturesHttpClient {
         };
 
         let response = self.raw.cancel_all_algo_orders(&params).await?;
-        if response.code == 200 {
+        if response.code.parse::<i32>().unwrap_or(0) == 200 {
             Ok(())
         } else {
             anyhow::bail!("Cancel all algo orders failed: {}", response.msg);

--- a/crates/adapters/binance/src/futures/http/models.rs
+++ b/crates/adapters/binance/src/futures/http/models.rs
@@ -840,7 +840,7 @@ pub struct BinanceLeverageResponse {
 #[serde(rename_all = "camelCase")]
 pub struct BinanceCancelAllOrdersResponse {
     /// Response code (200 = success).
-    pub code: i32,
+    pub code: String,
     /// Response message.
     pub msg: String,
 }
@@ -1306,7 +1306,7 @@ pub struct BinanceFuturesAlgoOrderCancelResponse {
     /// Client algo order ID.
     pub client_algo_id: String,
     /// Response code (200 for success).
-    pub code: i32,
+    pub code: String,
     /// Response message.
     pub msg: String,
 }
@@ -1631,7 +1631,7 @@ mod tests {
         let json = r#"{
             "algoId": 123456789,
             "clientAlgoId": "test-algo-order-1",
-            "code": 200,
+            "code": "200",
             "msg": "success"
         }"#;
 
@@ -1640,7 +1640,7 @@ mod tests {
 
         assert_eq!(response.algo_id, 123456789);
         assert_eq!(response.client_algo_id, "test-algo-order-1");
-        assert_eq!(response.code, 200);
+        assert_eq!(response.code, "200");
         assert_eq!(response.msg, "success");
     }
 }


### PR DESCRIPTION
# Pull Request

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR fixes Binance Futures algo order cancel response parsing by updating the `code` field type to match the API schema. `BinanceFuturesAlgoOrderCancelResponse.code` (and related cancel response types) are changed from `i32` to `String`, and the Futures HTTP client cancel helpers are updated to handle the string response code correctly. This prevents deserialization/type errors and avoids false failures when cancel requests succeed on Binance.

## Related Issues/PRs

- Related to: https://github.com/nautechsystems/nautilus_trader/issues/3645

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A


## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Tested by:
- Updated/ran the existing JSON deserialization test for `BinanceFuturesAlgoOrderCancelResponse` to use `"code": "200"` and validated it parses successfully.