### PR TITLE
feat: add Adanos custom data example

### DIFF
--- a/examples/backtest/example_12_adanos_custom_data/README.md
+++ b/examples/backtest/example_12_adanos_custom_data/README.md
@@ -1,0 +1,34 @@
+# Example - Adanos Market Sentiment Custom Data
+
+This example shows how to move Adanos market sentiment into NautilusTrader as
+`CustomData` and use it alongside equity bars in a backtest.
+
+## What You'll Learn
+
+- How to define a Nautilus-native custom data type for Adanos sentiment snapshots.
+- How to wrap source rows into `CustomData` for routing metadata.
+- How to subscribe to cross-source sentiment updates from a strategy.
+
+## Why This Matters
+
+Alternative data is most useful in NautilusTrader when it behaves like any other
+first-class data stream. This example keeps the integration simple:
+
+- build a normalized `AdanosSentimentSnapshot`
+- route it through the standard `subscribe_data()` / `on_data()` flow
+- persist the same snapshots in the Parquet catalog for research-to-live parity
+
+The example uses synthetic AAPL bars and synthetic Adanos compare rows so it can
+run without external API credentials.
+
+## Run The Example
+
+From the repository root:
+
+```bash
+PYTHONPATH=. .venv/bin/python examples/backtest/example_12_adanos_custom_data/run_example.py
+```
+
+You should see the strategy subscribe to the custom sentiment stream, log each
+sentiment update, and print a simple conviction verdict alongside each daily
+bar.

--- a/examples/backtest/example_12_adanos_custom_data/run_example.py
+++ b/examples/backtest/example_12_adanos_custom_data/run_example.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+
+from strategy import AdanosSentimentStrategy
+from strategy import AdanosSentimentStrategyConfig
+
+from nautilus_trader.adapters.adanos import build_adanos_sentiment_snapshot
+from nautilus_trader.adapters.adanos import wrap_adanos_sentiment_snapshot
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.config import BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.core.datetime import dt_to_unix_nanos
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.objects import Money
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.persistence.wranglers import BarDataWrangler
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+
+def _build_bars():
+    instrument = TestInstrumentProvider.equity(symbol="AAPL", venue="XNAS")
+    bar_type = BarType.from_str(f"{instrument.id}-1-DAY-LAST-EXTERNAL")
+
+    df = pd.DataFrame(
+        [
+            ("2024-03-04 14:30:00+00:00", 178.25, 181.10, 177.80, 180.55, 1_250_000),
+            ("2024-03-05 14:30:00+00:00", 180.60, 182.20, 179.50, 181.70, 1_410_000),
+            ("2024-03-06 14:30:00+00:00", 181.80, 183.10, 180.90, 182.95, 1_515_000),
+            ("2024-03-07 14:30:00+00:00", 183.00, 184.75, 182.10, 184.40, 1_605_000),
+        ],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.set_index("timestamp")
+
+    wrangler = BarDataWrangler(bar_type, instrument)
+    bars: list[Bar] = wrangler.process(df)
+
+    return instrument, bar_type, bars, df.index
+
+
+def _build_sentiment_data(instrument_id, timestamps):
+    sample_rows = [
+        {
+            "reddit": {"buzz_score": 63.0, "bullish_pct": 71, "mentions": 92, "company_name": "Apple Inc."},
+            "x": {"buzz_score": 59.5, "bullish_pct": 61, "mentions": 420},
+            "news": {"buzz_score": 51.0, "bullish_pct": 57, "mentions": 14},
+            "polymarket": {"buzz_score": 48.0, "bullish_pct": 54, "trade_count": 112, "market_count": 3},
+        },
+        {
+            "reddit": {"buzz_score": 67.0, "bullish_pct": 73, "mentions": 108, "company_name": "Apple Inc."},
+            "x": {"buzz_score": 65.0, "bullish_pct": 64, "mentions": 510},
+            "news": {"buzz_score": 56.0, "bullish_pct": 60, "mentions": 18},
+            "polymarket": {"buzz_score": 52.0, "bullish_pct": 58, "trade_count": 141, "market_count": 4},
+        },
+        {
+            "reddit": {"buzz_score": 49.0, "bullish_pct": 37, "mentions": 85, "company_name": "Apple Inc."},
+            "x": {"buzz_score": 54.0, "bullish_pct": 59, "mentions": 455},
+            "news": {"buzz_score": 52.5, "bullish_pct": 62, "mentions": 20},
+            "polymarket": {"buzz_score": 58.0, "bullish_pct": 66, "trade_count": 170, "market_count": 5},
+        },
+        {
+            "reddit": {"buzz_score": 42.0, "bullish_pct": 34, "mentions": 71, "company_name": "Apple Inc."},
+            "x": {"buzz_score": 46.0, "bullish_pct": 39, "mentions": 396},
+            "news": {"buzz_score": 49.0, "bullish_pct": 44, "mentions": 17},
+            "polymarket": {"buzz_score": 44.5, "bullish_pct": 41, "trade_count": 96, "market_count": 2},
+        },
+    ]
+
+    custom_data = []
+    for timestamp, rows in zip(timestamps, sample_rows, strict=True):
+        ts_event = dt_to_unix_nanos(pd.Timestamp(timestamp))
+        snapshot = build_adanos_sentiment_snapshot(
+            instrument_id,
+            ts_event=ts_event,
+            reddit=rows["reddit"],
+            x=rows["x"],
+            news=rows["news"],
+            polymarket=rows["polymarket"],
+        )
+        custom_data.append(wrap_adanos_sentiment_snapshot(snapshot))
+
+    return custom_data
+
+
+if __name__ == "__main__":
+    instrument, bar_type, bars, timestamps = _build_bars()
+    sentiment_data = _build_sentiment_data(instrument.id, timestamps)
+
+    catalog_path = Path(tempfile.mkdtemp(prefix="adanos_sentiment_catalog_"))
+    catalog = ParquetDataCatalog(str(catalog_path))
+    catalog.write_data([instrument])
+    catalog.write_data(bars)
+    catalog.write_data(sentiment_data)
+
+    print(f"Wrote {len(sentiment_data)} Adanos sentiment snapshots to {catalog_path}")
+
+    engine = BacktestEngine(
+        config=BacktestEngineConfig(
+            trader_id=TraderId("ADANOS-BACKTEST-001"),
+            logging=LoggingConfig(log_level="INFO"),
+        ),
+    )
+    engine.add_venue(
+        venue=Venue("XNAS"),
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        starting_balances=[Money(1_000_000, instrument.quote_currency)],
+        base_currency=instrument.quote_currency,
+        default_leverage=Decimal(1),
+    )
+    engine.add_instrument(instrument)
+    engine.add_data(bars)
+    engine.add_data(sentiment_data, ClientId("ADANOS"))
+    engine.add_strategy(
+        AdanosSentimentStrategy(
+            AdanosSentimentStrategyConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+            ),
+        ),
+    )
+    engine.run()
+    engine.dispose()

--- a/examples/backtest/example_12_adanos_custom_data/strategy.py
+++ b/examples/backtest/example_12_adanos_custom_data/strategy.py
@@ -1,0 +1,101 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.adapters.adanos import AdanosSentimentSnapshot
+from nautilus_trader.adapters.adanos import adanos_sentiment_data_type
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.data import Data
+from nautilus_trader.model import CustomData
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.trading.strategy import Strategy
+
+
+ADANOS_CLIENT_ID = ClientId("ADANOS")
+
+
+class AdanosSentimentStrategyConfig(StrategyConfig, frozen=True):
+    instrument_id: InstrumentId
+    bar_type: BarType
+
+
+class AdanosSentimentStrategy(Strategy):
+    def __init__(self, config: AdanosSentimentStrategyConfig) -> None:
+        super().__init__(config)
+        self._latest_sentiment: AdanosSentimentSnapshot | None = None
+
+    def on_start(self) -> None:
+        self.subscribe_bars(self.config.bar_type)
+        self.subscribe_data(
+            adanos_sentiment_data_type(self.config.instrument_id),
+            client_id=ADANOS_CLIENT_ID,
+        )
+        self.log.info(
+            f"Subscribed to bars and Adanos sentiment for {self.config.instrument_id}",
+            color=LogColor.YELLOW,
+        )
+
+    def on_stop(self) -> None:
+        self.unsubscribe_bars(self.config.bar_type)
+        self.unsubscribe_data(
+            adanos_sentiment_data_type(self.config.instrument_id),
+            client_id=ADANOS_CLIENT_ID,
+        )
+
+    def on_data(self, data: Data) -> None:
+        snapshot = _extract_snapshot(data)
+
+        if snapshot is not None:
+            self._latest_sentiment = snapshot
+            self.log.info(
+                "Sentiment update "
+                f"buzz={snapshot.average_buzz:.1f} "
+                f"bullish={snapshot.average_bullish_pct:.1f}% "
+                f"alignment={snapshot.source_alignment}",
+                color=LogColor.CYAN,
+            )
+
+    def on_bar(self, bar: Bar) -> None:
+        if self._latest_sentiment is None:
+            self.log.info(f"{bar.bar_type}: no sentiment snapshot yet", color=LogColor.YELLOW)
+            return
+
+        snapshot = self._latest_sentiment
+        if snapshot.average_buzz >= 60.0 and snapshot.average_bullish_pct >= 55.0:
+            verdict = "sentiment supports long bias"
+            color = LogColor.GREEN
+        elif snapshot.average_buzz < 40.0 or snapshot.source_alignment == "divergent":
+            verdict = "sentiment warns against conviction"
+            color = LogColor.RED
+        else:
+            verdict = "sentiment is neutral"
+            color = LogColor.BLUE
+
+        self.log.info(
+            f"{bar.bar_type} @ {bar.close} | {verdict} "
+            f"(coverage={snapshot.coverage}, alignment={snapshot.source_alignment})",
+            color=color,
+        )
+
+
+def _extract_snapshot(data: Data) -> AdanosSentimentSnapshot | None:
+    if isinstance(data, AdanosSentimentSnapshot):
+        return data
+    if isinstance(data, CustomData) and isinstance(data.data, AdanosSentimentSnapshot):
+        return data.data
+    return None

--- a/nautilus_trader/adapters/adanos/__init__.py
+++ b/nautilus_trader/adapters/adanos/__init__.py
@@ -1,0 +1,14 @@
+from nautilus_trader.adapters.adanos.types import AdanosSentimentSnapshot
+from nautilus_trader.adapters.adanos.types import adanos_sentiment_data_type
+from nautilus_trader.adapters.adanos.types import adanos_sentiment_metadata
+from nautilus_trader.adapters.adanos.types import build_adanos_sentiment_snapshot
+from nautilus_trader.adapters.adanos.types import wrap_adanos_sentiment_snapshot
+
+
+__all__ = [
+    "AdanosSentimentSnapshot",
+    "adanos_sentiment_data_type",
+    "adanos_sentiment_metadata",
+    "build_adanos_sentiment_snapshot",
+    "wrap_adanos_sentiment_snapshot",
+]

--- a/nautilus_trader/adapters/adanos/types.py
+++ b/nautilus_trader/adapters/adanos/types.py
@@ -1,0 +1,254 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from collections.abc import Mapping
+from math import isnan
+from typing import Any
+
+from nautilus_trader.core.data import Data
+from nautilus_trader.model.custom import customdataclass
+from nautilus_trader.model.data import CustomData
+from nautilus_trader.model.data import DataType
+from nautilus_trader.model.identifiers import InstrumentId
+
+
+_ADANOS_VENDOR = "adanos"
+
+
+@customdataclass
+class AdanosSentimentSnapshot(Data):
+    instrument_id: InstrumentId = InstrumentId.from_str("AAPL.XNAS")
+    symbol: str = ""
+    company_name: str = ""
+    source_alignment: str = "unavailable"
+    alignment_score: float = 0.0
+    coverage: int = 0
+    average_buzz: float = 0.0
+    average_bullish_pct: float = 0.0
+    reddit_buzz: float = 0.0
+    reddit_bullish_pct: float = 0.0
+    reddit_mentions: int = 0
+    x_buzz: float = 0.0
+    x_bullish_pct: float = 0.0
+    x_mentions: int = 0
+    news_buzz: float = 0.0
+    news_bullish_pct: float = 0.0
+    news_mentions: int = 0
+    polymarket_buzz: float = 0.0
+    polymarket_bullish_pct: float = 0.0
+    polymarket_trade_count: int = 0
+    polymarket_market_count: int = 0
+
+
+def adanos_sentiment_metadata(instrument_id: InstrumentId) -> dict[str, str]:
+    return {
+        "instrument_id": instrument_id.value,
+        "vendor": _ADANOS_VENDOR,
+    }
+
+
+def adanos_sentiment_data_type(instrument_id: InstrumentId) -> DataType:
+    return DataType(
+        AdanosSentimentSnapshot,
+        metadata=adanos_sentiment_metadata(instrument_id),
+    )
+
+
+def build_adanos_sentiment_snapshot(
+    instrument_id: InstrumentId,
+    *,
+    ts_event: int,
+    ts_init: int | None = None,
+    company_name: str = "",
+    reddit: Mapping[str, Any] | None = None,
+    x: Mapping[str, Any] | None = None,
+    news: Mapping[str, Any] | None = None,
+    polymarket: Mapping[str, Any] | None = None,
+) -> AdanosSentimentSnapshot:
+    ts_init = ts_event if ts_init is None else ts_init
+
+    reddit_buzz = _extract_float(reddit, "buzz_score")
+    reddit_bullish_pct = _extract_bullish_pct(reddit)
+    reddit_mentions = _extract_int(reddit, "mentions")
+
+    x_buzz = _extract_float(x, "buzz_score")
+    x_bullish_pct = _extract_bullish_pct(x)
+    x_mentions = _extract_int(x, "mentions")
+
+    news_buzz = _extract_float(news, "buzz_score")
+    news_bullish_pct = _extract_bullish_pct(news)
+    news_mentions = _extract_int(news, "mentions")
+
+    polymarket_buzz = _extract_float(polymarket, "buzz_score")
+    polymarket_bullish_pct = _extract_bullish_pct(polymarket)
+    polymarket_trade_count = _extract_int(polymarket, "trade_count")
+    polymarket_market_count = _extract_int(polymarket, "market_count")
+
+    buzz_values = [
+        value
+        for value in (reddit_buzz, x_buzz, news_buzz, polymarket_buzz)
+        if value > 0.0
+    ]
+    bullish_values = [
+        value
+        for value in (
+            reddit_bullish_pct,
+            x_bullish_pct,
+            news_bullish_pct,
+            polymarket_bullish_pct,
+        )
+        if value > 0.0
+    ]
+
+    coverage = sum(
+        1
+        for source in (reddit, x, news, polymarket)
+        if _source_has_signal(source)
+    )
+    source_alignment, alignment_score = _classify_alignment(bullish_values)
+
+    return AdanosSentimentSnapshot(
+        instrument_id=instrument_id,
+        symbol=instrument_id.symbol.value,
+        company_name=company_name
+        or _first_non_empty(reddit, x, news, polymarket, key="company_name"),
+        source_alignment=source_alignment,
+        alignment_score=alignment_score,
+        coverage=coverage,
+        average_buzz=_average(buzz_values),
+        average_bullish_pct=_average(bullish_values),
+        reddit_buzz=reddit_buzz,
+        reddit_bullish_pct=reddit_bullish_pct,
+        reddit_mentions=reddit_mentions,
+        x_buzz=x_buzz,
+        x_bullish_pct=x_bullish_pct,
+        x_mentions=x_mentions,
+        news_buzz=news_buzz,
+        news_bullish_pct=news_bullish_pct,
+        news_mentions=news_mentions,
+        polymarket_buzz=polymarket_buzz,
+        polymarket_bullish_pct=polymarket_bullish_pct,
+        polymarket_trade_count=polymarket_trade_count,
+        polymarket_market_count=polymarket_market_count,
+        ts_event=ts_event,
+        ts_init=ts_init,
+    )
+
+
+def wrap_adanos_sentiment_snapshot(snapshot: AdanosSentimentSnapshot) -> CustomData:
+    return CustomData(adanos_sentiment_data_type(snapshot.instrument_id), snapshot)
+
+
+def _extract_float(source: Mapping[str, Any] | None, key: str) -> float:
+    if not source:
+        return 0.0
+
+    value = source.get(key)
+    if value is None:
+        return 0.0
+
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if isnan(number):
+        return 0.0
+
+    return number
+
+
+def _extract_int(source: Mapping[str, Any] | None, key: str) -> int:
+    if not source:
+        return 0
+
+    value = source.get(key)
+    if value is None:
+        return 0
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract_bullish_pct(source: Mapping[str, Any] | None) -> float:
+    bullish_pct = _extract_float(source, "bullish_pct")
+    if bullish_pct > 0.0:
+        return bullish_pct
+
+    sentiment_score = _extract_float(source, "sentiment_score")
+    if sentiment_score == 0.0:
+        return 0.0
+
+    return max(0.0, min(100.0, ((sentiment_score + 1.0) / 2.0) * 100.0))
+
+
+def _source_has_signal(source: Mapping[str, Any] | None) -> bool:
+    if not source:
+        return False
+
+    return any(
+        [
+            _extract_float(source, "buzz_score") > 0.0,
+            _extract_float(source, "bullish_pct") > 0.0,
+            _extract_float(source, "sentiment_score") != 0.0,
+            _extract_int(source, "mentions") > 0,
+            _extract_int(source, "trade_count") > 0,
+            _extract_int(source, "market_count") > 0,
+        ],
+    )
+
+
+def _classify_alignment(bullish_values: list[float]) -> tuple[str, float]:
+    if not bullish_values:
+        return "unavailable", 0.0
+
+    directions = []
+    for bullish_pct in bullish_values:
+        if bullish_pct >= 60.0:
+            directions.append("bullish")
+        elif bullish_pct <= 40.0:
+            directions.append("bearish")
+        else:
+            directions.append("neutral")
+
+    directional = [direction for direction in directions if direction != "neutral"]
+    unique_directional = set(directional)
+
+    if len(bullish_values) == 1:
+        return "single_source", 0.25
+    if len(unique_directional) == 1 and directional:
+        return "aligned", 1.0
+    if len(unique_directional) > 1:
+        return "divergent", 0.0
+    return "mixed", 0.5
+
+
+def _average(values: list[float]) -> float:
+    if not values:
+        return 0.0
+
+    return sum(values) / len(values)
+
+
+def _first_non_empty(*sources: Mapping[str, Any] | None, key: str) -> str:
+    for source in sources:
+        if not source:
+            continue
+        value = source.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""

--- a/tests/unit_tests/adapters/test_adanos.py
+++ b/tests/unit_tests/adapters/test_adanos.py
@@ -1,0 +1,115 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+
+from nautilus_trader.adapters.adanos import AdanosSentimentSnapshot
+from nautilus_trader.adapters.adanos import adanos_sentiment_data_type
+from nautilus_trader.adapters.adanos import build_adanos_sentiment_snapshot
+from nautilus_trader.adapters.adanos import wrap_adanos_sentiment_snapshot
+from nautilus_trader.model.data import CustomData
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+
+def test_build_adanos_sentiment_snapshot_computes_aggregate_fields() -> None:
+    instrument = TestInstrumentProvider.equity(symbol="AAPL", venue="XNAS")
+
+    snapshot = build_adanos_sentiment_snapshot(
+        instrument.id,
+        ts_event=1,
+        reddit={"buzz_score": 70.0, "bullish_pct": 72, "mentions": 90, "company_name": "Apple Inc."},
+        x={"buzz_score": 60.0, "bullish_pct": 64, "mentions": 500},
+        news={"buzz_score": 40.0, "bullish_pct": 35, "mentions": 15},
+        polymarket={"buzz_score": 50.0, "bullish_pct": 61, "trade_count": 75, "market_count": 2},
+    )
+
+    assert snapshot.instrument_id == instrument.id
+    assert snapshot.symbol == "AAPL"
+    assert snapshot.company_name == "Apple Inc."
+    assert snapshot.coverage == 4
+    assert snapshot.average_buzz == pytest.approx(55.0)
+    assert snapshot.average_bullish_pct == pytest.approx(58.0)
+    assert snapshot.source_alignment == "divergent"
+    assert snapshot.alignment_score == pytest.approx(0.0)
+    assert snapshot.polymarket_trade_count == 75
+
+    wrapped = wrap_adanos_sentiment_snapshot(snapshot)
+    assert isinstance(wrapped, CustomData)
+    assert wrapped.data_type == adanos_sentiment_data_type(instrument.id)
+    assert wrapped.data_type.metadata == {
+        "instrument_id": instrument.id.value,
+        "vendor": "adanos",
+    }
+
+
+def test_adanos_sentiment_snapshot_roundtrips_via_catalog(tmp_path) -> None:
+    instrument = TestInstrumentProvider.equity(symbol="AAPL", venue="XNAS")
+    catalog_path = tmp_path / "catalog"
+    catalog_path.mkdir(parents=True, exist_ok=True)
+    catalog = ParquetDataCatalog(str(catalog_path))
+
+    snapshot = build_adanos_sentiment_snapshot(
+        instrument.id,
+        ts_event=1_000,
+        ts_init=1_500,
+        reddit={"buzz_score": 64.0, "bullish_pct": 69, "mentions": 80, "company_name": "Apple Inc."},
+        x={"buzz_score": 58.0, "bullish_pct": 60, "mentions": 320},
+        news={"buzz_score": 54.0, "bullish_pct": 57, "mentions": 12},
+    )
+    wrapped = wrap_adanos_sentiment_snapshot(snapshot)
+
+    catalog.write_data([wrapped])
+    restored_rows = catalog.query(AdanosSentimentSnapshot, identifiers=[instrument.id.value])
+
+    assert len(restored_rows) == 1
+    restored = restored_rows[0]
+    assert isinstance(restored, CustomData)
+    assert isinstance(restored.data, AdanosSentimentSnapshot)
+    assert restored.data.instrument_id == instrument.id
+    assert restored.data.average_buzz == pytest.approx(snapshot.average_buzz)
+    assert restored.data.average_bullish_pct == pytest.approx(snapshot.average_bullish_pct)
+    assert restored.data.source_alignment == "aligned"
+
+
+def test_adanos_sentiment_snapshot_uses_sentiment_score_fallback() -> None:
+    instrument = TestInstrumentProvider.equity(symbol="AAPL", venue="XNAS")
+
+    snapshot = build_adanos_sentiment_snapshot(
+        instrument.id,
+        ts_event=1,
+        reddit={"buzz_score": 50.0, "sentiment_score": 0.5, "mentions": 20},
+    )
+
+    assert snapshot.reddit_bullish_pct == pytest.approx(75.0)
+    assert snapshot.average_bullish_pct == pytest.approx(75.0)
+    assert snapshot.source_alignment == "single_source"
+    assert snapshot.alignment_score == pytest.approx(0.25)
+
+
+def test_adanos_sentiment_snapshot_serializes_roundtrip() -> None:
+    instrument = TestInstrumentProvider.equity(symbol="AAPL", venue="XNAS")
+
+    snapshot = build_adanos_sentiment_snapshot(
+        instrument.id,
+        ts_event=1_000,
+        ts_init=1_500,
+        company_name="Apple Inc.",
+        reddit={"buzz_score": 61.0, "bullish_pct": 68, "mentions": 50},
+        x={"buzz_score": 54.0, "bullish_pct": 58, "mentions": 220},
+    )
+
+    assert AdanosSentimentSnapshot.from_dict(snapshot.to_dict()) == snapshot
+    assert AdanosSentimentSnapshot.from_bytes(snapshot.to_bytes()) == snapshot


### PR DESCRIPTION
## Summary

This PR adds a small Adanos-based custom data example for equities.

It includes:
- a serializable `AdanosSentimentSnapshot` custom data type
- helpers for building and wrapping sentiment snapshots as `CustomData`
- a backtest example showing how to route Adanos sentiment alongside daily equity bars
- focused unit tests for aggregate fields, catalog roundtrips, and serialization behavior

## Why

NautilusTrader already has a strong custom data story, but it helps to show a realistic alternative-data example for equity workflows.

This patch keeps the scope narrow and example-first:
- no live adapter
- no execution or venue changes
- no dependency on external credentials for the example itself

The goal is to demonstrate how cross-source market sentiment can be normalized into a first-class Nautilus custom data stream and used in a standard `subscribe_data()` / `on_data()` strategy flow.

## What was added

### Adanos custom data type
New module:
- `nautilus_trader/adapters/adanos/types.py`

This defines `AdanosSentimentSnapshot`, plus helpers to:
- construct a normalized snapshot from per-source rows
- derive aggregate fields like `average_buzz`, `average_bullish_pct`, `coverage`, and `source_alignment`
- wrap the snapshot as `CustomData` with routing metadata

### Backtest example
New example:
- `examples/backtest/example_12_adanos_custom_data/`

The example uses:
- synthetic AAPL daily bars
- synthetic Adanos compare-style rows
- a simple strategy which subscribes to both bars and Adanos custom data

It runs without external API credentials and writes its temporary catalog into a temp directory to avoid polluting the repo root.

### Tests
New tests:
- `tests/unit_tests/adapters/test_adanos.py`

These cover:
- aggregate field computation
- sentiment score fallback
- catalog roundtrip behavior
- serialization roundtrip behavior

## Validation

Checks run locally:

- `.venv/bin/python -m pytest tests/unit_tests/adapters/test_adanos.py tests/unit_tests/model/test_custom_data.py tests/unit_tests/persistence/test_catalog.py -q`
- `PYTHONPATH=. .venv/bin/python examples/backtest/example_12_adanos_custom_data/run_example.py`
- `.venv/bin/python -m pytest tests/ -q`
- `git diff --check`

The focused tests are green and the example backtest runs cleanly.

The full `tests/` run still has the same 3 existing docs tutorial failures in `tests/docs_tests/test_tutorials.py`:
- `getting_started/quickstart.py`
- `getting_started/backtest_low_level.py`
- `tutorials/backtest_fx_bars.py`

All 3 fail with `ModuleNotFoundError: No module named 'nautilus_trader'` when executed from a temporary working directory, which appears unrelated to this patch.
