### PR TITLE
Upgrade ibapi to 10.45

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/common.py
@@ -248,6 +248,8 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
     sizeIncrement: Decimal = UNSET_DECIMAL
     suggestedSizeIncrement: Decimal = UNSET_DECIMAL
     minAlgoSize: Decimal = UNSET_DECIMAL
+    lastPricePrecision: Decimal = UNSET_DECIMAL
+    lastSizePrecision: Decimal = UNSET_DECIMAL
 
     # BOND values
     cusip: str = ""
@@ -294,8 +296,8 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
     @classmethod
     def from_contract_details(cls, contract_details) -> "IBContractDetails":
         """
-        Create from a raw ibapi ContractDetails, normalizing ibapi 10.43 protobuf
-        issues.
+        Create from a raw ibapi ContractDetails, normalizing known ibapi quirks and
+        tolerating additive upstream fields.
 
         ibapi 10.43's protobuf decoder (decoder.py:decodeContractDetails) has a typo:
         it writes ``contractDetails.underConid`` (lowercase 'i') instead of the
@@ -318,6 +320,8 @@ class IBContractDetails(NautilusConfig, frozen=True, repr_omit_defaults=True):
                 d["underConId"] = d.pop("underConid")
             else:
                 d.pop("underConid")
+        valid_fields = {field.name for field in msgspec.structs.fields(cls)}
+        d = {key: value for key, value in d.items() if key in valid_fields}
         return cls(**d)
 
 
@@ -335,7 +339,14 @@ def dict_to_contract_details(dict_details: dict) -> IBContractDetails:
 
     # Deserialize Decimal fields from strings back to Decimal objects
     # These fields are known to be Decimal type in IBContractDetails
-    decimal_fields = ["minSize", "sizeIncrement", "suggestedSizeIncrement", "minAlgoSize"]
+    decimal_fields = [
+        "minSize",
+        "sizeIncrement",
+        "suggestedSizeIncrement",
+        "minAlgoSize",
+        "lastPricePrecision",
+        "lastSizePrecision",
+    ]
     for field in decimal_fields:
         if field in details_copy and isinstance(details_copy[field], str):
             try:
@@ -363,6 +374,9 @@ def dict_to_contract_details(dict_details: dict) -> IBContractDetails:
             FundAssetType,
             details_copy["fundAssetType"],
         )
+
+    valid_fields = {field.name for field in msgspec.structs.fields(IBContractDetails)}
+    details_copy = {key: value for key, value in details_copy.items() if key in valid_fields}
 
     return IBContractDetails(**details_copy)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ generate-setup-file = false
 betfair = ["betfair-parser==0.19.1"] # Pinned to 0.19.1 for stability
 ib = [
   "defusedxml>=0.7.1,<1.0.0; python_version < '3.14'",
-  "nautilus-ibapi==10.43.2; python_version < '3.14'",
+  "nautilus-ibapi==10.45.1; python_version < '3.14'",
   "protobuf==5.29.5; python_version < '3.14'", # Pinned to 5.29.5 (fixes GHSA-8qvm-5x2c-j2w7)
 ]
 docker = ["docker>=7.1.0,<8.0.0"]

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -147,7 +147,7 @@ class IBTestContractStubs:
         contract_details.contract = IBTestContractStubs.convert_contract_to_ib_contract(
             contract_details.contract,
         )
-        return IBContractDetails(**contract_details.__dict__)
+        return IBContractDetails.from_contract_details(contract_details)
 
     @staticmethod
     def create_instrument(contract_details: ContractDetails) -> Instrument:

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -553,7 +553,7 @@ def test_parse_instrument_future_option():
     # Arrange
     contract_details = IBTestContractStubs.es_future_option_contract_details()
     contract_details.contract = IBContract(**contract_details.contract.__dict__)
-    contract_details = IBContractDetails(**contract_details.__dict__)
+    contract_details = IBContractDetails.from_contract_details(contract_details)
 
     # Act
     instrument = parse_instrument(contract_details, "CME")
@@ -590,7 +590,7 @@ def test_parse_instrument_option_on_index_has_caret_prefix():
         liquidHours="20240101:0830-20240101:1515",
         realExpirationDate="20240315",
     )
-    contract_details = IBContractDetails(**contract_details.__dict__)
+    contract_details = IBContractDetails.from_contract_details(contract_details)
 
     # Act
     instrument = parse_instrument(contract_details, "CBOE")

--- a/uv.lock
+++ b/uv.lock
@@ -1567,11 +1567,11 @@ wheels = [
 
 [[package]]
 name = "nautilus-ibapi"
-version = "10.43.2"
+version = "10.45.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/a7/cd2c00d99a2500a9fde23db64bbe5588e396cd13f933dd9973a6edb27fd0/nautilus_ibapi-10.43.2.tar.gz", hash = "sha256:e7d9b0c14c81f44f88815a27ac543ac93d22ead08d14cd4d3d336b31ec3f1753", size = 154445, upload-time = "2026-02-11T21:38:40.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/6bdd312813b2fae4a1acde596a769e45e2b69c8ef4ad8eac082e0ec6772e/nautilus_ibapi-10.45.1.tar.gz", hash = "sha256:92540e784793ecb87fc35f2cfb79a067145909deb8356eaf7c1a9e1042ecb374", size = 155663, upload-time = "2026-03-31T23:00:14.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/03/b810d53eea98bbc29c0cd6ba06ffe942bdbe22e0c09582df4a6741b119c3/nautilus_ibapi-10.43.2-py3-none-any.whl", hash = "sha256:2afa9f42bc9f662dea0938829a1261c04edc42ecabbee9b06a27d5494b1113dc", size = 325562, upload-time = "2026-02-11T21:38:38.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/81/46e4ba0b35bf3d5d5d32349ab4f54b1024e6a7e693a10cce3491c701a239/nautilus_ibapi-10.45.1-py3-none-any.whl", hash = "sha256:34ea8df8f520dd587667aab7a9916618d7b372103c2c2c1b68ec3b6e19c69c52", size = 329278, upload-time = "2026-03-31T23:00:13.632Z" },
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ requires-dist = [
     { name = "docker", marker = "extra == 'docker'", specifier = ">=7.1.0,<8.0.0" },
     { name = "fsspec", specifier = ">=2025.2.0,<=2026.2.0" },
     { name = "msgspec", specifier = ">=0.20.0,<1.0.0" },
-    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.43.2" },
+    { name = "nautilus-ibapi", marker = "python_full_version < '3.14' and extra == 'ib'", specifier = "==10.45.1" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pandas", specifier = ">=2.3.3,<3.0.0" },
     { name = "plotly", marker = "extra == 'visualization'", specifier = ">=6.6.0,<7.0.0" },


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Upgrade the optional Interactive Brokers dependency from `nautilus-ibapi==10.43.2` to `10.45.1`.
- Extend `IBContractDetails` to accept the new `lastPricePrecision` and `lastSizePrecision` fields added by upstream `ibapi`.
- Harden the adapter conversion path so additive upstream `ContractDetails` fields are filtered instead of failing strict struct construction.
- Update IB integration tests to build `IBContractDetails` through the shared compatibility constructor rather than unpacking raw `ibapi` objects directly.

## Why

`ibapi 10.45.1` adds new `ContractDetails` fields. Without adapter-side normalization, constructing `IBContractDetails` from upstream objects can fail when those extra keys are present. This change keeps the upgrade narrow: take the dependency bump, teach the adapter about the new precision fields, and make the conversion boundary tolerant of future additive fields.

## Changed Files

- `pyproject.toml`
- `uv.lock`
- `nautilus_trader/adapters/interactive_brokers/common.py`
- `tests/integration_tests/adapters/interactive_brokers/test_kit.py`
- `tests/integration_tests/adapters/interactive_brokers/test_parsing.py`

## Simplifications Made

- Reused `IBContractDetails.from_contract_details()` as the single compatibility boundary for raw `ibapi` objects.
- Reused the existing Decimal deserialization flow for the new precision fields instead of adding a separate parsing path.
- Generalized field filtering with `msgspec.structs.fields(...)` so additive upstream keys are ignored consistently in both conversion helpers.

## Testing

- `./.venv/bin/python -m ruff check nautilus_trader/adapters/interactive_brokers/common.py tests/integration_tests/adapters/interactive_brokers/test_kit.py tests/integration_tests/adapters/interactive_brokers/test_parsing.py`
- `pytest -q tests/integration_tests/adapters/interactive_brokers/test_kit.py tests/integration_tests/adapters/interactive_brokers/test_parsing.py`

## Remaining Risks

- I did not run the full repository test suite, only the touched Interactive Brokers integration tests plus a targeted Ruff check.
- This keeps the adapter tolerant of additive `ContractDetails` fields, but it does not validate semantics for any future upstream fields beyond the two new precision values introduced in `10.45.1`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
