### PR TITLE
Fix strategy receiving historical events during startup reconciliation

### DIFF
--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -956,6 +956,11 @@ pub trait Strategy: DataActor {
     fn handle_order_event(&mut self, event: OrderEventAny) {
         {
             let core = self.core_mut();
+
+            if core.actor.state() != ComponentState::Running {
+                return;
+            }
+
             let id = &core.actor.actor_id;
             let is_warning = matches!(
                 &event,
@@ -1019,6 +1024,11 @@ pub trait Strategy: DataActor {
     fn handle_position_event(&mut self, event: PositionEvent) {
         {
             let core = self.core_mut();
+
+            if core.actor.state() != ComponentState::Running {
+                return;
+            }
+
             if core.config.log_events {
                 let id = &core.actor.actor_id;
                 log::info!("{id} {RECV}{EVT} {event:?}");
@@ -1823,6 +1833,7 @@ mod tests {
     fn test_handle_order_event_dispatches_to_handler() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let event = OrderEventAny::Rejected(OrderRejected {
             trader_id: TraderId::from("TRADER-001"),
@@ -1847,6 +1858,7 @@ mod tests {
     fn test_handle_position_event_dispatches_to_handler() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let event = PositionEvent::PositionOpened(PositionOpened {
             trader_id: TraderId::from("TRADER-001"),
@@ -1948,6 +1960,7 @@ mod tests {
     fn test_handle_order_event_cancels_gtd_timer_on_filled() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let client_order_id = ClientOrderId::from("O-001");
         strategy
@@ -1985,6 +1998,7 @@ mod tests {
     fn test_handle_order_event_cancels_gtd_timer_on_canceled() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let client_order_id = ClientOrderId::from("O-001");
         strategy
@@ -2013,6 +2027,7 @@ mod tests {
     fn test_handle_order_event_cancels_gtd_timer_on_rejected() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let client_order_id = ClientOrderId::from("O-001");
         strategy
@@ -2042,6 +2057,7 @@ mod tests {
     fn test_handle_order_event_cancels_gtd_timer_on_expired() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);
+        start_strategy(&mut strategy);
 
         let client_order_id = ClientOrderId::from("O-001");
         strategy


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

### Problem
During live node startup, the strategy handler was printing ~100 historical `OrderAccepted`/`OrderCanceled` events from the reconciliation process. These were old orders from the last 2 hours being replayed through the strategy, polluting logs and making it impossible to distinguish live events from historical ones.

### Root Cause Investigation

**Startup sequence** (in `node.rs`):
1. `node.add_strategy()` → immediately subscribes the strategy's `handle_order_event` handler to the msgbus
2. `perform_startup_reconciliation()` → fetches order history from exchange, generates events, calls `exec_engine.process()` → `apply_order_event()` → `msgbus::publish_order_event()` 
3. `start_trader()` → transitions strategy to RUNNING state

The handler was connected at step 1, but reconciliation events were published at step 2 — **before** the strategy entered RUNNING state at step 3. So all historical events flowed straight through to the strategy.

### How Python/Cython Handles It

The Python implementation (`strategy.pyx:1886-1918`) has the exact same early subscription pattern, but includes a **state guard**:

```python
cpdef void handle_event(self, Event event):
    # ... logging ...
    
    if self._fsm.state != ComponentState.RUNNING:
        return  # ← silently drops events before strategy is running
    
    # ... dispatch to on_order_accepted, on_order_canceled, etc.
```

The Rust port was missing this guard entirely — events were unconditionally logged and dispatched regardless of component state.

### Fix

Added the same state guard to both `handle_order_event()` and `handle_position_event()` in `strategy/mod.rs`:

```rust
fn handle_order_event(&mut self, event: OrderEventAny) {
    let core = self.core_mut();
    if core.actor.state() != ComponentState::Running {
        return;  // Skip during reconciliation (strategy is in Ready state)
    }
    // ... logging and dispatch ...
}
```

Updated 6 existing tests to start the strategy before testing event handling (they previously only registered, leaving the strategy in Ready state).

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore