### PR TITLE
Add PyO3 v2 live config wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,6 +6074,7 @@ dependencies = [
  "nautilus-core",
  "nautilus-model",
  "pyo3",
+ "pyo3-stub-gen",
  "rstest",
  "rust_decimal",
  "rust_decimal_macros",

--- a/crates/live/src/builder.rs
+++ b/crates/live/src/builder.rs
@@ -28,7 +28,7 @@ use nautilus_system::{
 };
 
 use crate::{
-    config::LiveNodeConfig,
+    config::{LiveDataEngineConfig, LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig},
     manager::{ExecutionManager, ExecutionManagerConfig},
     node::LiveNode,
     runner::AsyncRunner,
@@ -179,6 +179,27 @@ impl LiveNodeBuilder {
         self
     }
 
+    /// Set the live data engine configuration.
+    #[must_use]
+    pub fn with_data_engine_config(mut self, config: LiveDataEngineConfig) -> Self {
+        self.config.data_engine = config;
+        self
+    }
+
+    /// Set the live risk engine configuration.
+    #[must_use]
+    pub fn with_risk_engine_config(mut self, config: LiveRiskEngineConfig) -> Self {
+        self.config.risk_engine = config;
+        self
+    }
+
+    /// Set the live execution engine configuration.
+    #[must_use]
+    pub fn with_exec_engine_config(mut self, config: LiveExecEngineConfig) -> Self {
+        self.config.exec_engine = config;
+        self
+    }
+
     /// Adds a data client factory with configuration.
     ///
     /// # Errors
@@ -239,6 +260,8 @@ impl LiveNodeBuilder {
             self.data_client_factories.len(),
             self.exec_client_factories.len()
         );
+
+        self.config.validate_live_path()?;
 
         let runner = AsyncRunner::new();
         runner.bind_senders();

--- a/crates/live/src/config.rs
+++ b/crates/live/src/config.rs
@@ -15,19 +15,23 @@
 
 //! Configuration types for live Nautilus system nodes.
 
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, str::FromStr, time::Duration};
 
 use nautilus_common::{
     cache::CacheConfig, enums::Environment, logging::logger::LoggerConfig,
-    msgbus::database::MessageBusConfig,
+    msgbus::database::MessageBusConfig, throttler::RateLimit,
 };
 use nautilus_core::UUID4;
 use nautilus_data::engine::config::DataEngineConfig;
 use nautilus_execution::engine::config::ExecutionEngineConfig;
-use nautilus_model::identifiers::TraderId;
+use nautilus_model::{
+    enums::BarIntervalType,
+    identifiers::{ClientId, TraderId},
+};
 use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_risk::engine::config::RiskEngineConfig;
 use nautilus_system::config::{NautilusKernelConfig, StreamingConfig};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for live data engines.
@@ -41,7 +45,35 @@ use serde::{Deserialize, Serialize};
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct LiveDataEngineConfig {
-    /// The queue size for the engine's internal queue buffers.
+    /// If time bar aggregators will build and emit bars with no new market updates.
+    #[builder(default = true)]
+    pub time_bars_build_with_no_updates: bool,
+    /// If time bar aggregators will timestamp `ts_event` on bar close.
+    #[builder(default = true)]
+    pub time_bars_timestamp_on_close: bool,
+    /// If time bar aggregators will skip emitting a bar if aggregation starts mid-interval.
+    #[builder(default)]
+    pub time_bars_skip_first_non_full_bar: bool,
+    /// Determines the interval semantics used for time aggregation.
+    #[builder(default = BarIntervalType::LeftOpen)]
+    pub time_bars_interval_type: BarIntervalType,
+    /// The build delay in microseconds before time bars are emitted.
+    #[builder(default)]
+    pub time_bars_build_delay: u64,
+    /// If data timestamp sequencing should be validated and handled.
+    #[builder(default)]
+    pub validate_data_sequence: bool,
+    /// If order book deltas should be buffered until the final delta flag is seen.
+    #[builder(default)]
+    pub buffer_deltas: bool,
+    /// Client IDs declared for external stream processing.
+    pub external_clients: Option<Vec<ClientId>>,
+    /// If debug mode is active (will provide extra debug logging).
+    #[builder(default)]
+    pub debug: bool,
+    /// Reserved for future queue sizing support.
+    ///
+    /// Not currently implemented on the current v2 live node path.
     #[builder(default = 100_000)]
     pub qsize: u32,
 }
@@ -53,8 +85,39 @@ impl Default for LiveDataEngineConfig {
 }
 
 impl From<LiveDataEngineConfig> for DataEngineConfig {
-    fn from(_config: LiveDataEngineConfig) -> Self {
-        Self::default()
+    fn from(config: LiveDataEngineConfig) -> Self {
+        Self {
+            time_bars_build_with_no_updates: config.time_bars_build_with_no_updates,
+            time_bars_timestamp_on_close: config.time_bars_timestamp_on_close,
+            time_bars_skip_first_non_full_bar: config.time_bars_skip_first_non_full_bar,
+            time_bars_interval_type: config.time_bars_interval_type,
+            time_bars_build_delay: config.time_bars_build_delay,
+            validate_data_sequence: config.validate_data_sequence,
+            buffer_deltas: config.buffer_deltas,
+            external_clients: config.external_clients,
+            debug: config.debug,
+            ..Self::default()
+        }
+    }
+}
+
+impl LiveDataEngineConfig {
+    fn validate_live_path(&self) -> anyhow::Result<()> {
+        let default = Self::default();
+        let mut unsupported = Vec::new();
+
+        if self.qsize != default.qsize {
+            unsupported.push("qsize");
+        }
+
+        if unsupported.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "Unsupported LiveDataEngineConfig field(s) on the current v2 live node path: {}",
+                unsupported.join(", ")
+            );
+        }
     }
 }
 
@@ -69,7 +132,24 @@ impl From<LiveDataEngineConfig> for DataEngineConfig {
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct LiveRiskEngineConfig {
-    /// The queue size for the engine's internal queue buffers.
+    /// If all pre-trade risk checks should be bypassed.
+    #[builder(default)]
+    pub bypass: bool,
+    /// The maximum submit order rate as `limit/HH:MM:SS`.
+    #[builder(default = "100/00:00:01".to_string())]
+    pub max_order_submit_rate: String,
+    /// The maximum modify order rate as `limit/HH:MM:SS`.
+    #[builder(default = "100/00:00:01".to_string())]
+    pub max_order_modify_rate: String,
+    /// The maximum notional per order keyed by instrument ID.
+    #[builder(default)]
+    pub max_notional_per_order: HashMap<String, String>,
+    /// If debug mode is active (will provide extra debug logging).
+    #[builder(default)]
+    pub debug: bool,
+    /// Reserved for future queue sizing support.
+    ///
+    /// Not currently implemented on the current v2 live node path.
     #[builder(default = 100_000)]
     pub qsize: u32,
 }
@@ -81,8 +161,49 @@ impl Default for LiveRiskEngineConfig {
 }
 
 impl From<LiveRiskEngineConfig> for RiskEngineConfig {
-    fn from(_config: LiveRiskEngineConfig) -> Self {
-        Self::default()
+    fn from(config: LiveRiskEngineConfig) -> Self {
+        let max_notional_per_order = config
+            .max_notional_per_order
+            .into_iter()
+            .map(|(instrument_id, notional)| {
+                let instrument_id = instrument_id
+                    .parse()
+                    .expect("LiveRiskEngineConfig instrument IDs must be validated before use");
+                let notional = Decimal::from_str(&notional)
+                    .expect("LiveRiskEngineConfig notionals must be validated before use");
+                (instrument_id, notional)
+            })
+            .collect();
+
+        Self {
+            bypass: config.bypass,
+            max_order_submit: parse_rate_limit(&config.max_order_submit_rate)
+                .expect("LiveRiskEngineConfig submit rate must be validated before use"),
+            max_order_modify: parse_rate_limit(&config.max_order_modify_rate)
+                .expect("LiveRiskEngineConfig modify rate must be validated before use"),
+            max_notional_per_order,
+            debug: config.debug,
+        }
+    }
+}
+
+impl LiveRiskEngineConfig {
+    fn validate_live_path(&self) -> anyhow::Result<()> {
+        let default = Self::default();
+        let mut unsupported = Vec::new();
+
+        if self.qsize != default.qsize {
+            unsupported.push("qsize");
+        }
+
+        if unsupported.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "Unsupported LiveRiskEngineConfig field(s) on the current v2 live node path: {}",
+                unsupported.join(", ")
+            );
+        }
     }
 }
 
@@ -97,6 +218,26 @@ impl From<LiveRiskEngineConfig> for RiskEngineConfig {
 )]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
 pub struct LiveExecEngineConfig {
+    /// If own order books should be maintained from commands and events.
+    #[builder(default)]
+    pub manage_own_order_books: bool,
+    /// Reserved for future snapshot persistence support.
+    ///
+    /// Not currently implemented on the current v2 live node path because the live kernel
+    /// does not yet wire a cache database adapter.
+    #[builder(default)]
+    pub snapshot_orders: bool,
+    /// Reserved for future snapshot persistence support.
+    ///
+    /// Not currently implemented on the current v2 live node path because the live kernel
+    /// does not yet wire a cache database adapter.
+    #[builder(default)]
+    pub snapshot_positions: bool,
+    /// If order fills exceeding order quantity are allowed.
+    #[builder(default)]
+    pub allow_overfills: bool,
+    /// Client IDs declared for external stream processing.
+    pub external_clients: Option<Vec<ClientId>>,
     /// If reconciliation is active at start-up.
     #[builder(default = true)]
     pub reconciliation: bool,
@@ -170,15 +311,24 @@ pub struct LiveExecEngineConfig {
     pub purge_account_events_interval_mins: Option<u32>,
     /// The time buffer (minutes) before account events can be purged.
     pub purge_account_events_lookback_mins: Option<u32>,
-    /// If purge operations should also delete from the backing database.
+    /// Reserved for future purge-to-database support.
+    ///
+    /// Not currently implemented on the current v2 live node path.
     #[builder(default)]
     pub purge_from_database: bool,
+    /// If debug mode is active (will provide extra debug logging).
+    #[builder(default)]
+    pub debug: bool,
     /// The interval (seconds) between auditing own books against public order books.
     pub own_books_audit_interval_secs: Option<f64>,
-    /// If the engine should gracefully shutdown when queue processing encounters unexpected errors.
+    /// Reserved for future graceful shutdown handling.
+    ///
+    /// Not currently implemented on the current v2 live node path.
     #[builder(default)]
     pub graceful_shutdown_on_error: bool,
-    /// The queue size for the engine's internal queue buffers.
+    /// Reserved for future queue sizing support.
+    ///
+    /// Not currently implemented on the current v2 live node path.
     #[builder(default = 100_000)]
     pub qsize: u32,
 }
@@ -194,7 +344,18 @@ impl Default for LiveExecEngineConfig {
 
 impl From<LiveExecEngineConfig> for ExecutionEngineConfig {
     fn from(config: LiveExecEngineConfig) -> Self {
+        let defaults = Self::default();
+
         Self {
+            // These engine knobs are intentionally pinned to defaults until the
+            // live kernel wires the remaining persistence/timer behavior.
+            load_cache: defaults.load_cache,
+            manage_own_order_books: config.manage_own_order_books,
+            snapshot_orders: config.snapshot_orders,
+            snapshot_positions: config.snapshot_positions,
+            snapshot_positions_interval_secs: defaults.snapshot_positions_interval_secs,
+            allow_overfills: config.allow_overfills,
+            external_clients: config.external_clients,
             purge_closed_orders_interval_mins: config.purge_closed_orders_interval_mins,
             purge_closed_orders_buffer_mins: config.purge_closed_orders_buffer_mins,
             purge_closed_positions_interval_mins: config.purge_closed_positions_interval_mins,
@@ -202,9 +363,84 @@ impl From<LiveExecEngineConfig> for ExecutionEngineConfig {
             purge_account_events_interval_mins: config.purge_account_events_interval_mins,
             purge_account_events_lookback_mins: config.purge_account_events_lookback_mins,
             purge_from_database: config.purge_from_database,
-            ..Self::default()
+            debug: config.debug,
         }
     }
+}
+
+impl LiveExecEngineConfig {
+    fn validate_live_path(&self) -> anyhow::Result<()> {
+        let default = Self::default();
+        let mut unsupported = Vec::new();
+
+        if self.snapshot_orders != default.snapshot_orders {
+            unsupported.push("snapshot_orders");
+        }
+
+        if self.snapshot_positions != default.snapshot_positions {
+            unsupported.push("snapshot_positions");
+        }
+
+        if self.purge_from_database != default.purge_from_database {
+            unsupported.push("purge_from_database");
+        }
+
+        if self.graceful_shutdown_on_error != default.graceful_shutdown_on_error {
+            unsupported.push("graceful_shutdown_on_error");
+        }
+
+        if self.qsize != default.qsize {
+            unsupported.push("qsize");
+        }
+
+        if unsupported.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "Unsupported LiveExecEngineConfig field(s) on the current v2 live node path: {}",
+                unsupported.join(", ")
+            );
+        }
+    }
+}
+
+fn parse_rate_limit(input: &str) -> anyhow::Result<RateLimit> {
+    let (limit, interval) = input
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("invalid rate limit '{input}': missing '/' separator"))?;
+
+    let limit = limit
+        .parse::<usize>()
+        .map_err(|e| anyhow::anyhow!("invalid rate limit '{input}': {e}"))?;
+
+    let mut parts = interval.split(':');
+    let hours = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid rate limit '{input}': missing hours"))?
+        .parse::<u64>()
+        .map_err(|e| anyhow::anyhow!("invalid rate limit '{input}': {e}"))?;
+    let minutes = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid rate limit '{input}': missing minutes"))?
+        .parse::<u64>()
+        .map_err(|e| anyhow::anyhow!("invalid rate limit '{input}': {e}"))?;
+    let seconds = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid rate limit '{input}': missing seconds"))?
+        .parse::<u64>()
+        .map_err(|e| anyhow::anyhow!("invalid rate limit '{input}': {e}"))?;
+
+    if parts.next().is_some() {
+        anyhow::bail!("invalid rate limit '{input}': expected HH:MM:SS interval");
+    }
+
+    let interval_ns = hours
+        .saturating_mul(3_600)
+        .saturating_add(minutes.saturating_mul(60))
+        .saturating_add(seconds)
+        .saturating_mul(1_000_000_000);
+
+    Ok(RateLimit::new(limit, interval_ns))
 }
 
 /// Configuration for live client message routing.
@@ -449,11 +685,36 @@ impl NautilusKernelConfig for LiveNodeConfig {
     }
 }
 
+impl LiveNodeConfig {
+    pub(crate) fn validate_live_path(&self) -> anyhow::Result<()> {
+        self.data_engine.validate_live_path()?;
+        self.risk_engine.validate_live_path()?;
+        self.exec_engine.validate_live_path()?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[rstest]
+    fn test_live_data_engine_config_defaults() {
+        let config = LiveDataEngineConfig::default();
+
+        assert!(config.time_bars_build_with_no_updates);
+        assert!(config.time_bars_timestamp_on_close);
+        assert!(!config.time_bars_skip_first_non_full_bar);
+        assert_eq!(config.time_bars_interval_type, BarIntervalType::LeftOpen);
+        assert_eq!(config.time_bars_build_delay, 0);
+        assert!(!config.validate_data_sequence);
+        assert!(!config.buffer_deltas);
+        assert_eq!(config.external_clients, None);
+        assert!(!config.debug);
+        assert_eq!(config.qsize, 100_000);
+    }
 
     #[rstest]
     fn test_trading_node_config_default() {
@@ -484,9 +745,77 @@ mod tests {
     }
 
     #[rstest]
+    fn test_live_data_engine_config_converts_to_data_engine_config() {
+        let config = LiveDataEngineConfig {
+            time_bars_build_with_no_updates: false,
+            time_bars_timestamp_on_close: false,
+            time_bars_skip_first_non_full_bar: true,
+            time_bars_interval_type: BarIntervalType::RightOpen,
+            time_bars_build_delay: 1_500,
+            validate_data_sequence: true,
+            buffer_deltas: true,
+            external_clients: Some(vec![ClientId::from("EXTERNAL")]),
+            debug: true,
+            qsize: 7,
+        };
+
+        let converted: DataEngineConfig = config.into();
+
+        assert!(!converted.time_bars_build_with_no_updates);
+        assert!(!converted.time_bars_timestamp_on_close);
+        assert!(converted.time_bars_skip_first_non_full_bar);
+        assert_eq!(
+            converted.time_bars_interval_type,
+            BarIntervalType::RightOpen
+        );
+        assert_eq!(converted.time_bars_build_delay, 1_500);
+        assert!(converted.validate_data_sequence);
+        assert!(converted.buffer_deltas);
+        assert_eq!(
+            converted.external_clients,
+            Some(vec![ClientId::from("EXTERNAL")])
+        );
+        assert!(converted.debug);
+    }
+
+    #[rstest]
+    fn test_live_risk_engine_config_converts_to_risk_engine_config() {
+        let config = LiveRiskEngineConfig {
+            bypass: true,
+            max_order_submit_rate: "12/00:00:03".to_string(),
+            max_order_modify_rate: "7/00:00:05".to_string(),
+            max_notional_per_order: HashMap::from([(
+                "ETHUSDT.BINANCE".to_string(),
+                "1000.5".to_string(),
+            )]),
+            debug: true,
+            qsize: 99,
+        };
+
+        let converted: RiskEngineConfig = config.into();
+
+        assert!(converted.bypass);
+        assert_eq!(
+            converted.max_order_submit,
+            RateLimit::new(12, 3_000_000_000)
+        );
+        assert_eq!(converted.max_order_modify, RateLimit::new(7, 5_000_000_000));
+        assert_eq!(
+            converted.max_notional_per_order[&"ETHUSDT.BINANCE".parse().unwrap()],
+            Decimal::from_str("1000.5").unwrap(),
+        );
+        assert!(converted.debug);
+    }
+
+    #[rstest]
     fn test_live_exec_engine_config_defaults() {
         let config = LiveExecEngineConfig::default();
 
+        assert!(!config.manage_own_order_books);
+        assert!(!config.snapshot_orders);
+        assert!(!config.snapshot_positions);
+        assert_eq!(config.external_clients, None);
+        assert!(!config.allow_overfills);
         assert!(config.reconciliation);
         assert_eq!(config.reconciliation_startup_delay_secs, 10.0);
         assert_eq!(config.reconciliation_lookback_mins, None);
@@ -504,9 +833,114 @@ mod tests {
         assert!(config.open_check_open_only);
         assert_eq!(config.position_check_retries, 3);
         assert!(!config.purge_from_database);
+        assert!(!config.debug);
         assert!(!config.graceful_shutdown_on_error);
         assert_eq!(config.qsize, 100_000);
         assert_eq!(config.reconciliation_startup_delay_secs, 10.0);
+    }
+
+    #[rstest]
+    fn test_live_exec_engine_config_converts_to_execution_engine_config() {
+        let config = LiveExecEngineConfig {
+            manage_own_order_books: true,
+            snapshot_orders: true,
+            snapshot_positions: true,
+            allow_overfills: true,
+            external_clients: Some(vec![ClientId::from("EXT-EXEC")]),
+            reconciliation: false,
+            reconciliation_startup_delay_secs: 5.0,
+            reconciliation_lookback_mins: Some(30),
+            reconciliation_instrument_ids: None,
+            filter_unclaimed_external_orders: true,
+            filter_position_reports: true,
+            filtered_client_order_ids: Some(vec!["O-123".to_string()]),
+            generate_missing_orders: false,
+            inflight_check_interval_ms: 2_500,
+            inflight_check_threshold_ms: 7_500,
+            inflight_check_retries: 6,
+            open_check_interval_secs: Some(10.0),
+            open_check_lookback_mins: Some(30),
+            open_check_threshold_ms: 8_000,
+            open_check_missing_retries: 8,
+            open_check_open_only: false,
+            max_single_order_queries_per_cycle: 9,
+            single_order_query_delay_ms: 150,
+            position_check_interval_secs: Some(20.0),
+            position_check_lookback_mins: 45,
+            position_check_threshold_ms: 9_000,
+            position_check_retries: 4,
+            purge_closed_orders_interval_mins: Some(1),
+            purge_closed_orders_buffer_mins: Some(2),
+            purge_closed_positions_interval_mins: Some(3),
+            purge_closed_positions_buffer_mins: Some(4),
+            purge_account_events_interval_mins: Some(5),
+            purge_account_events_lookback_mins: Some(6),
+            purge_from_database: true,
+            debug: true,
+            own_books_audit_interval_secs: Some(30.0),
+            graceful_shutdown_on_error: true,
+            qsize: 11,
+        };
+
+        let converted: ExecutionEngineConfig = config.into();
+
+        assert!(converted.manage_own_order_books);
+        assert!(converted.snapshot_orders);
+        assert!(converted.snapshot_positions);
+        assert!(converted.allow_overfills);
+        assert_eq!(
+            converted.external_clients,
+            Some(vec![ClientId::from("EXT-EXEC")]),
+        );
+        assert_eq!(converted.purge_closed_orders_interval_mins, Some(1));
+        assert_eq!(converted.purge_closed_orders_buffer_mins, Some(2));
+        assert_eq!(converted.purge_closed_positions_interval_mins, Some(3));
+        assert_eq!(converted.purge_closed_positions_buffer_mins, Some(4));
+        assert_eq!(converted.purge_account_events_interval_mins, Some(5));
+        assert_eq!(converted.purge_account_events_lookback_mins, Some(6));
+        assert!(converted.purge_from_database);
+        assert!(converted.debug);
+    }
+
+    #[rstest]
+    fn test_live_data_engine_config_rejects_unsupported_live_path_fields() {
+        let config = LiveDataEngineConfig {
+            qsize: 1,
+            ..Default::default()
+        };
+
+        let err = config.validate_live_path().unwrap_err().to_string();
+        assert!(err.contains("qsize"));
+    }
+
+    #[rstest]
+    fn test_live_risk_engine_config_rejects_unsupported_live_path_fields() {
+        let config = LiveRiskEngineConfig {
+            qsize: 1,
+            ..Default::default()
+        };
+
+        let err = config.validate_live_path().unwrap_err().to_string();
+        assert!(err.contains("qsize"));
+    }
+
+    #[rstest]
+    fn test_live_exec_engine_config_rejects_unsupported_live_path_fields() {
+        let config = LiveExecEngineConfig {
+            snapshot_orders: true,
+            snapshot_positions: true,
+            purge_from_database: true,
+            graceful_shutdown_on_error: true,
+            qsize: 1,
+            ..Default::default()
+        };
+
+        let err = config.validate_live_path().unwrap_err().to_string();
+        assert!(err.contains("snapshot_orders"));
+        assert!(err.contains("snapshot_positions"));
+        assert!(err.contains("purge_from_database"));
+        assert!(err.contains("graceful_shutdown_on_error"));
+        assert!(err.contains("qsize"));
     }
 
     #[rstest]

--- a/crates/live/src/config.rs
+++ b/crates/live/src/config.rs
@@ -26,7 +26,7 @@ use nautilus_data::engine::config::DataEngineConfig;
 use nautilus_execution::engine::config::ExecutionEngineConfig;
 use nautilus_model::{
     enums::BarIntervalType,
-    identifiers::{ClientId, TraderId},
+    identifiers::{ClientId, ClientOrderId, InstrumentId, TraderId},
 };
 use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_risk::engine::config::RiskEngineConfig;
@@ -189,6 +189,23 @@ impl From<LiveRiskEngineConfig> for RiskEngineConfig {
 
 impl LiveRiskEngineConfig {
     fn validate_live_path(&self) -> anyhow::Result<()> {
+        parse_rate_limit(&self.max_order_submit_rate)
+            .map_err(|e| anyhow::anyhow!("invalid `max_order_submit_rate`: {e}"))?;
+        parse_rate_limit(&self.max_order_modify_rate)
+            .map_err(|e| anyhow::anyhow!("invalid `max_order_modify_rate`: {e}"))?;
+
+        for (instrument_id, notional) in &self.max_notional_per_order {
+            instrument_id.parse::<InstrumentId>().map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid `max_notional_per_order` instrument ID {instrument_id:?}: {e}"
+                )
+            })?;
+
+            Decimal::from_str(notional).map_err(|e| {
+                anyhow::anyhow!("invalid `max_notional_per_order` notional {notional:?}: {e}")
+            })?;
+        }
+
         let default = Self::default();
         let mut unsupported = Vec::new();
 
@@ -370,6 +387,26 @@ impl From<LiveExecEngineConfig> for ExecutionEngineConfig {
 
 impl LiveExecEngineConfig {
     fn validate_live_path(&self) -> anyhow::Result<()> {
+        if let Some(instrument_ids) = &self.reconciliation_instrument_ids {
+            for instrument_id in instrument_ids {
+                instrument_id.parse::<InstrumentId>().map_err(|e| {
+                    anyhow::anyhow!(
+                        "invalid `reconciliation_instrument_ids` instrument ID {instrument_id:?}: {e}"
+                    )
+                })?;
+            }
+        }
+
+        if let Some(client_order_ids) = &self.filtered_client_order_ids {
+            for client_order_id in client_order_ids {
+                ClientOrderId::new_checked(client_order_id).map_err(|e| {
+                    anyhow::anyhow!(
+                        "invalid `filtered_client_order_ids` client order ID {client_order_id:?}: {e}"
+                    )
+                })?;
+            }
+        }
+
         let default = Self::default();
         let mut unsupported = Vec::new();
 
@@ -925,6 +962,17 @@ mod tests {
     }
 
     #[rstest]
+    fn test_live_risk_engine_config_rejects_invalid_supported_live_path_fields() {
+        let config = LiveRiskEngineConfig {
+            max_order_submit_rate: "bad-rate".to_string(),
+            ..Default::default()
+        };
+
+        let err = config.validate_live_path().unwrap_err().to_string();
+        assert!(err.contains("max_order_submit_rate"));
+    }
+
+    #[rstest]
     fn test_live_exec_engine_config_rejects_unsupported_live_path_fields() {
         let config = LiveExecEngineConfig {
             snapshot_orders: true,
@@ -941,6 +989,17 @@ mod tests {
         assert!(err.contains("purge_from_database"));
         assert!(err.contains("graceful_shutdown_on_error"));
         assert!(err.contains("qsize"));
+    }
+
+    #[rstest]
+    fn test_live_exec_engine_config_rejects_invalid_supported_live_path_fields() {
+        let config = LiveExecEngineConfig {
+            reconciliation_instrument_ids: Some(vec!["INVALID".to_string()]),
+            ..Default::default()
+        };
+
+        let err = config.validate_live_path().unwrap_err().to_string();
+        assert!(err.contains("reconciliation_instrument_ids"));
     }
 
     #[rstest]

--- a/crates/live/src/manager.rs
+++ b/crates/live/src/manager.rs
@@ -112,8 +112,6 @@ pub struct ExecutionManagerConfig {
     pub trader_id: TraderId,
     /// If reconciliation is active at start-up.
     pub reconciliation: bool,
-    /// The delay (seconds) before starting reconciliation at startup.
-    pub reconciliation_startup_delay_secs: f64,
     /// Number of minutes to look back during reconciliation.
     pub lookback_mins: Option<u64>,
     /// Instrument IDs to include during reconciliation (empty => all).
@@ -169,7 +167,6 @@ impl Default for ExecutionManagerConfig {
         Self {
             trader_id: TraderId::default(),
             reconciliation: true,
-            reconciliation_startup_delay_secs: 10.0,
             lookback_mins: Some(60),
             reconciliation_instrument_ids: AHashSet::new(),
             filter_unclaimed_external: false,
@@ -224,7 +221,6 @@ impl From<&LiveExecEngineConfig> for ExecutionManagerConfig {
         Self {
             trader_id: TraderId::default(), // Must be set separately via with_trader_id
             reconciliation: config.reconciliation,
-            reconciliation_startup_delay_secs: config.reconciliation_startup_delay_secs,
             lookback_mins: config.reconciliation_lookback_mins.map(|m| m as u64),
             reconciliation_instrument_ids,
             filter_unclaimed_external: config.filter_unclaimed_external_orders,

--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -276,6 +276,8 @@ impl LiveNode {
             }
         }
 
+        config.validate_live_path()?;
+
         let runner = AsyncRunner::new();
         runner.bind_senders();
 
@@ -348,6 +350,7 @@ impl LiveNode {
             return Ok(());
         }
 
+        self.await_startup_reconciliation_delay().await;
         self.perform_startup_reconciliation().await?;
 
         self.kernel.start_trader();
@@ -355,6 +358,17 @@ impl LiveNode {
         self.handle.set_state(NodeState::Running);
 
         Ok(())
+    }
+
+    async fn await_startup_reconciliation_delay(&self) {
+        let delay_secs = self.config.exec_engine.reconciliation_startup_delay_secs;
+        if !self.config.exec_engine.reconciliation || delay_secs <= 0.0 {
+            return;
+        }
+
+        let delay = Duration::from_secs_f64(delay_secs);
+        log::info!("Delaying startup reconciliation by {delay:?}");
+        tokio::time::sleep(delay).await;
     }
 
     /// Stop the live node.
@@ -697,6 +711,38 @@ impl LiveNode {
         );
 
         if engines_connected {
+            if self.config.exec_engine.reconciliation {
+                let delay_secs = self.config.exec_engine.reconciliation_startup_delay_secs;
+                if delay_secs > 0.0 {
+                    let delay = Duration::from_secs_f64(delay_secs);
+                    log::info!("Delaying startup reconciliation by {delay:?}");
+
+                    drive_with_event_buffering(
+                        tokio::time::sleep(delay),
+                        &mut pending,
+                        &mut time_evt_rx,
+                        &mut data_evt_rx,
+                        &mut data_cmd_rx,
+                        &mut exec_evt_rx,
+                        &mut exec_cmd_rx,
+                    )
+                    .await;
+
+                    flush_all_pending(
+                        &mut pending,
+                        &mut time_evt_rx,
+                        &mut data_evt_rx,
+                        &mut data_cmd_rx,
+                        &mut exec_evt_rx,
+                        &mut exec_cmd_rx,
+                    );
+                    debug_assert!(
+                        pending.is_empty(),
+                        "all startup events must be processed before reconciliation",
+                    );
+                }
+            }
+
             // Run reconciliation now that instruments are in cache and start trader
             self.perform_startup_reconciliation().await?;
             self.kernel.start_trader();
@@ -753,13 +799,7 @@ impl LiveNode {
             Duration::from_secs(1) // Unused, timer won't fire
         };
 
-        let startup_delay = if self.config.exec_engine.reconciliation {
-            Duration::from_secs_f64(exec_config.reconciliation_startup_delay_secs)
-        } else {
-            Duration::ZERO
-        };
-
-        let recon_start = tokio::time::Instant::now() + startup_delay;
+        let recon_start = tokio::time::Instant::now();
 
         let mut ts_last_inflight = self.exec_manager.generate_timestamp_ns();
         let mut ts_last_open = ts_last_inflight;
@@ -1612,6 +1652,7 @@ mod tests {
     use rstest::*;
 
     use super::*;
+    use crate::config::{LiveDataEngineConfig, LiveExecEngineConfig, LiveRiskEngineConfig};
 
     #[rstest]
     #[case(0, NodeState::Idle)]
@@ -1785,6 +1826,30 @@ mod tests {
             .with_delay_shutdown_secs(10);
 
         assert_eq!(builder.name(), "TestNode");
+    }
+
+    #[rstest]
+    fn test_builder_applies_engine_configs() {
+        let node = LiveNode::builder(TraderId::from("TRADER-001"), Environment::Live)
+            .unwrap()
+            .with_data_engine_config(LiveDataEngineConfig {
+                time_bars_build_with_no_updates: false,
+                ..LiveDataEngineConfig::default()
+            })
+            .with_risk_engine_config(LiveRiskEngineConfig {
+                bypass: true,
+                ..LiveRiskEngineConfig::default()
+            })
+            .with_exec_engine_config(LiveExecEngineConfig {
+                manage_own_order_books: true,
+                ..LiveExecEngineConfig::default()
+            })
+            .build()
+            .unwrap();
+
+        assert!(!node.config.data_engine.time_bars_build_with_no_updates);
+        assert!(node.config.risk_engine.bypass);
+        assert!(node.config.exec_engine.manage_own_order_books);
     }
 
     #[cfg(feature = "python")]

--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -1852,6 +1852,36 @@ mod tests {
         assert!(node.config.exec_engine.manage_own_order_books);
     }
 
+    #[rstest]
+    fn test_builder_rejects_invalid_supported_risk_config_values() {
+        let err = LiveNode::builder(TraderId::from("TRADER-001"), Environment::Live)
+            .unwrap()
+            .with_risk_engine_config(LiveRiskEngineConfig {
+                max_order_submit_rate: "bad-rate".to_string(),
+                ..LiveRiskEngineConfig::default()
+            })
+            .build()
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("max_order_submit_rate"));
+    }
+
+    #[rstest]
+    fn test_builder_rejects_invalid_supported_exec_config_values() {
+        let err = LiveNode::builder(TraderId::from("TRADER-001"), Environment::Live)
+            .unwrap()
+            .with_exec_engine_config(LiveExecEngineConfig {
+                reconciliation_instrument_ids: Some(vec!["INVALID".to_string()]),
+                ..LiveExecEngineConfig::default()
+            })
+            .build()
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("reconciliation_instrument_ids"));
+    }
+
     #[cfg(feature = "python")]
     #[rstest]
     fn test_node_build_and_initial_state() {

--- a/crates/live/src/python/config.rs
+++ b/crates/live/src/python/config.rs
@@ -13,32 +13,112 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, str::FromStr, time::Duration};
 
 use nautilus_common::{
     cache::CacheConfig, enums::Environment, logging::logger::LoggerConfig,
     msgbus::database::MessageBusConfig,
 };
 use nautilus_core::{UUID4, python::to_pyvalue_err};
-use nautilus_model::identifiers::TraderId;
+use nautilus_model::{
+    enums::BarIntervalType,
+    identifiers::{ClientId, InstrumentId, TraderId},
+};
 use nautilus_portfolio::config::PortfolioConfig;
 use pyo3::{PyResult, pymethods};
+use rust_decimal::Decimal;
 
 use crate::config::{
     InstrumentProviderConfig, LiveDataClientConfig, LiveDataEngineConfig, LiveExecClientConfig,
     LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig, RoutingConfig,
 };
 
+fn validate_rate_limit(value: &str, name: &str) -> PyResult<()> {
+    let (limit, interval) = value
+        .split_once('/')
+        .ok_or_else(|| to_pyvalue_err(format!("invalid `{name}`: expected 'limit/HH:MM:SS'")))?;
+
+    limit
+        .parse::<usize>()
+        .map_err(|e| to_pyvalue_err(format!("invalid `{name}`: {e}")))?;
+
+    let mut parts = interval.split(':');
+    for label in ["hours", "minutes", "seconds"] {
+        parts
+            .next()
+            .ok_or_else(|| {
+                to_pyvalue_err(format!(
+                    "invalid `{name}`: expected 'limit/HH:MM:SS' interval",
+                ))
+            })?
+            .parse::<u64>()
+            .map_err(|e| to_pyvalue_err(format!("invalid `{name}` {label}: {e}")))?;
+    }
+
+    if parts.next().is_some() {
+        return Err(to_pyvalue_err(format!(
+            "invalid `{name}`: expected 'limit/HH:MM:SS'",
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_max_notional_per_order(
+    max_notional_per_order: &HashMap<String, String>,
+) -> PyResult<()> {
+    for (instrument_id, notional) in max_notional_per_order {
+        instrument_id.parse::<InstrumentId>().map_err(|e| {
+            to_pyvalue_err(format!(
+                "invalid `max_notional_per_order` instrument ID {instrument_id:?}: {e}",
+            ))
+        })?;
+
+        Decimal::from_str(notional).map_err(|e| {
+            to_pyvalue_err(format!(
+                "invalid `max_notional_per_order` notional {notional:?}: {e}",
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl LiveDataEngineConfig {
     /// Configuration for live data engines.
     #[new]
-    #[pyo3(signature = (qsize=None))]
-    fn py_new(qsize: Option<u32>) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (time_bars_build_with_no_updates=None, time_bars_timestamp_on_close=None, time_bars_skip_first_non_full_bar=None, time_bars_interval_type=None, time_bars_build_delay=None, validate_data_sequence=None, buffer_deltas=None, external_clients=None, debug=None))]
+    fn py_new(
+        time_bars_build_with_no_updates: Option<bool>,
+        time_bars_timestamp_on_close: Option<bool>,
+        time_bars_skip_first_non_full_bar: Option<bool>,
+        time_bars_interval_type: Option<BarIntervalType>,
+        time_bars_build_delay: Option<u64>,
+        validate_data_sequence: Option<bool>,
+        buffer_deltas: Option<bool>,
+        external_clients: Option<Vec<ClientId>>,
+        debug: Option<bool>,
+    ) -> Self {
         let default = Self::default();
         Self {
-            qsize: qsize.unwrap_or(default.qsize),
+            time_bars_build_with_no_updates: time_bars_build_with_no_updates
+                .unwrap_or(default.time_bars_build_with_no_updates),
+            time_bars_timestamp_on_close: time_bars_timestamp_on_close
+                .unwrap_or(default.time_bars_timestamp_on_close),
+            time_bars_skip_first_non_full_bar: time_bars_skip_first_non_full_bar
+                .unwrap_or(default.time_bars_skip_first_non_full_bar),
+            time_bars_interval_type: time_bars_interval_type
+                .unwrap_or(default.time_bars_interval_type),
+            time_bars_build_delay: time_bars_build_delay.unwrap_or(default.time_bars_build_delay),
+            validate_data_sequence: validate_data_sequence
+                .unwrap_or(default.validate_data_sequence),
+            buffer_deltas: buffer_deltas.unwrap_or(default.buffer_deltas),
+            external_clients,
+            debug: debug.unwrap_or(default.debug),
+            qsize: default.qsize,
         }
     }
 
@@ -48,11 +128,6 @@ impl LiveDataEngineConfig {
 
     fn __str__(&self) -> String {
         format!("{self:?}")
-    }
-
-    #[getter]
-    fn qsize(&self) -> u32 {
-        self.qsize
     }
 }
 
@@ -61,12 +136,33 @@ impl LiveDataEngineConfig {
 impl LiveRiskEngineConfig {
     /// Configuration for live risk engines.
     #[new]
-    #[pyo3(signature = (qsize=None))]
-    fn py_new(qsize: Option<u32>) -> Self {
+    #[pyo3(signature = (bypass=None, max_order_submit_rate=None, max_order_modify_rate=None, max_notional_per_order=None, debug=None))]
+    fn py_new(
+        bypass: Option<bool>,
+        max_order_submit_rate: Option<String>,
+        max_order_modify_rate: Option<String>,
+        max_notional_per_order: Option<HashMap<String, String>>,
+        debug: Option<bool>,
+    ) -> PyResult<Self> {
         let default = Self::default();
-        Self {
-            qsize: qsize.unwrap_or(default.qsize),
-        }
+        let max_order_submit_rate =
+            max_order_submit_rate.unwrap_or_else(|| default.max_order_submit_rate.clone());
+        let max_order_modify_rate =
+            max_order_modify_rate.unwrap_or_else(|| default.max_order_modify_rate.clone());
+        let max_notional_per_order = max_notional_per_order.unwrap_or_default();
+
+        validate_rate_limit(&max_order_submit_rate, "max_order_submit_rate")?;
+        validate_rate_limit(&max_order_modify_rate, "max_order_modify_rate")?;
+        validate_max_notional_per_order(&max_notional_per_order)?;
+
+        Ok(Self {
+            bypass: bypass.unwrap_or(default.bypass),
+            max_order_submit_rate,
+            max_order_modify_rate,
+            max_notional_per_order,
+            debug: debug.unwrap_or(default.debug),
+            qsize: default.qsize,
+        })
     }
 
     fn __repr__(&self) -> String {
@@ -75,11 +171,6 @@ impl LiveRiskEngineConfig {
 
     fn __str__(&self) -> String {
         format!("{self:?}")
-    }
-
-    #[getter]
-    fn qsize(&self) -> u32 {
-        self.qsize
     }
 }
 
@@ -89,8 +180,11 @@ impl LiveExecEngineConfig {
     /// Configuration for live execution engines.
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (reconciliation=None, reconciliation_startup_delay_secs=None, reconciliation_lookback_mins=None, reconciliation_instrument_ids=None, filter_unclaimed_external_orders=None, filter_position_reports=None, filtered_client_order_ids=None, generate_missing_orders=None, inflight_check_interval_ms=None, inflight_check_threshold_ms=None, inflight_check_retries=None, open_check_interval_secs=None, open_check_lookback_mins=None, open_check_threshold_ms=None, open_check_missing_retries=None, open_check_open_only=None, max_single_order_queries_per_cycle=None, single_order_query_delay_ms=None, position_check_interval_secs=None, position_check_lookback_mins=None, position_check_threshold_ms=None, position_check_retries=None, purge_closed_orders_interval_mins=None, purge_closed_orders_buffer_mins=None, purge_closed_positions_interval_mins=None, purge_closed_positions_buffer_mins=None, purge_account_events_interval_mins=None, purge_account_events_lookback_mins=None, purge_from_database=None, own_books_audit_interval_secs=None, graceful_shutdown_on_error=None, qsize=None))]
+    #[pyo3(signature = (manage_own_order_books=None, external_clients=None, allow_overfills=None, reconciliation=None, reconciliation_startup_delay_secs=None, reconciliation_lookback_mins=None, reconciliation_instrument_ids=None, filter_unclaimed_external_orders=None, filter_position_reports=None, filtered_client_order_ids=None, generate_missing_orders=None, inflight_check_interval_ms=None, inflight_check_threshold_ms=None, inflight_check_retries=None, open_check_interval_secs=None, open_check_lookback_mins=None, open_check_threshold_ms=None, open_check_missing_retries=None, open_check_open_only=None, max_single_order_queries_per_cycle=None, single_order_query_delay_ms=None, position_check_interval_secs=None, position_check_lookback_mins=None, position_check_threshold_ms=None, position_check_retries=None, purge_closed_orders_interval_mins=None, purge_closed_orders_buffer_mins=None, purge_closed_positions_interval_mins=None, purge_closed_positions_buffer_mins=None, purge_account_events_interval_mins=None, purge_account_events_lookback_mins=None, debug=None, own_books_audit_interval_secs=None))]
     fn py_new(
+        manage_own_order_books: Option<bool>,
+        external_clients: Option<Vec<ClientId>>,
+        allow_overfills: Option<bool>,
         reconciliation: Option<bool>,
         reconciliation_startup_delay_secs: Option<f64>,
         reconciliation_lookback_mins: Option<u32>,
@@ -119,13 +213,17 @@ impl LiveExecEngineConfig {
         purge_closed_positions_buffer_mins: Option<u32>,
         purge_account_events_interval_mins: Option<u32>,
         purge_account_events_lookback_mins: Option<u32>,
-        purge_from_database: Option<bool>,
+        debug: Option<bool>,
         own_books_audit_interval_secs: Option<f64>,
-        graceful_shutdown_on_error: Option<bool>,
-        qsize: Option<u32>,
     ) -> Self {
         let default = Self::default();
         Self {
+            manage_own_order_books: manage_own_order_books
+                .unwrap_or(default.manage_own_order_books),
+            snapshot_orders: default.snapshot_orders,
+            snapshot_positions: default.snapshot_positions,
+            external_clients,
+            allow_overfills: allow_overfills.unwrap_or(default.allow_overfills),
             reconciliation: reconciliation.unwrap_or(default.reconciliation),
             reconciliation_startup_delay_secs: reconciliation_startup_delay_secs
                 .unwrap_or(default.reconciliation_startup_delay_secs),
@@ -168,11 +266,11 @@ impl LiveExecEngineConfig {
             purge_closed_positions_buffer_mins,
             purge_account_events_interval_mins,
             purge_account_events_lookback_mins,
-            purge_from_database: purge_from_database.unwrap_or(default.purge_from_database),
+            purge_from_database: default.purge_from_database,
+            debug: debug.unwrap_or(default.debug),
             own_books_audit_interval_secs,
-            graceful_shutdown_on_error: graceful_shutdown_on_error
-                .unwrap_or(default.graceful_shutdown_on_error),
-            qsize: qsize.unwrap_or(default.qsize),
+            graceful_shutdown_on_error: default.graceful_shutdown_on_error,
+            qsize: default.qsize,
         }
     }
 

--- a/crates/live/src/python/config.rs
+++ b/crates/live/src/python/config.rs
@@ -435,6 +435,7 @@ impl LiveExecClientConfig {
     }
 }
 
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl LiveNodeConfig {
     /// Configuration for live Nautilus system nodes.

--- a/crates/live/src/python/mod.rs
+++ b/crates/live/src/python/mod.rs
@@ -26,6 +26,12 @@ pub mod node;
 use nautilus_portfolio::config::PortfolioConfig;
 use pyo3::prelude::*;
 
+pyo3_stub_gen::reexport_module_members!(
+    "nautilus_trader.live",
+    "nautilus_trader.portfolio",
+    "PortfolioConfig"
+);
+
 /// Loaded as `nautilus_pyo3.live`.
 ///
 /// # Errors

--- a/crates/live/src/python/node.rs
+++ b/crates/live/src/python/node.rs
@@ -37,11 +37,22 @@ use pyo3::{
 };
 use serde_json;
 
-use crate::{builder::LiveNodeBuilder, node::LiveNode};
+use crate::{
+    builder::LiveNodeBuilder,
+    config::{LiveDataEngineConfig, LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig},
+    node::LiveNode,
+};
 
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl LiveNode {
+    #[staticmethod]
+    #[pyo3(name = "build")]
+    #[pyo3(signature = (name, config=None))]
+    fn py_build(name: String, config: Option<LiveNodeConfig>) -> PyResult<Self> {
+        Self::build(name, config).map_err(to_pyruntime_err)
+    }
+
     #[staticmethod]
     #[pyo3(name = "builder")]
     fn py_builder(
@@ -793,6 +804,45 @@ impl LiveNodeBuilderPy {
         let mut inner_ref = self.inner.borrow_mut();
         if let Some(builder) = inner_ref.take() {
             *inner_ref = Some(builder.with_logging(logging));
+            Ok(Self {
+                inner: self.inner.clone(),
+            })
+        } else {
+            Err(to_pyruntime_err("Builder already consumed"))
+        }
+    }
+
+    #[pyo3(name = "with_data_engine_config")]
+    fn py_with_data_engine_config(&self, config: LiveDataEngineConfig) -> PyResult<Self> {
+        let mut inner_ref = self.inner.borrow_mut();
+        if let Some(builder) = inner_ref.take() {
+            *inner_ref = Some(builder.with_data_engine_config(config));
+            Ok(Self {
+                inner: self.inner.clone(),
+            })
+        } else {
+            Err(to_pyruntime_err("Builder already consumed"))
+        }
+    }
+
+    #[pyo3(name = "with_risk_engine_config")]
+    fn py_with_risk_engine_config(&self, config: LiveRiskEngineConfig) -> PyResult<Self> {
+        let mut inner_ref = self.inner.borrow_mut();
+        if let Some(builder) = inner_ref.take() {
+            *inner_ref = Some(builder.with_risk_engine_config(config));
+            Ok(Self {
+                inner: self.inner.clone(),
+            })
+        } else {
+            Err(to_pyruntime_err("Builder already consumed"))
+        }
+    }
+
+    #[pyo3(name = "with_exec_engine_config")]
+    fn py_with_exec_engine_config(&self, config: LiveExecEngineConfig) -> PyResult<Self> {
+        let mut inner_ref = self.inner.borrow_mut();
+        if let Some(builder) = inner_ref.take() {
+            *inner_ref = Some(builder.with_exec_engine_config(config));
             Ok(Self {
                 inner: self.inner.clone(),
             })

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -1336,7 +1336,6 @@ fn test_config_default_values() {
     let config = ExecutionManagerConfig::default();
 
     assert!(config.reconciliation);
-    assert_eq!(config.reconciliation_startup_delay_secs, 10.0);
     assert_eq!(config.lookback_mins, Some(60));
     assert!(!config.filter_unclaimed_external);
     assert!(!config.filter_position_reports);

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -229,6 +229,23 @@ mod serial_tests {
     }
 
     #[rstest]
+    fn test_live_node_build_rejects_unsupported_v2_live_fields() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                snapshot_positions: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = LiveNode::build("TestNode".to_string(), Some(config))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("snapshot_positions"));
+    }
+
+    #[rstest]
     fn test_add_actor() {
         let mut node = LiveNode::build("TestNode".to_string(), None).unwrap();
 

--- a/crates/portfolio/Cargo.toml
+++ b/crates/portfolio/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["rlib", "cdylib"]
 [features]
 default = []
 extension-module = ["python", "pyo3/extension-module"]
-python = ["pyo3"]
+python = ["pyo3", "pyo3-stub-gen"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -36,6 +36,7 @@ nautilus-core = { workspace = true }
 nautilus-model = { workspace = true, features = ["stubs"] }
 
 pyo3 = { workspace = true, optional = true }
+pyo3-stub-gen = { workspace = true, optional = true }
 
 ahash = { workspace = true }
 bon = { workspace = true }

--- a/crates/portfolio/src/config.rs
+++ b/crates/portfolio/src/config.rs
@@ -21,6 +21,10 @@ use serde::{Deserialize, Serialize};
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.live", from_py_object)
 )]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.portfolio")
+)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, bon::Builder)]
 pub struct PortfolioConfig {
     /// The type of prices used for portfolio calculations, such as unrealized PnLs.

--- a/crates/portfolio/src/python/mod.rs
+++ b/crates/portfolio/src/python/mod.rs
@@ -24,6 +24,7 @@ use pyo3::pymethods;
 
 use crate::config::PortfolioConfig;
 
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl PortfolioConfig {
     /// Configuration for `Portfolio` instances.

--- a/python/generate_stubs.py
+++ b/python/generate_stubs.py
@@ -256,6 +256,7 @@ def generate_stubs() -> bool:
         relocate_classes_from_libnautilus(root)
         inject_module_constants(root, workspace_root)
         format_stub_files(root)
+        finalize_special_stubs(root)
 
     relative_root = dest_dir.relative_to(Path(__file__).parent)
     print(f"Type stubs written to {relative_root or Path('.')} ")
@@ -619,6 +620,100 @@ def rename_enum_variants(content: str, renamed_enums: set[str]) -> str:
         result.append(line)
 
     return "\n".join(result)
+
+
+LIVE_NODE_CONFIG_STUB = """\
+@typing.final
+class LiveNodeConfig:
+    @property
+    def environment(self) -> common.Environment: ...
+    @property
+    def trader_id(self) -> model.TraderId: ...
+    @property
+    def load_state(self) -> bool: ...
+    @property
+    def save_state(self) -> bool: ...
+    @property
+    def timeout_connection_secs(self) -> float: ...
+    @property
+    def timeout_reconciliation_secs(self) -> float: ...
+    @property
+    def timeout_portfolio_secs(self) -> float: ...
+    @property
+    def timeout_disconnection_secs(self) -> float: ...
+    @property
+    def delay_post_stop_secs(self) -> float: ...
+    @property
+    def timeout_shutdown_secs(self) -> float: ...
+    def __new__(
+        cls,
+        environment: common.Environment | None = None,
+        trader_id: model.TraderId | None = None,
+        load_state: bool | None = None,
+        save_state: bool | None = None,
+        logging: common.LoggerConfig | None = None,
+        instance_id: core.UUID4 | None = None,
+        timeout_connection_secs: float | None = None,
+        timeout_reconciliation_secs: float | None = None,
+        timeout_portfolio_secs: float | None = None,
+        timeout_disconnection_secs: float | None = None,
+        delay_post_stop_secs: float | None = None,
+        timeout_shutdown_secs: float | None = None,
+        cache: common.CacheConfig | None = None,
+        msgbus: common.MessageBusConfig | None = None,
+        portfolio: PortfolioConfig | None = None,
+        data_engine: LiveDataEngineConfig | None = None,
+        risk_engine: LiveRiskEngineConfig | None = None,
+        exec_engine: LiveExecEngineConfig | None = None,
+    ) -> LiveNodeConfig: ...
+"""
+
+LIVE_NODE_CONFIG_OPAQUE_RE = re.compile(
+    r"@typing\.final\nclass LiveNodeConfig: \.\.\.\n",
+    flags=re.MULTILINE,
+)
+
+
+def apply_live_module_fixups(content: str, relative_path: Path) -> str:
+    """
+    Patch live-module stubs that require cross-module aliases or manual signatures.
+    """
+    if relative_path != Path("live/__init__.pyi"):
+        return content
+
+    import_line = "from nautilus_trader.portfolio import PortfolioConfig"
+    if import_line not in content:
+        anchor = "from nautilus_trader import trading\n"
+        if anchor in content:
+            content = content.replace(anchor, f"{anchor}{import_line}\n", 1)
+        else:
+            content = content.replace("import typing\n", f"import typing\n\n{import_line}\n", 1)
+
+    content = _add_names_to_all(content, ["PortfolioConfig"])
+
+    if LIVE_NODE_CONFIG_OPAQUE_RE.search(content):
+        content = LIVE_NODE_CONFIG_OPAQUE_RE.sub(LIVE_NODE_CONFIG_STUB, content, count=1)
+
+    return content
+
+
+def finalize_special_stubs(root: Path) -> None:
+    """
+    Apply deterministic final-pass fixes after the normal stub pipeline.
+    """
+    live_stub = root / "live" / "__init__.pyi"
+    if not live_stub.exists():
+        return
+
+    content = live_stub.read_text()
+    updated = apply_live_module_fixups(content, Path("live/__init__.pyi"))
+    updated = normalize_stub_content(updated)
+
+    if updated == content:
+        return
+
+    live_stub.write_text(updated)
+    run_command(["ruff", "format", str(live_stub)])
 
 
 def fix_enum_defaults_in_signatures(content: str, renamed_enums: set[str]) -> str:

--- a/python/generate_stubs.py
+++ b/python/generate_stubs.py
@@ -256,7 +256,6 @@ def generate_stubs() -> bool:
         relocate_classes_from_libnautilus(root)
         inject_module_constants(root, workspace_root)
         format_stub_files(root)
-        finalize_special_stubs(root)
 
     relative_root = dest_dir.relative_to(Path(__file__).parent)
     print(f"Type stubs written to {relative_root or Path('.')} ")
@@ -620,100 +619,6 @@ def rename_enum_variants(content: str, renamed_enums: set[str]) -> str:
         result.append(line)
 
     return "\n".join(result)
-
-
-LIVE_NODE_CONFIG_STUB = """\
-@typing.final
-class LiveNodeConfig:
-    @property
-    def environment(self) -> common.Environment: ...
-    @property
-    def trader_id(self) -> model.TraderId: ...
-    @property
-    def load_state(self) -> bool: ...
-    @property
-    def save_state(self) -> bool: ...
-    @property
-    def timeout_connection_secs(self) -> float: ...
-    @property
-    def timeout_reconciliation_secs(self) -> float: ...
-    @property
-    def timeout_portfolio_secs(self) -> float: ...
-    @property
-    def timeout_disconnection_secs(self) -> float: ...
-    @property
-    def delay_post_stop_secs(self) -> float: ...
-    @property
-    def timeout_shutdown_secs(self) -> float: ...
-    def __new__(
-        cls,
-        environment: common.Environment | None = None,
-        trader_id: model.TraderId | None = None,
-        load_state: bool | None = None,
-        save_state: bool | None = None,
-        logging: common.LoggerConfig | None = None,
-        instance_id: core.UUID4 | None = None,
-        timeout_connection_secs: float | None = None,
-        timeout_reconciliation_secs: float | None = None,
-        timeout_portfolio_secs: float | None = None,
-        timeout_disconnection_secs: float | None = None,
-        delay_post_stop_secs: float | None = None,
-        timeout_shutdown_secs: float | None = None,
-        cache: common.CacheConfig | None = None,
-        msgbus: common.MessageBusConfig | None = None,
-        portfolio: PortfolioConfig | None = None,
-        data_engine: LiveDataEngineConfig | None = None,
-        risk_engine: LiveRiskEngineConfig | None = None,
-        exec_engine: LiveExecEngineConfig | None = None,
-    ) -> LiveNodeConfig: ...
-"""
-
-LIVE_NODE_CONFIG_OPAQUE_RE = re.compile(
-    r"@typing\.final\nclass LiveNodeConfig: \.\.\.\n",
-    flags=re.MULTILINE,
-)
-
-
-def apply_live_module_fixups(content: str, relative_path: Path) -> str:
-    """
-    Patch live-module stubs that require cross-module aliases or manual signatures.
-    """
-    if relative_path != Path("live/__init__.pyi"):
-        return content
-
-    import_line = "from nautilus_trader.portfolio import PortfolioConfig"
-    if import_line not in content:
-        anchor = "from nautilus_trader import trading\n"
-        if anchor in content:
-            content = content.replace(anchor, f"{anchor}{import_line}\n", 1)
-        else:
-            content = content.replace("import typing\n", f"import typing\n\n{import_line}\n", 1)
-
-    content = _add_names_to_all(content, ["PortfolioConfig"])
-
-    if LIVE_NODE_CONFIG_OPAQUE_RE.search(content):
-        content = LIVE_NODE_CONFIG_OPAQUE_RE.sub(LIVE_NODE_CONFIG_STUB, content, count=1)
-
-    return content
-
-
-def finalize_special_stubs(root: Path) -> None:
-    """
-    Apply deterministic final-pass fixes after the normal stub pipeline.
-    """
-    live_stub = root / "live" / "__init__.pyi"
-    if not live_stub.exists():
-        return
-
-    content = live_stub.read_text()
-    updated = apply_live_module_fixups(content, Path("live/__init__.pyi"))
-    updated = normalize_stub_content(updated)
-
-    if updated == content:
-        return
-
-    live_stub.write_text(updated)
-    run_command(["ruff", "format", str(live_stub)])
 
 
 def fix_enum_defaults_in_signatures(content: str, renamed_enums: set[str]) -> str:

--- a/python/nautilus_trader/__init__.pyi
+++ b/python/nautilus_trader/__init__.pyi
@@ -27,6 +27,7 @@ from . import network
 from . import okx
 from . import persistence
 from . import polymarket
+from . import portfolio
 from . import sandbox
 from . import serialization
 from . import tardis
@@ -59,6 +60,7 @@ __all__ = [
     "okx",
     "persistence",
     "polymarket",
+    "portfolio",
     "sandbox",
     "serialization",
     "tardis",

--- a/python/nautilus_trader/live/__init__.pyi
+++ b/python/nautilus_trader/live/__init__.pyi
@@ -52,9 +52,18 @@ class LiveDataClientConfig:
 
 @typing.final
 class LiveDataEngineConfig:
-    @property
-    def qsize(self) -> int: ...
-    def __new__(cls, qsize: int | None = None) -> LiveDataEngineConfig: ...
+    def __new__(
+        cls,
+        time_bars_build_with_no_updates: bool | None = None,
+        time_bars_timestamp_on_close: bool | None = None,
+        time_bars_skip_first_non_full_bar: bool | None = None,
+        time_bars_interval_type: model.BarIntervalType | None = None,
+        time_bars_build_delay: int | None = None,
+        validate_data_sequence: bool | None = None,
+        buffer_deltas: bool | None = None,
+        external_clients: typing.Sequence[model.ClientId] | None = None,
+        debug: bool | None = None,
+    ) -> LiveDataEngineConfig: ...
 
 @typing.final
 class LiveExecClientConfig:
@@ -72,6 +81,9 @@ class LiveExecClientConfig:
 class LiveExecEngineConfig:
     def __new__(
         cls,
+        manage_own_order_books: bool | None = None,
+        external_clients: typing.Sequence[model.ClientId] | None = None,
+        allow_overfills: bool | None = None,
         reconciliation: bool | None = None,
         reconciliation_startup_delay_secs: float | None = None,
         reconciliation_lookback_mins: int | None = None,
@@ -100,10 +112,8 @@ class LiveExecEngineConfig:
         purge_closed_positions_buffer_mins: int | None = None,
         purge_account_events_interval_mins: int | None = None,
         purge_account_events_lookback_mins: int | None = None,
-        purge_from_database: bool | None = None,
+        debug: bool | None = None,
         own_books_audit_interval_secs: float | None = None,
-        graceful_shutdown_on_error: bool | None = None,
-        qsize: int | None = None,
     ) -> LiveExecEngineConfig: ...
 
 @typing.final
@@ -116,6 +126,8 @@ class LiveNode:
     def instance_id(self) -> core.UUID4: ...
     @property
     def is_running(self) -> bool: ...
+    @staticmethod
+    def build(name: str, config: LiveNodeConfig | None = None) -> LiveNode: ...
     @staticmethod
     def builder(
         name: str, trader_id: model.TraderId, environment: common.Environment
@@ -143,6 +155,9 @@ class LiveNodeBuilder:
     def with_reconciliation(self, reconciliation: bool) -> LiveNodeBuilder: ...
     def with_reconciliation_lookback_mins(self, mins: int) -> LiveNodeBuilder: ...
     def with_logging(self, logging: common.LoggerConfig) -> LiveNodeBuilder: ...
+    def with_data_engine_config(self, config: LiveDataEngineConfig) -> LiveNodeBuilder: ...
+    def with_risk_engine_config(self, config: LiveRiskEngineConfig) -> LiveNodeBuilder: ...
+    def with_exec_engine_config(self, config: LiveExecEngineConfig) -> LiveNodeBuilder: ...
     def add_data_client(
         self, name: str | None, factory: typing.Any, config: typing.Any
     ) -> LiveNodeBuilder: ...
@@ -156,9 +171,14 @@ class LiveNodeConfig: ...
 
 @typing.final
 class LiveRiskEngineConfig:
-    @property
-    def qsize(self) -> int: ...
-    def __new__(cls, qsize: int | None = None) -> LiveRiskEngineConfig: ...
+    def __new__(
+        cls,
+        bypass: bool | None = None,
+        max_order_submit_rate: str | None = None,
+        max_order_modify_rate: str | None = None,
+        max_notional_per_order: typing.Mapping[str, str] | None = None,
+        debug: bool | None = None,
+    ) -> LiveRiskEngineConfig: ...
 
 @typing.final
 class RoutingConfig:

--- a/python/nautilus_trader/live/__init__.pyi
+++ b/python/nautilus_trader/live/__init__.pyi
@@ -5,6 +5,7 @@ import typing
 from nautilus_trader import common
 from nautilus_trader import core
 from nautilus_trader import model
+from nautilus_trader import portfolio
 from nautilus_trader import trading
 from nautilus_trader.portfolio import PortfolioConfig
 
@@ -206,7 +207,7 @@ class LiveNodeConfig:
         timeout_shutdown_secs: float | None = None,
         cache: common.CacheConfig | None = None,
         msgbus: common.MessageBusConfig | None = None,
-        portfolio: PortfolioConfig | None = None,
+        portfolio: portfolio.PortfolioConfig | None = None,
         data_engine: LiveDataEngineConfig | None = None,
         risk_engine: LiveRiskEngineConfig | None = None,
         exec_engine: LiveExecEngineConfig | None = None,

--- a/python/nautilus_trader/live/__init__.pyi
+++ b/python/nautilus_trader/live/__init__.pyi
@@ -6,6 +6,7 @@ from nautilus_trader import common
 from nautilus_trader import core
 from nautilus_trader import model
 from nautilus_trader import trading
+from nautilus_trader.portfolio import PortfolioConfig
 
 __all__ = [
     "InstrumentProviderConfig",
@@ -17,6 +18,7 @@ __all__ = [
     "LiveNodeBuilder",
     "LiveNodeConfig",
     "LiveRiskEngineConfig",
+    "PortfolioConfig",
     "RoutingConfig",
 ]
 
@@ -167,7 +169,48 @@ class LiveNodeBuilder:
     def build(self) -> LiveNode: ...
 
 @typing.final
-class LiveNodeConfig: ...
+class LiveNodeConfig:
+    @property
+    def environment(self) -> common.Environment: ...
+    @property
+    def trader_id(self) -> model.TraderId: ...
+    @property
+    def load_state(self) -> bool: ...
+    @property
+    def save_state(self) -> bool: ...
+    @property
+    def timeout_connection_secs(self) -> float: ...
+    @property
+    def timeout_reconciliation_secs(self) -> float: ...
+    @property
+    def timeout_portfolio_secs(self) -> float: ...
+    @property
+    def timeout_disconnection_secs(self) -> float: ...
+    @property
+    def delay_post_stop_secs(self) -> float: ...
+    @property
+    def timeout_shutdown_secs(self) -> float: ...
+    def __new__(
+        cls,
+        environment: common.Environment | None = None,
+        trader_id: model.TraderId | None = None,
+        load_state: bool | None = None,
+        save_state: bool | None = None,
+        logging: common.LoggerConfig | None = None,
+        instance_id: core.UUID4 | None = None,
+        timeout_connection_secs: float | None = None,
+        timeout_reconciliation_secs: float | None = None,
+        timeout_portfolio_secs: float | None = None,
+        timeout_disconnection_secs: float | None = None,
+        delay_post_stop_secs: float | None = None,
+        timeout_shutdown_secs: float | None = None,
+        cache: common.CacheConfig | None = None,
+        msgbus: common.MessageBusConfig | None = None,
+        portfolio: PortfolioConfig | None = None,
+        data_engine: LiveDataEngineConfig | None = None,
+        risk_engine: LiveRiskEngineConfig | None = None,
+        exec_engine: LiveExecEngineConfig | None = None,
+    ) -> LiveNodeConfig: ...
 
 @typing.final
 class LiveRiskEngineConfig:

--- a/python/nautilus_trader/portfolio/__init__.pyi
+++ b/python/nautilus_trader/portfolio/__init__.pyi
@@ -8,15 +8,6 @@ __all__ = [
 
 @typing.final
 class PortfolioConfig:
-    def __init__(
-        self,
-        use_mark_prices: bool | None = None,
-        use_mark_xrates: bool | None = None,
-        bar_updates: bool | None = None,
-        convert_to_account_base_currency: bool | None = None,
-        min_account_state_logging_interval_ms: int | None = None,
-        debug: bool | None = None,
-    ) -> None: ...
     @property
     def use_mark_prices(self) -> bool: ...
     @property
@@ -29,3 +20,12 @@ class PortfolioConfig:
     def min_account_state_logging_interval_ms(self) -> int | None: ...
     @property
     def debug(self) -> bool: ...
+    def __new__(
+        cls,
+        use_mark_prices: bool | None = None,
+        use_mark_xrates: bool | None = None,
+        bar_updates: bool | None = None,
+        convert_to_account_base_currency: bool | None = None,
+        min_account_state_logging_interval_ms: int | None = None,
+        debug: bool | None = None,
+    ) -> PortfolioConfig: ...

--- a/python/tests/unit/live/test_live_configs.py
+++ b/python/tests/unit/live/test_live_configs.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import pytest
+
 from nautilus_trader.live import InstrumentProviderConfig
 from nautilus_trader.live import LiveDataClientConfig
 from nautilus_trader.live import LiveDataEngineConfig
@@ -82,13 +84,18 @@ def test_live_data_client_config_explicit():
 def test_live_data_engine_config_defaults():
     config = LiveDataEngineConfig()
 
-    assert config.qsize == 100_000
+    assert isinstance(config, LiveDataEngineConfig)
 
 
 def test_live_data_engine_config_explicit():
-    config = LiveDataEngineConfig(qsize=50_000)
+    config = LiveDataEngineConfig(time_bars_build_with_no_updates=False)
 
-    assert config.qsize == 50_000
+    assert isinstance(config, LiveDataEngineConfig)
+
+
+def test_live_data_engine_config_rejects_unsupported_args():
+    with pytest.raises(TypeError, match="qsize"):
+        LiveDataEngineConfig(qsize=50_000)
 
 
 def test_live_exec_client_config_defaults():
@@ -113,16 +120,35 @@ def test_live_exec_engine_config_defaults():
     assert isinstance(config, LiveExecEngineConfig)
 
 
+def test_live_exec_engine_config_rejects_unsupported_args():
+    with pytest.raises(TypeError, match="snapshot_positions"):
+        LiveExecEngineConfig(snapshot_positions=True)
+
+    with pytest.raises(TypeError, match="purge_from_database"):
+        LiveExecEngineConfig(purge_from_database=True)
+
+    with pytest.raises(TypeError, match="graceful_shutdown_on_error"):
+        LiveExecEngineConfig(graceful_shutdown_on_error=True)
+
+    with pytest.raises(TypeError, match="qsize"):
+        LiveExecEngineConfig(qsize=1)
+
+
 def test_live_risk_engine_config_defaults():
     config = LiveRiskEngineConfig()
 
-    assert config.qsize == 100_000
+    assert isinstance(config, LiveRiskEngineConfig)
 
 
 def test_live_risk_engine_config_explicit():
-    config = LiveRiskEngineConfig(qsize=25_000)
+    config = LiveRiskEngineConfig(bypass=True)
 
-    assert config.qsize == 25_000
+    assert isinstance(config, LiveRiskEngineConfig)
+
+
+def test_live_risk_engine_config_rejects_unsupported_args():
+    with pytest.raises(TypeError, match="qsize"):
+        LiveRiskEngineConfig(qsize=25_000)
 
 
 def test_portfolio_config_defaults():

--- a/python/tests/unit/live/test_live_configs.py
+++ b/python/tests/unit/live/test_live_configs.py
@@ -140,8 +140,15 @@ def test_live_node_config_defaults():
 
     assert isinstance(config, LiveNodeConfig)
     assert config.load_state is False
-    assert config.save_state is True
+    assert config.save_state is False
     assert config.timeout_connection_secs > 0
+
+
+def test_live_node_config_accepts_portfolio_config_argument():
+    portfolio = PortfolioConfig()
+    config = LiveNodeConfig(portfolio=portfolio)
+
+    assert isinstance(config, LiveNodeConfig)
 
 
 def test_live_risk_engine_config_defaults():

--- a/python/tests/unit/live/test_live_configs.py
+++ b/python/tests/unit/live/test_live_configs.py
@@ -20,6 +20,7 @@ from nautilus_trader.live import LiveDataClientConfig
 from nautilus_trader.live import LiveDataEngineConfig
 from nautilus_trader.live import LiveExecClientConfig
 from nautilus_trader.live import LiveExecEngineConfig
+from nautilus_trader.live import LiveNodeConfig
 from nautilus_trader.live import LiveRiskEngineConfig
 from nautilus_trader.live import PortfolioConfig
 from nautilus_trader.live import RoutingConfig
@@ -132,6 +133,15 @@ def test_live_exec_engine_config_rejects_unsupported_args():
 
     with pytest.raises(TypeError, match="qsize"):
         LiveExecEngineConfig(qsize=1)
+
+
+def test_live_node_config_defaults():
+    config = LiveNodeConfig()
+
+    assert isinstance(config, LiveNodeConfig)
+    assert config.load_state is False
+    assert config.save_state is True
+    assert config.timeout_connection_secs > 0
 
 
 def test_live_risk_engine_config_defaults():

--- a/python/tests/unit/test_generate_stubs.py
+++ b/python/tests/unit/test_generate_stubs.py
@@ -730,6 +730,24 @@ def _parse_stub_enum_variants(stub_root: Path) -> dict[str, list[str]]:
 SCREAMING_SNAKE_RE = re.compile(r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*_?$")
 
 
+def test_live_stub_exposes_native_live_node_config_signature():
+    live_stub = (STUB_ROOT / "live" / "__init__.pyi").read_text()
+
+    assert "@typing.final\nclass LiveNodeConfig:" in live_stub
+    assert re.search(
+        r"portfolio:\s+(?:portfolio\.)?PortfolioConfig \| None = None",
+        live_stub,
+    )
+    assert '"PortfolioConfig"' in live_stub
+
+
+def test_package_stub_exports_portfolio_module():
+    package_stub = (STUB_ROOT / "__init__.pyi").read_text()
+
+    assert "from . import portfolio" in package_stub
+    assert '"portfolio"' in package_stub
+
+
 def test_stub_enum_variants_match_screaming_snake_case():
     """
     Verify every renamed enum in .pyi stubs uses SCREAMING_SNAKE_CASE variants.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This fixes the PyO3 v2 live config path so supported live engine config fields are actually propagated into the Rust v2 engines instead of being dropped back to defaults. It also narrows the exposed PyO3 v2 surface to config that currently produces real behavior, makes reserved unsupported fields fail fast on node build instead of silently no-oping, and corrects `reconciliation_startup_delay_secs` so it delays startup reconciliation itself rather than only offsetting the periodic reconciliation timers.

This branch also hardens the PyO3 v2 live-config validation path so malformed supported risk/exec values fail cleanly before any downstream `expect()` / infallible identifier conversion can be reached.

The typed PyO3 surface is now restored through native stub generation as well: `LiveNodeConfig` and `PortfolioConfig` are generated from the Rust-side PyO3 metadata again, and the old manual `nautilus_trader.live` stub patch has been removed.

## Related Issues/PRs

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [x] Improvement (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

On the PyO3 v2 live path, unsupported args that were previously exposed but not implemented are no longer accepted on the Python constructors (`qsize` on data/risk/exec, plus exec `snapshot_orders`, `snapshot_positions`, `purge_from_database`, and `graceful_shutdown_on_error`). The shared Rust live config still retains these fields as reserved for future work, but `LiveNode::build(...)` and the fluent builder now reject them explicitly on the current v2 live node path. The legacy live path is unchanged.

## Root cause

The PyO3 v2 live layer had drifted into a partial/placeholder state:

- `LiveDataEngineConfig` on the v2 path only exposed `qsize`, while supported data-engine fields were not surfaced in the binding.
- The shared live config conversion into `DataEngineConfig` fell back to `DataEngineConfig::default()` instead of carrying through v2 values.
- The PyO3 `LiveNode` surface did not provide a clean `build(..., config=...)` path plus engine-config setters for the fluent builder.
- `reconciliation_startup_delay_secs` only shifted the periodic reconciliation timers, while startup reconciliation still ran immediately.
- The PyO3 config types are `from_py_object`, so constructor-only validation was not sufficient to protect the v2 build path from malformed foreign objects.
- `LiveNodeConfig` was opaque in generated stubs because native stub coverage for this class graph was incomplete: `LiveNodeConfig` did not expose stub pymethod metadata, `PortfolioConfig` lacked stub coverage, and the `live` module did not declare the `PortfolioConfig` re-export for stub generation.

## What changed

- wired supported live data/risk/exec config fields through the PyO3 v2 live path into the Rust v2 engine configs
- exposed `LiveNode.build(name, config=...)` and engine-config builder setters for the PyO3 v2 path
- removed dead-end PyO3 v2 constructor args from the Python bindings
- added build-time validation so reserved-but-unsupported live config fields error explicitly instead of silently no-oping
- added validation for supported risk/exec fields at the shared live-config boundary so malformed values now return normal errors on the current v2 path instead of risking panic paths downstream
- corrected startup reconciliation delay semantics so `reconciliation_startup_delay_secs` delays startup reconciliation itself
- added native stub coverage for `PortfolioConfig` and `LiveNodeConfig`
- declared the `PortfolioConfig` live-module re-export for stub generation
- removed the manual live-module post-processing from `python/generate_stubs.py`
- corrected a stale PyO3 v2 test expectation for `LiveNodeConfig.save_state` to match the current runtime default (`false`)
- regenerated the affected package stubs and updated Rust/Python-facing tests around the v2 live config and stub surface

## Stub generation

The previous manual live-module stub patch is no longer needed.

This PR now uses the native PyO3 stub-generation path again by:

- adding stub metadata to `PortfolioConfig`
- adding stub metadata to `LiveNodeConfig`
- declaring the `PortfolioConfig` re-export for the `nautilus_trader.live` stub module

That keeps the typed surface aligned with the PyO3 v2 architecture instead of maintaining a module-specific Python-side workaround.

## Intentionally not exposed on the current v2 live node path

These were intentionally not carried onto the PyO3 v2 surface because they do not currently lead to honest end-to-end behavior:

- `emit_quotes_from_book` / `emit_quotes_from_book_depths`
  Reason: there is no Rust v2 `DataEngineConfig` destination for these fields.
- `time_bars_origins`
  Reason: Rust has the field, but there is not yet a clean PyO3 v2 origin/timedelta representation in this layer.
- `load_cache`
  Reason: `ExecutionEngine::load_cache()` exists, but the live kernel does not currently wire a cache database adapter on the v2 path.
- `snapshot_orders`, `snapshot_positions`, `snapshot_positions_interval_secs`
  Reason: snapshot persistence/timer wiring is not complete on the current live path.
- `purge_from_database`
  Reason: purge flows currently operate on the in-memory cache only.
- `graceful_shutdown_on_error`
  Reason: there is no active live/runtime consumer for the flag yet.
- `qsize`
  Reason: the current live v2 path has no downstream engine consumer for it.

## What remains after the underlying v2 support exists

Once the lower layers are ready, the follow-up work should be straightforward:

- wire the live kernel to construct cache database adapters on the v2 path
- implement the execution-engine snapshot timer behavior end-to-end
- re-expose snapshot/purge/load-cache config on the PyO3 v2 surface once those paths are functional
- add `time_bars_origins` once there is a clean PyO3 v2 representation for the field
- if v2 live state persistence semantics are intentionally expanded or aligned differently later, revisit whether `save_state` should default back to `true`
- decide whether any currently reserved fields should become supported v2 API, instead of remaining internal/reserved only

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No docs changed in this patch.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

Not added in this patch.

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validated with:

- `.venv/bin/python python/generate_stubs.py`
- `cargo test -p nautilus-live --features python --lib`
- `cargo test -p nautilus-portfolio --features python --lib`
- `PATH=/tmp/nautilus-uv-0.11.3:$PATH make pytest-v2`
- `PATH=/tmp/nautilus-uv-0.11.3:$PATH prek run --all-files`
- `PATH=/tmp/nautilus-uv-0.11.3:$PATH make check-capnp-schemas`
