### PR TITLE
Include .cargo config in sdist for correct platform builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ include = [
   { path = "crates/*", format = "sdist" },
   { path = "Cargo.lock", format = "sdist" },
   { path = "Cargo.toml", format = "sdist" },
+  { path = ".cargo/*", format = "sdist" },
   # Compiled extensions must be included in the wheel distributions
   { path = "nautilus_trader/**/*.so", format = "wheel" },
   { path = "nautilus_trader/**/*.pyd", format = "wheel" },


### PR DESCRIPTION
.cargo/config.toml contains platform-specific Cargo rustflags for Linux (link optimizations), macOS (dynamic_lookup), and Windows (crt-static). Poetry-core does not auto-include dot-directories, so the file was missing from the sdist, causing builds from source to use Cargo defaults instead of the intended flags.
