### PR TITLE
Refactor custom_data macro with zyn crate

### DIFF
--- a/.pre-commit-hooks/check_cargo_conventions.sh
+++ b/.pre-commit-hooks/check_cargo_conventions.sh
@@ -353,7 +353,7 @@ if [[ -f "Cargo.toml" ]]; then
   }
   ' Cargo.toml | while read -r dep; do
     # Check if any crate uses this dependency with workspace = true
-    if ! grep -rq "^${dep}[[:space:]]*=" crates/*/Cargo.toml crates/adapters/*/Cargo.toml 2> /dev/null; then
+    if ! rg -q "^${dep}[[:space:]]*=" crates -g "Cargo.toml"; then
       echo "  Cargo.toml: [workspace.dependencies] '$dep' is not used by any crate"
     fi
   done) || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,8 +6069,8 @@ name = "nautilus-persistence-macros"
 version = "0.55.0"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "rstest",
+ "zyn",
 ]
 
 [[package]]
@@ -10944,4 +10944,34 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zyn"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4cc63a0258eef63faf98127747922c45d2770ab9f918602d90307bddc469fe"
+dependencies = [
+ "zyn-core",
+ "zyn-derive",
+]
+
+[[package]]
+name = "zyn-core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552fd5767f6237d861274b24c74dcba5135dd02483c2c9e94ebf773dd8580979"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zyn-derive"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948da9db2c8273346a62e650afd5b133ba4e8d1dc4eb1bed1e3c0de24d00243"
+dependencies = [
+ "zyn-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ parquet = { version = "58.1.0", default-features = false, features = [
   "async",
 ] }
 pem = "3.0.6"
+proc-macro2 = "1.0"
 pyo3 = { version = "0.28.2", default-features = false, features = [
   "chrono",
   "hashbrown",
@@ -338,6 +339,7 @@ tonic = { version = "0.13.1", default-features = false, features = [
 ] }
 urlencoding = "2.1.3"
 zeroize = { version = "1.8.2", features = ["alloc", "zeroize_derive"] }
+zyn = "0.5.4"
 
 # -----------------------------------------------------------------------------
 # Dev dependencies

--- a/crates/persistence/macros/Cargo.toml
+++ b/crates/persistence/macros/Cargo.toml
@@ -20,6 +20,8 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = { workspace = true }
+zyn = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/persistence/macros/src/custom.rs
+++ b/crates/persistence/macros/src/custom.rs
@@ -55,12 +55,10 @@
 //! ```
 //! (The macro adds `#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]`.)
 
-use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::{
-    Field, Fields, Ident, ItemStruct, LitStr, Token, Type,
-    parse::{Parse, ParseStream},
-    parse2,
+use proc_macro2::Span;
+use zyn::{
+    Arg, Args, Output, format_ident,
+    syn::{self, Field, Fields, Ident, ItemStruct, LitStr, Type},
 };
 
 /// Last path segment of a type (e.g. "InstrumentId", "UnixNanos", "f64").
@@ -111,394 +109,453 @@ fn type_for_macro(ty: &Type) -> Option<(String, String)> {
     Some((seg.clone(), seg))
 }
 
-/// Returns true if the type uses string extraction (Utf8 or Utf8View).
-fn use_string_extract(ty: &Type) -> bool {
-    if let Some((outer, inner)) = type_for_macro(ty) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldKind {
+    InstrumentId,
+    AccountId,
+    Currency,
+    BarType,
+    UnixNanos,
+    F64,
+    F32,
+    Bool,
+    String,
+    U64,
+    I64,
+    U32,
+    I32,
+    VecU8,
+    VecF64,
+}
+
+impl FieldKind {
+    fn uses_string_extract(self) -> bool {
         matches!(
-            (outer.as_str(), inner.as_str()),
-            ("InstrumentId", "InstrumentId")
-                | ("AccountId", "AccountId")
-                | ("Currency", "Currency")
-                | ("BarType", "BarType")
-                | ("String", "String")
+            self,
+            Self::InstrumentId | Self::AccountId | Self::Currency | Self::BarType | Self::String
         )
-    } else {
-        false
     }
 }
 
-/// Arrow DataType and array type for encoding/decoding. Emits token streams that reference
-/// arrow::datatypes::DataType and arrow array types.
-fn arrow_type_for_rust_type(ty: &Type) -> Option<(TokenStream, TokenStream, TokenStream)> {
+fn classify_field_kind(ty: &Type) -> Option<FieldKind> {
     let (outer, inner) = type_for_macro(ty)?;
-    let (arrow_dt, array_type, extract_array_type): (TokenStream, TokenStream, TokenStream) = match (
-        outer.as_str(),
-        inner.as_str(),
-    ) {
-        ("Vec", "u8") => (
-            quote! { arrow::datatypes::DataType::Binary },
-            quote! { arrow::array::BinaryArray },
-            quote! { arrow::array::BinaryArray },
-        ),
-        ("Vec", "f64") => (
-            quote! { arrow::datatypes::DataType::List(std::sync::Arc::new(arrow::datatypes::Field::new("item", arrow::datatypes::DataType::Float64, true))) },
-            quote! { arrow::array::ListArray },
-            quote! { arrow::array::ListArray },
-        ),
-        _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" => (
-                quote! { arrow::datatypes::DataType::Utf8 },
-                quote! { arrow::array::StringArray },
-                quote! { arrow::array::StringArray },
-            ),
-            "UnixNanos" => (
-                quote! { arrow::datatypes::DataType::UInt64 },
-                quote! { arrow::array::UInt64Array },
-                quote! { arrow::array::UInt64Array },
-            ),
-            "f64" => (
-                quote! { arrow::datatypes::DataType::Float64 },
-                quote! { arrow::array::Float64Array },
-                quote! { arrow::array::Float64Array },
-            ),
-            "f32" => (
-                quote! { arrow::datatypes::DataType::Float32 },
-                quote! { arrow::array::Float32Array },
-                quote! { arrow::array::Float32Array },
-            ),
-            "bool" => (
-                quote! { arrow::datatypes::DataType::Boolean },
-                quote! { arrow::array::BooleanArray },
-                quote! { arrow::array::BooleanArray },
-            ),
-            "String" => (
-                quote! { arrow::datatypes::DataType::Utf8 },
-                quote! { arrow::array::StringArray },
-                quote! { arrow::array::StringArray },
-            ),
-            "u64" | "u32" => (
-                quote! { arrow::datatypes::DataType::UInt64 },
-                quote! { arrow::array::UInt64Array },
-                quote! { arrow::array::UInt64Array },
-            ),
-            "i64" => (
-                quote! { arrow::datatypes::DataType::Int64 },
-                quote! { arrow::array::Int64Array },
-                quote! { arrow::array::Int64Array },
-            ),
-            "i32" => (
-                quote! { arrow::datatypes::DataType::Int32 },
-                quote! { arrow::array::Int32Array },
-                quote! { arrow::array::Int32Array },
-            ),
-            _ => return None,
-        },
-        _ => return None,
-    };
-    Some((arrow_dt, array_type, extract_array_type))
-}
-
-/// How to encode a field value into an Arrow builder (append call).
-fn encode_field_expr(field_name: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
-    let name = field_name;
     match (outer.as_str(), inner.as_str()) {
-        ("Vec", "u8") => Some(quote! { builder.append_value(item.#name.as_slice()); }),
-        ("Vec", "f64") => Some(quote! {
-            for v in item.#name.iter() {
-                builder.values().append_value(*v);
-            }
-            builder.append(true);
-        }),
-        _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" => {
-                Some(quote! { builder.append_value(item.#name.to_string()); })
-            }
-            "UnixNanos" => Some(quote! { builder.append_value(item.#name.as_u64()); }),
-            "f64" | "f32" => Some(quote! { builder.append_value(item.#name); }),
-            "bool" => Some(quote! { builder.append_value(item.#name); }),
-            "String" => Some(quote! { builder.append_value(item.#name.as_str()); }),
-            "u64" | "i64" => Some(quote! { builder.append_value(item.#name); }),
-            "u32" => Some(quote! { builder.append_value(item.#name as u64); }),
-            "i32" => Some(quote! { builder.append_value(item.#name); }),
-            _ => None,
-        },
+        ("InstrumentId", "InstrumentId") => Some(FieldKind::InstrumentId),
+        ("AccountId", "AccountId") => Some(FieldKind::AccountId),
+        ("Currency", "Currency") => Some(FieldKind::Currency),
+        ("BarType", "BarType") => Some(FieldKind::BarType),
+        ("UnixNanos", "UnixNanos") => Some(FieldKind::UnixNanos),
+        ("f64", "f64") => Some(FieldKind::F64),
+        ("f32", "f32") => Some(FieldKind::F32),
+        ("bool", "bool") => Some(FieldKind::Bool),
+        ("String", "String") => Some(FieldKind::String),
+        ("u64", "u64") => Some(FieldKind::U64),
+        ("i64", "i64") => Some(FieldKind::I64),
+        ("u32", "u32") => Some(FieldKind::U32),
+        ("i32", "i32") => Some(FieldKind::I32),
+        ("Vec", "u8") => Some(FieldKind::VecU8),
+        ("Vec", "f64") => Some(FieldKind::VecF64),
         _ => None,
     }
 }
 
-/// RHS of a struct field when decoding from Arrow: uses col_ident.value(i) with optional conversion.
-fn decode_field_rhs(
-    field_name: &syn::Ident,
-    ty: &Type,
-    col_ident: &syn::Ident,
-) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
-    let name = field_name;
-    let col = col_ident;
-    match (outer.as_str(), inner.as_str()) {
-        ("Vec", "u8") => Some(quote! { #col.value(i).to_vec() }),
-        ("Vec", "f64") => Some(quote! {
-            {
-                let arr = #col.value(i);
-                let float_arr = arr.as_any().downcast_ref::<arrow::array::Float64Array>()
-                    .ok_or_else(|| nautilus_serialization::arrow::EncodingError::ParseError(
-                        stringify!(#name),
-                        format!("expected Float64Array for list element"),
-                    ))?;
-                (0..float_arr.len()).map(|j| float_arr.value(j)).collect::<Vec<f64>>()
-            }
-        }),
-        _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" => Some(quote! {
-                std::str::FromStr::from_str(#col.value(i)).map_err(|e| nautilus_serialization::arrow::EncodingError::ParseError(
-                    stringify!(#name),
-                    format!("expected valid identifier/type, was '{}'", e),
-                ))?
-            }),
-            "UnixNanos" => Some(quote! { #col.value(i).into() }),
-            "f64" | "f32" | "bool" | "u64" | "i64" => Some(quote! { #col.value(i) }),
-            "u32" => Some(quote! { #col.value(i) as u32 }),
-            "i32" => Some(quote! { #col.value(i) }),
-            "String" => Some(quote! { #col.value(i).to_string() }),
-            _ => None,
-        },
-        _ => None,
-    }
+#[derive(Debug, Clone)]
+struct FieldSpec {
+    ident: Ident,
+    ty: Type,
+    kind: FieldKind,
 }
 
-/// Builder type and initialisation for a field (e.g. StringBuilder::new() or Float64Array::builder(len)).
-fn encode_builder_for_field(ty: &Type, len_var: &syn::Ident) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
-    let len = len_var;
-    match (outer.as_str(), inner.as_str()) {
-        ("Vec", "u8") => Some(quote! { let mut builder = arrow::array::BinaryBuilder::new(); }),
-        ("Vec", "f64") => Some(quote! {
-            let mut builder = arrow::array::ListBuilder::new(arrow::array::Float64Builder::new());
-        }),
-        _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "String" => {
-                Some(quote! { let mut builder = arrow::array::StringBuilder::new(); })
-            }
-            "UnixNanos" | "u64" | "u32" => {
-                Some(quote! { let mut builder = arrow::array::UInt64Array::builder(#len); })
-            }
-            "f64" => Some(quote! { let mut builder = arrow::array::Float64Array::builder(#len); }),
-            "f32" => Some(quote! { let mut builder = arrow::array::Float32Array::builder(#len); }),
-            "bool" => Some(quote! { let mut builder = arrow::array::BooleanArray::builder(#len); }),
-            "i64" => Some(quote! { let mut builder = arrow::array::Int64Array::builder(#len); }),
-            "i32" => Some(quote! { let mut builder = arrow::array::Int32Array::builder(#len); }),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-/// Python constructor param type: UnixNanos -> u64, Vec<u8> -> &[u8] or Vec<u8>, rest unchanged.
-fn py_param_ty(ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
-    if outer == "UnixNanos" {
-        return Some(quote! { u64 });
+impl FieldSpec {
+    fn parse(field: &Field) -> Option<Self> {
+        Some(Self {
+            ident: field.ident.as_ref()?.clone(),
+            ty: field.ty.clone(),
+            kind: classify_field_kind(&field.ty)?,
+        })
     }
 
-    if outer == "Vec" && inner == "u8" {
-        return Some(quote! { Vec<u8> });
+    fn is_ts_field(&self) -> bool {
+        self.ident == "ts_event" || self.ident == "ts_init"
     }
 
-    if outer == "Vec" && inner == "f64" {
-        return Some(quote! { Vec<f64> });
-    }
-    Some(quote! { #ty })
-}
-
-/// Python constructor body RHS: UnixNanos fields use arg.into(), rest use arg.
-fn py_field_init(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, _) = type_for_macro(ty)?;
-    let name = ident;
-
-    if outer == "UnixNanos" {
-        return Some(quote! { #name.into() });
-    }
-    Some(quote! { #name })
-}
-
-/// Python getter return type: UnixNanos -> u64, rest unchanged.
-fn py_getter_ret_ty(ty: &Type) -> Option<TokenStream> {
-    let (outer, _) = type_for_macro(ty)?;
-
-    if outer == "UnixNanos" {
-        return Some(quote! { u64 });
-    }
-    Some(quote! { #ty })
-}
-
-/// Python getter body: UnixNanos -> self.x.as_u64(), Vec -> clone, String -> clone, rest -> self.x.
-fn py_getter_body(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, _inner) = type_for_macro(ty)?;
-    let name = ident;
-
-    if outer == "UnixNanos" {
-        return Some(quote! { self.#name.as_u64() });
-    }
-
-    if outer == "Vec" || outer == "String" {
-        return Some(quote! { self.#name.clone() });
-    }
-    Some(quote! { self.#name })
-}
-
-/// Finish the builder and wrap in Arc for RecordBatch::try_new columns.
-fn encode_finish_builder(ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
-    match (outer.as_str(), inner.as_str()) {
-        ("Vec", "u8" | "f64") => Some(quote! { std::sync::Arc::new(builder.finish()) }),
-        _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "String" => {
-                Some(quote! { std::sync::Arc::new(builder.finish()) })
-            }
-            "UnixNanos" | "u64" | "u32" | "f64" | "f32" | "bool" | "i64" | "i32" => {
-                Some(quote! { std::sync::Arc::new(builder.finish()) })
-            }
-            _ => None,
-        },
-        _ => None,
+    fn name_str(&self) -> String {
+        self.ident.to_string()
     }
 }
 
 /// Parsed options from #[custom_data(...)] attribute.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct CustomDataOptions {
     pyo3: bool,
     no_display: bool,
 }
 
-fn parse_option_ident(
-    ident: &syn::Ident,
-    options: &mut CustomDataOptions,
-) -> Result<(), syn::Error> {
-    let s = ident.to_string();
-    match s.as_str() {
-        "pyo3" | "python" => options.pyo3 = true,
-        "no_display" => options.no_display = true,
-        _ => {
-            return Err(syn::Error::new_spanned(
-                ident,
-                "expected `pyo3`, `python`, or `no_display`; unknown option",
-            ));
+fn parse_options(args: &Args) -> syn::Result<CustomDataOptions> {
+    let mut options = CustomDataOptions::default();
+
+    for arg in args {
+        match arg {
+            Arg::Flag(ident) if ident == "pyo3" || ident == "python" => {
+                options.pyo3 = true;
+            }
+            Arg::Flag(ident) if ident == "no_display" => {
+                options.no_display = true;
+            }
+            Arg::Flag(ident) => {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "expected `pyo3`, `python`, or `no_display`; unknown option",
+                ));
+            }
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    arg,
+                    "expected bare flags `pyo3`, `python`, or `no_display`",
+                ));
+            }
         }
     }
-    Ok(())
-}
 
-struct OptionIdents {
-    idents: Vec<Ident>,
-}
-
-impl Parse for OptionIdents {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut idents = Vec::new();
-        idents.push(input.parse()?);
-        while input.parse::<Option<Token![,]>>()?.is_some() {
-            idents.push(input.parse()?);
-        }
-        Ok(Self { idents })
-    }
-}
-
-/// Parse #[custom_data(pyo3)] or #[custom_data(pyo3, no_display)] etc.
-fn parse_options(attr: &TokenStream) -> Result<CustomDataOptions, syn::Error> {
-    let mut options = CustomDataOptions {
-        pyo3: false,
-        no_display: false,
-    };
-    let attr_str = attr.to_string();
-    let attr_str = attr_str.trim();
-    if attr_str.is_empty() {
-        return Ok(options);
-    }
-    let option_idents: OptionIdents = parse2(attr.clone())?;
-    for ident in &option_idents.idents {
-        parse_option_ident(ident, &mut options)?;
-    }
     Ok(options)
 }
 
-/// Context passed to each expansion generator for readability and testability.
-struct ExpansionContext<'a> {
-    name: &'a Ident,
-    name_str: &'a str,
-    generics: &'a syn::Generics,
-    vis: &'a syn::Visibility,
-    field_list: &'a [(Ident, Type)],
-    options: &'a CustomDataOptions,
+fn arrow_data_type(kind: FieldKind) -> Output {
+    match kind {
+        FieldKind::VecU8 => zyn::zyn!(arrow::datatypes::DataType::Binary),
+        FieldKind::VecF64 => zyn::zyn!(arrow::datatypes::DataType::List(std::sync::Arc::new(
+            arrow::datatypes::Field::new("item", arrow::datatypes::DataType::Float64, true,),
+        ))),
+        FieldKind::InstrumentId
+        | FieldKind::AccountId
+        | FieldKind::Currency
+        | FieldKind::BarType
+        | FieldKind::String => zyn::zyn!(arrow::datatypes::DataType::Utf8),
+        FieldKind::UnixNanos | FieldKind::U64 | FieldKind::U32 => {
+            zyn::zyn!(arrow::datatypes::DataType::UInt64)
+        }
+        FieldKind::F64 => zyn::zyn!(arrow::datatypes::DataType::Float64),
+        FieldKind::F32 => zyn::zyn!(arrow::datatypes::DataType::Float32),
+        FieldKind::Bool => zyn::zyn!(arrow::datatypes::DataType::Boolean),
+        FieldKind::I64 => zyn::zyn!(arrow::datatypes::DataType::Int64),
+        FieldKind::I32 => zyn::zyn!(arrow::datatypes::DataType::Int32),
+    }
 }
 
-fn gen_new_fn(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let vis = ctx.vis;
-    let field_list = ctx.field_list;
-    let (rust_ctor_name, rust_ctor_doc) = if ctx.options.pyo3 {
-        (
-            quote! { new },
-            quote! { "Constructor from all fields. Use from Rust; Python __init__ forwards to this." },
-        )
+fn arrow_array_type(kind: FieldKind) -> Output {
+    match kind {
+        FieldKind::VecU8 => zyn::zyn!(arrow::array::BinaryArray),
+        FieldKind::VecF64 => zyn::zyn!(arrow::array::ListArray),
+        FieldKind::InstrumentId
+        | FieldKind::AccountId
+        | FieldKind::Currency
+        | FieldKind::BarType
+        | FieldKind::String => zyn::zyn!(arrow::array::StringArray),
+        FieldKind::UnixNanos | FieldKind::U64 | FieldKind::U32 => {
+            zyn::zyn!(arrow::array::UInt64Array)
+        }
+        FieldKind::F64 => zyn::zyn!(arrow::array::Float64Array),
+        FieldKind::F32 => zyn::zyn!(arrow::array::Float32Array),
+        FieldKind::Bool => zyn::zyn!(arrow::array::BooleanArray),
+        FieldKind::I64 => zyn::zyn!(arrow::array::Int64Array),
+        FieldKind::I32 => zyn::zyn!(arrow::array::Int32Array),
+    }
+}
+
+fn py_param_ty(field: &FieldSpec) -> Output {
+    match field.kind {
+        FieldKind::UnixNanos => zyn::zyn!(u64),
+        FieldKind::VecU8 => zyn::zyn!(Vec<u8>),
+        FieldKind::VecF64 => zyn::zyn!(Vec<f64>),
+        _ => {
+            let ty = &field.ty;
+            zyn::zyn!({ { ty } })
+        }
+    }
+}
+
+fn py_field_init(field: &FieldSpec) -> Output {
+    let name = &field.ident;
+    match field.kind {
+        FieldKind::UnixNanos => zyn::zyn!({ { name } }.into()),
+        _ => zyn::zyn!({ { name } }),
+    }
+}
+
+fn py_getter_ret_ty(field: &FieldSpec) -> Output {
+    match field.kind {
+        FieldKind::UnixNanos => zyn::zyn!(u64),
+        _ => {
+            let ty = &field.ty;
+            zyn::zyn!({ { ty } })
+        }
+    }
+}
+
+fn py_getter_body(field: &FieldSpec) -> Output {
+    let name = &field.ident;
+    match field.kind {
+        FieldKind::UnixNanos => zyn::zyn!(self.{{ name }}.as_u64()),
+        FieldKind::VecU8 | FieldKind::VecF64 | FieldKind::String => {
+            zyn::zyn!(self.{{ name }}.clone())
+        }
+        _ => zyn::zyn!(self.{{ name }}),
+    }
+}
+
+fn repr_arg(field: &FieldSpec) -> Output {
+    let ident = &field.ident;
+    if field.is_ts_field() {
+        zyn::zyn!(nautilus_core::datetime::unix_nanos_to_iso8601(self.{{ ident }}))
     } else {
-        (quote! { new }, quote! { "Constructor." })
+        zyn::zyn!(self.{{ ident }})
+    }
+}
+
+fn finish_builder() -> Output {
+    zyn::zyn!(std::sync::Arc::new(builder.finish()))
+}
+
+#[zyn::element]
+fn arrow_schema_field<'a>(field: &'a FieldSpec) -> zyn::TokenStream {
+    let field_name = field.name_str();
+    zyn::zyn! {
+        arrow::datatypes::Field::new(
+            {{ field_name }},
+            {{ arrow_data_type(field.kind) }},
+            false
+        )
+    }
+}
+
+#[zyn::element]
+fn encode_builder<'a>(len_var: Ident, field: &'a FieldSpec) -> zyn::TokenStream {
+    match field.kind {
+        FieldKind::VecU8 => zyn::zyn!(let mut builder = arrow::array::BinaryBuilder::new();),
+        FieldKind::VecF64 => zyn::zyn! {
+            let mut builder = arrow::array::ListBuilder::new(arrow::array::Float64Builder::new());
+        },
+        FieldKind::InstrumentId
+        | FieldKind::AccountId
+        | FieldKind::Currency
+        | FieldKind::BarType
+        | FieldKind::String => {
+            zyn::zyn!(let mut builder = arrow::array::StringBuilder::new();)
+        }
+        FieldKind::UnixNanos | FieldKind::U64 | FieldKind::U32 => {
+            zyn::zyn!(let mut builder = arrow::array::UInt64Array::builder({{ len_var }});)
+        }
+        FieldKind::F64 => {
+            zyn::zyn!(let mut builder = arrow::array::Float64Array::builder({{ len_var }});)
+        }
+        FieldKind::F32 => {
+            zyn::zyn!(let mut builder = arrow::array::Float32Array::builder({{ len_var }});)
+        }
+        FieldKind::Bool => {
+            zyn::zyn!(let mut builder = arrow::array::BooleanArray::builder({{ len_var }});)
+        }
+        FieldKind::I64 => {
+            zyn::zyn!(let mut builder = arrow::array::Int64Array::builder({{ len_var }});)
+        }
+        FieldKind::I32 => {
+            zyn::zyn!(let mut builder = arrow::array::Int32Array::builder({{ len_var }});)
+        }
+    }
+}
+
+#[zyn::element]
+fn encode_field_append<'a>(field: &'a FieldSpec) -> zyn::TokenStream {
+    let ident = &field.ident;
+    match field.kind {
+        FieldKind::VecU8 => zyn::zyn!(builder.append_value(item.{{ ident }}.as_slice());),
+        FieldKind::VecF64 => zyn::zyn! {
+            for v in item.{{ ident }}.iter() {
+                builder.values().append_value(*v);
+            }
+            builder.append(true);
+        },
+        FieldKind::InstrumentId
+        | FieldKind::AccountId
+        | FieldKind::Currency
+        | FieldKind::BarType => zyn::zyn!(builder.append_value(item.{{ ident }}.to_string());),
+        FieldKind::UnixNanos => zyn::zyn!(builder.append_value(item.{{ ident }}.as_u64());),
+        FieldKind::F64
+        | FieldKind::F32
+        | FieldKind::Bool
+        | FieldKind::U64
+        | FieldKind::I64
+        | FieldKind::I32 => zyn::zyn!(builder.append_value(item.{{ ident }});),
+        FieldKind::String => zyn::zyn!(builder.append_value(item.{{ ident }}.as_str());),
+        FieldKind::U32 => zyn::zyn!(builder.append_value(item.{{ ident }} as u64);),
+    }
+}
+
+#[zyn::element]
+fn encode_column_block<'a>(idx: usize, len_var: Ident, field: &'a FieldSpec) -> zyn::TokenStream {
+    let col_name = format_ident!("col_{idx}");
+    zyn::zyn! {
+        @encode_builder(len_var = len_var.clone(), field = field)
+        for item in data {
+            let _append_guard = ();
+            @encode_field_append(field = field)
+        }
+        let {{ col_name }} = {{ finish_builder() }};
+    }
+}
+
+#[zyn::element]
+fn decode_field_value<'a>(col_ident: Ident, field: &'a FieldSpec) -> zyn::TokenStream {
+    let field_name = field.name_str();
+    match field.kind {
+        FieldKind::VecU8 => zyn::zyn!({ { col_ident } }.value(i).to_vec()),
+        FieldKind::VecF64 => zyn::zyn! {
+            {
+                let arr = {{ col_ident }}.value(i);
+                let float_arr = arr.as_any().downcast_ref::<arrow::array::Float64Array>()
+                    .ok_or_else(|| nautilus_serialization::arrow::EncodingError::ParseError(
+                        {{ field_name }},
+                        format!("expected Float64Array for list element"),
+                    ))?;
+                (0..float_arr.len()).map(|j| float_arr.value(j)).collect::<Vec<f64>>()
+            }
+        },
+        FieldKind::InstrumentId
+        | FieldKind::AccountId
+        | FieldKind::Currency
+        | FieldKind::BarType => zyn::zyn! {
+            std::str::FromStr::from_str({{ col_ident }}.value(i)).map_err(|e| nautilus_serialization::arrow::EncodingError::ParseError(
+                {{ field_name }},
+                format!("expected valid identifier/type, was '{}'", e),
+            ))?
+        },
+        FieldKind::UnixNanos => zyn::zyn!({ { col_ident } }.value(i).into()),
+        FieldKind::F64
+        | FieldKind::F32
+        | FieldKind::Bool
+        | FieldKind::U64
+        | FieldKind::I64
+        | FieldKind::I32 => zyn::zyn!({ { col_ident } }.value(i)),
+        FieldKind::U32 => zyn::zyn!({ { col_ident } }.value(i) as u32),
+        FieldKind::String => zyn::zyn!({ { col_ident } }.value(i).to_string()),
+    }
+}
+
+#[zyn::element]
+fn decode_extract<'a>(idx: usize, field: &'a FieldSpec) -> zyn::TokenStream {
+    let col_ident = format_ident!("col_{idx}");
+    let field_name = field.name_str();
+
+    if field.kind.uses_string_extract() {
+        zyn::zyn! {
+            let {{ col_ident }} = nautilus_serialization::arrow::extract_column_string(
+                record_batch.columns(),
+                {{ field_name }},
+                {{ idx }},
+            )?;
+        }
+    } else {
+        zyn::zyn! {
+            let {{ col_ident }} = nautilus_serialization::arrow::extract_column::<{{ arrow_array_type(field.kind) }}>(
+                record_batch.columns(),
+                {{ field_name }},
+                {{ idx }},
+                {{ arrow_data_type(field.kind) }},
+            )?;
+        }
+    }
+}
+
+#[zyn::element]
+fn decode_row_field<'a>(idx: usize, field: &'a FieldSpec) -> zyn::TokenStream {
+    let ident = &field.ident;
+    let col_ident = format_ident!("col_{idx}");
+    zyn::zyn! {
+        {{ ident }}: @decode_field_value(col_ident = col_ident, field = field)
+    }
+}
+
+#[zyn::element]
+fn py_getter<'a>(field: &'a FieldSpec) -> zyn::TokenStream {
+    let ident = &field.ident;
+    zyn::zyn! {
+        #[getter]
+        fn {{ ident }}(&self) -> {{ py_getter_ret_ty(field) }} {
+            let value = {{ py_getter_body(field) }};
+            value
+        }
+    }
+}
+
+#[zyn::element]
+fn new_fn<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    vis: &'a syn::Visibility,
+    field_list: &'a [FieldSpec],
+    pyo3_enabled: bool,
+) -> zyn::TokenStream {
+    let rust_ctor_name = format_ident!("new");
+    let rust_ctor_doc = if *pyo3_enabled {
+        "Constructor from all fields. Use from Rust; Python __init__ forwards to this."
+    } else {
+        "Constructor."
     };
-    let constructor_params = field_list.iter().map(|(i, ty)| quote! { #i: #ty });
-    let constructor_fields = field_list.iter().map(|(i, _)| quote! { #i });
-    quote! {
-        impl #generics #name #generics {
+
+    zyn::zyn! {
+        impl {{ generics }} {{ name }} {{ generics }} {
             #[allow(dead_code)]
             #[allow(clippy::too_many_arguments)]
-            #[doc = #rust_ctor_doc]
-            #vis fn #rust_ctor_name(#(#constructor_params),*) -> Self {
-                Self { #(#constructor_fields),* }
+            #[doc = {{ rust_ctor_doc }}]
+            {{ vis }} fn {{ rust_ctor_name }}(
+                @for (field in field_list.iter()) {
+                    {{ field.ident }}: {{ field.ty }},
+                }
+            ) -> Self {
+                Self {
+                    @for (field in field_list.iter()) {
+                        {{ field.ident }},
+                    }
+                }
             }
         }
     }
 }
 
-fn gen_repr_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    if ctx.options.no_display {
-        return quote! {};
-    }
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let name_str = ctx.name_str;
-    let field_list = ctx.field_list;
+#[zyn::element]
+fn repr_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    name_str: &'a str,
+    field_list: &'a [FieldSpec],
+) -> zyn::TokenStream {
     let repr_format_parts: Vec<String> = field_list
         .iter()
-        .map(|(ident, _)| {
-            let s = ident.to_string();
-            if s == "ts_event" || s == "ts_init" {
-                format!("{s}={{}}")
+        .map(|field: &FieldSpec| {
+            let name = field.name_str();
+            if field.is_ts_field() {
+                format!("{name}={{}}")
             } else {
-                format!("{s}={{:?}}")
+                format!("{name}={{:?}}")
             }
         })
         .collect();
     let repr_format_str = format!("{}({})", name_str, repr_format_parts.join(", "));
     let repr_format_lit = LitStr::new(&repr_format_str, Span::call_site());
-    let repr_args: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, _)| {
-            let s = ident.to_string();
-            if s == "ts_event" || s == "ts_init" {
-                quote! { nautilus_core::datetime::unix_nanos_to_iso8601(self.#ident) }
-            } else {
-                quote! { self.#ident }
-            }
-        })
-        .collect();
-    quote! {
-        impl #generics #name #generics {
+    let repr_args: Vec<Output> = field_list.iter().map(repr_arg).collect();
+
+    zyn::zyn! {
+        impl {{ generics }} {{ name }} {{ generics }} {
             /// Returns a string representation in the same style as Python CustomDataClass (fields and ts_event/ts_init as ISO8601).
             pub fn repr(&self) -> String {
-                format!(#repr_format_lit, #(#repr_args),*)
+                format!(
+                    {{ repr_format_lit }},
+                    @for (arg in repr_args.iter()) {
+                        {{ arg }},
+                    }
+                )
             }
         }
-        impl #generics std::fmt::Display for #name #generics {
+        impl {{ generics }} std::fmt::Display for {{ name }} {{ generics }} {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 std::write!(f, "{}", self.repr())
             }
@@ -506,11 +563,10 @@ fn gen_repr_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-fn gen_ts_init_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    quote! {
-        impl #generics nautilus_model::data::HasTsInit for #name #generics {
+#[zyn::element]
+fn ts_init_impl<'a>(name: &'a Ident, generics: &'a syn::Generics) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_model::data::HasTsInit for {{ name }} {{ generics }} {
             fn ts_init(&self) -> nautilus_core::UnixNanos {
                 self.ts_init
             }
@@ -518,55 +574,61 @@ fn gen_ts_init_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-fn gen_custom_data_trait_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let name_str = ctx.name_str;
-    quote! {
-        impl #generics nautilus_model::data::CustomDataTrait for #name #generics {
+#[zyn::element]
+fn custom_data_trait_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    name_str: &'a str,
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_model::data::CustomDataTrait for {{ name }} {{ generics }} {
             fn type_name(&self) -> &'static str {
-                    #name_str
+                let value = {{ name_str }};
+                value
+            }
+            fn type_name_static() -> &'static str {
+                let value = {{ name_str }};
+                value
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn ts_event(&self) -> nautilus_core::UnixNanos {
+                self.ts_event
+            }
+            fn to_json(&self) -> anyhow::Result<String> {
+                serde_json::to_string(self).map_err(Into::into)
+            }
+            fn clone_arc(&self) -> std::sync::Arc<dyn nautilus_model::data::CustomDataTrait> {
+                std::sync::Arc::new(std::clone::Clone::clone(self))
+            }
+            fn eq_arc(&self, other: &dyn nautilus_model::data::CustomDataTrait) -> bool {
+                if let Some(other) = other.as_any().downcast_ref::<Self>() {
+                    self == other
+                } else {
+                    false
                 }
-                fn type_name_static() -> &'static str {
-                    #name_str
-                }
-                fn as_any(&self) -> &dyn std::any::Any {
-                    self
-                }
-                fn ts_event(&self) -> nautilus_core::UnixNanos {
-                    self.ts_event
-                }
-                fn to_json(&self) -> anyhow::Result<String> {
-                    serde_json::to_string(self).map_err(Into::into)
-                }
-                fn clone_arc(&self) -> std::sync::Arc<dyn nautilus_model::data::CustomDataTrait> {
-                    std::sync::Arc::new(std::clone::Clone::clone(self))
-                }
-                fn eq_arc(&self, other: &dyn nautilus_model::data::CustomDataTrait) -> bool {
-                    if let Some(other) = other.as_any().downcast_ref::<Self>() {
-                        self == other
-                    } else {
-                        false
-                    }
-                }
-                fn from_json(value: serde_json::Value) -> anyhow::Result<std::sync::Arc<dyn nautilus_model::data::CustomDataTrait>> {
-                    let t: Self = serde_json::from_value(value)?;
-                    Ok(std::sync::Arc::new(t))
-                }
-                #[cfg(feature = "python")]
-                fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-                    nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
-                }
+            }
+            fn from_json(value: serde_json::Value) -> anyhow::Result<std::sync::Arc<dyn nautilus_model::data::CustomDataTrait>> {
+                let t: Self = serde_json::from_value(value)?;
+                Ok(std::sync::Arc::new(t))
+            }
+            #[cfg(feature = "python")]
+            fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+                nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
+            }
         }
     }
 }
 
-fn gen_custom_data_serialize_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let name_str = ctx.name_str;
-    quote! {
-        impl #generics nautilus_serialization::arrow::custom::CustomDataSerialize for #name #generics {
+#[zyn::element]
+fn custom_data_serialize_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    name_str: &'a str,
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_serialization::arrow::custom::CustomDataSerialize for {{ name }} {{ generics }} {
             fn schema(&self) -> anyhow::Result<arrow::datatypes::Schema> {
                 Ok(<Self as nautilus_serialization::arrow::ArrowSchemaProvider>::get_schema(
                     Some(nautilus_serialization::arrow::EncodeToRecordBatch::metadata(self))
@@ -581,7 +643,7 @@ fn gen_custom_data_serialize_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                     if let Some(c) = item.as_any().downcast_ref::<Self>() {
                         typed.push(std::clone::Clone::clone(c));
                     } else {
-                        anyhow::bail!("Expected {}, was different type", #name_str);
+                        anyhow::bail!("Expected {}, was different type", {{ name_str }});
                     }
                 }
                 let metadata = nautilus_serialization::arrow::EncodeToRecordBatch::metadata(self);
@@ -591,24 +653,20 @@ fn gen_custom_data_serialize_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-fn gen_arrow_schema_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let field_list = ctx.field_list;
-    let arrow_schema_fields: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, ty)| {
-            let (arrow_dt, _, _) = arrow_type_for_rust_type(ty).unwrap();
-            let fn_str = ident.to_string();
-            quote! {
-                arrow::datatypes::Field::new(#fn_str, #arrow_dt, false)
-            }
-        })
-        .collect();
-    quote! {
-        impl #generics nautilus_serialization::arrow::ArrowSchemaProvider for #name #generics {
+#[zyn::element]
+fn arrow_schema_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    field_list: &'a [FieldSpec],
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_serialization::arrow::ArrowSchemaProvider for {{ name }} {{ generics }} {
             fn get_schema(metadata: Option<std::collections::HashMap<String, String>>) -> arrow::datatypes::Schema {
-                let fields = vec![ #(#arrow_schema_fields),* ];
+                let fields = vec![
+                    @for (field in field_list.iter()) {
+                        @arrow_schema_field(field = field),
+                    }
+                ];
                 match metadata {
                     Some(m) => arrow::datatypes::Schema::new_with_metadata(fields, m),
                     None => arrow::datatypes::Schema::new(fields),
@@ -618,106 +676,64 @@ fn gen_arrow_schema_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-fn gen_encode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let name_str = ctx.name_str;
-    let field_list = ctx.field_list;
+#[zyn::element]
+fn encode_batch_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    name_str: &'a str,
+    field_list: &'a [FieldSpec],
+) -> zyn::TokenStream {
     let len_var = format_ident!("data_len");
-    let mut col_builds = Vec::new();
-    let mut col_names = Vec::new();
-    for (ident, ty) in field_list {
-        let builder = encode_builder_for_field(ty, &len_var).unwrap();
-        let append = encode_field_expr(ident, ty).unwrap();
-        let finish = encode_finish_builder(ty).unwrap();
-        let col_name = format_ident!("col_{}", col_builds.len());
-        col_names.push(col_name.clone());
-        col_builds.push(quote! {
-            #builder
-            for item in data {
-                #append
-            }
-            let #col_name = #finish;
-        });
-    }
-    let metadata_map = quote! {
-        let mut m = std::collections::HashMap::new();
-        m.insert("type_name".to_string(), #name_str.to_string());
-        m
-    };
-    quote! {
-        impl #generics nautilus_serialization::arrow::EncodeToRecordBatch for #name #generics {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_serialization::arrow::EncodeToRecordBatch for {{ name }} {{ generics }} {
             fn encode_batch(
                 metadata: &std::collections::HashMap<String, String>,
                 data: &[Self],
             ) -> std::result::Result<arrow::record_batch::RecordBatch, arrow::error::ArrowError> {
-                let #len_var = data.len();
-                #(#col_builds)*
+                let {{ len_var }} = data.len();
+                @for (idx in 0..field_list.len()) {
+                    @encode_column_block(idx = idx, len_var = len_var.clone(), field = &field_list[idx])
+                }
                 arrow::record_batch::RecordBatch::try_new(
                     <Self as nautilus_serialization::arrow::ArrowSchemaProvider>::get_schema(Some(metadata.clone())).into(),
-                    vec![ #(#col_names),* ],
+                    vec![
+                        @for (idx in 0..field_list.len()) {
+                            {{ format_ident!("col_{}", idx) }},
+                        }
+                    ],
                 )
             }
             fn metadata(&self) -> std::collections::HashMap<String, String> {
-                #metadata_map
+                let mut m = std::collections::HashMap::new();
+                m.insert("type_name".to_string(), {{ name_str }}.to_string());
+                m
             }
         }
     }
 }
 
-fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let field_list = ctx.field_list;
-    let decode_row_fields: Vec<TokenStream> = field_list
-        .iter()
-        .enumerate()
-        .map(|(idx, (ident, ty))| {
-            let col_name = format_ident!("col_{}", idx);
-            let rhs = decode_field_rhs(ident, ty, &col_name).unwrap();
-            quote! { #ident: #rhs }
-        })
-        .collect();
-    let decode_extracts: Vec<TokenStream> = field_list
-        .iter()
-        .enumerate()
-        .map(|(idx, (ident, ty))| {
-            let col_name = format_ident!("col_{}", idx);
-            let fn_str = ident.to_string();
-
-            if use_string_extract(ty) {
-                quote! {
-                    let #col_name = nautilus_serialization::arrow::extract_column_string(
-                        record_batch.columns(),
-                        #fn_str,
-                        #idx,
-                    )?;
-                }
-            } else {
-                let (arrow_dt, _, array_ty) = arrow_type_for_rust_type(ty).unwrap();
-                quote! {
-                    let #col_name = nautilus_serialization::arrow::extract_column::<#array_ty>(
-                        record_batch.columns(),
-                        #fn_str,
-                        #idx,
-                        #arrow_dt,
-                    )?;
-                }
-            }
-        })
-        .collect();
-    quote! {
-        impl #generics nautilus_serialization::arrow::DecodeDataFromRecordBatch for #name #generics {
+#[zyn::element]
+fn decode_batch_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    field_list: &'a [FieldSpec],
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_serialization::arrow::DecodeDataFromRecordBatch for {{ name }} {{ generics }} {
             fn decode_data_batch(
                 _metadata: &std::collections::HashMap<String, String>,
                 record_batch: arrow::record_batch::RecordBatch,
             ) -> std::result::Result<Vec<nautilus_model::data::Data>, nautilus_serialization::arrow::EncodingError> {
-                #(#decode_extracts)*
+                @for (idx in 0..field_list.len()) {
+                    @decode_extract(idx = idx, field = &field_list[idx])
+                }
                 let num_rows = record_batch.num_rows();
                 let mut results = Vec::with_capacity(num_rows);
                 for i in 0..num_rows {
                     let row = Self {
-                        #(#decode_row_fields),*
+                        @for (idx in 0..field_list.len()) {
+                            @decode_row_field(idx = idx, field = &field_list[idx]),
+                        }
                     };
                     results.push(nautilus_model::data::Data::Custom(nautilus_model::data::CustomData::from_arc(std::sync::Arc::new(row))));
                 }
@@ -727,29 +743,41 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-fn gen_catalog_path_and_conversions(
-    ctx: &ExpansionContext<'_>,
-) -> (TokenStream, TokenStream, TokenStream) {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let name_str = ctx.name_str;
-    let catalog_path = format!("custom/{name_str}");
-    let catalog_path_prefix_impl = quote! {
-        impl #generics nautilus_model::data::CatalogPathPrefix for #name #generics {
+#[zyn::element]
+fn catalog_path_prefix_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    catalog_path: &'a str,
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} nautilus_model::data::CatalogPathPrefix for {{ name }} {{ generics }} {
             fn path_prefix() -> &'static str {
-                #catalog_path
+                let value = {{ catalog_path }};
+                value
             }
         }
-    };
-    let from_impl = quote! {
-        impl #generics std::convert::From<#name #generics> for nautilus_model::data::Data {
-            fn from(value: #name #generics) -> Self {
+    }
+}
+
+#[zyn::element]
+fn from_impl<'a>(name: &'a Ident, generics: &'a syn::Generics) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} std::convert::From<{{ name }} {{ generics }}> for nautilus_model::data::Data {
+            fn from(value: {{ name }} {{ generics }}) -> Self {
                 nautilus_model::data::Data::Custom(nautilus_model::data::CustomData::from_arc(std::sync::Arc::new(value)))
             }
         }
-    };
-    let try_from_impl = quote! {
-        impl #generics std::convert::TryFrom<nautilus_model::data::Data> for #name #generics {
+    }
+}
+
+#[zyn::element]
+fn try_from_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    name_str: &'a str,
+) -> zyn::TokenStream {
+    zyn::zyn! {
+        impl {{ generics }} std::convert::TryFrom<nautilus_model::data::Data> for {{ name }} {{ generics }} {
             type Error = anyhow::Error;
             fn try_from(value: nautilus_model::data::Data) -> std::result::Result<Self, Self::Error> {
                 match value {
@@ -757,92 +785,71 @@ fn gen_catalog_path_and_conversions(
                         if let Some(c) = custom.data.as_any().downcast_ref::<Self>() {
                             Ok(std::clone::Clone::clone(c))
                         } else {
-                            anyhow::bail!("Expected {}", #name_str)
+                            anyhow::bail!("Expected {}", {{ name_str }})
                         }
                     }
                     _ => anyhow::bail!("Expected Custom data variant"),
                 }
             }
         }
-    };
-    (catalog_path_prefix_impl, from_impl, try_from_impl)
+    }
 }
 
-fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
-    let name = ctx.name;
-    let generics = ctx.generics;
-    let field_list = ctx.field_list;
-    if !ctx.options.pyo3 {
-        return quote! {};
-    }
-    let py_new_params: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, ty)| {
-            let py_ty = py_param_ty(ty).unwrap();
-            quote! { #ident: #py_ty }
-        })
-        .collect();
-    let py_let_bindings: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, ty)| {
-            let init = py_field_init(ident, ty).unwrap();
-            quote! { let #ident = #init; }
-        })
-        .collect();
-    let py_new_call_args: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, _)| quote! { #ident })
-        .collect();
-    let getters: Vec<TokenStream> = field_list
-        .iter()
-        .map(|(ident, ty)| {
-            let ret_ty = py_getter_ret_ty(ty).unwrap();
-            let body = py_getter_body(ident, ty).unwrap();
-            quote! {
-                #[getter]
-                fn #ident(&self) -> #ret_ty {
-                    #body
-                }
-            }
-        })
-        .collect();
-    let repr_str_methods = if ctx.options.no_display {
-        quote! {}
-    } else {
-        quote! {
-            /// Python `repr()`: uses the Rust `Display` implementation.
-            fn __repr__(&self) -> pyo3::PyResult<String> {
-                Ok(std::fmt::format(std::format_args!("{}", self)))
-            }
-
-            /// Python `str()`: uses the Rust `Display` implementation.
-            fn __str__(&self) -> pyo3::PyResult<String> {
-                Ok(std::fmt::format(std::format_args!("{}", self)))
-            }
-        }
-    };
-    quote! {
+#[zyn::element]
+fn pymethods_impl<'a>(
+    name: &'a Ident,
+    generics: &'a syn::Generics,
+    field_list: &'a [FieldSpec],
+    no_display: bool,
+) -> zyn::TokenStream {
+    zyn::zyn! {
         #[cfg(feature = "python")]
         use pyo3::prelude::*;
         /// PyO3 bindings (constructor, getters, to_json, from_json, record batch encode/decode). Only compiled when `feature = "python"`.
         #[cfg(feature = "python")]
         #[pyo3::pymethods]
         #[allow(clippy::needless_pass_by_value)]
-        impl #generics #name #generics {
+        impl {{ generics }} {{ name }} {{ generics }} {
             #[allow(clippy::too_many_arguments)]
             #[new]
-            #[pyo3(signature = (#(#py_new_call_args),*))]
-            fn py_new(#(#py_new_params),*) -> Self {
-                #(#py_let_bindings)*
-                Self::new(#(#py_new_call_args),*)
+            #[pyo3(signature = (
+                @for (field in field_list.iter()) {
+                    {{ field.ident }},
+                }
+            ))]
+            fn py_new(
+                @for (field in field_list.iter()) {
+                    {{ field.ident }}: {{ py_param_ty(field) }},
+                }
+            ) -> Self {
+                @for (field in field_list.iter()) {
+                    let {{ field.ident }} = {{ py_field_init(field) }};
+                }
+                Self::new(
+                    @for (field in field_list.iter()) {
+                        {{ field.ident }},
+                    }
+                )
             }
-            #(#getters)*
+            @for (field in field_list.iter()) {
+                @py_getter(field = field)
+            }
 
-            #repr_str_methods
+            @if (!*no_display) {
+                /// Python `repr()`: uses the Rust `Display` implementation.
+                fn __repr__(&self) -> pyo3::PyResult<String> {
+                    Ok(std::fmt::format(std::format_args!("{}", self)))
+                }
+
+                /// Python `str()`: uses the Rust `Display` implementation.
+                fn __str__(&self) -> pyo3::PyResult<String> {
+                    Ok(std::fmt::format(std::format_args!("{}", self)))
+                }
+            }
 
             /// Serializes to JSON string. Used by CustomData.to_json_bytes and PythonCustomDataWrapper.
             fn to_json(&self) -> pyo3::PyResult<String> {
-                <#name as nautilus_model::data::CustomDataTrait>::to_json_py(self)
+                <{{ name }} as nautilus_model::data::CustomDataTrait>::to_json_py(self)
                     .map_err(nautilus_core::python::to_pyvalue_err)
             }
 
@@ -861,9 +868,9 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                     .extract()?;
                 let value: serde_json::Value = serde_json::from_str(&json_str)
                     .map_err(|e| nautilus_core::python::to_pyvalue_err(format!("serde_json::from_str failed: {e}")))?;
-                let arc = <#name as nautilus_model::data::CustomDataTrait>::from_json(value)
+                let arc = <{{ name }} as nautilus_model::data::CustomDataTrait>::from_json(value)
                     .map_err(nautilus_core::python::to_pyvalue_err)?;
-                let inner = arc.as_any().downcast_ref::<#name>()
+                let inner = arc.as_any().downcast_ref::<{{ name }}>()
                     .ok_or_else(|| nautilus_core::python::to_pyvalue_err("from_json downcast failed"))?;
                 Ok(pyo3::Py::new(py, inner.clone())?.into_any())
             }
@@ -891,14 +898,14 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                 let struct_array = arrow::array::StructArray::from(struct_array_data);
                 let batch = arrow::record_batch::RecordBatch::from(&struct_array);
 
-                let data_list = <#name as nautilus_serialization::arrow::DecodeDataFromRecordBatch>::decode_data_batch(
+                let data_list = <{{ name }} as nautilus_serialization::arrow::DecodeDataFromRecordBatch>::decode_data_batch(
                     &metadata,
                     batch,
                 ).map_err(nautilus_core::python::to_pyvalue_err)?;
                 let mut py_items = Vec::new();
                 for d in data_list {
                     if let nautilus_model::data::Data::Custom(custom) = d {
-                        if let Some(m) = custom.data.as_any().downcast_ref::<#name>() {
+                        if let Some(m) = custom.data.as_any().downcast_ref::<{{ name }}>() {
                             py_items.push(pyo3::Py::new(py, m.clone())?.into_any());
                         }
                     }
@@ -914,13 +921,12 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                 py: pyo3::Python<'_>,
                 items: &pyo3::Bound<'_, pyo3::types::PyList>,
             ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-                use std::collections::HashMap;
-                let typed: Vec<#name> = items
+                let typed: Vec<{{ name }}> = items
                     .iter()
-                    .map(|obj| obj.extract::<#name>().map_err(|e| e.into()))
+                    .map(|obj| obj.extract::<{{ name }}>().map_err(|e| e.into()))
                     .collect::<pyo3::PyResult<Vec<_>>>()?;
-                let metadata = <#name as nautilus_serialization::arrow::EncodeToRecordBatch>::metadata(self);
-                let batch = <#name as nautilus_serialization::arrow::EncodeToRecordBatch>::encode_batch(
+                let metadata = <{{ name }} as nautilus_serialization::arrow::EncodeToRecordBatch>::metadata(self);
+                let batch = <{{ name }} as nautilus_serialization::arrow::EncodeToRecordBatch>::encode_batch(
                     &metadata,
                     &typed,
                 ).map_err(nautilus_core::python::to_pyvalue_err)?;
@@ -943,130 +949,204 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
-pub fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let options = match parse_options(&attr) {
-        Ok(o) => o,
-        Err(e) => return e.to_compile_error(),
+pub fn expand_custom_data(item: ItemStruct, args: &Args) -> Output {
+    let options = match parse_options(args) {
+        Ok(options) => options,
+        Err(e) => return e.to_compile_error().into(),
     };
 
-    let input: ItemStruct = match parse2(item) {
-        Ok(i) => i,
-        Err(e) => return e.to_compile_error(),
-    };
-
-    let name = &input.ident;
+    let name = &item.ident;
     let name_str = name.to_string();
-    let vis = &input.vis;
-    let generics = &input.generics;
+    let vis = &item.vis;
+    let generics = &item.generics;
 
-    let fields = match &input.fields {
-        Fields::Named(n) => &n.named,
+    let fields = match &item.fields {
+        Fields::Named(fields) => &fields.named,
         _ => {
             return syn::Error::new_spanned(
-                input,
+                item,
                 "#[custom_data] requires a struct with named fields",
             )
-            .to_compile_error();
+            .to_compile_error()
+            .into();
         }
     };
 
-    let field_list: Vec<_> = fields
-        .iter()
-        .map(|f| {
-            let ident = f.ident.as_ref().expect("named field");
-            let ty = &f.ty;
-            (ident.clone(), ty.clone())
-        })
-        .collect();
-
-    for (ident, ty) in &field_list {
-        if arrow_type_for_rust_type(ty).is_none() {
-            return syn::Error::new_spanned(
-                ty,
-                format!(
-                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>"
-                ),
-            )
-            .to_compile_error();
+    let mut field_specs = Vec::with_capacity(fields.len());
+    for field in fields {
+        match FieldSpec::parse(field) {
+            Some(field_spec) => field_specs.push(field_spec),
+            None => {
+                let ident = field.ident.as_ref().expect("named field");
+                return syn::Error::new_spanned(
+                    &field.ty,
+                    format!(
+                        "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>"
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
         }
     }
 
-    let ts_init_field = field_list
-        .iter()
-        .find(|(i, _)| *i == "ts_init")
-        .map(|(i, _)| i);
-    let ts_event_field = field_list
-        .iter()
-        .find(|(i, _)| *i == "ts_event")
-        .map(|(i, _)| i);
+    let has_ts_event = field_specs.iter().any(|field| field.ident == "ts_event");
+    let has_ts_init = field_specs.iter().any(|field| field.ident == "ts_init");
 
-    if ts_init_field.is_none() || ts_event_field.is_none() {
+    if !has_ts_event || !has_ts_init {
         return syn::Error::new_spanned(
-            input,
+            item,
             "#[custom_data] requires fields ts_event and ts_init (e.g. nautilus_core::UnixNanos)",
         )
-        .to_compile_error();
+        .to_compile_error()
+        .into();
     }
 
-    let ctx = ExpansionContext {
-        name,
-        name_str: &name_str,
-        generics,
-        vis,
-        field_list: &field_list,
-        options: &options,
-    };
-
-    let new_fn = gen_new_fn(&ctx);
-    let repr_impl = gen_repr_impl(&ctx);
-    let ts_init_impl = gen_ts_init_impl(&ctx);
-    let custom_data_trait_impl = gen_custom_data_trait_impl(&ctx);
-    let custom_data_serialize_impl = gen_custom_data_serialize_impl(&ctx);
-    let arrow_schema_impl = gen_arrow_schema_impl(&ctx);
-    let encode_batch_impl = gen_encode_batch_impl(&ctx);
-    let decode_batch_impl = gen_decode_batch_impl(&ctx);
-    let (catalog_path_prefix_impl, from_impl, try_from_impl) =
-        gen_catalog_path_and_conversions(&ctx);
-    let pymethods_impl = gen_pymethods_impl(&ctx);
-
-    let struct_attrs: Vec<syn::Attribute> = input
+    let struct_attrs: Vec<syn::Attribute> = item
         .attrs
         .iter()
-        .filter(|a| a.path().get_ident().is_none_or(|i| *i != "custom_data"))
+        .filter(|attr| {
+            attr.path()
+                .get_ident()
+                .is_none_or(|ident| *ident != "custom_data")
+        })
         .cloned()
         .collect();
-    let pyclass_attr_ts: TokenStream = if options.pyo3 {
-        quote! {
+    let fields_vec: Vec<Field> = fields.iter().cloned().collect();
+    let catalog_path = format!("custom/{name_str}");
+    let input: zyn::Input = syn::Item::Struct(item.clone()).into();
+
+    zyn::zyn! {
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+        @for (attr in struct_attrs.iter()) {
+            {{ attr }}
+        }
+        @if (options.pyo3) {
             #[cfg_attr(feature = "python", pyo3::pyclass(from_py_object))]
         }
-    } else {
-        quote! {}
-    };
-    let fields_vec: Vec<&Field> = fields.iter().collect();
-
-    let derived_attr = quote! {
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-    };
-    quote! {
-        #derived_attr
-        #(#struct_attrs)*
-        #pyclass_attr_ts
-        #vis struct #name #generics {
-            #(#fields_vec),*
+        {{ vis }} struct {{ name }} {{ generics }} {
+            @for (field in fields_vec.iter()) {
+                {{ field }},
+            }
         }
 
-        #new_fn
-        #repr_impl
-        #ts_init_impl
-        #custom_data_trait_impl
-        #custom_data_serialize_impl
-        #arrow_schema_impl
-        #encode_batch_impl
-        #decode_batch_impl
-        #catalog_path_prefix_impl
-        #from_impl
-        #try_from_impl
-        #pymethods_impl
+        @new_fn(
+            name = name,
+            generics = generics,
+            vis = vis,
+            field_list = field_specs.as_slice(),
+            pyo3_enabled = options.pyo3,
+        )
+
+        @if (!options.no_display) {
+            @repr_impl(
+                name = name,
+                generics = generics,
+                name_str = name_str.as_str(),
+                field_list = field_specs.as_slice(),
+            )
+        }
+
+        @ts_init_impl(name = name, generics = generics)
+        @custom_data_trait_impl(name = name, generics = generics, name_str = name_str.as_str())
+        @custom_data_serialize_impl(name = name, generics = generics, name_str = name_str.as_str())
+        @arrow_schema_impl(name = name, generics = generics, field_list = field_specs.as_slice())
+        @encode_batch_impl(
+            name = name,
+            generics = generics,
+            name_str = name_str.as_str(),
+            field_list = field_specs.as_slice(),
+        )
+        @decode_batch_impl(name = name, generics = generics, field_list = field_specs.as_slice())
+        @catalog_path_prefix_impl(name = name, generics = generics, catalog_path = catalog_path.as_str())
+        @from_impl(name = name, generics = generics)
+        @try_from_impl(name = name, generics = generics, name_str = name_str.as_str())
+
+        @if (options.pyo3) {
+            @pymethods_impl(
+                name = name,
+                generics = generics,
+                field_list = field_specs.as_slice(),
+                no_display = options.no_display,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use proc_macro2::TokenStream;
+    use rstest::rstest;
+    use zyn::syn::{self, ItemStruct};
+
+    use super::{expand_custom_data, parse_options};
+
+    fn normalize_tokens(tokens: &impl ToString) -> String {
+        tokens
+            .to_string()
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect()
+    }
+
+    #[rstest]
+    #[case(TokenStream::from_str("pyo3").unwrap(), true, false)]
+    #[case(TokenStream::from_str("python").unwrap(), true, false)]
+    #[case(TokenStream::from_str("python, pyo3").unwrap(), true, false)]
+    #[case(TokenStream::from_str("pyo3, no_display").unwrap(), true, true)]
+    #[case(TokenStream::new(), false, false)]
+    fn parse_options_supports_zyn_attribute_parser(
+        #[case] tokens: TokenStream,
+        #[case] pyo3_enabled: bool,
+        #[case] no_display: bool,
+    ) {
+        let args: zyn::Args = zyn::parse!(tokens => zyn::Args).unwrap();
+        let options = parse_options(&args).unwrap();
+
+        assert_eq!(options.pyo3, pyo3_enabled);
+        assert_eq!(options.no_display, no_display);
+    }
+
+    #[rstest]
+    fn parse_options_rejects_unknown_option() {
+        let args: zyn::Args =
+            zyn::parse!(TokenStream::from_str("bogus").unwrap() => zyn::Args).unwrap();
+        let error = parse_options(&args).unwrap_err();
+
+        assert_eq!(
+            format!("{error}"),
+            "expected `pyo3`, `python`, or `no_display`; unknown option"
+        );
+    }
+
+    #[rstest]
+    fn expand_custom_data_generates_valid_return_bodies() {
+        let item: ItemStruct = syn::parse_str(
+            "
+            pub struct ExampleCustomData {
+                pub instrument_id: InstrumentId,
+                pub payload: String,
+                pub ts_event: UnixNanos,
+                pub ts_init: UnixNanos,
+            }
+            ",
+        )
+        .unwrap();
+        let args: zyn::Args = syn::parse_str("python").unwrap();
+
+        let expanded = expand_custom_data(item, &args);
+        let normalized = normalize_tokens(&expanded);
+
+        assert!(
+            normalized.contains("#[cfg_attr(feature=\"python\",pyo3::pyclass(from_py_object))]")
+        );
+        assert!(normalized.contains("letvalue=\"ExampleCustomData\";value"));
+        assert!(normalized.contains("letvalue=\"custom/ExampleCustomData\";value"));
+        assert!(normalized.contains("\"ExampleCustomData\""));
+        assert!(normalized.contains("\"custom/ExampleCustomData\""));
+        assert!(normalized.contains("letvalue=self.payload.clone();value"));
+        assert!(normalized.contains("_append_guard"));
     }
 }

--- a/crates/persistence/macros/src/lib.rs
+++ b/crates/persistence/macros/src/lib.rs
@@ -18,8 +18,6 @@
 
 mod custom;
 
-use proc_macro::TokenStream;
-
 /// Expands a struct into a custom data type with generated impls: `#[derive(Debug, Clone,
 /// Serialize, Deserialize, PartialEq)]`, constructor, HasTsInit, CustomDataTrait,
 /// ArrowSchemaProvider, EncodeToRecordBatch, DecodeDataFromRecordBatch,
@@ -32,7 +30,7 @@ use proc_macro::TokenStream;
 /// `#[new]` constructor and `#[getter]` per field. When pyo3 is set, the Rust constructor is
 /// named `new`; Python `__init__` forwards to it.
 /// Use `#[custom_data(pyo3, no_display)]` to skip generating `repr()` and `Display` so you can implement them manually.
-#[proc_macro_attribute]
-pub fn custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
-    custom::expand_custom_data(attr.into(), item.into()).into()
+#[zyn::attribute]
+fn custom_data(#[zyn(input)] item: zyn::syn::ItemStruct, args: zyn::Args) -> zyn::TokenStream {
+    custom::expand_custom_data(item, &args)
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Refactored the `custom_data` proc-macro implementation in the persistence macro crate from a `syn` + `quote!` assembly style to an idiomatic `zyn` implementation.
- Replaced ad hoc parsing and token plumbing with `zyn` attribute parsing, `#[zyn::attribute]` entry points, and reusable `#[zyn::element]` code-generation components.
- Preserved the generated behavior for `#[custom_data(...)]` while making the macro implementation easier to read, reason about, and extend.

## What changed

- Replaced the direct `syn` dependency in [`crates/persistence/macros/Cargo.toml`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/Cargo.toml) with a path dependency on `zyn`.
- Updated [`crates/persistence/macros/src/lib.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/lib.rs) to use `#[zyn::attribute]` for the `custom_data` proc-macro entry point instead of a manual `proc_macro_attribute` wrapper.
- Reworked [`crates/persistence/macros/src/custom.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/custom.rs) around typed field metadata (`FieldKind`, `FieldSpec`) so the macro logic is driven by a structured model instead of repeated type inspection inside large token blocks.
- Replaced handwritten option parsing with `#[derive(zyn::Attribute)]` for `CustomDataOptions`, which moves `#[custom_data(...)]` argument handling into `zyn`'s typed parser.
- Split code generation into focused `#[zyn::element]` components for schema fields, encoding, decoding, constructors, trait impls, conversions, and Python bindings.
- Switched the top-level expansion to a single `zyn::zyn!` composition that reads in output order, instead of building many independent `TokenStream` fragments and stitching them together later.
- Added Rust tests covering the new option parsing behavior, including rejection of unknown arguments.

## Benefits

- Increased readability by replacing large, imperative `quote!` assembly functions with smaller `zyn` elements that map directly to the generated Rust structure.
- Reduced token-stream plumbing and conversion noise by moving composition into `zyn` templates instead of passing `TokenStream` fragments through multiple helper layers.
- Improved maintainability by centralizing field classification and reusing the resulting metadata across Arrow schema generation, batch encoding, batch decoding, display formatting, and Python bindings.
- Made future extensions safer because new supported field types or output sections can now be added in one place and reused across the macro.
- Brought the macro implementation in line with `zyn`'s intended patterns, which makes the crate more consistent with the framework it now depends on.

## Validation

- Ran `cargo test -p nautilus-persistence-macros`.
- Ran `make format`.
- Ran `make cargo-test-core`.
- Ran `make build-debug`.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
