### PR TITLE
Fix parsing of IB trailing stop order

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -468,6 +468,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             order_type = mapped_order_type_info
             time_in_force = ib_to_nautilus_time_in_force[ib_order.tif]
 
+        trigger_price, limit_offset, trailing_offset, trailing_offset_type = (
+            self._parse_ib_order_pricing_fields(
+                instrument=instrument,
+                ib_order=ib_order,
+                order_type=order_type,
+                price_magnifier=price_magnifier,
+            )
+        )
+
         order_status = OrderStatusReport(
             account_id=self.account_id,
             instrument_id=instrument.id,
@@ -488,16 +497,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             # contingency_type=,
             expire_time=expire_time,
             price=price,
-            trigger_price=(
-                instrument.make_price(
-                    ib_price_to_nautilus_price(ib_order.auxPrice, price_magnifier),
-                )
-                if ib_order.auxPrice != UNSET_DOUBLE
-                else None
-            ),
+            trigger_price=trigger_price,
             trigger_type=TriggerType.BID_ASK,
-            # limit_offset=,
-            # trailing_offset=,
+            limit_offset=limit_offset,
+            trailing_offset=trailing_offset,
+            trailing_offset_type=trailing_offset_type,
         )
         self._log.debug(f"Received {order_status!r}")
 
@@ -1552,14 +1556,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 converted_price = ib_price_to_nautilus_price(order.lmtPrice, price_magnifier)
                 price = instrument.make_price(converted_price)
 
-            trigger_price = None
-
-            if order.auxPrice != UNSET_DOUBLE:
-                converted_trigger_price = ib_price_to_nautilus_price(
-                    order.auxPrice,
-                    price_magnifier,
-                )
-                trigger_price = instrument.make_price(converted_trigger_price)
+            trigger_price, _, _, _ = self._parse_ib_order_pricing_fields(
+                instrument=instrument,
+                ib_order=order,
+                order_type=nautilus_order.order_type,
+                price_magnifier=price_magnifier,
+            )
 
             venue_order_id_modified = bool(
                 nautilus_order.venue_order_id is None
@@ -1583,6 +1585,56 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 order=nautilus_order,
                 ib_order=order,
             )
+
+    def _parse_ib_order_pricing_fields(
+        self,
+        instrument: Instrument,
+        ib_order: IBOrder,
+        order_type: OrderType,
+        price_magnifier: int,
+    ) -> tuple[
+        Price | None,
+        Decimal | None,
+        Decimal | None,
+        TrailingOffsetType | None,
+    ]:
+        trigger_price = None
+        limit_offset = None
+        trailing_offset = None
+        trailing_offset_type = None
+
+        if order_type in (OrderType.TRAILING_STOP_MARKET, OrderType.TRAILING_STOP_LIMIT):
+            if ib_order.trailStopPrice != UNSET_DOUBLE:
+                converted_trigger_price = ib_price_to_nautilus_price(
+                    ib_order.trailStopPrice,
+                    price_magnifier,
+                )
+                trigger_price = instrument.make_price(converted_trigger_price)
+
+            if ib_order.auxPrice != UNSET_DOUBLE:
+                trailing_offset = Decimal(str(ib_order.auxPrice))
+                trailing_offset_type = TrailingOffsetType.PRICE
+            elif getattr(ib_order, "trailingPercent", UNSET_DOUBLE) != UNSET_DOUBLE:
+                trailing_offset = Decimal(str(ib_order.trailingPercent)) * 100
+                trailing_offset_type = TrailingOffsetType.BASIS_POINTS
+
+            if (
+                order_type == OrderType.TRAILING_STOP_LIMIT
+                and ib_order.lmtPriceOffset != UNSET_DOUBLE
+            ):
+                limit_offset = Decimal(str(ib_order.lmtPriceOffset))
+                trailing_offset_type = trailing_offset_type or TrailingOffsetType.PRICE
+
+            return trigger_price, limit_offset, trailing_offset, trailing_offset_type
+
+        if ib_order.auxPrice != UNSET_DOUBLE:
+            converted_trigger_price = ib_price_to_nautilus_price(
+                ib_order.auxPrice,
+                price_magnifier,
+            )
+            trigger_price = instrument.make_price(converted_trigger_price)
+
+        return trigger_price, limit_offset, trailing_offset, trailing_offset_type
 
     def _on_order_status(  # noqa: C901 (complexity unavoidable due to IB status handling)
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
@@ -14,18 +14,23 @@
 # -------------------------------------------------------------------------------------------------
 
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from ibapi.const import UNSET_DOUBLE
 
 from nautilus_trader.adapters.interactive_brokers.client.common import IBPosition
 from nautilus_trader.core.uuid import UUID4
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
 from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import OrderType
 from nautilus_trader.model.enums import PositionSide
 from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.enums import TrailingOffsetType
 from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
@@ -39,6 +44,7 @@ from nautilus_trader.model.objects import Quantity
 from nautilus_trader.model.orders import MarketOrder
 from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
+from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestExecStubs
 
 
 def instrument_setup(exec_client, cache, instrument=None, contract_details=None):
@@ -123,6 +129,208 @@ async def test_generate_position_status_reports_flat_when_no_positions(exec_clie
     assert reports[0].position_side == PositionSide.FLAT
     assert reports[0].quantity.as_decimal() == Decimal(0)
     assert reports[0].instrument_id == instrument.id
+
+
+@pytest.mark.asyncio
+async def test_generate_order_status_reports_parses_trailing_stop_market_fields(
+    exec_client,
+    cache,
+):
+    """
+    Test that trailing stop reconciliation preserves the trailing offset fields.
+
+    Verifies fix for IB live restart reconciliation where open TRAIL orders crashed
+    during unpacking because the OrderStatusReport omitted trailing_offset.
+
+    """
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    instrument_setup(exec_client, cache, instrument=instrument)
+
+    ib_order = IBTestExecStubs.aapl_buy_ib_order(total_quantity="5")
+    ib_order.contract = IBTestContractStubs.aapl_equity_ib_contract()
+    ib_order.orderType = "TRAIL"
+    ib_order.tif = "GTC"
+    ib_order.lmtPrice = UNSET_DOUBLE
+    ib_order.auxPrice = 2.5
+    ib_order.trailStopPrice = 185.5
+    ib_order.filledQuantity = Decimal(0)
+    ib_order.order_state = SimpleNamespace(status="Submitted")
+
+    exec_client._client.get_open_orders = AsyncMock(return_value=[ib_order])
+
+    command = GenerateOrderStatusReports(
+        instrument_id=None,
+        start=None,
+        end=None,
+        open_only=True,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+
+    # Act
+    reports = await exec_client.generate_order_status_reports(command)
+
+    # Assert
+    assert len(reports) == 1
+    assert reports[0].order_type == OrderType.TRAILING_STOP_MARKET
+    assert reports[0].quantity.as_decimal() == Decimal(5)
+    assert reports[0].price is None
+    assert reports[0].trigger_price == Price.from_str("185.50")
+    assert reports[0].trailing_offset == Decimal("2.5")
+    assert reports[0].trailing_offset_type == TrailingOffsetType.PRICE
+    assert reports[0].limit_offset is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "ib_order_type",
+        "lmt_price",
+        "aux_price",
+        "trail_stop_price",
+        "lmt_price_offset",
+        "expected_order_type",
+        "expected_price",
+        "expected_trigger_price",
+        "expected_limit_offset",
+        "expected_trailing_offset",
+        "expected_trailing_offset_type",
+    ),
+    [
+        (
+            "MKT",
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.MARKET,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "LMT",
+            185.5,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.LIMIT,
+            Price.from_str("185.50"),
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "MIT",
+            UNSET_DOUBLE,
+            180.25,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.MARKET_IF_TOUCHED,
+            None,
+            Price.from_str("180.25"),
+            None,
+            None,
+            None,
+        ),
+        (
+            "LIT",
+            179.5,
+            180.25,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.LIMIT_IF_TOUCHED,
+            Price.from_str("179.50"),
+            Price.from_str("180.25"),
+            None,
+            None,
+            None,
+        ),
+        (
+            "STP",
+            UNSET_DOUBLE,
+            180.25,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.STOP_MARKET,
+            None,
+            Price.from_str("180.25"),
+            None,
+            None,
+            None,
+        ),
+        (
+            "STP LMT",
+            179.5,
+            180.25,
+            UNSET_DOUBLE,
+            UNSET_DOUBLE,
+            OrderType.STOP_LIMIT,
+            Price.from_str("179.50"),
+            Price.from_str("180.25"),
+            None,
+            None,
+            None,
+        ),
+        (
+            "TRAIL LIMIT",
+            UNSET_DOUBLE,
+            2.5,
+            185.5,
+            0.25,
+            OrderType.TRAILING_STOP_LIMIT,
+            None,
+            Price.from_str("185.50"),
+            Decimal("0.25"),
+            Decimal("2.5"),
+            TrailingOffsetType.PRICE,
+        ),
+    ],
+)
+async def test_parse_ib_order_to_order_status_report_maps_pricing_fields_by_order_type(
+    exec_client,
+    cache,
+    ib_order_type,
+    lmt_price,
+    aux_price,
+    trail_stop_price,
+    lmt_price_offset,
+    expected_order_type,
+    expected_price,
+    expected_trigger_price,
+    expected_limit_offset,
+    expected_trailing_offset,
+    expected_trailing_offset_type,
+):
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    instrument_setup(exec_client, cache, instrument=instrument)
+
+    ib_order = IBTestExecStubs.aapl_buy_ib_order(total_quantity="5")
+    ib_order.contract = IBTestContractStubs.aapl_equity_ib_contract()
+    ib_order.orderType = ib_order_type
+    ib_order.tif = "GTC"
+    ib_order.lmtPrice = lmt_price
+    ib_order.auxPrice = aux_price
+    ib_order.trailStopPrice = trail_stop_price
+    ib_order.lmtPriceOffset = lmt_price_offset
+    ib_order.filledQuantity = Decimal(0)
+    ib_order.order_state = SimpleNamespace(status="Submitted")
+
+    # Act
+    report = await exec_client._parse_ib_order_to_order_status_report(ib_order)
+
+    # Assert
+    assert report.order_type == expected_order_type
+    assert report.price == expected_price
+    assert report.trigger_price == expected_trigger_price
+    assert report.limit_offset == expected_limit_offset
+    assert report.trailing_offset == expected_trailing_offset
+    assert report.trailing_offset_type == expected_trailing_offset_type
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixed Interactive Brokers live reconciliation for open trailing stop orders by restoring the missing trailing fields in `OrderStatusReport`.
- Corrected IB pricing field parsing so trailing orders no longer treat `auxPrice` as a normal stop trigger during reconciliation and open-order updates.
- Added regression coverage for the IB order-type pricing mappings used by reconciliation, including `MKT`, `LMT`, `MIT`, `LIT`, `STP`, `STP LMT`, `TRAIL`, and `TRAIL LIMIT`.

## What changed

- Updated [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) so `_parse_ib_order_to_order_status_report()` delegates trigger, trailing, and limit-offset extraction to a shared helper before building the `OrderStatusReport`.
- Added `_parse_ib_order_pricing_fields(...)` in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) to parse IB fields by Nautilus order type instead of applying one generic `auxPrice` rule to every order.
- Mapped IB trailing orders in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) as follows: `trailStopPrice` to `trigger_price`, `auxPrice` to `trailing_offset`, and `lmtPriceOffset` to `limit_offset` for trailing-stop-limit orders.
- Preserved the existing non-trailing behavior in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) so `MIT`, `LIT`, `STP`, and `STP LMT` still interpret `auxPrice` as the trigger price.
- Reused the same pricing helper in `_on_open_order(...)` in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) so accepted open-order updates no longer misread trailing order fields after reconnects.
- Added a trailing-stop reconciliation regression test in [`tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py) that reproduces the live restart case for an open IB `TRAIL` order.
- Added a parameterized pricing-field matrix in [`tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py) to verify the reconciliation parser across the supported IB order types listed in [Summary](#summary).

## Design decisions

- Centralized IB price-field parsing in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py) so reconciliation and open-order event handling use one consistent interpretation of IB order fields.
- Kept the fix in Python adapter code rather than changing order reconstruction or Cython model behavior, because the root cause was an incomplete `OrderStatusReport` emitted by the IB adapter.
- Left non-trailing order mappings unchanged and added order-type coverage in [`tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py`](/Users/ata/Developer/nautilus/nautilus_trader/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py) to reduce the risk of a trailing-order fix regressing stop or touched-order reconciliation.
- Preserved IB trailing support as price-based in the adapter path, which matches the existing submit-side behavior already enforced in [`nautilus_trader/adapters/interactive_brokers/execution.py`](/Users/ata/Developer/nautilus/nautilus_trader/nautilus_trader/adapters/interactive_brokers/execution.py).

## Validation

- Ran `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py`.
- Ran `uv run --no-sync ruff check nautilus_trader/adapters/interactive_brokers/execution.py tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py`.
- Verified the targeted Interactive Brokers reconciliation suite passed with `16 passed`.
- Did not run the full project validation sequence (`make cargo-test-core-local`, `make build-debug`, `make pytest`, `make format`, `make pre-commit`).


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
