### PR TITLE
Refine docs to follow style guide (symbols, filler word)

### DIFF
--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -432,7 +432,7 @@ currently use `f64` for notional value and signed accumulation (these are being 
 fixed-point integer arithmetic). The choice of aggregation method has a modest impact on per-update
 overhead:
 
-- **Time bars** are the most efficient for high-throughput data. The aggregator simply accumulates
+- **Time bars** are the most efficient for high-throughput data. The aggregator accumulates
   OHLCV state per update; bar emission is driven by a timer rather than per-tick logic.
 - **Threshold bars** (tick, volume, value) add a lightweight counter or accumulator check per update.
   Volume and value bars may split a single large trade across multiple bars when it exceeds the

--- a/docs/integrations/okx.md
+++ b/docs/integrations/okx.md
@@ -219,7 +219,7 @@ strategy.submit_order(order)
 | `GTC`         | ✓                     | Good Till Canceled.                               |
 | `FOK`         | ✓                     | Fill or Kill.                                     |
 | `IOC`         | ✓                     | Immediate or Cancel.                              |
-| `GTD`         | ✗                     | *Not supported by OKX API.* |
+| `GTD`         | -                     | *Not supported by OKX API.*                       |
 
 :::note
 **GTD (Good Till Date) time in force**: OKX does not support native GTD functionality through their API.


### PR DESCRIPTION
Two small style-guide alignments in user-facing docs, both flagged directly by `docs/developer_guide/docs.md`.

## Changes

**`docs/integrations/okx.md`** — the OKX "Time in force" table marked `GTD` as unsupported with `✗`. The style guide (docs.md:85) says:

> Use `-` for unsupported features (not `✗` or other symbols).

Replaced with `-` and padded the `Notes` cell to the column width used by the rest of the table so the separators line up.

**`docs/concepts/data.md`** — the "Performance considerations" section described time bars with "The aggregator simply accumulates...". The style guide (docs.md:55) says:

> Be direct and concise; avoid filler words like "basically", "simply", "just".

Dropped the word; the meaning is unchanged.

## Why

Surfaced these while reading the docs and cross-referencing the style guide. Both are direct, literal rule violations that are easy to miss in review.

## Testing

Docs-only change, no code touched. No tests to add.