### PR TITLE
Fix Hyperliquid cancel-replace order modification

### DIFF
--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -432,7 +432,7 @@ currently use `f64` for notional value and signed accumulation (these are being 
 fixed-point integer arithmetic). The choice of aggregation method has a modest impact on per-update
 overhead:
 
-- **Time bars** are the most efficient for high-throughput data. The aggregator simply accumulates
+- **Time bars** are the most efficient for high-throughput data. The aggregator accumulates
   OHLCV state per update; bar emission is driven by a timer rather than per-tick logic.
 - **Threshold bars** (tick, volume, value) add a lightweight counter or accumulator check per update.
   Volume and value bars may split a single large trade across multiple bars when it exceeds the

--- a/docs/integrations/okx.md
+++ b/docs/integrations/okx.md
@@ -219,7 +219,7 @@ strategy.submit_order(order)
 | `GTC`         | ✓                     | Good Till Canceled.                               |
 | `FOK`         | ✓                     | Fill or Kill.                                     |
 | `IOC`         | ✓                     | Immediate or Cancel.                              |
-| `GTD`         | ✗                     | *Not supported by OKX API.* |
+| `GTD`         | -                     | *Not supported by OKX API.*                       |
 
 :::note
 **GTD (Good Till Date) time in force**: OKX does not support native GTD functionality through their API.

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -148,6 +148,11 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         self._accepted_orders: nautilus_pyo3.FifoCache = nautilus_pyo3.FifoCache()
         self._terminal_orders: nautilus_pyo3.FifoCache = nautilus_pyo3.FifoCache()
         self._pending_filled: set[str] = set()
+        # Hyperliquid implements order modification as a cancel-replace: the exchange
+        # cancels the original order and opens a new one with a new venue_order_id.
+        # Track in-flight modifies so we can emit OrderUpdated instead of OrderCanceled.
+        self._pending_modify: set[str] = set()  # client_order_id.value → modify sent
+        self._modify_cancel_skip: set[str] = set()  # client_order_id.value → updated, skip cancel
 
         self._fee_refresh_task: asyncio.Task | None = None
 
@@ -819,6 +824,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 client_order_id=pyo3_client_order_id,
             )
             self._log.info(f"Order modification requested for {command.client_order_id}")
+            self._pending_modify.add(command.client_order_id.value)
         except Exception as e:
             self.generate_order_modify_rejected(
                 strategy_id=command.strategy_id,
@@ -1099,6 +1105,22 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         elif report.order_status == OrderStatus.ACCEPTED:
             key = report.client_order_id.value
             if key in self._accepted_orders or key in self._terminal_orders:
+                if key in self._pending_modify:
+                    # Exchange implemented the modification as a cancel-replace.
+                    # The new venue_order_id is in this ACCEPTED report; emit
+                    # OrderUpdated so the order stays live with the new ID.
+                    self._pending_modify.discard(key)
+                    self._modify_cancel_skip.add(key)
+                    self.generate_order_updated(
+                        strategy_id=order.strategy_id,
+                        instrument_id=report.instrument_id,
+                        client_order_id=report.client_order_id,
+                        venue_order_id=report.venue_order_id,
+                        quantity=report.quantity,
+                        price=report.price,
+                        trigger_price=report.trigger_price,
+                        ts_event=report.ts_last,
+                    )
                 return
             self._accepted_orders.add(key)
 
@@ -1123,6 +1145,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         elif report.order_status == OrderStatus.CANCELED:
             key = report.client_order_id.value
             if key in self._terminal_orders:
+                return
+
+            if key in self._modify_cancel_skip:
+                # This CANCELED is the old-order leg of a cancel-replace modification.
+                # The order was already updated via OrderUpdated; skip the cancel.
+                self._modify_cancel_skip.discard(key)
                 return
 
             self._terminal_orders.add(key)

--- a/tests/integration_tests/adapters/hyperliquid/test_execution.py
+++ b/tests/integration_tests/adapters/hyperliquid/test_execution.py
@@ -31,9 +31,15 @@ from nautilus_trader.execution.messages import GeneratePositionStatusReports
 from nautilus_trader.execution.messages import ModifyOrder
 from nautilus_trader.execution.messages import SubmitOrder
 from nautilus_trader.execution.messages import SubmitOrderList
+from nautilus_trader.execution.reports import OrderStatusReport
 from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import OrderStatus
+from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.enums import TimeInForce
 from nautilus_trader.model.enums import TriggerType
+from nautilus_trader.model.identifiers import AccountId
 from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import OrderListId
@@ -1244,5 +1250,90 @@ async def test_submit_order_list_converts_to_pyo3(
         assert isinstance(submitted[0], nautilus_pyo3.MarketOrder)
         assert isinstance(submitted[1], nautilus_pyo3.LimitOrder)
         assert isinstance(submitted[2], nautilus_pyo3.StopMarketOrder)
+    finally:
+        await client._disconnect()
+
+
+@pytest.mark.asyncio
+async def test_modify_order_cancel_replace_emits_updated_not_canceled(
+    exec_client_builder,
+    monkeypatch,
+    instrument,
+    cache,
+):
+    """
+    Hyperliquid implements order modification as a cancel-replace: it cancels the
+    original order (old venue_order_id) and opens a replacement (new venue_order_id).
+    The adapter must emit OrderUpdated (not OrderCanceled) and keep the order live.
+    Regression test for GH-3827.
+    """
+    # Arrange
+    client, _, http_client, _ = exec_client_builder(monkeypatch)
+    await client._connect()
+
+    old_venue_id = VenueOrderId("375273671786")
+    new_venue_id = VenueOrderId("375273716474")
+    client_oid = ClientOrderId("O-20260409-080047-001-000-1")
+    account_id = AccountId("HYPERLIQUID-master")
+
+    order = LimitOrder(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        client_order_id=client_oid,
+        order_side=OrderSide.BUY,
+        quantity=Quantity.from_str("0.00020"),
+        price=Price.from_str("56730.0"),
+        init_id=TestIdStubs.uuid(),
+        ts_init=0,
+    )
+    cache.add_order(order, None)
+
+    # Simulate order already accepted with old venue ID
+    client._accepted_orders.put(client_oid.value)
+
+    # Simulate a modify having been sent (pending cancel-replace from exchange)
+    client._pending_modify.add(client_oid.value)
+
+    client.generate_order_updated = MagicMock()
+    client.generate_order_canceled = MagicMock()
+
+    def make_report(venue_order_id, status, price_str):
+        return OrderStatusReport(
+            account_id=account_id,
+            instrument_id=instrument.id,
+            venue_order_id=venue_order_id,
+            order_side=OrderSide.BUY,
+            order_type=OrderType.LIMIT,
+            time_in_force=TimeInForce.GTC,
+            order_status=status,
+            quantity=Quantity.from_str("0.00020"),
+            filled_qty=Quantity.from_str("0.00000"),
+            price=Price.from_str(price_str),
+            report_id=TestIdStubs.uuid(),
+            ts_accepted=0,
+            ts_last=1775721653824999936,
+            ts_init=0,
+            client_order_id=client_oid,
+        )
+
+    try:
+        # Act — exchange sends ACCEPTED for new order, then CANCELED for old order
+        accepted_report = make_report(new_venue_id, OrderStatus.ACCEPTED, "53893.0")
+        client._handle_order_status_report(accepted_report)
+
+        canceled_report = make_report(old_venue_id, OrderStatus.CANCELED, "56730.0")
+        client._handle_order_status_report(canceled_report)
+
+        # Assert — order updated with new venue ID, no cancel emitted
+        client.generate_order_updated.assert_called_once()
+        call_kwargs = client.generate_order_updated.call_args.kwargs
+        assert call_kwargs["venue_order_id"] == new_venue_id
+        assert call_kwargs["client_order_id"] == client_oid
+
+        client.generate_order_canceled.assert_not_called()
+
+        # Order must not be in terminal state
+        assert client_oid.value not in client._terminal_orders
     finally:
         await client._disconnect()


### PR DESCRIPTION
## Summary

Fixes #3827.

Hyperliquid implements order modification as a **cancel-replace**: the exchange cancels the original order (old `venue_order_id`) and opens a replacement with a new `venue_order_id`, both referencing the same `client_order_id`.

Previously the adapter mishandled this sequence:
1. `ACCEPTED` for the new order → silently dropped (client_order_id already in `_accepted_orders`)
2. `CANCELED` for the old order → incorrectly emitted `OrderCanceled`

The strategy then believed the order was terminated while it remained live at the exchange.

## Changes

**`execution.py`**
- `_pending_modify: set[str]` — populated after a successful modify HTTP call; marks client_order_ids awaiting a cancel-replace from the exchange
- `_modify_cancel_skip: set[str]` — set when the replacement `ACCEPTED` is processed; causes the subsequent `CANCELED` for the old order to be skipped
- `ACCEPTED` handler: if the order is already accepted and a modify is pending, emit `OrderUpdated` with the new `venue_order_id` from the report instead of returning early
- `CANCELED` handler: if the cancel corresponds to the old leg of a cancel-replace (tracked via `_modify_cancel_skip`), skip `OrderCanceled` and clean up

**`test_execution.py`**
- Regression test reproducing the exact two-message sequence from the issue logs: `ACCEPTED(new_venue_id)` → `CANCELED(old_venue_id)` with an in-flight modify
- Asserts `generate_order_updated` called once with the new venue ID, `generate_order_canceled` not called, order not in terminal state

## Test plan

- [x] `pytest tests/integration_tests/adapters/hyperliquid/test_execution.py::test_modify_order_cancel_replace_emits_updated_not_canceled`
- [x] Full Hyperliquid adapter test suite: `pytest tests/integration_tests/adapters/hyperliquid/`