### PR TITLE
Fix IB live-session synchronization

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -313,6 +313,7 @@ Released on 21st February 2026 (UTC).
 - Fixed Interactive Brokers parsing options for Stoxx50 (#3562), thanks @davidsblom
 - Fixed Interactive Brokers contract details for FESX futures (#3575), thanks @davidsblom
 - Fixed Interactive Brokers `ibapi` 10.43 protobuf compatibility: `IBContract.strike` default and `ContractDetails.underConId` field typo (#3599), thanks @shzhng
+- Fixed Interactive Brokers `track_option_exercise_from_position_update` not generating FLAT reports for expired options (zero-quantity position updates were silently skipped), thanks @shzhng
 - Fixed Interactive Brokers bar unsubscribe (#3588), thanks for reporting @pandashark
 - Fixed Kraken spot instrument fee/margin parsing where parameters were incorrectly swapped
 - Fixed Kraken spot XBT to BTC symbol normalization (#3509), thanks for reporting @chester0

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1560,7 +1560,14 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
             return
 
-        nautilus_order = self._cache.order(ClientOrderId(order_ref))
+        nautilus_order = None
+        if order_ref:
+            nautilus_order = self._cache.order(ClientOrderId(order_ref))
+
+        if nautilus_order is None and venue_order_id is not None:
+            mapped_client_order_id = self._cache.client_order_id(venue_order_id)
+            if mapped_client_order_id is not None:
+                nautilus_order = self._cache.order(mapped_client_order_id)
 
         if nautilus_order:
             # Update order with average fill price if provided and order is filled/partially filled
@@ -1598,7 +1605,13 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             ):
                 self._order_filled_qty.pop(venue_order_id, None)
         else:
-            self._log.warning(f"ClientOrderId {order_ref} not found in Cache")
+            if venue_order_id is not None:
+                self._log.warning(
+                    f"Order callback not found in cache for order_ref={order_ref!r}, "
+                    f"venue_order_id={venue_order_id}",
+                )
+            else:
+                self._log.warning(f"ClientOrderId {order_ref} not found in Cache")
 
     def _on_exec_details(
         self,
@@ -1607,12 +1620,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         commission_report: CommissionAndFeesReport,
         contract: IBContract,
     ) -> None:
-        if not execution.orderRef:
-            self._log.warning(f"ClientOrderId not available, execution={execution.__dict__}")
-            return
-
-        client_order_id = ClientOrderId(order_ref)
         venue_order_id = get_venue_order_id(execution.orderId, execution.permId)
+        client_order_id = ClientOrderId(order_ref) if order_ref else None
 
         # Find order by client_order_id or venue_order_id
         nautilus_order = self._find_order_for_execution(client_order_id, venue_order_id)
@@ -1685,13 +1694,14 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     def _find_order_for_execution(
         self,
-        client_order_id: ClientOrderId,
+        client_order_id: ClientOrderId | None,
         venue_order_id: VenueOrderId | None,
     ) -> Order | None:
         # Try client_order_id first
-        order = self._cache.order(client_order_id)
-        if order:
-            return order
+        if client_order_id is not None:
+            order = self._cache.order(client_order_id)
+            if order:
+                return order
 
         # Fallback to venue_order_id lookup
         if venue_order_id:
@@ -1983,17 +1993,60 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             contract_id = ib_position.contract.conId
             new_quantity = ib_position.quantity
 
-            # Skip zero positions (IB may send these for closed positions)
-            if new_quantity == 0:
-                # Remove from tracking if position is closed
-                self._known_positions.pop(contract_id, None)
-                return
-
-            # Check if this is an external position change
+            # Check if this is a known position
             known_quantity = self._known_positions.get(contract_id, Decimal(0))
 
             # If quantities match, this is likely from normal trading - skip
             if known_quantity == new_quantity:
+                return
+
+            # Handle position going to zero (option expiration, exercise closure, etc.)
+            if new_quantity == 0:
+                if known_quantity == 0:
+                    # Position was never tracked or already flat - noise, skip
+                    return
+
+                # Position went from non-zero to zero externally (e.g. option expired)
+                self._log.info(
+                    f"External position closure detected (likely option expiration): "
+                    f"Contract {contract_id} ({ib_position.contract.secType}), "
+                    f"quantity change: {known_quantity} -> 0",
+                    LogColor.YELLOW,
+                )
+
+                instrument = await self.instrument_provider.get_instrument(
+                    ib_position.contract,
+                )
+
+                if instrument is None:
+                    self._log.warning(
+                        f"Cannot process position closure: "
+                        f"instrument not found for contract ID {contract_id}",
+                    )
+                    # Keep the position tracked so the next IB position update can retry
+                    # the FLAT report once instrument lookup succeeds.
+                    return
+
+                if not self._cache.instrument(instrument.id):
+                    self._msgbus.send(endpoint="DataEngine.process", msg=instrument)
+
+                position_report = PositionStatusReport(
+                    account_id=self.account_id,
+                    instrument_id=instrument.id,
+                    position_side=PositionSide.FLAT,
+                    quantity=instrument.make_qty(0),
+                    report_id=UUID4(),
+                    ts_last=self._clock.timestamp_ns(),
+                    ts_init=self._clock.timestamp_ns(),
+                )
+
+                self._log.info(
+                    f"Position closed externally: {instrument.id} FLAT (was {known_quantity})",
+                    LogColor.CYAN,
+                )
+
+                self._send_position_status_report(position_report)
+                self._known_positions.pop(contract_id, None)
                 return
 
             # This is an external position change (likely option exercise)

--- a/nautilus_trader/execution/engine.pyx
+++ b/nautilus_trader/execution/engine.pyx
@@ -1379,9 +1379,10 @@ cdef class ExecutionEngine(Component):
         cdef OmsType oms_type = self._determine_oms_type(fill)
 
         # Determine position ID for leg fill without requiring an order in cache
-        cdef PositionId position_id
+        cdef PositionId position_id = self._cache.position_id(fill.client_order_id)
         if oms_type == OmsType.HEDGING:
-            position_id = self._determine_hedging_position_id(fill)
+            if position_id is None:
+                position_id = self._determine_hedging_position_id(fill)
         elif oms_type == OmsType.NETTING:
             # Assign netted position ID
             position_id = self._determine_netting_position_id(fill)
@@ -1486,6 +1487,7 @@ cdef class ExecutionEngine(Component):
             self._log.debug(f"Assigned primary order {position_id!r}", LogColor.MAGENTA)
 
     cpdef PositionId _determine_hedging_position_id(self, OrderFilled fill, Order order=None):
+        cdef PositionId position_id
         if fill.position_id is not None:
             if self.debug:
                 self._log.debug(f"Already had a position ID of: {fill.position_id!r}", LogColor.MAGENTA)
@@ -1496,6 +1498,17 @@ cdef class ExecutionEngine(Component):
         if order is None:
             order = self._cache.order(fill.client_order_id)
             if order is None:
+                if self._is_leg_fill(fill):
+                    position_id = self._pos_id_generator.generate(fill.strategy_id)
+
+                    if self.debug:
+                        self._log.debug(
+                            f"Generated synthetic leg {position_id!r} for {fill}",
+                            LogColor.MAGENTA,
+                        )
+
+                    return position_id
+
                 raise RuntimeError(
                     f"Order for {fill.client_order_id!r} not found to determine position ID",
                 )

--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -69,6 +69,7 @@ from nautilus_trader.model.book import py_should_handle_own_book_order
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import OrderStatus
 from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.enums import PositionSide
 from nautilus_trader.model.enums import TimeInForce
 from nautilus_trader.model.enums import TriggerType
 from nautilus_trader.model.enums import trailing_offset_type_to_str
@@ -83,6 +84,7 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import PositionId
 from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import TradeId
+from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.instruments import CurrencyPair
 from nautilus_trader.model.instruments import Instrument
@@ -902,11 +904,12 @@ class LiveExecutionEngine(ExecutionEngine):
             self._log.debug("No execution clients to check position consistency, early return")
             return
 
-        venue_positions = await self._query_position_status_reports()
+        venue_positions, failed_position_report_venues = await self._query_position_status_reports()
 
         await self._process_cached_position_discrepancies(
             positions_by_instrument,
             venue_positions,
+            failed_position_report_venues,
         )
 
         await self._process_venue_reported_positions(
@@ -920,8 +923,10 @@ class LiveExecutionEngine(ExecutionEngine):
         for iid in stale:
             self._position_recon_retries.pop(iid, None)
 
-    async def _query_position_status_reports(self) -> dict[InstrumentId, PositionStatusReport]:
-        clients = self._clients.values()
+    async def _query_position_status_reports(
+        self,
+    ) -> tuple[dict[InstrumentId, PositionStatusReport], set[Venue | None]]:
+        clients = list(self._clients.values())
 
         tasks = [
             c.generate_position_status_reports(
@@ -941,14 +946,17 @@ class LiveExecutionEngine(ExecutionEngine):
             position_reports_all = await asyncio.gather(*tasks, return_exceptions=True)
         except Exception as e:
             self._log.error(f"Failed to gather position status reports: {e}")
-            return {}
+            return {}, {client.venue for client in clients}
 
         # Build mapping: instrument_id -> venue report
         venue_positions: dict[InstrumentId, PositionStatusReport] = {}
-        for reports_or_exception in position_reports_all:
+        failed_venues: set[Venue | None] = set()
+        for client, reports_or_exception in zip(clients, position_reports_all, strict=True):
             if isinstance(reports_or_exception, Exception):
+                failed_venues.add(client.venue)
                 self._log.error(
-                    f"Failed to generate position status reports: {reports_or_exception}",
+                    f"Failed to generate position status reports for venue {client.venue}: "
+                    f"{reports_or_exception}",
                 )
                 continue
 
@@ -956,17 +964,29 @@ class LiveExecutionEngine(ExecutionEngine):
             for report in reports:
                 venue_positions[report.instrument_id] = report
 
-        return venue_positions
+        return venue_positions, failed_venues
 
     async def _process_cached_position_discrepancies(
         self,
         positions_by_instrument: dict[InstrumentId, list[Position]],
         venue_positions: dict[InstrumentId, PositionStatusReport],
+        failed_position_report_venues: set[Venue | None] | None = None,
     ) -> None:
         clients = self._clients.values()
 
         for instrument_id, cached_positions in positions_by_instrument.items():
             venue_report = venue_positions.get(instrument_id)
+
+            if venue_report is None and self._did_position_status_query_fail(
+                instrument_id,
+                failed_position_report_venues,
+            ):
+                self._log.warning(
+                    f"Skipping position reconciliation for {instrument_id}: "
+                    f"failed to query venue position status for {instrument_id.venue}",
+                    LogColor.YELLOW,
+                )
+                continue
 
             has_discrepancy = self._check_position_discrepancy(
                 cached_positions,
@@ -1001,7 +1021,11 @@ class LiveExecutionEngine(ExecutionEngine):
                 LogColor.YELLOW,
             )
 
-            missing_fills = await self._query_and_find_missing_fills(instrument_id, clients)
+            missing_fills, had_fill_query_errors = await self._query_and_find_missing_fills(
+                instrument_id,
+                clients,
+            )
+
             await self._reconcile_missing_fills(missing_fills, instrument_id)
 
             # Re-read positions from cache (may have changed during reconciliation)
@@ -1012,6 +1036,27 @@ class LiveExecutionEngine(ExecutionEngine):
                 instrument_id,
             )
             if still_discrepant:
+                reconciliation_report = venue_report or self._create_flat_position_report(
+                    instrument_id=instrument_id,
+                    account_id=cached_positions[0].account_id,
+                )
+
+                if (
+                    not had_fill_query_errors
+                    and self.generate_missing_orders
+                    and self._reconcile_position_report(reconciliation_report)
+                ):
+                    current_positions = self._cache.positions_open(instrument_id=instrument_id)
+                    still_discrepant = self._check_position_discrepancy(
+                        current_positions,
+                        venue_report,
+                        instrument_id,
+                    )
+
+                if not still_discrepant:
+                    self._position_recon_retries.pop(instrument_id, None)
+                    continue
+
                 self._position_recon_retries[instrument_id] = retries + 1
                 if retries + 1 >= self.position_check_retries:
                     self._log.error(
@@ -1020,7 +1065,7 @@ class LiveExecutionEngine(ExecutionEngine):
                         f"(cached_qty={cached_qty}, venue_qty={venue_qty}); "
                         f"no further reconciliation attempts will be made",
                     )
-                elif not missing_fills:
+                elif not missing_fills and not had_fill_query_errors:
                     self._log.warning(
                         f"Position discrepancy for {instrument_id} persists but no missing fills found; "
                         f"possible causes: fills outside lookback window ({self.position_check_lookback_mins}min), "
@@ -1029,6 +1074,38 @@ class LiveExecutionEngine(ExecutionEngine):
                     )
             else:
                 self._position_recon_retries.pop(instrument_id, None)
+
+    def _did_position_status_query_fail(
+        self,
+        instrument_id: InstrumentId,
+        failed_position_report_venues: set[Venue | None] | None,
+    ) -> bool:
+        if not failed_position_report_venues:
+            return False
+
+        return (
+            None in failed_position_report_venues
+            or instrument_id.venue in failed_position_report_venues
+        )
+
+    def _create_flat_position_report(
+        self,
+        instrument_id: InstrumentId,
+        account_id: AccountId,
+    ) -> PositionStatusReport:
+        ts_now = self._clock.timestamp_ns()
+        instrument = self._cache.instrument(instrument_id)
+        quantity = instrument.make_qty(0) if instrument is not None else Quantity.zero()
+
+        return PositionStatusReport(
+            account_id=account_id,
+            instrument_id=instrument_id,
+            position_side=PositionSide.FLAT,
+            quantity=quantity,
+            report_id=UUID4(),
+            ts_last=ts_now,
+            ts_init=ts_now,
+        )
 
     def _check_position_discrepancy(
         self,
@@ -1133,7 +1210,10 @@ class LiveExecutionEngine(ExecutionEngine):
                 LogColor.YELLOW,
             )
 
-            missing_fills = await self._query_and_find_missing_fills(instrument_id, clients)
+            missing_fills, had_fill_query_errors = await self._query_and_find_missing_fills(
+                instrument_id,
+                clients,
+            )
             await self._reconcile_missing_fills(missing_fills, instrument_id)
 
             # Re-check using tolerance-aware comparison
@@ -1153,7 +1233,7 @@ class LiveExecutionEngine(ExecutionEngine):
                         f"(cached_qty={cached_qty_now}, venue_qty={venue_qty}); "
                         f"no further reconciliation attempts will be made",
                     )
-                elif not missing_fills:
+                elif not missing_fills and not had_fill_query_errors:
                     self._log.warning(
                         f"Position discrepancy for {instrument_id} persists but no missing fills found; "
                         f"possible causes: fills outside lookback window ({self.position_check_lookback_mins}min), "
@@ -1167,7 +1247,7 @@ class LiveExecutionEngine(ExecutionEngine):
         self,
         instrument_id: InstrumentId,
         clients: Iterable[ExecutionClient],
-    ) -> list[FillReport]:
+    ) -> tuple[list[FillReport], bool]:
         fill_lookback_start = self._clock.utc_now() - pd.Timedelta(
             minutes=self.position_check_lookback_mins,
         )
@@ -1189,8 +1269,10 @@ class LiveExecutionEngine(ExecutionEngine):
         fill_reports_all = await asyncio.gather(*fill_tasks, return_exceptions=True)
 
         venue_fills: list[FillReport] = []
+        had_fill_query_errors = False
         for fills_or_exception in fill_reports_all:
             if isinstance(fills_or_exception, Exception):
+                had_fill_query_errors = True
                 self._log.error(
                     f"Failed to generate fill reports for {instrument_id}: {fills_or_exception}",
                 )
@@ -1213,7 +1295,7 @@ class LiveExecutionEngine(ExecutionEngine):
             and fill.trade_id not in self._recent_fills_cache
         ]
 
-        return missing_fills
+        return missing_fills, had_fill_query_errors
 
     async def _reconcile_missing_fills(
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -16,6 +16,7 @@
 import asyncio
 from decimal import Decimal
 from functools import partial
+from types import SimpleNamespace
 
 import pytest
 from ibapi.order_state import OrderState as IBOrderState
@@ -27,6 +28,7 @@ from nautilus_trader.adapters.interactive_brokers.factories import (
 from nautilus_trader.execution.messages import QueryAccount
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import OrderStatus
+from nautilus_trader.model.enums import PositionSide
 from nautilus_trader.model.identifiers import PositionId
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.objects import Price
@@ -714,6 +716,83 @@ async def test_on_order_status_with_avg_px(
 
 
 @pytest.mark.asyncio
+async def test_on_order_status_resolves_cached_external_order_by_venue_order_id(
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    venue_order_id = VenueOrderId("9001")
+    external_order_id = TestIdStubs.client_order_id()
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=external_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    cache.add_venue_order_id(order.client_order_id, venue_order_id)
+
+    exec_client._on_order_status(
+        order_ref="",
+        order_status="Cancelled",
+        avg_fill_price=0.0,
+        filled=Decimal(0),
+        remaining=Decimal(100),
+        venue_order_id=venue_order_id,
+    )
+
+    assert cache.order(external_order_id).status == OrderStatus.CANCELED
+
+
+@pytest.mark.asyncio
+async def test_on_exec_details_resolves_cached_external_order_by_venue_order_id(
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    venue_order_id = VenueOrderId("9002")
+    external_order_id = TestIdStubs.client_order_id()
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=external_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    cache.add_venue_order_id(order.client_order_id, venue_order_id)
+
+    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution.orderRef = ""
+    commission_report = IBTestExecStubs.commission()
+
+    exec_client._on_exec_details(
+        order_ref="",
+        execution=execution,
+        commission_report=commission_report,
+        contract=contract_details.contract,
+    )
+
+    assert cache.order(external_order_id).filled_qty == Quantity(100, 0)
+    assert cache.order(external_order_id).status == OrderStatus.FILLED
+
+
+@pytest.mark.asyncio
 async def test_on_exec_details_uses_stored_avg_px(
     mocker,
     exec_client,
@@ -811,6 +890,55 @@ async def test_on_exec_details_uses_stored_avg_px(
 async def test_on_account_update(mocker, exec_client):
     # TODO:
     pass
+
+
+@pytest.mark.asyncio
+async def test_handle_position_update_retries_flat_report_after_transient_instrument_lookup_failure(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    contract_id = contract_details.contract.conId
+    exec_client._known_positions[contract_id] = Decimal(2)
+    ib_position = SimpleNamespace(
+        contract=contract_details.contract,
+        quantity=Decimal(0),
+        avg_cost=0.0,
+    )
+
+    get_instrument = mocker.patch.object(
+        exec_client.instrument_provider,
+        "get_instrument",
+        side_effect=[None, instrument],
+    )
+    send_position_status_report = mocker.patch.object(
+        exec_client,
+        "_send_position_status_report",
+    )
+
+    await exec_client._handle_position_update(ib_position)
+
+    assert exec_client._known_positions[contract_id] == Decimal(2)
+    send_position_status_report.assert_not_called()
+
+    await exec_client._handle_position_update(ib_position)
+
+    assert get_instrument.call_count == 2
+    send_position_status_report.assert_called_once()
+    position_report = send_position_status_report.call_args.args[0]
+    assert position_report.instrument_id == instrument.id
+    assert position_report.position_side == PositionSide.FLAT
+    assert position_report.quantity == instrument.make_qty(0)
+    assert contract_id not in exec_client._known_positions
 
 
 @pytest.fixture

--- a/tests/unit_tests/execution/test_engine_leg_fills.py
+++ b/tests/unit_tests/execution/test_engine_leg_fills.py
@@ -28,6 +28,7 @@ from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.execution.engine import ExecutionEngine
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.enums import LiquiditySide
+from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.events.order import OrderFilled
@@ -242,6 +243,48 @@ class TestExecutionEngineLegFills:
         position = positions[0]
         assert position.instrument_id == self.put_option.id
         assert position.quantity == Quantity.from_int(9)  # 6 + 3
+
+    def test_handle_leg_fill_without_order_in_hedging_reuses_leg_position_id(self):
+        """
+        Test that hedging leg fills create and reuse a synthetic leg position ID.
+        """
+        self.exec_engine._oms_overrides[self.strategy_id] = OmsType.HEDGING
+
+        first_fill = self.create_leg_fill(
+            instrument_id=self.call_option.id,
+            client_order_id=ClientOrderId("O-20260312-083715-000-000-1-LEG-E1AQ5 C6400"),
+            venue_order_id=VenueOrderId("213-LEG-0"),
+            trade_id=TradeId("0000e1a7.6882c67b.03.01-0"),
+            side=OrderSide.BUY,
+            quantity=3,
+            price=52.75,
+        )
+
+        self.exec_engine._handle_leg_fill_without_order(first_fill)
+
+        first_position = self.cache.positions()[0]
+        assert first_fill.position_id == first_position.id
+        assert self.cache.position_id(first_fill.client_order_id) == first_position.id
+
+        second_fill = self.create_leg_fill(
+            instrument_id=self.call_option.id,
+            client_order_id=first_fill.client_order_id,
+            venue_order_id=VenueOrderId("214-LEG-0"),
+            trade_id=TradeId("0000e1a7.6882c67b.04.01-0"),
+            side=OrderSide.BUY,
+            quantity=2,
+            price=53.25,
+        )
+
+        self.exec_engine._handle_leg_fill_without_order(second_fill)
+
+        positions = self.cache.positions()
+        assert len(positions) == 1
+        position = positions[0]
+        assert second_fill.position_id == first_position.id
+        assert position.id == first_position.id
+        assert position.quantity == Quantity.from_int(5)
+        assert str(position.avg_px_open) == "52.95"
 
     def test_handle_leg_fill_without_order_missing_instrument(self):
         """

--- a/tests/unit_tests/live/test_execution_recon.py
+++ b/tests/unit_tests/live/test_execution_recon.py
@@ -3183,9 +3183,7 @@ class TestLiveExecutionReconciliationEdgeCases:
         assert result is True, "FLAT report should be successfully reconciled"
 
 
-# =============================================================================
-# FIXTURES FOR STANDALONE TESTS
-# =============================================================================
+# Fixtures for standalone tests
 
 
 @pytest.fixture
@@ -3251,9 +3249,7 @@ def cache():
     return cache
 
 
-# =============================================================================
-# TESTS FOR _query_position_status_reports
-# =============================================================================
+# Tests for _query_position_status_reports
 
 
 @pytest.mark.asyncio
@@ -3277,12 +3273,13 @@ async def test_query_position_status_reports_success(live_exec_engine, exec_clie
     exec_client.add_position_status_report(report)
 
     # Act
-    venue_positions = await live_exec_engine._query_position_status_reports()
+    venue_positions, failed_venues = await live_exec_engine._query_position_status_reports()
 
     # Assert
     assert len(venue_positions) == 1
     assert AUDUSD_SIM.id in venue_positions
     assert venue_positions[AUDUSD_SIM.id].quantity == Quantity.from_int(1000)
+    assert failed_venues == set()
 
 
 @pytest.mark.asyncio
@@ -3300,10 +3297,11 @@ async def test_query_position_status_reports_handles_exceptions(live_exec_engine
     exec_client.generate_position_status_reports = raise_error
 
     # Act
-    venue_positions = await live_exec_engine._query_position_status_reports()
+    venue_positions, failed_venues = await live_exec_engine._query_position_status_reports()
 
     # Assert
     assert len(venue_positions) == 0
+    assert failed_venues == {exec_client.venue}
 
 
 @pytest.mark.asyncio
@@ -3341,17 +3339,16 @@ async def test_query_position_status_reports_multiple_instruments(
     exec_client.add_position_status_report(report2)
 
     # Act
-    venue_positions = await live_exec_engine._query_position_status_reports()
+    venue_positions, failed_venues = await live_exec_engine._query_position_status_reports()
 
     # Assert
     assert len(venue_positions) == 2
     assert AUDUSD_SIM.id in venue_positions
     assert GBPUSD_SIM.id in venue_positions
+    assert failed_venues == set()
 
 
-# =============================================================================
-# TESTS FOR _query_and_find_missing_fills
-# =============================================================================
+# Tests for _query_and_find_missing_fills
 
 
 @pytest.mark.asyncio
@@ -3431,7 +3428,7 @@ async def test_query_and_find_missing_fills_finds_missing(
     exec_client.add_fill_reports(VenueOrderId("V-1"), [fill_report1, fill_report2])
 
     # Act
-    missing_fills = await live_exec_engine._query_and_find_missing_fills(
+    missing_fills, had_fill_query_errors = await live_exec_engine._query_and_find_missing_fills(
         AUDUSD_SIM.id,
         live_exec_engine._clients.values(),
     )
@@ -3439,6 +3436,7 @@ async def test_query_and_find_missing_fills_finds_missing(
     # Assert
     assert len(missing_fills) == 1
     assert missing_fills[0].trade_id == TradeId("T-2")
+    assert not had_fill_query_errors
 
 
 @pytest.mark.asyncio
@@ -3456,13 +3454,14 @@ async def test_query_and_find_missing_fills_handles_exceptions(live_exec_engine,
     exec_client.generate_fill_reports = raise_error
 
     # Act
-    missing_fills = await live_exec_engine._query_and_find_missing_fills(
+    missing_fills, had_fill_query_errors = await live_exec_engine._query_and_find_missing_fills(
         AUDUSD_SIM.id,
         live_exec_engine._clients.values(),
     )
 
     # Assert
     assert len(missing_fills) == 0
+    assert had_fill_query_errors
 
 
 @pytest.mark.asyncio
@@ -3526,18 +3525,17 @@ async def test_query_and_find_missing_fills_no_missing(
     exec_client.add_fill_reports(VenueOrderId("V-1"), [fill_report])
 
     # Act
-    missing_fills = await live_exec_engine._query_and_find_missing_fills(
+    missing_fills, had_fill_query_errors = await live_exec_engine._query_and_find_missing_fills(
         AUDUSD_SIM.id,
         live_exec_engine._clients.values(),
     )
 
     # Assert
     assert len(missing_fills) == 0
+    assert not had_fill_query_errors
 
 
-# =============================================================================
-# TESTS FOR _reconcile_missing_fills
-# =============================================================================
+# Tests for _reconcile_missing_fills
 
 
 @pytest.mark.asyncio
@@ -3642,9 +3640,7 @@ async def test_reconcile_missing_fills_handles_failure(live_exec_engine, cache, 
     # Assert - method should handle gracefully
 
 
-# =============================================================================
-# TESTS FOR _process_cached_position_discrepancies
-# =============================================================================
+# Tests for _process_cached_position_discrepancies
 
 
 @pytest.mark.asyncio
@@ -3760,6 +3756,7 @@ async def test_position_check_retries_stops_after_max(live_exec_engine, exec_cli
     # Arrange
     live_exec_engine.register_client(exec_client)
     live_exec_engine.position_check_retries = 2
+    live_exec_engine.generate_missing_orders = False
 
     if AUDUSD_SIM.id not in [i.id for i in cache.instruments()]:
         cache.add_instrument(AUDUSD_SIM)
@@ -3800,6 +3797,111 @@ async def test_position_check_retries_stops_after_max(live_exec_engine, exec_cli
 
 
 @pytest.mark.asyncio
+async def test_process_cached_position_discrepancies_reconciles_missing_venue_position_as_flat(
+    live_exec_engine,
+    exec_client,
+    cache,
+):
+    # Arrange
+    live_exec_engine.register_client(exec_client)
+    live_exec_engine.generate_missing_orders = True
+
+    if AUDUSD_SIM.id not in [i.id for i in cache.instruments()]:
+        cache.add_instrument(AUDUSD_SIM)
+
+    order = TestExecStubs.limit_order(instrument=AUDUSD_SIM, order_side=OrderSide.BUY)
+    fill = TestEventStubs.order_filled(
+        order,
+        instrument=AUDUSD_SIM,
+        last_qty=Quantity.from_int(1000),
+        last_px=Price.from_str("1.00000"),
+        position_id=PositionId("P-FLAT-001"),
+    )
+    position = Position(instrument=AUDUSD_SIM, fill=fill)
+    cache.add_position(position, OmsType.NETTING)
+
+    async def no_missing_fills(instrument_id, clients):
+        return [], False
+
+    live_exec_engine._query_and_find_missing_fills = no_missing_fills
+
+    reconcile_calls = []
+    original_reconcile = live_exec_engine._reconcile_position_report
+
+    def spy_reconcile(report):
+        reconcile_calls.append(report)
+        return original_reconcile(report)
+
+    live_exec_engine._reconcile_position_report = spy_reconcile
+
+    # Act
+    await live_exec_engine._process_cached_position_discrepancies(
+        {AUDUSD_SIM.id: [position]},
+        {},
+    )
+
+    # Assert
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0].instrument_id == AUDUSD_SIM.id
+    assert reconcile_calls[0].position_side == PositionSide.FLAT
+    assert reconcile_calls[0].quantity == AUDUSD_SIM.make_qty(0)
+
+
+@pytest.mark.asyncio
+async def test_process_cached_position_discrepancies_skips_flat_reconciliation_on_query_failure(
+    live_exec_engine,
+    exec_client,
+    cache,
+):
+    # Arrange
+    live_exec_engine.register_client(exec_client)
+    live_exec_engine.generate_missing_orders = True
+
+    if AUDUSD_SIM.id not in [i.id for i in cache.instruments()]:
+        cache.add_instrument(AUDUSD_SIM)
+
+    order = TestExecStubs.limit_order(instrument=AUDUSD_SIM, order_side=OrderSide.BUY)
+    fill = TestEventStubs.order_filled(
+        order,
+        instrument=AUDUSD_SIM,
+        last_qty=Quantity.from_int(1000),
+        last_px=Price.from_str("1.00000"),
+        position_id=PositionId("P-FLAT-ERR-001"),
+    )
+    position = Position(instrument=AUDUSD_SIM, fill=fill)
+    cache.add_position(position, OmsType.NETTING)
+
+    query_called = False
+
+    async def capture_query(instrument_id, clients):
+        nonlocal query_called
+        query_called = True
+        return [], False
+
+    live_exec_engine._query_and_find_missing_fills = capture_query
+
+    reconcile_calls = []
+
+    def spy_reconcile(report):
+        reconcile_calls.append(report)
+        return True
+
+    live_exec_engine._reconcile_position_report = spy_reconcile
+
+    # Act
+    await live_exec_engine._process_cached_position_discrepancies(
+        {AUDUSD_SIM.id: [position]},
+        {},
+        {AUDUSD_SIM.id.venue},
+    )
+
+    # Assert
+    assert not query_called
+    assert reconcile_calls == []
+    assert AUDUSD_SIM.id not in live_exec_engine._position_recon_retries
+
+
+@pytest.mark.asyncio
 async def test_position_check_retries_clears_on_resolved(live_exec_engine, exec_client, cache):
     # Arrange
     live_exec_engine.register_client(exec_client)
@@ -3823,7 +3925,7 @@ async def test_position_check_retries_clears_on_resolved(live_exec_engine, exec_
 
     # Stub out query to return no fills (discrepancy persists)
     async def no_fills_query(instrument_id, clients):
-        return []
+        return [], False
 
     live_exec_engine._query_and_find_missing_fills = no_fills_query
 
@@ -3912,7 +4014,7 @@ async def test_venue_reported_position_retries_stop_after_max(
     async def counting_query(instrument_id, clients):
         nonlocal query_count
         query_count += 1
-        return []
+        return [], False
 
     live_exec_engine._query_and_find_missing_fills = counting_query
 
@@ -3962,7 +4064,7 @@ async def test_venue_reported_position_tolerance_does_not_consume_retries(
     )
 
     async def no_fills_query(instrument_id, clients):
-        return []
+        return [], False
 
     live_exec_engine._query_and_find_missing_fills = no_fills_query
 
@@ -3976,9 +4078,7 @@ async def test_venue_reported_position_tolerance_does_not_consume_retries(
     assert ethusdt.id not in live_exec_engine._position_recon_retries
 
 
-# =============================================================================
-# TESTS FOR _process_venue_reported_positions
-# =============================================================================
+# Tests for _process_venue_reported_positions
 
 
 @pytest.mark.asyncio
@@ -4081,9 +4181,7 @@ async def test_process_venue_reported_positions_venue_has_position(
     assert query_called  # Should query when venue has position we don't
 
 
-# =============================================================================
-# TESTS FOR _handle_order_status_transitions
-# =============================================================================
+# Tests for _handle_order_status_transitions
 
 
 @pytest.mark.asyncio
@@ -4450,9 +4548,7 @@ async def test_should_update_returns_true_when_report_quantity_greater_than_fill
     assert result is True
 
 
-# =============================================================================
-# TESTS FOR _handle_fill_quantity_mismatch
-# =============================================================================
+# Tests for _handle_fill_quantity_mismatch
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Hardens Interactive Brokers live reconciliation so Nautilus can converge cache state when venue callbacks are incomplete, positions close externally, or hedging leg fills arrive without the original parent order in cache.

## What Changed

- `nautilus_trader/live/execution_engine.py` now reconciles cached-open and venue-flat discrepancies through a synthesized `FLAT` `PositionStatusReport`, instead of only retrying missing-fill queries.
- The same live reconciliation path now tracks venue position-status query failures per venue and skips synthetic flat reconciliation for those instruments, so a temporary snapshot failure is not mistaken for a real flat venue state.
- Fill-query failures are now tracked separately from the "no missing fills found" case, which keeps the retry and warning behavior aligned with the actual failure mode.
- The reconciliation call sites now unpack `_query_and_find_missing_fills()` directly, removing the old list-or-tuple compatibility branch so the function contract is explicit.
- Synthetic `FLAT` reports created during reconciliation now use `instrument.make_qty(0)` when the instrument is cached, matching the precision-aware quantity construction used in the IB adapter.
- `nautilus_trader/adapters/interactive_brokers/execution.py` now resolves cached orders by `venue_order_id` when IB sends `orderStatus` or `execDetails` without `orderRef`.
- Interactive Brokers position updates now emit a `FLAT` `PositionStatusReport` when a tracked option position goes from non-zero to zero, and the transient instrument-lookup retry behavior is now called out explicitly in code comments.
- `nautilus_trader/execution/engine.pyx` now reuses an existing cached `position_id` for hedging leg fills with the same leg `client_order_id`, and generates a synthetic hedging position ID when a leg fill arrives without a cached parent order.
- `tests/unit_tests/live/test_execution_recon.py` no longer uses banner-style section comments, and its reconciliation test doubles now match the real tuple return signature.

## Why

Previously:

- If the venue was already flat, continuous reconciliation could detect the discrepancy but still leave the cached position open because it only searched for missing fills.
- If the venue position snapshot failed, the missing report could be conflated with a genuine venue-flat state and trigger an incorrect synthetic close.
- IB manual or external order updates could be ignored when callbacks arrived with an empty `orderRef`, even though the order was already mapped by `venue_order_id`.
- IB option expirations reported through position updates could leave stale positions in cache because zero-quantity updates were treated as noise, and a transient instrument lookup miss could discard the closure signal before a retry.
- Hedging leg fills without a cached parent order could fail position assignment or split repeated fills for the same leg across inconsistent positions.

This branch makes those recovery paths consistent so the live cache can converge correctly without requiring a restart.

## Validation

Verified with targeted tests:

```bash
uv run --no-sync pytest \
  tests/unit_tests/execution/test_engine_leg_fills.py::TestExecutionEngineLegFills::test_handle_leg_fill_without_order_in_hedging_reuses_leg_position_id \
  tests/unit_tests/live/test_execution_recon.py::test_query_position_status_reports_handles_exceptions \
  tests/unit_tests/live/test_execution_recon.py::test_process_cached_position_discrepancies_reconciles_missing_venue_position_as_flat \
  tests/unit_tests/live/test_execution_recon.py::test_process_cached_position_discrepancies_skips_flat_reconciliation_on_query_failure \
  tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_on_order_status_resolves_cached_external_order_by_venue_order_id \
  tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_on_exec_details_resolves_cached_external_order_by_venue_order_id \
  tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_handle_position_update_retries_flat_report_after_transient_instrument_lookup_failure
```

Additional verification for the review follow-up changes:

```bash
uv run --no-sync pytest \
  tests/unit_tests/live/test_execution_recon.py -k 'query_and_find_missing_fills or process_cached_position_discrepancies or venue_reported_position_retries_stop_after_max or position_check_retries' \
  tests/integration_tests/adapters/interactive_brokers/test_execution.py -k 'handle_position_update_retries_flat_report_after_transient_instrument_lookup_failure' \
  tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
```

The review-driven cleanup passed these targeted unit and integration checks.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3655

https://github.com/nautechsystems/nautilus_trader/pull/3618

https://github.com/nautechsystems/nautilus_trader/issues/3712

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
