### PR TITLE
Fix position index blob pollution in update_position

### DIFF
--- a/nautilus_trader/cache/database.pyx
+++ b/nautilus_trader/cache/database.pyx
@@ -1209,12 +1209,17 @@ cdef class CacheDatabaseAdapter(CacheDatabaseFacade):
         cdef list payload = [self._serializer.serialize(position.last_event_c())]
         self._backing.update(key, payload)
 
+        # Use position_id bytes for SET index operations (not the serialized blob).
+        # This matches the pattern in add_position() and update_order().
+        cdef bytes position_id_bytes = position_id_str.encode()
+        cdef list index_payload = [position_id_bytes]
+
         if position.is_open_c():
-            self._backing.insert(_INDEX_POSITIONS_OPEN, payload)
-            self._backing.delete(_INDEX_POSITIONS_CLOSED, payload)
+            self._backing.insert(_INDEX_POSITIONS_OPEN, index_payload)
+            self._backing.delete(_INDEX_POSITIONS_CLOSED, index_payload)
         elif position.is_closed_c():
-            self._backing.insert(_INDEX_POSITIONS_CLOSED, payload)
-            self._backing.delete(_INDEX_POSITIONS_OPEN, payload)
+            self._backing.insert(_INDEX_POSITIONS_CLOSED, index_payload)
+            self._backing.delete(_INDEX_POSITIONS_OPEN, index_payload)
 
         self._log.debug(f"Updated {position}")
 


### PR DESCRIPTION
## Summary

Fix `CacheDatabaseAdapter.update_position()` writing serialized msgpack blobs to Redis SET indices (`positions_open`, `positions_closed`) instead of position_id strings.

## Problem

In `update_position()` (database.pyx line 1213-1217), the `payload` variable containing the full serialized position event blob was reused for SADD/SREM operations on SET indices. This caused:

- Binary msgpack data stored in SET indices that should only contain position_id strings
- SET index queries returning unparseable binary data
- SREM operations silently failing (blob doesn't match existing string members)

## Root Cause

`add_position()` correctly creates a separate `position_id_bytes` variable (line 1047) for SET operations. `update_order()` also correctly reassigns `payload` to order ID only (line 1171). But `update_position()` reuses the serialized blob payload.

## Fix

Create a separate `position_id_bytes` variable for SET index operations, matching the existing pattern in `add_position()` and `update_order()`.

```python
# Before (bug): serialized blob written to SET index
cdef list payload = [self._serializer.serialize(position.last_event_c())]
self._backing.update(key, payload)
self._backing.insert(_INDEX_POSITIONS_OPEN, payload)  # blob!

# After (fix): position_id string written to SET index  
cdef bytes position_id_bytes = position_id_str.encode()
cdef list index_payload = [position_id_bytes]
self._backing.insert(_INDEX_POSITIONS_OPEN, index_payload)  # correct
```

## Test plan
- [x] Verified pattern matches `add_position()` and `update_order()`
- [ ] Integration test with Redis to verify SET index contents after position update