### PR TITLE
Refine make cargo-test

### DIFF
--- a/crates/adapters/architect_ax/Cargo.toml
+++ b/crates/adapters/architect_ax/Cargo.toml
@@ -111,24 +111,28 @@ harness = false
 name = "ax-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 # cargo run -p nautilus-architect-ax --bin ax-ws-data
 [[bin]]
 name = "ax-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 # cargo run -p nautilus-architect-ax --bin ax-ws-orders
 [[bin]]
 name = "ax-ws-orders"
 path = "bin/ws_orders.rs"
 doc = false
+test = false
 
 # cargo run -p nautilus-architect-ax --bin ax-flatten
 [[bin]]
 name = "ax-flatten"
 path = "bin/flatten.rs"
 doc = false
+test = false
 
 # cargo run --example ax-data-tester -p nautilus-architect-ax
 [[example]]

--- a/crates/adapters/binance/Cargo.toml
+++ b/crates/adapters/binance/Cargo.toml
@@ -106,11 +106,13 @@ harness = false
 name = "binance-spot-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "binance-spot-ws-data"
 path = "bin/ws_spot_data.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "binance-spot-http-capture-fixtures"
@@ -121,6 +123,7 @@ doc = false
 name = "binance-spot-ws-user-data-capture"
 path = "bin/capture_spot_ws_user_data.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example binance-spot-data-tester --package nautilus-binance`
 [[example]]

--- a/crates/adapters/bitmex/Cargo.toml
+++ b/crates/adapters/bitmex/Cargo.toml
@@ -98,16 +98,19 @@ url = { workspace = true }
 name = "bitmex-http"
 path = "bin/http.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "bitmex-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "bitmex-ws-exec"
 path = "bin/ws_exec.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example bitmex-data-tester --package nautilus-bitmex`
 [[example]]

--- a/crates/adapters/blockchain/Cargo.toml
+++ b/crates/adapters/blockchain/Cargo.toml
@@ -91,6 +91,7 @@ name = "node_wallet"
 path = "bin/node_wallet.rs"
 required-features = ["hypersync"]
 doc = false
+test = false
 
 [[example]]
 name = "blockchain-data-tester"

--- a/crates/adapters/bybit/Cargo.toml
+++ b/crates/adapters/bybit/Cargo.toml
@@ -105,12 +105,14 @@ harness = false
 name = "bybit-http"
 path = "bin/http.rs"
 doc = false
+test = false
 
 # Run with `cargo run -p nautilus-bybit --bin bybit-ws-data`.
 [[bin]]
 name = "bybit-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example bybit-data-tester --package nautilus-bybit`.
 [[example]]

--- a/crates/adapters/coinbase/tests/data_client.rs
+++ b/crates/adapters/coinbase/tests/data_client.rs
@@ -34,15 +34,15 @@ use nautilus_common::{
     messages::{
         DataEvent, DataResponse,
         data::{
-            RequestBookSnapshot, RequestInstrument, RequestInstruments, SubscribeBookDeltas,
-            SubscribeQuotes, SubscribeTrades,
+            RequestBars, RequestBookSnapshot, RequestInstrument, RequestInstruments, RequestTrades,
+            SubscribeBars, SubscribeBookDeltas, SubscribeQuotes, SubscribeTrades,
         },
     },
     testing::wait_until_async,
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
-    data::Data,
+    data::{BarType, Data},
     enums::BookType,
     identifiers::{ClientId, InstrumentId, Venue},
 };
@@ -167,6 +167,7 @@ async fn handle_ws_socket(mut socket: WebSocket) {
                                 "market_trades" => load_json_str("ws_market_trades.json"),
                                 "ticker" => load_json_str("ws_ticker.json"),
                                 "level2" => load_json_str("ws_l2_data_snapshot.json"),
+                                "candles" => load_json_str("ws_candles.json"),
                                 _ => json!({"channel": channel}).to_string(),
                             };
 
@@ -639,6 +640,154 @@ async fn test_data_client_request_book_snapshot_with_depth() {
         }
         other => panic!("Expected Book response, was: {other:?}"),
     }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_client_request_bars() {
+    let state = TestServerState::default();
+    let addr = start_mock_server(state).await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    set_data_event_sender(tx);
+
+    let config = create_data_client_config(addr);
+    let mut client = CoinbaseDataClient::new(ClientId::new("COINBASE"), config).unwrap();
+    client.connect().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    while rx.try_recv().is_ok() {}
+
+    let bar_type = BarType::from("BTC-USD.COINBASE-1-HOUR-LAST-EXTERNAL");
+    let request = RequestBars::new(
+        bar_type,
+        None,
+        None,
+        None,
+        Some(ClientId::new("COINBASE")),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    );
+    client.request_bars(request).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timeout waiting for bars response")
+        .expect("channel closed");
+
+    match event {
+        DataEvent::Response(DataResponse::Bars(bars_response)) => {
+            assert_eq!(bars_response.bar_type, bar_type);
+            assert!(!bars_response.data.is_empty(), "should have bars");
+
+            // Bars should be sorted ascending by ts_event
+            let events: Vec<_> = bars_response.data.iter().map(|b| b.ts_event).collect();
+
+            for window in events.windows(2) {
+                assert!(window[0] <= window[1], "bars not sorted ascending");
+            }
+        }
+        other => panic!("Expected Bars response, was: {other:?}"),
+    }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_client_request_trades() {
+    let state = TestServerState::default();
+    let addr = start_mock_server(state).await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    set_data_event_sender(tx);
+
+    let config = create_data_client_config(addr);
+    let mut client = CoinbaseDataClient::new(ClientId::new("COINBASE"), config).unwrap();
+    client.connect().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    while rx.try_recv().is_ok() {}
+
+    let instrument_id = InstrumentId::from("BTC-USD.COINBASE");
+    let request = RequestTrades::new(
+        instrument_id,
+        None,
+        None,
+        None,
+        Some(ClientId::new("COINBASE")),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    );
+    client.request_trades(request).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timeout waiting for trades response")
+        .expect("channel closed");
+
+    match event {
+        DataEvent::Response(DataResponse::Trades(trades_response)) => {
+            assert_eq!(trades_response.instrument_id, instrument_id);
+            assert!(!trades_response.data.is_empty(), "should have trades");
+
+            // Trades should be sorted ascending by ts_event
+            let events: Vec<_> = trades_response.data.iter().map(|t| t.ts_event).collect();
+
+            for window in events.windows(2) {
+                assert!(window[0] <= window[1], "trades not sorted ascending");
+            }
+        }
+        other => panic!("Expected Trades response, was: {other:?}"),
+    }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_client_subscribe_bars() {
+    let state = TestServerState::default();
+    let addr = start_mock_server(state).await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    set_data_event_sender(tx);
+
+    let config = create_data_client_config(addr);
+    let mut client = CoinbaseDataClient::new(ClientId::new("COINBASE"), config).unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let bar_type = BarType::from("BTC-USD.COINBASE-5-MINUTE-LAST-EXTERNAL");
+    let cmd = SubscribeBars::new(
+        bar_type,
+        Some(ClientId::new("COINBASE")),
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.subscribe_bars(&cmd).unwrap();
+
+    wait_until_async(
+        || {
+            let found = loop {
+                match rx.try_recv() {
+                    Ok(DataEvent::Data(Data::Bar(_))) => break true,
+                    Ok(_) => {}
+                    Err(_) => break false,
+                }
+            };
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
 
     client.disconnect().await.unwrap();
 }

--- a/crates/adapters/databento/Cargo.toml
+++ b/crates/adapters/databento/Cargo.toml
@@ -97,6 +97,7 @@ name = "databento-sandbox"
 path = "bin/sandbox.rs"
 required-features = ["python"]
 doc = false
+test = false
 
 [[example]]
 name = "databento-data-tester"

--- a/crates/adapters/deribit/Cargo.toml
+++ b/crates/adapters/deribit/Cargo.toml
@@ -104,18 +104,21 @@ harness = false
 name = "deribit-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 # Run with `cargo run -p nautilus-deribit --bin deribit-http-private`
 [[bin]]
 name = "deribit-http-private"
 path = "bin/http_private.rs"
 doc = false
+test = false
 
 # Run with `cargo run -p nautilus-deribit --bin deribit-ws-data`
 [[bin]]
 name = "deribit-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 # Run with `cargo run -p nautilus-deribit --example deribit-data-tester`
 [[example]]

--- a/crates/adapters/dydx/Cargo.toml
+++ b/crates/adapters/dydx/Cargo.toml
@@ -103,26 +103,31 @@ url = { workspace = true }
 name = "dydx-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "dydx-http-private"
 path = "bin/http_private.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "dydx-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "dydx-grpc-exec"
 path = "bin/grpc_exec.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "dydx-ws-exec"
 path = "bin/ws_exec.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example dydx-data-tester --package nautilus-dydx`
 [[example]]

--- a/crates/adapters/hyperliquid/Cargo.toml
+++ b/crates/adapters/hyperliquid/Cargo.toml
@@ -100,31 +100,37 @@ rstest = { workspace = true }
 name = "hyperliquid-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "hyperliquid-http-private"
 path = "bin/http_private.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "hyperliquid-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "hyperliquid-ws-exec"
 path = "bin/ws_exec.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "hyperliquid-http-exec"
 path = "bin/http_exec.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "hyperliquid-capture-test-data"
 path = "bin/capture_test_data.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example hyperliquid-data-tester --package nautilus-hyperliquid`.
 [[example]]

--- a/crates/adapters/kraken/Cargo.toml
+++ b/crates/adapters/kraken/Cargo.toml
@@ -100,16 +100,19 @@ harness = false
 name = "kraken-http-spot-raw"
 path = "bin/http_spot_raw.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "kraken-http-spot-public"
 path = "bin/http_spot_public.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "kraken-ws-spot-data"
 path = "bin/ws_spot_data.rs"
 doc = false
+test = false
 
 # Run with `cargo run -p nautilus-kraken --example kraken-data-tester`
 [[example]]

--- a/crates/adapters/okx/Cargo.toml
+++ b/crates/adapters/okx/Cargo.toml
@@ -105,21 +105,25 @@ harness = false
 name = "okx-http-public"
 path = "bin/http_public.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "okx-http-private"
 path = "bin/http_private.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "okx-ws-data"
 path = "bin/ws_data.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "okx-ws-exec"
 path = "bin/ws_exec.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example okx-data-tester --package nautilus-okx`.
 [[example]]

--- a/crates/adapters/polymarket/Cargo.toml
+++ b/crates/adapters/polymarket/Cargo.toml
@@ -100,31 +100,37 @@ rstest = { workspace = true }
 name = "polymarket-updown-markets"
 path = "bin/updown_markets.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "polymarket-trending-markets"
 path = "bin/trending_markets.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "polymarket-composite-filter"
 path = "bin/composite_filter.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "polymarket-search-markets"
 path = "bin/search_markets.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "polymarket-event-discovery"
 path = "bin/event_discovery.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "polymarket-create-api-key"
 path = "bin/create_api_key.rs"
 doc = false
+test = false
 
 [[example]]
 name = "polymarket-data-tester"

--- a/crates/adapters/tardis/Cargo.toml
+++ b/crates/adapters/tardis/Cargo.toml
@@ -101,23 +101,27 @@ rstest = { workspace = true }
 name = "tardis-csv"
 path = "bin/example_csv.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "tardis-http"
 path = "bin/example_http.rs"
 doc = false
+test = false
 
 [[bin]]
 name = "tardis-replay"
 path = "bin/example_replay.rs"
 required-features = ["replay"]
 doc = false
+test = false
 
 # Run with `cargo run --bin stream_deltas_bench --profile bench`
 [[bin]]
 name = "stream_deltas_bench"
 path = "bin/stream_deltas_bench.rs"
 doc = false
+test = false
 
 # Run with `cargo run --example tardis-data-tester -p nautilus-tardis`
 [[example]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,3 +46,4 @@ ustr = { workspace = true }
 name = "nautilus"
 path = "src/bin/cli.rs"
 doc = false
+test = false

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -107,9 +107,11 @@ name = "to_json"
 path = "bin/to_json.rs"
 required-features = ["python"]
 doc = false
+test = false
 
 [[bin]]
 name = "to_parquet"
 path = "bin/to_parquet.rs"
 required-features = ["python"]
 doc = false
+test = false

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -136,3 +136,4 @@ pyo3-stub-gen = { workspace = true }
 name = "python-stub-gen"
 path = "bin/stub_gen.rs"
 doc = false
+test = false


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Reduces the artifact footprint of `make cargo-test` by marking utility `[[bin]]` targets that do not define tests as `test = false`.
- Prevents Cargo from generating unnecessary bin test harnesses for adapter tools, CLI helpers, persistence conversion binaries, and the PyO3 stub generator during workspace test runs.
- Leaves the one bin target that does contain tests unchanged: `crates/adapters/binance/bin/capture_spot_http_fixtures.rs`.

## Changed files

- `crates/adapters/architect_ax/Cargo.toml`
- `crates/adapters/binance/Cargo.toml`
- `crates/adapters/bitmex/Cargo.toml`
- `crates/adapters/blockchain/Cargo.toml`
- `crates/adapters/bybit/Cargo.toml`
- `crates/adapters/databento/Cargo.toml`
- `crates/adapters/deribit/Cargo.toml`
- `crates/adapters/dydx/Cargo.toml`
- `crates/adapters/hyperliquid/Cargo.toml`
- `crates/adapters/kraken/Cargo.toml`
- `crates/adapters/okx/Cargo.toml`
- `crates/adapters/polymarket/Cargo.toml`
- `crates/adapters/tardis/Cargo.toml`
- `crates/cli/Cargo.toml`
- `crates/persistence/Cargo.toml`
- `crates/pyo3/Cargo.toml`

## Design notes

- The change is limited to explicit `[[bin]]` manifest entries; library, integration-test, and doctest behavior is unchanged.
- Only bins with no in-file test modules were opted out of test harness generation.
- `binance-spot-http-capture-fixtures` was intentionally excluded because its source file contains `#[cfg(test)]` coverage.
- The added `test = false` flags do not affect normal `cargo run --bin ...` usage for these tools.

## Verification

- Measured a clean baseline `make cargo-test` run before the manifest changes.
- Measured a second clean `make cargo-test` run after the manifest changes.
- Confirmed by source scan that the only bin file with bin-local tests is `crates/adapters/binance/bin/capture_spot_http_fixtures.rs`.

## Results

- Clean baseline build phase: `7m 06s`.
- Clean build phase after the manifest changes: `5m 51s`.
- Clean baseline end-state artifact size: `77G target`.
- Clean end-state artifact size after the manifest changes: `62G target`.
- Whole-disk usage on `/System/Volumes/Data` at build end dropped from `764Gi` to `750Gi` in the measured runs.

## Remaining risks

- The change reduces but does not eliminate `cargo-test` disk growth because Cargo still emits large non-test bin artifacts and static libraries for the selected feature set.
- Any future tests added to one of these opted-out bin targets would require removing `test = false` for that bin.
- The measured reduction comes from local runs on this machine with the current workspace features and toolchain; exact numbers may vary on other environments.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
