### PR TITLE
Fix PRICE_UNDEF panic in OrderBookDelta.to_pyo3_list

### DIFF
--- a/nautilus_trader/model/data.pyx
+++ b/nautilus_trader/model/data.pyx
@@ -2953,10 +2953,17 @@ cdef class OrderBookDelta(Data):
             if size_prec == 0:
                 size_prec = delta._mem.order.size.precision
 
+            # Use per-delta precision for sentinel values (PRICE_UNDEF has precision=0)
             pyo3_book_order = nautilus_pyo3.BookOrder(
                nautilus_pyo3.OrderSide(order_side_to_str(delta._mem.order.side)),
-               nautilus_pyo3.Price.from_raw(delta._mem.order.price.raw, price_prec),
-               nautilus_pyo3.Quantity.from_raw(delta._mem.order.size.raw, size_prec),
+               nautilus_pyo3.Price.from_raw(
+                   delta._mem.order.price.raw,
+                   delta._mem.order.price.precision if delta._mem.order.price.precision == 0 else price_prec,
+               ),
+               nautilus_pyo3.Quantity.from_raw(
+                   delta._mem.order.size.raw,
+                   delta._mem.order.size.precision if delta._mem.order.size.precision == 0 else size_prec,
+               ),
                delta._mem.order.order_id,
             )
 


### PR DESCRIPTION
## Summary

- `OrderBookDelta.to_pyo3_list()` caches `price_prec` from the first non-zero delta and applies it to all subsequent deltas
- When a CLEAR (action=4) message carries `PRICE_UNDEF` (which requires `precision=0`), the cached precision (e.g. 2) is incorrectly used
- This triggers a Rust panic in `Price::from_raw`: `"precision must be 0 when raw is PRICE_UNDEF"`
- The fix in #3183 addressed the DBN decode path but missed this Cython→pyo3 conversion path, which is hit during Arrow serialization (`catalog.write_data`)

## Fix

Use the delta's own precision when it is 0 (sentinel value), otherwise use the cached precision as before. Same logic applied to both price and size.

## Reproduction

Load Databento MBO data containing CLEAR messages (e.g. NQ futures) via `DatabentoDataLoader.from_dbn_file()` with `as_legacy_cython=True`, then write to `ParquetDataCatalog`. The panic occurs in `ArrowSerializer.rust_defined_to_record_batch` → `OrderBookDelta.to_pyo3_list` → `Price.from_raw`.

## Test plan

- [ ] Load MBO `.dbn.zst` files containing CLEAR messages with `PRICE_UNDEF` via `from_dbn_file(as_legacy_cython=True, include_trades=True)`
- [ ] Write decoded `OrderBookDelta` list to `ParquetDataCatalog` — should no longer panic
- [ ] Verify normal (non-UNDEF) deltas still use the correct cached precision