### PR TITLE
Fix quote_quantity propagation in exec algorithm spawn orders

### DIFF
--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -319,7 +319,7 @@ pub trait ExecutionAlgorithm: DataActor {
             UUID4::new(),
             ts_init,
             reduce_only,
-            false, // quote_quantity
+            primary.is_quote_quantity(),
             primary.contingency_type(),
             primary.order_list_id(),
             primary.linked_order_ids().map(|ids| ids.to_vec()),
@@ -382,7 +382,7 @@ pub trait ExecutionAlgorithm: DataActor {
             expire_time,
             post_only,
             reduce_only,
-            false, // quote_quantity
+            primary.is_quote_quantity(),
             display_qty,
             emulation_trigger,
             None, // trigger_instrument_id
@@ -447,7 +447,7 @@ pub trait ExecutionAlgorithm: DataActor {
             expire_time,
             false, // post_only
             reduce_only,
-            false, // quote_quantity
+            primary.is_quote_quantity(),
             display_qty,
             primary.contingency_type(),
             primary.order_list_id(),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The primary quantity reduction logic works with raw quantity values and does not care if the quantity is in base or quote currency (as long as it is consistent, which it is since all spawn orders inherit this setting from the primary). 

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
