### PR TITLE
Fix hedging leg-fill position assignment

### DIFF
--- a/nautilus_trader/execution/engine.pyx
+++ b/nautilus_trader/execution/engine.pyx
@@ -1379,9 +1379,10 @@ cdef class ExecutionEngine(Component):
         cdef OmsType oms_type = self._determine_oms_type(fill)
 
         # Determine position ID for leg fill without requiring an order in cache
-        cdef PositionId position_id
+        cdef PositionId position_id = self._cache.position_id(fill.client_order_id)
         if oms_type == OmsType.HEDGING:
-            position_id = self._determine_hedging_position_id(fill)
+            if position_id is None:
+                position_id = self._determine_hedging_position_id(fill)
         elif oms_type == OmsType.NETTING:
             # Assign netted position ID
             position_id = self._determine_netting_position_id(fill)
@@ -1486,6 +1487,7 @@ cdef class ExecutionEngine(Component):
             self._log.debug(f"Assigned primary order {position_id!r}", LogColor.MAGENTA)
 
     cpdef PositionId _determine_hedging_position_id(self, OrderFilled fill, Order order=None):
+        cdef PositionId position_id
         if fill.position_id is not None:
             if self.debug:
                 self._log.debug(f"Already had a position ID of: {fill.position_id!r}", LogColor.MAGENTA)
@@ -1496,6 +1498,17 @@ cdef class ExecutionEngine(Component):
         if order is None:
             order = self._cache.order(fill.client_order_id)
             if order is None:
+                if self._is_leg_fill(fill):
+                    position_id = self._pos_id_generator.generate(fill.strategy_id)
+
+                    if self.debug:
+                        self._log.debug(
+                            f"Generated synthetic leg {position_id!r} for {fill}",
+                            LogColor.MAGENTA,
+                        )
+
+                    return position_id
+
                 raise RuntimeError(
                     f"Order for {fill.client_order_id!r} not found to determine position ID",
                 )

--- a/tests/unit_tests/execution/test_engine_leg_fills.py
+++ b/tests/unit_tests/execution/test_engine_leg_fills.py
@@ -28,6 +28,7 @@ from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.engine import ExecutionEngine
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.enums import LiquiditySide
+from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.events.order import OrderFilled
@@ -242,6 +243,48 @@ class TestExecutionEngineLegFills:
         position = positions[0]
         assert position.instrument_id == self.put_option.id
         assert position.quantity == Quantity.from_int(9)  # 6 + 3
+
+    def test_handle_leg_fill_without_order_in_hedging_reuses_leg_position_id(self):
+        """
+        Test that hedging leg fills create and reuse a synthetic leg position ID.
+        """
+        self.exec_engine._oms_overrides[self.strategy_id] = OmsType.HEDGING
+
+        first_fill = self.create_leg_fill(
+            instrument_id=self.call_option.id,
+            client_order_id=ClientOrderId("O-20260312-083715-000-000-1-LEG-E1AQ5 C6400"),
+            venue_order_id=VenueOrderId("213-LEG-0"),
+            trade_id=TradeId("0000e1a7.6882c67b.03.01-0"),
+            side=OrderSide.BUY,
+            quantity=3,
+            price=52.75,
+        )
+
+        self.exec_engine._handle_leg_fill_without_order(first_fill)
+
+        first_position = self.cache.positions()[0]
+        assert first_fill.position_id == first_position.id
+        assert self.cache.position_id(first_fill.client_order_id) == first_position.id
+
+        second_fill = self.create_leg_fill(
+            instrument_id=self.call_option.id,
+            client_order_id=first_fill.client_order_id,
+            venue_order_id=VenueOrderId("214-LEG-0"),
+            trade_id=TradeId("0000e1a7.6882c67b.04.01-0"),
+            side=OrderSide.BUY,
+            quantity=2,
+            price=53.25,
+        )
+
+        self.exec_engine._handle_leg_fill_without_order(second_fill)
+
+        positions = self.cache.positions()
+        assert len(positions) == 1
+        position = positions[0]
+        assert second_fill.position_id == first_position.id
+        assert position.id == first_position.id
+        assert position.quantity == Quantity.from_int(5)
+        assert str(position.avg_px_open) == "52.95"
 
     def test_handle_leg_fill_without_order_missing_instrument(self):
         """


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fix hedging leg-fill position assignment when the parent order is not present in cache.
- Add coverage to ensure repeated leg fills for the same client order reuse the same synthetic position.

## Problem

- `_handle_leg_fill_without_order` now checks the cache for an existing position ID before generating or resolving one.
- In hedging mode, `_determine_hedging_position_id` previously raised if the order was missing, even for leg fills that need to be processed without the parent order in cache.
- That could split related leg fills across positions or fail processing altogether.

## Changes

- Update [nautilus_trader/execution/engine.pyx](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/execution/engine.pyx) so leg fills first reuse any cached position ID for the client order.
- In hedging mode, only generate a new position ID when no cached mapping exists.
- Allow `_determine_hedging_position_id` to generate a synthetic hedging position ID for leg fills when the parent order cannot be loaded from cache.
- Keep the existing netting path unchanged.

## Testing

- Add [tests/unit_tests/execution/test_engine_leg_fills.py](/Users/ata/Developer/nautilus/nautilus_trader/tests/unit_tests/execution/test_engine_leg_fills.py) coverage for hedging leg fills without an order in cache.
- Verify the first fill creates a synthetic position and stores the client-order-to-position mapping.
- Verify a second fill with the same client order reuses that position and updates the aggregate quantity and average open price.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3712

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
