### PR TITLE
Refine combo fill average price in IB adapter

### DIFF
--- a/examples/live/interactive_brokers/notebooks/spread_example.py
+++ b/examples/live/interactive_brokers/notebooks/spread_example.py
@@ -49,6 +49,7 @@ from nautilus_trader.model.events import OrderFilled
 from nautilus_trader.model.events import OrderRejected
 from nautilus_trader.model.events import OrderSubmitted
 from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import generic_spread_id_to_list
 from nautilus_trader.model.identifiers import new_generic_spread_id
 from nautilus_trader.trading.config import StrategyConfig
 from nautilus_trader.trading.strategy import Strategy
@@ -68,6 +69,11 @@ class SpreadTestStrategy(Strategy):
     def __init__(self, config: SpreadTestConfig):
         super().__init__(config=config)
         self.order_placed = False
+        self.exit_order_placed = False
+        self.entry_fill_received = False
+        self.waiting_for_cleanup = False
+        self.related_leg_ids: list[InstrumentId] = []
+        self.spread_instrument = None
         self.execution_events: list[OrderFilled] = []
         self.order_events: list[OrderAccepted | OrderSubmitted | OrderRejected] = []
         self.quote_tick_count = 0
@@ -94,15 +100,17 @@ class SpreadTestStrategy(Strategy):
         """
         self.log.info(f"Received instrument: {instrument.id}")
         self.log.info(f"Instrument type: {type(instrument)}")
+        self.spread_instrument = instrument
+        self.related_leg_ids = [
+            leg_id for leg_id, _ratio in generic_spread_id_to_list(instrument.id)
+        ]
 
         # Mark instrument as loaded and subscribe to quote ticks
         self.instrument_loaded = True
         self.log.info("Subscribing to quote ticks for spread instrument...")
         self.subscribe_quote_ticks(instrument.id)
 
-        # Place order immediately after getting instrument
-        if not self.order_placed:
-            self._place_ratio_spread_order(instrument)
+        self._cleanup_positions_then_maybe_enter()
 
     def _place_ratio_spread_order(self, instrument):
         """
@@ -135,6 +143,71 @@ class SpreadTestStrategy(Strategy):
             "Market order submitted for futures calendar spread",
             color=LogColor.GREEN,
         )
+
+    def _place_flatten_order(self, quantity):
+        """
+        Submit the offsetting spread order to flatten the example position.
+        """
+        self.log.info("=" * 60, color=LogColor.YELLOW)
+        self.log.info("PLACING FLATTENING SPREAD MARKET ORDER (DAY)", color=LogColor.YELLOW)
+        self.log.info("=" * 60, color=LogColor.YELLOW)
+
+        order = self.order_factory.market(
+            instrument_id=self.config.spread_instrument_id,
+            order_side=OrderSide.SELL,
+            quantity=quantity,
+            time_in_force=TimeInForce.DAY,
+        )
+
+        self.log.info("Flatten order details:")
+        self.log.info(f"   Client Order ID: {order.client_order_id}")
+        self.log.info(f"   Instrument: {order.instrument_id}")
+        self.log.info(f"   Side: {order.side}")
+        self.log.info(f"   Quantity: {order.quantity}")
+
+        self.submit_order(order)
+        self.exit_order_placed = True
+
+        self.log.info(
+            "Flattening market order submitted for spread",
+            color=LogColor.YELLOW,
+        )
+
+    def _related_open_positions(self):
+        positions = []
+        for leg_id in self.related_leg_ids:
+            positions.extend(self.cache.positions_open(instrument_id=leg_id))
+        return positions
+
+    def _cleanup_positions_then_maybe_enter(self):
+        if self.is_exiting():
+            return
+
+        if self.order_placed or self.spread_instrument is None:
+            return
+
+        open_positions = self._related_open_positions()
+        if open_positions:
+            self.waiting_for_cleanup = True
+            self.log.info(
+                f"Found {len(open_positions)} open leg position(s); flattening before entry...",
+                color=LogColor.YELLOW,
+            )
+
+            for position in open_positions:
+                self.log.info(f"   Closing existing position: {position}")
+                self.close_position(
+                    position,
+                    time_in_force=TimeInForce.DAY,
+                    reduce_only=False,
+                )
+            return
+
+        if self.waiting_for_cleanup:
+            self.log.info("Existing leg positions flattened, continuing with entry order")
+            self.waiting_for_cleanup = False
+
+        self._place_ratio_spread_order(self.spread_instrument)
 
     def on_quote_tick(self, tick):
         """
@@ -207,12 +280,31 @@ class SpreadTestStrategy(Strategy):
         self.log.info(f"   Fill Price: {event.last_px}")
         self.log.info(f"   Commission: {event.commission}")
         self.log.info(f"   Trade ID: {event.trade_id}")
+        self.log.info(f"   Info: {event.info}")
+        if event.info and "avg_px" in event.info:
+            self.log.info(f"   avg_px info: {event.info['avg_px']}", color=LogColor.GREEN)
 
         # Analyze fill quantity interpretation
         self._analyze_fill(event)
 
         # Check portfolio state
         self._check_portfolio_state()
+
+        if (
+            str(event.instrument_id) == str(self.config.spread_instrument_id)
+            and not self.entry_fill_received
+        ):
+            self.entry_fill_received = True
+            if not self.exit_order_placed:
+                self._place_flatten_order(event.last_qty)
+
+    def on_position_changed(self, event):
+        if self.waiting_for_cleanup:
+            self._cleanup_positions_then_maybe_enter()
+
+    def on_position_closed(self, event):
+        if self.waiting_for_cleanup:
+            self._cleanup_positions_then_maybe_enter()
 
     def _analyze_fill(self, event: OrderFilled):
         """
@@ -227,7 +319,7 @@ class SpreadTestStrategy(Strategy):
             self.log.info("   Expected: 1 contract per spread unit", color=LogColor.CYAN)
         elif event.order_side == OrderSide.SELL:
             self.log.info(f"   SHORT leg fill: {fill_qty} contracts", color=LogColor.CYAN)
-            self.log.info("   Expected: 1 contract per spread unit (ESH6)", color=LogColor.CYAN)
+            self.log.info("   Expected: 1 contract per spread unit", color=LogColor.CYAN)
 
         # Check if this is spread-level or leg-level fill
         if str(event.instrument_id) == str(self.config.spread_instrument_id):
@@ -279,8 +371,7 @@ class SpreadTestStrategy(Strategy):
             self.log.info(f"BUY fills: {len(buy_fills)} (total qty: {buy_qty})")
             self.log.info(f"SELL fills: {len(sell_fills)} (total qty: {sell_qty})")
 
-            # Expected: 3 long (ESZ5), 3 short (ESH6) for 3 spread units
-            self.log.info("Expected for 3 spread units: 3 long (ESZ5), 3 short (ESH6)")
+            self.log.info("Expected for 3 spread units: 3 long ESM6 P6800, 3 short ESM6 P6775")
 
             if buy_qty == 3 and sell_qty == 3:
                 self.log.info("EXECUTION MATCHES EXPECTED RATIOS", color=LogColor.GREEN)
@@ -291,22 +382,20 @@ class SpreadTestStrategy(Strategy):
 
 
 # %%
-# leg1_id = InstrumentId.from_str("ESH6.XCME")
-# leg2_id = InstrumentId.from_str("ESM6.XCME")
-
-leg1_id = InstrumentId.from_str("ESH6 P6800.XCME")
-leg2_id = InstrumentId.from_str("ESH6 P6775.XCME")
+# Valid April 10, 2026 IB paper-trading spread used to exercise combo fill handling.
+leg1_id = InstrumentId.from_str("ESM6 P6800.XCME")
+leg2_id = InstrumentId.from_str("ESM6 P6775.XCME")
 
 spread_id = new_generic_spread_id(
     [
-        (leg1_id, 1),  # Long 1 ESZ5 per spread unit
-        (leg2_id, -1),  # Short 1 ESH6 per spread unit
+        (leg1_id, 1),
+        (leg2_id, -1),
     ],
 )
 
 print(f"Testing spread: {spread_id}")
 print("Order: 3 spread units")
-print("Expected execution: Long 3 ESZ5, Short 3 ESH6")
+print("Expected execution: Long 3 ESM6 P6800, Short 3 ESM6 P6775")
 print()
 
 # Configure instrument provider (no pre-loaded spread IDs)
@@ -348,7 +437,12 @@ config_node = TradingNodeConfig(
 
 # Create and configure node
 node = TradingNode(config=config_node)
-strategy_config = SpreadTestConfig(spread_instrument_id=spread_id)
+strategy_config = SpreadTestConfig(
+    spread_instrument_id=spread_id,
+    manage_stop=True,
+    market_exit_time_in_force=TimeInForce.DAY,
+    market_exit_reduce_only=False,
+)
 strategy = SpreadTestStrategy(config=strategy_config)
 
 node.trader.add_strategy(strategy)
@@ -357,15 +451,16 @@ node.add_exec_client_factory(IB, InteractiveBrokersLiveExecClientFactory)
 node.build()
 
 # %%
-print("Starting Futures Spread Test (Dynamic Loading + Quote Ticks)...")
+print("Starting Option Spread Test (Dynamic Loading + Quote Ticks)...")
 print("This will:")
 print("1. Connect to Interactive Brokers")
-print("2. Dynamically request the futures calendar spread instrument (not pre-loaded)")
-print("3. Request market data to get tick size from tickReqParams (for futures spreads)")
+print("2. Dynamically request the spread instrument (not pre-loaded)")
+print("3. Request market data to discover spread pricing")
 print("4. Subscribe to quote ticks for the spread")
 print("5. Place a market order for 3 spread units")
-print("6. Monitor execution events and quote ticks for 60 seconds")
-print("7. Auto-stop and analyze results")
+print("6. Submit the offsetting spread order after the entry fill")
+print("7. Monitor execution events and quote ticks")
+print("8. Auto-stop and analyze results")
 print()
 print("IMPORTANT: Make sure TWS/IB Gateway is running!")
 print("IMPORTANT: This will place a REAL market order in paper trading!")
@@ -388,8 +483,8 @@ def auto_stop_node(node, delay_seconds=15):
 
 
 # %%
-# Start auto-stop timer (10 seconds to observe tickReqParams behavior)
-auto_stop_node(node, delay_seconds=10)
+# Allow enough time for entry and flattening fills before shutdown.
+auto_stop_node(node, delay_seconds=20)
 
 try:
     node.run()

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import json
+from collections import deque
 from datetime import timedelta
 from decimal import Decimal
 from typing import Any
@@ -239,8 +240,16 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # Track processed fill IDs
         self._spread_fill_tracking: dict[ClientOrderId, set[str]] = {}
 
+        # Queue spread combo fills until orderStatus provides the matching avg fill price chunk.
+        self._pending_combo_fills: dict[
+            ClientOrderId,
+            deque[tuple[Order, Execution, IBContract, CommissionAndFeesReport, Decimal]],
+        ] = {}
+        self._pending_combo_fill_avgs: dict[ClientOrderId, deque[tuple[Decimal, Price]]] = {}
+
         # Track average fill prices for orders
         self._order_avg_prices: dict[ClientOrderId, Price] = {}
+        self._order_fill_progress: dict[ClientOrderId, tuple[Decimal, Decimal]] = {}
 
         # Track filled quantities from orderStatus callbacks (keyed by VenueOrderId)
         # This is needed because IB's openOrder callback doesn't include accurate filledQuantity
@@ -1656,6 +1665,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         if filled_decimal > 0 and venue_order_id is not None:
             self._order_filled_qty[venue_order_id] = filled_decimal
 
+        ignore_order_event = False
+
         if order_status in ["ApiCancelled", "Cancelled"]:
             status = OrderStatus.CANCELED
         elif order_status == "PendingCancel":
@@ -1675,10 +1686,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             if not reason:
                 reason = "Order inactive (IB)"
         elif order_status in ["PendingSubmit", "PreSubmitted", "Submitted"]:
-            self._log.debug(
-                f"Ignoring `_on_order_status` event for {order_status=} is handled in `_on_open_order`",
-            )
-            return
+            ignore_order_event = True
+            status = OrderStatus.ACCEPTED
         else:
             self._log.warning(
                 f"Unknown {order_status=} received on `_on_order_status` for {order_ref=}",
@@ -1696,32 +1705,33 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 nautilus_order = self._cache.order(mapped_client_order_id)
 
         if nautilus_order:
-            # Update order with average fill price if provided and order is filled/partially filled
-            if avg_fill_price and avg_fill_price > 0 and status == OrderStatus.FILLED:
-                # Generate an order updated event with the average fill price
-                instrument = self._cache.instrument(nautilus_order.instrument_id)
-                if instrument:
-                    price_magnifier = self.instrument_provider.get_price_magnifier(
-                        nautilus_order.instrument_id,
-                    )
-                    converted_avg_price = ib_price_to_nautilus_price(
-                        avg_fill_price,
-                        price_magnifier,
-                    )
-                    avg_px = instrument.make_price(converted_avg_price)
-
-                    # Store the average price for later use in fill events
-                    self._order_avg_prices[nautilus_order.client_order_id] = avg_px
-
-                    self._log.debug(
-                        f"Updated order {nautilus_order.client_order_id} with avg_px={avg_px}",
-                    )
-
-            self._handle_order_event(
-                status=status,
-                order=nautilus_order,
-                reason=reason,
+            self._update_order_avg_price(
+                nautilus_order=nautilus_order,
+                avg_fill_price=avg_fill_price,
+                filled_decimal=filled_decimal,
             )
+
+            if ignore_order_event:
+                self._log.debug(
+                    f"Ignoring `_on_order_status` event for {order_status=} after caching fill progress",
+                )
+            else:
+                self._handle_order_event(
+                    status=status,
+                    order=nautilus_order,
+                    reason=reason,
+                )
+
+            if status in (
+                OrderStatus.FILLED,
+                OrderStatus.CANCELED,
+                OrderStatus.REJECTED,
+                OrderStatus.EXPIRED,
+            ):
+                self._flush_pending_combo_fills(nautilus_order.client_order_id)
+                self._pending_combo_fills.pop(nautilus_order.client_order_id, None)
+                self._pending_combo_fill_avgs.pop(nautilus_order.client_order_id, None)
+                self._order_fill_progress.pop(nautilus_order.client_order_id, None)
 
             if venue_order_id is not None and status in (
                 OrderStatus.FILLED,
@@ -1844,6 +1854,92 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         return None
 
+    def _update_order_avg_price(
+        self,
+        nautilus_order: Order,
+        avg_fill_price: float,
+        filled_decimal: Decimal,
+    ) -> None:
+        if not avg_fill_price or avg_fill_price <= 0 or filled_decimal <= 0:
+            return
+
+        instrument = self._cache.instrument(nautilus_order.instrument_id)
+        if instrument is None:
+            return
+
+        price_magnifier = self.instrument_provider.get_price_magnifier(
+            nautilus_order.instrument_id,
+        )
+        converted_avg_price = ib_price_to_nautilus_price(
+            avg_fill_price,
+            price_magnifier,
+        )
+        avg_px = instrument.make_price(converted_avg_price)
+        client_order_id = nautilus_order.client_order_id
+
+        self._order_avg_prices[client_order_id] = avg_px
+        self._log.debug(f"Updated order {client_order_id} with avg_px={avg_px}")
+
+        previous_filled, previous_notional = self._order_fill_progress.get(
+            client_order_id,
+            (Decimal(0), Decimal(0)),
+        )
+        total_notional = filled_decimal * Decimal(str(converted_avg_price))
+        fill_delta = filled_decimal - previous_filled
+
+        self._order_fill_progress[client_order_id] = (filled_decimal, total_notional)
+
+        if fill_delta <= 0 or not is_generic_spread_id(nautilus_order.instrument_id):
+            return
+
+        notional_delta = total_notional - previous_notional
+        partial_avg_value = float(notional_delta / fill_delta)
+        partial_avg_px = instrument.make_price(partial_avg_value)
+
+        self._pending_combo_fill_avgs.setdefault(client_order_id, deque()).append(
+            (fill_delta, partial_avg_px),
+        )
+        self._flush_pending_combo_fills(client_order_id)
+
+    def _flush_pending_combo_fills(self, client_order_id: ClientOrderId) -> None:
+        pending_combo_fills = self._pending_combo_fills.get(client_order_id)
+        pending_avg_chunks = self._pending_combo_fill_avgs.get(client_order_id)
+
+        if not pending_combo_fills or not pending_avg_chunks:
+            return
+
+        while pending_combo_fills and pending_avg_chunks:
+            (
+                nautilus_order,
+                execution,
+                contract,
+                commission_report,
+                combo_quantity,
+            ) = pending_combo_fills[0]
+            avg_chunk_quantity, avg_px = pending_avg_chunks[0]
+
+            if combo_quantity > avg_chunk_quantity:
+                break
+
+            pending_combo_fills.popleft()
+            self._generate_combo_fill(
+                nautilus_order,
+                execution,
+                contract,
+                commission_report,
+                avg_px_override=avg_px,
+            )
+
+            if combo_quantity == avg_chunk_quantity:
+                pending_avg_chunks.popleft()
+            else:
+                pending_avg_chunks[0] = (avg_chunk_quantity - combo_quantity, avg_px)
+
+        if not pending_combo_fills:
+            self._pending_combo_fills.pop(client_order_id, None)
+        if not pending_avg_chunks:
+            self._pending_combo_fill_avgs.pop(client_order_id, None)
+
     def _handle_spread_execution(
         self,
         nautilus_order: Order,
@@ -1872,14 +1968,23 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
             self._spread_fill_tracking[client_order_id].add(fill_id)
 
-            if len(self._spread_fill_tracking[client_order_id]) == 1:
-                # Combo fill for order management, generated only once per combo
-                self._generate_combo_fill(
-                    nautilus_order,
-                    execution,
-                    contract,
-                    commission_report,
+            spread_n_legs = generic_spread_id_n_legs(nautilus_order.instrument_id)
+
+            if (len(self._spread_fill_tracking[client_order_id]) - 1) % spread_n_legs == 0:
+                combo_quantity = self._calculate_combo_quantity(nautilus_order, execution, contract)
+                self._pending_combo_fills.setdefault(
+                    nautilus_order.client_order_id,
+                    deque(),
+                ).append(
+                    (
+                        nautilus_order,
+                        execution,
+                        contract,
+                        commission_report,
+                        combo_quantity,
+                    ),
                 )
+                self._flush_pending_combo_fills(nautilus_order.client_order_id)
 
             # Leg fill to update leg position in nautilus
             self._generate_leg_fill(
@@ -1897,6 +2002,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         execution: Execution,
         contract: IBContract,
         commission_report: CommissionAndFeesReport,
+        avg_px_override: Price | None = None,
     ) -> None:
         """
         Generate combo fill from leg fill for order management.
@@ -1920,10 +2026,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 precision=spread_instrument.price_precision,
             )
 
-            # Combo quantity
-            combo_quantity_value = execution.shares / abs(ratio)
             combo_quantity = Quantity(
-                combo_quantity_value,
+                self._calculate_combo_quantity(nautilus_order, execution, contract),
                 precision=spread_instrument.size_precision,
             )
 
@@ -1953,7 +2057,9 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             # Include avg_px in info if we have it stored
             info = {}
 
-            if nautilus_order.client_order_id in self._order_avg_prices:
+            if avg_px_override is not None:
+                info["avg_px"] = avg_px_override
+            elif nautilus_order.client_order_id in self._order_avg_prices:
                 info["avg_px"] = self._order_avg_prices[nautilus_order.client_order_id]
 
             self.generate_order_filled(
@@ -1975,6 +2081,18 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
         except Exception as e:
             self._log.error(f"Error generating combo fill: {e}")
+
+    def _calculate_combo_quantity(
+        self,
+        nautilus_order: Order,
+        execution: Execution,
+        contract: IBContract,
+    ) -> Decimal:
+        _leg_instrument_id, ratio = self._get_leg_instrument_id_and_ratio(
+            nautilus_order.instrument_id,
+            contract,
+        )
+        return Decimal(execution.shares) / Decimal(abs(ratio))
 
     def _generate_leg_fill(
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -26,11 +26,21 @@ from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveExecClientFactory,
 )
 from nautilus_trader.execution.messages import QueryAccount
+from nautilus_trader.model.enums import AssetClass
+from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import OrderStatus
 from nautilus_trader.model.enums import PositionSide
+from nautilus_trader.model.identifiers import ClientOrderId
+from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import PositionId
+from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.identifiers import VenueOrderId
+from nautilus_trader.model.identifiers import new_generic_spread_id
+from nautilus_trader.model.instruments import OptionContract
+from nautilus_trader.model.instruments import OptionSpread
+from nautilus_trader.model.objects import Currency
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.test_kit.stubs.commands import TestCommandStubs
@@ -82,6 +92,48 @@ def order_setup(
         raise ValueError(status)
     exec_client._cache.add_order(order, PositionId("1"))
     return order
+
+
+def make_option_contract(symbol_str: str, kind: OptionKind) -> OptionContract:
+    return OptionContract(
+        instrument_id=InstrumentId(Symbol(symbol_str), Venue("SMART")),
+        raw_symbol=Symbol(symbol_str),
+        asset_class=AssetClass.EQUITY,
+        currency=Currency.from_str("USD"),
+        price_precision=2,
+        price_increment=Price.from_str("0.01"),
+        multiplier=Quantity.from_int(100),
+        lot_size=Quantity.from_int(1),
+        underlying="SPY",
+        option_kind=kind,
+        activation_ns=0,
+        expiration_ns=1640995200000000000,
+        strike_price=Price.from_str("400.0")
+        if kind == OptionKind.CALL
+        else Price.from_str("390.0"),
+        ts_event=0,
+        ts_init=0,
+    )
+
+
+def make_option_spread(call: OptionContract, put: OptionContract) -> OptionSpread:
+    spread_id = new_generic_spread_id([(call.id, 1), (put.id, -1)])
+    return OptionSpread(
+        instrument_id=spread_id,
+        raw_symbol=spread_id.symbol,
+        asset_class=AssetClass.EQUITY,
+        currency=Currency.from_str("USD"),
+        price_precision=2,
+        price_increment=Price.from_str("0.01"),
+        multiplier=Quantity.from_int(100),
+        lot_size=Quantity.from_int(1),
+        underlying="SPY",
+        strategy_type="VERTICAL",
+        activation_ns=0,
+        expiration_ns=1640995200000000000,
+        ts_event=0,
+        ts_init=0,
+    )
 
 
 def account_summary_setup(client, **kwargs):
@@ -885,6 +937,217 @@ async def test_on_exec_details_uses_stored_avg_px(
     assert exec_client._order_avg_prices[
         cache.order(client_order_id).client_order_id
     ] == Price.from_str("99.75")
+
+
+@pytest.mark.asyncio
+async def test_spread_combo_fill_waits_for_order_status_avg_px(mocker, exec_client, cache):
+    call = make_option_contract("SPY C400", OptionKind.CALL)
+    put = make_option_contract("SPY P390", OptionKind.PUT)
+    spread = make_option_spread(call, put)
+
+    for instrument in [call, put, spread]:
+        exec_client.instrument_provider.add(instrument)
+        cache.add_instrument(instrument)
+
+    call_contract = IBTestContractStubs.create_contract(
+        conId=9001,
+        symbol="SPY",
+        secType="OPT",
+        exchange="SMART",
+        currency="USD",
+        localSymbol="SPY C400",
+    )
+    exec_client.instrument_provider.contract_id_to_instrument_id[call_contract.conId] = call.id
+
+    client_order_id = ClientOrderId("O-SPREAD-001")
+    venue_order_id = VenueOrderId("7001")
+    order = TestExecStubs.limit_order(
+        instrument=spread,
+        client_order_id=client_order_id,
+        quantity=Quantity.from_int(1),
+        price=Price.from_str("1.00"),
+    )
+    order = TestExecStubs.make_accepted_order(order, venue_order_id=venue_order_id)
+    cache.add_order(order, None)
+    cache.add_venue_order_id(client_order_id, venue_order_id)
+
+    generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
+
+    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution.orderRef = str(client_order_id)
+    execution.execId = "combo-fill-1"
+    execution.shares = Decimal(1)
+    execution.price = 3.30
+
+    commission_report = IBTestExecStubs.commission()
+    commission_report.execId = execution.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution,
+        commission_report=commission_report,
+        contract=call_contract,
+    )
+
+    assert generate_order_filled.call_count == 1
+    leg_fill_call = generate_order_filled.call_args_list[0].kwargs
+    assert leg_fill_call["instrument_id"] == call.id
+    assert leg_fill_call["info"] is None
+    assert client_order_id in exec_client._pending_combo_fills
+
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Filled",
+        avg_fill_price=2.75,
+        filled=Decimal(1),
+        remaining=Decimal(0),
+        venue_order_id=venue_order_id,
+    )
+
+    assert generate_order_filled.call_count == 2
+    combo_fill_call = generate_order_filled.call_args_list[1].kwargs
+    assert combo_fill_call["instrument_id"] == spread.id
+    assert combo_fill_call["info"] == {"avg_px": Price.from_str("2.75")}
+    assert client_order_id not in exec_client._pending_combo_fills
+
+
+@pytest.mark.asyncio
+async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
+    mocker,
+    exec_client,
+    cache,
+):
+    call = make_option_contract("SPY C400", OptionKind.CALL)
+    put = make_option_contract("SPY P390", OptionKind.PUT)
+    spread = make_option_spread(call, put)
+
+    for instrument in [call, put, spread]:
+        exec_client.instrument_provider.add(instrument)
+        cache.add_instrument(instrument)
+
+    put_contract = IBTestContractStubs.create_contract(
+        conId=9002,
+        symbol="SPY",
+        secType="OPT",
+        exchange="SMART",
+        currency="USD",
+        localSymbol="SPY P390",
+    )
+    call_contract = IBTestContractStubs.create_contract(
+        conId=9003,
+        symbol="SPY",
+        secType="OPT",
+        exchange="SMART",
+        currency="USD",
+        localSymbol="SPY C400",
+    )
+    exec_client.instrument_provider.contract_id_to_instrument_id[put_contract.conId] = put.id
+    exec_client.instrument_provider.contract_id_to_instrument_id[call_contract.conId] = call.id
+
+    client_order_id = ClientOrderId("O-SPREAD-MULTI-001")
+    venue_order_id = VenueOrderId("7002")
+    order = TestExecStubs.limit_order(
+        instrument=spread,
+        client_order_id=client_order_id,
+        quantity=Quantity.from_int(3),
+        price=Price.from_str("1.00"),
+    )
+    order = TestExecStubs.make_accepted_order(order, venue_order_id=venue_order_id)
+    cache.add_order(order, None)
+    cache.add_venue_order_id(client_order_id, venue_order_id)
+
+    generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
+
+    execution1 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution1.orderRef = str(client_order_id)
+    execution1.execId = "combo-fill-1"
+    execution1.shares = Decimal(1)
+    execution1.price = 2.40
+
+    commission_report1 = IBTestExecStubs.commission()
+    commission_report1.execId = execution1.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution1,
+        commission_report=commission_report1,
+        contract=put_contract,
+    )
+    execution1_leg2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution1_leg2.orderRef = str(client_order_id)
+    execution1_leg2.execId = "combo-fill-1-leg-2"
+    execution1_leg2.shares = Decimal(1)
+    execution1_leg2.price = 2.60
+
+    commission_report1_leg2 = IBTestExecStubs.commission()
+    commission_report1_leg2.execId = execution1_leg2.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution1_leg2,
+        commission_report=commission_report1_leg2,
+        contract=call_contract,
+    )
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Submitted",
+        avg_fill_price=2.50,
+        filled=Decimal(1),
+        remaining=Decimal(2),
+        venue_order_id=venue_order_id,
+    )
+
+    execution2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution2.orderRef = str(client_order_id)
+    execution2.execId = "combo-fill-2"
+    execution2.shares = Decimal(2)
+    execution2.price = 3.20
+
+    commission_report2 = IBTestExecStubs.commission()
+    commission_report2.execId = execution2.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution2,
+        commission_report=commission_report2,
+        contract=put_contract,
+    )
+    execution2_leg2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution2_leg2.orderRef = str(client_order_id)
+    execution2_leg2.execId = "combo-fill-2-leg-2"
+    execution2_leg2.shares = Decimal(2)
+    execution2_leg2.price = 3.00
+
+    commission_report2_leg2 = IBTestExecStubs.commission()
+    commission_report2_leg2.execId = execution2_leg2.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution2_leg2,
+        commission_report=commission_report2_leg2,
+        contract=call_contract,
+    )
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Filled",
+        avg_fill_price=2.90,
+        filled=Decimal(3),
+        remaining=Decimal(0),
+        venue_order_id=venue_order_id,
+    )
+
+    combo_fill_calls = [
+        call.kwargs
+        for call in generate_order_filled.call_args_list
+        if call.kwargs["instrument_id"] == spread.id
+    ]
+
+    assert len(combo_fill_calls) == 2
+    assert combo_fill_calls[0]["last_qty"] == Quantity.from_int(1)
+    assert combo_fill_calls[0]["info"] == {"avg_px": Price.from_str("2.50")}
+    assert combo_fill_calls[1]["last_qty"] == Quantity.from_int(2)
+    assert combo_fill_calls[1]["info"] == {"avg_px": Price.from_str("3.10")}
+    assert client_order_id not in exec_client._pending_combo_fills
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes Interactive Brokers combo/spread `OrderFilled.info["avg_px"]` when IB sends `execDetails` before `orderStatus`.
- Extends the fix to multi-fill spread orders by matching queued combo-fill chunks against cumulative IB `filled` and `avgFillPrice` updates, so each combo fill gets the correct incremental average.
- Updates the live IB spread example to use a currently resolvable option spread, logs `event.info`, and submits an offsetting spread order after entry so the example exits its own spread cleanly.

## Validation

- `pytest -q tests/integration_tests/adapters/interactive_brokers/test_execution.py -k "spread_combo_fill"`
- `pre-commit run --files nautilus_trader/adapters/interactive_brokers/execution.py tests/integration_tests/adapters/interactive_brokers/test_execution.py examples/live/interactive_brokers/notebooks/spread_example.py`
- Live run of `examples/live/interactive_brokers/notebooks/spread_example.py`
  - observed spread-level `OrderFilled.info["avg_px"]`
  - observed expected long/short option-leg ratios
  - observed example flattening its own spread legs before shutdown

## Key Changes

- `nautilus_trader/adapters/interactive_brokers/execution.py`
  - queues pending combo fills per `ClientOrderId`
  - tracks cumulative fill progress per order
  - derives incremental combo average prices from IB cumulative `avgFillPrice`
  - flushes queued combo fills in fill order with the matching avg price chunk

- `tests/integration_tests/adapters/interactive_brokers/test_execution.py`
  - adds regression coverage for callback ordering
  - adds regression coverage for multi-fill spread orders with incremental averages

- `examples/live/interactive_brokers/notebooks/spread_example.py`
  - switches to a valid June 2026 ES put spread
  - logs `OrderFilled.info` and `avg_px`
  - flattens existing spread-leg positions before entry
  - submits an offsetting spread order after the first combo fill
  - enables managed stop as a fallback market exit

## Residual Notes

- The example now exits the spread it opens, but it does not flatten unrelated positions already present in the account.
- IB still reports cumulative average prices at the order level; the adapter now converts those cumulative updates into per-combo-fill averages by fill delta.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3833

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
