### PR TITLE
Add Polymarket complementary arbitrage Rust tutorial

### DIFF
--- a/crates/adapters/polymarket/Cargo.toml
+++ b/crates/adapters/polymarket/Cargo.toml
@@ -91,6 +91,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true, features = ["examples"] }
 
 axum = { workspace = true }
 rstest = { workspace = true }
@@ -143,4 +144,9 @@ doc = false
 [[example]]
 name = "polymarket-new-market-monitor"
 path = "examples/new_market_monitor.rs"
+doc = false
+
+[[example]]
+name = "polymarket-complement-arb"
+path = "examples/complement_arb.rs"
 doc = false

--- a/crates/adapters/polymarket/examples/complement_arb.rs
+++ b/crates/adapters/polymarket/examples/complement_arb.rs
@@ -1,0 +1,142 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Example demonstrating complement arbitrage on Polymarket binary options.
+//!
+//! Uses an [`EventParamsFilter`] to load liquid sports markets from the Gamma
+//! events API, plus a [`NewMarketPredicateFilter`] to accept only sport-tagged
+//! new markets via WebSocket. The [`ComplementArb`] strategy discovers complement
+//! pairs (same condition ID, opposite Yes/No outcomes) and monitors for arbitrage
+//! when combined ask < 1.0 (buy arb) or combined bid > 1.0 (sell arb).
+//!
+//! Prerequisites:
+//! - Set `POLYMARKET_PK` (EOA signer private key)
+//! - Set `POLYMARKET_API_KEY`, `POLYMARKET_API_SECRET`, `POLYMARKET_PASSPHRASE`
+//! - Set `POLYMARKET_FUNDER` (Gnosis Safe proxy address)
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --example polymarket-complement-arb --package nautilus-polymarket
+//! ```
+
+use std::sync::Arc;
+
+use log::LevelFilter;
+use nautilus_common::{enums::Environment, logging::logger::LoggerConfig};
+use nautilus_live::node::LiveNode;
+use nautilus_model::identifiers::{AccountId, ClientId, StrategyId, TraderId, Venue};
+use nautilus_polymarket::{
+    common::enums::SignatureType,
+    config::{PolymarketDataClientConfig, PolymarketExecClientConfig},
+    factories::{PolymarketDataClientFactory, PolymarketExecutionClientFactory},
+    filters::{EventParamsFilter, NewMarketPredicateFilter},
+    http::query::GetGammaEventsParams,
+};
+use nautilus_trading::{
+    examples::strategies::{ComplementArb, ComplementArbConfig},
+    strategy::StrategyConfig,
+};
+use rust_decimal_macros::dec;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    let environment = Environment::Live;
+    let trader_id = TraderId::from("TESTER-001");
+    let account_id = AccountId::from("POLYMARKET-001");
+    let client_id = ClientId::new("POLYMARKET");
+    let venue = Venue::new("POLYMARKET");
+
+    // Filter to liquid sports markets via events endpoint
+    let sports_events = GetGammaEventsParams {
+        active: Some(true),
+        closed: Some(false),
+        tag_slug: Some("sports".into()),
+        liquidity_min: Some(100000.0),
+        max_events: Some(10),
+        ..Default::default()
+    };
+    let data_filter = EventParamsFilter::new(sports_events);
+
+    // Filter new markets (WS) to only accept sport-tagged markets
+    let new_market_filter = NewMarketPredicateFilter::new("sports-only", |nm| {
+        nm.tags
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case("sports") || t.eq_ignore_ascii_case("sport"))
+    });
+
+    let data_config = PolymarketDataClientConfig {
+        subscribe_new_markets: true,
+        filters: vec![Arc::new(data_filter)],
+        new_market_filter: Some(Arc::new(new_market_filter)),
+        ..Default::default()
+    };
+
+    let exec_config = PolymarketExecClientConfig {
+        trader_id,
+        account_id,
+        signature_type: SignatureType::PolyGnosisSafe,
+        ..Default::default()
+    };
+
+    let log_config = LoggerConfig {
+        stdout_level: LevelFilter::Info,
+        ..Default::default()
+    };
+
+    let mut node = LiveNode::builder(trader_id, environment)?
+        .with_name("POLYMARKET-COMPLEMENT-ARB-001".to_string())
+        .with_logging(log_config)
+        .add_data_client(
+            None,
+            Box::new(PolymarketDataClientFactory),
+            Box::new(data_config),
+        )?
+        .add_exec_client(
+            None,
+            Box::new(PolymarketExecutionClientFactory),
+            Box::new(exec_config),
+        )?
+        .with_reconciliation(true)
+        .with_reconciliation_lookback_mins(120)
+        .with_timeout_reconciliation(60)
+        .with_delay_post_stop_secs(5)
+        .build()?;
+
+    let strategy_config = ComplementArbConfig::builder()
+        .venue(venue)
+        .client_id(client_id)
+        .min_profit_bps(dec!(50))
+        .trade_size(dec!(10))
+        .live_trading(false)
+        .order_expire_secs(15)
+        .base(StrategyConfig {
+            strategy_id: Some(StrategyId::from("COMPLEMENT_ARB-001")),
+            order_id_tag: Some("001".to_string()),
+            log_events: false,
+            log_commands: false,
+            ..Default::default()
+        })
+        .build();
+
+    let strategy = ComplementArb::new(strategy_config);
+
+    node.add_strategy(strategy)?;
+    node.run().await?;
+
+    Ok(())
+}

--- a/crates/trading/src/examples/strategies/complement_arb/README.md
+++ b/crates/trading/src/examples/strategies/complement_arb/README.md
@@ -1,0 +1,141 @@
+# Complement Arbitrage
+
+Binary option complement arbitrage strategy that exploits pricing
+inefficiencies in Yes/No market pairs.
+
+For an end-to-end walkthrough — event flow, state machine, live order
+submission, partial-fill unwinding, monitoring, and tuning — see the
+[Polymarket complement arb tutorial](../../../../../../docs/tutorials/complement_arb_polymarket.md).
+
+## Strategy overview
+
+Binary options have a mathematical complement constraint: at resolution,
+`Yes + No = 1.0`. When market inefficiencies cause the combined ask
+prices to fall below 1.0 (after fees), buying both sides locks in
+risk-free profit. When combined bid prices exceed 1.0, selling both
+sides does the same. The strategy continuously monitors all discovered
+complement pairs and, when `live_trading = true`, submits both legs as
+GTD limit orders.
+
+### Pair discovery
+
+On startup the strategy queries the instrument cache for all
+`BinaryOption` instruments on the configured `venue`, groups them by
+condition ID (the symbol prefix before the last `-`), and pairs
+instruments that share a condition ID and have complementary `Yes` /
+`No` outcomes. It then subscribes to quotes for both legs and to new
+instrument events on the venue, so newly listed markets are paired
+dynamically via `on_instrument` (`try_match_complement`).
+
+### Detection
+
+For every quote update, the strategy evaluates both sides of the pair:
+
+```
+combined_ask = yes_ask + no_ask        # buy arb
+combined_bid = yes_bid + no_bid        # sell arb
+fee          = combined_* * fee_estimate_bps / 10_000
+profit_bps   = (1.0 - combined_ask - fee) * 10_000   # buy
+profit_bps   = (combined_bid - fee - 1.0) * 10_000   # sell
+```
+
+An arb is actionable when `profit_bps >= min_profit_bps`,
+`profit_per_share * trade_size >= min_profit_abs`, and the relevant
+side of the book has at least `trade_size` of liquidity on both legs.
+
+### Execution
+
+When `live_trading = true` and an arb is actionable, the strategy
+submits both legs as GTD limit orders (post-only by default) and
+transitions the pair through a small state machine:
+
+```
+Idle → PendingEntry → (both fill) → ARB COMPLETE → Idle
+                   → (one fills, other fails) → Unwinding → Idle
+```
+
+If one leg fills but the other is rejected, expires, or is canceled,
+the strategy submits an IOC unwind order on the filled leg's instrument
+to exit the position (priced aggressively using `unwind_slippage_bps`).
+A second guard, `max_concurrent_arbs`, bounds the total in-flight arbs
+across all pairs (per-pair concurrency is always 1).
+
+When `live_trading = false`, the strategy detects and logs arbs but
+submits no orders — useful for tuning thresholds before committing
+capital.
+
+### Diagnostics
+
+The strategy maintains detection counters
+(`quotes_processed`, `buy_arbs_detected`, `sell_arbs_detected`,
+`best_buy_spread`, `best_sell_spread`) and execution counters
+(`arbs_submitted`, `arbs_completed`, `arbs_unwound`, `arbs_failed`),
+and emits a periodic `SUMMARY` log every 500 quote evaluations.
+
+### Exit
+
+`on_stop` cancels all active arb orders (entry and unwind legs) and
+logs final detection + execution counts. It does not forcibly unwind
+filled positions; that's the job of the runtime unwind path.
+
+## Configuration
+
+| Parameter             | Type               | Default     | Description                                                           |
+|-----------------------|--------------------|-------------|-----------------------------------------------------------------------|
+| `venue`               | `Venue`            | *required*  | Venue to scan for binary option instruments (e.g. `POLYMARKET`).      |
+| `client_id`           | `Option<ClientId>` | `None`      | Client ID for data subscriptions and order routing.                   |
+| `fee_estimate_bps`    | `Decimal`          | `0`         | Conservative fee estimate in basis points. 0 = no fee adjustment.     |
+| `min_profit_bps`      | `Decimal`          | `50`        | Minimum profit (bps) after fees to trigger arb (50 = 0.5%).           |
+| `min_profit_abs`      | `Decimal`          | `0`         | Minimum absolute dollar profit per arb (0 = disabled).                |
+| `trade_size`          | `Decimal`          | `10`        | Number of shares per leg.                                             |
+| `max_concurrent_arbs` | `usize`            | `1`         | Max simultaneous in-flight arbs across all pairs (per-pair = 1).      |
+| `use_post_only`       | `bool`             | `true`      | Submit entry orders post-only (0% maker fee on Polymarket).           |
+| `order_expire_secs`   | `u64`              | `15`        | GTD expiry for entry limit orders, in seconds.                        |
+| `unwind_slippage_bps` | `Decimal`          | `50`        | Slippage tolerance for IOC unwind orders, in bps.                     |
+| `live_trading`        | `bool`             | `false`     | Enable live order submission. False = detection-only.                 |
+
+### Inherited from `StrategyConfig`
+
+The `base` field carries the standard strategy configuration. The most
+relevant fields:
+
+- `strategy_id`: defaults to `COMPLEMENT_ARB-001`.
+- `order_id_tag`: defaults to `001`. Set to a unique value when running
+  multiple instances.
+
+## Risk considerations
+
+- **Fee model**: the flat `fee_estimate_bps` is a simplification.
+  Polymarket uses a price-dependent fee curve that varies per leg. A
+  production deployment should use the venue's actual fee formula.
+- **Execution risk**: detection and order submission are not atomic.
+  Between detection and fill, prices can move, eliminating the arb.
+- **Partial fills**: if one leg fills but the other does not, the
+  strategy unwinds via an IOC order; loss is bounded by
+  `unwind_slippage_bps` plus fees, but unwind itself can fail in thin
+  books and require manual intervention.
+- **Liquidity**: binary option books can be thin. The strategy checks
+  `ask_size`/`bid_size` against `trade_size` before acting, but posted
+  liquidity can be stale.
+- **Quote staleness**: the strategy uses the latest cached quotes. If
+  one leg's quote is stale, the detected spread may not reflect the
+  live market.
+
+## Rust usage
+
+```rust
+use nautilus_trading::examples::strategies::{ComplementArb, ComplementArbConfig};
+use rust_decimal_macros::dec;
+
+let config = ComplementArbConfig::builder()
+    .venue(Venue::new("POLYMARKET"))
+    .client_id(ClientId::new("POLYMARKET"))
+    .min_profit_bps(dec!(50))
+    .trade_size(dec!(10))
+    .live_trading(false)        // detection-only until validated
+    .order_expire_secs(15)
+    .build();
+
+let strategy = ComplementArb::new(config);
+node.add_strategy(strategy)?;
+```

--- a/crates/trading/src/examples/strategies/complement_arb/config.rs
+++ b/crates/trading/src/examples/strategies/complement_arb/config.rs
@@ -1,0 +1,72 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Configuration for the complement arbitrage strategy.
+
+use nautilus_model::identifiers::{ClientId, StrategyId, Venue};
+use rust_decimal::Decimal;
+
+use crate::strategy::StrategyConfig;
+
+fn default_base_config() -> StrategyConfig {
+    StrategyConfig {
+        strategy_id: Some(StrategyId::from("COMPLEMENT_ARB-001")),
+        order_id_tag: Some("001".to_string()),
+        ..Default::default()
+    }
+}
+
+/// Configuration for the complement arbitrage strategy.
+#[derive(Debug, Clone, bon::Builder)]
+pub struct ComplementArbConfig {
+    /// Base strategy configuration.
+    #[builder(default = default_base_config())]
+    pub base: StrategyConfig,
+    /// Venue to scan for binary option instruments.
+    pub venue: Venue,
+    /// Optional client ID for data subscriptions and order routing.
+    pub client_id: Option<ClientId>,
+    /// Conservative fee estimate in basis points (default: 0 = no fee).
+    #[builder(default)]
+    pub fee_estimate_bps: Decimal,
+    /// Minimum profit in basis points after fees to trigger arb (default: 50 = 0.5%).
+    #[builder(default = Decimal::new(50, 0))]
+    pub min_profit_bps: Decimal,
+    /// Minimum absolute profit in dollars per arb to trigger (default: 0.0 = disabled).
+    #[builder(default)]
+    pub min_profit_abs: Decimal,
+    /// Number of shares per leg (default: 10).
+    #[builder(default = Decimal::new(10, 0))]
+    pub trade_size: Decimal,
+    /// Maximum simultaneous in-flight arb executions across all pairs (default: 1).
+    ///
+    /// Note: per-market concurrency is already capped at 1 because each pair is keyed
+    /// by `condition_id` and `has_active_arb` rejects a second arb on the same pair.
+    /// This setting bounds total concurrent arbs across the strategy.
+    #[builder(default = 1)]
+    pub max_concurrent_arbs: usize,
+    /// Use post-only orders for maker fee = 0% (default: true).
+    #[builder(default = true)]
+    pub use_post_only: bool,
+    /// Order expiry in seconds for GTD time-in-force (default: 15).
+    #[builder(default = 15)]
+    pub order_expire_secs: u64,
+    /// Slippage tolerance in bps for IOC unwind orders (default: 50).
+    #[builder(default = Decimal::new(50, 0))]
+    pub unwind_slippage_bps: Decimal,
+    /// Master switch: submit orders when true, detect-only when false (default: false).
+    #[builder(default = false)]
+    pub live_trading: bool,
+}

--- a/crates/trading/src/examples/strategies/complement_arb/mod.rs
+++ b/crates/trading/src/examples/strategies/complement_arb/mod.rs
@@ -13,14 +13,19 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! Example trading strategies for backtesting and demonstration.
+//! Complement arbitrage strategy for binary option markets.
+//!
+//! Binary options have a mathematical complement constraint: Yes + No = 1.0 at
+//! resolution. When market inefficiencies cause `yes_ask + no_ask < 1.0 - fees`,
+//! buying both sides locks in risk-free profit. When `yes_bid + no_bid > 1.0 + fees`,
+//! selling both does the same. This strategy continuously monitors all discovered
+//! complement pairs and logs when profitable opportunities appear.
 
-pub mod complement_arb;
-pub mod delta_neutral_vol;
-pub mod ema_cross;
-pub mod grid_mm;
+pub mod config;
+pub mod strategy;
 
-pub use complement_arb::{ComplementArb, ComplementArbConfig};
-pub use delta_neutral_vol::{DeltaNeutralVol, DeltaNeutralVolConfig};
-pub use ema_cross::EmaCross;
-pub use grid_mm::{GridMarketMaker, GridMarketMakerConfig};
+#[cfg(test)]
+mod tests;
+
+pub use config::ComplementArbConfig;
+pub use strategy::ComplementArb;

--- a/crates/trading/src/examples/strategies/complement_arb/strategy.rs
+++ b/crates/trading/src/examples/strategies/complement_arb/strategy.rs
@@ -1,0 +1,1096 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Complement arbitrage strategy implementation.
+
+use std::fmt::Debug;
+
+use ahash::AHashMap;
+use nautilus_common::actor::DataActor;
+use nautilus_core::datetime::NANOSECONDS_IN_SECOND;
+use nautilus_model::{
+    data::QuoteTick,
+    enums::{OrderSide, TimeInForce},
+    events::{OrderCanceled, OrderExpired, OrderFilled, OrderRejected},
+    identifiers::{ClientOrderId, InstrumentId},
+    instruments::{Instrument, InstrumentAny},
+    orders::Order,
+    types::{Price, Quantity},
+};
+use rust_decimal::Decimal;
+use ustr::Ustr;
+
+use super::config::ComplementArbConfig;
+use crate::{
+    nautilus_strategy,
+    strategy::{Strategy, StrategyCore},
+};
+
+/// A matched Yes/No complement pair sharing the same condition ID.
+#[derive(Debug, Clone)]
+pub(super) struct ComplementPair {
+    pub condition_id: String,
+    pub yes_id: InstrumentId,
+    pub no_id: InstrumentId,
+    pub label: String,
+}
+
+/// State of a per-pair arb execution attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ArbState {
+    Idle,
+    PendingEntry,
+    PartialFill,
+    Unwinding,
+}
+
+/// Tracks the lifecycle of a single arb attempt on a complement pair.
+#[derive(Debug, Clone)]
+pub(super) struct ArbExecution {
+    pub state: ArbState,
+    pub arb_side: OrderSide,
+    pub yes_order_id: ClientOrderId,
+    pub no_order_id: ClientOrderId,
+    pub yes_filled_qty: Decimal,
+    pub no_filled_qty: Decimal,
+    pub unwind_order_id: Option<ClientOrderId>,
+}
+
+/// Complement arbitrage strategy that exploits Yes + No < 1.0 (buy arb) or
+/// Yes + No > 1.0 (sell arb) on binary option pairs.
+pub struct ComplementArb {
+    pub(super) core: StrategyCore,
+    config: ComplementArbConfig,
+    /// condition_id -> matched pair
+    pub(super) pairs: AHashMap<String, ComplementPair>,
+    /// instrument_id -> condition_id (reverse lookup)
+    pub(super) instrument_to_pair: AHashMap<InstrumentId, String>,
+    /// Latest quote per instrument
+    pub(super) quotes: AHashMap<InstrumentId, QuoteTick>,
+    /// Instruments awaiting their complement, keyed by condition ID.
+    /// Value: (instrument_id, outcome, label)
+    pub(super) pending_complements: AHashMap<String, (InstrumentId, String, String)>,
+    /// Active arb execution per pair: condition_id -> ArbExecution
+    pub(super) arb_executions: AHashMap<String, ArbExecution>,
+    /// Reverse lookup: client_order_id -> condition_id
+    pub(super) order_to_pair: AHashMap<ClientOrderId, String>,
+    /// Diagnostic counters
+    pub(super) quotes_processed: u64,
+    pub(super) buy_arbs_detected: u64,
+    pub(super) sell_arbs_detected: u64,
+    pub(super) arbs_submitted: u64,
+    pub(super) arbs_completed: u64,
+    pub(super) arbs_unwound: u64,
+    pub(super) arbs_failed: u64,
+    /// Tightest spreads seen (closest to arb opportunity)
+    pub(super) best_buy_spread: Decimal,
+    pub(super) best_sell_spread: Decimal,
+    pub(super) best_buy_label: String,
+    pub(super) best_sell_label: String,
+}
+
+impl ComplementArb {
+    /// Creates a new [`ComplementArb`] instance from config.
+    #[must_use]
+    pub fn new(config: ComplementArbConfig) -> Self {
+        Self {
+            core: StrategyCore::new(config.base.clone()),
+            config,
+            pairs: AHashMap::new(),
+            instrument_to_pair: AHashMap::new(),
+            pending_complements: AHashMap::new(),
+            quotes: AHashMap::new(),
+            arb_executions: AHashMap::new(),
+            order_to_pair: AHashMap::new(),
+            quotes_processed: 0,
+            buy_arbs_detected: 0,
+            sell_arbs_detected: 0,
+            arbs_submitted: 0,
+            arbs_completed: 0,
+            arbs_unwound: 0,
+            arbs_failed: 0,
+            best_buy_spread: Decimal::TWO,   // start high, track min
+            best_sell_spread: Decimal::ZERO, // start low, track max
+            best_buy_label: String::new(),
+            best_sell_label: String::new(),
+        }
+    }
+
+    /// Per-share fee for one leg using the Polymarket fee curve.
+    /// Formula: (fee_rate_bps / 10_000) x p x (1 - p)
+    /// Peaks at p=0.50, drops to zero at extremes.
+    // 10_000 as Decimal (lo=10000, mid=0, hi=0, negative=false, scale=0)
+    const BPS_DIVISOR: Decimal = Decimal::from_parts(10_000, 0, 0, false, 0);
+
+    fn leg_fee(fee_rate_bps: Decimal, price: Decimal) -> Decimal {
+        fee_rate_bps / Self::BPS_DIVISOR * price * (Decimal::ONE - price)
+    }
+
+    /// Extract pair key from instrument ID.
+    ///
+    /// For Polymarket-style IDs like `0xabc...def-<token_id>.POLYMARKET`,
+    /// the condition ID (hex prefix before the last `-`) groups Yes/No pairs.
+    pub(super) fn extract_pair_key(id: &InstrumentId) -> Option<String> {
+        let s = id.symbol.as_str();
+        let dash_pos = s.rfind('-')?;
+        if dash_pos == 0 {
+            return None;
+        }
+        Some(s[..dash_pos].to_string())
+    }
+
+    /// Attempt to match an instrument with a pending complement in O(1).
+    ///
+    /// If the complement is already pending, forms a pair and returns it.
+    /// Otherwise stores the instrument as pending and returns `None`.
+    pub(super) fn try_match_complement(
+        &mut self,
+        id: InstrumentId,
+        outcome: &str,
+        label: &str,
+    ) -> Option<ComplementPair> {
+        let key = Self::extract_pair_key(&id)?;
+
+        // Already have a complete pair
+        if self.pairs.contains_key(&key) {
+            return None;
+        }
+
+        // Check pending for complement
+        if let Some((other_id, other_outcome, other_label)) = self.pending_complements.remove(&key)
+        {
+            let (yes_id, no_id, pair_label) = match (outcome, other_outcome.as_str()) {
+                ("Yes", "No") => (id, other_id, label.to_string()),
+                ("No", "Yes") => (other_id, id, other_label),
+                _ => {
+                    // Same outcome or invalid — re-insert original, skip
+                    self.pending_complements
+                        .insert(key, (other_id, other_outcome, other_label));
+                    return None;
+                }
+            };
+
+            let pair = ComplementPair {
+                condition_id: key.clone(),
+                yes_id,
+                no_id,
+                label: pair_label,
+            };
+
+            self.instrument_to_pair.insert(yes_id, key.clone());
+            self.instrument_to_pair.insert(no_id, key.clone());
+            self.pairs.insert(key, pair.clone());
+
+            Some(pair)
+        } else {
+            // No complement yet — store as pending
+            self.pending_complements
+                .insert(key, (id, outcome.to_string(), label.to_string()));
+            None
+        }
+    }
+
+    /// Discover complement pairs from cached instruments.
+    fn discover_pairs(&mut self) {
+        type Entry = (InstrumentId, Option<String>, Option<String>);
+
+        let venue = self.config.venue;
+        let instruments: Vec<Entry> = {
+            let cache = self.cache();
+            cache
+                .instruments(&venue, None)
+                .iter()
+                .filter_map(|inst| {
+                    if let InstrumentAny::BinaryOption(opt) = inst {
+                        Some((
+                            opt.id,
+                            opt.description.map(|d| d.to_string()),
+                            opt.outcome.map(|o| o.to_string()),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        // Group by pair key (condition ID)
+        let mut groups: AHashMap<String, Vec<Entry>> = AHashMap::new();
+        for (id, desc, outcome) in &instruments {
+            if let Some(key) = Self::extract_pair_key(id) {
+                groups
+                    .entry(key)
+                    .or_default()
+                    .push((*id, desc.clone(), outcome.clone()));
+            }
+        }
+
+        // Build pairs from groups with exactly 2 instruments
+        for (key, members) in &groups {
+            if members.len() != 2 {
+                continue;
+            }
+
+            let (yes_idx, no_idx) = match (members[0].2.as_deref(), members[1].2.as_deref()) {
+                (Some("Yes"), Some("No")) => (0, 1),
+                (Some("No"), Some("Yes")) => (1, 0),
+                _ => continue,
+            };
+
+            let label = members[yes_idx].1.clone().unwrap_or_else(|| key.clone());
+
+            let pair = ComplementPair {
+                condition_id: key.clone(),
+                yes_id: members[yes_idx].0,
+                no_id: members[no_idx].0,
+                label,
+            };
+
+            self.instrument_to_pair.insert(pair.yes_id, key.clone());
+            self.instrument_to_pair.insert(pair.no_id, key.clone());
+            self.pairs.insert(key.clone(), pair);
+        }
+
+        // Store singles as pending complements for incremental discovery
+        for (key, members) in &groups {
+            if members.len() != 1 {
+                continue;
+            }
+
+            if self.pairs.contains_key(key) {
+                continue;
+            }
+            let (id, desc, outcome) = &members[0];
+            if let Some(out) = outcome {
+                let label = desc.clone().unwrap_or_else(|| key.clone());
+                self.pending_complements
+                    .insert(key.clone(), (*id, out.clone(), label));
+            }
+        }
+    }
+
+    /// Returns true if there is an active (non-Idle) arb execution for this pair.
+    pub(super) fn has_active_arb(&self, pair_key: &str) -> bool {
+        self.arb_executions
+            .get(pair_key)
+            .is_some_and(|exec| exec.state != ArbState::Idle)
+    }
+
+    /// Submit both legs of an arb as GTD limit orders.
+    fn submit_arb(
+        &mut self,
+        pair: &ComplementPair,
+        arb_side: OrderSide,
+        yes_price: Price,
+        no_price: Price,
+        profit_bps: Decimal,
+    ) -> anyhow::Result<()> {
+        if !self.config.live_trading {
+            return Ok(());
+        }
+
+        if self.has_active_arb(&pair.condition_id) {
+            return Ok(());
+        }
+
+        // Guard: global concurrency limit across all pairs.
+        // Per-market concurrency is already enforced by `has_active_arb` above.
+        let active_count = self
+            .arb_executions
+            .values()
+            .filter(|e| e.state != ArbState::Idle)
+            .count();
+
+        if active_count >= self.config.max_concurrent_arbs {
+            return Ok(());
+        }
+
+        let now_ns = self.core.clock().timestamp_ns();
+        let expire_ns = now_ns + self.config.order_expire_secs * NANOSECONDS_IN_SECOND;
+        let trade_size = Quantity::from_decimal(self.config.trade_size)?;
+        let post_only = Some(self.config.use_post_only);
+
+        let yes_order = self.core.order_factory().limit(
+            pair.yes_id,
+            arb_side,
+            trade_size,
+            yes_price,
+            Some(TimeInForce::Gtd),
+            Some(expire_ns),
+            post_only,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vec![Ustr::from("arb")]),
+            None,
+        );
+
+        let no_order = self.core.order_factory().limit(
+            pair.no_id,
+            arb_side,
+            trade_size,
+            no_price,
+            Some(TimeInForce::Gtd),
+            Some(expire_ns),
+            post_only,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vec![Ustr::from("arb")]),
+            None,
+        );
+
+        let yes_order_id = yes_order.client_order_id();
+        let no_order_id = no_order.client_order_id();
+
+        let client_id = self.config.client_id;
+        self.submit_order(yes_order, None, client_id)?;
+        self.submit_order(no_order, None, client_id)?;
+
+        log::info!(
+            "ARB SUBMITTED | {} | side={arb_side} | profit={profit_bps:.1}bps | \
+             yes={yes_order_id} no={no_order_id}",
+            pair.label,
+        );
+
+        let exec = ArbExecution {
+            state: ArbState::PendingEntry,
+            arb_side,
+            yes_order_id,
+            no_order_id,
+            yes_filled_qty: Decimal::ZERO,
+            no_filled_qty: Decimal::ZERO,
+            unwind_order_id: None,
+        };
+
+        let pair_key = pair.condition_id.clone();
+        self.order_to_pair.insert(yes_order_id, pair_key.clone());
+        self.order_to_pair.insert(no_order_id, pair_key.clone());
+        self.arb_executions.insert(pair_key, exec);
+        self.arbs_submitted += 1;
+
+        Ok(())
+    }
+
+    /// Submit an IOC unwind order to exit a partially-filled position.
+    fn submit_unwind(
+        &mut self,
+        pair_key: &str,
+        instrument_id: InstrumentId,
+        filled_qty: Decimal,
+        arb_side: OrderSide,
+    ) -> anyhow::Result<()> {
+        let unwind_side = match arb_side {
+            OrderSide::Buy => OrderSide::Sell,
+            _ => OrderSide::Buy,
+        };
+
+        // Get current quote for aggressive pricing
+        let quote = self
+            .quotes
+            .get(&instrument_id)
+            .ok_or_else(|| anyhow::anyhow!("No quote for unwind instrument {instrument_id}"))?;
+
+        let slippage_bps = self.config.unwind_slippage_bps;
+        let slippage_mult = slippage_bps / Self::BPS_DIVISOR;
+
+        let aggressive_price = match unwind_side {
+            OrderSide::Sell => {
+                // Selling back: price at bid minus slippage
+                let bid = quote.bid_price.as_decimal();
+                bid * (Decimal::ONE - slippage_mult)
+            }
+            _ => {
+                // Buying back: price at ask plus slippage
+                let ask = quote.ask_price.as_decimal();
+                ask * (Decimal::ONE + slippage_mult)
+            }
+        };
+
+        let price = Price::from_decimal(aggressive_price)?;
+        let quantity = Quantity::from_decimal(filled_qty)?;
+
+        let order = self.core.order_factory().limit(
+            instrument_id,
+            unwind_side,
+            quantity,
+            price,
+            Some(TimeInForce::Ioc),
+            None,
+            Some(false), // not post_only for IOC
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vec![Ustr::from("arb-unwind")]),
+            None,
+        );
+
+        let unwind_order_id = order.client_order_id();
+
+        let client_id = self.config.client_id;
+        self.submit_order(order, None, client_id)?;
+
+        log::warn!(
+            "UNWIND SUBMITTED | pair={pair_key} | {instrument_id} | \
+             side={unwind_side} qty={filled_qty} price={aggressive_price:.4} | id={unwind_order_id}",
+        );
+
+        // Update execution state
+        if let Some(exec) = self.arb_executions.get_mut(pair_key) {
+            exec.state = ArbState::Unwinding;
+            exec.unwind_order_id = Some(unwind_order_id);
+        }
+
+        self.order_to_pair
+            .insert(unwind_order_id, pair_key.to_string());
+
+        Ok(())
+    }
+
+    /// Handle a fill event — update fill tracking and drive state transitions.
+    pub(super) fn handle_fill(&mut self, event: &OrderFilled) {
+        let pair_key = match self.order_to_pair.get(&event.client_order_id) {
+            Some(key) => key.clone(),
+            None => return,
+        };
+
+        let fill_qty = event.last_qty.as_decimal();
+        let fill_px = event.last_px.as_decimal();
+
+        // Extract info we need before mutating, to avoid borrow conflicts
+        let (is_unwind, is_yes, yes_order_id, no_order_id) = {
+            let exec = match self.arb_executions.get(&pair_key) {
+                Some(e) => e,
+                None => return,
+            };
+            (
+                exec.unwind_order_id == Some(event.client_order_id),
+                exec.yes_order_id == event.client_order_id,
+                exec.yes_order_id,
+                exec.no_order_id,
+            )
+        };
+
+        // Handle unwind order fill
+        if is_unwind {
+            let closed = {
+                let cache = self.cache();
+                cache
+                    .order(&event.client_order_id)
+                    .is_some_and(|o| o.is_closed())
+            };
+
+            if closed {
+                log::info!("UNWIND COMPLETE | {pair_key} | filled @ {fill_px:.4}",);
+                self.arbs_unwound += 1;
+                self.cleanup_arb(&pair_key);
+            }
+            return;
+        }
+
+        // Entry leg fill — update tracking
+        {
+            let exec = match self.arb_executions.get_mut(&pair_key) {
+                Some(e) => e,
+                None => return,
+            };
+
+            if is_yes {
+                exec.yes_filled_qty += fill_qty;
+            } else {
+                exec.no_filled_qty += fill_qty;
+            }
+        } // drop mutable borrow
+
+        // Check if this order is fully closed
+        let this_closed = {
+            let cache = self.cache();
+            cache
+                .order(&event.client_order_id)
+                .is_some_and(|o| o.is_closed())
+        };
+
+        if !this_closed {
+            return; // partial fill on this order, wait for more
+        }
+
+        // This order is fully filled — check the other leg
+        let other_id = if is_yes { no_order_id } else { yes_order_id };
+
+        let other_closed = {
+            let cache = self.cache();
+            cache.order(&other_id).is_some_and(|o| o.is_closed())
+        };
+
+        let exec = match self.arb_executions.get(&pair_key) {
+            Some(e) => e,
+            None => return,
+        };
+
+        if other_closed {
+            // Both legs closed and we have fills on both → arb complete
+            if exec.yes_filled_qty > Decimal::ZERO && exec.no_filled_qty > Decimal::ZERO {
+                // Read VWAP fill prices from the framework's order state (the cache
+                // accumulates `avg_px` across all `OrderFilled` events for each order).
+                let (yes_avg_px, no_avg_px) = {
+                    let cache = self.cache();
+                    let yes_px = cache
+                        .order(&yes_order_id)
+                        .and_then(|o| o.avg_px())
+                        .unwrap_or(0.0);
+                    let no_px = cache
+                        .order(&no_order_id)
+                        .and_then(|o| o.avg_px())
+                        .unwrap_or(0.0);
+                    (yes_px, no_px)
+                };
+                log::info!(
+                    "ARB COMPLETE | {pair_key} | yes_px={yes_avg_px:.4} no_px={no_avg_px:.4}",
+                );
+                self.arbs_completed += 1;
+                self.cleanup_arb(&pair_key);
+            } else {
+                self.arbs_failed += 1;
+                self.cleanup_arb(&pair_key);
+            }
+        } else {
+            // This leg filled, other still open → PartialFill
+            if let Some(exec) = self.arb_executions.get_mut(&pair_key)
+                && exec.state == ArbState::PendingEntry
+            {
+                log::warn!("PARTIAL FILL | {pair_key} | one leg closed, other still open",);
+                exec.state = ArbState::PartialFill;
+            }
+        }
+    }
+
+    /// Handle a terminal (non-fill) order event: rejected, expired, or canceled.
+    pub(super) fn handle_order_terminal(&mut self, client_order_id: ClientOrderId, reason: &str) {
+        let pair_key = match self.order_to_pair.get(&client_order_id) {
+            Some(key) => key.clone(),
+            None => return,
+        };
+
+        let exec = match self.arb_executions.get(&pair_key) {
+            Some(e) => e.clone(),
+            None => return,
+        };
+
+        match exec.state {
+            ArbState::PendingEntry => {
+                // Determine which leg this is
+                let is_yes = exec.yes_order_id == client_order_id;
+                let (this_filled, other_filled) = if is_yes {
+                    (exec.yes_filled_qty, exec.no_filled_qty)
+                } else {
+                    (exec.no_filled_qty, exec.yes_filled_qty)
+                };
+                let other_id = if is_yes {
+                    exec.no_order_id
+                } else {
+                    exec.yes_order_id
+                };
+
+                // Check if the other leg is also closed
+                let other_closed = {
+                    let cache = self.cache();
+                    cache.order(&other_id).is_some_and(|o| o.is_closed())
+                };
+
+                if other_closed {
+                    // Both legs closed
+                    if this_filled > Decimal::ZERO || other_filled > Decimal::ZERO {
+                        // One side has fills → need to unwind
+                        self.initiate_unwind(&pair_key);
+                    } else {
+                        // Neither side filled → clean failure
+                        log::info!("ARB FAILED | {pair_key} | both legs {reason} with no fills",);
+                        self.arbs_failed += 1;
+                        self.cleanup_arb(&pair_key);
+                    }
+                } else if this_filled > Decimal::ZERO {
+                    // This leg had fills but terminated, other still open
+                    // → cancel other leg and unwind our fills
+                    let order_to_cancel = {
+                        let cache = self.cache();
+                        cache.order(&other_id).cloned()
+                    };
+
+                    if let Some(order) = order_to_cancel
+                        && !order.is_closed()
+                        && let Err(e) = self.cancel_order(order, self.config.client_id)
+                    {
+                        log::error!("Failed to cancel other leg {other_id}: {e}",);
+                    }
+                    self.initiate_unwind(&pair_key);
+                } else {
+                    // This leg failed with no fills, other still open → cancel the other
+                    log::info!("ARB LEG {reason} | {pair_key} | canceling other leg {other_id}",);
+                    let order_to_cancel = {
+                        let cache = self.cache();
+                        cache.order(&other_id).cloned()
+                    };
+
+                    if let Some(order) = order_to_cancel
+                        && !order.is_closed()
+                        && let Err(e) = self.cancel_order(order, self.config.client_id)
+                    {
+                        log::error!("Failed to cancel other leg {other_id}: {e}",);
+                    }
+                }
+            }
+            ArbState::PartialFill => {
+                // The pending leg just failed → unwind the filled leg
+                self.initiate_unwind(&pair_key);
+            }
+            ArbState::Unwinding => {
+                // Only react to the unwind order itself failing
+                if exec.unwind_order_id == Some(client_order_id) {
+                    log::error!(
+                        "UNWIND FAILED | {pair_key} | unwind order {client_order_id} {reason} — \
+                         manual intervention required",
+                    );
+                    self.arbs_failed += 1;
+                    self.cleanup_arb(&pair_key);
+                }
+                // Ignore terminal events for entry leg orders during unwind
+            }
+            ArbState::Idle => {}
+        }
+    }
+
+    /// Determine which leg was filled and submit an unwind order for it.
+    fn initiate_unwind(&mut self, pair_key: &str) {
+        let exec = match self.arb_executions.get(pair_key) {
+            Some(e) => e.clone(),
+            None => return,
+        };
+
+        let pair = match self.pairs.get(pair_key) {
+            Some(p) => p.clone(),
+            None => {
+                log::error!("UNWIND | {pair_key} | pair not found, cannot unwind");
+                self.arbs_failed += 1;
+                self.cleanup_arb(pair_key);
+                return;
+            }
+        };
+
+        // Determine which leg has fills
+        let (instrument_id, filled_qty) = if exec.yes_filled_qty > Decimal::ZERO {
+            (pair.yes_id, exec.yes_filled_qty)
+        } else if exec.no_filled_qty > Decimal::ZERO {
+            (pair.no_id, exec.no_filled_qty)
+        } else {
+            // No fills on either side — nothing to unwind
+            log::info!("ARB FAILED | {pair_key} | no fills to unwind");
+            self.arbs_failed += 1;
+            self.cleanup_arb(pair_key);
+            return;
+        };
+
+        if let Err(e) = self.submit_unwind(pair_key, instrument_id, filled_qty, exec.arb_side) {
+            log::error!(
+                "UNWIND FAILED | {pair_key} | submit error: {e} — manual intervention required",
+            );
+            self.arbs_failed += 1;
+            self.cleanup_arb(pair_key);
+        }
+    }
+
+    /// Remove all tracking state for a completed/failed arb.
+    pub(super) fn cleanup_arb(&mut self, pair_key: &str) {
+        if let Some(exec) = self.arb_executions.remove(pair_key) {
+            self.order_to_pair.remove(&exec.yes_order_id);
+            self.order_to_pair.remove(&exec.no_order_id);
+            if let Some(unwind_id) = exec.unwind_order_id {
+                self.order_to_pair.remove(&unwind_id);
+            }
+        }
+    }
+
+    /// Check for buy arb: buy Yes + buy No when combined ask < 1.0.
+    pub(super) fn check_buy_arb(&mut self, pair: &ComplementPair) -> bool {
+        let (yes_quote, no_quote) =
+            match (self.quotes.get(&pair.yes_id), self.quotes.get(&pair.no_id)) {
+                (Some(y), Some(n)) => (y, n),
+                _ => return false,
+            };
+
+        let trade_size = self.config.trade_size;
+        let fee_bps = self.config.fee_estimate_bps;
+        let min_profit = self.config.min_profit_bps;
+
+        let yes_ask = yes_quote.ask_price.as_decimal();
+        let no_ask = no_quote.ask_price.as_decimal();
+        let combined_ask = yes_ask + no_ask;
+
+        // Track tightest buy spread
+        if combined_ask < self.best_buy_spread {
+            self.best_buy_spread = combined_ask;
+            self.best_buy_label = pair.label.clone();
+        }
+
+        if combined_ask >= Decimal::ONE {
+            return false;
+        }
+
+        let fee = Self::leg_fee(fee_bps, yes_ask) + Self::leg_fee(fee_bps, no_ask);
+        let profit_bps = (Decimal::ONE - combined_ask - fee) * Self::BPS_DIVISOR;
+
+        if profit_bps < min_profit {
+            return false;
+        }
+
+        let profit_abs = (Decimal::ONE - combined_ask - fee) * trade_size;
+
+        if profit_abs < self.config.min_profit_abs {
+            return false;
+        }
+
+        self.buy_arbs_detected += 1;
+
+        log::info!(
+            "BUY ARB | {} | profit={profit_bps:.1}bps | \
+             yes_ask={yes_ask:.3} + no_ask={no_ask:.3} = {combined_ask:.3} | fee={fee:.4} | $profit={profit_abs:.4}",
+            pair.label,
+        );
+
+        // Check liquidity
+        let yes_liq = yes_quote.ask_size.as_decimal();
+        let no_liq = no_quote.ask_size.as_decimal();
+
+        if yes_liq < trade_size || no_liq < trade_size {
+            log::info!(
+                "BUY ARB | {} | skipped: insufficient liquidity \
+                 yes={yes_liq} no={no_liq} need={trade_size}",
+                pair.label,
+            );
+            return false;
+        }
+
+        // Capture prices before mutable borrow
+        let yes_price = yes_quote.ask_price;
+        let no_price = no_quote.ask_price;
+
+        if let Err(e) = self.submit_arb(pair, OrderSide::Buy, yes_price, no_price, profit_bps) {
+            log::error!("BUY ARB | {} | submit failed: {e}", pair.label);
+        }
+
+        true
+    }
+
+    /// Check for sell arb: sell Yes + sell No when combined bid > 1.0.
+    pub(super) fn check_sell_arb(&mut self, pair: &ComplementPair) -> bool {
+        let (yes_quote, no_quote) =
+            match (self.quotes.get(&pair.yes_id), self.quotes.get(&pair.no_id)) {
+                (Some(y), Some(n)) => (y, n),
+                _ => return false,
+            };
+
+        let trade_size = self.config.trade_size;
+        let fee_bps = self.config.fee_estimate_bps;
+        let min_profit = self.config.min_profit_bps;
+
+        let yes_bid = yes_quote.bid_price.as_decimal();
+        let no_bid = no_quote.bid_price.as_decimal();
+        let combined_bid = yes_bid + no_bid;
+
+        // Track tightest sell spread
+        if combined_bid > self.best_sell_spread {
+            self.best_sell_spread = combined_bid;
+            self.best_sell_label = pair.label.clone();
+        }
+
+        if combined_bid <= Decimal::ONE {
+            return false;
+        }
+
+        let fee = Self::leg_fee(fee_bps, yes_bid) + Self::leg_fee(fee_bps, no_bid);
+        let profit_bps = (combined_bid - fee - Decimal::ONE) * Self::BPS_DIVISOR;
+
+        if profit_bps < min_profit {
+            return false;
+        }
+
+        let profit_abs = (combined_bid - fee - Decimal::ONE) * trade_size;
+
+        if profit_abs < self.config.min_profit_abs {
+            return false;
+        }
+
+        self.sell_arbs_detected += 1;
+
+        log::info!(
+            "SELL ARB | {} | profit={profit_bps:.1}bps | \
+             yes_bid={yes_bid:.3} + no_bid={no_bid:.3} = {combined_bid:.3} | fee={fee:.4} | $profit={profit_abs:.4}",
+            pair.label,
+        );
+
+        // Check liquidity
+        let yes_liq = yes_quote.bid_size.as_decimal();
+        let no_liq = no_quote.bid_size.as_decimal();
+
+        if yes_liq < trade_size || no_liq < trade_size {
+            log::info!(
+                "SELL ARB | {} | skipped: insufficient liquidity \
+                 yes={yes_liq} no={no_liq} need={trade_size}",
+                pair.label,
+            );
+            return false;
+        }
+
+        // Capture prices before mutable borrow
+        let yes_price = yes_quote.bid_price;
+        let no_price = no_quote.bid_price;
+
+        if let Err(e) = self.submit_arb(pair, OrderSide::Sell, yes_price, no_price, profit_bps) {
+            log::error!("SELL ARB | {} | submit failed: {e}", pair.label);
+        }
+
+        true
+    }
+
+    pub(super) fn log_diagnostic_summary(&self) {
+        log::info!(
+            "SUMMARY | quotes={} buy_arbs={} sell_arbs={} \
+             submitted={} completed={} unwound={} failed={} | \
+             best_buy_spread={:.4} ({}) best_sell_spread={:.4} ({})",
+            self.quotes_processed,
+            self.buy_arbs_detected,
+            self.sell_arbs_detected,
+            self.arbs_submitted,
+            self.arbs_completed,
+            self.arbs_unwound,
+            self.arbs_failed,
+            self.best_buy_spread,
+            self.best_buy_label,
+            self.best_sell_spread,
+            self.best_sell_label,
+        );
+    }
+}
+
+nautilus_strategy!(ComplementArb, {
+    fn on_order_rejected(&mut self, event: OrderRejected) {
+        log::warn!(
+            "Order rejected: {} — {}",
+            event.client_order_id,
+            event.reason,
+        );
+        self.handle_order_terminal(event.client_order_id, "rejected");
+    }
+    fn on_order_expired(&mut self, event: OrderExpired) {
+        self.handle_order_terminal(event.client_order_id, "expired");
+    }
+});
+
+impl Debug for ComplementArb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(ComplementArb))
+            .field("pairs", &self.pairs.len())
+            .field("buy_arbs_detected", &self.buy_arbs_detected)
+            .field("sell_arbs_detected", &self.sell_arbs_detected)
+            .field("arbs_submitted", &self.arbs_submitted)
+            .field("arbs_completed", &self.arbs_completed)
+            .finish()
+    }
+}
+
+impl DataActor for ComplementArb {
+    fn on_start(&mut self) -> anyhow::Result<()> {
+        self.discover_pairs();
+
+        let instrument_ids: Vec<InstrumentId> = self
+            .pairs
+            .values()
+            .flat_map(|p| [p.yes_id, p.no_id])
+            .collect();
+
+        let client_id = self.config.client_id;
+        for id in instrument_ids {
+            self.subscribe_quotes(id, client_id, None);
+        }
+
+        // Subscribe to new instruments arriving on this venue (e.g. new sport markets)
+        self.subscribe_instruments(self.config.venue, client_id, None);
+
+        log::info!(
+            "ComplementArb started: {} pairs, trade_size={}, min_profit={}bps, fee={}bps, live={}",
+            self.pairs.len(),
+            self.config.trade_size,
+            self.config.min_profit_bps,
+            self.config.fee_estimate_bps,
+            self.config.live_trading,
+        );
+
+        Ok(())
+    }
+
+    fn on_stop(&mut self) -> anyhow::Result<()> {
+        // Cancel all active arb orders
+        let active_order_ids: Vec<ClientOrderId> = self
+            .arb_executions
+            .values()
+            .flat_map(|exec| {
+                let mut ids = vec![exec.yes_order_id, exec.no_order_id];
+                if let Some(unwind_id) = exec.unwind_order_id {
+                    ids.push(unwind_id);
+                }
+                ids
+            })
+            .collect();
+
+        let client_id = self.config.client_id;
+        for order_id in &active_order_ids {
+            let order_to_cancel = {
+                let cache = self.cache();
+                cache.order(order_id).cloned()
+            };
+
+            if let Some(order) = order_to_cancel
+                && !order.is_closed()
+                && let Err(e) = self.cancel_order(order, client_id)
+            {
+                log::error!("Failed to cancel order {order_id} on stop: {e}");
+            }
+        }
+
+        log::info!(
+            "ComplementArb stopped: buy_arbs={} sell_arbs={} \
+             submitted={} completed={} unwound={} failed={}",
+            self.buy_arbs_detected,
+            self.sell_arbs_detected,
+            self.arbs_submitted,
+            self.arbs_completed,
+            self.arbs_unwound,
+            self.arbs_failed,
+        );
+        Ok(())
+    }
+
+    fn on_instrument(&mut self, instrument: &InstrumentAny) -> anyhow::Result<()> {
+        let id = instrument.id();
+        log::info!("INSTRUMENT RECEIVED | {id}");
+
+        // Skip instruments we already track
+        if self.instrument_to_pair.contains_key(&id) {
+            return Ok(());
+        }
+
+        if let InstrumentAny::BinaryOption(opt) = instrument {
+            let outcome = opt.outcome.map(|o| o.to_string()).unwrap_or_default();
+            let description = opt
+                .description
+                .map_or_else(|| id.to_string(), |d| d.to_string());
+
+            log::info!("NEW INSTRUMENT | {description} | outcome={outcome} | {id}",);
+
+            if let Some(pair) = self.try_match_complement(id, &outcome, &description) {
+                let client_id = self.config.client_id;
+                self.subscribe_quotes(pair.yes_id, client_id, None);
+                self.subscribe_quotes(pair.no_id, client_id, None);
+
+                log::info!(
+                    "Paired new complement: {} (total: {})",
+                    pair.label,
+                    self.pairs.len(),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn on_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+        let instrument_id = quote.instrument_id;
+        self.quotes.insert(instrument_id, *quote);
+
+        // Look up which pair this instrument belongs to
+        let pair_key = match self.instrument_to_pair.get(&instrument_id) {
+            Some(key) => key.clone(),
+            None => return Ok(()),
+        };
+
+        let pair = match self.pairs.get(&pair_key) {
+            Some(p) => p.clone(),
+            None => return Ok(()),
+        };
+
+        self.quotes_processed += 1;
+
+        // Skip arb checks if pair has an active execution
+        if !self.arb_executions.contains_key(&pair_key) {
+            self.check_buy_arb(&pair);
+            self.check_sell_arb(&pair);
+        }
+
+        // Periodic diagnostic summary
+        if self.quotes_processed.is_multiple_of(500) {
+            self.log_diagnostic_summary();
+        }
+
+        Ok(())
+    }
+
+    fn on_order_filled(&mut self, event: &OrderFilled) -> anyhow::Result<()> {
+        log::info!(
+            "Order filled: {} {} @ {}",
+            event.client_order_id,
+            event.order_side,
+            event.last_px,
+        );
+        self.handle_fill(event);
+        Ok(())
+    }
+
+    fn on_order_canceled(&mut self, event: &OrderCanceled) -> anyhow::Result<()> {
+        self.handle_order_terminal(event.client_order_id, "canceled");
+        Ok(())
+    }
+
+    fn on_reset(&mut self) -> anyhow::Result<()> {
+        self.pairs.clear();
+        self.instrument_to_pair.clear();
+        self.pending_complements.clear();
+        self.quotes.clear();
+        self.arb_executions.clear();
+        self.order_to_pair.clear();
+        self.quotes_processed = 0;
+        self.buy_arbs_detected = 0;
+        self.sell_arbs_detected = 0;
+        self.arbs_submitted = 0;
+        self.arbs_completed = 0;
+        self.arbs_unwound = 0;
+        self.arbs_failed = 0;
+        self.best_buy_spread = Decimal::TWO;
+        self.best_sell_spread = Decimal::ZERO;
+        self.best_buy_label.clear();
+        self.best_sell_label.clear();
+        Ok(())
+    }
+}

--- a/crates/trading/src/examples/strategies/complement_arb/tests.rs
+++ b/crates/trading/src/examples/strategies/complement_arb/tests.rs
@@ -1,0 +1,1897 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Unit tests for complement arbitrage detection and execution logic.
+
+use std::{cell::RefCell, rc::Rc};
+
+use nautilus_common::{
+    actor::DataActor,
+    cache::Cache,
+    clock::{Clock, TestClock},
+};
+use nautilus_core::UnixNanos;
+use nautilus_model::{
+    data::QuoteTick,
+    enums::{AssetClass, LiquiditySide, OrderSide, OrderType},
+    events::{OrderEventAny, OrderFilled},
+    identifiers::{
+        AccountId, ClientOrderId, InstrumentId, StrategyId, Symbol, TradeId, TraderId, Venue,
+        VenueOrderId,
+    },
+    instruments::{BinaryOption, InstrumentAny},
+    orders::{
+        Order, OrderAny, OrderTestBuilder,
+        stubs::{TestOrderEventStubs, TestOrderStubs},
+    },
+    types::{Currency, Price, Quantity},
+};
+use nautilus_portfolio::portfolio::Portfolio;
+use rstest::rstest;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use ustr::Ustr;
+
+use super::{
+    config::ComplementArbConfig,
+    strategy::{ArbExecution, ArbState, ComplementArb, ComplementPair},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Helper to create a strategy with default test config.
+fn test_strategy() -> ComplementArb {
+    let config = ComplementArbConfig::builder()
+        .venue(Venue::new("POLYMARKET"))
+        .min_profit_bps(dec!(50))
+        .trade_size(dec!(10))
+        .build();
+    ComplementArb::new(config)
+}
+
+/// Helper to create a test pair (pair A).
+fn test_pair() -> ComplementPair {
+    ComplementPair {
+        condition_id: "0xabc".to_string(),
+        yes_id: InstrumentId::from("0xabc-111.POLYMARKET"),
+        no_id: InstrumentId::from("0xabc-222.POLYMARKET"),
+        label: "Test Market".to_string(),
+    }
+}
+
+/// Helper to create a second test pair (pair B) with different condition ID.
+fn test_pair_b() -> ComplementPair {
+    ComplementPair {
+        condition_id: "0xdef".to_string(),
+        yes_id: InstrumentId::from("0xdef-333.POLYMARKET"),
+        no_id: InstrumentId::from("0xdef-444.POLYMARKET"),
+        label: "Test Market B".to_string(),
+    }
+}
+
+/// Helper to create a QuoteTick with consistent 3-decimal precision.
+fn quote(id: InstrumentId, bid: f64, ask: f64, size: f64) -> QuoteTick {
+    QuoteTick::new(
+        id,
+        Price::from(format!("{bid:.3}").as_str()),
+        Price::from(format!("{ask:.3}").as_str()),
+        Quantity::from(format!("{size:.1}").as_str()),
+        Quantity::from(format!("{size:.1}").as_str()),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
+}
+
+/// Helper to create an `ArbExecution` in PendingEntry state with default fill values.
+fn make_arb_execution(
+    yes_order_id: ClientOrderId,
+    no_order_id: ClientOrderId,
+    arb_side: OrderSide,
+) -> ArbExecution {
+    ArbExecution {
+        state: ArbState::PendingEntry,
+        arb_side,
+        yes_order_id,
+        no_order_id,
+        yes_filled_qty: Decimal::ZERO,
+        no_filled_qty: Decimal::ZERO,
+        unwind_order_id: None,
+    }
+}
+
+/// Register a strategy with test clock, cache, and portfolio so it can
+/// access `self.cache()`, `self.core.clock()`, `self.core.order_factory()`, etc.
+fn register_strategy(strategy: &mut ComplementArb) {
+    let trader_id = TraderId::from("TESTER-001");
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let portfolio = Rc::new(RefCell::new(Portfolio::new(
+        cache.clone(),
+        clock.clone(),
+        None,
+    )));
+    strategy
+        .core
+        .register(trader_id, clock, cache, portfolio)
+        .unwrap();
+}
+
+/// Create a `BinaryOption` instrument for the given instrument ID with an outcome.
+fn make_binary_option(id: InstrumentId, outcome: &str, description: &str) -> BinaryOption {
+    let raw_symbol = Symbol::new(id.symbol.as_str());
+    BinaryOption::new(
+        id,
+        raw_symbol,
+        AssetClass::Alternative,
+        Currency::USDC(),
+        UnixNanos::default(),
+        UnixNanos::from(1_000_000_000_000u64),
+        3,
+        2,
+        Price::from("0.001"),
+        Quantity::from("0.01"),
+        Some(Ustr::from(outcome)),
+        Some(Ustr::from(description)),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
+}
+
+/// Build a limit order via `OrderTestBuilder` for a given instrument, side, price, qty, and order ID.
+fn build_limit_order(
+    instrument_id: InstrumentId,
+    side: OrderSide,
+    price: &str,
+    qty: &str,
+    order_id: &str,
+) -> OrderAny {
+    OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_id)
+        .client_order_id(ClientOrderId::new(order_id))
+        .side(side)
+        .price(Price::from(price))
+        .quantity(Quantity::from(qty))
+        .build()
+}
+
+/// Insert a pair's instrument_to_pair mappings into a strategy (needed for on_quote routing).
+fn wire_pair(strategy: &mut ComplementArb, pair: &ComplementPair) {
+    strategy
+        .pairs
+        .insert(pair.condition_id.clone(), pair.clone());
+    strategy
+        .instrument_to_pair
+        .insert(pair.yes_id, pair.condition_id.clone());
+    strategy
+        .instrument_to_pair
+        .insert(pair.no_id, pair.condition_id.clone());
+}
+
+mod signal_detection {
+    use super::*;
+
+    // ---- extract_pair_key tests ----
+
+    #[rstest]
+    fn test_extract_pair_key_valid() {
+        let id = InstrumentId::from("0xabc-12345.POLYMARKET");
+        let key = ComplementArb::extract_pair_key(&id);
+        assert_eq!(key, Some("0xabc".to_string()));
+    }
+
+    #[rstest]
+    fn test_extract_pair_key_multiple_dashes() {
+        let id = InstrumentId::from("0xabc-def-12345.POLYMARKET");
+        let key = ComplementArb::extract_pair_key(&id);
+        assert_eq!(key, Some("0xabc-def".to_string()));
+    }
+
+    #[rstest]
+    fn test_extract_pair_key_no_dash() {
+        let id = InstrumentId::from("NODASH.POLYMARKET");
+        let key = ComplementArb::extract_pair_key(&id);
+        assert_eq!(key, None);
+    }
+
+    // ---- buy arb detection ----
+
+    #[rstest]
+    fn test_buy_arb_detected() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_ask = 0.48 + 0.48 = 0.96 < 1.0 → profit = 400 bps
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1);
+    }
+
+    #[rstest]
+    fn test_buy_arb_not_detected_efficient_market() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_ask = 0.52 + 0.52 = 1.04 >= 1.0
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 0);
+    }
+
+    #[rstest]
+    fn test_buy_arb_below_min_profit() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_ask = 0.498 + 0.498 = 0.996 → profit = 40 bps < 50 bps min
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.498, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.498, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 0);
+    }
+
+    #[rstest]
+    fn test_buy_arb_missing_quote_returns_false() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Only insert one side
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_insufficient_liquidity_skipped_buy() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Good spread but size = 5 < trade_size = 10
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 5.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1); // detected but skipped
+    }
+
+    // ---- buy arb abs profit tests ----
+
+    #[rstest]
+    fn test_buy_arb_below_min_abs_profit() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .min_profit_abs(dec!(1))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // combined_ask = 0.48 + 0.48 = 0.96 → profit_per_share = 0.04 → abs = 0.04 * 10 = $0.40 < $1.0
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_buy_arb_above_min_abs_profit() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .min_profit_abs(dec!(1))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // combined_ask = 0.40 + 0.40 = 0.80 → profit_per_share = 0.20 → abs = 0.20 * 10 = $2.0 > $1.0
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.38, 0.40, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.38, 0.40, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+    }
+
+    // ---- sell arb tests ----
+
+    #[rstest]
+    fn test_sell_arb_detected() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_bid = 0.52 + 0.52 = 1.04 > 1.0 → profit = 400 bps
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.52, 0.55, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.52, 0.55, 100.0));
+
+        assert!(strategy.check_sell_arb(&pair));
+        assert_eq!(strategy.sell_arbs_detected, 1);
+    }
+
+    #[rstest]
+    fn test_sell_arb_not_detected() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_bid = 0.48 + 0.48 = 0.96 <= 1.0
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+
+        assert!(!strategy.check_sell_arb(&pair));
+        assert_eq!(strategy.sell_arbs_detected, 0);
+    }
+
+    #[rstest]
+    fn test_sell_arb_missing_quote_returns_false() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.52, 0.55, 100.0));
+
+        assert!(!strategy.check_sell_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_insufficient_liquidity_skipped_sell() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Good spread but size = 5 < trade_size = 10
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.52, 0.55, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.52, 0.55, 5.0));
+
+        assert!(!strategy.check_sell_arb(&pair));
+        assert_eq!(strategy.sell_arbs_detected, 1); // detected but skipped
+    }
+
+    // ---- fee tests ----
+
+    #[rstest]
+    fn test_fee_reduces_profit_below_threshold() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200)) // 2% fee
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // combined_ask = 0.495 + 0.495 = 0.99 → raw profit = 100 bps
+        // per-leg fee = 200/10000 * 0.495 * 0.505 ≈ 0.005 → total fee ≈ 0.01 → net ≈ 0 bps
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.495, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.495, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_fee_still_allows_large_arb() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // combined_ask = 0.40 + 0.40 = 0.80 → raw profit = 2000 bps, fee ≈ 96 bps → net ≈ 1904
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.38, 0.40, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.38, 0.40, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+    }
+
+    // ---- per-leg fee asymmetric ----
+
+    #[rstest]
+    fn test_buy_arb_per_leg_fee_asymmetric_prices() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // yes_ask=0.10, no_ask=0.85 → combined=0.95 → raw profit = 500 bps
+        // per-leg fee is much lower at extreme prices → net ≈ 456 bps > 50
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.08, 0.10, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.83, 0.85, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_sell_arb_per_leg_fee_asymmetric_prices() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // yes_bid=0.90, no_bid=0.15 → combined=1.05 → net ≈ 456 bps > 50
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.90, 0.92, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.15, 0.17, 100.0));
+
+        assert!(strategy.check_sell_arb(&pair));
+    }
+
+    // ---- spread tracking ----
+
+    #[rstest]
+    fn test_best_buy_spread_tracking() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+
+        strategy.check_buy_arb(&pair);
+        assert_eq!(strategy.best_buy_spread, dec!(1.04));
+        assert_eq!(strategy.best_buy_label, "Test Market");
+    }
+
+    #[rstest]
+    fn test_best_sell_spread_tracking() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+
+        strategy.check_sell_arb(&pair);
+        assert_eq!(strategy.best_sell_spread, dec!(0.96));
+        assert_eq!(strategy.best_sell_label, "Test Market");
+    }
+
+    // ---- scenario: spread narrowing to arb ----
+
+    #[rstest]
+    fn test_scenario_spread_narrowing_to_arb() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Market starts efficient: combined_ask=1.04 → no arb
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 0);
+
+        // Tightens to 1.02 → still no arb
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.51, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.51, 100.0));
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 0);
+
+        // Tightens to 1.00 → still no arb (needs strictly < 1.0)
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.50, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.50, 100.0));
+        assert!(!strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 0);
+
+        // Drops to 0.96 → arb triggers
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1);
+
+        // Best spread should track the tightest (0.96)
+        assert_eq!(strategy.best_buy_spread, dec!(0.96));
+    }
+
+    // ---- scenario: multi-pair independent detection ----
+
+    #[rstest]
+    fn test_scenario_multi_pair_independent_detection() {
+        let mut strategy = test_strategy();
+        let pair_a = test_pair();
+        let pair_b = test_pair_b();
+
+        // Pair A has arb spread: combined_ask = 0.96
+        strategy
+            .quotes
+            .insert(pair_a.yes_id, quote(pair_a.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair_a.no_id, quote(pair_a.no_id, 0.45, 0.48, 100.0));
+
+        // Pair B is efficient: combined_ask = 1.04
+        strategy
+            .quotes
+            .insert(pair_b.yes_id, quote(pair_b.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair_b.no_id, quote(pair_b.no_id, 0.48, 0.52, 100.0));
+
+        // Only pair A triggers
+        assert!(strategy.check_buy_arb(&pair_a));
+        assert!(!strategy.check_buy_arb(&pair_b));
+        assert_eq!(strategy.buy_arbs_detected, 1);
+
+        // Best spread should be pair A's 0.96, not pair B's 1.04
+        assert_eq!(strategy.best_buy_spread, dec!(0.96));
+        assert_eq!(strategy.best_buy_label, "Test Market");
+    }
+
+    // ---- boundary precision tests ----
+
+    #[rstest]
+    fn test_buy_arb_exact_threshold_no_profit() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_ask = 0.500 + 0.500 = 1.000 exactly → should NOT trigger (>= 1.0 check)
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.500, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.500, 100.0));
+
+        assert!(!strategy.check_buy_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_sell_arb_exact_threshold_no_profit() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // combined_bid = 0.500 + 0.500 = 1.000 exactly → should NOT trigger (<= 1.0 check)
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.500, 0.55, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.500, 0.55, 100.0));
+
+        assert!(!strategy.check_sell_arb(&pair));
+    }
+
+    #[rstest]
+    fn test_buy_arb_min_profit_exact_boundary() {
+        // min_profit_bps = 50, set spread so profit_bps == 50 exactly → should pass (< comparison)
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // combined_ask = 0.995 → profit_bps = (1.0 - 0.995) * 10000 = 50 bps
+        // But 50 < 50 is false, so this should NOT trigger
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.4975, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.4975, 100.0));
+
+        // combined_ask = 0.4975 + 0.4975 = 0.9950 → profit_bps = 50
+        // The code does `profit_bps < min_profit` i.e. 50 < 50 = false → passes
+        assert!(strategy.check_buy_arb(&pair));
+    }
+
+    // ---- fee eliminates marginal arb ----
+
+    #[rstest]
+    fn test_scenario_fee_eliminates_marginal_arb() {
+        let pair = test_pair();
+
+        // Without fees: combined_ask=0.992 → raw profit = 80 bps > 50 min → arb
+        let config_no_fee = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy_no_fee = ComplementArb::new(config_no_fee);
+        strategy_no_fee
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.496, 100.0));
+        strategy_no_fee
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.496, 100.0));
+        assert!(strategy_no_fee.check_buy_arb(&pair));
+
+        // With 200bps fee: per-leg fee ≈ 0.02 * 0.496 * 0.504 ≈ 0.005 → total ≈ 0.01
+        // net profit = (1.0 - 0.992 - 0.01) * 10000 = -20 bps → no arb
+        let config_fee = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy_fee = ComplementArb::new(config_fee);
+        strategy_fee
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.496, 100.0));
+        strategy_fee
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.496, 100.0));
+        assert!(!strategy_fee.check_buy_arb(&pair));
+    }
+
+    // ---- both filters must pass ----
+
+    #[rstest]
+    fn test_scenario_both_filters_must_pass() {
+        let pair = test_pair();
+
+        // Config: min_profit_bps=50, min_profit_abs=1.0, trade_size=10
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .min_profit_abs(dec!(1))
+            .trade_size(dec!(10))
+            .build();
+
+        // Case 1: bps passes (400 bps) but abs fails ($0.40 < $1.0)
+        let mut s1 = ComplementArb::new(config);
+        // combined_ask = 0.96 → profit_per_share = 0.04 → abs = 0.04 * 10 = $0.40
+        // profit_bps = 400 → passes bps, fails abs
+        s1.quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        s1.quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+        assert!(!s1.check_buy_arb(&pair));
+
+        // Case 2: abs passes ($2.0) but bps would only pass if bps filter were higher
+        // We can't easily make abs pass but bps fail with these params since
+        // profit_abs = profit_per_share * trade_size and bps = profit_per_share * 10000.
+        // With trade_size=10, to get abs >= 1.0 we need per_share >= 0.1 = 1000 bps,
+        // which always passes bps=50. Instead test with trade_size=100:
+        let config2 = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(500))
+            .min_profit_abs(dec!(1))
+            .trade_size(dec!(100))
+            .build();
+        let mut s2 = ComplementArb::new(config2);
+        // combined_ask = 0.97 → profit_per_share = 0.03 → bps = 300 < 500, abs = 3.0 > 1.0
+        s2.quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.485, 200.0));
+        s2.quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.485, 200.0));
+        assert!(!s2.check_buy_arb(&pair));
+
+        // Case 3: both pass
+        let config3 = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .min_profit_abs(dec!(1))
+            .trade_size(dec!(100))
+            .build();
+        let mut s3 = ComplementArb::new(config3);
+        // combined_ask = 0.80 → profit_per_share = 0.20 → bps = 2000 > 50, abs = 20.0 > 1.0
+        s3.quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.38, 0.40, 200.0));
+        s3.quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.38, 0.40, 200.0));
+        assert!(s3.check_buy_arb(&pair));
+    }
+
+    // ---- buy and sell arb mutually exclusive ----
+
+    #[rstest]
+    fn test_scenario_buy_and_sell_arb_mutually_exclusive() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Symmetric quotes: bid=0.48, ask=0.52 → combined_ask=1.04, combined_bid=0.96
+        // Neither side crosses the threshold in profitable direction
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.48, 0.52, 100.0));
+        let buy = strategy.check_buy_arb(&pair);
+        let sell = strategy.check_sell_arb(&pair);
+        assert!(!buy && !sell, "symmetric efficient market triggers neither");
+
+        // Arb-worthy buy: combined_ask=0.96 but combined_bid=0.90 (bid < ask)
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+        let buy = strategy.check_buy_arb(&pair);
+        let sell = strategy.check_sell_arb(&pair);
+        assert!(buy, "should detect buy arb");
+        assert!(!sell, "should NOT detect sell arb simultaneously");
+
+        // Arb-worthy sell: combined_bid=1.04 but combined_ask=1.10
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.52, 0.55, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.52, 0.55, 100.0));
+        let buy = strategy.check_buy_arb(&pair);
+        let sell = strategy.check_sell_arb(&pair);
+        assert!(!buy, "should NOT detect buy arb");
+        assert!(sell, "should detect sell arb");
+    }
+}
+
+mod pair_discovery {
+    use super::*;
+
+    #[rstest]
+    fn test_try_match_complement_forms_pair() {
+        let mut strategy = test_strategy();
+
+        let yes_id = InstrumentId::from("0xabc-111.POLYMARKET");
+        let no_id = InstrumentId::from("0xabc-222.POLYMARKET");
+
+        // Insert a pending No instrument
+        strategy.pending_complements.insert(
+            "0xabc".to_string(),
+            (no_id, "No".to_string(), "Test Market".to_string()),
+        );
+
+        // Match with Yes
+        let result = strategy.try_match_complement(yes_id, "Yes", "Test Market");
+        assert!(result.is_some());
+
+        let pair = result.unwrap();
+        assert_eq!(pair.yes_id, yes_id);
+        assert_eq!(pair.no_id, no_id);
+        assert_eq!(pair.condition_id, "0xabc");
+        assert!(strategy.pairs.contains_key("0xabc"));
+        assert!(strategy.pending_complements.is_empty());
+    }
+
+    #[rstest]
+    fn test_try_match_complement_stores_pending() {
+        let mut strategy = test_strategy();
+        let yes_id = InstrumentId::from("0xabc-111.POLYMARKET");
+
+        let result = strategy.try_match_complement(yes_id, "Yes", "Test Market");
+        assert!(result.is_none());
+
+        assert!(strategy.pending_complements.contains_key("0xabc"));
+        let (stored_id, stored_outcome, stored_label) =
+            strategy.pending_complements.get("0xabc").unwrap();
+        assert_eq!(*stored_id, yes_id);
+        assert_eq!(stored_outcome, "Yes");
+        assert_eq!(stored_label, "Test Market");
+    }
+
+    #[rstest]
+    fn test_try_match_complement_same_outcome_rejected() {
+        let mut strategy = test_strategy();
+
+        let first_yes_id = InstrumentId::from("0xabc-111.POLYMARKET");
+        let second_yes_id = InstrumentId::from("0xabc-222.POLYMARKET");
+
+        strategy.pending_complements.insert(
+            "0xabc".to_string(),
+            (first_yes_id, "Yes".to_string(), "Test Market".to_string()),
+        );
+
+        let result = strategy.try_match_complement(second_yes_id, "Yes", "Test Market 2");
+        assert!(result.is_none());
+
+        // Original pending should be preserved
+        let (stored_id, stored_outcome, _) = strategy.pending_complements.get("0xabc").unwrap();
+        assert_eq!(*stored_id, first_yes_id);
+        assert_eq!(stored_outcome, "Yes");
+    }
+
+    #[rstest]
+    fn test_scenario_incremental_pair_formation_via_on_instrument() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let yes_id = InstrumentId::from("0xnew-111.POLYMARKET");
+        let no_id = InstrumentId::from("0xnew-222.POLYMARKET");
+
+        // First instrument arrives → goes to pending
+        let yes_opt = make_binary_option(yes_id, "Yes", "Will it rain?");
+        strategy
+            .on_instrument(&InstrumentAny::BinaryOption(yes_opt))
+            .unwrap();
+
+        assert!(strategy.pending_complements.contains_key("0xnew"));
+        assert!(!strategy.pairs.contains_key("0xnew"));
+
+        // Complement arrives → pair formed
+        let no_opt = make_binary_option(no_id, "No", "Will it rain?");
+        strategy
+            .on_instrument(&InstrumentAny::BinaryOption(no_opt))
+            .unwrap();
+
+        assert!(strategy.pairs.contains_key("0xnew"));
+        assert!(strategy.pending_complements.is_empty());
+
+        // Verify instrument_to_pair mappings
+        assert_eq!(strategy.instrument_to_pair.get(&yes_id).unwrap(), "0xnew");
+        assert_eq!(strategy.instrument_to_pair.get(&no_id).unwrap(), "0xnew");
+    }
+
+    #[rstest]
+    fn test_scenario_duplicate_instrument_ignored() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let yes_id = InstrumentId::from("0xdup-111.POLYMARKET");
+        let no_id = InstrumentId::from("0xdup-222.POLYMARKET");
+
+        // Form a pair
+        let yes_opt = make_binary_option(yes_id, "Yes", "Duplicate test");
+        let no_opt = make_binary_option(no_id, "No", "Duplicate test");
+        strategy
+            .on_instrument(&InstrumentAny::BinaryOption(yes_opt.clone()))
+            .unwrap();
+        strategy
+            .on_instrument(&InstrumentAny::BinaryOption(no_opt))
+            .unwrap();
+        assert_eq!(strategy.pairs.len(), 1);
+
+        // Receive same instrument again → no duplicate
+        strategy
+            .on_instrument(&InstrumentAny::BinaryOption(yes_opt))
+            .unwrap();
+        assert_eq!(strategy.pairs.len(), 1);
+    }
+}
+
+mod execution_state_machine {
+    use super::*;
+
+    // ---- has_active_arb ----
+
+    #[rstest]
+    fn test_has_active_arb_false_when_empty() {
+        let strategy = test_strategy();
+        assert!(!strategy.has_active_arb("0xabc"));
+    }
+
+    #[rstest]
+    fn test_has_active_arb_true_when_pending() {
+        let mut strategy = test_strategy();
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(
+                ClientOrderId::new("O-001"),
+                ClientOrderId::new("O-002"),
+                OrderSide::Buy,
+            ),
+        );
+        assert!(strategy.has_active_arb("0xabc"));
+    }
+
+    #[rstest]
+    fn test_has_active_arb_false_when_idle() {
+        let mut strategy = test_strategy();
+        let mut exec = make_arb_execution(
+            ClientOrderId::new("O-001"),
+            ClientOrderId::new("O-002"),
+            OrderSide::Buy,
+        );
+        exec.state = ArbState::Idle;
+        strategy.arb_executions.insert("0xabc".to_string(), exec);
+        assert!(!strategy.has_active_arb("0xabc"));
+    }
+
+    // ---- submit_arb ----
+
+    #[rstest]
+    fn test_submit_arb_noop_when_live_trading_false() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1);
+        assert_eq!(strategy.arbs_submitted, 0);
+        assert!(strategy.arb_executions.is_empty());
+    }
+
+    #[rstest]
+    fn test_submit_arb_blocked_by_active_arb() {
+        let mut strategy = test_strategy();
+        let yes_order_id = ClientOrderId::new("O-001");
+        let no_order_id = ClientOrderId::new("O-002");
+
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy),
+        );
+
+        assert!(strategy.has_active_arb("0xabc"));
+    }
+
+    #[rstest]
+    fn test_scenario_submit_arb_creates_two_orders() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .live_trading(true)
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.arbs_submitted, 1);
+        assert!(strategy.arb_executions.contains_key("0xabc"));
+        assert_eq!(strategy.order_to_pair.len(), 2);
+
+        let exec = strategy.arb_executions.get("0xabc").unwrap();
+        assert_eq!(exec.state, ArbState::PendingEntry);
+        assert_eq!(exec.arb_side, OrderSide::Buy);
+    }
+
+    #[rstest]
+    fn test_scenario_active_arb_suppresses_detection() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+
+        // Insert active PendingEntry execution
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(
+                ClientOrderId::new("O-001"),
+                ClientOrderId::new("O-002"),
+                OrderSide::Buy,
+            ),
+        );
+
+        // Feed arb-worthy quotes via on_quote
+        let arb_quote_yes = quote(pair.yes_id, 0.45, 0.48, 100.0);
+        strategy.on_quote(&arb_quote_yes).unwrap();
+
+        // Detection should be suppressed — counter stays at 0
+        assert_eq!(strategy.buy_arbs_detected, 0);
+        assert_eq!(strategy.sell_arbs_detected, 0);
+    }
+
+    #[rstest]
+    fn test_scenario_active_arb_on_pair_a_allows_pair_b() {
+        let mut strategy = test_strategy();
+        let pair_a = test_pair();
+        let pair_b = test_pair_b();
+        wire_pair(&mut strategy, &pair_a);
+        wire_pair(&mut strategy, &pair_b);
+
+        // Active arb on pair A
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(
+                ClientOrderId::new("O-001"),
+                ClientOrderId::new("O-002"),
+                OrderSide::Buy,
+            ),
+        );
+
+        // Feed arb-worthy quotes for pair A → suppressed
+        strategy
+            .quotes
+            .insert(pair_a.yes_id, quote(pair_a.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair_a.no_id, quote(pair_a.no_id, 0.45, 0.48, 100.0));
+        let a_quote = quote(pair_a.yes_id, 0.45, 0.48, 100.0);
+        strategy.on_quote(&a_quote).unwrap();
+        assert_eq!(strategy.buy_arbs_detected, 0);
+
+        // Feed arb-worthy quotes for pair B → should detect
+        strategy
+            .quotes
+            .insert(pair_b.yes_id, quote(pair_b.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair_b.no_id, quote(pair_b.no_id, 0.45, 0.48, 100.0));
+        let b_quote = quote(pair_b.yes_id, 0.45, 0.48, 100.0);
+        strategy.on_quote(&b_quote).unwrap();
+        assert_eq!(strategy.buy_arbs_detected, 1);
+    }
+
+    // ---- handle_fill scenarios ----
+
+    #[rstest]
+    fn test_scenario_handle_fill_both_legs_complete() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+        let instrument_yes =
+            InstrumentAny::BinaryOption(make_binary_option(pair.yes_id, "Yes", "Test Market"));
+        let instrument_no =
+            InstrumentAny::BinaryOption(make_binary_option(pair.no_id, "No", "Test Market"));
+
+        // Build two orders with distinct IDs
+        let yes_order = build_limit_order(pair.yes_id, OrderSide::Buy, "0.480", "10", "O-YES-1");
+        let no_order = build_limit_order(pair.no_id, OrderSide::Buy, "0.480", "10", "O-NO-1");
+        let yes_order_id = yes_order.client_order_id();
+        let no_order_id = no_order.client_order_id();
+
+        // Put both in cache as "accepted" (open, not yet filled)
+        let yes_accepted = TestOrderStubs::make_accepted_order(&yes_order);
+        let no_accepted = TestOrderStubs::make_accepted_order(&no_order);
+        {
+            let cache_rc = strategy.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(yes_accepted, None, None, false)
+                .unwrap();
+            cache_rc
+                .borrow_mut()
+                .add_order(no_accepted, None, None, false)
+                .unwrap();
+        }
+
+        // Set up arb execution
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy),
+        );
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+
+        // Step 1: Apply fill to yes order in cache, then handle_fill
+        let yes_fill_event = TestOrderEventStubs::filled(
+            &yes_order,
+            &instrument_yes,
+            None,
+            None,
+            Some(Price::from("0.480")),
+            None,
+            Some(LiquiditySide::Taker),
+            None,
+            None,
+            None,
+        );
+        {
+            let cache_rc = strategy.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            let order = cache.mut_order(&yes_order_id).unwrap();
+            order.apply(yes_fill_event.clone()).unwrap();
+        }
+        let yes_fill = match &yes_fill_event {
+            OrderEventAny::Filled(f) => *f,
+            _ => unreachable!(),
+        };
+        strategy.handle_fill(&yes_fill);
+
+        // Yes leg closed, no leg still open → PartialFill
+        let exec = strategy.arb_executions.get("0xabc").unwrap();
+        assert_eq!(exec.state, ArbState::PartialFill);
+        assert_eq!(exec.yes_filled_qty, dec!(10));
+
+        // Step 2: Apply fill to no order in cache, then handle_fill
+        let no_fill_event = TestOrderEventStubs::filled(
+            &no_order,
+            &instrument_no,
+            None,
+            None,
+            Some(Price::from("0.480")),
+            None,
+            Some(LiquiditySide::Taker),
+            None,
+            None,
+            None,
+        );
+        {
+            let cache_rc = strategy.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            let order = cache.mut_order(&no_order_id).unwrap();
+            order.apply(no_fill_event.clone()).unwrap();
+        }
+        let no_fill = match &no_fill_event {
+            OrderEventAny::Filled(f) => *f,
+            _ => unreachable!(),
+        };
+        strategy.handle_fill(&no_fill);
+
+        // Both legs filled → arb complete
+        assert_eq!(strategy.arbs_completed, 1);
+        assert!(strategy.arb_executions.is_empty());
+        assert!(strategy.order_to_pair.is_empty());
+    }
+
+    #[rstest]
+    fn test_scenario_handle_fill_partial_state_transition() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+        let instrument =
+            InstrumentAny::BinaryOption(make_binary_option(pair.yes_id, "Yes", "Test Market"));
+
+        // Build orders: yes will be filled, no will remain open (not in cache)
+        let yes_order = build_limit_order(pair.yes_id, OrderSide::Buy, "0.480", "10", "O-YES-2");
+        let no_order = build_limit_order(pair.no_id, OrderSide::Buy, "0.480", "10", "O-NO-2");
+        let yes_order_id = yes_order.client_order_id();
+        let no_order_id = no_order.client_order_id();
+
+        // Make yes filled (closed), leave no out of cache (= not closed)
+        let yes_filled =
+            TestOrderStubs::make_filled_order(&yes_order, &instrument, LiquiditySide::Taker);
+        {
+            let cache_rc = strategy.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(yes_filled, None, None, false)
+                .unwrap();
+        }
+
+        // Set up arb execution
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy),
+        );
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+
+        // Fill the yes leg
+        let yes_fill = OrderFilled::new(
+            TraderId::from("TESTER-001"),
+            StrategyId::from("COMPLEMENT_ARB-001"),
+            pair.yes_id,
+            yes_order_id,
+            VenueOrderId::from("V-001"),
+            AccountId::from("SIM-001"),
+            TradeId::new("T-001"),
+            OrderSide::Buy,
+            OrderType::Limit,
+            Quantity::from("10"),
+            Price::from("0.480"),
+            Currency::USDC(),
+            LiquiditySide::Taker,
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            false,
+            None,
+            None,
+        );
+        strategy.handle_fill(&yes_fill);
+
+        // Other leg not closed → should transition to PartialFill
+        let exec = strategy.arb_executions.get("0xabc").unwrap();
+        assert_eq!(exec.state, ArbState::PartialFill);
+        assert_eq!(exec.yes_filled_qty, dec!(10));
+        assert_eq!(exec.no_filled_qty, Decimal::ZERO);
+    }
+
+    #[rstest]
+    fn test_scenario_handle_fill_unwind_order_completes() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+        let instrument =
+            InstrumentAny::BinaryOption(make_binary_option(pair.yes_id, "Yes", "Test Market"));
+
+        // Build and fill the unwind order
+        let unwind_order =
+            build_limit_order(pair.yes_id, OrderSide::Sell, "0.470", "10", "O-UNWIND-3");
+        let unwind_order_id = unwind_order.client_order_id();
+        let unwind_filled =
+            TestOrderStubs::make_filled_order(&unwind_order, &instrument, LiquiditySide::Taker);
+        {
+            let cache_rc = strategy.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(unwind_filled, None, None, false)
+                .unwrap();
+        }
+
+        // Set up Unwinding state
+        let yes_order_id = ClientOrderId::new("O-ENTRY-YES");
+        let no_order_id = ClientOrderId::new("O-ENTRY-NO");
+        let mut exec = make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy);
+        exec.state = ArbState::Unwinding;
+        exec.yes_filled_qty = dec!(10);
+        exec.unwind_order_id = Some(unwind_order_id);
+        strategy.arb_executions.insert("0xabc".to_string(), exec);
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(unwind_order_id, "0xabc".to_string());
+
+        // Fill event for unwind order
+        let unwind_fill = OrderFilled::new(
+            TraderId::from("TESTER-001"),
+            StrategyId::from("COMPLEMENT_ARB-001"),
+            pair.yes_id,
+            unwind_order_id,
+            VenueOrderId::from("V-UNW"),
+            AccountId::from("SIM-001"),
+            TradeId::new("T-UNW"),
+            OrderSide::Sell,
+            OrderType::Limit,
+            Quantity::from("10"),
+            Price::from("0.470"),
+            Currency::USDC(),
+            LiquiditySide::Taker,
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            false,
+            None,
+            None,
+        );
+        strategy.handle_fill(&unwind_fill);
+
+        // Unwind complete → cleaned up
+        assert_eq!(strategy.arbs_unwound, 1);
+        assert!(strategy.arb_executions.is_empty());
+        assert!(strategy.order_to_pair.is_empty());
+    }
+
+    // ---- handle_order_terminal scenarios ----
+
+    #[rstest]
+    fn test_scenario_handle_terminal_both_legs_no_fills() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+
+        // Build two orders and make them accepted then canceled (closed, no fills)
+        let yes_order = build_limit_order(pair.yes_id, OrderSide::Buy, "0.480", "10", "O-YES-4");
+        let no_order = build_limit_order(pair.no_id, OrderSide::Buy, "0.480", "10", "O-NO-4");
+        let yes_order_id = yes_order.client_order_id();
+        let no_order_id = no_order.client_order_id();
+
+        // Make accepted then canceled → closed with 0 fills
+        let mut yes_accepted = TestOrderStubs::make_accepted_order(&yes_order);
+        let yes_cancel =
+            TestOrderEventStubs::canceled(&yes_accepted, AccountId::from("SIM-001"), None);
+        yes_accepted.apply(yes_cancel).unwrap();
+
+        let mut no_accepted = TestOrderStubs::make_accepted_order(&no_order);
+        let no_cancel =
+            TestOrderEventStubs::canceled(&no_accepted, AccountId::from("SIM-001"), None);
+        no_accepted.apply(no_cancel).unwrap();
+
+        // Add to cache
+        {
+            let cache_rc = strategy.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(yes_accepted, None, None, false)
+                .unwrap();
+            cache_rc
+                .borrow_mut()
+                .add_order(no_accepted, None, None, false)
+                .unwrap();
+        }
+
+        // Set up arb execution with zero fills
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy),
+        );
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+
+        // First leg terminal arrives
+        strategy.handle_order_terminal(yes_order_id, "expired");
+
+        // Both closed, no fills → ARB FAILED
+        assert_eq!(strategy.arbs_failed, 1);
+        assert!(strategy.arb_executions.is_empty());
+    }
+
+    #[rstest]
+    fn test_scenario_handle_terminal_triggers_unwind() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+        let instrument =
+            InstrumentAny::BinaryOption(make_binary_option(pair.yes_id, "Yes", "Test Market"));
+
+        // Yes leg: filled (closed)
+        let yes_order = build_limit_order(pair.yes_id, OrderSide::Buy, "0.480", "10", "O-YES-5");
+        let no_order = build_limit_order(pair.no_id, OrderSide::Buy, "0.480", "10", "O-NO-5");
+        let yes_order_id = yes_order.client_order_id();
+        let no_order_id = no_order.client_order_id();
+
+        let yes_filled =
+            TestOrderStubs::make_filled_order(&yes_order, &instrument, LiquiditySide::Taker);
+
+        // No leg: accepted then canceled (closed, no fills)
+        let mut no_accepted = TestOrderStubs::make_accepted_order(&no_order);
+        let no_cancel =
+            TestOrderEventStubs::canceled(&no_accepted, AccountId::from("SIM-001"), None);
+        no_accepted.apply(no_cancel).unwrap();
+
+        {
+            let cache_rc = strategy.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(yes_filled, None, None, false)
+                .unwrap();
+            cache_rc
+                .borrow_mut()
+                .add_order(no_accepted, None, None, false)
+                .unwrap();
+        }
+
+        // Set up execution: yes has fills, no does not
+        let mut exec = make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy);
+        exec.yes_filled_qty = dec!(10);
+        strategy.arb_executions.insert("0xabc".to_string(), exec);
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+
+        // Need a quote for unwind pricing
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+
+        // No leg terminal arrives → both closed, yes has fills → initiate_unwind
+        strategy.handle_order_terminal(no_order_id, "expired");
+
+        // Should be in Unwinding state (or failed if submit_unwind errors in test env)
+        let exec = strategy.arb_executions.get("0xabc");
+        if let Some(e) = exec {
+            assert_eq!(e.state, ArbState::Unwinding);
+            assert!(e.unwind_order_id.is_some());
+        } else {
+            // If unwind submission failed (no message bus), it should have cleaned up
+            assert!(strategy.arbs_failed > 0);
+        }
+    }
+
+    #[rstest]
+    fn test_scenario_unwinding_ignores_entry_leg_terminal() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+
+        let yes_order_id = ClientOrderId::new("O-YES");
+        let no_order_id = ClientOrderId::new("O-NO");
+        let unwind_order_id = ClientOrderId::new("O-UNWIND");
+
+        let mut exec = make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy);
+        exec.state = ArbState::Unwinding;
+        exec.unwind_order_id = Some(unwind_order_id);
+        exec.yes_filled_qty = dec!(10);
+
+        strategy.arb_executions.insert("0xabc".to_string(), exec);
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(unwind_order_id, "0xabc".to_string());
+
+        // Entry leg terminal → should be ignored during unwind
+        strategy.handle_order_terminal(yes_order_id, "canceled");
+
+        // State unchanged
+        let exec = strategy.arb_executions.get("0xabc").unwrap();
+        assert_eq!(exec.state, ArbState::Unwinding);
+        assert_eq!(strategy.arbs_failed, 0);
+        assert_eq!(strategy.arbs_unwound, 0);
+    }
+
+    #[rstest]
+    fn test_scenario_unwind_order_rejected_fails() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        let pair = test_pair();
+        wire_pair(&mut strategy, &pair);
+
+        let yes_order_id = ClientOrderId::new("O-YES");
+        let no_order_id = ClientOrderId::new("O-NO");
+        let unwind_order_id = ClientOrderId::new("O-UNWIND");
+
+        let mut exec = make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy);
+        exec.state = ArbState::Unwinding;
+        exec.unwind_order_id = Some(unwind_order_id);
+        exec.yes_filled_qty = dec!(10);
+
+        strategy.arb_executions.insert("0xabc".to_string(), exec);
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(unwind_order_id, "0xabc".to_string());
+
+        // Unwind order terminal → UNWIND FAILED
+        strategy.handle_order_terminal(unwind_order_id, "rejected");
+
+        assert_eq!(strategy.arbs_failed, 1);
+        assert!(strategy.arb_executions.is_empty());
+        assert!(strategy.order_to_pair.is_empty());
+    }
+
+    #[rstest]
+    fn test_scenario_handle_terminal_unknown_order_noop() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        // Random order ID not in order_to_pair → no-op
+        strategy.handle_order_terminal(ClientOrderId::new("O-UNKNOWN"), "rejected");
+
+        assert_eq!(strategy.arbs_failed, 0);
+        assert_eq!(strategy.arbs_completed, 0);
+    }
+
+    #[rstest]
+    fn test_scenario_handle_fill_unknown_order_noop() {
+        let mut strategy = test_strategy();
+        register_strategy(&mut strategy);
+
+        // Fill for unknown order → no-op
+        let fill = OrderFilled::new(
+            TraderId::from("TESTER-001"),
+            StrategyId::from("COMPLEMENT_ARB-001"),
+            InstrumentId::from("0xabc-111.POLYMARKET"),
+            ClientOrderId::new("O-UNKNOWN"),
+            VenueOrderId::from("V-001"),
+            AccountId::from("SIM-001"),
+            TradeId::new("T-001"),
+            OrderSide::Buy,
+            OrderType::Limit,
+            Quantity::from("10"),
+            Price::from("0.480"),
+            Currency::USDC(),
+            LiquiditySide::Taker,
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            false,
+            None,
+            None,
+        );
+        strategy.handle_fill(&fill);
+
+        assert_eq!(strategy.arbs_completed, 0);
+        assert_eq!(strategy.arbs_failed, 0);
+    }
+}
+
+mod lifecycle {
+    use super::*;
+
+    #[rstest]
+    fn test_on_reset_clears_all_state() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        strategy.pairs.insert("test".to_string(), pair.clone());
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.48, 0.52, 100.0));
+        strategy.buy_arbs_detected = 5;
+
+        strategy.on_reset().unwrap();
+
+        assert!(strategy.pairs.is_empty());
+        assert!(strategy.quotes.is_empty());
+        assert_eq!(strategy.buy_arbs_detected, 0);
+        assert_eq!(strategy.best_buy_spread, dec!(2));
+        assert_eq!(strategy.best_sell_spread, dec!(0));
+    }
+
+    #[rstest]
+    fn test_on_reset_clears_execution_state() {
+        let mut strategy = test_strategy();
+        let yes_order_id = ClientOrderId::new("O-001");
+        let no_order_id = ClientOrderId::new("O-002");
+
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(yes_order_id, no_order_id, OrderSide::Buy),
+        );
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy.arbs_submitted = 5;
+        strategy.arbs_completed = 3;
+        strategy.arbs_unwound = 1;
+        strategy.arbs_failed = 1;
+
+        strategy.on_reset().unwrap();
+
+        assert!(strategy.arb_executions.is_empty());
+        assert!(strategy.order_to_pair.is_empty());
+        assert_eq!(strategy.arbs_submitted, 0);
+        assert_eq!(strategy.arbs_completed, 0);
+        assert_eq!(strategy.arbs_unwound, 0);
+        assert_eq!(strategy.arbs_failed, 0);
+    }
+
+    #[rstest]
+    fn test_pending_complements_cleared_on_reset() {
+        let mut strategy = test_strategy();
+
+        strategy.pending_complements.insert(
+            "0xabc".to_string(),
+            (
+                InstrumentId::from("0xabc-111.POLYMARKET"),
+                "Yes".to_string(),
+                "Test".to_string(),
+            ),
+        );
+
+        strategy.on_reset().unwrap();
+        assert!(strategy.pending_complements.is_empty());
+    }
+
+    #[rstest]
+    fn test_scenario_full_detection_cycle_with_reset() {
+        let mut strategy = test_strategy();
+        let pair = test_pair();
+
+        // Detect arbs
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.45, 0.48, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.45, 0.48, 100.0));
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1);
+        assert_eq!(strategy.best_buy_spread, dec!(0.96));
+
+        // Reset
+        strategy.on_reset().unwrap();
+        assert_eq!(strategy.buy_arbs_detected, 0);
+        assert_eq!(strategy.best_buy_spread, dec!(2));
+        assert!(strategy.quotes.is_empty());
+
+        // Detect arbs again with different quotes
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.38, 0.40, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.38, 0.40, 100.0));
+        assert!(strategy.check_buy_arb(&pair));
+        assert_eq!(strategy.buy_arbs_detected, 1); // counter starts fresh
+        assert_eq!(strategy.best_buy_spread, dec!(0.80));
+    }
+
+    #[rstest]
+    fn test_cleanup_arb_removes_all_tracking() {
+        let mut strategy = test_strategy();
+
+        let yes_order_id = ClientOrderId::new("O-001");
+        let no_order_id = ClientOrderId::new("O-002");
+        let unwind_order_id = ClientOrderId::new("O-003");
+
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            ArbExecution {
+                state: ArbState::Unwinding,
+                arb_side: OrderSide::Buy,
+                yes_order_id,
+                no_order_id,
+                yes_filled_qty: dec!(10),
+                no_filled_qty: Decimal::ZERO,
+                unwind_order_id: Some(unwind_order_id),
+            },
+        );
+        strategy
+            .order_to_pair
+            .insert(yes_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(no_order_id, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(unwind_order_id, "0xabc".to_string());
+
+        strategy.cleanup_arb("0xabc");
+
+        assert!(strategy.arb_executions.is_empty());
+        assert!(strategy.order_to_pair.is_empty());
+    }
+
+    #[rstest]
+    fn test_scenario_cleanup_isolation_between_pairs() {
+        let mut strategy = test_strategy();
+
+        let pair_a_yes = ClientOrderId::new("O-A-YES");
+        let pair_a_no = ClientOrderId::new("O-A-NO");
+        let pair_b_yes = ClientOrderId::new("O-B-YES");
+        let pair_b_no = ClientOrderId::new("O-B-NO");
+
+        strategy.arb_executions.insert(
+            "0xabc".to_string(),
+            make_arb_execution(pair_a_yes, pair_a_no, OrderSide::Buy),
+        );
+        strategy
+            .order_to_pair
+            .insert(pair_a_yes, "0xabc".to_string());
+        strategy
+            .order_to_pair
+            .insert(pair_a_no, "0xabc".to_string());
+
+        strategy.arb_executions.insert(
+            "0xdef".to_string(),
+            make_arb_execution(pair_b_yes, pair_b_no, OrderSide::Sell),
+        );
+        strategy
+            .order_to_pair
+            .insert(pair_b_yes, "0xdef".to_string());
+        strategy
+            .order_to_pair
+            .insert(pair_b_no, "0xdef".to_string());
+
+        // Cleanup pair A only
+        strategy.cleanup_arb("0xabc");
+
+        // Pair A cleaned
+        assert!(!strategy.arb_executions.contains_key("0xabc"));
+        assert!(!strategy.order_to_pair.contains_key(&pair_a_yes));
+        assert!(!strategy.order_to_pair.contains_key(&pair_a_no));
+
+        // Pair B untouched
+        assert!(strategy.arb_executions.contains_key("0xdef"));
+        assert!(strategy.order_to_pair.contains_key(&pair_b_yes));
+        assert!(strategy.order_to_pair.contains_key(&pair_b_no));
+    }
+
+    #[rstest]
+    fn test_scenario_diagnostic_summary_does_not_panic() {
+        let mut strategy = test_strategy();
+
+        // Set various counter states
+        strategy.arbs_submitted = 10;
+        strategy.arbs_completed = 5;
+        strategy.arbs_unwound = 2;
+        strategy.arbs_failed = 3;
+        strategy.buy_arbs_detected = 15;
+        strategy.sell_arbs_detected = 8;
+        strategy.quotes_processed = 1000;
+        strategy.best_buy_spread = dec!(0.95);
+        strategy.best_buy_label = "Some Market".to_string();
+        strategy.best_sell_spread = dec!(1.05);
+        strategy.best_sell_label = "Other Market".to_string();
+
+        // Should not panic
+        strategy.log_diagnostic_summary();
+
+        // Also test with default/zero state
+        let fresh_strategy = test_strategy();
+        fresh_strategy.log_diagnostic_summary();
+    }
+}
+
+mod configuration {
+    use super::*;
+
+    #[rstest]
+    fn test_config_defaults() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .build();
+
+        assert_eq!(config.order_expire_secs, 15);
+        assert_eq!(config.unwind_slippage_bps, dec!(50));
+        assert!(!config.live_trading);
+    }
+
+    #[rstest]
+    fn test_config_post_only_false_still_works() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .use_post_only(false)
+            .build();
+
+        assert!(!config.use_post_only);
+
+        // Strategy initializes correctly
+        let strategy = ComplementArb::new(config);
+        assert_eq!(strategy.buy_arbs_detected, 0);
+    }
+
+    #[rstest]
+    fn test_config_zero_fee_no_fee_deduction() {
+        let config = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(0))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy = ComplementArb::new(config);
+        let pair = test_pair();
+
+        // Marginal arb: combined_ask = 0.994 → raw profit = 60 bps
+        // With zero fee, net profit = 60 bps > 50 → should pass
+        strategy
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.497, 100.0));
+        strategy
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.497, 100.0));
+
+        assert!(strategy.check_buy_arb(&pair));
+
+        // Same with a fee that would kill it
+        let config_fee = ComplementArbConfig::builder()
+            .venue(Venue::new("POLYMARKET"))
+            .fee_estimate_bps(dec!(200))
+            .min_profit_bps(dec!(50))
+            .trade_size(dec!(10))
+            .build();
+        let mut strategy_fee = ComplementArb::new(config_fee);
+        strategy_fee
+            .quotes
+            .insert(pair.yes_id, quote(pair.yes_id, 0.49, 0.497, 100.0));
+        strategy_fee
+            .quotes
+            .insert(pair.no_id, quote(pair.no_id, 0.49, 0.497, 100.0));
+
+        assert!(!strategy_fee.check_buy_arb(&pair));
+    }
+}

--- a/docs/tutorials/complement_arb_polymarket.md
+++ b/docs/tutorials/complement_arb_polymarket.md
@@ -1,0 +1,820 @@
+# Complement Arbitrage on Polymarket Binary Options
+
+This tutorial walks through running a complement arbitrage strategy on Polymarket using the
+Rust-native `LiveNode`.
+
+**What you'll learn:**
+
+- How complement arbitrage works on binary options and why `Yes + No = 1.0` creates
+  risk-free profit opportunities.
+- How to configure the Polymarket data pipeline — startup filters, WebSocket market
+  discovery, and instrument pairing by condition ID.
+- How the per-pair state machine manages execution risk: entry orders, partial fill
+  detection, and automatic unwind.
+- How to run the strategy in detection-only mode, tune parameters, and graduate to
+  live execution.
+
+## Introduction
+
+### What is complement arbitrage?
+
+Binary options have a mathematical constraint: at resolution, `Yes + No = 1.0`. A Yes
+contract pays $1 if the outcome is true and $0 otherwise; a No contract pays the opposite.
+Holding both sides guarantees a $1 payout regardless of the outcome.
+
+When market inefficiencies cause the combined ask price of a Yes/No pair to fall below $1.00,
+buying both sides locks in risk-free profit. When the combined bid exceeds $1.00, selling both
+sides does the same. These are **buy arbs** and **sell arbs** respectively.
+
+```
+Buy arb:  yes_ask + no_ask < 1.0   →  cost < guaranteed payout
+Sell arb: yes_bid + no_bid > 1.0   →  revenue > guaranteed liability
+```
+
+### Why Polymarket?
+
+Polymarket is the largest prediction market by volume, with thousands of active binary option
+markets across politics, sports, crypto, and current events. Several features make it
+well-suited for complement arbitrage:
+
+- **Binary option pairs**: every market has a Yes and No token sharing a condition ID.
+  These are mathematically complementary — one must resolve to $1 and the other to $0.
+- **On-chain settlement**: CTF (Conditional Token Framework) tokens settle deterministically
+  on Polygon. Holding Yes + No guarantees a $1 redemption.
+- **Deep liquidity on popular markets**: sports and political markets routinely have
+  $100k+ in liquidity, providing enough depth for meaningful arb sizes.
+- **WebSocket market discovery**: the adapter supports real-time new market notifications,
+  enabling the strategy to discover and monitor new pairs as they are listed.
+- **Post-only orders**: maker orders have 0% fee on Polymarket, eliminating fee drag on
+  arb execution.
+
+### Complement pair mechanics
+
+Each Polymarket market creates two CLOB tokens sharing a condition ID. The adapter represents
+these as `BinaryOption` instruments with IDs like:
+
+```
+0xabc...def-<yes_token_id>.POLYMARKET   (outcome: "Yes")
+0xabc...def-<no_token_id>.POLYMARKET    (outcome: "No")
+```
+
+The strategy groups instruments by the hex prefix before the last `-` (the condition ID) and
+matches pairs where one has outcome `"Yes"` and the other `"No"`.
+
+## Prerequisites
+
+### Polymarket account
+
+You need a Polymarket account with:
+
+1. **A wallet for signing orders.** Polymarket supports three signing modes
+   (configured via `signature_type` on the execution client):
+   - **`PolyGnosisSafe` (recommended)** — proxy wallet backed by a Gnosis Safe.
+     This is what you get when you create an account through the Polymarket web UI
+     by connecting MetaMask (or any browser wallet). Two big advantages: order
+     submission is **gas-free** (the Polymarket relayer pays gas) and the same
+     account is visible in the Polymarket web GUI, so you can monitor positions
+     and intervene manually if needed.
+   - **`PolyProxy`** — older proxy wallet variant. Use this if you have a legacy
+     Polymarket account that was created before the Gnosis Safe migration.
+   - **`Eoa`** — direct on-chain signing with an EOA private key. No proxy, no
+     relayer, no GUI integration — you pay gas yourself. Intended for advanced
+     users who want direct on-chain control. Most traders should not start here.
+2. **API credentials** (key, secret, passphrase) for the L2 CLOB API.
+3. **USDC.e allowance** set for the CTF Exchange contract on Polygon.
+
+For the proxy wallet modes (`PolyGnosisSafe` / `PolyProxy`), `POLYMARKET_PK` is
+the private key of the **owner** wallet (e.g. your MetaMask key) that controls
+the proxy — *not* a separate trading key — and `POLYMARKET_FUNDER` is the
+on-chain address of the proxy itself (visible in the Polymarket UI under your
+profile / settings).
+
+See the [Polymarket integration guide](../integrations/polymarket.md) for detailed setup
+instructions, including wallet configuration, allowance scripts, and API key generation.
+
+### Environment variables
+
+```bash
+# Required: signer private key (hex, with or without 0x prefix).
+# In proxy modes (PolyGnosisSafe / PolyProxy) this is the *owner* wallet —
+# e.g. the MetaMask private key that controls your Polymarket proxy.
+# In Eoa mode it is the trading key itself.
+export POLYMARKET_PK="0x..."
+
+# Required: L2 API credentials.
+export POLYMARKET_API_KEY="your-api-key"
+export POLYMARKET_API_SECRET="your-api-secret"
+export POLYMARKET_PASSPHRASE="your-passphrase"
+
+# Required for proxy modes: the on-chain address of your Polymarket proxy
+# (Gnosis Safe or PolyProxy contract). Find it in the Polymarket UI under
+# your profile / settings.
+export POLYMARKET_FUNDER="0x..."
+```
+
+Alternatively, place these in a `.env` file in the project root (loaded automatically
+via `dotenvy`).
+
+#### Generating API credentials
+
+If you don't already have CLOB API credentials, the adapter ships with a small
+helper binary that signs an EIP-712 `ClobAuth` message with your `POLYMARKET_PK`
+and calls the CLOB auth endpoints to create or derive a key/secret/passphrase
+triple for that signer:
+
+```bash
+export POLYMARKET_PK="0x..."  # owner wallet for proxy modes, trading key for Eoa
+cargo run -p nautilus-polymarket --bin polymarket-create-api-key
+```
+
+The script prints the credentials to stdout. Copy them into your `.env` (or
+export them as `POLYMARKET_API_KEY` / `POLYMARKET_API_SECRET` /
+`POLYMARKET_PASSPHRASE`) and you're set. Source: `crates/adapters/polymarket/bin/create_api_key.rs`.
+
+## Strategy overview
+
+### Pair discovery
+
+On startup, the strategy:
+
+1. Queries the instrument cache for all `BinaryOption` instruments on the configured venue.
+2. Groups instruments by condition ID (extracted from the symbol via `rfind('-')`).
+3. Matches groups of exactly two instruments where one has outcome `"Yes"` and the other
+   `"No"`.
+4. Subscribes to quotes for both legs of each discovered pair.
+5. Subscribes to new instruments on the venue for dynamic pair discovery.
+
+When new instruments arrive via the `on_instrument` handler, the strategy performs an O(1)
+lookup against pending unpaired instruments. If the complement is already pending, a pair
+is formed immediately and quotes are subscribed. Otherwise the instrument is stored as
+pending until its complement arrives.
+
+### Buy arb detection
+
+A buy arb exists when the cost of buying both sides is less than the guaranteed $1 payout:
+
+```
+combined_ask = yes_ask + no_ask
+fee          = leg_fee(yes_ask) + leg_fee(no_ask)
+               where leg_fee(p) = fee_estimate_bps / 10_000 × p × (1 - p)
+profit_bps   = (1.0 - combined_ask - fee) * 10_000
+```
+
+The strategy triggers when:
+
+- `combined_ask < 1.0` (raw arb exists)
+- `profit_bps >= min_profit_bps` (profit exceeds minimum threshold)
+- `ask_size >= trade_size` on both legs (sufficient liquidity)
+
+### Sell arb detection
+
+A sell arb exists when selling both sides collects more than the $1 liability:
+
+```
+combined_bid = yes_bid + no_bid
+fee          = leg_fee(yes_bid) + leg_fee(no_bid)
+               where leg_fee(p) = fee_estimate_bps / 10_000 × p × (1 - p)
+profit_bps   = (combined_bid - fee - 1.0) * 10_000
+```
+
+Same trigger conditions apply, using bid prices and bid sizes.
+
+### Execution
+
+#### Why execution is the hard part
+
+Detecting a complement arb is straightforward — if `yes_ask + no_ask < 1.0` after fees,
+there's profit. The challenge is *capturing* that profit. Polymarket's CLOB does not
+support atomic cross-instrument orders, so the strategy must submit two independent limit
+orders (one per leg) and manage the risk that only one fills.
+
+Without proper execution logic, three things can go wrong:
+
+1. **Stale arbs**: the spread closes before orders fill, resulting in no execution or
+   an unfavorable fill.
+2. **Partial fills**: one leg fills but the other is rejected, expires, or gets cancelled.
+   You now hold a directional binary option position — one side resolves to $0.
+3. **Duplicate entries**: a new arb signal fires on the same pair while the previous
+   attempt is still pending, doubling exposure.
+
+The strategy addresses these with a per-pair state machine, GTD expiry, and automatic
+unwind logic.
+
+#### Per-pair state machine
+
+Each complement pair has an independent execution state:
+
+```
+Idle ──[arb detected]──→ PendingEntry ──[both legs fill]──→ Idle (arb complete)
+                              │
+                    [one fills, other fails]
+                              │
+                              ▼
+                        PartialFill ──[other leg fills]──→ Idle (arb complete)
+                              │
+                    [other leg rejected/expired/canceled]
+                              │
+                              ▼
+                         Unwinding ──[unwind fills]──→ Idle (loss cut)
+```
+
+- **Idle**: no active orders on this pair. Arb detection runs on every quote update.
+- **PendingEntry**: both leg orders submitted as GTD limit orders. Arb detection is
+  suppressed for this pair to prevent duplicate entries.
+- **PartialFill**: one leg has filled but the other is still open. The strategy waits
+  for the second leg — if it also fills, the arb succeeds. If it fails, the strategy
+  transitions to Unwinding.
+- **Unwinding**: one leg filled, the other failed. The strategy submits an IOC limit
+  order on the filled leg's instrument to exit the position at the current market price
+  (adjusted for `unwind_slippage_bps`). Once the unwind fills, the pair returns to Idle.
+
+#### Entry orders
+
+When an arb is detected and `live_trading` is `true`:
+
+1. **Guard checks**: no active arb on this pair, in-flight arbs < `max_concurrent_arbs`.
+2. **Both legs submitted** as limit orders at the detected ask/bid prices.
+   - `TimeInForce::Gtd` with `order_expire_secs` expiry — orders auto-cancel if not
+     filled within the window.
+   - `post_only = use_post_only` — for 0% maker fee when enabled.
+3. **State transitions** to `PendingEntry`. Quote-driven arb detection is suppressed
+   for this pair until the attempt resolves.
+
+#### Unwind logic
+
+If one leg fills but the other is rejected, expires, or is externally canceled:
+
+1. The filled quantity and instrument are identified from the execution tracker.
+2. An **IOC limit order** is submitted on the filled leg's instrument at the opposite
+   side (sell back what was bought, or buy back what was sold).
+3. The IOC price is set aggressively: current bid/ask widened by `unwind_slippage_bps`
+   to maximize fill probability.
+4. If the unwind fills, the loss is limited to slippage + fees. If the unwind itself
+   fails (no liquidity), a critical error is logged and the position requires manual
+   intervention.
+
+#### Execution diagnostics
+
+The strategy tracks four execution counters alongside the detection counters:
+
+- **`arbs_submitted`**: total arb attempts with orders sent to the venue.
+- **`arbs_completed`**: both legs filled successfully — profit captured.
+- **`arbs_unwound`**: one leg failed, position was unwound — controlled loss.
+- **`arbs_failed`**: both legs failed or unwind failed — no position or stuck position.
+
+These appear in the periodic diagnostic summary log.
+
+### Diagnostic tracking
+
+The strategy maintains real-time diagnostics:
+
+- **`quotes_processed`**: total quote evaluations across all pairs.
+- **`buy_arbs_detected`** / **`sell_arbs_detected`**: arb opportunity counts.
+- **`best_buy_spread`**: lowest combined ask seen (closest to buy arb).
+- **`best_sell_spread`**: highest combined bid seen (closest to sell arb).
+
+A diagnostic summary is logged every 500 quote evaluations:
+
+```
+SUMMARY | quotes=1500 buy_arbs=2 sell_arbs=0 submitted=1 completed=1 unwound=0 failed=0 | best_buy_spread=0.9823 (NBA Finals) best_sell_spread=0.9412 (World Cup)
+```
+
+## Data pipeline: how instruments reach the strategy
+
+Understanding the data flow is key to configuring the strategy correctly.
+
+### Instrument loading (startup)
+
+```
+Gamma Events API
+  │
+  ├── EventParamsFilter queries: GET /events?active=true&tag_slug=sports&liquidity_min=100000
+  │
+  ├── Returns events with markets → adapter fetches instrument details per market
+  │
+  └── BinaryOption instruments added to cache
+        │
+        └── Strategy.on_start() → discover_pairs() → subscribe_quotes()
+```
+
+The `EventParamsFilter` controls which markets are loaded at startup. By filtering on
+`tag_slug`, `liquidity_min`, and `max_events`, you control the initial universe of pairs.
+
+### Dynamic market discovery (runtime)
+
+```
+WebSocket (subscribe_new_markets: true)
+  │
+  ├── Polymarket publishes new market events
+  │
+  ├── NewMarketPredicateFilter checks tags → accepts/rejects
+  │
+  ├── Accepted → adapter fetches full instrument details → adds to cache
+  │
+  └── Strategy.on_instrument() → try_match_complement() → subscribes new quotes
+```
+
+When `subscribe_new_markets: true`, the adapter subscribes to a WebSocket channel that
+pushes new market listings. The `NewMarketPredicateFilter` gates which markets are
+accepted — in this example, only markets tagged with "sports" or "sport".
+
+## Configuration
+
+### Strategy parameters
+
+| Parameter                 | Type              | Default       | Description                                                       |
+|---------------------------|-------------------|---------------|-------------------------------------------------------------------|
+| `venue`                   | `Venue`           | *required*    | Venue to scan for binary options (e.g. `POLYMARKET`).             |
+| `client_id`               | `Option<ClientId>`| `None`        | Client ID for data subscriptions and order routing.               |
+| `fee_estimate_bps`        | `Decimal`         | `0`           | Conservative fee estimate in basis points.                        |
+| `min_profit_bps`          | `Decimal`         | `50`          | Minimum profit (bps) after fees to trigger arb. 50 = 0.5%.        |
+| `min_profit_abs`          | `Decimal`         | `0`           | Minimum absolute dollar profit per arb (0 = disabled).            |
+| `trade_size`              | `Decimal`         | `10`          | Number of shares per leg.                                         |
+| `max_concurrent_arbs`     | `usize`           | `1`           | Maximum simultaneous in‑flight arbs across all pairs.             |
+| `use_post_only`           | `bool`            | `true`        | Use post‑only orders for 0% maker fee.                            |
+| `order_expire_secs`       | `u64`             | `15`          | GTD expiry for entry orders in seconds.                           |
+| `unwind_slippage_bps`     | `Decimal`         | `50`          | Slippage tolerance for IOC unwind orders, in bps.                 |
+| `live_trading`            | `bool`            | `false`       | Enable live order submission. False = detect‑only.                |
+
+### Choosing parameters
+
+**`fee_estimate_bps`**: The strategy uses Polymarket's per-leg fee curve:
+`fee_per_leg = (fee_estimate_bps / 10_000) × p × (1 - p)`. This peaks at p=0.50 and
+drops to zero at price extremes. Set to `0.0` for post-only orders (maker fee = 0% on
+Polymarket), or `200.0` for taker orders (Polymarket's current 2% base rate).
+
+**`min_profit_bps`**: 50 bps (0.5%) is a conservative starting point. On a 10-share
+position at $0.50/share, that's $0.025 absolute profit.
+
+**`min_profit_abs`**: Set a dollar floor to avoid chasing sub-cent arbs. For example,
+`min_profit_abs = 0.50` requires at least $0.50 absolute profit per pair (computed as
+`profit_per_share * trade_size`). Works alongside `min_profit_bps` — both gates must pass.
+Default `0.0` disables this check.
+
+**`trade_size`**: Start small (10 shares) to validate the pipeline, then scale up based
+on observed liquidity. The strategy checks `ask_size`/`bid_size` against `trade_size`
+before triggering.
+
+**`live_trading`**: Defaults to `false` for safety — the strategy detects and logs arbs
+without submitting orders. Set to `true` only after validating detection output on your
+target markets. This two-mode design lets you tune `min_profit_bps`, `fee_estimate_bps`,
+and `trade_size` in observation mode before committing capital.
+
+**`order_expire_secs`**: Controls GTD expiry for entry limit orders. Default 15 seconds.
+Shorter values reduce stale-order risk (arb may have evaporated by the time the order
+fills) but increase the chance of both legs expiring before filling. For liquid markets,
+10-15 seconds is reasonable. For illiquid markets, consider 30-60 seconds.
+
+**`unwind_slippage_bps`**: When one leg fills but the other fails (partial fill), the
+strategy submits an IOC (Immediate-or-Cancel) unwind order to exit the filled position.
+The price is widened by this amount from the current bid/ask. Default 50 bps (0.5%).
+Higher values increase fill probability but worsen the loss on failed arbs.
+
+### Data client filter parameters
+
+The `EventParamsFilter` wraps `GetGammaEventsParams` for controlling which markets load
+at startup:
+
+| Parameter        | Type             | Description                                           |
+|------------------|------------------|-------------------------------------------------------|
+| `active`         | `Option<bool>`   | Only active (non‑resolved) markets.                   |
+| `closed`         | `Option<bool>`   | Exclude closed markets.                               |
+| `tag_slug`       | `Option<String>` | Filter by category tag (e.g. `"sports"`, `"politics"`).|
+| `liquidity_min`  | `Option<f64>`    | Minimum liquidity in USD.                             |
+| `liquidity_max`  | `Option<f64>`    | Maximum liquidity in USD.                             |
+| `volume_min`     | `Option<f64>`    | Minimum volume in USD.                                |
+| `max_events`     | `Option<u32>`    | Client‑side cap on number of events to load.          |
+| `limit`          | `Option<u32>`    | Server‑side page size.                                |
+| `offset`         | `Option<u32>`    | Server‑side pagination offset.                        |
+
+### Polymarket execution client
+
+| Parameter          | Type            | Default                | Description                                        |
+|--------------------|-----------------|------------------------|----------------------------------------------------|
+| `trader_id`        | `TraderId`      | `TraderId::default()`  | Trader identifier.                                 |
+| `account_id`       | `AccountId`     | `"POLYMARKET-001"`     | Account identifier.                                |
+| `signature_type`   | `SignatureType`  | `Eoa`                  | Signing method: `Eoa`, `PolyProxy`, or `PolyGnosisSafe`. |
+| `http_timeout_secs`| `u64`           | `60`                   | HTTP request timeout.                              |
+| `max_retries`      | `u32`           | `3`                    | Maximum retry attempts for failed requests.        |
+| `ack_timeout_secs` | `u64`           | `5`                    | Timeout waiting for order acknowledgement.         |
+
+## Code walkthrough
+
+This section walks through the complete `main()` function from `complement_arb.rs`,
+connecting each block back to the concepts covered earlier.
+
+### Instrument universe: startup filters
+
+The first thing to configure is *which markets the strategy will see*. This maps directly
+to the [data pipeline](#data-pipeline-how-instruments-reach-the-strategy) described above —
+the `EventParamsFilter` controls the Gamma API query that populates the instrument cache
+before `on_start()` runs pair discovery.
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    let environment = Environment::Live;
+    let trader_id = TraderId::from("TESTER-001");
+    let account_id = AccountId::from("POLYMARKET-001");
+    let client_id = ClientId::new("POLYMARKET");
+    let venue = Venue::new("POLYMARKET");
+
+    // Startup filter: controls which instruments load into cache via the Gamma API.
+    // The strategy's discover_pairs() in on_start() will only see instruments that
+    // pass this filter. Here we target active sports markets with >$100k liquidity,
+    // capped at 10 events to stay within WebSocket subscription limits.
+    let sports_events = GetGammaEventsParams {
+        active: Some(true),
+        closed: Some(false),
+        tag_slug: Some("sports".into()),
+        liquidity_min: Some(100000.0),
+        max_events: Some(10),
+        ..Default::default()
+    };
+    let data_filter = EventParamsFilter::new(sports_events);
+```
+
+### Dynamic discovery: runtime filters
+
+With `subscribe_new_markets: true`, the adapter pushes new market listings via WebSocket.
+The `NewMarketPredicateFilter` gates which of those reach the strategy's `on_instrument()`
+handler, where the O(1) complement matching logic tries to form new pairs at runtime.
+
+```rust
+    // Runtime filter: gates WebSocket new-market events before they reach the strategy.
+    // Without this, every newly listed market (politics, crypto, pop culture) would
+    // trigger on_instrument() and potentially subscribe quotes for irrelevant pairs.
+    let new_market_filter = NewMarketPredicateFilter::new("sports-only", |nm| {
+        nm.tags
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case("sports") || t.eq_ignore_ascii_case("sport"))
+    });
+
+    let data_config = PolymarketDataClientConfig {
+        subscribe_new_markets: true,       // enable WebSocket market discovery
+        filters: vec![Arc::new(data_filter)],
+        new_market_filter: Some(Arc::new(new_market_filter)),
+        ..Default::default()
+    };
+```
+
+### Execution client: signing and order routing
+
+The execution client handles order submission, cancellation, and fill reporting. The
+`signature_type` determines how orders are signed — this is relevant to the
+[execution](#execution) section's entry and unwind orders, which both flow through this
+client.
+
+```rust
+    // PolyGnosisSafe uses the browser wallet proxy signing mode.
+    // Switch to SignatureType::Eoa for standard EOA signing with POLYMARKET_PK.
+    let exec_config = PolymarketExecClientConfig {
+        trader_id,
+        account_id,
+        signature_type: SignatureType::PolyGnosisSafe,
+        ..Default::default()
+    };
+```
+
+### Node assembly: reconciliation and lifecycle
+
+The `LiveNode` ties data and execution together. Reconciliation is critical for the
+state machine — on restart, the node queries the Polymarket REST API for open orders
+and positions so the strategy doesn't submit duplicate arbs on pairs that already have
+active entries. The `delay_post_stop_secs` grace period ensures that residual fill and
+cancel events from the [unwind logic](#unwind-logic) are processed before shutdown.
+
+```rust
+    let log_config = LoggerConfig {
+        stdout_level: LevelFilter::Info,
+        ..Default::default()
+    };
+
+    let mut node = LiveNode::builder(trader_id, environment)?
+        .with_name("POLYMARKET-COMPLEMENT-ARB-001".to_string())
+        .with_logging(log_config)
+        .add_data_client(
+            None,
+            Box::new(PolymarketDataClientFactory),
+            Box::new(data_config),
+        )?
+        .add_exec_client(
+            None,
+            Box::new(PolymarketExecutionClientFactory),
+            Box::new(exec_config),
+        )?
+        // Reconcile open orders/positions on startup — prevents the state machine
+        // from treating existing positions as Idle and submitting duplicate entries.
+        .with_reconciliation(true)
+        .with_reconciliation_lookback_mins(120)
+        .with_timeout_reconciliation(60)
+        // Grace period for residual fill/cancel events during shutdown.
+        .with_delay_post_stop_secs(5)
+        .build()?;
+```
+
+### Strategy config: arb detection and execution thresholds
+
+These parameters directly control the [buy/sell arb detection](#buy-arb-detection) gates
+and the [per-pair state machine](#per-pair-state-machine) behavior. Note that
+`fee_estimate_bps` defaults to `0.0` here because `use_post_only` defaults to `true` —
+maker orders have 0% fee on Polymarket, so no fee adjustment is needed. The
+`order_expire_secs` sets the GTD window for entry orders; if both legs expire, the pair
+returns to Idle with no harm done.
+
+All bps/quantity/dollar fields are `rust_decimal::Decimal`, so the `dec!` macro from
+`rust_decimal_macros` is the cleanest way to pass literals:
+
+```rust
+use rust_decimal_macros::dec;
+
+    let strategy_config = ComplementArbConfig::builder()
+        .venue(venue)
+        .client_id(client_id)
+        .min_profit_bps(dec!(50))    // minimum 0.5% profit after fees to trigger
+        .min_profit_abs(dec!(0.50))  // minimum $0.50 absolute profit per arb
+        .trade_size(dec!(10))        // 10 shares per leg — checked against ask/bid size
+        .live_trading(true)          // false = detection-only, no orders submitted
+        .order_expire_secs(15)       // GTD expiry — state machine transitions on expiry
+        .build();
+
+    let strategy = ComplementArb::new(strategy_config);
+
+    node.add_strategy(strategy)?;
+    node.run().await?;
+
+    Ok(())
+}
+```
+
+## Event flow
+
+```
+LiveNode starts
+  │
+  ├── connect() → HTTP: load instruments via Gamma API (filtered by EventParamsFilter)
+  │                WebSocket: subscribe market channels
+  │
+  ├── on_start()
+  │     ├── discover_pairs() → match Yes/No pairs by condition ID
+  │     ├── subscribe_quotes() for each pair leg
+  │     └── subscribe_instruments(POLYMARKET) for new market discovery
+  │
+  ├── on_quote() [repeated for each pair leg]
+  │     ├── Cache latest quote
+  │     ├── Look up pair by instrument ID
+  │     ├── Skip arb checks if pair has active execution
+  │     ├── check_buy_arb(): yes_ask + no_ask < 1.0? → submit_arb() if live_trading
+  │     ├── check_sell_arb(): yes_bid + no_bid > 1.0? → submit_arb() if live_trading
+  │     └── Log diagnostic summary every 500 evaluations
+  │
+  ├── on_order_filled()
+  │     ├── Update cumulative fill qty (avg fill price read from order cache via Order::avg_px())
+  │     ├── Both legs filled? → ARB COMPLETE, cleanup
+  │     ├── One leg filled, other open? → transition to PartialFill
+  │     └── Unwind order filled? → UNWIND COMPLETE, cleanup
+  │
+  ├── on_order_rejected() / on_order_expired() / on_order_canceled()
+  │     ├── Neither leg had fills? → cancel other leg, cleanup
+  │     ├── One leg had fills? → initiate unwind (IOC exit order)
+  │     └── Unwind order failed? → log critical error, cleanup
+  │
+  └── on_stop()
+        ├── Cancel all active arb orders
+        └── Log final execution summary
+```
+
+## Running the example
+
+```bash
+cargo run --example polymarket-complement-arb --package nautilus-polymarket
+```
+
+### Expected startup output
+
+```
+ComplementArb started: 14 pairs, trade_size=10, min_profit=50bps, fee=0bps, live=true
+INSTRUMENT RECEIVED | 0xabc...111.POLYMARKET
+NEW INSTRUMENT | Premier League Title - Manchester City | outcome=Yes | 0xabc...111.POLYMARKET
+NEW INSTRUMENT | Premier League Title - Manchester City | outcome=No | 0xabc...222.POLYMARKET
+Paired new complement: Premier League Title - Manchester City (total: 15)
+```
+
+### Expected steady-state output
+
+```
+SUMMARY | quotes=500 buy_arbs=0 sell_arbs=0 submitted=0 completed=0 unwound=0 failed=0 | best_buy_spread=0.9912 (NBA Finals Game 7) best_sell_spread=0.9534 (World Cup Winner)
+BUY ARB | Premier League Title | profit=124.0bps | yes_ask=0.480 + no_ask=0.496 = 0.976 | fee=0.0000 | $profit=0.2400
+ARB SUBMITTED | Premier League Title | side=Buy | profit=124.0bps | yes=O-20260403-001-001 no=O-20260403-001-002
+ARB COMPLETE | 0xabc...def | yes_px=0.4800 no_px=0.4960
+```
+
+### Graceful shutdown
+
+Press **Ctrl+C** to stop the node. The shutdown sequence:
+
+1. SIGINT received, trader stops, `on_stop()` fires.
+2. Strategy cancels all active arb orders.
+3. Strategy logs final execution summary.
+4. 5-second grace period (`delay_post_stop_secs`) processes residual events.
+5. Clients disconnect, node exits.
+
+## Monitoring and understanding output
+
+### Key log messages
+
+| Log message                                                   | Meaning                                              |
+|---------------------------------------------------------------|------------------------------------------------------|
+| `ComplementArb started: N pairs, ...`                         | Strategy initialized with N complement pairs.        |
+| `INSTRUMENT RECEIVED \| <id>`                                 | New instrument arrived from venue.                   |
+| `NEW INSTRUMENT \| <description> \| outcome=<Yes/No> \| <id>` | Runtime instrument discovery picked up a new market. |
+| `Paired new complement: <label> (total: M)`                   | Runtime discovery matched a Yes/No pair.             |
+| `BUY ARB \| <label> \| profit=Xbps \| ... \| $profit=Y`       | Buy arb detected with absolute profit Y.             |
+| `SELL ARB \| <label> \| profit=Xbps \| ... \| $profit=Y`      | Sell arb detected with absolute profit Y.            |
+| `BUY ARB \| <label> \| skipped: insufficient ...`             | Arb found but liquidity too thin for trade_size.     |
+| `ARB SUBMITTED \| <label> \| side=X \| ...`                   | Both leg orders sent to venue.                       |
+| `ARB COMPLETE \| <label> \| yes_px=X no_px=Y`                 | Both legs filled — arb profit locked in.             |
+| `ARB LEG <reason> \| <pair_key> \| canceling other leg ...`   | One leg rejected/expired/canceled with no fills — strategy cancels its sibling. |
+| `PARTIAL FILL \| <label> \| one leg closed...`                | One leg filled, other still pending — at risk.      |
+| `UNWIND SUBMITTED \| pair=<key> \| <id> \| ...`               | IOC unwind order sent for a partial‑fill leg.        |
+| `UNWIND COMPLETE \| <label> \| filled @ X`                    | Unwind order filled — loss controlled.               |
+| `UNWIND FAILED \| <label> \| ...`                             | Unwind order failed — manual intervention needed.    |
+| `SUMMARY \| ... submitted=N completed=M unwound=X failed=Y`   | Execution counters in periodic summary.              |
+| `Order rejected: <id> — <reason>`                             | Order rejected by venue.                             |
+
+### Understanding the diagnostics
+
+The `best_buy_spread` and `best_sell_spread` fields show how close the market has come to
+an arb opportunity:
+
+- **`best_buy_spread` approaching 1.0 from below**: the market is near-efficient on the
+  buy side. Values like `0.998` mean the combined ask is only 20 bps from arb.
+- **`best_sell_spread` approaching 1.0 from above**: similar for sell side. Values like
+  `1.002` mean the combined bid is only 20 bps from arb.
+- **`best_buy_spread` well below 1.0** (e.g. `0.95`): large structural mispricing or
+  illiquid market with wide spreads.
+
+### Troubleshooting execution counters
+
+If your summary line shows unexpected values, use the counters to narrow the problem:
+
+- **`arbs_failed` > 0, `unwound` = 0**: both legs are failing before either fills. Look
+  for `Order rejected` messages in the log — common causes are insufficient USDC.e
+  allowance, expired API credentials, or `trade_size` exceeding the venue's minimum/maximum
+  order size. If rejections mention "post-only", the market may have moved and your limit
+  price would cross the spread; try setting `use_post_only: false` or reducing
+  `order_expire_secs`.
+- **`unwound` high relative to `completed`**: one leg fills consistently but the other
+  doesn't. This usually means the arb is closing between the first and second leg
+  submission — the market is faster than your execution. Consider raising `min_profit_bps`
+  to only trigger on wider spreads that survive the submission latency, or reduce
+  `order_expire_secs` to fail faster and limit exposure.
+- **`UNWIND FAILED` in logs**: the IOC exit order found no liquidity on the filled leg's
+  side. The position is now stuck and requires manual intervention. Check the instrument's
+  order book depth — if the book is empty, the market may be illiquid or near resolution.
+  Raise `liquidity_min` in `EventParamsFilter` to avoid thin markets, or increase
+  `unwind_slippage_bps` to price the exit more aggressively.
+- **`submitted` > 0 but `completed` + `unwound` + `failed` = 0**: arb orders are in
+  flight but nothing has resolved yet. This is normal during the first few seconds. If it
+  persists, check that the WebSocket feed is delivering fill and cancel events — a stalled
+  connection will leave the state machine stuck in `PendingEntry`.
+
+## Risk considerations
+
+### Execution risks
+
+- **Non-atomic execution**: Polymarket does not support atomic cross-instrument orders.
+  The strategy submits both legs as fast as possible, but there is inherent latency
+  between submissions. Detection-to-fill latency matters — the CLOB is
+  first-come-first-served. Use `live_trading: false` to validate detection before
+  enabling execution.
+- **Partial fill risk**: because the two legs are submitted independently, one may fill
+  while the other is rejected or expires. The strategy automatically unwinds partial fills
+  via IOC exit orders, but the unwind price may be worse than the entry price, resulting
+  in a small loss. The `unwind_slippage_bps` parameter controls how aggressively the
+  unwind is priced.
+- **Unwind failure**: if the IOC unwind order cannot fill (empty book on that side), the
+  strategy logs a critical error and the position must be closed manually. Monitor the
+  `arbs_failed` counter and `UNWIND FAILED` log messages.
+
+### Market risks
+
+- **Quote staleness**: the strategy evaluates arbs using the latest cached quote per
+  instrument. If one leg's quote is stale (e.g. the WebSocket connection lagged), the
+  detected spread may not reflect the live market.
+- **Liquidity depth**: the strategy checks top-of-book `ask_size`/`bid_size` against
+  `trade_size`, but the posted liquidity may be pulled or stale. Large `trade_size`
+  values may not fill at the quoted price.
+- **Market resolution**: binary options settle to 0 or 1. Holding both sides until
+  resolution guarantees the $1 payout. Early exit requires finding liquidity on both
+  sides, which may not exist for illiquid markets.
+
+### Operational risks
+
+- **Fee curve accuracy**: the strategy uses Polymarket's per-leg fee formula
+  `(fee_estimate_bps / 10_000) × p × (1 - p)`, which peaks at p=0.50 and drops to zero at
+  extremes. Set `fee_estimate_bps` to match the venue's base fee rate: `200.0` for taker
+  orders (2% on Polymarket), or `0.0` with `use_post_only: true` for maker orders (0% fee).
+- **GTD expiry tuning**: too-short expiry increases the chance of both legs expiring
+  (no harm, but missed opportunities). Too-long expiry risks filling a stale arb where
+  the spread has closed. 15 seconds is a reasonable default.
+- **WebSocket subscription limits**: Polymarket limits the number of concurrent WebSocket
+  subscriptions. Loading too many markets via `EventParamsFilter` can exhaust this limit.
+  Use `max_events` and `liquidity_min` to control the universe size.
+
+## Customization tips
+
+### Filtering by category
+
+Change the `tag_slug` to target different market categories:
+
+```rust
+let events = GetGammaEventsParams {
+    tag_slug: Some("politics".into()),  // or "crypto", "pop-culture", etc.
+    liquidity_min: Some(50000.0),
+    max_events: Some(20),
+    ..Default::default()
+};
+```
+
+### Adjusting sensitivity
+
+| Goal                        | Adjustment                                                     |
+|-----------------------------|----------------------------------------------------------------|
+| Catch more arbs             | Lower `min_profit_bps` (e.g. 10 = 0.1%).                      |
+| Reduce false positives      | Raise `min_profit_bps` (e.g. 100 = 1.0%).                     |
+| Set absolute profit floor   | Use `.min_profit_abs(0.50)` to require $0.50/arb.              |
+| Trade larger size           | Increase `trade_size` (check liquidity first).                 |
+| Cover more markets          | Raise `max_events`, lower `liquidity_min`.                     |
+| Reduce WebSocket load       | Lower `max_events`, raise `liquidity_min`.                     |
+| Accept all market categories| Remove `tag_slug` filter and `NewMarketPredicateFilter`.       |
+| Enable execution            | Set `live_trading(true)`.                                      |
+| Wider unwind tolerance      | Increase `unwind_slippage_bps` for better fill probability.    |
+| Faster order expiry         | Lower `order_expire_secs` (e.g. 10s for liquid markets).      |
+
+### Disabling dynamic discovery
+
+If you only want to monitor markets loaded at startup (no new market subscriptions):
+
+```rust
+let data_config = PolymarketDataClientConfig {
+    subscribe_new_markets: false,  // no WebSocket market discovery
+    filters: vec![Arc::new(data_filter)],
+    new_market_filter: None,
+    ..Default::default()
+};
+```
+
+The strategy's `subscribe_instruments` call in `on_start` will have no effect without
+new market events flowing from the adapter.
+
+## What's next
+
+### Validate before risking capital
+
+Run in detection-only mode (`live_trading: false`) for at least 24 hours. Check the
+diagnostic summary: if no arbs are detected, lower `min_profit_bps` to 10 (0.1%) to
+see what exists, then tune upward. Frequent "skipped: insufficient liquidity" means
+`trade_size` is too large for available depth. If `best_buy_spread` stays above 0.99,
+arbs are rare on those markets — widen the universe.
+
+### Backtesting
+
+Record `QuoteTick` streams using NautilusTrader's data catalog, then swap `LiveNode`
+for `BacktestNode` to replay them through the same arb detection logic. Compare
+`arbs_detected` vs. `arbs_completed` for theoretical capture rate. Note that historical
+quotes don't reflect fill competition — treat results as an upper bound. See the
+[backtesting guide](../concepts/backtesting.md) for setup.
+
+### Improving execution
+
+Detection is the easy part — alpha loss is in execution.
+
+- **Sequential legs.** Submit the less liquid leg first; once filled, submit the second.
+  Eliminates partial fills at the cost of missing arbs where the second leg moves.
+- **Adaptive pricing.** Submit slightly above ask / below bid (e.g. +0.001) to increase
+  fill priority. Add a `price_aggression_bps` parameter.
+- **Quote staleness guard.** Reject arb signals where either leg's `ts_event` is older
+  than a threshold (500ms–1s). Prevents phantom arbs from a lagging WebSocket.
+- **Unwind retries.** Retry with progressively wider slippage instead of treating a
+  single IOC failure as terminal.
+
+### Expanding the strategy
+
+- **Order book depth.** Subscribe to `OrderBookDeltas` to walk the book on both legs
+  and compute the exact maximum arb size where cumulative cost stays below 1.0 — this
+  replaces the fixed `trade_size` parameter entirely.
+- **Multi-venue arb.** Match Yes on one venue against No on another by event description
+  rather than condition ID.
+- **Categorical markets.** Markets with 3+ outcomes generalize the constraint: all prices
+  must sum to 1.0. Extend `discover_pairs` to handle arbitrary outcome counts.
+- **Taker mode.** IOC orders trade fee cost for fill certainty. Auto-adjust the threshold:
+  `effective_min_profit = min_profit_bps + 2 × taker_fee_bps`.
+
+### Risk controls for production
+
+- **Daily loss limit.** Track cumulative P&L from unwinds; pause trading above a threshold.
+- **Circuit breaker.** Pause submissions if `arbs_failed` spikes (e.g. 3 in 5 minutes).
+- **Per-pair cooldown.** Skip a pair for a configurable period after an unwind or failure.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -52,12 +52,13 @@ For task-oriented data recipes, see the [how-to guides](../how_to/):
 
 ## Strategy patterns
 
-| Tutorial                                                                            | Description                                       | Data              |
-|:------------------------------------------------------------------------------------|:--------------------------------------------------|:------------------|
-| [Mean Reversion with Proxy FX Data (AX Exchange)](fx_mean_reversion_ax)             | Bollinger Band mean reversion on EURUSD‑PERP.     | TrueFX proxy      |
-| [Gold Perpetual Book Imbalance (AX Exchange)](gold_book_imbalance_ax)               | Order book imbalance on XAU‑PERP.                 | Databento API key |
-| [Grid Market Making with a Deadman's Switch (BitMEX)](grid_market_maker_bitmex)     | Grid MM with server‑side safety on XBTUSD.        | Tardis.dev        |
-| [On‑Chain Grid Market Making with Short‑Term Orders (dYdX)](grid_market_maker_dydx) | Grid MM on dYdX v4 perpetuals.                    | User‑provided     |
+| Tutorial                                                                            | Description                                       | Data                 |
+|:------------------------------------------------------------------------------------|:--------------------------------------------------|:---------------------|
+| [Mean Reversion with Proxy FX Data (AX Exchange)](fx_mean_reversion_ax)             | Bollinger Band mean reversion on EURUSD‑PERP.     | TrueFX proxy         |
+| [Gold Perpetual Book Imbalance (AX Exchange)](gold_book_imbalance_ax)               | Order book imbalance on XAU‑PERP.                 | Databento API key    |
+| [Grid Market Making with a Deadman's Switch (BitMEX)](grid_market_maker_bitmex)     | Grid MM with server‑side safety on XBTUSD.        | Tardis.dev           |
+| [On‑Chain Grid Market Making with Short‑Term Orders (dYdX)](grid_market_maker_dydx) | Grid MM on dYdX v4 perpetuals.                    | User‑provided        |
+| [Complement arbitrage on Polymarket binary options](complement_arb_polymarket)      | Binary option complement arb on Polymarket   | Live                 |
 
 ## Options
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds a new binary-option complement arbitrage strategy to `nautilus-trading` examples, plus a Polymarket runnable example, end-to-end tutorial, and README.

The strategy exploits the `Yes + No = 1.0` constraint on binary option pairs: when combined asks fall below 1.0 (or combined bids exceed 1.0) after fees, it submits both legs as GTD limit orders to lock in risk-free profit. Pairs are discovered from the instrument cache by `condition_id` and dynamically extended via `on_instrument`. A small state machine (`Idle → PendingEntry → Complete | Unwinding`) manages execution, with IOC unwind on partial fills bounded by `unwind_slippage_bps`.

## Changes

- **Strategy** (`crates/trading/src/examples/strategies/complement_arb/`)
  - `strategy.rs` — pair discovery, detection, GTD entry submission, partial-fill unwind, diagnostics counters and periodic SUMMARY logs
  - `config.rs` — `bon::Builder` config with `Decimal` thresholds, `max_concurrent_arbs`, `live_trading` switch
  - `tests.rs` — 60 unit tests covering detection, state machine, unwind, concurrency guards
  - `README.md` — high-level overview + config table
- **Polymarket example** (`crates/adapters/polymarket/examples/complement_arb.rs`) — runnable live node wired to `PolyGnosisSafe` proxy wallet
- **Tutorial** (`docs/tutorials/complement_arb_polymarket.md`) — event flow, state machine, wallet setup (proxy wallet recommended), API key generation via `polymarket-create-api-key`, threshold tuning, log message reference
- `docs/tutorials/index.md` updated with the new tutorial entry


## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore
