### PR TITLE
Fix macOS source build missing RUSTFLAGS

### DIFF
--- a/build.py
+++ b/build.py
@@ -84,6 +84,15 @@ if IS_MACOS and IS_ARM64:
     os.environ["CFLAGS"] = f"{os.environ.get('CFLAGS', '')} -arch arm64"
     os.environ["LDFLAGS"] = f"{os.environ.get('LDFLAGS', '')} -arch arm64 -w"
 
+# macOS requires -undefined dynamic_lookup so that PyO3 extension modules
+# can reference Python C API symbols resolved at load time. Without this,
+# the macOS linker (ld64) rejects undefined symbols and the build fails.
+if IS_MACOS:
+    _existing_rustflags = os.environ.get("RUSTFLAGS", "")
+    os.environ["RUSTFLAGS"] = (
+        f"{_existing_rustflags} -C link-arg=-undefined -C link-arg=dynamic_lookup"
+    )
+
 if IS_LINUX and IS_ARM64:
     os.environ["CFLAGS"] = f"{os.environ.get('CFLAGS', '')} -fPIC"
     os.environ["LDFLAGS"] = f"{os.environ.get('LDFLAGS', '')} -fPIC"


### PR DESCRIPTION
The macOS linker (ld64) rejects undefined symbols by default. PyO3 extension modules reference Python C API symbols that are only resolved at runtime when Python loads the shared library, requiring the -undefined dynamic_lookup linker flag.

build.py already sets RUSTFLAGS for Linux ARM64 builds; this adds the equivalent for all macOS targets. The flag is appended to any existing RUSTFLAGS to preserve values set by the caller. CI was unaffected because it explicitly exports the flag in the workflow action.

This PR works in conjunction with #3647 to enable nautilus_trader to run on macOS Intel machines.