### PR TITLE
feat(poc): mono MakerV3 single-leg suite (with execution plan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ tests/test_data/**/backtest/**
 !tests/test_data/nautilus/*/**.parquet
 !tests/integration_tests/adapters/betfair/responses/*.log
 !/nautilus_core/adapters/src/databento/test_data/*
+
+.worktrees/

--- a/docs/plans/2026-03-03-nautilus-makerv3-single-leg-poc.md
+++ b/docs/plans/2026-03-03-nautilus-makerv3-single-leg-poc.md
@@ -1,0 +1,768 @@
+# Nautilus MakerV3 Single-Leg 3-Band Quoter MVP Implementation Plan (Fluxboard TokenMM UI)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a NautilusTrader live POC that runs a single-leg MakerV3-style quoting strategy (`strategy_market` only) with 3 quote bands, and minimal Chainsaw wiring: params in, signals/state out, balances, trades, alerts, with **GUI provided by existing Fluxboard TokenMM surface** (no new UI).
+
+**Architecture:** One Nautilus live `TradingNode` connects to Bybit (execution + market data) and Binance (market data only, for connector + bookbuilding validation). A single strategy manages post-only limit ladders on the `strategy_market` using 3 bands. The strategy publishes compact JSON events/state externally to a Redis stream (recommended: via Nautilus MessageBus backing with aggressive `types_filter` to avoid flooding Redis with market data). A small bridge consumes the stream and writes **FluxAPI-compatible Redis keys** (state/events/trades/alerts/balances/last:*/fvs.snapshot) so **Fluxboard TokenMM** can display the strategy via the existing Flask backend + Socket.IO.
+
+**Tech Stack:** NautilusTrader Python API + Bybit/Binance adapters, Nautilus `MessageBusConfig` Redis Streams, Redis, small Python bridge (`redis-py`), existing Chainsaw `fluxapi` + `fluxboard` for UI.
+
+---
+
+## Dependency management (POC)
+
+This POC includes one optional runtime dependency which is not guaranteed to be present in the NautilusTrader python environment:
+1. `redis` (redis-py) for the bridge.
+
+Pick one approach early and stick to it across agents:
+1. Recommended (fast, low repo churn): run the bridge in a separate venv or in an existing environment which already has these deps (for example the Chainsaw environment), while keeping the code in `examples/live/poc/`.
+1. Repo-contained (more churn): add a new dependency group (for example `[dependency-groups].poc`) and update lockfiles so `uv` installs are reproducible.
+
+If you choose the recommended approach, document it in `examples/live/poc/README.md` and avoid changing NautilusTrader lockfiles for the POC.
+
+## Scope (MVP)
+
+1. Single strategy market only (`strategy_market`).
+1. 3 quote bands on both sides (bid + ask), post-only limit orders.
+1. Basic order lifecycle: place, replace, cancel, clear-on-off.
+1. Params:
+1. Read MakerV3-compatible Redis param keys: `strategy.<strategy_id>.<param>`.
+1. Support hot updates by polling at a fixed interval (no fancy watchers).
+1. Observability:
+1. Emit state snapshots and per-event messages to Redis Streams (MessageBus backing).
+1. Bridge emits FluxAPI/Fluxboard-compatible keys:
+1. `maker_arb:<strategy_id>:state`
+1. `maker_arb:<strategy_id>:events`
+1. `trades.blotter` (rows on fills)
+1. `alerts.blotter` (rows on alerts)
+1. `balances.snapshot` and `balances` hash (rows for Bybit; optional Binance rows if connected)
+1. `last:<exchange>:<symbol>` BBO snapshots for Fluxboard Market Data and Signal calculations
+1. `fvs.snapshot` (Fluxboard Signal hard-requires non-empty FV snapshot to render any strategies)
+1. Market data:
+1. Bybit: L2 book building + trades for `strategy_market` (required).
+1. Binance: market-data connector enabled and bookbuilding validated (required; not used by strategy logic).
+1. Risk/circuit breaker:
+1. Use Nautilus pre-trade checks and trading-state gating where possible.
+1. Strategy-level gating is limited to `bot_on` and simple staleness logic.
+1. GUI:
+1. Fluxboard TokenMM surface must show: Signal, Params, Balances, Trades, Alerts.
+
+## Explicit non-goals (MVP)
+
+1. No hedge leg, no multi-instrument fair value, no inventory hedging.
+1. No portfolio-level risk model beyond Nautilus defaults (no custom risk engine).
+1. No attempt to perfectly match every MakerV3 edge-case or Redis schema field.
+1. No distributed orchestration, HA, or production hardening.
+
+## Reference files (source of truth)
+
+Nautilus multi-venue and adapter patterns:
+1. [examples/live/bybit/bybit_exec_tester.py](/home/ubuntu/nautilus_trader/examples/live/bybit/bybit_exec_tester.py)
+1. [examples/live/binance/binance_data_tester.py](/home/ubuntu/nautilus_trader/examples/live/binance/binance_data_tester.py)
+1. [docs/integrations/bybit.md](/home/ubuntu/nautilus_trader/docs/integrations/bybit.md)
+1. [docs/integrations/binance.md](/home/ubuntu/nautilus_trader/docs/integrations/binance.md)
+1. [docs/concepts/message_bus.md](/home/ubuntu/nautilus_trader/docs/concepts/message_bus.md)
+
+MakerV3 param key conventions (input surface):
+1. [chainsaw engine/strategies/maker_v3/task.py](/home/ubuntu/chainsaw/engine/strategies/maker_v3/task.py)
+
+Fluxboard TokenMM UI + FluxAPI backend:
+1. [chainsaw fluxboard README.md](/home/ubuntu/chainsaw/fluxboard/README.md)
+1. [chainsaw fluxapi blueprint signal.py](/home/ubuntu/chainsaw/fluxapi/blueprints/signal.py)
+1. [chainsaw fluxapi realtime strategies.py](/home/ubuntu/chainsaw/fluxapi/realtime/strategies.py)
+
+## Interfaces (contracts)
+
+### Nautilus conventions (implementation guardrails)
+
+Strategy + runner code should follow Nautilus patterns:
+1. Use `InstrumentId` (`InstrumentId.from_str(...)`) and `Venue`/adapter constants (`BYBIT`, `BINANCE`) instead of ad-hoc venue strings.
+1. Use Nautilus value types (`Price`, `Quantity`) when creating orders (via `order_factory`).
+1. Build L2 books via Nautilus `OrderBook` and `OrderBookDeltas` (bookbuilding), not by trusting BBO ticks.
+1. Keep external I/O out of the strategy hot-path when possible (use buffered publish + bridge process).
+
+### Redis params (input)
+
+Key format (must match Chainsaw MakerV3):
+1. `strategy.<strategy_id>.<param>`
+
+MVP param set:
+1. `bot_on` (bool-ish string)
+1. `qty` (decimal string)
+1. `max_age_ms` (int)
+1. Band 1:
+1. `bid_edge1` (bps)
+1. `ask_edge1` (bps)
+1. `n_orders1` (int)
+1. `distance1` (bps)
+1. `place_edge1` (bps, optional)
+1. Band 2:
+1. `bid_edge2`, `ask_edge2`, `n_orders2`, `distance2`, `place_edge2`
+1. Band 3:
+1. `bid_edge3`, `ask_edge3`, `n_orders3`, `distance3`, `place_edge3`
+
+Notes:
+1. Treat missing Redis values as "unset" and fall back to defaults in code/config.
+1. Treat empty Redis strings as "unset" (matches MakerV3 behavior).
+
+### Redis Streams (from Nautilus MessageBus backing)
+
+Stream key:
+1. Set `MessageBusConfig.stream_per_topic=False`.
+1. Set `streams_prefix="maker_poc"` and disable trader/id prefixes for a stable stream key.
+1. Set `types_filter` to exclude high-volume market data types (otherwise enabling MessageBus backing will flood Redis when subscribed to L2 deltas).
+
+Topics and payloads:
+1. `maker_poc.state` payload is a JSON string.
+1. `maker_poc.event` payload is a JSON string.
+1. `maker_poc.trade` payload is a JSON string.
+1. `maker_poc.alert` payload is a JSON string.
+1. `maker_poc.balances` payload is a JSON string (bridge uses this to write `balances.snapshot`).
+1. `maker_poc.market_bbo` payload is a JSON string (bridge uses this to write `last:*` keys).
+1. `maker_poc.fv` payload is a JSON string (bridge uses this to write `fvs.snapshot`).
+
+### Chainsaw Redis outputs (from bridge)
+
+State:
+1. `maker_arb:<strategy_id>:state` is JSON.
+
+Events:
+1. `maker_arb:<strategy_id>:events` is append-only (list or stream, pick one and be consistent).
+
+Blotters:
+1. `trades.blotter` rows on fills.
+1. `alerts.blotter` rows on alerts.
+1. `balances.snapshot` JSON list and `balances` hash (Fluxboard Balances + Signal readiness).
+1. `last:<exchange>:<symbol>` JSON objects (Fluxboard Market Data + Signal helper reads).
+1. `fvs.snapshot` JSON list (Fluxboard Signal initial load hard-requires non-empty FV snapshot).
+
+## Minimal message schema (bridge contract)
+
+Bridge and downstream consumers should treat the following keys as stable for the MVP.
+
+State payload (`maker_poc.state` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "strategy_id": "STRAT-001",
+  "strategy_class": "maker_v3_single_leg",
+  "mode": "QUOTING",
+  "reason": null,
+  "instrument_id": "PLUMEUSDT-LINEAR.BYBIT",
+  "venue": "BYBIT",
+  "top": {"bid": "0", "ask": "0", "ts_ms": 0},
+  "bands": [
+    {"band": 1, "bid_edge_bps": "0", "ask_edge_bps": "0", "distance_bps": "0", "n_orders": 0},
+    {"band": 2, "bid_edge_bps": "0", "ask_edge_bps": "0", "distance_bps": "0", "n_orders": 0},
+    {"band": 3, "bid_edge_bps": "0", "ask_edge_bps": "0", "distance_bps": "0", "n_orders": 0}
+  ],
+  "orders": {
+    "bid": [{"level": 1, "client_order_id": "X", "px": "0", "qty": "0", "status": "WORKING"}],
+    "ask": [{"level": 1, "client_order_id": "X", "px": "0", "qty": "0", "status": "WORKING"}]
+  }
+}
+```
+
+Event payload (`maker_poc.event` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "strategy_id": "STRAT-001",
+  "type": "quote.placed",
+  "instrument_id": "ETHUSDT-LINEAR.BYBIT",
+  "side": "bid",
+  "band": 1,
+  "level": 1,
+  "px": "0",
+  "qty": "0",
+  "details": {}
+}
+```
+
+Trade payload (`maker_poc.trade` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "strategy_id": "STRAT-001",
+  "type": "fill",
+  "instrument_id": "ETHUSDT-LINEAR.BYBIT",
+  "side": "buy",
+  "px": "0",
+  "qty": "0",
+  "liquidity": "maker",
+  "fee": "0",
+  "client_order_id": "X"
+}
+```
+
+Alert payload (`maker_poc.alert` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "strategy_id": "STRAT-001",
+  "severity": "warning",
+  "message": "stale_market_data",
+  "context": {}
+}
+```
+
+Market BBO payload (`maker_poc.market_bbo` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "instrument_id": "PLUMEUSDT-LINEAR.BYBIT",
+  "bid": "0",
+  "ask": "0"
+}
+```
+
+FV payload (`maker_poc.fv` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "instrument_id": "PLUMEUSDT-LINEAR.BYBIT",
+  "fv_bid": "0",
+  "fv_ask": "0",
+  "update_ts_ms": 0
+}
+```
+
+Balances payload (`maker_poc.balances` topic, JSON string):
+```json
+{
+  "ts_ms": 0,
+  "venue": "BYBIT",
+  "rows": [
+    {"coin": "USDT", "qty": 0.0, "mark": 1.0, "mv": 0.0, "update_time": "2026-03-03 00:00:00"}
+  ]
+}
+```
+
+## Execution model (parallel agents + worktrees)
+
+We will execute in parallel. Each workstream owns a disjoint file set to avoid merge conflicts.
+
+Required workflow skills:
+1. Use `superpowers:using-git-worktrees` before any implementation in a repo.
+1. Each agent uses its own worktree and branch.
+1. Lead agent integrates by merging branches after per-workstream verification.
+
+Worktree directory convention:
+1. Prefer repo-local `.worktrees/` if present and ignored.
+1. Otherwise use repo-local `worktrees/` if present and ignored.
+1. If neither exists, create `.worktrees/`, add to `.gitignore`, commit, then proceed.
+
+Branch naming:
+1. `poc/makerv3-singleleg-scaffold`
+1. `poc/makerv3-singleleg-data`
+1. `poc/makerv3-singleleg-strategy`
+1. `poc/makerv3-singleleg-bridge`
+1. `poc/makerv3-singleleg-fluxboard` (in `/home/ubuntu/chainsaw` only; docs/runbook/config tweaks)
+
+Workstream ownership matrix:
+1. Scaffold:
+1. Owns: `examples/live/poc/README.md`, shared contracts module, runbook docs.
+1. Data smoke tests:
+1. Owns: `examples/live/poc/multivenue_book_smoke.py`
+1. Strategy:
+1. Owns: `nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py`, runner script.
+1. Bridge:
+1. Owns: `examples/live/poc/chainsaw_bridge.py`
+1. Fluxboard integration:
+1. Owns: changes in `/home/ubuntu/chainsaw` only (runbook, optional config entry), and the validation checklist for TokenMM pages.
+
+## Merge and integration strategy (lead-owned)
+
+Merge order (minimize conflicts):
+1. Merge scaffold first.
+1. Merge strategy next (it defines the payloads and topics).
+1. Merge bridge next (it binds to payload schema).
+1. Merge Fluxboard integration notes last (no code changes in Nautilus repo unless needed).
+1. Merge data smoke test whenever (independent).
+
+Conflict rule:
+1. Only the scaffold branch changes `examples/live/poc/contracts.py` after the first merge.
+1. If other branches need contract changes, they submit a follow-up PR/branch to scaffold instead of editing it directly.
+
+## Plan review (what changed vs. earlier version)
+
+1. Removed hedge market, fair value from second leg, and all hedging logic.
+1. Refocused strategy on a single `strategy_market` with 3 bands.
+1. Kept Binance+Bybit connector setup only as a market data/bookbuilding proof step.
+1. Added a workstream-based execution plan with explicit file ownership and merge strategy.
+
+---
+
+## Tasks (bite-sized, parallelizable)
+
+### Task 1: Worktree setup (both repos)
+
+**Owner:** Lead agent.
+
+**Files:**
+1. Modify (if needed): `.gitignore`
+
+**Step 1: Create worktree directory**
+
+Run in `/home/ubuntu/nautilus_trader`:
+```bash
+ls -d .worktrees 2>/dev/null || ls -d worktrees 2>/dev/null || true
+```
+
+**Step 2: Verify ignore and create if missing**
+
+If using repo-local `.worktrees/` or `worktrees/`:
+```bash
+git check-ignore -q .worktrees || git check-ignore -q worktrees
+```
+
+If not ignored, add to `.gitignore` and commit.
+
+**Step 3: Create worktrees and branches**
+
+Create worktrees for each workstream:
+```bash
+git worktree add .worktrees/makerv3-scaffold -b poc/makerv3-singleleg-scaffold
+git worktree add .worktrees/makerv3-data -b poc/makerv3-singleleg-data
+git worktree add .worktrees/makerv3-strategy -b poc/makerv3-singleleg-strategy
+git worktree add .worktrees/makerv3-bridge -b poc/makerv3-singleleg-bridge
+```
+
+Create a Chainsaw worktree for Fluxboard integration notes (optional but recommended if you need config/runbook tweaks):
+```bash
+cd /home/ubuntu/chainsaw
+ls -d .worktrees 2>/dev/null || ls -d worktrees 2>/dev/null || true
+git check-ignore -q .worktrees || git check-ignore -q worktrees
+git worktree add .worktrees/makerv3-fluxboard -b poc/makerv3-singleleg-fluxboard
+```
+
+**Step 4: Baseline sanity check**
+
+Run in each worktree (pick one python workflow and stick to it):
+```bash
+python -V
+pytest -q
+```
+
+Expected: tests pass or failures are documented as pre-existing.
+
+### Task 2: Scaffold shared POC directory and documentation
+
+**Owner:** Scaffold agent.
+
+**Files:**
+1. Create: `examples/live/poc/README.md`
+1. Create: `examples/live/poc/__init__.py`
+1. Create: `examples/live/poc/contracts.py`
+
+**Step 1: Add POC README**
+
+Include:
+1. Env vars for Bybit and Binance (testnet/demo/live).
+1. Redis connection env vars for bridge.
+1. Run commands for node, bridge, FluxAPI, Fluxboard.
+
+**Step 2: Define contract helpers**
+
+In `contracts.py`, define:
+1. `StrategyParams` dataclass or typed dict for the MVP param set.
+1. `EventType` string constants for `quote.placed`, `quote.replaced`, `quote.canceled`, `quote.failed`, `fill`, `alert`.
+1. Helper `json_dumps_compact(obj) -> str` that only emits JSON primitives.
+1. A mapping object for Fluxboard/Redis translation (kept out of the strategy logic):
+1. `instrument_id` (Nautilus `InstrumentId` string, e.g. `PLUMEUSDT-LINEAR.BYBIT`)
+1. `chainsaw_exchange` (e.g. `bybit_linear`)
+1. `chainsaw_symbol` (e.g. `plume/usdt`)
+1. `last_key` components are derived from (`chainsaw_exchange`, `chainsaw_symbol`) as `last:<exchange>:<BASE>_<QUOTE>`
+1. FV `coin` string uses `chainsaw_symbol` (slash form) so FluxAPI `_find_fv_for_leg` matches.
+
+**Step 3: Commit**
+
+```bash
+git add examples/live/poc
+git commit -m "poc: add makerv3 single-leg scaffold and contracts"
+```
+
+### Task 3: Multi-venue bookbuilding smoke test (Binance + Bybit)
+
+**Owner:** Data agent.
+
+**Files:**
+1. Create: `examples/live/poc/multivenue_book_smoke.py`
+
+**Step 1: Implement smoke strategy**
+
+Implement a minimal `Strategy` that:
+1. Subscribes to order book deltas and trades for `ETHUSDT-LINEAR.BYBIT`.
+1. Subscribes to order book deltas and trades for `ETHUSDT.BINANCE`.
+1. Maintains a local `OrderBook` per instrument and logs BBO changes.
+
+**Step 2: Run and verify**
+
+Run:
+```bash
+python examples/live/poc/multivenue_book_smoke.py
+```
+
+Expected:
+1. Continuous deltas.
+1. BBO updates derived from local book.
+
+**Step 3: Commit**
+
+```bash
+git add examples/live/poc/multivenue_book_smoke.py
+git commit -m "poc: add multi-venue bookbuilding smoke test"
+```
+
+### Task 4: Strategy pure functions (3-band ladder calculation)
+
+**Owner:** Strategy agent.
+
+**Files:**
+1. Create: `nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py`
+1. Test: `tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py`
+
+**Step 1: Write failing unit tests**
+
+Tests should cover:
+1. Given top-of-book bid/ask and params, compute deterministic target prices for each band/level/side.
+1. Prices move outward by `distanceX` bps for each additional level.
+1. No orders are generated if `n_ordersX` is 0.
+
+**Step 2: Run unit tests (fail)**
+
+Run:
+```bash
+pytest -q tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py
+```
+
+Expected: failing due to missing implementation.
+
+**Step 3: Implement ladder builder**
+
+Implement a pure function like:
+```python
+def build_band_prices_bps(
+    *,
+    side: str,
+    anchor_px: Decimal,
+    edge_bps: Decimal,
+    distance_bps: Decimal,
+    n_orders: int,
+) -> list[Decimal]:
+    ...
+```
+
+Anchor convention (MVP):
+1. Bid anchor is maker best bid.
+1. Ask anchor is maker best ask.
+
+Price convention (MVP):
+1. Bid price decreases by `(edge_bps + k*distance_bps)` from anchor.
+1. Ask price increases by `(edge_bps + k*distance_bps)` from anchor.
+
+**Step 4: Run unit tests (pass)**
+
+Run:
+```bash
+pytest -q tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py
+git add tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py
+git commit -m "poc: add makerv3 single-leg ladder builder + unit tests"
+```
+
+### Task 5: Strategy live order management (place/replace/cancel)
+
+**Owner:** Strategy agent.
+
+**Files:**
+1. Modify: `nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py`
+
+**Step 1: Implement Strategy class skeleton**
+
+Implement:
+1. `on_start`: subscribe instrument, book deltas, trades.
+1. `on_order_book_deltas`: update local book.
+1. Throttled on-book handler to run quote cycle (internal constant throttle; no `cooldown` param).
+
+**Step 2: Add slot model**
+
+Implement stable slots per band:
+1. Band 1 levels map to 1-10.
+1. Band 2 levels map to 11-20.
+1. Band 3 levels map to 21-30.
+
+**Step 3: Implement quote cycle**
+
+Inputs:
+1. Current maker BBO.
+1. Current open orders in slots.
+1. Current params.
+
+Outputs:
+1. Submit new orders for empty slots.
+1. Replace orders whose target price changed beyond a tick threshold or exceeded `max_age_ms`.
+1. Cancel orders for slots now out of range (when `n_ordersX` decreases or bot off).
+
+**Step 4: Add minimal event emission hooks**
+
+Emit internal events (in-memory) for:
+1. `quote.placed`
+1. `quote.replaced`
+1. `quote.canceled`
+1. `quote.failed`
+1. `fill`
+1. `alert`
+
+**Step 5: Publish external bridge messages (Nautilus-first schema)**
+
+On each quote cycle (throttled):
+1. Publish `maker_poc.state` (JSON string) with current mode + top-of-book + band config + open orders.
+1. Publish `maker_poc.market_bbo` (JSON string) for the strategy instrument (this is the bridge's source of truth for `last:*`).
+1. Optionally publish `maker_poc.fv` (JSON string) if you want the bridge to be dumb; otherwise bridge derives FV from BBO mid.
+
+On a slower interval (for example 1-5 seconds):
+1. Publish `maker_poc.balances` (JSON string) using Nautilus portfolio/account state for the venue.
+
+**Step 5: Commit**
+
+```bash
+git add nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py
+git commit -m "poc: implement makerv3 single-leg order management"
+```
+
+### Task 6: Param ingestion from Chainsaw-style Redis keys
+
+**Owner:** Strategy agent (or Bridge agent if you prefer to centralize Redis access).
+
+**Files:**
+1. Modify: `nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py`
+
+**Step 1: Implement param loader**
+
+Implement best-effort polling:
+1. Load `strategy.<strategy_id>.<param>` keys.
+1. Ignore missing keys.
+1. Treat empty strings as unset.
+1. Parse types into strongly typed values with safe defaults.
+
+**Step 2: Integrate into quote cycle**
+
+On each cycle:
+1. Refresh params if a `params_refresh_interval_ms` has elapsed.
+1. If `bot_on` is false:
+1. Cancel all managed orders.
+1. Emit `mode=OFF` in state.
+
+**Step 3: Commit**
+
+```bash
+git add nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py
+git commit -m "poc: add redis param polling for makerv3 single-leg"
+```
+
+### Task 7: Live node runner (Bybit strategy_market) + MessageBus Redis Streams backing
+
+**Owner:** Strategy agent.
+
+**Files:**
+1. Create: `examples/live/poc/makerv3_single_leg_node.py`
+
+**Step 1: Create TradingNodeConfig**
+
+Include:
+1. Bybit `data_clients` and `exec_clients` for `BybitProductType.LINEAR`.
+1. Instrument provider loads only the selected `strategy_market` instrument id.
+1. `message_bus=MessageBusConfig(database=DatabaseConfig(...), encoding="json", timestamps_as_iso8601=True, stream_per_topic=False, streams_prefix="maker_poc", use_trader_prefix=False, use_trader_id=False, use_instance_id=False, types_filter=[QuoteTick, TradeTick, OrderBookDeltas])`
+
+Note: add more types to `types_filter` as needed if you see Redis stream volume explode after enabling MessageBus backing.
+
+**Step 2: Add strategy**
+
+Instantiate strategy with:
+1. `strategy_id`
+1. `instrument_id`
+1. `client_id` pointing at BYBIT exec client id
+
+**Step 3: Run**
+
+Run:
+```bash
+python examples/live/poc/makerv3_single_leg_node.py
+```
+
+Expected:
+1. Node connects.
+1. Strategy receives market data.
+1. Strategy publishes state/events to Redis stream `maker_poc`.
+
+**Step 4: Commit**
+
+```bash
+git add examples/live/poc/makerv3_single_leg_node.py
+git commit -m "poc: add live node runner with msgbus redis stream backing"
+```
+
+### Task 8: Bridge from Redis Streams to Chainsaw keys
+
+**Owner:** Bridge agent.
+
+**Files:**
+1. Create: `examples/live/poc/chainsaw_bridge.py`
+
+**Step 1: Implement stream consumer**
+
+Consume stream `maker_poc` using `XREAD` or consumer groups.
+
+**Step 2: Map messages to Chainsaw schema**
+
+Minimum mapping:
+1. `maker_poc.state` to `maker_arb:<strategy_id>:state`
+1. `maker_poc.event` append to `maker_arb:<strategy_id>:events`
+1. `maker_poc.trade` upsert/append to `trades.blotter`
+1. `maker_poc.alert` append to `alerts.blotter`
+1. `maker_poc.balances` to `balances.snapshot` (plus `balances` hash rows)
+1. `maker_poc.market_bbo` to `last:<chainsaw_exchange>:<BASE>_<QUOTE>` using the mapping defined in `contracts.py`
+1. `maker_poc.fv` to `fvs.snapshot` using the mapping defined in `contracts.py` (or derive FV mid from `market_bbo` if you want the bridge to be self-contained)
+
+**Step 3: Run**
+
+Run:
+```bash
+python examples/live/poc/chainsaw_bridge.py
+```
+
+Expected:
+1. Keys update continuously while node runs.
+
+**Step 4: Commit**
+
+```bash
+git add examples/live/poc/chainsaw_bridge.py
+git commit -m "poc: add bridge from msgbus stream to chainsaw redis keys"
+```
+
+### Task 9: Fluxboard TokenMM UI integration (required GUI)
+
+**Owner:** Fluxboard integration agent.
+
+**Files:**
+1. No new Nautilus UI files. This task operates in `/home/ubuntu/chainsaw` to run the existing UI and validate Redis compatibility.
+
+**Step 1: Ensure strategy is visible on TokenMM surface**
+
+Fluxboard TokenMM Signal table filters by strategy meta `strategy_groups=tokenmm` from `configs/strategies.ini`:
+1. Prefer reusing an existing TokenMM MakerV3 strategy id already defined in Chainsaw `configs/strategies.ini` (example: `bybit_binance_plumeusdt_makerv3`) to avoid config changes.
+1. If you create a new strategy id, add a new `[strategy:<id>]` section with:
+1. `class = maker_v3`
+1. `strategy_groups = tokenmm`
+1. `exchange = bybit_linear` and a valid market key (plus `hedge_exchange` if FluxAPI expects it for builder paths).
+
+**Step 2: Start FluxAPI backend**
+
+Run in `/home/ubuntu/chainsaw`:
+```bash
+gunicorn -k eventlet -w 1 -b 0.0.0.0:${PORT:-5000} fluxapi.web:app
+```
+
+**Step 3: Start Fluxboard**
+
+Production mode (served by Flask) uses the built assets already wired in Chainsaw.
+
+If you need dev mode (optional), in `/home/ubuntu/chainsaw/fluxboard`:
+```bash
+pnpm install
+pnpm dev
+```
+
+**Step 4: Validate TokenMM panels**
+
+Navigate to:
+1. `/tokenmm/signal`
+1. `/tokenmm/params`
+1. `/tokenmm/balances`
+1. `/tokenmm/trades`
+1. `/tokenmm/alerts`
+
+Expected:
+1. Strategy row exists and updates (REST initial load; WebSocket updates if enabled).
+1. Params read/write round-trips to `strategy.<id>.*` keys.
+1. Balances show at least Bybit rows.
+1. Trades populate on fills.
+1. Alerts populate on errors/blocked states.
+
+### Task 10: End-to-end runbook + acceptance criteria
+
+**Owner:** Scaffold agent (with input from all).
+
+**Files:**
+1. Modify: `examples/live/poc/README.md`
+
+**Step 1: Document run order**
+
+Document:
+1. Start Redis.
+1. Start Nautilus node runner.
+1. Start bridge.
+1. Start FluxAPI + Fluxboard (TokenMM UI).
+
+**Step 2: Acceptance checklist**
+
+Checklist:
+1. Bybit bookbuilding works and quoting places 3-band ladders.
+1. `bot_on=false` cancels all quotes within one cycle.
+1. Redis keys update: state, events, alerts (and trades when fills happen).
+1. Fluxboard TokenMM pages (Signal/Params/Balances/Trades/Alerts) show the strategy and update.
+
+**Step 3: Commit**
+
+```bash
+git add examples/live/poc/README.md
+git commit -m "docs: add makerv3 single-leg poc runbook and acceptance checklist"
+```
+
+---
+
+## Execution decisions (locked 2026-03-03)
+
+1. `strategy_id` for Fluxboard TokenMM target is **Option A** (reuse existing config): `bybit_binance_plumeusdt_makerv3`.
+1. Strategy execution venue is Bybit linear perp only (single execution leg).
+1. Market data venues are Bybit + Binance (Binance data-only) for bookbuilding validation and Fluxboard leg hydration.
+1. Integration order is fixed: scaffold -> strategy -> bridge -> data (chainsaw notes last).
+
+## Open questions (resolve early in execution)
+
+1. `place_edgeX` semantics:
+1. MVP can treat it as extra bps away from anchor.
+1. If Flux UI expects a specific meaning, reconcile later.
+1. Events list storage type:
+1. Use a Redis list (`RPUSH`) for simplicity, or a stream if you need per-event IDs.
+1. Fluxboard data prerequisites:
+1. Signal page hard-requires non-empty `fvs.snapshot`. Decide whether bridge publishes a minimal FV snapshot, or you run an existing FV publisher.
+
+## Improvements backlog (post-MVP)
+
+1. Replace Redis param polling with a typed config feed and evented updates.
+1. Add a deterministic "dry-run" mode that replays recorded book deltas to test order logic without live trading.
+1. Add a consumer-group based bridge for at-least-once delivery and crash recovery.
+1. Add explicit Nautilus RiskEngine config for max orders, max position, notional limits.
+
+## Execution tracking (lead-owned)
+
+Update this table during orchestration:
+
+| Workstream | Branch | Worktree path | Owner | Status | Notes |
+|---|---|---|---|---|---|
+| Scaffold | `poc/makerv3-singleleg-scaffold` | `.worktrees/makerv3-scaffold` | `Heisenberg` | `done` | `commit 3d7e7580; review APPROVED` |
+| Data | `poc/makerv3-singleleg-data` | `.worktrees/makerv3-data` | `Banach` | `done` | `commit cd3b7980; review APPROVED` |
+| Strategy | `poc/makerv3-singleleg-strategy` | `.worktrees/makerv3-strategy` | `Franklin` | `done` | `commit d3acc35a; review APPROVED` |
+| Bridge | `poc/makerv3-singleleg-bridge` | `.worktrees/makerv3-bridge` | `Boyle -> Galileo` | `done` | `commits c6a35b3d + a0af7cda; review+fix loop complete` |
+| Fluxboard integration | `poc/makerv3-singleleg-fluxboard` | `/home/ubuntu/chainsaw/.worktrees/makerv3-fluxboard` | `Darwin -> Fermat -> Boole` | `done` | `commits db671dcf + 4dc394ce + f5eb2257; docs lint green` |

--- a/examples/live/poc/README.md
+++ b/examples/live/poc/README.md
@@ -1,0 +1,35 @@
+# MakerV3 Single-Leg POC Scaffold
+
+This directory defines the shared translation contract for the MakerV3 single-leg POC:
+
+- `strategy_id`: `bybit_binance_plumeusdt_makerv3`
+- Execution venue: Bybit linear perp only
+- Market data venues: Bybit + Binance (Binance is data-only)
+
+## Run Order
+
+1. Start Redis.
+
+   ```bash
+   redis-server
+   ```
+
+2. Run the Nautilus strategy node.
+
+   ```bash
+   python examples/live/poc/makerv3_single_leg_node.py
+   ```
+
+3. Run the Redis bridge.
+
+   ```bash
+   python examples/live/poc/redis_bridge.py
+   ```
+
+4. Run the standalone Nautilus GUI/API server.
+
+   ```bash
+   PORT=5022 python examples/live/poc/nautilus_fluxapi.py
+   ```
+
+5. Open `http://<host>:5022/tokenmm` (or any `/tokenmm/*` route).

--- a/examples/live/poc/__init__.py
+++ b/examples/live/poc/__init__.py
@@ -1,0 +1,38 @@
+from .contracts import INSTRUMENT_CONTRACTS
+from .contracts import INSTRUMENT_CONTRACTS_BY_ID
+from .contracts import STRATEGY_ID
+from .contracts import TOPIC_ALERT
+from .contracts import TOPIC_BALANCES
+from .contracts import TOPIC_EVENT
+from .contracts import TOPIC_FV
+from .contracts import TOPIC_MARKET_BBO
+from .contracts import TOPIC_STATE
+from .contracts import TOPIC_TRADE
+from .contracts import InstrumentContract
+from .contracts import get_instrument_contract
+from .contracts import json_dumps_compact
+from .contracts import make_fv_coin
+from .contracts import make_fv_coin_for_instrument
+from .contracts import make_last_key_component
+from .contracts import make_last_key_component_for_instrument
+
+
+__all__ = [
+    "INSTRUMENT_CONTRACTS",
+    "INSTRUMENT_CONTRACTS_BY_ID",
+    "STRATEGY_ID",
+    "TOPIC_ALERT",
+    "TOPIC_BALANCES",
+    "TOPIC_EVENT",
+    "TOPIC_FV",
+    "TOPIC_MARKET_BBO",
+    "TOPIC_STATE",
+    "TOPIC_TRADE",
+    "InstrumentContract",
+    "get_instrument_contract",
+    "json_dumps_compact",
+    "make_fv_coin",
+    "make_fv_coin_for_instrument",
+    "make_last_key_component",
+    "make_last_key_component_for_instrument",
+]

--- a/examples/live/poc/chainsaw_bridge.py
+++ b/examples/live/poc/chainsaw_bridge.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import logging
+import signal
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import redis
+
+DEFAULT_STRATEGY_ID = "bybit_binance_plumeusdt_makerv3"
+
+DEFAULT_TOPICS = {
+    "state": "maker_poc.state",
+    "event": "maker_poc.event",
+    "trade": "maker_poc.trade",
+    "alert": "maker_poc.alert",
+    "market_bbo": "maker_poc.market_bbo",
+    "fv": "maker_poc.fv",
+    "balances": "maker_poc.balances",
+}
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _to_json(obj: Any) -> str:
+    return json.dumps(obj, separators=(",", ":"), default=_json_default)
+
+
+def _decode_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_ts_ms(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", errors="replace")
+        ts = float(value)
+    except (TypeError, ValueError):
+        try:
+            ts = datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+        except (TypeError, ValueError):
+            return None
+    if ts <= 0:
+        return None
+    if ts < 1_000_000_000_000:
+        return int(ts * 1000)
+    if ts >= 1_000_000_000_000_000_000:
+        return int(ts / 1_000_000)
+    if ts >= 1_000_000_000_000_000:
+        return int(ts / 1000)
+    return int(ts)
+
+
+def _load_json_payload(raw_payload: Any) -> Any:
+    if raw_payload is None:
+        return None
+    if isinstance(raw_payload, (dict, list)):
+        return raw_payload
+    if isinstance(raw_payload, (int, float, bool)):
+        return raw_payload
+    if isinstance(raw_payload, bytes):
+        try:
+            text = raw_payload.decode("utf-8")
+        except UnicodeDecodeError:
+            return raw_payload
+    else:
+        text = str(raw_payload)
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _as_dict(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return dict(payload)
+    if isinstance(payload, list):
+        return {"rows": payload}
+    if isinstance(payload, bytes):
+        payload = _decode_text(payload)
+    if isinstance(payload, str):
+        parsed = _load_json_payload(payload)
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        return {"value": payload}
+    return {"value": payload}
+
+
+def _as_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [dict(row) for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("rows", "trades", "alerts", "data", "items", "values"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                rows = [dict(row) for row in value if isinstance(row, dict)]
+                if rows:
+                    return rows
+        return [dict(payload)]
+    if isinstance(payload, str):
+        parsed = _load_json_payload(payload)
+        return _as_rows(parsed)
+    return []
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = _decode_text(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _normalize_symbol_parts(
+    *,
+    base: Any = None,
+    quote: Any = None,
+    symbol: Any = None,
+) -> tuple[str, str]:
+    base_text = _decode_text(base).strip().upper()
+    quote_text = _decode_text(quote).strip().upper()
+    if base_text and quote_text:
+        return base_text, quote_text
+
+    symbol_text = _decode_text(symbol).strip().upper()
+    if not symbol_text:
+        return "", ""
+
+    cleaned = symbol_text.replace("-", "_").replace("/", "_")
+    if "_" in cleaned:
+        left, right = cleaned.split("_", 1)
+        return left, right
+
+    known_quotes = (
+        "USDT",
+        "USDC",
+        "PUSD",
+        "USDE",
+        "USD",
+        "BTC",
+        "ETH",
+        "EUR",
+        "GBP",
+        "JPY",
+        "BNB",
+    )
+    for candidate in known_quotes:
+        if cleaned.endswith(candidate) and len(cleaned) > len(candidate):
+            return cleaned[: -len(candidate)], candidate
+
+    return cleaned, ""
+
+
+def _load_contracts_module(logger: logging.Logger) -> Any:
+    contracts_path = Path(__file__).with_name("contracts.py")
+    if not contracts_path.exists():
+        raise FileNotFoundError(f"Required contracts.py not found at {contracts_path}")
+
+    spec = importlib.util.spec_from_file_location("poc_contracts", contracts_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Failed to load contracts.py spec at {contracts_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        raise ImportError(f"Failed importing contracts.py ({exc})") from exc
+    logger.info("Loaded contracts.py from %s", contracts_path)
+    return module
+
+
+class ContractsAdapter:
+    def __init__(self, module: Any) -> None:
+        self._module = module
+
+    def _call_first(self, names: Iterable[str], *args: Any) -> Any | None:
+        for name in names:
+            fn = getattr(self._module, name, None)
+            if callable(fn):
+                try:
+                    return fn(*args)
+                except TypeError:
+                    continue
+                except Exception as exc:
+                    raise RuntimeError(f"contracts.py helper `{name}` failed: {exc}") from exc
+        return None
+
+    def _value_first(self, names: Iterable[str]) -> Any | None:
+        for name in names:
+            if hasattr(self._module, name):
+                return getattr(self._module, name)
+        return None
+
+    @staticmethod
+    def _require_text(value: Any, *, required: str) -> str:
+        if isinstance(value, str) and value:
+            return value
+        raise RuntimeError(f"contracts.py missing required mapping: {required}")
+
+    def topic(self, name: str, default: str) -> str:
+        value = self._call_first((f"{name}_topic", f"topic_{name}", f"get_{name}_topic"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(
+            (
+                f"{name.upper()}_TOPIC",
+                f"TOPIC_{name.upper()}",
+                f"MAKER_POC_{name.upper()}_TOPIC",
+            ),
+        )
+        return self._require_text(
+            value,
+            required=f"topic `{name}` (expected default `{default}`)",
+        )
+
+    def state_key(self, strategy_id: str) -> str:
+        value = self._call_first(
+            ("state_key", "maker_state_key", "get_state_key", "maker_state_redis_key"),
+            strategy_id,
+        )
+        if isinstance(value, str) and value:
+            return value
+        return f"maker_arb:{strategy_id}:state"
+
+    def events_key(self, strategy_id: str) -> str:
+        value = self._call_first(
+            ("events_key", "maker_events_key", "get_events_key", "maker_events_redis_key"),
+            strategy_id,
+        )
+        if isinstance(value, str) and value:
+            return value
+        return f"maker_arb:{strategy_id}:events"
+
+    def market_key(self, exchange: str, base: str, quote: str) -> str:
+        value = self._call_first(
+            ("market_bbo_key", "market_last_key", "last_market_key", "compose_last_key"),
+            exchange,
+            base,
+            quote,
+        )
+        if isinstance(value, str) and value:
+            return value
+        value = self._call_first(
+            ("make_last_key_component",),
+            exchange,
+            f"{base.lower()}/{quote.lower()}",
+        )
+        if isinstance(value, str) and value:
+            return value
+        return f"last:{exchange}:{base}_{quote}"
+
+    def balances_snapshot_key(self) -> str:
+        value = self._call_first(("balances_snapshot_key", "get_balances_snapshot_key"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(("BALANCES_SNAPSHOT_KEY", "balances_snapshot_key"))
+        if isinstance(value, str) and value:
+            return value
+        return "balances.snapshot"
+
+    def balances_hash_key(self) -> str:
+        value = self._call_first(("balances_hash_key", "get_balances_hash_key"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(("BALANCES_HASH_KEY", "balances_hash_key"))
+        if isinstance(value, str) and value:
+            return value
+        return "balances"
+
+    def fvs_snapshot_key(self) -> str:
+        value = self._call_first(("fvs_snapshot_key", "get_fvs_snapshot_key"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(("FVS_SNAPSHOT_KEY", "fvs_snapshot_key"))
+        if isinstance(value, str) and value:
+            return value
+        return "fvs.snapshot"
+
+    def trades_blotter_key(self) -> str:
+        value = self._call_first(("trades_blotter_key", "get_trades_blotter_key"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(("TRADES_BLOTTER_KEY", "trades_blotter_key"))
+        if isinstance(value, str) and value:
+            return value
+        return "trades.blotter"
+
+    def alerts_blotter_key(self) -> str:
+        value = self._call_first(("alerts_blotter_key", "get_alerts_blotter_key"))
+        if isinstance(value, str) and value:
+            return value
+        value = self._value_first(("ALERTS_BLOTTER_KEY", "alerts_blotter_key"))
+        if isinstance(value, str) and value:
+            return value
+        return "alerts.blotter"
+
+    def normalize_exchange(self, exchange: Any) -> str:
+        value = self._call_first(
+            ("normalize_exchange_name", "normalize_exchange", "to_chainsaw_exchange"),
+            exchange,
+        )
+        if isinstance(value, str) and value:
+            return value
+        return _decode_text(exchange).strip().lower()
+
+
+class ChainsawBridge:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self._logger = logging.getLogger("chainsaw-bridge")
+        self._redis = redis.Redis(
+            host=args.redis_host,
+            port=args.redis_port,
+            db=args.redis_db,
+            username=args.redis_username,
+            password=args.redis_password,
+            decode_responses=False,
+        )
+        self._contracts = ContractsAdapter(_load_contracts_module(self._logger))
+        self._stream_prefix = args.stream_prefix
+        self._stream_per_topic = args.stream_per_topic
+        self._explicit_streams = list(args.streams or [])
+        self._scan_interval_sec = max(1.0, args.scan_interval_sec)
+        self._block_ms = max(10, args.block_ms)
+        self._read_count = max(1, args.read_count)
+        self._start_id = args.start_id
+        self._strategy_id = _decode_text(args.strategy_id).strip() or DEFAULT_STRATEGY_ID
+        self._events_max = max(1, args.events_max)
+        self._trades_max = max(1, args.trades_max)
+        self._alerts_max = max(1, args.alerts_max)
+        self._rebuild_balances_hash = not args.no_balances_hash
+        self._last_scan_ts = 0.0
+        self._running = True
+        self._stream_ids: dict[str, str] = {}
+        self._state_keys: dict[str, str] = {}
+        self._events_keys: dict[str, str] = {}
+
+        self._topics = {
+            name: self._contracts.topic(name, default)
+            for name, default in DEFAULT_TOPICS.items()
+        }
+        self._state_keys[self._strategy_id] = self._contracts.state_key(self._strategy_id)
+        self._events_keys[self._strategy_id] = self._contracts.events_key(self._strategy_id)
+        self._trades_key = self._contracts.trades_blotter_key()
+        self._alerts_key = self._contracts.alerts_blotter_key()
+        self._fvs_key = self._contracts.fvs_snapshot_key()
+        self._balances_snapshot_key = self._contracts.balances_snapshot_key()
+        self._balances_hash_key = self._contracts.balances_hash_key()
+
+        self._handlers: dict[str, Callable[[Any], None]] = {
+            self._topics["state"]: self._handle_state,
+            self._topics["event"]: self._handle_event,
+            self._topics["trade"]: self._handle_trade,
+            self._topics["alert"]: self._handle_alert,
+            self._topics["market_bbo"]: self._handle_market_bbo,
+            self._topics["fv"]: self._handle_fv,
+            self._topics["balances"]: self._handle_balances,
+        }
+
+    def _install_signals(self) -> None:
+        signal.signal(signal.SIGINT, self._on_signal)
+        signal.signal(signal.SIGTERM, self._on_signal)
+
+    def _on_signal(self, sig: int, _frame: Any) -> None:
+        self._logger.info("Received signal %s, stopping", sig)
+        self._running = False
+
+    def _scan_patterns(self) -> list[str]:
+        if self._stream_per_topic:
+            patterns = []
+            for topic in self._handlers:
+                patterns.append(f"{self._stream_prefix}:{topic}")
+                patterns.append(f"*:{self._stream_prefix}:{topic}")
+            return patterns
+        return [self._stream_prefix, f"*:{self._stream_prefix}"]
+
+    def _track_stream_key(self, key: str, *, source: str) -> None:
+        try:
+            redis_type = _decode_text(self._redis.type(key)).strip().lower()
+        except redis.RedisError as exc:
+            self._logger.warning("Skipping %s key %s (failed TYPE: %s)", source, key, exc)
+            self._stream_ids.pop(key, None)
+            return
+        if redis_type != "stream":
+            if redis_type and redis_type != "none":
+                self._logger.warning(
+                    "Skipping %s key %s (redis type=%s, expected stream)",
+                    source,
+                    key,
+                    redis_type,
+                )
+            self._stream_ids.pop(key, None)
+            return
+        if key not in self._stream_ids:
+            self._logger.info("Discovered stream key %s", key)
+            self._stream_ids[key] = self._start_id
+
+    def _drop_non_stream_keys(self, *, reason: str) -> int:
+        dropped = 0
+        for key in list(self._stream_ids):
+            try:
+                redis_type = _decode_text(self._redis.type(key)).strip().lower()
+            except redis.RedisError as exc:
+                self._logger.warning(
+                    "Failed TYPE for key %s while handling %s: %s",
+                    key,
+                    reason,
+                    exc,
+                )
+                continue
+            if redis_type == "stream":
+                continue
+            dropped += 1
+            self._stream_ids.pop(key, None)
+            self._logger.warning(
+                "Dropped stream key %s after %s (redis type=%s)",
+                key,
+                reason,
+                redis_type or "unknown",
+            )
+        return dropped
+
+    def _refresh_streams(self, force: bool = False) -> None:
+        if self._explicit_streams:
+            for key in self._explicit_streams:
+                self._track_stream_key(key, source="explicit")
+            return
+
+        now = time.time()
+        if not force and (now - self._last_scan_ts) < self._scan_interval_sec:
+            return
+
+        discovered: set[str] = set()
+        for pattern in self._scan_patterns():
+            cursor = 0
+            while True:
+                cursor, keys = self._redis.scan(cursor=cursor, match=pattern, count=500)
+                for raw_key in keys:
+                    discovered.add(_decode_text(raw_key))
+                if cursor == 0:
+                    break
+
+        for key in sorted(discovered):
+            self._track_stream_key(key, source="discovered")
+
+        self._last_scan_ts = now
+
+    def _infer_topic(self, stream_key: str) -> str:
+        marker = f":{self._stream_prefix}:"
+        if marker in stream_key:
+            return stream_key.split(marker, 1)[1]
+        if stream_key.startswith(f"{self._stream_prefix}:"):
+            return stream_key.split(":", 1)[1]
+        return ""
+
+    def _parse_bus_message(self, fields: dict[Any, Any], stream_key: str) -> tuple[str, Any]:
+        topic = _first_text(fields.get("topic"), fields.get(b"topic"))
+        if not topic:
+            topic = self._infer_topic(stream_key)
+        raw_payload = fields.get("payload")
+        if raw_payload is None:
+            raw_payload = fields.get(b"payload")
+        payload = _load_json_payload(raw_payload)
+        return topic, payload
+
+    def _strategy_id_for_payload(self, payload: Any) -> str:
+        parsed = payload
+        if isinstance(payload, (str, bytes)):
+            parsed = _load_json_payload(payload)
+        if isinstance(parsed, dict):
+            strategy_id = _decode_text(parsed.get("strategy_id")).strip()
+            if strategy_id:
+                return strategy_id
+        return self._strategy_id
+
+    def _state_key_for_strategy(self, strategy_id: str) -> str:
+        key = self._state_keys.get(strategy_id)
+        if key is None:
+            key = self._contracts.state_key(strategy_id)
+            self._state_keys[strategy_id] = key
+        return key
+
+    def _events_key_for_strategy(self, strategy_id: str) -> str:
+        key = self._events_keys.get(strategy_id)
+        if key is None:
+            key = self._contracts.events_key(strategy_id)
+            self._events_keys[strategy_id] = key
+        return key
+
+    def _json_state(self, payload: Any, strategy_id: str) -> str:
+        if isinstance(payload, dict):
+            payload = dict(payload)
+            payload.setdefault("strategy_id", strategy_id)
+            return _to_json(payload)
+        if isinstance(payload, list):
+            return _to_json(payload)
+        if isinstance(payload, str):
+            parsed = _load_json_payload(payload)
+            if isinstance(parsed, dict):
+                parsed = dict(parsed)
+                parsed.setdefault("strategy_id", strategy_id)
+                return _to_json(parsed)
+            if isinstance(parsed, list):
+                return _to_json(parsed)
+            return _to_json({"value": payload, "strategy_id": strategy_id})
+        return _to_json({"value": payload, "strategy_id": strategy_id})
+
+    def _handle_state(self, payload: Any) -> None:
+        strategy_id = self._strategy_id_for_payload(payload)
+        self._redis.set(
+            self._state_key_for_strategy(strategy_id),
+            self._json_state(payload, strategy_id),
+        )
+
+    def _handle_event(self, payload: Any) -> None:
+        row = _as_dict(payload)
+        strategy_id = self._strategy_id_for_payload(row)
+        row.setdefault("strategy_id", strategy_id)
+        row.setdefault("ts_ms", _now_ms())
+        events_key = self._events_key_for_strategy(strategy_id)
+        pipe = self._redis.pipeline(transaction=True)
+        # Events are append-only in chronological order: oldest -> newest.
+        pipe.rpush(events_key, _to_json(row))
+        pipe.ltrim(events_key, -self._events_max, -1)
+        pipe.execute()
+
+    def _synth_trade_row_id(self, row: dict[str, Any]) -> str:
+        ts_ms = _coerce_ts_ms(
+            row.get("ts_ms")
+            or row.get("ts")
+            or row.get("created_ts_ms")
+            or row.get("timestamp")
+            or _now_ms()
+        ) or _now_ms()
+        exch = _first_text(row.get("exchange"), row.get("venue"), "unknown").lower()
+        symbol = _first_text(row.get("coin"), row.get("symbol"), "unknown").upper()
+        trade_ref = _first_text(
+            row.get("trade_id"),
+            row.get("exchange_trade_id"),
+            row.get("id"),
+            row.get("tx_hash"),
+            row.get("hash"),
+            uuid.uuid4().hex[:10],
+        )
+        return f"{exch}:{symbol}:{ts_ms}:{trade_ref}"
+
+    def _handle_trade_row(self, row: dict[str, Any]) -> None:
+        clean = dict(row)
+        incoming_strategy_id = _decode_text(clean.get("strategy_id")).strip()
+        if incoming_strategy_id:
+            if incoming_strategy_id != self._strategy_id:
+                self._logger.debug(
+                    "Preserving upstream trade strategy_id=%s (configured --strategy-id=%s)",
+                    incoming_strategy_id,
+                    self._strategy_id,
+                )
+        else:
+            clean.setdefault("strategy_id", self._strategy_id)
+            if not _decode_text(clean.get("strategy_id")).strip():
+                clean["strategy_id"] = self._strategy_id
+        clean["op"] = _first_text(clean.get("op"), "upsert")
+
+        ts_ms = _coerce_ts_ms(
+            clean.get("ts_ms")
+            or clean.get("ts")
+            or clean.get("created_ts_ms")
+            or clean.get("timestamp")
+            or clean.get("time")
+            or clean.get("datetime")
+        ) or _now_ms()
+        clean["ts_ms"] = ts_ms
+        clean.setdefault("ts", ts_ms)
+        clean.setdefault(
+            "time",
+            datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        row_id = _first_text(
+            clean.get("row_id"),
+            clean.get("exchange_trade_id"),
+            clean.get("trade_id"),
+            clean.get("id"),
+            clean.get("tx_hash"),
+            clean.get("hash"),
+        )
+        if not row_id:
+            row_id = self._synth_trade_row_id(clean)
+        clean["row_id"] = row_id
+
+        seq = int(self._redis.incr("trades.seq"))
+        version = int(self._redis.incr(f"trades.ver:{row_id}"))
+        clean["seq"] = seq
+        clean["version"] = version
+        serialized = _to_json(clean)
+
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.lpush(self._trades_key, serialized)
+        pipe.ltrim(self._trades_key, 0, self._trades_max - 1)
+        pipe.hset("trades.map", row_id, serialized)
+        pipe.zadd("trades.index.seq", {row_id: seq})
+        pipe.zadd("trades.index.ts", {row_id: ts_ms})
+        pipe.execute()
+
+    def _prune_trade_indices(self) -> None:
+        for key in ("trades.index.seq", "trades.index.ts"):
+            size = int(self._redis.zcard(key) or 0)
+            overflow = size - self._trades_max
+            if overflow > 0:
+                self._redis.zremrangebyrank(key, 0, overflow - 1)
+
+    def _handle_trade(self, payload: Any) -> None:
+        rows = _as_rows(payload)
+        if not rows:
+            row = _as_dict(payload)
+            if row:
+                rows = [row]
+        if not rows:
+            return
+        for row in rows:
+            self._handle_trade_row(row)
+        self._prune_trade_indices()
+
+    def _handle_alert(self, payload: Any) -> None:
+        rows = _as_rows(payload)
+        if not rows:
+            row = _as_dict(payload)
+            if row:
+                rows = [row]
+        if not rows:
+            return
+
+        pipe = self._redis.pipeline(transaction=True)
+        now_ts = time.time()
+        for row in rows:
+            alert = dict(row)
+            alert.setdefault("strategy_id", self._strategy_id)
+            alert.setdefault("id", str(uuid.uuid4()))
+            alert.setdefault("timestamp", now_ts)
+            pipe.rpush(self._alerts_key, _to_json(alert))
+        pipe.ltrim(self._alerts_key, -self._alerts_max, -1)
+        pipe.execute()
+
+    def _handle_market_bbo(self, payload: Any) -> None:
+        row = _as_dict(payload)
+        exchange = self._contracts.normalize_exchange(
+            _first_text(
+                row.get("chainsaw_exchange"),
+                row.get("exchange"),
+                row.get("venue"),
+                row.get("market_exchange"),
+            ),
+        )
+        base, quote = _normalize_symbol_parts(
+            base=row.get("base"),
+            quote=row.get("quote"),
+            symbol=_first_text(
+                row.get("symbol"),
+                row.get("market_key"),
+                row.get("coin"),
+                row.get("pair"),
+            ),
+        )
+        if not exchange or not base or not quote:
+            self._logger.warning("Skipping market_bbo without key fields: %s", row)
+            return
+
+        bid = _safe_float(row.get("bid") or row.get("best_bid") or row.get("bid_px"))
+        ask = _safe_float(row.get("ask") or row.get("best_ask") or row.get("ask_px"))
+        if bid is None and ask is None:
+            self._logger.warning("Skipping market_bbo without bid/ask: %s", row)
+            return
+
+        ts_ms = _coerce_ts_ms(
+            row.get("ts_ms")
+            or row.get("timestamp")
+            or row.get("observed_ts")
+            or row.get("ts")
+        ) or _now_ms()
+
+        out = dict(row)
+        out["chainsaw_exchange"] = exchange
+        out["base"] = base
+        out["quote"] = quote
+        if bid is not None:
+            out["bid"] = bid
+        if ask is not None:
+            out["ask"] = ask
+        out["ts_ms"] = ts_ms
+
+        key = self._contracts.market_key(exchange, base, quote)
+        self._redis.set(key, _to_json(out))
+
+    def _handle_fv(self, payload: Any) -> None:
+        rows = _as_rows(payload)
+        if not rows:
+            self._logger.warning("Ignoring empty maker_poc.fv payload to keep fvs.snapshot non-empty")
+            return
+        self._redis.set(self._fvs_key, _to_json(rows))
+
+    def _balance_hash_field(self, row: dict[str, Any], idx: int) -> str:
+        exchange = self._contracts.normalize_exchange(
+            _first_text(row.get("exchange"), row.get("venue"), row.get("source"), "unknown"),
+        )
+        coin = _first_text(row.get("coin"), row.get("asset"), row.get("symbol"), "UNKNOWN").upper()
+        location = _first_text(row.get("balance_location"), row.get("scope"), str(idx))
+        return f"{exchange}:{coin}:{location}"
+
+    def _handle_balances(self, payload: Any) -> None:
+        rows = _as_rows(payload)
+        snapshot = _to_json(rows)
+        if not self._rebuild_balances_hash:
+            self._redis.set(self._balances_snapshot_key, snapshot)
+            return
+
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.set(self._balances_snapshot_key, snapshot)
+        pipe.delete(self._balances_hash_key)
+        for idx, row in enumerate(rows):
+            pipe.hset(self._balances_hash_key, self._balance_hash_field(row, idx), _to_json(row))
+        pipe.execute()
+
+    def run(self) -> None:
+        self._install_signals()
+        self._refresh_streams(force=True)
+        self._logger.info("Bridge default strategy_id=%s", self._strategy_id)
+        self._logger.info("Listening for topics: %s", sorted(self._handlers))
+
+        while self._running:
+            self._refresh_streams(force=False)
+
+            if not self._stream_ids:
+                time.sleep(0.5)
+                continue
+
+            try:
+                stream_bulk = self._redis.xread(
+                    streams=self._stream_ids,
+                    count=self._read_count,
+                    block=self._block_ms,
+                )
+            except redis.RedisError as exc:
+                message = _decode_text(exc).upper()
+                if "WRONGTYPE" in message or "XREAD" in message:
+                    dropped = self._drop_non_stream_keys(reason=f"xread error ({exc})")
+                    if dropped:
+                        continue
+                self._logger.error("xread failed: %s", exc)
+                time.sleep(1.0)
+                continue
+
+            if not stream_bulk:
+                continue
+
+            for stream_raw, entries in stream_bulk:
+                stream_key = _decode_text(stream_raw)
+                for entry_id_raw, fields in entries:
+                    entry_id = _decode_text(entry_id_raw)
+                    self._stream_ids[stream_key] = entry_id
+
+                    topic, payload = self._parse_bus_message(fields, stream_key)
+                    if not topic:
+                        self._logger.debug(
+                            "Skipping stream entry without topic stream=%s id=%s",
+                            stream_key,
+                            entry_id,
+                        )
+                        continue
+
+                    handler = self._handlers.get(topic)
+                    if handler is None:
+                        continue
+
+                    try:
+                        handler(payload)
+                    except Exception as exc:
+                        self._logger.exception(
+                            "Handler failed topic=%s stream=%s id=%s err=%s",
+                            topic,
+                            stream_key,
+                            entry_id,
+                            exc,
+                        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bridge Nautilus msgbus Redis streams into Fluxboard-compatible Redis keys.",
+    )
+    parser.add_argument("--redis-host", default="127.0.0.1")
+    parser.add_argument("--redis-port", type=int, default=6379)
+    parser.add_argument("--redis-db", type=int, default=0)
+    parser.add_argument("--redis-username", default=None)
+    parser.add_argument("--redis-password", default=None)
+    parser.add_argument("--stream-prefix", default="maker_poc")
+    parser.add_argument("--stream-per-topic", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--streams", nargs="*", default=[])
+    parser.add_argument("--scan-interval-sec", type=float, default=3.0)
+    parser.add_argument("--block-ms", type=int, default=1000)
+    parser.add_argument("--read-count", type=int, default=200)
+    parser.add_argument("--start-id", default="$")
+    parser.add_argument("--strategy-id", default=DEFAULT_STRATEGY_ID)
+    parser.add_argument("--events-max", type=int, default=300)
+    parser.add_argument("--trades-max", type=int, default=1000)
+    parser.add_argument("--alerts-max", type=int, default=1000)
+    parser.add_argument("--no-balances-hash", action="store_true")
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+    )
+
+    bridge = ChainsawBridge(args)
+    bridge.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/live/poc/contracts.py
+++ b/examples/live/poc/contracts.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+import math
+from types import MappingProxyType
+from typing import Any
+from typing import TypeAlias
+
+
+TOPIC_STATE = "maker_poc.state"
+TOPIC_EVENT = "maker_poc.event"
+TOPIC_TRADE = "maker_poc.trade"
+TOPIC_ALERT = "maker_poc.alert"
+TOPIC_MARKET_BBO = "maker_poc.market_bbo"
+TOPIC_FV = "maker_poc.fv"
+TOPIC_BALANCES = "maker_poc.balances"
+
+STRATEGY_ID = "bybit_binance_plumeusdt_makerv3"
+
+JSONPrimitive: TypeAlias = None | bool | int | float | str
+JSONValue: TypeAlias = JSONPrimitive | list["JSONValue"] | dict[str, "JSONValue"]
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentContract:
+    instrument_id: str
+    chainsaw_exchange: str
+    chainsaw_symbol: str
+
+
+INSTRUMENT_CONTRACTS: tuple[InstrumentContract, ...] = (
+    InstrumentContract(
+        instrument_id="PLUMEUSDT-LINEAR.BYBIT",
+        chainsaw_exchange="bybit_linear",
+        chainsaw_symbol="plume/usdt",
+    ),
+    InstrumentContract(
+        instrument_id="PLUMEUSDT.BINANCE",
+        chainsaw_exchange="binance_spot",
+        chainsaw_symbol="plume/usdt",
+    ),
+)
+
+INSTRUMENT_CONTRACTS_BY_ID: Mapping[str, InstrumentContract] = MappingProxyType(
+    {item.instrument_id: item for item in INSTRUMENT_CONTRACTS},
+)
+
+
+def json_dumps_compact(obj: Any) -> str:
+    normalized = _to_json_value(obj)
+    return json.dumps(
+        normalized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def get_instrument_contract(instrument_id: str) -> InstrumentContract:
+    try:
+        return INSTRUMENT_CONTRACTS_BY_ID[instrument_id]
+    except KeyError as exc:
+        msg = f"Unknown instrument_id '{instrument_id}'."
+        raise KeyError(msg) from exc
+
+
+def make_last_key_component(chainsaw_exchange: str, chainsaw_symbol: str) -> str:
+    base, quote = _split_symbol(chainsaw_symbol)
+    return f"last:{chainsaw_exchange}:{base}_{quote}"
+
+
+def make_last_key_component_for_instrument(instrument_id: str) -> str:
+    contract = get_instrument_contract(instrument_id)
+    return make_last_key_component(contract.chainsaw_exchange, contract.chainsaw_symbol)
+
+
+def make_fv_coin(chainsaw_symbol: str) -> str:
+    base, quote = _split_symbol(chainsaw_symbol)
+    return f"{base.lower()}/{quote.lower()}"
+
+
+def make_fv_coin_for_instrument(instrument_id: str) -> str:
+    contract = get_instrument_contract(instrument_id)
+    return make_fv_coin(contract.chainsaw_symbol)
+
+
+def _split_symbol(chainsaw_symbol: str) -> tuple[str, str]:
+    parts = chainsaw_symbol.split("/", maxsplit=1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        msg = (
+            "Invalid chainsaw_symbol format "
+            f"'{chainsaw_symbol}', expected '<base>/<quote>'."
+        )
+        raise ValueError(msg)
+    return parts[0].upper(), parts[1].upper()
+
+
+def _to_json_value(value: Any, *, path: str = "$") -> JSONValue:
+    if value is None or isinstance(value, str | bool | int):
+        return value
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            msg = f"Non-finite float at {path}: {value!r}"
+            raise ValueError(msg)
+        return value
+
+    if isinstance(value, list | tuple):
+        return [_to_json_value(item, path=f"{path}[{index}]") for index, item in enumerate(value)]
+
+    if isinstance(value, Mapping):
+        normalized: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                msg = f"Unsupported dict key type at {path}: {type(key).__name__}"
+                raise TypeError(msg)
+            normalized[key] = _to_json_value(item, path=f"{path}.{key}")
+        return normalized
+
+    msg = f"Unsupported value type at {path}: {type(value).__name__}"
+    raise TypeError(msg)
+
+
+__all__ = [
+    "INSTRUMENT_CONTRACTS",
+    "INSTRUMENT_CONTRACTS_BY_ID",
+    "STRATEGY_ID",
+    "TOPIC_ALERT",
+    "TOPIC_BALANCES",
+    "TOPIC_EVENT",
+    "TOPIC_FV",
+    "TOPIC_MARKET_BBO",
+    "TOPIC_STATE",
+    "TOPIC_TRADE",
+    "InstrumentContract",
+    "get_instrument_contract",
+    "json_dumps_compact",
+    "make_fv_coin",
+    "make_fv_coin_for_instrument",
+    "make_last_key_component",
+    "make_last_key_component_for_instrument",
+]

--- a/examples/live/poc/makerv3_single_leg_node.py
+++ b/examples/live/poc/makerv3_single_leg_node.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from decimal import Decimal
+import importlib.util
+import os
+from pathlib import Path
+
+from nautilus_trader.adapters.binance import BINANCE
+from nautilus_trader.adapters.binance import BinanceAccountType
+from nautilus_trader.adapters.binance import BinanceDataClientConfig
+from nautilus_trader.adapters.binance import BinanceLiveDataClientFactory
+from nautilus_trader.adapters.bybit import BYBIT
+from nautilus_trader.adapters.bybit import BybitDataClientConfig
+from nautilus_trader.adapters.bybit import BybitExecClientConfig
+from nautilus_trader.adapters.bybit import BybitLiveDataClientFactory
+from nautilus_trader.adapters.bybit import BybitLiveExecClientFactory
+from nautilus_trader.adapters.bybit import BybitProductType
+from nautilus_trader.config import DatabaseConfig
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import MessageBusConfig
+from nautilus_trader.config import TradingNodeConfig
+try:
+    from nautilus_trader.examples.strategies.makerv3_single_leg_quoter import (
+        MakerV3SingleLegQuoter,
+    )
+    from nautilus_trader.examples.strategies.makerv3_single_leg_quoter import (
+        MakerV3SingleLegQuoterConfig,
+    )
+except ModuleNotFoundError:
+    _strategy_path = (
+        Path(__file__).resolve().parents[3]
+        / "nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py"
+    )
+    _spec = importlib.util.spec_from_file_location("makerv3_single_leg_quoter_local", _strategy_path)
+    if _spec is None or _spec.loader is None:
+        raise RuntimeError(f"Failed to load strategy module from {_strategy_path}")
+    _module = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_module)
+    MakerV3SingleLegQuoter = _module.MakerV3SingleLegQuoter
+    MakerV3SingleLegQuoterConfig = _module.MakerV3SingleLegQuoterConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.model.data import OrderBookDeltas
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TraderId
+
+
+BYBIT_EXEC_INSTRUMENT_ID = InstrumentId.from_str("PLUMEUSDT-LINEAR.BYBIT")
+BINANCE_DATA_INSTRUMENT_ID = InstrumentId.from_str("PLUMEUSDT-PERP.BINANCE")
+ENABLE_EXEC = os.getenv("POC_ENABLE_EXEC", "0") == "1"
+REDIS_HOST = os.getenv("POC_REDIS_HOST", "127.0.0.1")
+REDIS_PORT = int(os.getenv("POC_REDIS_PORT", "6379"))
+REDIS_USERNAME = os.getenv("POC_REDIS_USERNAME") or None
+REDIS_PASSWORD = os.getenv("POC_REDIS_PASSWORD") or None
+
+config_node = TradingNodeConfig(
+    trader_id=TraderId("MAKER-POC-001"),
+    logging=LoggingConfig(log_level="INFO", use_pyo3=True),
+    message_bus=MessageBusConfig(
+        database=DatabaseConfig(
+            type="redis",
+            host=REDIS_HOST,
+            port=REDIS_PORT,
+            username=REDIS_USERNAME,
+            password=REDIS_PASSWORD,
+        ),
+        encoding="json",
+        use_trader_prefix=False,
+        use_trader_id=False,
+        use_instance_id=False,
+        streams_prefix="maker_poc",
+        stream_per_topic=False,
+        types_filter=[QuoteTick, TradeTick, OrderBookDeltas],
+    ),
+    data_clients={
+        BYBIT: BybitDataClientConfig(
+            api_key=None,
+            api_secret=None,
+            instrument_provider=InstrumentProviderConfig(
+                load_ids=frozenset([BYBIT_EXEC_INSTRUMENT_ID]),
+            ),
+            product_types=(BybitProductType.LINEAR,),
+            testnet=False,
+            demo=False,
+        ),
+        BINANCE: BinanceDataClientConfig(
+            api_key=None,
+            api_secret=None,
+            account_type=BinanceAccountType.USDT_FUTURES,
+            instrument_provider=InstrumentProviderConfig(
+                load_ids=frozenset([BINANCE_DATA_INSTRUMENT_ID]),
+            ),
+        ),
+    },
+    exec_clients=(
+        {
+            BYBIT: BybitExecClientConfig(
+                api_key=None,
+                api_secret=None,
+                instrument_provider=InstrumentProviderConfig(
+                    load_ids=frozenset([BYBIT_EXEC_INSTRUMENT_ID]),
+                ),
+                product_types=(BybitProductType.LINEAR,),
+                testnet=False,
+                demo=False,
+            ),
+        }
+        if ENABLE_EXEC
+        else {}
+    ),
+    timeout_connection=20.0,
+    timeout_reconciliation=10.0,
+    timeout_portfolio=10.0,
+    timeout_disconnection=10.0,
+    timeout_post_stop=5.0,
+)
+
+node = TradingNode(config=config_node)
+
+strategy_config = MakerV3SingleLegQuoterConfig(
+    strategy_id="MAKERV3-SINGLELEG-001",
+    bybit_instrument_id=BYBIT_EXEC_INSTRUMENT_ID,
+    binance_instrument_id=BINANCE_DATA_INSTRUMENT_ID,
+    external_strategy_id="bybit_binance_plumeusdt_makerv3",
+    external_order_claims=[BYBIT_EXEC_INSTRUMENT_ID],
+    order_qty=Decimal("1"),
+    bot_on=False,
+    max_age_ms=2_000,
+    bid_edge1=0.0005,
+    ask_edge1=0.0005,
+    distance1=0.0002,
+    n_orders1=2,
+    bid_edge2=0.0012,
+    ask_edge2=0.0012,
+    distance2=0.0004,
+    n_orders2=2,
+    bid_edge3=0.0024,
+    ask_edge3=0.0024,
+    distance3=0.0008,
+    n_orders3=2,
+)
+strategy = MakerV3SingleLegQuoter(config=strategy_config)
+node.trader.add_strategy(strategy)
+
+node.add_data_client_factory(BYBIT, BybitLiveDataClientFactory)
+if ENABLE_EXEC:
+    node.add_exec_client_factory(BYBIT, BybitLiveExecClientFactory)
+node.add_data_client_factory(BINANCE, BinanceLiveDataClientFactory)
+node.build()
+
+
+if __name__ == "__main__":
+    try:
+        node.run()
+    finally:
+        node.dispose()

--- a/examples/live/poc/multivenue_book_smoke.py
+++ b/examples/live/poc/multivenue_book_smoke.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Smoke test proving Bybit + Binance bookbuilding in Nautilus.
+
+Subscribes to L2 deltas and trades for both venues, maintains local books,
+and logs top-of-book updates as deltas stream in.
+"""
+
+from nautilus_trader.adapters.binance import BINANCE
+from nautilus_trader.adapters.binance import BinanceAccountType
+from nautilus_trader.adapters.binance import BinanceDataClientConfig
+from nautilus_trader.adapters.binance import BinanceLiveDataClientFactory
+from nautilus_trader.adapters.bybit import BYBIT
+from nautilus_trader.adapters.bybit import BybitDataClientConfig
+from nautilus_trader.adapters.bybit import BybitLiveDataClientFactory
+from nautilus_trader.adapters.bybit import BybitProductType
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.model.book import OrderBook
+from nautilus_trader.model.data import OrderBookDeltas
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.trading.strategy import Strategy
+
+
+class MultiVenueBookSmokeConfig(StrategyConfig, frozen=True):
+    instrument_ids: tuple[InstrumentId, ...]
+
+
+class MultiVenueBookSmoke(Strategy):
+    def __init__(self, config: MultiVenueBookSmokeConfig) -> None:
+        super().__init__(config)
+        self._books: dict[InstrumentId, OrderBook] = {}
+        self._last_bbo: dict[InstrumentId, tuple[str, str, str, str]] = {}
+
+    def on_start(self) -> None:
+        for instrument_id in self.config.instrument_ids:
+            instrument = self.cache.instrument(instrument_id)
+            if instrument is None:
+                self.log.error(f"Could not find instrument for {instrument_id}")
+                self.stop()
+                return
+
+            self._books[instrument_id] = OrderBook(
+                instrument_id=instrument.id,
+                book_type=BookType.L2_MBP,
+            )
+            self.subscribe_order_book_deltas(
+                instrument_id=instrument_id,
+                book_type=BookType.L2_MBP,
+            )
+            self.subscribe_trade_ticks(instrument_id=instrument_id)
+            self.log.info(f"Subscribed to deltas + trades for {instrument_id}")
+
+    def on_order_book_deltas(self, deltas: OrderBookDeltas) -> None:
+        book = self._books.get(deltas.instrument_id)
+        if book is None:
+            return
+
+        book.apply_deltas(deltas)
+
+        bid_price = book.best_bid_price()
+        ask_price = book.best_ask_price()
+        bid_size = book.best_bid_size()
+        ask_size = book.best_ask_size()
+
+        if bid_price is None or ask_price is None or bid_size is None or ask_size is None:
+            return
+
+        bbo = (str(bid_price), str(bid_size), str(ask_price), str(ask_size))
+        if bbo == self._last_bbo.get(deltas.instrument_id):
+            return
+
+        self._last_bbo[deltas.instrument_id] = bbo
+        self.log.info(
+            f"BBO {deltas.instrument_id} | bid={bbo[1]} @ {bbo[0]} | ask={bbo[3]} @ {bbo[2]}",
+        )
+
+    def on_trade_tick(self, tick: TradeTick) -> None:
+        self.log.info(f"TRADE {tick.instrument_id} | px={tick.price} qty={tick.size}")
+
+
+BYBIT_INSTRUMENT_ID = InstrumentId.from_str(f"BTCUSDT-LINEAR.{BYBIT}")
+BINANCE_INSTRUMENT_ID = InstrumentId.from_str(f"BTCUSDT.{BINANCE}")
+
+config_node = TradingNodeConfig(
+    trader_id=TraderId("TESTER-001"),
+    logging=LoggingConfig(
+        log_level="INFO",
+        use_pyo3=True,
+    ),
+    data_clients={
+        BYBIT: BybitDataClientConfig(
+            api_key=None,
+            api_secret=None,
+            product_types=(BybitProductType.LINEAR,),
+            instrument_provider=InstrumentProviderConfig(
+                load_all=False,
+                load_ids=frozenset({BYBIT_INSTRUMENT_ID}),
+            ),
+        ),
+        BINANCE: BinanceDataClientConfig(
+            api_key=None,
+            api_secret=None,
+            account_type=BinanceAccountType.SPOT,
+            instrument_provider=InstrumentProviderConfig(
+                load_all=False,
+                load_ids=frozenset({BINANCE_INSTRUMENT_ID}),
+            ),
+        ),
+    },
+    timeout_connection=20.0,
+    timeout_disconnection=10.0,
+    timeout_post_stop=1.0,
+)
+
+node = TradingNode(config=config_node)
+
+strategy = MultiVenueBookSmoke(
+    config=MultiVenueBookSmokeConfig(
+        instrument_ids=(
+            BYBIT_INSTRUMENT_ID,
+            BINANCE_INSTRUMENT_ID,
+        ),
+    ),
+)
+
+node.trader.add_strategy(strategy)
+node.add_data_client_factory(BYBIT, BybitLiveDataClientFactory)
+node.add_data_client_factory(BINANCE, BinanceLiveDataClientFactory)
+node.build()
+
+if __name__ == "__main__":
+    try:
+        node.run()
+    finally:
+        node.dispose()

--- a/examples/live/poc/nautilus_fluxapi.py
+++ b/examples/live/poc/nautilus_fluxapi.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import redis
+from flask import Flask
+from flask import jsonify
+from flask import request
+
+
+DEFAULT_STRATEGY_ID = "bybit_binance_plumeusdt_makerv3"
+DEFAULT_BYBIT_LAST_KEY = "last:bybit_linear:PLUME_USDT"
+DEFAULT_BINANCE_LAST_KEY = "last:binance_spot:PLUME_USDT"
+
+HTML_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Nautilus POC TokenMM</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial; margin: 20px; background: #0b1220; color: #dbe5ff; }
+    h1 { margin: 0 0 8px 0; }
+    .muted { color: #94a3b8; margin-bottom: 14px; }
+    .card { border: 1px solid #223250; border-radius: 10px; padding: 12px; margin: 12px 0; background: #101a2d; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { border-bottom: 1px solid #223250; text-align: left; padding: 8px 6px; }
+    th { color: #93c5fd; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .badge { padding: 2px 8px; border-radius: 999px; font-size: 12px; border: 1px solid #334155; }
+    .ok { color: #86efac; }
+    .warn { color: #fcd34d; }
+  </style>
+</head>
+<body>
+  <h1>Nautilus POC TokenMM</h1>
+  <div class="muted">No Chainsaw runtime. Data source: Redis stream + keys produced by Nautilus node and bridge.</div>
+
+  <div class="card">
+    <div><b>Strategy</b> <span id="sid" class="mono"></span> <span id="mode" class="badge"></span></div>
+    <div id="ts" class="muted"></div>
+    <table>
+      <thead>
+        <tr><th>Leg</th><th>Exchange</th><th>Bid</th><th>Ask</th><th>Mid</th><th>Age ms</th></tr>
+      </thead>
+      <tbody id="legs"></tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <b>FV Snapshot</b>
+    <pre id="fv" class="mono"></pre>
+  </div>
+
+  <div class="card">
+    <b>Balances Snapshot</b>
+    <pre id="balances" class="mono"></pre>
+  </div>
+
+  <script>
+    async function tick() {
+      const res = await fetch('/api/v1/signals?profile=tokenmm');
+      const payload = await res.json();
+      const strat = payload?.data?.strategies?.[0];
+      if (!strat) return;
+      document.getElementById('sid').textContent = strat.id || 'unknown';
+      const mode = strat?.maker_v3?.quote_snapshot?.mode || 'UNKNOWN';
+      const modeEl = document.getElementById('mode');
+      modeEl.textContent = mode;
+      modeEl.className = 'badge ' + (mode === 'OFF' ? 'warn' : 'ok');
+      document.getElementById('ts').textContent = 'server_ts_ms=' + (payload?.data?.server_ts_ms ?? 'n/a');
+
+      const legs = strat.legs || {};
+      const rows = [];
+      for (const name of ['A', 'B']) {
+        const leg = legs[name] || {};
+        rows.push(`<tr>
+          <td class="mono">${name}</td>
+          <td class="mono">${leg.exchange || '-'}</td>
+          <td class="mono">${leg.decision_bid ?? '-'}</td>
+          <td class="mono">${leg.decision_ask ?? '-'}</td>
+          <td class="mono">${leg.mid ?? '-'}</td>
+          <td class="mono">${leg.md_age_ms ?? '-'}</td>
+        </tr>`);
+      }
+      document.getElementById('legs').innerHTML = rows.join('');
+
+      document.getElementById('fv').textContent = JSON.stringify(strat.fv_row || {}, null, 2);
+      document.getElementById('balances').textContent = JSON.stringify(payload?.data?.balances || [], null, 2);
+    }
+
+    tick();
+    setInterval(tick, 2000);
+  </script>
+</body>
+</html>
+"""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _decode_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return "" if value is None else str(value)
+
+
+def _json_load(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list, int, float, bool)):
+        return value
+    text = _decode_text(value).strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _coerce_ts_ms(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if num <= 0:
+        return None
+    if num < 1_000_000_000_000:
+        return int(num * 1000)
+    if num >= 1_000_000_000_000_000_000:
+        return int(num / 1_000_000)
+    if num >= 1_000_000_000_000_000:
+        return int(num / 1000)
+    return int(num)
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mid(bid: Any, ask: Any) -> float | None:
+    bid_f = _safe_float(bid)
+    ask_f = _safe_float(ask)
+    if bid_f is None or ask_f is None:
+        return None
+    return (bid_f + ask_f) / 2.0
+
+
+def _build_leg(row: dict[str, Any] | None, now_ms: int) -> dict[str, Any]:
+    row = row or {}
+    bid = _safe_float(row.get("bid") or row.get("best_bid"))
+    ask = _safe_float(row.get("ask") or row.get("best_ask"))
+    ts_ms = _coerce_ts_ms(row.get("ts_ms") or row.get("timestamp") or row.get("ts_event"))
+    age_ms = max(0, now_ms - ts_ms) if ts_ms is not None else None
+    return {
+        "exchange": _decode_text(row.get("chainsaw_exchange") or row.get("exchange") or ""),
+        "symbol": _decode_text(row.get("symbol") or ""),
+        "decision_bid": bid,
+        "decision_ask": ask,
+        "mid": _mid(bid, ask),
+        "md_ts_ms": ts_ms,
+        "md_age_ms": age_ms,
+    }
+
+
+def _first_fv_row(fv_payload: Any, strategy_id: str) -> dict[str, Any]:
+    if not isinstance(fv_payload, list):
+        return {}
+    for row in fv_payload:
+        if isinstance(row, dict) and _decode_text(row.get("strategy_id")) == strategy_id:
+            return row
+    for row in fv_payload:
+        if isinstance(row, dict):
+            return row
+    return {}
+
+
+def _build_payload(
+    client: redis.Redis,
+    *,
+    strategy_id: str,
+    bybit_last_key: str,
+    binance_last_key: str,
+) -> dict[str, Any]:
+    now_ms = _now_ms()
+    state = _json_load(client.get(f"maker_arb:{strategy_id}:state")) or {}
+    bybit_row = _json_load(client.get(bybit_last_key)) or {}
+    binance_row = _json_load(client.get(binance_last_key)) or {}
+    fv_payload = _json_load(client.get("fvs.snapshot")) or []
+    balances = _json_load(client.get("balances.snapshot")) or []
+
+    bot_on = bool(state.get("bot_on", False))
+    mode = "ON" if bot_on else "OFF"
+
+    strategy = {
+        "id": strategy_id,
+        "meta": {
+            "class": "maker_v3",
+            "strategy_groups": "tokenmm",
+            "base_asset": "PLUME",
+            "quote_asset": "USDT",
+        },
+        "blocked": not bot_on,
+        "tradeable": bool(bot_on),
+        "near_tradeable": False,
+        "maker_v3": {
+            "quote_snapshot": {
+                "mode": mode,
+                "reason": _decode_text(state.get("state") or ("bot_on" if bot_on else "bot_off")),
+                "ts_ms": _coerce_ts_ms(state.get("ts_event")),
+            },
+        },
+        "legs": {
+            "A": _build_leg(bybit_row, now_ms),
+            "B": _build_leg(binance_row, now_ms),
+        },
+        "fv_row": _first_fv_row(fv_payload, strategy_id),
+    }
+
+    server_time = datetime.fromtimestamp(now_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return {
+        "strategies": [strategy],
+        "balances": balances if isinstance(balances, list) else [],
+        "server_time": server_time,
+        "server_ts_ms": now_ms,
+    }
+
+
+def build_app() -> Flask:
+    app = Flask(__name__)
+
+    redis_host = os.getenv("POC_REDIS_HOST", "127.0.0.1")
+    redis_port = int(os.getenv("POC_REDIS_PORT", "6380"))
+    redis_db = int(os.getenv("POC_REDIS_DB", "0"))
+    redis_username = os.getenv("POC_REDIS_USERNAME") or None
+    redis_password = os.getenv("POC_REDIS_PASSWORD") or None
+    strategy_id = os.getenv("POC_STRATEGY_ID", DEFAULT_STRATEGY_ID)
+    bybit_last_key = os.getenv("POC_BYBIT_LAST_KEY", DEFAULT_BYBIT_LAST_KEY)
+    binance_last_key = os.getenv("POC_BINANCE_LAST_KEY", DEFAULT_BINANCE_LAST_KEY)
+
+    client = redis.Redis(
+        host=redis_host,
+        port=redis_port,
+        db=redis_db,
+        username=redis_username,
+        password=redis_password,
+        decode_responses=False,
+    )
+
+    @app.get("/")
+    @app.get("/tokenmm")
+    @app.get("/tokenmm/signal")
+    @app.get("/tokenmm/params")
+    @app.get("/tokenmm/balances")
+    @app.get("/tokenmm/trades")
+    @app.get("/tokenmm/alerts")
+    @app.get("/tokenmm/order-view")
+    def tokenmm_index() -> str:
+        return HTML_PAGE
+
+    @app.get("/api/v1/healthz")
+    def healthz() -> Any:
+        return jsonify({"ok": True}), 200
+
+    @app.get("/api/v1/readyz")
+    def readyz() -> Any:
+        try:
+            pong = bool(client.ping())
+        except redis.RedisError:
+            pong = False
+        payload = _build_payload(
+            client,
+            strategy_id=strategy_id,
+            bybit_last_key=bybit_last_key,
+            binance_last_key=binance_last_key,
+        )
+        has_fvs = bool(payload["strategies"][0].get("fv_row"))
+        ready = bool(pong and has_fvs)
+        data = {
+            "ready": ready,
+            "redis": pong,
+            "has_fvs": has_fvs,
+            "redis_target": {
+                "host": redis_host,
+                "port": redis_port,
+                "db": redis_db,
+            },
+        }
+        return jsonify({"ok": ready, "data": data, "error": None if ready else "not_ready"}), (200 if ready else 503)
+
+    @app.get("/api/v1/signals")
+    def signals() -> Any:
+        _ = request.args.get("profile")
+        payload = _build_payload(
+            client,
+            strategy_id=strategy_id,
+            bybit_last_key=bybit_last_key,
+            binance_last_key=binance_last_key,
+        )
+        return jsonify({"ok": True, "data": payload, "error": None}), 200
+
+    return app
+
+
+def main() -> None:
+    app = build_app()
+    port = int(os.getenv("PORT", "5022"))
+    host = os.getenv("HOST", "0.0.0.0")
+    app.run(host=host, port=port, debug=False, use_reloader=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/live/poc/redis_bridge.py
+++ b/examples/live/poc/redis_bridge.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from chainsaw_bridge import main
+
+
+if __name__ == "__main__":
+    main()

--- a/nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py
+++ b/nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Iterable
+
+
+def _to_decimal(value: Decimal | float | str) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+def _validate_three_band_input(values: Iterable[object], name: str) -> tuple[object, object, object]:
+    parsed = tuple(values)
+    if len(parsed) != 3:
+        raise ValueError(f"{name}: expected three bands, got {len(parsed)}")
+    return parsed  # type: ignore[return-value]
+
+
+def build_ladder_targets(
+    anchor_bid: Decimal | float | str,
+    anchor_ask: Decimal | float | str,
+    bid_edges: Iterable[Decimal | float | str],
+    ask_edges: Iterable[Decimal | float | str],
+    distances: Iterable[Decimal | float | str],
+    n_orders: Iterable[int],
+) -> tuple[list[Decimal], list[Decimal]]:
+    """
+    Build deterministic 3-band bid/ask target ladders from anchor prices.
+
+    For each band ``i`` and level ``j`` (starting from 0):
+    - bid price  = ``anchor_bid - bid_edge_i - distance_i * j``
+    - ask price  = ``anchor_ask + ask_edge_i + distance_i * j``
+    """
+    bid_edge_1, bid_edge_2, bid_edge_3 = _validate_three_band_input(bid_edges, "bid_edges")
+    ask_edge_1, ask_edge_2, ask_edge_3 = _validate_three_band_input(ask_edges, "ask_edges")
+    dist_1, dist_2, dist_3 = _validate_three_band_input(distances, "distances")
+    n_1, n_2, n_3 = _validate_three_band_input(n_orders, "n_orders")
+
+    bid_edge_vals = (_to_decimal(bid_edge_1), _to_decimal(bid_edge_2), _to_decimal(bid_edge_3))
+    ask_edge_vals = (_to_decimal(ask_edge_1), _to_decimal(ask_edge_2), _to_decimal(ask_edge_3))
+    distance_vals = (_to_decimal(dist_1), _to_decimal(dist_2), _to_decimal(dist_3))
+    n_orders_vals = (int(n_1), int(n_2), int(n_3))
+
+    if any(distance < 0 for distance in distance_vals):
+        raise ValueError("distances must be non-negative")
+    if any(edge < 0 for edge in bid_edge_vals + ask_edge_vals):
+        raise ValueError("edges must be non-negative")
+    if any(levels < 0 for levels in n_orders_vals):
+        raise ValueError("n_orders must be non-negative")
+
+    anchor_bid_dec = _to_decimal(anchor_bid)
+    anchor_ask_dec = _to_decimal(anchor_ask)
+
+    bid_prices: list[Decimal] = []
+    ask_prices: list[Decimal] = []
+    for band in range(3):
+        for level in range(n_orders_vals[band]):
+            step = distance_vals[band] * level
+            bid_prices.append(anchor_bid_dec - bid_edge_vals[band] - step)
+            ask_prices.append(anchor_ask_dec + ask_edge_vals[band] + step)
+
+    return bid_prices, ask_prices
+
+
+_NAUTILUS_IMPORT_ERROR: ModuleNotFoundError | None = None
+try:
+    from nautilus_trader.config import NonNegativeFloat
+    from nautilus_trader.config import NonNegativeInt
+    from nautilus_trader.config import PositiveInt
+    from nautilus_trader.config import StrategyConfig
+    from nautilus_trader.model.data import QuoteTick
+    from nautilus_trader.model.enums import OrderSide
+    from nautilus_trader.model.events import OrderFilled
+    from nautilus_trader.model.identifiers import InstrumentId
+    from nautilus_trader.model.instruments import Instrument
+    from nautilus_trader.model.objects import Quantity
+    from nautilus_trader.trading.strategy import Strategy
+except ModuleNotFoundError as exc:  # pragma: no cover - local pure-math test fallback
+    _NAUTILUS_IMPORT_ERROR = exc
+
+
+if _NAUTILUS_IMPORT_ERROR is None:
+    TOPIC_STATE = "maker_poc.state"
+    TOPIC_EVENT = "maker_poc.event"
+    TOPIC_TRADE = "maker_poc.trade"
+    TOPIC_ALERT = "maker_poc.alert"
+    TOPIC_MARKET_BBO = "maker_poc.market_bbo"
+    TOPIC_FV = "maker_poc.fv"
+    TOPIC_BALANCES = "maker_poc.balances"
+
+
+    class MakerV3SingleLegQuoterConfig(StrategyConfig, frozen=True):
+        """
+        Configuration for Maker V3 single-execution-leg 3-band post-only quoting.
+        """
+
+        bybit_instrument_id: InstrumentId
+        binance_instrument_id: InstrumentId
+        order_qty: Decimal
+        external_strategy_id: str = "bybit_binance_plumeusdt_makerv3"
+        bot_on: bool = True
+        max_age_ms: PositiveInt = 2_000
+        bid_edge1: NonNegativeFloat = 0.05
+        ask_edge1: NonNegativeFloat = 0.05
+        distance1: NonNegativeFloat = 0.02
+        n_orders1: NonNegativeInt = 1
+        bid_edge2: NonNegativeFloat = 0.15
+        ask_edge2: NonNegativeFloat = 0.15
+        distance2: NonNegativeFloat = 0.04
+        n_orders2: NonNegativeInt = 1
+        bid_edge3: NonNegativeFloat = 0.35
+        ask_edge3: NonNegativeFloat = 0.35
+        distance3: NonNegativeFloat = 0.08
+        n_orders3: NonNegativeInt = 1
+
+
+    class MakerV3SingleLegQuoter(Strategy):
+        """
+        Single-leg post-only quoter:
+        - executes only on Bybit linear perp,
+        - ingests Bybit + Binance market data,
+        - publishes bridge payloads over MessageBus.
+        """
+
+        INTERNAL_REQUOTE_THROTTLE_MS = 150
+
+        def __init__(self, config: MakerV3SingleLegQuoterConfig) -> None:
+            super().__init__(config)
+            self._bybit_instrument: Instrument | None = None
+            self._order_qty: Quantity | None = None
+            self._price_precision: int = 8
+            self._bybit_quote: QuoteTick | None = None
+            self._binance_quote: QuoteTick | None = None
+            self._last_requote_ns: int = 0
+            self._last_fv: Decimal | None = None
+            self._external_strategy_id: str = (
+                self.config.external_strategy_id.strip()
+                if self.config.external_strategy_id
+                else "bybit_binance_plumeusdt_makerv3"
+            )
+
+        def on_start(self) -> None:
+            instrument_id = self.config.bybit_instrument_id
+            self._bybit_instrument = self.cache.instrument(instrument_id)
+            if self._bybit_instrument is None:
+                self._publish_alert(f"Could not find instrument for {instrument_id}")
+                self.stop()
+                return
+
+            instrument_text = str(instrument_id)
+            if ".BYBIT" not in instrument_text or "-LINEAR" not in instrument_text:
+                self._publish_alert(
+                    f"Execution leg must be Bybit linear only, got {instrument_text}",
+                    level="error",
+                )
+                self.stop()
+                return
+
+            self._order_qty = self._bybit_instrument.make_qty(self.config.order_qty)
+            self._price_precision = self._bybit_instrument.price_precision
+
+            self.subscribe_quote_ticks(self.config.bybit_instrument_id)
+            self.subscribe_quote_ticks(self.config.binance_instrument_id)
+
+            self._publish_event("started")
+            self._publish_balances()
+            self._publish_state("on_start")
+
+        def on_stop(self) -> None:
+            self._cancel_managed_quotes("on_stop")
+            self.unsubscribe_quote_ticks(self.config.bybit_instrument_id)
+            self.unsubscribe_quote_ticks(self.config.binance_instrument_id)
+            self._publish_state("on_stop")
+
+        def on_quote_tick(self, quote: QuoteTick) -> None:
+            instrument_id = quote.instrument_id
+            if instrument_id == self.config.bybit_instrument_id:
+                self._bybit_quote = quote
+                source = "bybit"
+            elif instrument_id == self.config.binance_instrument_id:
+                self._binance_quote = quote
+                source = "binance"
+            else:
+                return
+
+            self._publish_market_bbo(source=source, quote=quote)
+            self._recompute_and_publish_fv()
+
+            if not self.config.bot_on:
+                self._cancel_managed_quotes("bot_off")
+                self._publish_state("bot_off")
+                return
+
+            if self._bybit_quote is None:
+                return
+
+            now_ns = self.clock.timestamp_ns()
+            if now_ns - self._last_requote_ns < self.INTERNAL_REQUOTE_THROTTLE_MS * 1_000_000:
+                return
+
+            self._refresh_quotes(now_ns=now_ns)
+
+        def on_order_filled(self, event: OrderFilled) -> None:
+            self._publish_json(
+                TOPIC_TRADE,
+                {
+                    "strategy_id": self._external_strategy_id,
+                    "instrument_id": str(event.instrument_id),
+                    "client_order_id": str(event.client_order_id),
+                    "trade_id": str(event.trade_id),
+                    "side": str(event.order_side),
+                    "qty": str(event.last_qty),
+                    "price": str(event.last_px),
+                    "ts_event": int(event.ts_event),
+                },
+            )
+
+        def _refresh_quotes(self, now_ns: int) -> None:
+            if self._bybit_quote is None or self._bybit_instrument is None or self._order_qty is None:
+                return
+
+            bybit_bid = self._bybit_quote.bid_price.as_decimal()
+            bybit_ask = self._bybit_quote.ask_price.as_decimal()
+            if bybit_bid <= 0 or bybit_ask <= bybit_bid:
+                self._publish_alert(
+                    f"Invalid Bybit BBO bid={bybit_bid} ask={bybit_ask}",
+                    level="warning",
+                )
+                return
+
+            fair_value = self._last_fv if self._last_fv is not None else (bybit_bid + bybit_ask) / Decimal("2")
+            half_spread = (bybit_ask - bybit_bid) / Decimal("2")
+            anchor_bid = fair_value - half_spread
+            anchor_ask = fair_value + half_spread
+
+            bid_targets, ask_targets = build_ladder_targets(
+                anchor_bid=anchor_bid,
+                anchor_ask=anchor_ask,
+                bid_edges=(self.config.bid_edge1, self.config.bid_edge2, self.config.bid_edge3),
+                ask_edges=(self.config.ask_edge1, self.config.ask_edge2, self.config.ask_edge3),
+                distances=(self.config.distance1, self.config.distance2, self.config.distance3),
+                n_orders=(self.config.n_orders1, self.config.n_orders2, self.config.n_orders3),
+            )
+
+            desired_orders = []
+            for bid in bid_targets:
+                if bid > 0:
+                    desired_orders.append(
+                        (OrderSide.BUY, self._bybit_instrument.make_price(bid)),
+                    )
+            for ask in ask_targets:
+                if ask > 0:
+                    desired_orders.append(
+                        (OrderSide.SELL, self._bybit_instrument.make_price(ask)),
+                    )
+
+            active_orders = self._managed_orders()
+            if not desired_orders:
+                self._cancel_managed_quotes("no_targets")
+                self._last_requote_ns = now_ns
+                return
+
+            if not self._should_replace(active_orders=active_orders, desired_orders=desired_orders, now_ns=now_ns):
+                self._last_requote_ns = now_ns
+                return
+
+            if active_orders:
+                self._cancel_managed_quotes("replace")
+
+            for side, price in desired_orders:
+                order = self.order_factory.limit(
+                    instrument_id=self.config.bybit_instrument_id,
+                    order_side=side,
+                    quantity=self._order_qty,
+                    price=price,
+                    post_only=True,
+                )
+                self.submit_order(order)
+
+            self._last_requote_ns = now_ns
+            self._publish_event(
+                "quotes_replaced",
+                bid_levels=len([1 for side, _ in desired_orders if side == OrderSide.BUY]),
+                ask_levels=len([1 for side, _ in desired_orders if side == OrderSide.SELL]),
+                anchor_bid=str(anchor_bid),
+                anchor_ask=str(anchor_ask),
+            )
+            self._publish_state("quotes_replaced")
+
+        def _should_replace(self, active_orders, desired_orders, now_ns: int) -> bool:
+            if len(active_orders) != len(desired_orders):
+                return True
+
+            if self._has_stale_orders(active_orders=active_orders, now_ns=now_ns):
+                return True
+
+            current = sorted(
+                (str(order.side), round(float(order.price), self._price_precision))
+                for order in active_orders
+            )
+            desired = sorted(
+                (str(side), round(float(price), self._price_precision))
+                for side, price in desired_orders
+            )
+            return current != desired
+
+        def _has_stale_orders(self, active_orders, now_ns: int) -> bool:
+            max_age_ns = int(self.config.max_age_ms) * 1_000_000
+            for order in active_orders:
+                ts_init = int(getattr(order, "ts_init", 0))
+                if ts_init > 0 and now_ns - ts_init >= max_age_ns:
+                    return True
+            return False
+
+        def _managed_orders(self):
+            return [
+                *self.cache.orders_open(
+                    instrument_id=self.config.bybit_instrument_id,
+                    strategy_id=self.id,
+                ),
+                *self.cache.orders_inflight(
+                    instrument_id=self.config.bybit_instrument_id,
+                    strategy_id=self.id,
+                ),
+            ]
+
+        def _cancel_managed_quotes(self, reason: str) -> None:
+            if self._managed_orders():
+                self.cancel_all_orders(self.config.bybit_instrument_id)
+                self._publish_event("quotes_canceled", reason=reason)
+
+        def _recompute_and_publish_fv(self) -> None:
+            bybit_mid = None
+            binance_mid = None
+            if self._bybit_quote is not None:
+                bybit_mid = (
+                    self._bybit_quote.bid_price.as_decimal() + self._bybit_quote.ask_price.as_decimal()
+                ) / Decimal("2")
+            if self._binance_quote is not None:
+                binance_mid = (
+                    self._binance_quote.bid_price.as_decimal() + self._binance_quote.ask_price.as_decimal()
+                ) / Decimal("2")
+
+            if bybit_mid is None and binance_mid is None:
+                return
+
+            if bybit_mid is not None and binance_mid is not None:
+                self._last_fv = (bybit_mid + binance_mid) / Decimal("2")
+            else:
+                self._last_fv = bybit_mid if bybit_mid is not None else binance_mid
+
+            self._publish_json(
+                TOPIC_FV,
+                {
+                    "strategy_id": self._external_strategy_id,
+                    "fv": str(self._last_fv),
+                    "bybit_mid": str(bybit_mid) if bybit_mid is not None else None,
+                    "binance_mid": str(binance_mid) if binance_mid is not None else None,
+                    "ts_event": int(self.clock.timestamp_ns()),
+                },
+            )
+
+        def _publish_market_bbo(self, source: str, quote: QuoteTick) -> None:
+            instrument_id = str(quote.instrument_id)
+            chainsaw_exchange = "bybit_linear" if ".BYBIT" in instrument_id else "binance_spot"
+            symbol_token = instrument_id.split(".", maxsplit=1)[0]
+            symbol_root = symbol_token.split("-", maxsplit=1)[0]
+            known_quotes = ("USDT", "USDC", "USD", "BTC", "ETH", "EUR", "BNB")
+            base = symbol_root
+            quote_ccy = "USDT"
+            for candidate in known_quotes:
+                if symbol_root.endswith(candidate) and len(symbol_root) > len(candidate):
+                    base = symbol_root[: -len(candidate)]
+                    quote_ccy = candidate
+                    break
+            slash_symbol = f"{base.lower()}/{quote_ccy.lower()}"
+
+            self._publish_json(
+                TOPIC_MARKET_BBO,
+                {
+                    "strategy_id": self._external_strategy_id,
+                    "source": source,
+                    "instrument_id": instrument_id,
+                    "exchange": chainsaw_exchange,
+                    "base": base,
+                    "quote": quote_ccy,
+                    "symbol": slash_symbol,
+                    "bid": str(quote.bid_price),
+                    "ask": str(quote.ask_price),
+                    "ts_event": int(quote.ts_event),
+                    "ts_init": int(quote.ts_init),
+                },
+            )
+
+        def _publish_state(self, state: str) -> None:
+            self._publish_json(
+                TOPIC_STATE,
+                {
+                    "strategy_id": self._external_strategy_id,
+                    "state": state,
+                    "bot_on": bool(self.config.bot_on),
+                    "managed_orders": len(self._managed_orders()),
+                    "ts_event": int(self.clock.timestamp_ns()),
+                },
+            )
+
+        def _publish_event(self, name: str, **payload) -> None:
+            data = {
+                "strategy_id": self._external_strategy_id,
+                "event": name,
+                "ts_event": int(self.clock.timestamp_ns()),
+            }
+            data.update(payload)
+            self._publish_json(TOPIC_EVENT, data)
+
+        def _publish_alert(self, message: str, level: str = "warning") -> None:
+            self._publish_json(
+                TOPIC_ALERT,
+                {
+                    "strategy_id": self._external_strategy_id,
+                    "level": level,
+                    "message": message,
+                    "ts_event": int(self.clock.timestamp_ns()) if self.clock is not None else 0,
+                },
+            )
+
+        def _publish_balances(self) -> None:
+            payload = {"strategy_id": self._external_strategy_id, "accounts": []}
+            for account in self.cache.accounts():
+                if hasattr(account, "to_dict"):
+                    payload["accounts"].append(account.to_dict())
+                else:
+                    payload["accounts"].append({"repr": repr(account)})
+            payload["ts_event"] = int(self.clock.timestamp_ns())
+            self._publish_json(TOPIC_BALANCES, payload)
+
+        def _publish_json(self, topic: str, payload: dict) -> None:
+            self.msgbus.publish(topic=topic, msg=json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+else:
+    class MakerV3SingleLegQuoterConfig:  # pragma: no cover - fallback for pure-math tests
+        pass
+
+
+    class MakerV3SingleLegQuoter:  # pragma: no cover - fallback for pure-math tests
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise ModuleNotFoundError(
+                "NautilusTrader runtime modules are unavailable in this environment",
+            ) from _NAUTILUS_IMPORT_ERROR

--- a/tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py
+++ b/tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py
@@ -1,0 +1,89 @@
+from decimal import Decimal
+from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+try:
+    from nautilus_trader.examples.strategies.makerv3_single_leg_quoter import (
+        build_ladder_targets,
+    )
+except ModuleNotFoundError:
+    module_path = (
+        Path(__file__).resolve().parents[4]
+        / "nautilus_trader"
+        / "examples"
+        / "strategies"
+        / "makerv3_single_leg_quoter.py"
+    )
+    spec = spec_from_file_location("makerv3_single_leg_quoter", module_path)
+    module = module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    build_ladder_targets = module.build_ladder_targets
+
+
+def test_build_ladder_targets_three_bands_is_deterministic():
+    bid_prices, ask_prices = build_ladder_targets(
+        anchor_bid=Decimal("100.0"),
+        anchor_ask=Decimal("101.0"),
+        bid_edges=(Decimal("0.10"), Decimal("0.30"), Decimal("0.80")),
+        ask_edges=(Decimal("0.20"), Decimal("0.50"), Decimal("1.20")),
+        distances=(Decimal("0.05"), Decimal("0.10"), Decimal("0.20")),
+        n_orders=(2, 1, 3),
+    )
+
+    assert bid_prices == [
+        Decimal("99.90"),
+        Decimal("99.85"),
+        Decimal("99.70"),
+        Decimal("99.20"),
+        Decimal("99.00"),
+        Decimal("98.80"),
+    ]
+    assert ask_prices == [
+        Decimal("101.20"),
+        Decimal("101.25"),
+        Decimal("101.50"),
+        Decimal("102.20"),
+        Decimal("102.40"),
+        Decimal("102.60"),
+    ]
+
+    bid_prices2, ask_prices2 = build_ladder_targets(
+        anchor_bid=Decimal("100.0"),
+        anchor_ask=Decimal("101.0"),
+        bid_edges=(Decimal("0.10"), Decimal("0.30"), Decimal("0.80")),
+        ask_edges=(Decimal("0.20"), Decimal("0.50"), Decimal("1.20")),
+        distances=(Decimal("0.05"), Decimal("0.10"), Decimal("0.20")),
+        n_orders=(2, 1, 3),
+    )
+    assert bid_prices2 == bid_prices
+    assert ask_prices2 == ask_prices
+
+
+def test_build_ladder_targets_skips_empty_bands():
+    bid_prices, ask_prices = build_ladder_targets(
+        anchor_bid=Decimal("10"),
+        anchor_ask=Decimal("10.5"),
+        bid_edges=(Decimal("0.1"), Decimal("0.2"), Decimal("0.3")),
+        ask_edges=(Decimal("0.1"), Decimal("0.2"), Decimal("0.3")),
+        distances=(Decimal("0.01"), Decimal("0.02"), Decimal("0.03")),
+        n_orders=(0, 2, 0),
+    )
+
+    assert bid_prices == [Decimal("9.8"), Decimal("9.78")]
+    assert ask_prices == [Decimal("10.7"), Decimal("10.72")]
+
+
+def test_build_ladder_targets_requires_three_band_params():
+    with pytest.raises(ValueError, match="expected three bands"):
+        build_ladder_targets(
+            anchor_bid=Decimal("1"),
+            anchor_ask=Decimal("2"),
+            bid_edges=(Decimal("0.1"), Decimal("0.2")),
+            ask_edges=(Decimal("0.1"), Decimal("0.2"), Decimal("0.3")),
+            distances=(Decimal("0.01"), Decimal("0.02"), Decimal("0.03")),
+            n_orders=(1, 1, 1),
+        )


### PR DESCRIPTION
## Summary
This PR squashes the full MakerV3 single-leg POC suite into one reviewable changeset, including the execution plan artifact.

Included in this mono PR:
- POC scaffold and translation contract (`examples/live/poc/contracts.py`, `examples/live/poc/__init__.py`, `examples/live/poc/README.md`)
- Multi-venue data smoke (`examples/live/poc/multivenue_book_smoke.py`)
- Strategy + runner + unit tests (`nautilus_trader/examples/strategies/makerv3_single_leg_quoter.py`, `examples/live/poc/makerv3_single_leg_node.py`, tests)
- Redis bridge (`examples/live/poc/chainsaw_bridge.py`) plus local alias entrypoint (`examples/live/poc/redis_bridge.py`)
- Standalone Nautilus-hosted TokenMM GUI/API (`examples/live/poc/nautilus_fluxapi.py`)
- Plan document (`docs/plans/2026-03-03-nautilus-makerv3-single-leg-poc.md`)
- Local worktree ignore setup (`.gitignore`)

## Why mono
The prior work was split across scaffold/data/strategy/bridge workstreams and iterative fixes. This PR provides a single branch/PR for full-suite review and merge.

## Validation
- `python -m py_compile` on POC + strategy files
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --noconftest tests/unit_tests/examples/strategies/test_makerv3_single_leg_quoter.py`
- Runtime sanity: strategy node + bridge + standalone GUI/API on `:5002` / `:5022`

## Notes
- Runtime defaults remain safe/non-trading (`POC_ENABLE_EXEC=0`, `bot_on=false` unless explicitly changed).
