### PR TITLE
 Fix Portfolio RefCell borrow conflict for Cash accounts

### DIFF
--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -770,20 +770,22 @@ impl Portfolio {
         };
 
         for (instrument, orders_open) in &orders_and_instruments {
-            let mut cache = self.cache.borrow_mut();
-            let account = if let Some(account) = cache.account_for_venue(&instrument.id().venue) {
-                account
-            } else {
-                log::error!(
-                    "Cannot update initial (order) margin: no account registered for {}",
-                    instrument.id().venue
-                );
-                initialized = false;
-                break;
+            let account = {
+                let cache = self.cache.borrow();
+                if let Some(account) = cache.account_for_venue(&instrument.id().venue) {
+                    account.clone()
+                } else {
+                    log::error!(
+                        "Cannot update initial (order) margin: no account registered for {}",
+                        instrument.id().venue
+                    );
+                    initialized = false;
+                    break;
+                }
             };
 
             let result = self.inner.borrow_mut().accounts.update_orders(
-                account,
+                &account,
                 instrument,
                 orders_open.iter().collect(),
                 self.clock.borrow().timestamp_ns(),
@@ -791,7 +793,10 @@ impl Portfolio {
 
             match result {
                 Some((updated_account, _)) => {
-                    cache.update_account(&updated_account).unwrap();
+                    self.cache
+                        .borrow_mut()
+                        .update_account(&updated_account)
+                        .unwrap();
                 }
                 None => {
                     initialized = false;

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -725,6 +725,63 @@ fn test_order_accept_updates_margin_init(
 }
 
 #[rstest]
+fn test_initialize_orders_cash_account_with_base_currency() {
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("AUD/USD"),
+        Some(Venue::from("SIM")),
+    ));
+
+    let mut cache = Cache::new(None, None);
+    cache.add_instrument(instrument.clone()).unwrap();
+
+    let cache = Rc::new(RefCell::new(cache));
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let mut portfolio = Portfolio::new(cache.clone(), clock, None);
+
+    // Cash account with base_currency set (like Polymarket with USDC)
+    let account_state = AccountState::new(
+        AccountId::from("SIM-001"),
+        AccountType::Cash,
+        vec![AccountBalance::new(
+            Money::new(1000.0, Currency::USD()),
+            Money::new(0.0, Currency::USD()),
+            Money::new(1000.0, Currency::USD()),
+        )],
+        vec![],
+        true,
+        UUID4::new(),
+        0.into(),
+        0.into(),
+        Some(Currency::USD()),
+    );
+    portfolio.update_account(&account_state);
+
+    // Create and accept an open order
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("100"))
+        .price(Price::new(0.50, 2))
+        .build();
+
+    cache
+        .borrow_mut()
+        .add_order(order.clone(), None, None, true)
+        .unwrap();
+
+    let submitted = submit_order(&order);
+    order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+    cache.borrow_mut().update_order(&order).unwrap();
+
+    let accepted = accept_order(&order);
+    order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+    cache.borrow_mut().update_order(&order).unwrap();
+
+    // This previously panicked with "RefCell already mutably borrowed"
+    portfolio.initialize_orders();
+}
+
+#[rstest]
 fn test_update_positions(mut portfolio: Portfolio, instrument_audusd: InstrumentAny) {
     let account_state = get_cash_account(None);
     portfolio.update_account(&account_state);


### PR DESCRIPTION
Clone account before dropping cache borrow to avoid double-borrow panic when Cash account has base_currency set (triggers xrate calculation path). Adds regression test for the scenario.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fix RefCell borrow conflict in `Portfolio::initialize_orders` that panicked on startup when reconciliation produced open orders for a Cash account with `base_currency` set.

## What was wrong

`initialize_orders()` held a **mutable borrow** on the shared `Rc<RefCell<Cache>>` while calling `AccountManager::update_orders()`, which internally calls `calculate_xrate_to_base()` → `self.cache.borrow()` on the **same** RefCell. A `borrow()` while `borrow_mut()` is active causes a runtime panic:

```
Portfolio::initialize_orders()
  └─ self.cache.borrow_mut()              ← mutable borrow starts
       └─ cache.account_for_venue()       ← returns reference into borrowed cache
            └─ update_orders(account, ..) ← account still borrows from cache
                 └─ update_balance_locked()
                      └─ calculate_xrate_to_base()
                           └─ self.cache.borrow()  ← PANIC: already mutably borrowed
```

### Why it wasn't caught before

Three conditions must align to trigger this:

1. **Cash account** (not Margin) — routes through `update_balance_locked`, not `update_margin_init`
2. **`base_currency` set** on the account — otherwise `calculate_xrate_to_base` returns `Some(1.0)` without touching the cache
3. **Open orders surviving reconciliation** — `initialize_orders` must have orders to process

This combination never occurred because:
- **Other adapters** (Bybit, Binance, etc.): use Margin accounts or have `base_currency: None`
- **Portfolio unit tests**: all used Margin accounts with `base_currency: None`
- **Live manager tests**: test reconciliation only, never call `initialize_orders()` afterwards

Note: `initialize_positions()` already handled this correctly by calling `drop(cache)` before `update_positions`. The fix aligns `initialize_orders` with that same pattern.

## What was fixed

Clone the account and drop the cache borrow before calling `update_orders`, then re-borrow mutably only to write back the result. Added a regression test that reproduces the exact panic with a Cash account + `base_currency` + open order.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
