### PR TITLE
Implement Bybit native TP/SL params for order placement

### DIFF
--- a/nautilus_trader/adapters/bybit/execution.py
+++ b/nautilus_trader/adapters/bybit/execution.py
@@ -188,7 +188,13 @@ def _parse_bybit_tp_sl_params(params: dict | None) -> dict:
 
 def _apply_tp_sl_fields(order_params: object, tp_sl: dict) -> None:
     """
-    Write validated TP/SL fields onto a ``BybitWsPlaceOrderParams`` object.
+    Write extra TP/SL fields onto a ``BybitWsPlaceOrderParams`` object.
+
+    ``take_profit`` and ``stop_loss`` are passed directly to
+    ``build_place_order_params`` as ``Price`` objects so that the Rust layer
+    can set ``tpsl_mode`` and the default trigger types automatically.  This
+    helper applies only the remaining override fields that are not accepted by
+    ``build_place_order_params``.
 
     All relevant fields on ``BybitWsPlaceOrderParams`` are exposed with
     ``#[pyo3(get, set)]`` and can therefore be set directly from Python
@@ -196,8 +202,6 @@ def _apply_tp_sl_fields(order_params: object, tp_sl: dict) -> None:
 
     """
     for attr in (
-        "take_profit",
-        "stop_loss",
         "tp_trigger_by",
         "sl_trigger_by",
         "tp_order_type",
@@ -1079,8 +1083,20 @@ class BybitExecutionClient(LiveExecutionClient):
                     is_leverage=is_leverage,
                 )
             elif tp_sl.get("take_profit") or tp_sl.get("stop_loss"):
-                # Native TP/SL: build params object then set all TP/SL fields directly
-                # on the mutable BybitWsPlaceOrderParams object via _apply_tp_sl_fields.
+                # Native TP/SL: pass take_profit/stop_loss as Price objects so the Rust
+                # layer sets tpsl_mode="Full" and default trigger types automatically.
+                # _apply_tp_sl_fields then applies any override fields (trigger type,
+                # order type, limit prices, etc.).
+                pyo3_take_profit = (
+                    nautilus_pyo3.Price.from_str(tp_sl["take_profit"])
+                    if tp_sl.get("take_profit")
+                    else None
+                )
+                pyo3_stop_loss = (
+                    nautilus_pyo3.Price.from_str(tp_sl["stop_loss"])
+                    if tp_sl.get("stop_loss")
+                    else None
+                )
                 order_params = self._ws_trade_client.build_place_order_params(
                     product_type=product_type,
                     instrument_id=pyo3_instrument_id,
@@ -1095,6 +1111,8 @@ class BybitExecutionClient(LiveExecutionClient):
                     post_only=order.is_post_only,
                     reduce_only=order.is_reduce_only,
                     is_leverage=is_leverage,
+                    take_profit=pyo3_take_profit,
+                    stop_loss=pyo3_stop_loss,
                 )
                 _apply_tp_sl_fields(order_params, tp_sl)
                 await self._ws_trade_client.batch_place_orders(
@@ -1287,6 +1305,14 @@ class BybitExecutionClient(LiveExecutionClient):
                 order.is_quote_quantity if hasattr(order, "is_quote_quantity") else False
             )
 
+            pyo3_take_profit = (
+                nautilus_pyo3.Price.from_str(tp_sl["take_profit"])
+                if tp_sl.get("take_profit")
+                else None
+            )
+            pyo3_stop_loss = (
+                nautilus_pyo3.Price.from_str(tp_sl["stop_loss"]) if tp_sl.get("stop_loss") else None
+            )
             ws_params = self._ws_trade_client.build_place_order_params(
                 product_type=product_type,
                 instrument_id=pyo3_instrument_id,
@@ -1301,6 +1327,8 @@ class BybitExecutionClient(LiveExecutionClient):
                 post_only=order.is_post_only,
                 reduce_only=order.is_reduce_only,
                 is_leverage=is_leverage,
+                take_profit=pyo3_take_profit,
+                stop_loss=pyo3_stop_loss,
             )
             _apply_tp_sl_fields(ws_params, tp_sl)
             order_params.append(ws_params)

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -7092,6 +7092,8 @@ class BybitWebSocketClient:
         post_only: bool | None = None,
         reduce_only: bool | None = None,
         is_leverage: bool = False,
+        take_profit: Price | None = None,
+        stop_loss: Price | None = None,
     ) -> BybitWsPlaceOrderParams: ...
     def build_amend_order_params(
         self,

--- a/tests/integration_tests/adapters/bybit/test_execution.py
+++ b/tests/integration_tests/adapters/bybit/test_execution.py
@@ -503,9 +503,9 @@ async def test_submit_limit_order_with_take_profit_stop_loss(
         await client._submit_order(command)
 
         ws_trade_client.build_place_order_params.assert_called_once()
-        order_params = ws_trade_client.build_place_order_params.return_value
-        assert order_params.take_profit == "55000.00"
-        assert order_params.stop_loss == "47000.00"
+        call_kwargs = ws_trade_client.build_place_order_params.call_args.kwargs
+        assert call_kwargs["take_profit"] == nautilus_pyo3.Price.from_str("55000.00")
+        assert call_kwargs["stop_loss"] == nautilus_pyo3.Price.from_str("47000.00")
         ws_trade_client.batch_place_orders.assert_awaited_once()
     finally:
         await client._disconnect()
@@ -557,9 +557,9 @@ async def test_submit_market_order_with_take_profit_only(
         await client._submit_order(command)
 
         ws_trade_client.build_place_order_params.assert_called_once()
-        order_params = ws_trade_client.build_place_order_params.return_value
-        assert order_params.take_profit == "55000.00"
-        # stop_loss not in params → _apply_tp_sl_fields never sets it (correct behavior)
+        call_kwargs = ws_trade_client.build_place_order_params.call_args.kwargs
+        assert call_kwargs["take_profit"] == nautilus_pyo3.Price.from_str("55000.00")
+        assert call_kwargs.get("stop_loss") is None
         ws_trade_client.batch_place_orders.assert_awaited_once()
     finally:
         await client._disconnect()


### PR DESCRIPTION
Closes #3748

- Add _parse_bybit_tp_sl_params() helper with validation before order submission
- Add _apply_tp_sl_fields() helper to set mutable PyO3 fields post-build
- Validate enum fields (tp/sl_trigger_by, tp/sl_order_type) against Bybit V5 PascalCase values; invalid values emit generate_order_denied before submission
- Wire take_profit, stop_loss, tp/sl_trigger_price, tp/sl_limit_price, tp/sl_trigger_by, tp/sl_order_type and close_on_trigger through params dict
- Single SubmitOrder with TP/SL routes through build_place_order_params + batch_place_orders to carry the full BybitWsPlaceOrderParams payload
- SubmitOrderList validates params at list level; all orders denied on error
- Add 5 integration tests covering happy path, enum fields, and denied cases

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Wires the `SubmitOrder.params` dictionary through to Bybit's native TP/SL order placement fields, enabling exchange-managed Take Profit / Stop Loss on a single `submit_order` call. The infrastructure was already present end-to-end (`BybitWsPlaceOrderParams` fields, `build_place_order_params()`), but the Python execution client never read from `params` — all TP/SL fields were effectively dead code. This PR connects them, following the pattern established in #3701 (OKX).

## Related Issues/PRs

Closes #3748
Related to #3701 (OKX equivalent implementation, used as pattern reference)

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Five new integration tests added to `tests/integration_tests/adapters/bybit/test_execution.py`:

| Test | Covers |
|------|--------|
| `test_submit_limit_order_with_take_profit_stop_loss` | Both TP and SL route through `build_place_order_params` + `batch_place_orders` with correct `Price` objects |
| `test_submit_market_order_with_take_profit_only` | Only TP present; SL is `None` |
| `test_submit_order_with_tp_sl_enum_fields` | `tp_trigger_by`, `sl_trigger_by`, `tp_order_type`, `sl_order_type`, `tp_limit_price`, `sl_trigger_price`, `close_on_trigger` set via setattr on PyO3 params object |
| `test_submit_order_with_invalid_tp_trigger_type_emits_order_denied` | Unrecognised trigger type → `generate_order_denied`, nothing sent to exchange |
| `test_submit_order_with_invalid_sl_order_type_emits_order_denied` | Unrecognised order type → `generate_order_denied`, nothing sent to exchange |

## Implementation details

### `nautilus_trader/adapters/bybit/execution.py`

Two module-level helpers added before `BybitExecutionClient`:

**`_parse_bybit_tp_sl_params(params)`**
- Parses and validates all Bybit-specific TP/SL keys from the `params` dict
- Validates `tp_trigger_by` / `sl_trigger_by` against `{"LastPrice", "MarkPrice", "IndexPrice"}`
- Validates `tp_order_type` / `sl_order_type` against `{"Market", "Limit"}`
- Raises `ValueError` with a descriptive message on invalid values
- Fully documented with valid string values (Bybit V5 uses PascalCase throughout)

**`_apply_tp_sl_fields(order_params, tp_sl)`**
- Applies validated enum/price fields directly onto the `BybitWsPlaceOrderParams` object
- Uses `setattr` — all fields on the PyO3 class carry `#[pyo3(get, set)]` and are mutable from Python after construction

**`_submit_order` changes:**
- Param parsing and validation now runs **before** `generate_order_submitted`; invalid values emit `generate_order_denied` (consistent with how other validation failures are handled)
- When `take_profit` or `stop_loss` is present, routes through `build_place_order_params` + `batch_place_orders([params])` to carry the full payload — the existing `submit_order` path doesn't accept TP/SL fields
- `_apply_tp_sl_fields` is called on the returned params object to set trigger types, order types, trigger prices, limit prices, and `close_on_trigger`

**`_submit_order_list` / `_submit_order_list_ws` changes:**
- Params validated once at list level; all orders in the list receive `generate_order_denied` if params are invalid
- `_submit_order_list_ws` signature changed from `is_leverage: bool` to `tp_sl: dict` to carry all parsed params through

## Usage

```python
order = self.order_factory.market(
    instrument_id=instrument_id,
    order_side=OrderSide.BUY,
    quantity=instrument.make_qty(0.001),
    time_in_force=TimeInForce.GTC,
)

# Minimal — TP/SL with exchange defaults (LastPrice trigger, Market order type)
self.submit_order(order, params={
    "take_profit": "77000.00",
    "stop_loss":   "63000.00",
})

# Full — explicit trigger types and limit TP
self.submit_order(order, params={
    "take_profit":     "77000.00",
    "stop_loss":       "63000.00",
    "tp_trigger_by":   "MarkPrice",   # "LastPrice" | "MarkPrice" | "IndexPrice"
    "sl_trigger_by":   "LastPrice",
    "tp_order_type":   "Limit",       # "Market" | "Limit"
    "tp_limit_price":  "76990.00",
    "close_on_trigger": True,
})
```

All param values that map to Bybit enum fields must use Bybit V5 PascalCase strings exactly as shown above. Invalid values are rejected with `generate_order_denied` before the order reaches the exchange.

## Known Limitations / Follow-up Scope

This PR covers the **submission path only**. The following are explicitly out of scope and left for follow-up:

1. **Read-back into Nautilus cache** — after placement, Nautilus does not reconstruct the TP/SL as internal `Order` objects. The attached orders exist on Bybit's side but are invisible to the framework's cache and portfolio state.

2. **WebSocket event mapping on trigger** — when a TP or SL triggers, the adapter currently sees only a position close, not the individual leg fills. Proper mapping would require handling Bybit's algo-order WebSocket messages, similar to what was done for OKX in #3701.

3. **HTTP (demo mode) path** — the `_is_demo=True` branch calls `_http_client.submit_order()` which does not accept TP/SL parameters in the current HTTP client API. TP/SL params are silently ignored on the demo path.

## Reference

- OKX equivalent implementation: #3701 (used as pattern reference)
- Bybit V5 TP/SL API docs: https://bybit-exchange.github.io/docs/v5/order/create-order
