### PR TITLE
Standardize Polymarket data client to use strategy-driven subscriptions

### DIFF
--- a/crates/adapters/polymarket/src/data.rs
+++ b/crates/adapters/polymarket/src/data.rs
@@ -784,23 +784,9 @@ impl DataClient for PolymarketDataClient {
 
         self.ws_client.connect().await?;
 
-        // Subscribe all loaded instruments to WS market channel.
-        let token_ids: Vec<String> = self
-            .instruments
-            .load()
-            .values()
-            .map(|inst| inst.raw_symbol().as_str().to_string())
-            .collect();
-
-        if !token_ids.is_empty() || self.config.subscribe_new_markets {
-            log::info!(
-                "Subscribing {} token IDs to WS market channel (subscribe_new_markets={})...",
-                token_ids.len(),
-                self.config.subscribe_new_markets,
-            );
-            self.ws_client.subscribe_market(token_ids).await?;
-        } else {
-            log::info!("No instruments to subscribe (skipped)");
+        if self.config.subscribe_new_markets {
+            log::info!("Subscribing to new markets...");
+            self.ws_client.subscribe_market(vec![]).await?;
         }
 
         let rx = self


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Hello there! this PR in only a proposal, on how i would prefer how things are wired 🙏 


Currently on bootstrap, polymarket adapter automatically subscribe to all instruments, I believe this should be only a strategy responsibility to ask for data subscription

Considering the limited filtering capabilities of polymarket, example single tag_id, it is very hard to only have the markets we are really interested in without spending more than neccessary time on figuring out exact AND/OR with client side predicates which do help on filtering a big part, I still end up with 4-5k instruments...

I'm completely fine loading more that necessary instruments, but subscribing to the data slightly less...

Please let me know if there is any concerns

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
