### PR TITLE
Fix RiskEngine RefCell re-entrancy panic on order denial

### DIFF
--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -38,6 +38,7 @@ static EXEC_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static EXEC_PROCESS_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static EXEC_RECONCILE_REPORT_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
+static RISK_QUEUE_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_PROCESS_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static ORDER_EMULATOR_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static PORTFOLIO_ACCOUNT_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
@@ -140,6 +141,15 @@ macro_rules! define_switchboard {
             #[must_use]
             pub fn risk_engine_execute() -> MStr<Endpoint> {
                 *RISK_EXECUTE_ENDPOINT.get_or_init(|| "RiskEngine.execute".into())
+            }
+
+            /// Queued endpoint for deferred command execution (re-entrancy safe).
+            /// Falls back to direct endpoint when no `TradingCommandSender` is
+            /// available (backtest / test environments).
+            #[inline]
+            #[must_use]
+            pub fn risk_engine_queue_execute() -> MStr<Endpoint> {
+                *RISK_QUEUE_EXECUTE_ENDPOINT.get_or_init(|| "RiskEngine.queue_execute".into())
             }
 
             #[inline]

--- a/crates/execution/src/order_manager/manager.rs
+++ b/crates/execution/src/order_manager/manager.rs
@@ -571,7 +571,11 @@ impl OrderManager {
 
     pub fn send_risk_command(&self, command: TradingCommand) {
         log_cmd_send(&command);
-        let endpoint = MessagingSwitchboard::risk_engine_execute();
+
+        // Use queued endpoint for re-entrancy safety, commands may be sent from
+        // within event handlers which hold a mutable borrow on the strategy.
+        // This mirrors the pattern used by `send_exec_command()`.
+        let endpoint = MessagingSwitchboard::risk_engine_queue_execute();
         msgbus::send_trading_command(endpoint, command);
     }
 

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -28,6 +28,7 @@ use nautilus_common::{
     messages::execution::{ModifyOrder, SubmitOrder, SubmitOrderList, TradingCommand},
     msgbus,
     msgbus::{MessagingSwitchboard, TypedIntoHandler},
+    runner::try_get_trading_cmd_sender,
     throttler::Throttler,
 };
 use nautilus_core::{UUID4, WeakCell};
@@ -112,6 +113,26 @@ impl RiskEngine {
             TypedIntoHandler::from(move |cmd: TradingCommand| {
                 if let Some(rc) = weak.upgrade() {
                     rc.borrow_mut().execute(cmd);
+                }
+            }),
+        );
+
+        // Queued endpoint for deferred command execution (re-entrancy safe).
+        // When a strategy calls `submit_order()` from within an event handler
+        // (e.g., `on_order_filled`), the command is routed through this endpoint.
+        // In live mode the `TradingCommandSender` queues the command for the next
+        // event-loop iteration, preventing a synchronous `deny_order()` from
+        // dispatching an `OrderDenied` back into a strategy that still holds a
+        // mutable borrow — which would otherwise panic on `RefCell` re-entrancy.
+        // In backtest/test mode (no sender), falls back to the direct endpoint.
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            TypedIntoHandler::from(move |cmd: TradingCommand| {
+                if let Some(sender) = try_get_trading_cmd_sender() {
+                    sender.execute(cmd);
+                } else {
+                    let endpoint = MessagingSwitchboard::risk_engine_execute();
+                    msgbus::send_trading_command(endpoint, cmd);
                 }
             }),
         );


### PR DESCRIPTION
## Summary

- Add `RiskEngine.queue_execute` endpoint mirroring the existing `ExecEngine.queue_execute` pattern
- Route `send_risk_command()` through the queued endpoint for re-entrancy safety
- In live mode, commands are deferred via `TradingCommandSender`; in backtest/test mode, falls back to direct dispatch

Fixes #3679

## Problem

When a strategy calls `submit_order()` from an event handler (e.g., `on_order_filled`) and the RiskEngine denies the order synchronously, the `OrderDenied` event is dispatched back into the strategy while it still holds a mutable borrow — causing a `RefCell` re-entrancy panic.

This is the same class of bug already solved for `ExecEngine` via `ExecEngine.queue_execute` + `TradingCommandSender`.

## Changes

| File | Change |
|------|--------|
| `crates/common/src/msgbus/switchboard.rs` | Add `risk_engine_queue_execute()` endpoint |
| `crates/risk/src/engine/mod.rs` | Register queued handler using `TradingCommandSender` |
| `crates/execution/src/order_manager/manager.rs` | Route `send_risk_command()` through queued endpoint |

36 lines added, 1 modified. Zero behavioral change for backtest/test environments.

## Verification

- Live tested in 2h46m session: 141 fills, 12 hedges, 2× `NOTIONAL_EXCEEDS_FREE_BALANCE` denials handled gracefully, 0 crashes
- Additional 30-min verification session after rebase to v0.55.0-dev: 27 fills, 0 crashes
- `cargo clippy --workspace --all-targets` clean
- `cargo nextest run --workspace` passes (8,864/8,865 — the 1 failure is a pre-existing `test_bar_query` precision mismatch unrelated to this change)