### PR TITLE
Add Hyperliquid product type config for live clients

### DIFF
--- a/docs/integrations/hyperliquid.md
+++ b/docs/integrations/hyperliquid.md
@@ -183,8 +183,10 @@ allows qualified deployers to launch permissionless perp dexes on Hyperliquid. T
 include equities (TSLA, NVDA, AAPL), commodities (gold, crude oil), indices (S&P 500), and
 pre-IPO tokens (SpaceX, OpenAI).
 
-HIP-3 instruments are excluded by default. To load them, construct the instrument
-provider directly with `PERP_HIP3` in the product types:
+HIP-3 instruments are excluded by default. To load them, include
+`HyperliquidProductType.PERP_HIP3` in the requested product types.
+
+For direct instrument provider usage:
 
 ```python
 from nautilus_trader.adapters.hyperliquid.enums import HyperliquidProductType
@@ -200,11 +202,28 @@ provider = HyperliquidInstrumentProvider(
 )
 ```
 
-:::note
-The default `TradingNodeConfig` factory path does not pass `product_types` to the
-provider. To include HIP-3 instruments through a trading node, construct the provider
-directly and pass it to the client factory.
-:::
+For live `TradingNode` usage, pass the same `product_types` through the Hyperliquid
+client config:
+
+```python
+from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidProductType
+
+HyperliquidDataClientConfig(
+    product_types=(
+        HyperliquidProductType.PERP,
+        HyperliquidProductType.PERP_HIP3,
+    ),
+)
+
+HyperliquidExecClientConfig(
+    product_types=(
+        HyperliquidProductType.PERP,
+        HyperliquidProductType.PERP_HIP3,
+    ),
+)
+```
 
 Once HIP-3 instruments are loaded, you can filter them with `InstrumentProviderConfig`:
 
@@ -490,6 +509,7 @@ backoff (full jitter) on rate limit (429) and server error (5xx) responses.
 |---------------------|---------|-------------------------------------------------|
 | `base_url_ws`       | `None`  | Override for the WebSocket base URL.            |
 | `testnet`           | `False` | Connect to the Hyperliquid testnet when `True`. |
+| `product_types`     | `None`  | Optional product types to load, for example `PERP_HIP3` for HIP-3 perps. |
 | `http_timeout_secs` | `10`    | Timeout (seconds) applied to REST calls.        |
 | `http_proxy_url`    | `None`  | Optional HTTP proxy URL.                        |
 | `ws_proxy_url`      | `None`  | Reserved; WebSocket proxy not yet implemented.  |
@@ -503,6 +523,7 @@ backoff (full jitter) on rate limit (429) and server error (5xx) responses.
 | `account_address`        | `None`  | Main account address for agent wallet trading; loaded from `HYPERLIQUID_ACCOUNT_ADDRESS`. |
 | `base_url_ws`            | `None`  | Override for the WebSocket base URL.                                                      |
 | `testnet`                | `False` | Connect to the Hyperliquid testnet when `True`.                                           |
+| `product_types`          | `None`  | Optional product types to load, for example `PERP_HIP3` for HIP-3 perps.                  |
 | `max_retries`            | `None`  | Maximum retry attempts for submit, cancel, or modify order requests.                      |
 | `retry_delay_initial_ms` | `None`  | Initial delay (milliseconds) between retries.                                             |
 | `retry_delay_max_ms`     | `None`  | Maximum delay (milliseconds) between retries.                                             |
@@ -517,6 +538,7 @@ backoff (full jitter) on rate limit (429) and server error (5xx) responses.
 from nautilus_trader.adapters.hyperliquid import HYPERLIQUID
 from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
 from nautilus_trader.adapters.hyperliquid import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidProductType
 from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.config import TradingNodeConfig
 
@@ -524,6 +546,10 @@ config = TradingNodeConfig(
     data_clients={
         HYPERLIQUID: HyperliquidDataClientConfig(
             instrument_provider=InstrumentProviderConfig(load_all=True),
+            product_types=(
+                HyperliquidProductType.PERP,
+                HyperliquidProductType.PERP_HIP3,
+            ),
             testnet=True,  # Use testnet
         ),
     },
@@ -532,6 +558,10 @@ config = TradingNodeConfig(
             private_key=None,  # Loads from HYPERLIQUID_TESTNET_PK env var
             vault_address=None,  # Optional: loads from HYPERLIQUID_TESTNET_VAULT
             instrument_provider=InstrumentProviderConfig(load_all=True),
+            product_types=(
+                HyperliquidProductType.PERP,
+                HyperliquidProductType.PERP_HIP3,
+            ),
             testnet=True,  # Use testnet
             normalize_prices=True,  # Rounds prices to 5 significant figures
         ),

--- a/nautilus_trader/adapters/hyperliquid/config.py
+++ b/nautilus_trader/adapters/hyperliquid/config.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from nautilus_trader.adapters.hyperliquid.enums import HyperliquidProductType
 from nautilus_trader.common.config import PositiveInt
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
@@ -36,6 +37,9 @@ class HyperliquidDataClientConfig(LiveDataClientConfig, frozen=True):
         for future functionality. Use `http_proxy_url` for REST API proxy support.
     testnet : bool, default False
         If the client is connecting to the Hyperliquid testnet API.
+    product_types : tuple[HyperliquidProductType, ...], optional
+        The Hyperliquid product types to load for the client instrument provider.
+        If ``None`` then the instrument provider defaults are used.
     http_timeout_secs : PositiveInt, default 10
         The timeout (seconds) for HTTP requests.
 
@@ -45,6 +49,7 @@ class HyperliquidDataClientConfig(LiveDataClientConfig, frozen=True):
     http_proxy_url: str | None = None
     ws_proxy_url: str | None = None
     testnet: bool = False
+    product_types: tuple[HyperliquidProductType, ...] | None = None
     http_timeout_secs: PositiveInt = 10
 
 
@@ -78,6 +83,9 @@ class HyperliquidExecClientConfig(LiveExecClientConfig, frozen=True):
         for future functionality. Use `http_proxy_url` for REST API proxy support.
     testnet : bool, default False
         If the client is connecting to the Hyperliquid testnet API.
+    product_types : tuple[HyperliquidProductType, ...], optional
+        The Hyperliquid product types to load for the client instrument provider.
+        If ``None`` then the instrument provider defaults are used.
     max_retries : PositiveInt, optional
         The maximum number of times a submit, cancel or modify order request will be retried.
     retry_delay_initial_ms : PositiveInt, optional
@@ -106,6 +114,7 @@ class HyperliquidExecClientConfig(LiveExecClientConfig, frozen=True):
     http_proxy_url: str | None = None
     ws_proxy_url: str | None = None
     testnet: bool = False
+    product_types: tuple[HyperliquidProductType, ...] | None = None
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None
     retry_delay_max_ms: PositiveInt | None = None

--- a/nautilus_trader/adapters/hyperliquid/factories.py
+++ b/nautilus_trader/adapters/hyperliquid/factories.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import asyncio
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 from nautilus_trader.adapters.hyperliquid.config import HyperliquidDataClientConfig
 from nautilus_trader.adapters.hyperliquid.config import HyperliquidExecClientConfig
 from nautilus_trader.adapters.hyperliquid.data import HyperliquidDataClient
+from nautilus_trader.adapters.hyperliquid.enums import HyperliquidProductType
 from nautilus_trader.adapters.hyperliquid.execution import HyperliquidExecutionClient
 from nautilus_trader.adapters.hyperliquid.providers import HyperliquidInstrumentProvider
 from nautilus_trader.cache.cache import Cache
@@ -30,6 +32,10 @@ from nautilus_trader.config import InstrumentProviderConfig
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.live.factories import LiveDataClientFactory
 from nautilus_trader.live.factories import LiveExecClientFactory
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @lru_cache(1)
@@ -96,6 +102,7 @@ def get_cached_hyperliquid_http_client(
 def get_cached_hyperliquid_instrument_provider(
     client: nautilus_pyo3.HyperliquidHttpClient,
     config: InstrumentProviderConfig | None = None,
+    product_types: tuple[HyperliquidProductType, ...] | None = None,
 ) -> HyperliquidInstrumentProvider:
     """
     Cache and return a Hyperliquid instrument provider.
@@ -108,6 +115,8 @@ def get_cached_hyperliquid_instrument_provider(
         The Hyperliquid HTTP client.
     config : InstrumentProviderConfig, optional
         The instrument provider configuration, by default None.
+    product_types : tuple[HyperliquidProductType, ...], optional
+        The Hyperliquid product types to enable for the provider.
 
     Returns
     -------
@@ -117,7 +126,17 @@ def get_cached_hyperliquid_instrument_provider(
     return HyperliquidInstrumentProvider(
         client=client,
         config=config,
+        product_types=product_types,
     )
+
+
+def _resolve_product_types(
+    product_types: Iterable[HyperliquidProductType] | None,
+) -> tuple[HyperliquidProductType, ...] | None:
+    if product_types is None:
+        return None
+
+    return tuple(HyperliquidProductType(pt) for pt in product_types)
 
 
 class HyperliquidLiveDataClientFactory(LiveDataClientFactory):
@@ -165,6 +184,7 @@ class HyperliquidLiveDataClientFactory(LiveDataClientFactory):
         provider = get_cached_hyperliquid_instrument_provider(
             client=client,
             config=config.instrument_provider,
+            product_types=_resolve_product_types(config.product_types),
         )
         return HyperliquidDataClient(
             loop=loop,
@@ -227,6 +247,7 @@ class HyperliquidLiveExecClientFactory(LiveExecClientFactory):
         provider = get_cached_hyperliquid_instrument_provider(
             client=client,
             config=config.instrument_provider,
+            product_types=_resolve_product_types(config.product_types),
         )
         return HyperliquidExecutionClient(
             loop=loop,

--- a/tests/integration_tests/adapters/hyperliquid/test_factories.py
+++ b/tests/integration_tests/adapters/hyperliquid/test_factories.py
@@ -17,6 +17,7 @@ import pytest
 
 from nautilus_trader.adapters.hyperliquid.config import HyperliquidDataClientConfig
 from nautilus_trader.adapters.hyperliquid.config import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid.enums import HyperliquidProductType
 
 
 class TestHyperliquidDataClientConfig:
@@ -60,6 +61,21 @@ class TestHyperliquidDataClientConfig:
 
         # Assert
         assert config.http_proxy_url == "http://proxy:8080"
+
+    def test_with_product_types(self):
+        # Arrange & Act
+        config = HyperliquidDataClientConfig(
+            product_types=(
+                HyperliquidProductType.PERP,
+                HyperliquidProductType.PERP_HIP3,
+            ),
+        )
+
+        # Assert
+        assert config.product_types == (
+            HyperliquidProductType.PERP,
+            HyperliquidProductType.PERP_HIP3,
+        )
 
 
 class TestHyperliquidExecClientConfig:
@@ -135,6 +151,21 @@ class TestHyperliquidExecClientConfig:
 
         # Assert
         assert config.base_url_ws == "wss://custom.ws.com"
+
+    def test_with_product_types(self):
+        # Arrange & Act
+        config = HyperliquidExecClientConfig(
+            product_types=(
+                HyperliquidProductType.PERP,
+                HyperliquidProductType.PERP_HIP3,
+            ),
+        )
+
+        # Assert
+        assert config.product_types == (
+            HyperliquidProductType.PERP,
+            HyperliquidProductType.PERP_HIP3,
+        )
 
 
 class TestConfigValidation:


### PR DESCRIPTION
## Summary
- add `product_types` to Hyperliquid live data and exec client configs
- thread configured product types through the live client factories into the
  instrument provider
- document how to enable HIP-3 products in live `TradingNode` configs

## Why
HIP-3 instruments can be discovered through the provider, but live
  Hyperliquid clients need an explicit way to request `PERP_HIP3` when loading instruments through the factory/config path.

## Testing
- updated Hyperliquid factory
  config tests
- updated Hyperliquid integration docs for HIP-3 live client configuration