### PR TITLE
Add support for Params and dict in custom data

### DIFF
--- a/crates/persistence/macros/src/custom.rs
+++ b/crates/persistence/macros/src/custom.rs
@@ -32,8 +32,8 @@
 //!
 //! - Struct must have named fields
 //! - Must include `ts_event` and `ts_init` fields (e.g. `nautilus_core::UnixNanos`)
-//! - Supported field types: InstrumentId, AccountId, Currency, BarType, UnixNanos, f64, f32, bool,
-//!   String, u64, i64, u32, i32, `Vec<f64>`, `Vec<u8>`
+//! - Supported field types: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64,
+//!   f32, bool, String, u64, i64, u32, i32, `Vec<f64>`, `Vec<u8>`
 //!
 //! # Options
 //!
@@ -120,6 +120,7 @@ fn use_string_extract(ty: &Type) -> bool {
                 | ("AccountId", "AccountId")
                 | ("Currency", "Currency")
                 | ("BarType", "BarType")
+                | ("Params", "Params")
                 | ("String", "String")
         )
     } else {
@@ -146,7 +147,7 @@ fn arrow_type_for_rust_type(ty: &Type) -> Option<(TokenStream, TokenStream, Toke
             quote! { arrow::array::ListArray },
         ),
         _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" => (
+            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "Params" => (
                 quote! { arrow::datatypes::DataType::Utf8 },
                 quote! { arrow::array::StringArray },
                 quote! { arrow::array::StringArray },
@@ -214,6 +215,14 @@ fn encode_field_expr(field_name: &syn::Ident, ty: &Type) -> Option<TokenStream> 
             "InstrumentId" | "AccountId" | "Currency" | "BarType" => {
                 Some(quote! { builder.append_value(item.#name.to_string()); })
             }
+            "Params" => Some(quote! {
+                let value = serde_json::to_string(&item.#name).map_err(|e| {
+                    arrow::error::ArrowError::InvalidArgumentError(
+                        format!("failed to serialize Params field '{}': {e}", stringify!(#name)),
+                    )
+                })?;
+                builder.append_value(value);
+            }),
             "UnixNanos" => Some(quote! { builder.append_value(item.#name.as_u64()); }),
             "f64" | "f32" => Some(quote! { builder.append_value(item.#name); }),
             "bool" => Some(quote! { builder.append_value(item.#name); }),
@@ -256,6 +265,14 @@ fn decode_field_rhs(
                     format!("expected valid identifier/type, was '{}'", e),
                 ))?
             }),
+            "Params" => Some(quote! {
+                serde_json::from_str::<nautilus_core::Params>(#col.value(i)).map_err(|e| {
+                    nautilus_serialization::arrow::EncodingError::ParseError(
+                        stringify!(#name),
+                        format!("row {i}: {e}"),
+                    )
+                })?
+            }),
             "UnixNanos" => Some(quote! { #col.value(i).into() }),
             "f64" | "f32" | "bool" | "u64" | "i64" => Some(quote! { #col.value(i) }),
             "u32" => Some(quote! { #col.value(i) as u32 }),
@@ -277,7 +294,7 @@ fn encode_builder_for_field(ty: &Type, len_var: &syn::Ident) -> Option<TokenStre
             let mut builder = arrow::array::ListBuilder::new(arrow::array::Float64Builder::new());
         }),
         _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "String" => {
+            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "Params" | "String" => {
                 Some(quote! { let mut builder = arrow::array::StringBuilder::new(); })
             }
             "UnixNanos" | "u64" | "u32" => {
@@ -294,11 +311,15 @@ fn encode_builder_for_field(ty: &Type, len_var: &syn::Ident) -> Option<TokenStre
     }
 }
 
-/// Python constructor param type: UnixNanos -> u64, Vec<u8> -> &[u8] or Vec<u8>, rest unchanged.
+/// Python constructor param type: UnixNanos -> u64, Params -> PyDict, Vec<u8> -> Vec<u8>, rest unchanged.
 fn py_param_ty(ty: &Type) -> Option<TokenStream> {
     let (outer, inner) = type_for_macro(ty)?;
     if outer == "UnixNanos" {
         return Some(quote! { u64 });
+    }
+
+    if outer == inner && outer == "Params" {
+        return Some(quote! { pyo3::Py<pyo3::types::PyDict> });
     }
 
     if outer == "Vec" && inner == "u8" {
@@ -313,32 +334,46 @@ fn py_param_ty(ty: &Type) -> Option<TokenStream> {
 
 /// Python constructor body RHS: UnixNanos fields use arg.into(), rest use arg.
 fn py_field_init(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, _) = type_for_macro(ty)?;
+    let (outer, inner) = type_for_macro(ty)?;
     let name = ident;
 
     if outer == "UnixNanos" {
         return Some(quote! { #name.into() });
+    }
+
+    if outer == inner && outer == "Params" {
+        return Some(quote! {
+            pyo3::Python::attach(|py| nautilus_core::from_pydict(py, #name))?.unwrap_or_default()
+        });
     }
     Some(quote! { #name })
 }
 
 /// Python getter return type: UnixNanos -> u64, rest unchanged.
 fn py_getter_ret_ty(ty: &Type) -> Option<TokenStream> {
-    let (outer, _) = type_for_macro(ty)?;
+    let (outer, inner) = type_for_macro(ty)?;
 
     if outer == "UnixNanos" {
         return Some(quote! { u64 });
+    }
+
+    if outer == inner && outer == "Params" {
+        return Some(quote! { pyo3::PyResult<pyo3::Py<pyo3::types::PyDict>> });
     }
     Some(quote! { #ty })
 }
 
 /// Python getter body: UnixNanos -> self.x.as_u64(), Vec -> clone, String -> clone, rest -> self.x.
 fn py_getter_body(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, _inner) = type_for_macro(ty)?;
+    let (outer, inner) = type_for_macro(ty)?;
     let name = ident;
 
     if outer == "UnixNanos" {
         return Some(quote! { self.#name.as_u64() });
+    }
+
+    if outer == inner && outer == "Params" {
+        return Some(quote! { pyo3::Python::attach(|py| self.#name.to_pydict(py)) });
     }
 
     if outer == "Vec" || outer == "String" {
@@ -353,7 +388,7 @@ fn encode_finish_builder(ty: &Type) -> Option<TokenStream> {
     match (outer.as_str(), inner.as_str()) {
         ("Vec", "u8" | "f64") => Some(quote! { std::sync::Arc::new(builder.finish()) }),
         _ if outer == inner => match outer.as_str() {
-            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "String" => {
+            "InstrumentId" | "AccountId" | "Currency" | "BarType" | "Params" | "String" => {
                 Some(quote! { std::sync::Arc::new(builder.finish()) })
             }
             "UnixNanos" | "u64" | "u32" | "f64" | "f32" | "bool" | "i64" | "i32" => {
@@ -832,9 +867,9 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
             #[allow(clippy::too_many_arguments)]
             #[new]
             #[pyo3(signature = (#(#py_new_call_args),*))]
-            fn py_new(#(#py_new_params),*) -> Self {
+            fn py_new(#(#py_new_params),*) -> pyo3::PyResult<Self> {
                 #(#py_let_bindings)*
-                Self::new(#(#py_new_call_args),*)
+                Ok(Self::new(#(#py_new_call_args),*))
             }
             #(#getters)*
 
@@ -985,7 +1020,7 @@ pub fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
             return syn::Error::new_spanned(
                 ty,
                 format!(
-                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>"
+                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>"
                 ),
             )
             .to_compile_error();

--- a/crates/persistence/macros/src/lib.rs
+++ b/crates/persistence/macros/src/lib.rs
@@ -26,6 +26,8 @@ use proc_macro::TokenStream;
 /// CatalogPathPrefix, From/TryFrom for Data. Call `nautilus_serialization::ensure_custom_data_registered::<T>()`
 /// and (for Python) `nautilus_model::data::register_rust_extractor::<T>()` once per type.
 /// Requires fields to include `ts_event` and `ts_init` (e.g. `nautilus_core::UnixNanos`).
+/// Supported field types include InstrumentId, AccountId, Currency, BarType, Params, UnixNanos,
+/// f64, f32, bool, String, u64, i64, u32, i32, `Vec<f64>`, and `Vec<u8>`.
 ///
 /// Use `#[custom_data(pyo3)]` or `#[custom_data(python)]` to also generate Python bindings:
 /// `#[cfg_attr(feature = "python", pyo3::pyclass)]` on the struct and a `#[pymethods]` impl with

--- a/crates/persistence/src/python/mod.rs
+++ b/crates/persistence/src/python/mod.rs
@@ -38,8 +38,10 @@ use pyo3::prelude::*;
 pub fn persistence(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     ensure_custom_data_registered::<crate::test_data::RustTestCustomData>();
     ensure_custom_data_registered::<crate::test_data::MacroYieldCurveData>();
+    ensure_custom_data_registered::<crate::test_data::RustTestParamsCustomData>();
     let _ = ensure_rust_extractor_registered::<crate::test_data::RustTestCustomData>();
     let _ = ensure_rust_extractor_registered::<crate::test_data::MacroYieldCurveData>();
+    let _ = ensure_rust_extractor_registered::<crate::test_data::RustTestParamsCustomData>();
 
     // Test/example types (RustTestCustomData, MacroYieldCurveData) are exposed so Python tests
     // and examples can use them; they are not gated behind cfg(test) to keep the extension build simple.
@@ -55,5 +57,6 @@ pub fn persistence(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<wranglers::trade::TradeTickDataWrangler>()?;
     m.add_class::<crate::test_data::RustTestCustomData>()?;
     m.add_class::<crate::test_data::MacroYieldCurveData>()?;
+    m.add_class::<crate::test_data::RustTestParamsCustomData>()?;
     Ok(())
 }

--- a/crates/persistence/src/test_data.rs
+++ b/crates/persistence/src/test_data.rs
@@ -18,7 +18,7 @@
 //! Exposed to Python via the persistence PyO3 module so Python tests can exercise
 //! custom data write/query roundtrips.
 
-use nautilus_core::UnixNanos;
+use nautilus_core::{Params, UnixNanos};
 use nautilus_model::identifiers::InstrumentId;
 use nautilus_persistence_macros::custom_data;
 
@@ -47,8 +47,18 @@ pub struct MacroYieldCurveData {
     pub ts_init: UnixNanos,
 }
 
+/// Rust custom data type that exercises `Params` field support in the macro.
+#[custom_data(pyo3)]
+pub struct RustTestParamsCustomData {
+    pub name: String,
+    pub params: Params,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
 #[cfg(test)]
 mod tests {
+    use arrow::datatypes::DataType;
     use nautilus_serialization::arrow::ArrowSchemaProvider;
     use rstest::rstest;
 
@@ -66,5 +76,13 @@ mod tests {
             field_names.iter().any(|f| f == "ts_event"),
             "Schema must have ts_event; got: {field_names:?}",
         );
+    }
+
+    #[rstest]
+    fn test_rust_test_params_custom_data_schema_uses_utf8_for_params() {
+        let schema = RustTestParamsCustomData::get_schema(None);
+        let params_field = schema.field_with_name("params").unwrap();
+
+        assert_eq!(params_field.data_type(), &DataType::Utf8);
     }
 }

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -35,7 +35,7 @@ use nautilus_persistence::{
         catalog::ParquetDataCatalog,
         session::{DataBackendSession, QueryResult},
     },
-    test_data::{MacroYieldCurveData, RustTestCustomData},
+    test_data::{MacroYieldCurveData, RustTestCustomData, RustTestParamsCustomData},
 };
 use nautilus_serialization::{arrow::ArrowSchemaProvider, ensure_custom_data_registered};
 use nautilus_testkit::common::get_nautilus_test_data_file_path;
@@ -56,6 +56,7 @@ fn ensure_test_custom_data_registered() {
     ONCE.call_once(|| {
         ensure_custom_data_registered::<MacroYieldCurveData>();
         ensure_custom_data_registered::<RustTestCustomData>();
+        ensure_custom_data_registered::<RustTestParamsCustomData>();
     });
 }
 
@@ -2908,6 +2909,83 @@ fn test_rust_custom_data_roundtrip() {
                 .as_any()
                 .downcast_ref::<RustTestCustomData>()
                 .expect("Expected RustTestCustomData");
+            assert_eq!(expected, rust);
+        } else {
+            panic!("Expected Data::Custom variant");
+        }
+    }
+}
+
+#[rstest]
+fn test_rust_custom_data_roundtrip_with_params_field() {
+    use std::sync::Arc;
+
+    use nautilus_model::data::{CustomData, Data, DataType};
+
+    ensure_test_custom_data_registered();
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let data_type = DataType::new("RustTestParamsCustomData", None, None);
+
+    let mut params_a = Params::new();
+    params_a.insert("key".to_string(), json!("alpha"));
+    params_a.insert("count".to_string(), json!(1_u64));
+    params_a.insert("enabled".to_string(), json!(true));
+
+    let mut params_b = Params::new();
+    params_b.insert("key".to_string(), json!("beta"));
+    params_b.insert(
+        "nested".to_string(),
+        json!({"level": 2, "tags": ["x", "y"]}),
+    );
+
+    let original_data = [
+        RustTestParamsCustomData {
+            name: "first".to_string(),
+            params: params_a,
+            ts_event: UnixNanos::from(10),
+            ts_init: UnixNanos::from(10),
+        },
+        RustTestParamsCustomData {
+            name: "second".to_string(),
+            params: params_b,
+            ts_event: UnixNanos::from(20),
+            ts_init: UnixNanos::from(20),
+        },
+    ];
+
+    let custom_data: Vec<CustomData> = original_data
+        .iter()
+        .cloned()
+        .map(|item| CustomData::new(Arc::new(item), data_type.clone()))
+        .collect();
+
+    catalog
+        .write_custom_data_batch(custom_data, None, None, Some(false))
+        .unwrap();
+
+    let loaded: Vec<Data> = catalog
+        .query_custom_data_dynamic(
+            "RustTestParamsCustomData",
+            None,
+            None,
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(loaded.len(), original_data.len());
+
+    for (expected, actual) in original_data.iter().zip(loaded.iter()) {
+        if let Data::Custom(custom) = actual {
+            assert_eq!(custom.data_type.type_name(), "RustTestParamsCustomData");
+            let rust: &RustTestParamsCustomData = custom
+                .data
+                .as_any()
+                .downcast_ref::<RustTestParamsCustomData>()
+                .expect("Expected RustTestParamsCustomData");
             assert_eq!(expected, rust);
         } else {
             panic!("Expected Data::Custom variant");

--- a/nautilus_trader/model/custom.py
+++ b/nautilus_trader/model/custom.py
@@ -17,6 +17,7 @@ import json
 import sys
 from dataclasses import dataclass
 from typing import Any
+from typing import get_origin
 
 import msgspec
 import pyarrow as pa
@@ -87,16 +88,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
         if "to_dict" not in cls.__dict__:
 
             def to_dict(self) -> dict[str, Any]:
-                # Python 3.14+ uses PEP 649 lazy annotations
-                if (
-                    sys.version_info >= (3, 14)
-                    and hasattr(self.__class__, "__annotate__")
-                    and self.__class__.__annotate__
-                ):
-                    annotations = self.__class__.__annotate__(1)  # 1 = eval annotations
-                else:
-                    annotations = getattr(self.__class__, "__annotations__", {})
-
+                annotations = _get_annotations(self.__class__)
                 result = {attr: getattr(self, attr) for attr in annotations}
 
                 if hasattr(self, "instrument_id"):
@@ -114,11 +106,16 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
 
             @classmethod
             def from_dict(cls, data: dict[str, Any]) -> cls:
+                data = dict(data)
                 data.pop("type", None)
                 data.pop("data_type", None)
 
                 if "instrument_id" in data:
                     data["instrument_id"] = InstrumentId.from_str(data["instrument_id"])
+
+                for attr, annotation in _get_annotations(cls).items():
+                    if attr in data:
+                        data[attr] = _deserialize_field_value(annotation, data[attr])
 
                 return cls(**data)
 
@@ -142,7 +139,10 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
         if "to_arrow" not in cls.__dict__:
 
             def to_arrow(self) -> pa.RecordBatch:
-                return pa.RecordBatch.from_pylist([self.to_dict()], schema=cls._schema)
+                return pa.RecordBatch.from_pylist(
+                    [_arrow_dict_for_instance(self)],
+                    schema=cls._schema,
+                )
 
             cls.to_arrow = to_arrow
 
@@ -155,27 +155,7 @@ def customdataclass(*args, **kwargs):  # noqa: C901 (too complex)
             cls.from_arrow = from_arrow
 
         if "_schema" not in cls.__dict__:
-            type_mapping = {
-                "InstrumentId": pa.string(),
-                "str": pa.string(),
-                "bool": pa.bool_(),
-                "float": pa.float64(),
-                "int": pa.int64(),
-                "bytes": pa.binary(),
-                "ndarray": pa.binary(),
-            }
-
-            cls._schema = pa.schema(
-                {
-                    attr: type_mapping[cls.__annotations__[attr].__name__]
-                    for attr in cls.__annotations__
-                }
-                | {
-                    "type": pa.string(),
-                    "ts_event": pa.int64(),
-                    "ts_init": pa.int64(),
-                },
-            )
+            cls._schema = _arrow_schema_for_class(cls)
 
         register_serializable_type(cls, cls.to_dict, cls.from_dict)
         register_arrow(cls, cls._schema, cls.to_arrow, cls.from_arrow)
@@ -238,7 +218,9 @@ def customdataclass_pyo3(*args, **kwargs):  # noqa: C901 (too complex)
                         "catalog can encode record batches."
                     )
                     raise AttributeError(msg)
-                dicts = [x.to_dict() for x in items]
+
+                dicts = [_arrow_dict_for_instance(x) for x in items]
+
                 return pa.RecordBatch.from_pylist(dicts, schema=self.__class__._schema)
 
             cls.encode_record_batch_py = encode_record_batch_py
@@ -257,3 +239,96 @@ def customdataclass_pyo3(*args, **kwargs):  # noqa: C901 (too complex)
         return wrapper(args[0])
 
     return wrapper
+
+
+def _arrow_schema_for_class(cls) -> pa.Schema:
+    type_mapping = {
+        "InstrumentId": pa.string(),
+        "str": pa.string(),
+        "bool": pa.bool_(),
+        "float": pa.float64(),
+        "int": pa.int64(),
+        "bytes": pa.binary(),
+        "ndarray": pa.binary(),
+        "dict": pa.string(),
+    }
+    annotations = _get_annotations(cls)
+    fields = {}
+
+    for attr, annotation in annotations.items():
+        annotation_name = _annotation_name(annotation)
+        if annotation_name not in type_mapping:
+            msg = (
+                f"Unsupported custom data field type for `{cls.__name__}.{attr}`: "
+                f"{annotation!r}. Supported types are: {', '.join(type_mapping)}"
+            )
+            raise TypeError(msg)
+
+        fields[attr] = type_mapping[annotation_name]
+
+    return pa.schema(
+        fields
+        | {
+            "type": pa.string(),
+            "ts_event": pa.int64(),
+            "ts_init": pa.int64(),
+        },
+    )
+
+
+def _annotation_name(annotation: Any) -> str:
+    if _is_dict_annotation(annotation):
+        return "dict"
+
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+
+    origin = get_origin(annotation)
+    if origin is not None and hasattr(origin, "__name__"):
+        return origin.__name__
+
+    msg = f"Unsupported custom data annotation: {annotation!r}"
+
+    raise TypeError(msg)
+
+
+def _arrow_dict_for_instance(instance: Any) -> dict[str, Any]:
+    data = instance.to_dict().copy()
+    annotations = _get_annotations(instance.__class__)
+
+    for attr, annotation in annotations.items():
+        data[attr] = _serialize_field_value(annotation, data[attr])
+
+    return data
+
+
+def _serialize_field_value(annotation: Any, value: Any) -> Any:
+    if value is None:
+        return None
+
+    if _is_dict_annotation(annotation):
+        return json.dumps(value, sort_keys=True)
+
+    return value
+
+
+def _get_annotations(cls) -> dict[str, Any]:
+    # Python 3.14+ uses PEP 649 lazy annotations.
+    if sys.version_info >= (3, 14) and hasattr(cls, "__annotate__") and cls.__annotate__:
+        return cls.__annotate__(1)  # 1 = eval annotations
+
+    return getattr(cls, "__annotations__", {})
+
+
+def _deserialize_field_value(annotation: Any, value: Any) -> Any:
+    if value is None:
+        return None
+
+    if _is_dict_annotation(annotation) and isinstance(value, str):
+        return json.loads(value)
+
+    return value
+
+
+def _is_dict_annotation(annotation: Any) -> bool:
+    return annotation is dict or get_origin(annotation) is dict

--- a/tests/unit_tests/model/test_custom_data.py
+++ b/tests/unit_tests/model/test_custom_data.py
@@ -14,6 +14,11 @@
 # -------------------------------------------------------------------------------------------------
 
 
+import json
+from dataclasses import field
+
+import pyarrow as pa
+
 from nautilus_trader.core.data import Data
 from nautilus_trader.model.custom import customdataclass
 from nautilus_trader.model.identifiers import InstrumentId
@@ -23,6 +28,12 @@ from nautilus_trader.model.identifiers import InstrumentId
 class GreeksTestData(Data):
     instrument_id: InstrumentId = InstrumentId.from_str("ES.GLBX")
     delta: float = 0.0
+
+
+@customdataclass
+class JsonTestData(Data):
+    name: str = ""
+    payload: dict[str, object] = field(default_factory=dict)
 
 
 def test_customdata_decorator_properties() -> None:
@@ -111,3 +122,37 @@ def test_customdata_decorator_arrow_identity() -> None:
 
     # Assert
     assert new_data == data
+
+
+def test_customdata_decorator_arrow_identity_with_dict_payload() -> None:
+    # Arrange
+    payload = {
+        "symbol": "CLM4",
+        "nested": {"count": 2, "enabled": True},
+        "values": [1, 2, 3],
+    }
+    data = JsonTestData(
+        ts_event=1,
+        ts_init=2,
+        name="snapshot",
+        payload=payload,
+    )
+
+    # Act
+    data_dict = data.to_dict()
+    arrow_batch = data.to_arrow()
+    arrow_row = arrow_batch.to_pylist()[0]
+    new_data = JsonTestData.from_arrow(arrow_batch)[0]
+
+    # Assert
+    assert data_dict == {
+        "name": "snapshot",
+        "payload": payload,
+        "type": "JsonTestData",
+        "ts_event": 1,
+        "ts_init": 2,
+    }
+    assert JsonTestData._schema.field("payload").type == pa.string()
+    assert arrow_row["payload"] == json.dumps(payload, sort_keys=True)
+    assert new_data == data
+    assert isinstance(new_data.payload, dict)

--- a/tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py
+++ b/tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py
@@ -209,6 +209,93 @@ def test_macro_yield_curve_data_roundtrip(tmp_path):
     _assert_custom_data_json_roundtrip(result, MacroYieldCurveData, assert_yield_curve)
 
 
+def test_rust_params_custom_data_roundtrip(tmp_path):
+    """Test RustTestParamsCustomData roundtrip via catalog - exercises Params <-> dict interop."""
+    from nautilus_trader.core.nautilus_pyo3 import ParquetDataCatalogV2
+    from nautilus_trader.core.nautilus_pyo3.model import CustomData
+    from nautilus_trader.core.nautilus_pyo3.model import DataType
+    from nautilus_trader.core.nautilus_pyo3.model import register_custom_data_class
+    from nautilus_trader.core.nautilus_pyo3.persistence import RustTestParamsCustomData
+
+    register_custom_data_class(RustTestParamsCustomData)
+    catalog_path = tmp_path / "catalog_params"
+    catalog_path.mkdir(parents=True, exist_ok=True)
+    pyo3_catalog = ParquetDataCatalogV2(str(catalog_path))
+
+    metadata = {"source": "unit-test", "kind": "params"}
+    data_type = DataType("RustTestParamsCustomData", metadata, None)
+
+    original_params = [
+        {
+            "key": "alpha",
+            "count": 1,
+            "enabled": True,
+        },
+        {
+            "key": "beta",
+            "nested": {"level": 2, "tags": ["x", "y"]},
+            "ratio": 1.25,
+        },
+    ]
+    original_data = [
+        RustTestParamsCustomData("first", original_params[0], 10, 10),
+        RustTestParamsCustomData("second", original_params[1], 20, 20),
+    ]
+    wrapped = [CustomData(data_type, item) for item in original_data]
+
+    pyo3_catalog.write_custom_data(wrapped)
+
+    result = pyo3_catalog.query(
+        "RustTestParamsCustomData",
+        None,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+
+    roundtripped = []
+    for item in result:
+        assert isinstance(item, CustomData), f"Expected CustomData, found {type(item)}"
+        inner = item.data
+        assert isinstance(inner, RustTestParamsCustomData), (
+            f"Expected RustTestParamsCustomData in .data, found {type(inner)}"
+        )
+        assert isinstance(inner.params, dict)
+        roundtripped.append(inner)
+
+    assert len(roundtripped) == len(original_data)
+
+    for item in result:
+        assert item.data_type.type_name == "RustTestParamsCustomData"
+        assert item.data_type.metadata == metadata
+        assert item.data_type.identifier is None
+
+    for expected, expected_params, actual in zip(
+        original_data,
+        original_params,
+        roundtripped,
+        strict=True,
+    ):
+        assert expected.name == actual.name
+        assert actual.params == expected_params
+        assert expected.ts_event == actual.ts_event
+        assert expected.ts_init == actual.ts_init
+
+    def assert_params_data(orig, rt):
+        assert orig.name == rt.name
+        assert rt.params == orig.params
+        assert orig.ts_event == rt.ts_event
+        assert orig.ts_init == rt.ts_init
+
+    _assert_custom_data_json_roundtrip(
+        result,
+        RustTestParamsCustomData,
+        assert_params_data,
+    )
+
+
 def test_python_only_customdataclass_pyo3_roundtrip(tmp_path):
     """
     Test Python-only custom data via customdataclass_pyo3 and
@@ -285,6 +372,100 @@ def test_python_only_customdataclass_pyo3_roundtrip(tmp_path):
         assert orig.ts_init == rt.ts_init
 
     _assert_custom_data_json_roundtrip(result, MarketTickPython, assert_market_tick)
+
+
+def test_python_only_customdataclass_pyo3_dict_roundtrip(tmp_path):
+    """
+    Test Python-only custom data dict fields roundtrip via JSON-backed Arrow strings.
+    """
+    import json as json_module
+    from dataclasses import field
+
+    import pyarrow as pa
+
+    from nautilus_trader.core.nautilus_pyo3 import ParquetDataCatalogV2
+    from nautilus_trader.core.nautilus_pyo3.model import CustomData
+    from nautilus_trader.core.nautilus_pyo3.model import DataType
+    from nautilus_trader.core.nautilus_pyo3.model import custom_data_backend_kind
+    from nautilus_trader.core.nautilus_pyo3.model import register_custom_data_class
+    from nautilus_trader.model.custom import customdataclass_pyo3
+
+    @customdataclass_pyo3()
+    class JsonBlobPython:
+        name: str = ""
+        payload: dict[str, object] = field(default_factory=dict)
+
+    register_custom_data_class(JsonBlobPython)
+    catalog_path = tmp_path / "catalog_python_dict"
+    catalog_path.mkdir(parents=True, exist_ok=True)
+    pyo3_catalog = ParquetDataCatalogV2(str(catalog_path))
+
+    metadata = {"source": "python", "format": "json-dict"}
+    identifier = "PYTHON-DICT"
+    data_type = DataType("JsonBlobPython", metadata, identifier)
+    original_payloads = [
+        {"symbol": "AAPL", "nested": {"count": 2, "enabled": True}},
+        {"symbol": "MSFT", "values": [1, 2, 3], "ratio": 1.25},
+    ]
+    original_data = [
+        JsonBlobPython(1, 1, "first", original_payloads[0]),
+        JsonBlobPython(2, 2, "second", original_payloads[1]),
+    ]
+    wrapped = [CustomData(data_type, item) for item in original_data]
+
+    assert JsonBlobPython._schema.field("payload").type == pa.string()
+    assert [custom_data_backend_kind(item) for item in wrapped] == ["python", "python"]
+
+    arrow_row = original_data[0].to_arrow().to_pylist()[0]
+    assert arrow_row["payload"] == json_module.dumps(original_payloads[0], sort_keys=True)
+
+    pyo3_catalog.write_custom_data(wrapped)
+    result = pyo3_catalog.query(
+        "JsonBlobPython",
+        None,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+
+    roundtripped = []
+    for item in result:
+        assert isinstance(item, CustomData), f"Expected CustomData, found {type(item)}"
+        assert custom_data_backend_kind(item) == "python"
+        inner = item.data
+        assert isinstance(inner, JsonBlobPython), (
+            f"Expected JsonBlobPython in .data, found {type(inner)}"
+        )
+        assert isinstance(inner.payload, dict)
+        roundtripped.append(inner)
+
+    assert len(roundtripped) == len(original_data)
+
+    for item in result:
+        assert item.data_type.type_name == "JsonBlobPython"
+        assert item.data_type.metadata == metadata
+        assert item.data_type.identifier == identifier
+
+    for expected, expected_payload, actual in zip(
+        original_data,
+        original_payloads,
+        roundtripped,
+        strict=True,
+    ):
+        assert expected.name == actual.name
+        assert actual.payload == expected_payload
+        assert expected.ts_event == actual.ts_event
+        assert expected.ts_init == actual.ts_init
+
+    def assert_json_blob(orig, rt):
+        assert orig.name == rt.name
+        assert rt.payload == orig.payload
+        assert orig.ts_event == rt.ts_event
+        assert orig.ts_init == rt.ts_init
+
+    _assert_custom_data_json_roundtrip(result, JsonBlobPython, assert_json_blob)
 
 
 def test_python_custom_data_equality_by_identity():


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Added `Params` support to the Rust `#[custom_data]` proc macro so macro-backed custom data can persist generic key-value payloads without manual wrappers.
- Added Python `dict` support to `@customdataclass` and `@customdataclass_pyo3`, using JSON-backed Arrow `string` columns so the existing custom-data persistence paths can roundtrip structured payloads.
- Added Rust, Python PyO3, and plain Python `@customdataclass` regression tests to cover schema generation, Arrow encoding and decoding, catalog roundtrips, and JSON serialization.

## What changed

- Updated [`crates/persistence/macros/src/custom.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/custom.rs) so `Params` is treated as a supported field type in the Rust custom-data macro.
- Encoded Rust `Params` fields as Arrow `Utf8` JSON during macro-generated batch encoding, and decoded them back into `nautilus_core::Params` during batch decoding in [`crates/persistence/macros/src/custom.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/custom.rs).
- Extended the generated PyO3 constructor and getter logic in [`crates/persistence/macros/src/custom.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/custom.rs) so Python callers pass and receive `dict` values for Rust `Params` fields.
- Updated the macro documentation in [`crates/persistence/macros/src/lib.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/macros/src/lib.rs) to include `Params` in the supported field type list.
- Added the `RustTestParamsCustomData` fixture in [`crates/persistence/src/test_data.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/src/test_data.rs) and registered it in the PyO3 persistence module in [`crates/persistence/src/python/mod.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/src/python/mod.rs).
- Added a Rust catalog roundtrip regression test in [`crates/persistence/tests/test_catalog.rs`](/Users/ata/Developer/nautilus/nautilus_trader/crates/persistence/tests/test_catalog.rs) covering nested and mixed JSON values inside `Params`.
- Refactored [`nautilus_trader/model/custom.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/model/custom.py) to resolve annotations centrally, recognize `dict` and `dict[...]` fields, map them to Arrow `string`, and serialize and deserialize them with `json.dumps(...)` and `json.loads(...)` on the Arrow and catalog paths.
- Kept `to_dict()` behavior unchanged in [`nautilus_trader/model/custom.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/model/custom.py) so Python callers still see native `dict` payloads instead of JSON text outside the persistence boundary.
- Added a Python PyO3 roundtrip regression test in [`tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py) for both Rust `Params` interop and Python-only `customdataclass_pyo3` dict payloads.
- Added a plain `@customdataclass` regression test in [`tests/unit_tests/model/test_custom_data.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/unit_tests/model/test_custom_data.py) to verify the current Cython-era path stores dict payloads as JSON in Arrow while restoring them as native Python `dict` values on decode.

## Design decisions

- Represented both Rust `Params` and Python `dict` payloads as Arrow `Utf8` JSON rather than introducing Arrow map schemas, because the existing custom-data infrastructure already serializes through JSON-friendly structures and the string representation keeps the integration small and compatible with the current decode path.
- Kept the Python support focused on the persistence boundary in [`nautilus_trader/model/custom.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/model/custom.py), so application-facing `to_dict()` and object attributes continue to expose native Python values instead of transport-specific JSON strings.
- Reused the existing persistence and model test modules instead of adding standalone test files, which keeps the new coverage aligned with the current Rust, PyO3, and plain Python custom-data workflows.

## Validation

- Ran `cargo test -p nautilus-persistence test_rust_test_params_custom_data_schema_uses_utf8_for_params --lib`.
- Ran `cargo test -p nautilus-persistence test_rust_custom_data_roundtrip_with_params_field --test test_catalog`.
- Ran `cargo check -p nautilus-persistence --features python`.
- Ran `uv run --no-sync pytest tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py`.
- Ran `uv run --no-sync pytest tests/unit_tests/model/test_custom_data.py tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py`.
- Ran `make cargo-test-core-local`.
- Ran `make build-debug`.
- Ran `make pytest`.
- Ran `make format`.
- Ran `make pre-commit`.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
