### PR TITLE
Fix option chains emitting data after expiry

### DIFF
--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -120,6 +120,7 @@ use crate::{
 pub(crate) enum DeferredCommand {
     Subscribe(SubscribeCommand),
     Unsubscribe(UnsubscribeCommand),
+    ExpireSeries(OptionSeriesId),
 }
 
 /// Shared queue for deferred subscribe/unsubscribe commands.
@@ -1243,25 +1244,59 @@ impl DataEngine {
     /// managers (or any other component) and executes them against the appropriate
     /// data client.
     fn drain_deferred_commands(&mut self) {
-        let commands: VecDeque<DeferredCommand> =
-            std::mem::take(&mut *self.deferred_cmd_queue.borrow_mut());
+        // Loop because handlers (e.g. expire_series) may push new commands during processing
+        loop {
+            let commands: VecDeque<DeferredCommand> =
+                std::mem::take(&mut *self.deferred_cmd_queue.borrow_mut());
 
-        for cmd in commands {
-            match cmd {
-                DeferredCommand::Subscribe(sub) => {
-                    let client = self.get_client(sub.client_id(), sub.venue());
-                    if let Some(client) = client {
-                        client.execute_subscribe(&sub);
+            if commands.is_empty() {
+                break;
+            }
+
+            for cmd in commands {
+                match cmd {
+                    DeferredCommand::Subscribe(sub) => {
+                        let client = self.get_client(sub.client_id(), sub.venue());
+                        if let Some(client) = client {
+                            client.execute_subscribe(&sub);
+                        }
                     }
-                }
-                DeferredCommand::Unsubscribe(unsub) => {
-                    let client = self.get_client(unsub.client_id(), unsub.venue());
-                    if let Some(client) = client {
-                        client.execute_unsubscribe(&unsub);
+                    DeferredCommand::Unsubscribe(unsub) => {
+                        let client = self.get_client(unsub.client_id(), unsub.venue());
+                        if let Some(client) = client {
+                            client.execute_unsubscribe(&unsub);
+                        }
+                    }
+                    DeferredCommand::ExpireSeries(series_id) => {
+                        self.expire_series(series_id);
                     }
                 }
             }
         }
+    }
+
+    /// Proactively expires all instruments for a series and tears down the manager.
+    fn expire_series(&mut self, series_id: OptionSeriesId) {
+        let Some(manager_rc) = self.option_chain_managers.get(&series_id).cloned() else {
+            return;
+        };
+
+        let instrument_ids: Vec<InstrumentId> = self
+            .option_chain_instrument_index
+            .iter()
+            .filter(|(_, sid)| **sid == series_id)
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in &instrument_ids {
+            self.option_chain_instrument_index.remove(id);
+            manager_rc.borrow_mut().handle_instrument_expired(id);
+        }
+
+        manager_rc.borrow_mut().teardown(&self.clock);
+        self.option_chain_managers.remove(&series_id);
+
+        log::info!("Proactively torn down expired option chain {series_id}");
     }
 
     // -- SUBSCRIPTION HANDLERS -------------------------------------------------------------------

--- a/crates/data/src/option_chains/aggregator.rs
+++ b/crates/data/src/option_chains/aggregator.rs
@@ -135,6 +135,12 @@ impl OptionChainAggregator {
         self.series_id
     }
 
+    /// Returns `true` if the given timestamp is at or past the series expiration.
+    #[must_use]
+    pub fn is_expired(&self, now_ns: UnixNanos) -> bool {
+        now_ns >= self.series_id.expiration_ns
+    }
+
     /// Returns a reference to the full instrument set.
     #[must_use]
     pub fn instruments(&self) -> &HashMap<InstrumentId, (Price, OptionKind)> {
@@ -270,6 +276,16 @@ impl OptionChainAggregator {
 
     /// Handles an incoming quote tick by updating the accumulator buffers.
     pub fn update_quote(&mut self, quote: &QuoteTick) {
+        if self.is_expired(quote.ts_event) {
+            log::warn!(
+                "Dropping quote for {} — series {} expired at {}",
+                quote.instrument_id,
+                self.series_id,
+                self.series_id.expiration_ns,
+            );
+            return;
+        }
+
         if !self.active_ids.contains(&quote.instrument_id) {
             return;
         }
@@ -307,6 +323,16 @@ impl OptionChainAggregator {
     /// the greeks are stored in `pending_greeks` and will be attached when
     /// the first quote arrives.
     pub fn update_greeks(&mut self, greeks: &OptionGreeks) {
+        if self.is_expired(greeks.ts_event) {
+            log::warn!(
+                "Dropping greeks for {} — series {} expired at {}",
+                greeks.instrument_id,
+                self.series_id,
+                self.series_id.expiration_ns,
+            );
+            return;
+        }
+
         if !self.active_ids.contains(&greeks.instrument_id) {
             return;
         }
@@ -1233,5 +1259,48 @@ mod tests {
 
         let _ = agg.remove_instrument(&put_id);
         assert!(agg.is_catalog_empty());
+    }
+
+    // -- Expiry guard tests --
+
+    #[rstest]
+    fn test_expired_quote_is_dropped() {
+        let (mut agg, call_id, _) = make_aggregator();
+        // Series expires at 1_700_000_000_000_000_000; send quote AT that timestamp
+        let expired_quote = QuoteTick::new(
+            call_id,
+            Price::from("100.00"),
+            Price::from("101.00"),
+            Quantity::from("1.0"),
+            Quantity::from("1.0"),
+            UnixNanos::from(1_700_000_000_000_000_000u64),
+            UnixNanos::from(1_700_000_000_000_000_000u64),
+        );
+        agg.update_quote(&expired_quote);
+        assert!(agg.is_buffer_empty());
+    }
+
+    #[rstest]
+    fn test_expired_greeks_are_dropped() {
+        let (mut agg, call_id, _) = make_aggregator();
+        // First add a valid quote so greeks would normally land in the buffer
+        let quote = make_quote(call_id, "100.00", "101.00");
+        agg.update_quote(&quote);
+        assert_eq!(agg.call_buffer_len(), 1);
+
+        // Send greeks at expiry timestamp — should be dropped
+        let greeks = OptionGreeks {
+            instrument_id: call_id,
+            ts_event: UnixNanos::from(1_700_000_000_000_000_000u64),
+            greeks: OptionGreekValues {
+                delta: 0.55,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        agg.update_greeks(&greeks);
+
+        let strike = Price::from("50000");
+        assert!(agg.get_call_greeks_from_buffer(&strike).is_none());
     }
 }

--- a/crates/data/src/option_chains/manager.rs
+++ b/crates/data/src/option_chains/manager.rs
@@ -709,6 +709,14 @@ impl OptionChainManager {
 
     /// Takes the accumulated snapshot and publishes it to the msgbus.
     pub fn publish_slice(&mut self, ts: nautilus_core::UnixNanos) {
+        // Proactive expiry safeguard
+        if self.aggregator.is_expired(ts) {
+            self.deferred_cmd_queue
+                .borrow_mut()
+                .push_back(DeferredCommand::ExpireSeries(self.aggregator.series_id()));
+            return;
+        }
+
         self.maybe_rebalance(ts);
 
         let series_id = self.aggregator.series_id();
@@ -1118,5 +1126,43 @@ mod tests {
         // Empty manager returns true (catalog was already empty)
         assert!(is_empty);
         assert!(queue.borrow().is_empty()); // no deferred commands pushed
+    }
+
+    #[rstest]
+    fn test_publish_slice_pushes_expire_series_when_expired() {
+        let (mut manager, queue) = make_option_chain_manager();
+        bootstrap_via_greeks(&mut manager);
+        queue.borrow_mut().clear();
+
+        // Publish at the expiration timestamp — should push ExpireSeries, not publish
+        let expiry_ns = manager.aggregator.series_id().expiration_ns;
+        manager.publish_slice(expiry_ns);
+
+        let cmds: Vec<_> = queue.borrow().iter().cloned().collect();
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], DeferredCommand::ExpireSeries(_)));
+    }
+
+    #[rstest]
+    fn test_expired_instrument_unsubscribes_include_instrument_status() {
+        let (mut manager, queue) = make_option_chain_manager();
+        bootstrap_via_greeks(&mut manager);
+        queue.borrow_mut().clear();
+
+        let expired_id = InstrumentId::from("BTC-20240101-50000-C.DERIBIT");
+        manager.handle_instrument_expired(&expired_id);
+
+        let cmds: Vec<_> = queue.borrow().iter().cloned().collect();
+        // Should have exactly one InstrumentStatus unsubscribe among the 3
+        let status_unsubs = cmds
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c,
+                    DeferredCommand::Unsubscribe(UnsubscribeCommand::InstrumentStatus(_))
+                )
+            })
+            .count();
+        assert_eq!(status_unsubs, 1);
     }
 }

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -1601,6 +1601,10 @@ cdef class DataEngine(Component):
         """Timer callback to publish option chain snapshots."""
         cdef str timer_name = event.name
         cdef str series_key = None
+        cdef uint64_t ts_ns
+        cdef uint64_t expiration_ns
+        cdef Venue venue
+        cdef MarketDataClient client
 
         # Find series key from timer name
         for sk, tn in self._option_chain_timer_names.items():
@@ -1615,7 +1619,18 @@ cdef class DataEngine(Component):
         if manager is None:
             return
 
-        cdef uint64_t ts_ns = self._clock.timestamp_ns()
+        ts_ns = self._clock.timestamp_ns()
+
+        # Safeguard: proactively teardown expired series
+        expiration_ns = manager.series_id.expiration_ns
+        if ts_ns >= expiration_ns:
+            self._log.warning(
+                f"Option chain {series_key} expired at {expiration_ns}, tearing down",
+            )
+            venue = Venue(str(manager.series_id.venue))
+            client = self._routing_map.get(venue)
+            self._teardown_option_chain(series_key, client)
+            return
 
         # Check rebalance and forward subscribe/unsubscribe for changed instruments
         rebalance = manager.check_rebalance(ts_ns)
@@ -2762,6 +2777,15 @@ cdef class DataEngine(Component):
         manager = self._option_chain_managers.get(series_key)
         if manager is None:
             return
+
+        # Safeguard: reject data past expiry
+        if tick.ts_event >= manager.series_id.expiration_ns:
+            self._log.warning(
+                f"Dropping quote for {tick.instrument_id} — series {series_key} expired",
+            )
+            self._expire_option_chain_instrument(tick.instrument_id, series_key)
+            return
+
         try:
             pyo3_tick = tick.to_pyo3()
             bootstrapped = manager.handle_quote(pyo3_tick)
@@ -2783,6 +2807,15 @@ cdef class DataEngine(Component):
         manager = self._option_chain_managers.get(series_key)
         if manager is None:
             return
+
+        # Safeguard: reject data past expiry
+        if option_greeks.ts_event >= manager.series_id.expiration_ns:
+            self._log.warning(
+                f"Dropping greeks for {option_greeks.instrument_id} — series {series_key} expired",
+            )
+            self._expire_option_chain_instrument(option_greeks.instrument_id, series_key)
+            return
+
         try:
             pyo3_greeks = option_greeks.to_pyo3()
             bootstrapped = manager.handle_greeks(pyo3_greeks)

--- a/tests/unit_tests/data/test_engine_option_chain.py
+++ b/tests/unit_tests/data/test_engine_option_chain.py
@@ -32,6 +32,7 @@ from nautilus_trader.data.messages import UnsubscribeOptionChain
 from nautilus_trader.data.messages import UnsubscribeOptionGreeks
 from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import OptionGreeks
+from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.identifiers import ClientId
@@ -186,7 +187,7 @@ class TestOptionChainEngine:
 
     _UNSET = object()
 
-    def _subscribe_and_bootstrap(self, series_id, strike_range=_UNSET):
+    def _subscribe_and_bootstrap(self, series_id, strike_range=_UNSET, snapshot_interval_ms=None):
         """
         Subscribe to an option chain and complete the bootstrap by simulating an empty
         forward price response.
@@ -197,7 +198,7 @@ class TestOptionChainEngine:
         sub_cmd = SubscribeOptionChain(
             series_id=series_id,
             strike_range=strike_range,
-            snapshot_interval_ms=None,
+            snapshot_interval_ms=snapshot_interval_ms,
             client_id=self.client.id,
             venue=OPRA,
             command_id=UUID4(),
@@ -525,3 +526,58 @@ class TestOptionChainEngine:
 
         # Assert
         assert inst_id not in self.client.subscribed_option_greeks()
+
+    def test_snapshot_timer_tears_down_expired_series(self):
+        # Arrange: set clock close to expiry so advance doesn't generate billions of events
+        self.clock.set_time(EXPIRY_NS - 5_000_000_000)  # 5 seconds before expiry
+
+        series_key = str(self.series_id)
+        self._subscribe_and_bootstrap(self.series_id, snapshot_interval_ms=1000)
+
+        assert series_key in self.data_engine._option_chain_managers
+        assert series_key in self.data_engine._option_chain_timer_names
+
+        # Act: advance clock past expiration and fire the timer
+        events = self.clock.advance_time(EXPIRY_NS + 1_000_000_000)
+        for event in events:
+            event.handle()
+
+        # Assert: manager, timer, and instrument index all cleaned up
+        assert series_key not in self.data_engine._option_chain_managers
+        assert series_key not in self.data_engine._option_chain_timer_names
+        for sk in self.data_engine._option_chain_instrument_index.values():
+            assert sk != series_key
+
+    def test_snapshot_timer_publishes_slice_to_bus(self):
+        # Arrange: subscribe with snapshot interval
+        series_key = str(self.series_id)
+        self._subscribe_and_bootstrap(self.series_id, snapshot_interval_ms=1000)
+
+        # Feed greeks with underlying_price to trigger ATM bootstrap
+        greeks = _make_greeks(self.aapl_call_150.id)
+        self.data_engine.process(greeks)
+
+        # Feed a quote tick so the aggregator has data for the snapshot
+        quote = QuoteTick(
+            self.aapl_call_150.id,
+            Price.from_str("5.00"),
+            Price.from_str("5.50"),
+            Quantity.from_int(10),
+            Quantity.from_int(10),
+            0,
+            0,
+        )
+        self.data_engine.process(quote)
+
+        # Subscribe to the option chain topic
+        received = []
+        topic = f"data.option_chain.{series_key}"
+        self.msgbus.subscribe(topic=topic, handler=received.append)
+
+        # Act: advance clock by 1 second to trigger the snapshot timer
+        events = self.clock.advance_time(1_000_000_000)
+        for event in events:
+            event.handle()
+
+        # Assert: snapshot was published to the bus
+        assert len(received) == 1


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary


- **Subscribe to `InstrumentStatus`** for all option chain instruments so the engine's existing expiry logic (`handle_instrument_status → expire_option_chain_instrument`) actually fires. Previously only `QuoteTicks` and `OptionGreeks` were subscribed, meaning venue-sent expiry events were silently ignored.
- **Add time-based expiry guards** as defense-in-depth: the aggregator drops quotes/greeks with timestamps at or past expiration, the manager short-circuits `publish_slice()` with an `ExpireSeries` deferred command, and the Cython engine rejects expired data in feed methods and tears down expired series in the snapshot timer.
- **Add `ExpireSeries` deferred command** and `expire_series()` bulk teardown in the Rust `DataEngine`, with a looping `drain_deferred_commands()` to handle commands pushed during expiry processing.

## Problem

Option chains continued feeding data (including non-NaN IV values) after options expired. The root cause was that `_subscribe_option_chain_instruments` (both Rust and Cython) subscribed to `QuoteTicks` and `OptionGreeks` but **not** `InstrumentStatus`. Since the Deribit adapter only sends `InstrumentStatus` events when explicitly subscribed, the engine's expiry path never triggered.

A secondary concern: even with the subscription fix, a race window exists where data arrives between the expiry timestamp and the venue's status change event, so time-based safeguards are needed.

## Changes

### Rust `crates/data/src/option_chains/manager.rs`
- Import `SubscribeInstrumentStatus` / `UnsubscribeInstrumentStatus`
- `forward_client_subscriptions()`: subscribe `InstrumentStatus` alongside quotes + greeks
- `forward_instrument_subscriptions()`: same for dynamically discovered instruments
- `push_subscribe_pair()` → now pushes 3 deferred commands (quotes + greeks + instrument status)
- `push_unsubscribe_pair()` → same for unsubscribe
- `publish_slice()`: early-return with `ExpireSeries` if series is expired
- Updated test assertions (12→18 commands, 2→3 unsubscribes) and added 2 new tests

### Rust `crates/data/src/option_chains/aggregator.rs`
- Added `is_expired(now_ns)` helper
- `update_quote()` / `update_greeks()`: early-return with warning if data timestamp ≥ expiration
- Added 2 tests for expired quote/greeks rejection

### Rust `crates/data/src/engine/mod.rs`
- Added `ExpireSeries(OptionSeriesId)` variant to `DeferredCommand`
- Refactored `drain_deferred_commands()` to loop until queue is empty (handles commands pushed by `expire_series`)
- Added `expire_series()` method: collects instruments for the series, calls `handle_instrument_expired` on each, tears down manager, removes from index

### Cython `nautilus_trader/data/engine.pyx`
- `_subscribe_option_chain_instruments()`: added `InstrumentStatus` subscription
- `_unsubscribe_option_chain_instruments()`: added `InstrumentStatus` unsubscription
- `_feed_quote_to_option_chain()`: expiry guard — drops quote and expires instrument if `ts_event ≥ expiration_ns`
- `_feed_greeks_to_option_chain()`: same expiry guard
- `_option_chain_snapshot()`: proactive teardown if current time ≥ expiration

### Test `tests/unit_tests/data/test_engine_option_chain.py`
- Added `subscribe_instrument_status` / `unsubscribe_instrument_status` to `MockOptionDataClient`
- Added `test_snapshot_timer_tears_down_expired_series`: verifies full cleanup when timer fires after expiry
- Added `test_snapshot_timer_publishes_slice_to_bus`: verifies snapshot publication with greeks bootstrap + quote feed


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
