### PR TITLE
Fix reconciliation when trigger_price is set for non-conditional orders

### DIFF
--- a/crates/execution/src/reconciliation.rs
+++ b/crates/execution/src/reconciliation.rs
@@ -1158,6 +1158,22 @@ pub fn create_reconciliation_updated(
     report: &OrderStatusReport,
     ts_now: UnixNanos,
 ) -> OrderEventAny {
+    // Only pass trigger_price for order types that support it.
+    // Limit, Market, and MarketToLimit orders assert trigger_price.is_none()
+    // in their update() methods — passing a spurious trigger_price from the
+    // venue report (e.g. Bybit sends "0.00" for non-conditional orders)
+    // causes a panic. Positive list ensures new order types without
+    // trigger_price support won't accidentally receive one.
+    let trigger_price = match order.order_type() {
+        OrderType::StopMarket
+        | OrderType::StopLimit
+        | OrderType::MarketIfTouched
+        | OrderType::LimitIfTouched
+        | OrderType::TrailingStopMarket
+        | OrderType::TrailingStopLimit => report.trigger_price,
+        _ => None,
+    };
+
     OrderEventAny::Updated(OrderUpdated::new(
         order.trader_id(),
         order.strategy_id(),
@@ -1171,7 +1187,7 @@ pub fn create_reconciliation_updated(
         order.venue_order_id(),
         order.account_id(),
         report.price,
-        report.trigger_price,
+        trigger_price,
         None, // protection_price
     ))
 }


### PR DESCRIPTION
## Summary

- Fixes #3672
- `create_reconciliation_updated()` now filters `trigger_price` by order type using a positive list
- Only StopMarket, StopLimit, MarketIfTouched, LimitIfTouched, TrailingStopMarket, TrailingStopLimit receive `trigger_price` from the venue report
- All other order types (Limit, Market, MarketToLimit) get `None`, preventing panics in their `update()` methods

## Test plan

- [x] `cargo nextest run -p nautilus-execution` — 431/431 pass
- [x] `cargo clippy -p nautilus-execution --all-targets` — clean
- [x] Verified live: Bybit spot `modify_order()` on limit orders no longer panics
- [ ] Verify with other venues that report trigger_price for non-conditional orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)