### PR TITLE
Fix Polymarket ts_init timestamps on reports and reconciliation

### DIFF
--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -253,7 +253,7 @@ pub(crate) async fn generate_mass_status(
     venue: Venue,
     lookback_mins: Option<u64>,
 ) -> anyhow::Result<Option<ExecutionMassStatus>> {
-    let ts_init = UnixNanos::default();
+    let ts_init = ctx.clock.get_time_ns();
 
     // Fetch orders
     let orders = http_client

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -102,7 +102,9 @@ fn dispatch_order_update(order: &PolymarketUserOrder, ctx: &WsDispatchContext<'_
     let ts_event = parse_timestamp_ms(&order.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
     let venue_order_id = VenueOrderId::from(order.id.as_str());
 
-    let mut report = build_ws_order_status_report(order, &instrument, ctx.account_id, ts_event);
+    let ts_init = ctx.clock.get_time_ns();
+    let mut report =
+        build_ws_order_status_report(order, &instrument, ctx.account_id, ts_event, ts_init);
     let is_accepted = ctx.fill_tracker.contains(&venue_order_id);
 
     // Order updates can race ahead of trade messages, so cap filled_qty
@@ -190,11 +192,12 @@ fn dispatch_trade_update(
     let is_maker = trade.trader_side == PolymarketLiquiditySide::Maker;
     let liquidity_side = parse_liquidity_side(trade.trader_side);
     let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
+    let ts_init = ctx.clock.get_time_ns();
 
     if is_maker {
-        dispatch_maker_fills(trade, ctx, liquidity_side, ts_event);
+        dispatch_maker_fills(trade, ctx, liquidity_side, ts_event, ts_init);
     } else {
-        dispatch_taker_fill(trade, ctx, liquidity_side, ts_event);
+        dispatch_taker_fill(trade, ctx, liquidity_side, ts_event, ts_init);
     }
 
     if needs_refresh {
@@ -209,6 +212,7 @@ fn dispatch_maker_fills(
     ctx: &WsDispatchContext<'_>,
     liquidity_side: LiquiditySide,
     ts_event: UnixNanos,
+    ts_init: UnixNanos,
 ) {
     let user_orders: Vec<_> = trade
         .maker_orders
@@ -243,7 +247,7 @@ fn dispatch_maker_fills(
             crate::execution::get_usdc_currency(),
             liquidity_side,
             ts_event,
-            ts_event,
+            ts_init,
         );
         let maker_venue_order_id = report.venue_order_id;
         report.last_qty = ctx
@@ -275,6 +279,7 @@ fn dispatch_taker_fill(
     ctx: &WsDispatchContext<'_>,
     liquidity_side: LiquiditySide,
     ts_event: UnixNanos,
+    ts_init: UnixNanos,
 ) {
     let instrument = match ctx.token_instruments.get_cloned(&trade.asset_id) {
         Some(i) => i,
@@ -286,8 +291,14 @@ fn dispatch_taker_fill(
 
     let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
 
-    let mut report =
-        build_ws_taker_fill_report(trade, &instrument, ctx.account_id, liquidity_side, ts_event);
+    let mut report = build_ws_taker_fill_report(
+        trade,
+        &instrument,
+        ctx.account_id,
+        liquidity_side,
+        ts_event,
+        ts_init,
+    );
     report.last_qty = ctx
         .fill_tracker
         .snap_fill_qty(&venue_order_id, report.last_qty);
@@ -317,6 +328,7 @@ fn build_ws_order_status_report(
     instrument: &InstrumentAny,
     account_id: AccountId,
     ts_event: UnixNanos,
+    ts_init: UnixNanos,
 ) -> OrderStatusReport {
     let venue_order_id = VenueOrderId::from(order.id.as_str());
     let order_status =
@@ -349,7 +361,7 @@ fn build_ws_order_status_report(
         filled_qty,
         ts_event,
         ts_event,
-        ts_event,
+        ts_init,
         None,
     );
     report.price = Some(price);
@@ -362,6 +374,7 @@ fn build_ws_taker_fill_report(
     account_id: AccountId,
     liquidity_side: LiquiditySide,
     ts_event: UnixNanos,
+    ts_init: UnixNanos,
 ) -> FillReport {
     let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
     let trade_id = make_composite_trade_id(&trade.id, &trade.taker_order_id);
@@ -399,7 +412,7 @@ fn build_ws_taker_fill_report(
         liquidity_side,
         report_id: UUID4::new(),
         ts_event,
-        ts_init: ts_event,
+        ts_init,
         client_order_id: None,
         venue_position_id: None,
     }
@@ -486,17 +499,21 @@ mod tests {
         let order: PolymarketUserOrder = load("ws_user_order_placement.json");
         let instrument = test_instrument();
         let ts_event = UnixNanos::from(1_000_000_000u64);
+        let ts_init = UnixNanos::from(2_000_000_000u64);
 
         let report = build_ws_order_status_report(
             &order,
             &instrument,
             AccountId::from("POLY-001"),
             ts_event,
+            ts_init,
         );
 
         assert_eq!(report.order_side, OrderSide::Buy);
         assert_eq!(report.order_type, OrderType::Limit);
         assert!(report.price.is_some());
+        assert_eq!(report.ts_accepted, ts_event);
+        assert_eq!(report.ts_init, ts_init);
     }
 
     #[rstest]
@@ -504,12 +521,14 @@ mod tests {
         let order: PolymarketUserOrder = load("ws_user_order_venue_cancel.json");
         let instrument = test_instrument();
         let ts_event = UnixNanos::from(1_000_000_000u64);
+        let ts_init = UnixNanos::from(2_000_000_000u64);
 
         let report = build_ws_order_status_report(
             &order,
             &instrument,
             AccountId::from("POLY-001"),
             ts_event,
+            ts_init,
         );
 
         assert_eq!(report.order_status, OrderStatus::Canceled);
@@ -520,6 +539,7 @@ mod tests {
         let trade: PolymarketUserTrade = load("ws_user_trade.json");
         let instrument = test_instrument();
         let ts_event = UnixNanos::from(1_000_000_000u64);
+        let ts_init = UnixNanos::from(2_000_000_000u64);
 
         let report = build_ws_taker_fill_report(
             &trade,
@@ -527,11 +547,13 @@ mod tests {
             AccountId::from("POLY-001"),
             LiquiditySide::Taker,
             ts_event,
+            ts_init,
         );
 
         assert_eq!(report.order_side, OrderSide::Buy);
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.ts_event, ts_event);
+        assert_eq!(report.ts_init, ts_init);
     }
 
     #[rstest]


### PR DESCRIPTION
WebSocket order and fill report builders were using the exchange event timestamp for both ts_event and ts_init. Now ts_event is the exchange timestamp (when the event occurred on venue) and ts_init is the local clock time (when our system received the message).

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The Polymarket adapter was incorrectly setting `ts_init` (initialization/processing timestamp) equal to `ts_event` (exchange event timestamp) on all WebSocket execution reports, and using `UnixNanos::default()` (epoch zero) during HTTP reconciliation. This made Polymarket the only adapter that didn't follow the established NautilusTrader convention for timestamp semantics.

### Background

NautilusTrader execution reports carry two timestamps with distinct semantics:
- **`ts_event`** — when the event occurred at the exchange (parsed from venue message)
- **`ts_init`** — when the local system processed/received the event (`clock.get_time_ns()`)

A cross-adapter audit confirmed that **Bybit, OKX, Deribit, Hyperliquid, and dYdX** all correctly separate these two values. Polymarket was the outlier — it collapsed both to the venue timestamp on `OrderStatusReport`, `FillReport` (taker), and `FillReport` (maker) in the WebSocket dispatch layer.

While the downstream `ExecutionEventEmitter` overwrites `ts_init` when converting reports to final events (so the bug was effectively masked at the event level), correct report-level timestamps are important for:
- Accurate latency measurement between exchange event and local processing
- Consistent debugging/logging across all adapters
- Correct behavior if reports are ever consumed directly without the emitter layer

### Changes

- **`dispatch.rs`** — Capture `let ts_init = ctx.clock.get_time_ns()` in `dispatch_order_update` and `dispatch_trade_update`, and thread it through to all three report builder functions (`build_ws_order_status_report`, `build_ws_taker_fill_report`, `build_maker_fill_report`) instead of reusing `ts_event`
- **`reconciliation.rs`** — Replace `UnixNanos::default()` (zero) with `ctx.clock.get_time_ns()` in `generate_mass_status`, so HTTP reconciliation reports also get a meaningful `ts_init`
- **Tests** — Updated to use distinct `ts_event=1_000_000_000` and `ts_init=2_000_000_000` values with explicit assertions verifying the separation

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
