### PR TITLE
Refine SpreadQuoteAggregator transition from historical to live mode

### DIFF
--- a/crates/backtest/src/accumulator.rs
+++ b/crates/backtest/src/accumulator.rs
@@ -29,6 +29,9 @@ pub struct ScheduledTimeEventHandler(pub TimeEventHandler);
 impl PartialEq for ScheduledTimeEventHandler {
     fn eq(&self, other: &Self) -> bool {
         self.0.event.ts_event == other.0.event.ts_event
+            && self.0.event.name == other.0.event.name
+            && self.0.event.ts_init == other.0.event.ts_init
+            && self.0.event.event_id.as_str() == other.0.event.event_id.as_str()
     }
 }
 
@@ -42,8 +45,24 @@ impl PartialOrd for ScheduledTimeEventHandler {
 
 impl Ord for ScheduledTimeEventHandler {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Reverse ordering for min-heap behavior (earlier timestamps = higher priority)
-        other.0.event.ts_event.cmp(&self.0.event.ts_event)
+        // Reverse ordering for min-heap behavior (earlier timestamps = higher priority).
+        // For equal timestamps, preserve the clock's name-based ordering so same-timestamp
+        // spread quote timers fire before time-bar timers.
+        other
+            .0
+            .event
+            .ts_event
+            .cmp(&self.0.event.ts_event)
+            .then_with(|| other.0.event.name.cmp(&self.0.event.name))
+            .then_with(|| other.0.event.ts_init.cmp(&self.0.event.ts_init))
+            .then_with(|| {
+                other
+                    .0
+                    .event
+                    .event_id
+                    .as_str()
+                    .cmp(self.0.event.event_id.as_str())
+            })
     }
 }
 
@@ -189,6 +208,52 @@ mod tests {
             assert_eq!(popped3.event.ts_event, time_event2.ts_event);
 
             assert!(accumulator.is_empty());
+        });
+    }
+
+    #[rstest]
+    fn test_accumulator_pop_same_timestamp_in_name_order() {
+        Python::initialize();
+        Python::attach(|py| {
+            let py_list = PyList::empty(py);
+            let py_append = Py::from(py_list.getattr("append").unwrap());
+
+            let mut accumulator = TimeEventAccumulator::new();
+            let callback = TimeEventCallback::from(py_append.into_any());
+
+            let spread_event = TimeEvent::new(
+                Ustr::from("spread_quote_ESM4"),
+                UUID4::new(),
+                100.into(),
+                100.into(),
+            );
+            let time_bar_event = TimeEvent::new(
+                Ustr::from("time_bar_ESM4-2-MINUTE-ASK-INTERNAL"),
+                UUID4::new(),
+                100.into(),
+                100.into(),
+            );
+
+            accumulator
+                .heap
+                .push(ScheduledTimeEventHandler(TimeEventHandler::new(
+                    time_bar_event.clone(),
+                    callback.clone(),
+                )));
+            accumulator
+                .heap
+                .push(ScheduledTimeEventHandler(TimeEventHandler::new(
+                    spread_event.clone(),
+                    callback,
+                )));
+
+            let popped1 = accumulator.pop_next_at_or_before(100.into()).unwrap();
+            assert_eq!(popped1.event.ts_event, spread_event.ts_event);
+            assert_eq!(popped1.event.name, spread_event.name);
+
+            let popped2 = accumulator.pop_next_at_or_before(100.into()).unwrap();
+            assert_eq!(popped2.event.ts_event, time_bar_event.ts_event);
+            assert_eq!(popped2.event.name, time_bar_event.name);
         });
     }
 

--- a/crates/data/src/aggregation.rs
+++ b/crates/data/src/aggregation.rs
@@ -2251,6 +2251,25 @@ impl SpreadQuoteAggregator {
         }
     }
 
+    /// Flushes the deferred historical timer event, if any.
+    ///
+    /// This is intended for historical request finalization, where we know no more historical
+    /// quotes will arrive for the requested range and should not require a later live tick just
+    /// to release the final same-timestamp spread quote.
+    pub fn flush_pending_historical_quote(&mut self) {
+        if self.update_interval_seconds.is_none() || !self.historical_mode {
+            return;
+        }
+
+        let Some(event) = self.historical_event_at_ts_init.take() else {
+            return;
+        };
+
+        if self.last_quotes.len() == self.n_legs {
+            self.build_and_send_quote(event.ts_event);
+        }
+    }
+
     /// Advances the historical clock and collects timer events. Events at `ts_init` are
     /// deferred until the next call when time advances. The deferred event is only flushed
     /// when all legs have quotes and time has moved past the deferred timestamp. This
@@ -5348,6 +5367,72 @@ mod tests {
             1,
             "deferred event at ts2 is processed when we have all legs and advance to ts3"
         );
+    }
+
+    #[rstest]
+    fn test_spread_quote_historical_flush_emits_pending_final_quote(equity_aapl: Equity) {
+        let instrument = InstrumentAny::Equity(equity_aapl);
+        let leg1 = instrument.id();
+        let leg2 = InstrumentId::from("MSFT.XNAS");
+        let spread_id = InstrumentId::from("SPREAD.XNAS");
+        let legs = vec![(leg1, 1_i64), (leg2, -1_i64)];
+        let handler = Arc::new(Mutex::new(Vec::new()));
+        let handler_clone = Arc::clone(&handler);
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+
+        let agg = SpreadQuoteAggregator::new(
+            spread_id,
+            &legs,
+            true,
+            instrument.price_precision(),
+            0,
+            Box::new(move |q: QuoteTick| {
+                handler_clone.lock().expect(MUTEX_POISONED).push(q);
+            }),
+            #[allow(clippy::redundant_clone)] // need clock for set_clock after
+            clock.clone(),
+            true,
+            Some(1),
+            0,
+            None,
+            None,
+        );
+        let rc = Rc::new(RefCell::new(agg));
+        rc.borrow_mut().prepare_for_timer_mode(&rc);
+        rc.borrow_mut().set_clock(clock);
+
+        let ts1 = UnixNanos::from(1_000_000_000);
+        let ts2 = UnixNanos::from(2_000_000_000);
+        rc.borrow_mut().handle_quote_tick(QuoteTick::new(
+            leg1,
+            Price::from("100.00"),
+            Price::from("100.10"),
+            Quantity::from(10),
+            Quantity::from(10),
+            ts1,
+            ts1,
+        ));
+        rc.borrow_mut().handle_quote_tick(QuoteTick::new(
+            leg2,
+            Price::from("99.00"),
+            Price::from("99.10"),
+            Quantity::from(10),
+            Quantity::from(10),
+            ts2,
+            ts2,
+        ));
+
+        assert_eq!(handler.lock().expect(MUTEX_POISONED).len(), 0);
+
+        rc.borrow_mut().flush_pending_historical_quote();
+
+        let quotes = handler.lock().expect(MUTEX_POISONED);
+        assert_eq!(
+            quotes.len(),
+            1,
+            "final historical quote should be emitted when the deferred event is flushed",
+        );
+        assert_eq!(quotes[0].ts_event, ts2);
     }
 
     #[rstest]

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -213,6 +213,7 @@ cdef class SpreadQuoteAggregator:
     cpdef void set_running(self, bint is_running)
     cpdef void set_clock(self, Clock clock)
     cpdef void handle_quote_tick(self, QuoteTick tick)
+    cpdef void flush_pending_historical_quotes(self)
 
     cdef void _process_historical_events(self, uint64_t ts_init)
     cdef void _build_and_send_quote(self, uint64_t ts_event)

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -1888,6 +1888,29 @@ cdef class SpreadQuoteAggregator:
             self._build_and_send_quote(tick.ts_init)
             return
 
+    cpdef void flush_pending_historical_quotes(self):
+        cdef list event_handlers
+        cdef object event_handler
+
+        if self._update_interval_seconds is None or not self.historical_mode:
+            return
+
+        if not self._historical_events:
+            return
+
+        event_handlers = self._historical_events
+        self._historical_events = []
+
+        if len(self._last_quotes) != self._n_legs:
+            self._log.debug(
+                f"Cannot flush pending historical spread quotes for {self._spread_instrument_id}: "
+                f"missing quotes for one or more legs",
+            )
+            return
+
+        for event_handler in event_handlers:
+            self._build_and_send_quote(event_handler.event.ts_event)
+
     cdef void _process_historical_events(self, uint64_t ts_init):
         if self._clock.timestamp_ns() == 0:
             self._clock.set_time(ts_init)

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -3864,6 +3864,8 @@ cdef class DataEngine(Component):
         key = self._get_spread_quote_aggregator_key(spread_instrument_id, used_request_id)
         aggregator = self._spread_quote_aggregators.get(key)
         if aggregator:
+            aggregator.flush_pending_historical_quotes()
+
             # After a request we set is_running to False so a request using the same aggregator
             # or a subscription can use the aggregator
             aggregator.set_running(False)

--- a/tests/acceptance_tests/test_backtest.py
+++ b/tests/acceptance_tests/test_backtest.py
@@ -1944,8 +1944,8 @@ class TestBacktestNodeWithBacktestDataIterator:
         expected_spread_bar_messages = [
             "Historical Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12928.25,12928.25,12927.25,12927.25,4,1715248560000000000, ts=2024-05-09T09:56:00.000000000Z",
             "Historical Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12927.50,12928.00,12927.50,12928.00,3,1715248680000000000, ts=2024-05-09T09:58:00.000000000Z",
-            "Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12930.25,12930.25,12930.25,12930.25,1,1715248800000000000, ts=2024-05-09T10:00:00.000000000Z",
-            "Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12930.50,12931.75,12930.25,12931.75,10,1715248920000000000, ts=2024-05-09T10:02:00.000000000Z",
+            "Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12930.25,12930.50,12930.25,12930.50,3,1715248800000000000, ts=2024-05-09T10:00:00.000000000Z",
+            "Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12930.25,12931.75,12930.25,12931.75,8,1715248920000000000, ts=2024-05-09T10:02:00.000000000Z",
             "Bar: ((1))ESM4___(1)NQM4.XCME-2-MINUTE-ASK-INTERNAL,12933.00,12933.00,12932.50,12932.50,4,1715249040000000000, ts=2024-05-09T10:04:00.000000000Z",
         ]
         assert spread_bar_messages == expected_spread_bar_messages
@@ -2334,8 +2334,7 @@ class OptionStrategy(Strategy):
         self.request_quote_ticks(
             self.config.spread_id2,
             start=time_object_to_dt(self.config.start_time),
-            # Note: we need to request up to 10:00 so the spread quote at 9:59 is produced
-            end=self.clock.utc_now() - pd.Timedelta(minutes=0),
+            end=self.clock.utc_now() - pd.Timedelta(minutes=1),
             params=self.default_data_params,
         )
 
@@ -2343,8 +2342,7 @@ class OptionStrategy(Strategy):
         self.request_aggregated_bars(
             [self.bar_type_3],
             start=time_object_to_dt(self.config.start_time),
-            # Note: we need to request up to 10:00 so the spread quote at 9:59 is produced
-            end=self.clock.utc_now() - pd.Timedelta(minutes=0),
+            end=self.clock.utc_now() - pd.Timedelta(minutes=1),
             update_subscriptions=True,
             params=self.default_data_params,
         )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- This PR fixes spread quote and spread bar boundary handling in backtests when timer-driven spread aggregation transitions across historical and live processing.
- The change makes same-timestamp timer execution deterministic in the backtest accumulator and adds an explicit historical end-of-request flush for pending spread quotes in both the Cython and Rust aggregators.
- Acceptance coverage was updated so spread quote requests can end at `09:59` while still producing the final `09:59` historical spread quote and the correct `10:00` and `10:02` spread bars.

## What changed

- Updated [`crates/backtest/src/accumulator.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/backtest/src/accumulator.rs) to preserve timer name ordering for equal-timestamp events, so `spread_quote_*` timers execute before `time_bar_*` timers in backtests.
- Added a Rust regression test in [`crates/backtest/src/accumulator.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/backtest/src/accumulator.rs) covering same-timestamp spread quote versus time bar ordering.
- Added `flush_pending_historical_quote()` to [`crates/data/src/aggregation.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/data/src/aggregation.rs) so the final deferred historical spread quote can be emitted when a historical request completes instead of waiting for the first live tick.
- Added the matching Cython flush API in [`nautilus_trader/data/aggregation.pxd`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/data/aggregation.pxd) and [`nautilus_trader/data/aggregation.pyx`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/data/aggregation.pyx), then invoked it during request finalization in [`nautilus_trader/data/engine.pyx`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/data/engine.pyx).
- Updated [`tests/acceptance_tests/test_backtest.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/acceptance_tests/test_backtest.py) so spread quote and spread bar requests now end at `self.clock.utc_now() - pd.Timedelta(minutes=1)` and the expected spread bar values reflect the corrected `10:00` and `10:02` bucket contents.
- Added a Rust regression test in [`crates/data/src/aggregation.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/data/src/aggregation.rs) proving the final pending historical spread quote can be emitted directly by a request-end flush.

## Why

- The spread aggregator intentionally defers a timer event at the current historical timestamp so all leg quotes for that timestamp can arrive before a synthetic spread quote is built.
- In the backtest path, the merged time-event accumulator did not preserve same-timestamp timer name ordering, so spread quote timers and time bar timers could execute in the wrong order.
- Separately, the last deferred historical spread quote depended on a later live tick to be emitted, which made it necessary to request data through `10:00` just to obtain the `09:59` spread quote.
- Together, these issues produced surprising request semantics and incorrect spread bar bucketing at the historical/live boundary.

## Result

- Backtests now preserve the intended timer invariant for equal timestamps.
- Historical spread quote requests can stop at `09:59` and still emit the `09:59` spread quote.
- The `10:00` spread `2-MINUTE` bar now contains both the `09:59` and `10:00` spread asks, and the `10:02` bar contains the `10:01` and `10:02` asks instead of inheriting the delayed `10:00` quote.

## Validation

- Ran `cargo test -p nautilus-backtest accumulator --features python`.
- Ran `cargo test -p nautilus-data spread_quote_historical --features python`.
- Ran `make build-debug`.
- Ran `uv run --no-sync pytest tests/acceptance_tests/test_backtest.py::TestBacktestNodeWithBacktestDataIterator::test_spread_quote_bars_values tests/acceptance_tests/test_backtest.py::TestBacktestNodeWithBacktestDataIterator::test_backtest_same_with_and_without_data_configs -q`.
- Ran `make format`.
- Ran `uv run --no-sync pre-commit run --files crates/backtest/src/accumulator.rs crates/data/src/aggregation.rs nautilus_trader/data/aggregation.pxd nautilus_trader/data/aggregation.pyx nautilus_trader/data/engine.pyx tests/acceptance_tests/test_backtest.py`.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
