### PR TITLE
Fix IB adapter not reconnecting on error 326 during gateway restart

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -36,7 +36,7 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
 
     WARNING_CODES: Final[set[int]] = {1101, 1102, 110, 165, 202, 399, 404, 434, 492, 10167}
     CLIENT_ERRORS: Final[set[int]] = {502, 503, 504, 10038, 10182, 1100, 2110}
-    CONNECTIVITY_LOST_CODES: Final[set[int]] = {1100, 1300, 2110}
+    CONNECTIVITY_LOST_CODES: Final[set[int]] = {326, 1100, 1300, 2110}
     CONNECTIVITY_RESTORED_CODES: Final[set[int]] = {1101, 1102}
     ORDER_REJECTION_CODES: Final[set[int]] = {201, 203, 321, 10289, 10293}
     SUPPRESS_ERROR_LOGGING_CODES: Final[set[int]] = {200}

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
@@ -52,6 +52,26 @@ async def test_ib_is_ready_by_notification_1102(ib_client):
 
 
 @pytest.mark.asyncio
+async def test_ib_is_not_ready_by_error_326(ib_client):
+    """
+    Test that error 326 (client id already in use) clears the connection flag.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=326,
+        error_string="Unable to connect as the client id is already in use",
+    )
+
+    # Assert
+    assert not ib_client._is_ib_connected.is_set()
+
+
+@pytest.mark.asyncio
 async def test_ib_is_not_ready_by_error_10182(ib_client):
     # Arrange
     req_id = 6


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

When IB Gateway performs its nightly restart, connected clients receive error code 326 ("Unable to connect as the client id is already in use") because old TCP sessions haven't fully torn down. The adapter currently does not include 326 in `CONNECTIVITY_LOST_CODES`, so it logs the error and gives up instead of retrying. This adds 326 to the set so the adapter clears `_is_ib_connected`, allowing the connection watchdog to trigger `_handle_disconnection` and retry.

## Related Issues/PRs

Related to #3733 (historical bar subscriptions not restored after daily gateway restart)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_ib_is_not_ready_by_error_326` integration test in `tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py` to verify that error 326 clears the `_is_ib_connected` flag, following the existing test pattern for connectivity-lost error codes.