### PR TITLE
Fix purge_order KeyError for position/exec_algorithm index access

### DIFF
--- a/nautilus_trader/cache/cache.pyx
+++ b/nautilus_trader/cache/cache.pyx
@@ -963,10 +963,14 @@ cdef class Cache(CacheFacade):
                         self._index_account_orders.pop(order.account_id, None)
 
             if order.position_id is not None:
-                self._index_position_orders[order.position_id].discard(client_order_id)
+                position_orders = self._index_position_orders.get(order.position_id)
+                if position_orders is not None:
+                    position_orders.discard(client_order_id)
 
             if order.exec_algorithm_id is not None:
-                self._index_exec_algorithm_orders[order.exec_algorithm_id].discard(client_order_id)
+                exec_algo_orders = self._index_exec_algorithm_orders.get(order.exec_algorithm_id)
+                if exec_algo_orders is not None:
+                    exec_algo_orders.discard(client_order_id)
 
             # Clean up strategy orders reverse index
             strategy_orders = self._index_strategy_orders.get(order.strategy_id)

--- a/tests/unit_tests/cache/test_execution.py
+++ b/tests/unit_tests/cache/test_execution.py
@@ -2301,6 +2301,79 @@ class TestCache:
         orders_for_strategy_after = self.cache.orders(strategy_id=strategy_id)
         assert order not in orders_for_strategy_after
 
+    def test_purge_order_after_position_purged_does_not_crash(self):
+        """
+        Regression test: purge_order should not KeyError when the
+        associated position has already been purged from the cache.
+        """
+        # Arrange
+        order = self.strategy.order_factory.market(
+            AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+        )
+
+        position_id = PositionId("P-1")
+        self.cache.add_order(order, position_id)
+
+        order.apply(TestEventStubs.order_submitted(order))
+        self.cache.update_order(order)
+
+        order.apply(TestEventStubs.order_accepted(order))
+        self.cache.update_order(order)
+
+        fill = TestEventStubs.order_filled(
+            order,
+            instrument=AUDUSD_SIM,
+            position_id=position_id,
+            last_px=Price.from_str("1.00001"),
+        )
+        order.apply(fill)
+        self.cache.update_order(order)
+
+        position = Position(instrument=AUDUSD_SIM, fill=fill)
+        self.cache.add_position(position, OmsType.HEDGING)
+
+        # Close the position
+        order2 = self.strategy.order_factory.market(
+            AUDUSD_SIM.id,
+            OrderSide.SELL,
+            Quantity.from_int(100_000),
+        )
+        self.cache.add_order(order2, position_id)
+
+        order2.apply(TestEventStubs.order_submitted(order2))
+        self.cache.update_order(order2)
+
+        order2.apply(TestEventStubs.order_accepted(order2))
+        self.cache.update_order(order2)
+
+        fill2 = TestEventStubs.order_filled(
+            order2,
+            instrument=AUDUSD_SIM,
+            position_id=position_id,
+            last_px=Price.from_str("1.00001"),
+            trade_id=TradeId("2"),
+        )
+        order2.apply(fill2)
+        self.cache.update_order(order2)
+
+        position.apply(fill2)
+        self.cache.update_position(position)
+
+        assert position.is_closed
+
+        # Purge the position first
+        self.cache.purge_position(position_id)
+
+        # Act - purge order whose position is already gone (should not crash)
+        self.cache.purge_order(order.client_order_id)
+        self.cache.purge_order(order2.client_order_id)
+
+        # Assert
+        assert not self.cache.order_exists(order.client_order_id)
+        assert not self.cache.order_exists(order2.client_order_id)
+
     def test_purge_order_cleans_up_exec_spawn_orders_index(self):
         # Arrange
         parent_order = self.strategy.order_factory.market(


### PR DESCRIPTION
## Summary

- Use safe `.get()` with `None` check instead of bracket `[]` notation for `_index_position_orders` and `_index_exec_algorithm_orders` in `Cache.purge_order()`
- Prevents `KeyError` when the position or exec algorithm has already been purged from the cache

## Problem

In `Cache.purge_order()` (cache.pyx line 966/969), bracket notation `[]` was used to access `_index_position_orders` and `_index_exec_algorithm_orders`. When `purge_closed_orders` runs after positions have been cleaned from the cache (e.g., via `purge_closed_positions`), the position key no longer exists in the index dict, causing a `KeyError`.

## Fix

Replace unsafe `[]` access with `.get()` + `None` check, matching the safe pattern already used for `_index_account_orders` (line 959) and the Rust equivalent (`cache/mod.rs` lines 1044-1048 uses `get_mut` with conditional check).

## Test

Added regression test: `test_purge_order_after_position_purged_does_not_crash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)