### PR TITLE
Fix IB inactive order status handling to prevent silent dropping

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -353,6 +353,7 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
                     avg_fill_price=avg_fill_price,
                     filled=filled,
                     remaining=remaining,
+                    why_held=why_held,
                 )
 
     async def process_exec_details(

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1527,6 +1527,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         remaining: Decimal = Decimal(0),
         reason: str = "",
         venue_order_id: VenueOrderId | None = None,
+        why_held: str = "",
     ) -> None:
         # Cache filled quantity for use in OrderStatusReport generation during reconciliation.
         # IB's openOrder callback doesn't include accurate filledQuantity, but orderStatus does.
@@ -1545,10 +1546,14 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         elif order_status == "Filled":
             status = OrderStatus.FILLED
         elif order_status == "Inactive":
-            self._log.warning(
-                f"Order status is 'Inactive' because it is invalid or triggered an error for {order_ref=}",
-            )
-            return
+            if why_held == "locate":
+                self._log.warning(
+                    f"Order {order_ref} held for short-sell locate, order remains active",
+                )
+                return
+            status = OrderStatus.REJECTED
+            if not reason:
+                reason = "Order inactive (IB)"
         elif order_status in ["PendingSubmit", "PreSubmitted", "Submitted"]:
             self._log.debug(
                 f"Ignoring `_on_order_status` event for {order_status=} is handled in `_on_open_order`",

--- a/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/execution.py
@@ -97,7 +97,7 @@ MAP_ORDER_STATUS = {
     "ApiCancelled": OrderStatus.CANCELED,
     "Cancelled": OrderStatus.CANCELED,
     "Filled": OrderStatus.FILLED,
-    "Inactive": OrderStatus.DENIED,
+    "Inactive": OrderStatus.REJECTED,
 }
 
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
@@ -244,6 +244,7 @@ async def test_orderStatus(ib_client):
         avg_fill_price=100.0,
         filled=Decimal(100),
         remaining=Decimal(0),
+        why_held="",
     )
 
 
@@ -285,6 +286,7 @@ async def test_orderStatus_with_zero_avg_fill_price(ib_client):
         avg_fill_price=0.0,
         filled=Decimal(50),
         remaining=Decimal(50),
+        why_held="",
     )
 
 


### PR DESCRIPTION
## Summary

- Route IB `Inactive` order status through `REJECTED` instead of silently dropping it
- Preserve `whyHeld="locate"` carve-out for short-sell locate holds
- Fix `MAP_ORDER_STATUS` reconciliation mapping from `DENIED` to `REJECTED`
- Forward `why_held` from `process_order_status` through the handler callback

## Problem

`_on_order_status` silently swallowed `Inactive` — logged a warning and returned.
The order stayed stuck as `SUBMITTED` forever. The strategy could not cancel,
replace, or react. For options trading this typically means a margin rejection
went unnoticed.

## Changes

| File | Change |
|------|--------|
| `client/order.py` | Forward `why_held=why_held` through handler callback |
| `execution.py` | Add `why_held` param; route Inactive → REJECTED with locate carve-out |
| `parsing/execution.py` | `MAP_ORDER_STATUS["Inactive"]` = `REJECTED` (was `DENIED`) |
| `test_client_order.py` | Update mock assertions to include `why_held=""` |

## Behavior

| `whyHeld` value | Result |
|-----------------|--------|
| `"locate"` | Log warning, order stays active (IB searching for borrow) |
| `""` (anything else) | `REJECTED` with reason `"Order inactive (IB)"` or IB's error string |

## Why REJECTED and not DENIED

`DENIED` = Nautilus rejected the order before it reached the venue (risk checks, invalid params)
`REJECTED` = the venue rejected it after submission

IB's `Inactive` happens after the order reaches IB's servers, so `REJECTED` is the correct mapping.

## Test plan

- [x] 373 IB adapter integration tests passing
- [x] Updated `test_orderStatus` and `test_orderStatus_with_zero_avg_fill_price` mock assertions
- [ ] Manual validation against live TWS/Gateway with an order that triggers Inactive

Closes #3603