### PR TITLE
fix(bybit): make is_reduce_only optional in position structs

### DIFF
--- a/crates/adapters/bybit/src/http/models.rs
+++ b/crates/adapters/bybit/src/http/models.rs
@@ -1254,6 +1254,7 @@ pub struct BybitPosition {
     pub cur_realised_pnl: String,
     pub cum_realised_pnl: String,
     pub seq: i64,
+    #[serde(default)]
     pub is_reduce_only: bool,
     pub mmr_sys_updated_time: String,
     pub leverage_sys_updated_time: String,

--- a/crates/adapters/bybit/src/websocket/messages.rs
+++ b/crates/adapters/bybit/src/websocket/messages.rs
@@ -941,6 +941,7 @@ pub struct BybitWsAccountPosition {
     pub created_time: String,
     pub updated_time: String,
     pub seq: i64,
+    #[serde(default)]
     pub is_reduce_only: bool,
     pub mmr_sys_updated_time: String,
     pub leverage_sys_updated_time: String,


### PR DESCRIPTION
## Summary

Fixes #3836.

Bybit's `/v5/position/list` API and the private WebSocket position stream may omit the `isReduceOnly` field when a position has been closed or is empty. The Rust structs `BybitPosition` and `BybitWsAccountPosition` declared `is_reduce_only: bool` without `#[serde(default)]`, causing hard deserialization failures during position reconciliation.

## Changes

Add `#[serde(default)]` to `is_reduce_only` in both structs. `bool::default()` is `false`, which is the correct semantic for a closed/empty position (it is not reduce-only).

| File | Struct | Line |
|------|--------|------|
| `crates/adapters/bybit/src/http/models.rs` | `BybitPosition` | 1257 |
| `crates/adapters/bybit/src/websocket/messages.rs` | `BybitWsAccountPosition` | 944 |

## Test plan

- [x] `cargo test -p nautilus-bybit` — 57 passed, 0 failed

Backwards compatible: existing JSON with `"isReduceOnly": false` or `"isReduceOnly": true` continues to deserialize correctly. Only the absent-field case changes (from hard error to `false`).