### PR TITLE
Fix stop_timer in TimeBarAggregator

### DIFF
--- a/crates/data/src/aggregation.rs
+++ b/crates/data/src/aggregation.rs
@@ -3614,6 +3614,41 @@ mod tests {
     }
 
     #[rstest]
+    fn test_time_bar_aggregator_stop_clears_timer_and_allows_restart(equity_aapl: Equity) {
+        let instrument = InstrumentAny::Equity(equity_aapl);
+        let bar_spec = BarSpecification::new(1, BarAggregation::Second, PriceType::Last);
+        let bar_type = BarType::new(instrument.id(), bar_spec, AggregationSource::Internal);
+        let timer_name = bar_type.to_string();
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+
+        let aggregator = TimeBarAggregator::new(
+            bar_type,
+            instrument.price_precision(),
+            instrument.size_precision(),
+            clock.clone(),
+            |_bar: Bar| {},
+            true,
+            false,
+            BarIntervalType::LeftOpen,
+            None,
+            15,
+            false,
+        );
+
+        let boxed: Box<dyn BarAggregator> = Box::new(aggregator);
+        let rc = Rc::new(RefCell::new(boxed));
+
+        rc.borrow_mut().start_timer(Some(Rc::clone(&rc)));
+        assert_eq!(clock.borrow().timer_names(), vec![timer_name.as_str()]);
+
+        rc.borrow_mut().stop();
+        assert!(clock.borrow().timer_names().is_empty());
+
+        rc.borrow_mut().start_timer(Some(Rc::clone(&rc)));
+        assert_eq!(clock.borrow().timer_names(), vec![timer_name.as_str()]);
+    }
+
+    #[rstest]
     fn test_time_bar_aggregator_left_open_interval(equity_aapl: Equity) {
         let instrument = InstrumentAny::Equity(equity_aapl);
         let bar_spec = BarSpecification::new(1, BarAggregation::Second, PriceType::Last);

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -1538,7 +1538,7 @@ cdef class TimeBarAggregator(BarAggregator):
                         f"next_close_ns={unix_nanos_to_dt(self.next_close_ns)}")
 
     cpdef void stop_timer(self):
-        cdef str timer_name = str(self.bar_type)
+        cdef str timer_name = self._timer_name
         if timer_name in self._clock.timer_names:
             self._clock.cancel_timer(timer_name)
 

--- a/tests/unit_tests/backtest/test_engine.py
+++ b/tests/unit_tests/backtest/test_engine.py
@@ -1732,6 +1732,32 @@ class BarSubscriberStrategy(Strategy):
         self.subscribe_bars(self._bar_type)
 
 
+class BarResubscriberStrategy(Strategy):
+    """
+    Strategy that unsubscribes and re-subscribes to the same internal bar type.
+    """
+
+    def __init__(self, bar_type):
+        super().__init__()
+        self._bar_type = bar_type
+        self.received_bars = []
+        self.resubscribe_count = 0
+
+    def on_start(self):
+        self.subscribe_bars(self._bar_type)
+
+    def on_bar(self, bar):
+        if bar.bar_type != self._bar_type:
+            return
+
+        self.received_bars.append(bar)
+
+        if len(self.received_bars) == 2 and self.resubscribe_count == 0:
+            self.unsubscribe_bars(self._bar_type)
+            self.subscribe_bars(self._bar_type)
+            self.resubscribe_count += 1
+
+
 class TestBacktestEngineStreamingBars:
     def setup_method(self):
         self.instrument = TestInstrumentProvider.default_fx_ccy("USD/JPY")
@@ -1838,3 +1864,23 @@ class TestBacktestEngineStreamingBars:
         assert len(bars_after_end) <= 4, (
             f"Expected at most 4 bars after end() flush to 20s, found {len(bars_after_end)}"
         )
+
+    def test_internal_bar_resubscribe_after_unsubscribe_does_not_raise(self):
+        bar_type = BarType(
+            instrument_id=self.instrument.id,
+            bar_spec=BarSpecification(1, BarAggregation.SECOND, PriceType.MID),
+            aggregation_source=AggregationSource.INTERNAL,
+        )
+        strategy = BarResubscriberStrategy(bar_type)
+        self.engine.add_strategy(strategy)
+
+        batch = self._make_quotes(self.instrument, 1, 10)
+        self.engine.add_data(batch)
+
+        self.engine.run(
+            end=pd.Timestamp("1970-01-01 00:00:10", tz="UTC"),
+            streaming=False,
+        )
+
+        assert strategy.resubscribe_count == 1
+        assert len(strategy.received_bars) >= 3

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -3487,6 +3487,32 @@ class TestTimeBarAggregator:
         # Assert
         assert aggregator.next_close_ns == expected
 
+    def test_stop_timer_cancels_registered_timer_and_allows_restart(self):
+        # Arrange
+        clock = TestClock()
+        clock.set_time(1)
+        handler = []
+        bar_type = BarType(
+            TestIdStubs.audusd_id(),
+            BarSpecification(1, BarAggregation.MINUTE, PriceType.MID),
+        )
+        aggregator = TimeBarAggregator(
+            AUDUSD_SIM,
+            bar_type.standard(),
+            handler.append,
+            clock,
+        )
+        timer_name = f"time_bar_{bar_type.standard()}"
+
+        # Act
+        aggregator.start_timer()
+        aggregator.stop_timer()
+        assert timer_name not in clock.timer_names
+        aggregator.start_timer()
+
+        # Assert
+        assert timer_name in clock.timer_names
+
     def test_update_timer_with_test_clock_sends_single_bar_to_handler(self):
         # Arrange
         clock = TestClock()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Fix INTERNAL time-bar re-subscribe after unsubscribe.

This fixes issue #3819, where unsubscribing and then re-subscribing to the same INTERNAL time bar could raise a `KeyError` due to a stale timer name remaining registered on the clock. The root cause was in the Cython `TimeBarAggregator`: `start_timer()` registered `time_bar_{bar_type}`, but `stop_timer()` checked the plain bar type string instead of the actual timer name. After unsubscribe, the timer was left behind, and the next subscribe collided on timer registration.

The fix makes `TimeBarAggregator.stop_timer()` cancel the real registered timer name. Regression coverage was added in two places: a low-level Cython test that proves the timer is removed and can be restarted, and a backtest-level test that reproduces unsubscribe followed by re-subscribe for an INTERNAL bar type and confirms it no longer fails. I also added a matching Rust-side regression test to confirm the Rust bar aggregator lifecycle already handles stop/start correctly and to keep that invariant protected.

## Changed files

- `nautilus_trader/data/aggregation.pyx`
- `tests/unit_tests/data/test_aggregation.py`
- `tests/unit_tests/backtest/test_engine.py`
- `crates/data/src/aggregation.rs`

## Simplifications made

- Reused the existing canonical timer name instead of adding new lifecycle state or special-case logic.
- Kept the fix local to timer teardown and covered behavior with focused regressions.

## Verification

- `make build-debug`
- `pytest tests/unit_tests/data/test_aggregation.py -k "stop_timer_cancels_registered_timer_and_allows_restart"`
- `pytest tests/unit_tests/backtest/test_engine.py -k "internal_bar_resubscribe_after_unsubscribe_does_not_raise"`
- `ruff check tests/unit_tests/data/test_aggregation.py tests/unit_tests/backtest/test_engine.py`
- `cargo test -p nautilus-data --lib aggregation::tests::test_time_bar_aggregator_stop_clears_timer_and_allows_restart -- --exact`

## Remaining risk

- I verified the focused regression paths rather than running the full repository test suite or full pre-commit over all files.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

#3819

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
