### PR TITLE
Unify adapter command ownership and params in Rust

### DIFF
--- a/crates/adapters/architect_ax/src/data.rs
+++ b/crates/adapters/architect_ax/src/data.rs
@@ -462,19 +462,19 @@ impl DataClient for AxDataClient {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         // AX does not have a real-time instruments channel; instruments are fetched via HTTP
         log::debug!("Instruments subscription not applicable for AX (use request_instruments)");
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         // AX does not have a real-time instrument channel; instruments are fetched via HTTP
         log::debug!("Instrument subscription not applicable for AX (use request_instrument)");
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         let symbol = cmd.instrument_id.symbol.to_string();
         let level = Self::map_book_type_to_market_data_level(cmd.book_type);
         if cmd.book_type == BookType::L1_MBP {
@@ -497,7 +497,7 @@ impl DataClient for AxDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         self.ws_symbol_op(
             cmd.instrument_id,
             |ws, s| async move { ws.subscribe_quotes(&s).await },
@@ -505,7 +505,7 @@ impl DataClient for AxDataClient {
         )
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         self.ws_symbol_op(
             cmd.instrument_id,
             |ws, s| async move { ws.subscribe_trades(&s).await },
@@ -513,7 +513,7 @@ impl DataClient for AxDataClient {
         )
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         self.ws_symbol_op(
             cmd.instrument_id,
             |ws, s| async move { ws.subscribe_mark_prices(&s).await },
@@ -521,12 +521,12 @@ impl DataClient for AxDataClient {
         )
     }
 
-    fn subscribe_index_prices(&mut self, _cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, _cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         log::warn!("Index prices not supported by AX Exchange");
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
         let symbol = bar_type.instrument_id().symbol.to_string();
         let width = map_bar_spec_to_candle_width(&bar_type.spec())?;
@@ -545,7 +545,7 @@ impl DataClient for AxDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let poll_interval_mins = self.config.funding_rate_poll_interval_mins.max(1);
 
         // Use 7-day lookback to capture latest rate across weekends/holidays
@@ -628,7 +628,7 @@ impl DataClient for AxDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         self.ws_symbol_op(
             cmd.instrument_id,
@@ -637,10 +637,7 @@ impl DataClient for AxDataClient {
         )
     }
 
-    fn subscribe_instrument_close(
-        &mut self,
-        _cmd: &SubscribeInstrumentClose,
-    ) -> anyhow::Result<()> {
+    fn subscribe_instrument_close(&mut self, _cmd: SubscribeInstrumentClose) -> anyhow::Result<()> {
         log::warn!("Instrument close not supported by AX Exchange");
         Ok(())
     }

--- a/crates/adapters/architect_ax/src/execution.rs
+++ b/crates/adapters/architect_ax/src/execution.rs
@@ -517,12 +517,12 @@ impl ExecutionClient for AxExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         self.update_account_state();
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let account_id = self.core.account_id;
         let client_order_id = cmd.client_order_id;
@@ -609,7 +609,7 @@ impl ExecutionClient for AxExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         {
             let cache = self.core.cache();
             let order = cache.order(&cmd.client_order_id).ok_or_else(|| {
@@ -649,10 +649,10 @@ impl ExecutionClient for AxExecutionClient {
             self.emitter.emit_order_submitted(order);
         }
 
-        self.submit_order_internal(cmd)
+        self.submit_order_internal(&cmd)
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         for (client_order_id, order_init) in cmd
             .order_list
             .client_order_ids
@@ -672,12 +672,12 @@ impl ExecutionClient for AxExecutionClient {
                 UUID4::new(),
                 cmd.ts_init,
             );
-            self.submit_order(&submit_cmd)?;
+            self.submit_order(submit_cmd)?;
         }
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let venue_order_id = match cmd.venue_order_id {
             Some(ref voi) => *voi,
             None => {
@@ -756,12 +756,12 @@ impl ExecutionClient for AxExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        self.cancel_order_internal(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        self.cancel_order_internal(&cmd);
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let emitter = self.emitter.clone();
         let clock = self.clock;
@@ -834,7 +834,7 @@ impl ExecutionClient for AxExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         for cancel in &cmd.cancels {
             self.cancel_order_internal(cancel);
         }

--- a/crates/adapters/architect_ax/tests/data_client.rs
+++ b/crates/adapters/architect_ax/tests/data_client.rs
@@ -256,7 +256,7 @@ async fn test_data_client_emits_quote_tick_via_channel() {
         params: None,
     };
     client
-        .subscribe_quotes(&subscribe_cmd)
+        .subscribe_quotes(subscribe_cmd)
         .expect("Subscribe failed");
 
     // Wait for quote event (skip instrument events emitted during connect)
@@ -314,7 +314,7 @@ async fn test_data_client_emits_trade_tick_via_channel() {
         params: None,
     };
     client
-        .subscribe_trades(&subscribe_cmd)
+        .subscribe_trades(subscribe_cmd)
         .expect("Subscribe failed");
 
     // Collect events - mock server sends book then trade
@@ -436,7 +436,7 @@ async fn test_data_client_subscribe_book_deltas_via_channel() {
         None,
     );
     client
-        .subscribe_book_deltas(&subscribe_cmd)
+        .subscribe_book_deltas(subscribe_cmd)
         .expect("Subscribe failed");
 
     // Wait for a Deltas event (skip instrument events from connect)
@@ -491,7 +491,7 @@ async fn test_data_client_subscribe_bars_via_channel() {
         None,
     );
     client
-        .subscribe_bars(&subscribe_cmd)
+        .subscribe_bars(subscribe_cmd)
         .expect("Subscribe failed");
 
     // Wait for a Bar event (mock server sends 2 candles with different

--- a/crates/adapters/architect_ax/tests/exec_client.rs
+++ b/crates/adapters/architect_ax/tests/exec_client.rs
@@ -268,10 +268,11 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("AX-001"),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
     client
-        .query_account(&cmd)
+        .query_account(cmd)
         .expect("query_account should not panic with nested runtime");
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
@@ -378,7 +379,7 @@ async fn test_cancel_all_orders_uses_http_endpoint() {
     };
 
     client
-        .cancel_all_orders(&cmd)
+        .cancel_all_orders(cmd)
         .expect("cancel_all_orders should not error");
 
     // Allow spawned task to complete
@@ -441,7 +442,7 @@ async fn test_batch_cancel_orders_does_not_error() {
 
     // AX has no batch cancel endpoint; delegates to individual WS cancels
     client
-        .batch_cancel_orders(&cmd)
+        .batch_cancel_orders(cmd)
         .expect("batch_cancel_orders should not error");
 
     client.disconnect().await.expect("Failed to disconnect");

--- a/crates/adapters/betfair/src/data.rs
+++ b/crates/adapters/betfair/src/data.rs
@@ -803,7 +803,7 @@ impl DataClient for BetfairDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
 
@@ -861,7 +861,7 @@ impl DataClient for BetfairDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         // Trades are included in market subscription via EX_TRADED
         log::debug!(
             "Trade data included in book subscription for {}",
@@ -880,7 +880,7 @@ impl DataClient for BetfairDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         // Instrument status is included in market subscription via EX_MARKET_DEF
         log::debug!(

--- a/crates/adapters/betfair/src/execution.rs
+++ b/crates/adapters/betfair/src/execution.rs
@@ -1160,7 +1160,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(reports)
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self.core.get_order(&cmd.client_order_id)?;
 
         if order.is_closed() {
@@ -1396,7 +1396,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
 
@@ -1513,7 +1513,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
 
@@ -1753,7 +1753,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
 
@@ -1780,7 +1780,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
 
@@ -1928,7 +1928,7 @@ impl ExecutionClient for BetfairExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let market_id = extract_market_id(&instrument_id)?;
         let (selection_id, handicap) = extract_selection_id(&instrument_id)?;

--- a/crates/adapters/betfair/tests/data_client.rs
+++ b/crates/adapters/betfair/tests/data_client.rs
@@ -167,7 +167,7 @@ async fn test_data_client_subscribe_sends_market_subscription() {
         None,
         None,
     );
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -255,8 +255,8 @@ async fn test_data_client_deduplicates_same_market_subscription() {
         None,
     );
 
-    client.subscribe_book_deltas(&first_cmd).unwrap();
-    client.subscribe_book_deltas(&second_cmd).unwrap();
+    client.subscribe_book_deltas(first_cmd).unwrap();
+    client.subscribe_book_deltas(second_cmd).unwrap();
 
     let (first_msg, saw_second_message) = server.await.unwrap();
     let json: Value = serde_json::from_str(&first_msg).unwrap();

--- a/crates/adapters/betfair/tests/exec_client.rs
+++ b/crates/adapters/betfair/tests/exec_client.rs
@@ -343,7 +343,7 @@ async fn test_cancel_order_bet_taken_or_lapsed_treated_as_success() {
     while rx.try_recv().is_ok() {}
 
     let cmd = make_cancel_order("1.179082386-235-0.BETFAIR", "O-001", "1");
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -386,7 +386,7 @@ async fn test_cancel_order_instruction_failure_emits_rejected() {
     while rx.try_recv().is_ok() {}
 
     let cmd = make_cancel_order("1.179082386-235-0.BETFAIR", "O-002", "1");
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -440,7 +440,7 @@ async fn test_cancel_order_result_failure_no_instructions_emits_rejected() {
     while rx.try_recv().is_ok() {}
 
     let cmd = make_cancel_order("1.179082386-235-0.BETFAIR", "O-003", "1");
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -490,7 +490,7 @@ async fn test_cancel_order_success_no_rejected_event() {
     while rx.try_recv().is_ok() {}
 
     let cmd = make_cancel_order("1.179082386-235-0.BETFAIR", "O-004", "1");
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -561,7 +561,7 @@ async fn test_submit_order_success_emits_accepted() {
     add_order_to_cache(&cache, order.clone());
 
     let cmd = make_submit_order_cmd(&order);
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // First event should be OrderSubmitted (emitted synchronously)
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -623,7 +623,7 @@ async fn test_submit_order_error_emits_rejected() {
     add_order_to_cache(&cache, order.clone());
 
     let cmd = make_submit_order_cmd(&order);
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let _ = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -692,7 +692,7 @@ async fn test_modify_order_price_and_quantity_rejects() {
         UnixNanos::default(),
         None,
     );
-    client.modify_order(&cmd).unwrap();
+    client.modify_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -752,7 +752,7 @@ async fn test_modify_order_no_effective_change_rejects() {
         UnixNanos::default(),
         None,
     );
-    client.modify_order(&cmd).unwrap();
+    client.modify_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -802,7 +802,7 @@ async fn test_cancel_all_orders_sends_request() {
         UnixNanos::default(),
         None,
     );
-    client.cancel_all_orders(&cmd).unwrap();
+    client.cancel_all_orders(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -1126,7 +1126,7 @@ async fn test_submit_order_registers_customer_order_ref() {
     add_order_to_cache(&cache, order.clone());
 
     let cmd = make_submit_order_cmd(&order);
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Wait for submitted + accepted
     let _ = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;

--- a/crates/adapters/binance/src/futures/data.rs
+++ b/crates/adapters/binance/src/futures/data.rs
@@ -1071,21 +1071,21 @@ impl DataClient for BinanceFuturesDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instruments: Binance Futures instruments are fetched via HTTP on connect"
         );
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instrument: Binance Futures instruments are fetched via HTTP on connect"
         );
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("Binance Futures only supports L2_MBP order book deltas");
         }
@@ -1153,7 +1153,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client.clone();
 
@@ -1174,7 +1174,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client.clone();
 
@@ -1192,7 +1192,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
         let ws = self.ws_client.clone();
         let interval = bar_spec_to_binance_interval(bar_type.spec())?;
@@ -1214,7 +1214,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         // Mark/index/funding share the same stream - use ref counting
@@ -1251,7 +1251,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         // Mark/index/funding share the same stream - use ref counting
@@ -1288,7 +1288,7 @@ impl DataClient for BinanceFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         let should_subscribe = {
@@ -1326,7 +1326,7 @@ impl DataClient for BinanceFuturesDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instrument_status: {id} (status changes detected via periodic exchange info polling)",

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -1569,16 +1569,16 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         self.update_account_state();
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("query_order: client_order_id={}", cmd.client_order_id);
 
         let http_client = self.http_client.clone();
-        let command = cmd.clone();
+        let command = cmd;
         let emitter = self.emitter.clone();
         let account_id = self.core.account_id;
         let clock = self.clock;
@@ -1711,7 +1711,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -1778,10 +1778,10 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         log::debug!("OrderSubmitted client_order_id={}", order.client_order_id());
         self.emitter.emit_order_submitted(&order);
 
-        self.submit_order_internal(cmd)
+        self.submit_order_internal(&cmd)
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         log::warn!(
             "submit_order_list not yet implemented for Binance Futures (got {} orders)",
             cmd.order_list.client_order_ids.len()
@@ -1789,7 +1789,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let order = {
             let cache = self.core.cache();
             cache.order(&cmd.client_order_id).cloned()
@@ -1821,16 +1821,15 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         };
 
         let http_client = self.http_client.clone();
-        let command = cmd.clone();
         let emitter = self.emitter.clone();
         let trader_id = self.core.trader_id;
         let account_id = self.core.account_id;
-        let instrument_id = command.instrument_id;
-        let venue_order_id = command.venue_order_id;
-        let client_order_id = Some(command.client_order_id);
+        let instrument_id = cmd.instrument_id;
+        let venue_order_id = cmd.venue_order_id;
+        let client_order_id = Some(cmd.client_order_id);
         let order_side = order.order_side();
-        let quantity = command.quantity.unwrap_or_else(|| order.quantity());
-        let price = command.price.or_else(|| order.price());
+        let quantity = cmd.quantity.unwrap_or_else(|| order.quantity());
+        let price = cmd.price.or_else(|| order.price());
 
         let Some(price) = price else {
             log::warn!(
@@ -1856,6 +1855,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                 .send_order_event(OrderEventAny::ModifyRejected(rejected_event));
             return Ok(());
         };
+        let command = cmd;
         let clock = self.clock;
 
         if self.ws_trading_active() {
@@ -1993,12 +1993,12 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        self.cancel_order_internal(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        self.cancel_order_internal(&cmd);
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let instrument_id = cmd.instrument_id;
         let ws_active = self.ws_trading_active();
@@ -2045,7 +2045,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         const BATCH_SIZE: usize = 5;
 
         if cmd.cancels.is_empty() {
@@ -2053,7 +2053,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         }
 
         let http_client = self.http_client.clone();
-        let command = cmd.clone();
+        let command = cmd;
 
         let emitter = self.emitter.clone();
         let trader_id = self.core.trader_id;

--- a/crates/adapters/binance/src/spot/data.rs
+++ b/crates/adapters/binance/src/spot/data.rs
@@ -462,17 +462,17 @@ impl DataClient for BinanceSpotDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!("subscribe_instruments: Binance instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log::debug!("subscribe_instrument: Binance instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("Binance SBE only supports L2_MBP order book deltas");
         }
@@ -505,7 +505,7 @@ impl DataClient for BinanceSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client.clone();
 
@@ -525,7 +525,7 @@ impl DataClient for BinanceSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client.clone();
 
@@ -542,7 +542,7 @@ impl DataClient for BinanceSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
         let ws = self.ws_client.clone();
         let interval = bar_spec_to_binance_interval(bar_type.spec())?;
@@ -566,7 +566,7 @@ impl DataClient for BinanceSpotDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instrument_status: {id} (status changes detected via periodic exchange info polling)",

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -651,16 +651,16 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         self.update_account_state();
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("query_order: client_order_id={}", cmd.client_order_id);
 
         let http_client = self.http_client.clone();
-        let command = cmd.clone();
+        let command = cmd;
         let event_emitter = self.emitter.clone();
         let account_id = self.core.account_id;
 
@@ -899,7 +899,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -916,10 +916,10 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         log::debug!("OrderSubmitted client_order_id={}", order.client_order_id());
         self.emitter.emit_order_submitted(&order);
 
-        self.submit_order_internal(cmd)
+        self.submit_order_internal(&cmd)
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         log::warn!(
             "submit_order_list not yet implemented for Binance Spot execution client (got {} orders)",
             cmd.order_list.client_order_ids.len()
@@ -927,7 +927,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         // Binance Spot uses cancel-replace for order modification, which requires
         // the full order specification (side, type, time_in_force). Since ModifyOrder
         // doesn't include these fields, we need to look up the original order from cache.
@@ -958,7 +958,6 @@ impl ExecutionClient for BinanceSpotExecutionClient {
             return Ok(());
         };
 
-        let command = cmd.clone();
         let event_emitter = self.emitter.clone();
         let trader_id = self.core.trader_id;
         let account_id = self.core.account_id;
@@ -970,6 +969,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         let quantity = cmd.quantity.unwrap_or_else(|| order.quantity());
 
         if self.ws_trading_active() {
+            let command = cmd;
             let ws_client = self.ws_trading_client.as_ref().unwrap().clone();
             let dispatch_state = self.dispatch_state.clone();
             let params = build_cancel_replace_params(&command, &order, quantity)?;
@@ -1011,6 +1011,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                 Ok(())
             });
         } else {
+            let command = cmd;
             let http_client = self.http_client.clone();
             log::debug!("WS trading not active, falling back to HTTP for modify_order");
 
@@ -1081,13 +1082,12 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        self.cancel_order_internal(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        self.cancel_order_internal(&cmd);
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
-        let command = cmd.clone();
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let event_emitter = self.emitter.clone();
         let trader_id = self.core.trader_id;
         let account_id = self.core.account_id;
@@ -1121,6 +1121,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                 .collect()
         };
 
+        let command = cmd;
         self.spawn_task("cancel_all_orders_http", async move {
             let canceled_orders = http_client.cancel_all_orders(command.instrument_id).await?;
 
@@ -1152,7 +1153,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         const BATCH_SIZE: usize = 5;
 
         if cmd.cancels.is_empty() {
@@ -1160,7 +1161,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         }
 
         let http_client = self.http_client.clone();
-        let command = cmd.clone();
+        let command = cmd;
 
         let event_emitter = self.emitter.clone();
         let trader_id = self.core.trader_id;

--- a/crates/adapters/binance/tests/futures/data_client.rs
+++ b/crates/adapters/binance/tests/futures/data_client.rs
@@ -348,7 +348,7 @@ async fn test_subscribe_trades() {
         None,
     );
 
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -396,7 +396,7 @@ async fn test_subscribe_quotes() {
         None,
     );
 
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -447,7 +447,7 @@ async fn test_subscribe_book_deltas() {
         None,
     );
 
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -495,7 +495,7 @@ async fn test_subscribe_mark_prices() {
         None,
     );
 
-    client.subscribe_mark_prices(&cmd).unwrap();
+    client.subscribe_mark_prices(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -543,7 +543,7 @@ async fn test_unsubscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&sub_cmd).unwrap();
+    client.subscribe_trades(sub_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -605,7 +605,7 @@ async fn test_unsubscribe_quotes() {
         None,
         None,
     );
-    client.subscribe_quotes(&sub_cmd).unwrap();
+    client.subscribe_quotes(sub_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -721,8 +721,8 @@ async fn test_subscribe_trades_and_quotes_simultaneously() {
         None,
     );
 
-    client.subscribe_trades(&trades_cmd).unwrap();
-    client.subscribe_quotes(&quotes_cmd).unwrap();
+    client.subscribe_trades(trades_cmd).unwrap();
+    client.subscribe_quotes(quotes_cmd).unwrap();
 
     let mut data_count = 0;
     wait_until_async(

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -744,7 +744,7 @@ async fn test_submit_order_generates_submitted_event() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     // Futures HTTP submit emits OrderSubmitted synchronously;
     // OrderAccepted arrives via the WS user data stream
@@ -829,7 +829,7 @@ async fn test_submit_trailing_stop_order_uses_activate_price_and_precise_callbac
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -875,7 +875,7 @@ async fn test_cancel_all_orders_completes() {
     );
 
     // Futures cancel_all returns success code via HTTP; cancel events arrive through WS
-    let result = client.cancel_all_orders(&cancel_all_cmd);
+    let result = client.cancel_all_orders(cancel_all_cmd);
     assert!(result.is_ok());
 }
 
@@ -946,7 +946,7 @@ async fn test_cancel_order_completes() {
     // Futures cancel queues an async HTTP task. The actual OrderCanceled event
     // arrives via the WS user data stream, which this mock does not simulate.
     // We verify the command is accepted and the HTTP request completes without error.
-    let result = client.cancel_order(&cancel_cmd);
+    let result = client.cancel_order(cancel_cmd);
     assert!(result.is_ok());
 }
 
@@ -1017,7 +1017,7 @@ async fn test_modify_order_completes() {
         None,
     );
 
-    client.modify_order(&modify_cmd).unwrap();
+    client.modify_order(modify_cmd).unwrap();
 
     // Futures modify_order HTTP path emits OrderUpdated on success
     wait_until_async(
@@ -1103,7 +1103,7 @@ async fn test_cancel_order_ws_rejection_emits_cancel_rejected() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     let cancel_cmd = CancelOrder::new(
         trader_id,
@@ -1117,7 +1117,7 @@ async fn test_cancel_order_ws_rejection_emits_cancel_rejected() {
         None,
     );
 
-    client.cancel_order(&cancel_cmd).unwrap();
+    client.cancel_order(cancel_cmd).unwrap();
 
     match recv_until(&mut rx, |event| {
         matches!(
@@ -1206,7 +1206,7 @@ async fn test_modify_order_ws_rejection_emits_modify_rejected() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     let modify_cmd = ModifyOrder::new(
         trader_id,
@@ -1223,7 +1223,7 @@ async fn test_modify_order_ws_rejection_emits_modify_rejected() {
         None,
     );
 
-    client.modify_order(&modify_cmd).unwrap();
+    client.modify_order(modify_cmd).unwrap();
 
     match recv_until(&mut rx, |event| {
         matches!(
@@ -1334,7 +1334,7 @@ async fn test_submit_order_with_price_match_sends_price_match_and_omits_price() 
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -1601,9 +1601,10 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("BINANCE-001"),
         nautilus_core::UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    let result = client.query_account(&cmd);
+    let result = client.query_account(cmd);
     assert!(result.is_ok());
 
     match recv_until(&mut rx, |event| matches!(event, ExecutionEvent::Account(_))).await {

--- a/crates/adapters/binance/tests/spot/data_client.rs
+++ b/crates/adapters/binance/tests/spot/data_client.rs
@@ -516,7 +516,7 @@ async fn test_subscribe_trades() {
         None,
     );
 
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -564,7 +564,7 @@ async fn test_subscribe_quotes() {
         None,
     );
 
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -615,7 +615,7 @@ async fn test_subscribe_book_deltas() {
         None,
     );
 
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -664,7 +664,7 @@ async fn test_unsubscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&sub_cmd).unwrap();
+    client.subscribe_trades(sub_cmd).unwrap();
 
     // Wait for data to arrive
     wait_until_async(
@@ -729,7 +729,7 @@ async fn test_unsubscribe_quotes() {
         None,
         None,
     );
-    client.subscribe_quotes(&sub_cmd).unwrap();
+    client.subscribe_quotes(sub_cmd).unwrap();
 
     // Wait for data to arrive
     wait_until_async(
@@ -848,8 +848,8 @@ async fn test_subscribe_trades_and_quotes_simultaneously() {
         None,
     );
 
-    client.subscribe_trades(&trades_cmd).unwrap();
-    client.subscribe_quotes(&quotes_cmd).unwrap();
+    client.subscribe_trades(trades_cmd).unwrap();
+    client.subscribe_quotes(quotes_cmd).unwrap();
 
     // Should receive data events for both subscriptions
     let mut data_count = 0;

--- a/crates/adapters/binance/tests/spot/exec_client.rs
+++ b/crates/adapters/binance/tests/spot/exec_client.rs
@@ -745,7 +745,7 @@ async fn test_submit_order_generates_submitted_and_accepted_events() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -784,7 +784,7 @@ async fn test_cancel_all_orders_generates_canceled_events() {
         None,
     );
 
-    client.cancel_all_orders(&cancel_all_cmd).unwrap();
+    client.cancel_all_orders(cancel_all_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -862,7 +862,7 @@ async fn test_cancel_order_generates_canceled_event() {
         None,
     );
 
-    client.cancel_order(&cancel_cmd).unwrap();
+    client.cancel_order(cancel_cmd).unwrap();
 
     wait_until_async(
         || {
@@ -943,7 +943,7 @@ async fn test_modify_order_generates_events() {
     );
 
     // Modify uses cancel-replace on Binance Spot, which generates cancel + new events
-    let result = client.modify_order(&modify_cmd);
+    let result = client.modify_order(modify_cmd);
     assert!(result.is_ok());
 
     // Should get at least one execution event (cancel or accepted for the replacement)
@@ -997,9 +997,10 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("BINANCE-001"),
         nautilus_core::UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    let result = client.query_account(&query_cmd);
+    let result = client.query_account(query_cmd);
     assert!(result.is_ok());
 
     wait_until_async(

--- a/crates/adapters/bitmex/src/data.rs
+++ b/crates/adapters/bitmex/src/data.rs
@@ -711,7 +711,7 @@ impl DataClient for BitmexDataClient {
         self.is_disconnected()
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         let ws = self.ws_client()?.clone();
 
         self.spawn_ws(
@@ -725,7 +725,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         if let Some(instrument) = self.instruments.load().get(&instrument_id).cloned() {
@@ -750,7 +750,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("BitMEX only supports L2_MBP order book deltas");
         }
@@ -793,7 +793,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_book_depth10(&mut self, cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
         let book_channels = Arc::clone(&self.book_channels);
@@ -811,7 +811,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
 
@@ -826,7 +826,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
 
@@ -841,7 +841,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
 
@@ -856,7 +856,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
 
@@ -871,7 +871,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();
 
@@ -886,7 +886,7 @@ impl DataClient for BitmexDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
         let ws = self.ws_client()?.clone();
 
@@ -903,7 +903,7 @@ impl DataClient for BitmexDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws_client()?.clone();

--- a/crates/adapters/bitmex/src/execution.rs
+++ b/crates/adapters/bitmex/src/execution.rs
@@ -894,7 +894,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let emitter = self.emitter.clone();
         let account_id = self.core.account_id;
@@ -910,7 +910,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let instrument_id = cmd.instrument_id;
         let client_order_id = Some(cmd.client_order_id);
@@ -931,7 +931,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let submit_tries = cmd
             .params
             .as_ref()
@@ -960,7 +960,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         if cmd.order_list.client_order_ids.is_empty() {
             log::debug!("submit_order_list called with empty order list");
             return Ok(());
@@ -996,7 +996,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         self.ensure_order_identity(cmd.client_order_id, cmd.strategy_id, cmd.instrument_id);
         let http_client = self.http_client.clone();
         let emitter = self.emitter.clone();
@@ -1028,7 +1028,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         self.ensure_order_identity(cmd.client_order_id, cmd.strategy_id, cmd.instrument_id);
         let canceller = self._canceller.clone_for_async();
         let emitter = self.emitter.clone();
@@ -1059,7 +1059,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let canceller = self._canceller.clone_for_async();
         let emitter = self.emitter.clone();
         let dispatch_state = Arc::clone(&self.ws_dispatch_state);
@@ -1097,7 +1097,7 @@ impl ExecutionClient for BitmexExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         let canceller = self._canceller.clone_for_async();
         let emitter = self.emitter.clone();
         let dispatch_state = Arc::clone(&self.ws_dispatch_state);

--- a/crates/adapters/blockchain/src/data/client.rs
+++ b/crates/adapters/blockchain/src/data/client.rs
@@ -907,50 +907,41 @@ impl DataClient for BlockchainDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_blocks(&mut self, cmd: &SubscribeBlocks) -> anyhow::Result<()> {
-        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::Blocks(cmd.clone()));
+    fn subscribe_blocks(&mut self, cmd: SubscribeBlocks) -> anyhow::Result<()> {
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::Blocks(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }
 
-    fn subscribe_pool(&mut self, cmd: &SubscribePool) -> anyhow::Result<()> {
-        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::Pool(cmd.clone()));
+    fn subscribe_pool(&mut self, cmd: SubscribePool) -> anyhow::Result<()> {
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::Pool(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }
 
-    fn subscribe_pool_swaps(&mut self, cmd: &SubscribePoolSwaps) -> anyhow::Result<()> {
-        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolSwaps(cmd.clone()));
+    fn subscribe_pool_swaps(&mut self, cmd: SubscribePoolSwaps) -> anyhow::Result<()> {
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolSwaps(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }
 
     fn subscribe_pool_liquidity_updates(
         &mut self,
-        cmd: &SubscribePoolLiquidityUpdates,
+        cmd: SubscribePoolLiquidityUpdates,
     ) -> anyhow::Result<()> {
-        let command =
-            DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolLiquidityUpdates(cmd.clone()));
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolLiquidityUpdates(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }
 
-    fn subscribe_pool_fee_collects(
-        &mut self,
-        cmd: &SubscribePoolFeeCollects,
-    ) -> anyhow::Result<()> {
-        let command =
-            DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolFeeCollects(cmd.clone()));
+    fn subscribe_pool_fee_collects(&mut self, cmd: SubscribePoolFeeCollects) -> anyhow::Result<()> {
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolFeeCollects(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }
 
-    fn subscribe_pool_flash_events(
-        &mut self,
-        cmd: &SubscribePoolFlashEvents,
-    ) -> anyhow::Result<()> {
-        let command =
-            DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolFlashEvents(cmd.clone()));
+    fn subscribe_pool_flash_events(&mut self, cmd: SubscribePoolFlashEvents) -> anyhow::Result<()> {
+        let command = DefiDataCommand::Subscribe(DefiSubscribeCommand::PoolFlashEvents(cmd));
         self.command_tx.send(command)?;
         Ok(())
     }

--- a/crates/adapters/blockchain/src/execution/client.rs
+++ b/crates/adapters/blockchain/src/execution/client.rs
@@ -231,35 +231,35 @@ impl ExecutionClient for BlockchainExecutionClient {
         todo!("implement stop")
     }
 
-    fn submit_order(&self, _cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, _cmd: SubmitOrder) -> anyhow::Result<()> {
         todo!("implement submit_order")
     }
 
-    fn submit_order_list(&self, _cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, _cmd: SubmitOrderList) -> anyhow::Result<()> {
         todo!("implement submit_order_list")
     }
 
-    fn modify_order(&self, _cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, _cmd: ModifyOrder) -> anyhow::Result<()> {
         todo!("implement modify_order")
     }
 
-    fn cancel_order(&self, _cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, _cmd: CancelOrder) -> anyhow::Result<()> {
         todo!("implement cancel_order")
     }
 
-    fn cancel_all_orders(&self, _cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, _cmd: CancelAllOrders) -> anyhow::Result<()> {
         todo!("implement cancel_all_orders")
     }
 
-    fn batch_cancel_orders(&self, _cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, _cmd: BatchCancelOrders) -> anyhow::Result<()> {
         todo!("implement batch_cancel_orders")
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         todo!("implement query_account")
     }
 
-    fn query_order(&self, _cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, _cmd: QueryOrder) -> anyhow::Result<()> {
         todo!("implement query_order")
     }
 

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -819,7 +819,7 @@ impl DataClient for BybitDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("Bybit only supports L2_MBP order book deltas");
         }
@@ -858,7 +858,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self
             .get_product_type_for_instrument(instrument_id)
@@ -904,7 +904,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self
             .get_product_type_for_instrument(instrument_id)
@@ -928,7 +928,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self
             .get_product_type_for_instrument(instrument_id)
@@ -963,7 +963,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self
             .get_product_type_for_instrument(instrument_id)
@@ -998,7 +998,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self
             .get_product_type_for_instrument(instrument_id)
@@ -1033,7 +1033,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
         let instrument_id = bar_type.instrument_id();
         let product_type = self
@@ -1332,7 +1332,7 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.option_greeks_subs.insert(instrument_id);
 
@@ -1408,7 +1408,7 @@ impl DataClient for BybitDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instrument_status: {id} (status changes detected via periodic instrument info polling)",

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -523,12 +523,12 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         self.update_account_state();
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self.get_product_type_for_instrument(instrument_id);
         let client_order_id = cmd.client_order_id;
@@ -875,7 +875,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = {
             let cache = self.core.cache();
             let order = cache
@@ -1028,7 +1028,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         if cmd.order_list.client_order_ids.is_empty() {
             return Ok(());
         }
@@ -1246,7 +1246,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self.get_product_type_for_instrument(instrument_id);
         let client_order_id = cmd.client_order_id;
@@ -1384,7 +1384,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let product_type = self.get_product_type_for_instrument(instrument_id);
         let client_order_id = cmd.client_order_id;
@@ -1471,7 +1471,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         if cmd.order_side != OrderSide::NoOrderSide {
             log::warn!(
                 "Bybit does not support order_side filtering for cancel all orders; \
@@ -1505,7 +1505,7 @@ impl ExecutionClient for BybitExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         if cmd.cancels.is_empty() {
             return Ok(());
         }

--- a/crates/adapters/bybit/tests/data_client.rs
+++ b/crates/adapters/bybit/tests/data_client.rs
@@ -451,7 +451,7 @@ async fn test_data_client_subscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     wait_until_async(
         || async { !state.subscription_events.lock().await.is_empty() },
@@ -503,7 +503,7 @@ async fn test_data_client_subscribe_quotes_linear() {
         None,
         None,
     );
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     wait_until_async(
         || async {
@@ -564,7 +564,7 @@ async fn test_data_client_subscribe_book_deltas() {
         None,
         None,
     );
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     wait_until_async(
         || async {

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -726,9 +726,10 @@ async fn test_exec_client_query_order() {
         None,
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    client.query_order(&cmd).unwrap();
+    client.query_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -774,9 +775,10 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("BYBIT-001"),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    client.query_account(&cmd).unwrap();
+    client.query_account(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -939,7 +941,7 @@ async fn test_exec_client_submit_order_list_demo() {
         UnixNanos::default(),
     );
 
-    client.submit_order_list(&cmd).unwrap();
+    client.submit_order_list(cmd).unwrap();
 
     let mut submitted_count = 0;
 
@@ -1119,7 +1121,7 @@ async fn test_exec_client_submit_order_list_denies_all_on_invalid_leg() {
         UnixNanos::default(),
     );
 
-    client.submit_order_list(&cmd).unwrap();
+    client.submit_order_list(cmd).unwrap();
 
     // Both orders should be denied (not just the invalid one)
     let mut denied_count = 0;

--- a/crates/adapters/coinbase/src/data.rs
+++ b/crates/adapters/coinbase/src/data.rs
@@ -363,7 +363,7 @@ impl DataClient for CoinbaseDataClient {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         let instruments = self.instruments.load();
 
         if let Some(instrument) = instruments.get(&cmd.instrument_id) {
@@ -380,7 +380,7 @@ impl DataClient for CoinbaseDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, subscription: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, subscription: SubscribeBookDeltas) -> anyhow::Result<()> {
         log::debug!("Subscribing to book deltas: {}", subscription.instrument_id);
 
         if subscription.book_type != BookType::L2_MBP {
@@ -399,7 +399,7 @@ impl DataClient for CoinbaseDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, subscription: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, subscription: SubscribeQuotes) -> anyhow::Result<()> {
         log::debug!("Subscribing to quotes: {}", subscription.instrument_id);
 
         let ws = self.ws_client.clone();
@@ -414,7 +414,7 @@ impl DataClient for CoinbaseDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, subscription: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, subscription: SubscribeTrades) -> anyhow::Result<()> {
         log::debug!("Subscribing to trades: {}", subscription.instrument_id);
 
         let ws = self.ws_client.clone();
@@ -432,7 +432,7 @@ impl DataClient for CoinbaseDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, subscription: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, subscription: SubscribeBars) -> anyhow::Result<()> {
         log::debug!("Subscribing to bars: {}", subscription.bar_type);
 
         let instrument_id = subscription.bar_type.instrument_id();

--- a/crates/adapters/coinbase/tests/data_client.rs
+++ b/crates/adapters/coinbase/tests/data_client.rs
@@ -369,7 +369,7 @@ async fn test_data_client_subscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     wait_until_async(
         || {
@@ -413,7 +413,7 @@ async fn test_data_client_subscribe_quotes() {
         None,
         None,
     );
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -455,7 +455,7 @@ async fn test_data_client_subscribe_book_deltas() {
         None,
         None,
     );
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -772,7 +772,7 @@ async fn test_data_client_subscribe_bars() {
         None,
         None,
     );
-    client.subscribe_bars(&cmd).unwrap();
+    client.subscribe_bars(cmd).unwrap();
 
     wait_until_async(
         || {

--- a/crates/adapters/databento/src/data.rs
+++ b/crates/adapters/databento/src/data.rs
@@ -480,7 +480,7 @@ impl DataClient for DatabentoDataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription request fails.
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log::debug!("Subscribe instrument: {cmd:?}");
 
         let dataset = self.get_dataset_for_venue(cmd.instrument_id.venue)?;
@@ -515,7 +515,7 @@ impl DataClient for DatabentoDataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription request fails.
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         log::debug!("Subscribe quotes: {cmd:?}");
 
         let dataset = self.get_dataset_for_venue(cmd.instrument_id.venue)?;
@@ -550,7 +550,7 @@ impl DataClient for DatabentoDataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription request fails.
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         log::debug!("Subscribe trades: {cmd:?}");
 
         let dataset = self.get_dataset_for_venue(cmd.instrument_id.venue)?;
@@ -585,7 +585,7 @@ impl DataClient for DatabentoDataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription request fails.
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         log::debug!("Subscribe book deltas: {cmd:?}");
 
         let dataset = self.get_dataset_for_venue(cmd.instrument_id.venue)?;
@@ -622,7 +622,7 @@ impl DataClient for DatabentoDataClient {
     /// Returns an error if the subscription request fails.
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::debug!("Subscribe instrument status: {cmd:?}");
 

--- a/crates/adapters/deribit/src/data.rs
+++ b/crates/adapters/deribit/src/data.rs
@@ -508,7 +508,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, cmd: SubscribeInstruments) -> anyhow::Result<()> {
         // Extract kind and currency from params, defaulting to "any.any" (all instruments)
         let kind = cmd
             .params
@@ -540,7 +540,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         // Check if instrument is in cache (should be from connect())
@@ -573,7 +573,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("Deribit only supports L2_MBP order book deltas");
         }
@@ -633,7 +633,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_book_depth10(&mut self, cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("Deribit only supports L2_MBP order book depth");
         }
@@ -672,7 +672,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()
@@ -691,7 +691,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()
@@ -715,7 +715,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()
@@ -742,7 +742,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()
@@ -769,7 +769,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()
@@ -787,7 +787,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         // Validate instrument is a perpetual - funding rates only apply to perpetual contracts
@@ -831,7 +831,7 @@ impl DataClient for DeribitDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let (kind, currency) = parse_instrument_kind_currency(&instrument_id);
@@ -853,7 +853,7 @@ impl DataClient for DeribitDataClient {
         Ok(())
     }
 
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         let ws = self
             .ws_client
             .as_ref()

--- a/crates/adapters/deribit/src/execution.rs
+++ b/crates/adapters/deribit/src/execution.rs
@@ -667,7 +667,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let account_id = self.core.account_id;
         let emitter = self.emitter.clone();
@@ -685,7 +685,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         let ws_client = self.ws_client.clone();
 
         // Extract venue order ID (Deribit's order_id)
@@ -721,7 +721,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -732,7 +732,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         if cmd.order_list.client_order_ids.is_empty() {
             log::debug!("submit_order_list called with empty order list");
             return Ok(());
@@ -756,7 +756,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let ws_client = self.ws_client.clone();
 
         // Extract venue order ID (Deribit's order_id)
@@ -830,7 +830,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let ws_client = self.ws_client.clone();
 
         // Extract venue order ID (Deribit's order_id)
@@ -884,7 +884,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         // If NoOrderSide, use efficient bulk cancel via Deribit API
@@ -990,7 +990,7 @@ impl ExecutionClient for DeribitExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         if cmd.cancels.is_empty() {
             log::debug!("batch_cancel_orders called with empty cancels list");
             return Ok(());

--- a/crates/adapters/deribit/tests/data_client.rs
+++ b/crates/adapters/deribit/tests/data_client.rs
@@ -462,7 +462,7 @@ async fn test_data_client_subscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     wait_until_async(
         || async { !state.subscription_events.lock().await.is_empty() },
@@ -512,7 +512,7 @@ async fn test_data_client_subscribe_quotes() {
         None,
         None,
     );
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     wait_until_async(
         || async {
@@ -572,7 +572,7 @@ async fn test_data_client_subscribe_book_deltas() {
         None,
         None,
     );
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     wait_until_async(
         || async {

--- a/crates/adapters/dydx/src/data.rs
+++ b/crates/adapters/dydx/src/data.rs
@@ -417,14 +417,14 @@ impl DataClient for DydxDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!(
             "subscribe_instruments: dYdX instruments discovered via global v4_markets channel"
         );
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         if let Some(instrument) = self.instrument_cache.get(&cmd.instrument_id) {
             log::debug!("Sending cached instrument for {}", cmd.instrument_id);
             if let Err(e) = self.data_sender.send(DataEvent::Instrument(instrument)) {
@@ -440,7 +440,7 @@ impl DataClient for DydxDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!(
                 "dYdX only supports L2_MBP order book deltas, received {:?}",
@@ -466,7 +466,7 @@ impl DataClient for DydxDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         log::debug!(
             "Subscribe_quotes for {}: subscribing to orderbook WS channel for quote synthesis",
             cmd.instrument_id
@@ -489,7 +489,7 @@ impl DataClient for DydxDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let ws = self.ws_client.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -507,21 +507,21 @@ impl DataClient for DydxDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.active_mark_price_subs.insert(instrument_id);
         log::info!("Subscribed to mark prices for {instrument_id} (via v4_markets channel)");
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.active_index_price_subs.insert(instrument_id);
         log::info!("Subscribed to index prices for {instrument_id} (via v4_markets channel)");
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let ws = self.ws_client.clone();
         let instrument_id = cmd.bar_type.instrument_id();
         let spec = cmd.bar_type.spec();
@@ -547,7 +547,7 @@ impl DataClient for DydxDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.active_funding_rate_subs.insert(instrument_id);
         log::info!("Subscribed to funding rates for {instrument_id} (via v4_markets channel)");
@@ -556,7 +556,7 @@ impl DataClient for DydxDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.active_instrument_status_subs.insert(instrument_id);

--- a/crates/adapters/dydx/src/execution/mod.rs
+++ b/crates/adapters/dydx/src/execution/mod.rs
@@ -1062,7 +1062,7 @@ impl ExecutionClient for DydxExecutionClient {
     ///
     /// Validates synchronously, generates OrderSubmitted event, then spawns async task for
     /// gRPC submission to avoid blocking. Unsupported order types generate OrderRejected.
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         // Check connection status first (doesn't need order)
         if !self.is_connected() {
             let reason = "Cannot submit order: execution client not connected";
@@ -1398,7 +1398,7 @@ impl ExecutionClient for DydxExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let orders = self.core.get_orders_for_list(&cmd.order_list)?;
         let order_count = orders.len();
 
@@ -1480,7 +1480,7 @@ impl ExecutionClient for DydxExecutionClient {
                     cmd.ts_init,
                 );
 
-                if let Err(e) = self.submit_order(&submit_cmd) {
+                if let Err(e) = self.submit_order(submit_cmd) {
                     log::error!(
                         "Failed to submit order {} from order list: {e}",
                         order.client_order_id()
@@ -1750,7 +1750,7 @@ impl ExecutionClient for DydxExecutionClient {
     /// dYdX does not support native order modification.
     ///
     /// Strategies should handle `OrderModifyRejected` by canceling and resubmitting.
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let reason = "dYdX does not support order modification. Use cancel and resubmit instead.";
         log::error!("{reason}");
 
@@ -1782,7 +1782,7 @@ impl ExecutionClient for DydxExecutionClient {
     ///
     /// - `OrderCanceled` - Generated when WebSocket confirms cancellation.
     /// - `OrderCancelRejected` - Generated if exchange rejects cancellation.
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         if !self.is_connected() {
             anyhow::bail!("Cannot cancel order: not connected");
         }
@@ -1938,7 +1938,7 @@ impl ExecutionClient for DydxExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         if !self.is_connected() {
             anyhow::bail!("Cannot cancel orders: not connected");
         }
@@ -2045,7 +2045,7 @@ impl ExecutionClient for DydxExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         if cmd.cancels.is_empty() {
             return Ok(());
         }
@@ -2115,7 +2115,7 @@ impl ExecutionClient for DydxExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let wallet_address = self.wallet_address.clone();
         let subaccount_number = self.subaccount_number;
@@ -2140,7 +2140,7 @@ impl ExecutionClient for DydxExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("Querying order: client_order_id={}", cmd.client_order_id);
 
         let http_client = self.http_client.clone();

--- a/crates/adapters/hyperliquid/src/data/mod.rs
+++ b/crates/adapters/hyperliquid/src/data/mod.rs
@@ -851,7 +851,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         let instruments = self.instruments.load();
         if let Some(instrument) = instruments.get(&cmd.instrument_id) {
             if let Err(e) = self
@@ -866,7 +866,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, subscription: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, subscription: SubscribeTrades) -> anyhow::Result<()> {
         log::debug!("Subscribing to trades: {}", subscription.instrument_id);
 
         let ws = self.ws_client.clone();
@@ -899,7 +899,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, subscription: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, subscription: SubscribeBookDeltas) -> anyhow::Result<()> {
         log::debug!("Subscribing to book deltas: {}", subscription.instrument_id);
 
         if subscription.book_type != BookType::L2_MBP {
@@ -939,7 +939,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, subscription: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, subscription: SubscribeQuotes) -> anyhow::Result<()> {
         log::debug!("Subscribing to quotes: {}", subscription.instrument_id);
 
         let ws = self.ws_client.clone();
@@ -972,7 +972,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let ws = self.ws_client.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -998,7 +998,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let ws = self.ws_client.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1024,7 +1024,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let ws = self.ws_client.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1050,7 +1050,7 @@ impl DataClient for HyperliquidDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, subscription: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, subscription: SubscribeBars) -> anyhow::Result<()> {
         log::debug!("Subscribing to bars: {}", subscription.bar_type);
 
         let instrument_id = subscription.bar_type.instrument_id();

--- a/crates/adapters/hyperliquid/src/execution/mod.rs
+++ b/crates/adapters/hyperliquid/src/execution/mod.rs
@@ -460,7 +460,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -613,7 +613,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         log::debug!(
             "Submitting order list with {} orders",
             cmd.order_list.client_order_ids.len()
@@ -786,7 +786,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         log::debug!("Modifying order: {cmd:?}");
 
         let venue_order_id = match cmd.venue_order_id {
@@ -950,7 +950,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         log::debug!("Cancelling order: {cmd:?}");
 
         let http_client = self.http_client.clone();
@@ -1029,7 +1029,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         log::debug!("Cancelling all orders: {cmd:?}");
 
         let cache = self.core.cache();
@@ -1086,7 +1086,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         log::debug!("Batch cancelling orders: {cmd:?}");
 
         if cmd.cancels.is_empty() {
@@ -1143,7 +1143,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let account_address = self.get_account_address()?;
         let emitter = self.emitter.clone();
@@ -1173,7 +1173,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("Querying order: {cmd:?}");
 
         let cache = self.core.cache();

--- a/crates/adapters/hyperliquid/tests/data_client.rs
+++ b/crates/adapters/hyperliquid/tests/data_client.rs
@@ -589,7 +589,7 @@ async fn test_data_client_subscribe_trades() {
         None,
         None,
     );
-    client.subscribe_trades(&cmd).unwrap();
+    client.subscribe_trades(cmd).unwrap();
 
     // Drain until we get a trade (subscription is async via get_runtime)
     wait_until_async(
@@ -633,7 +633,7 @@ async fn test_data_client_subscribe_quotes() {
         None,
         None,
     );
-    client.subscribe_quotes(&cmd).unwrap();
+    client.subscribe_quotes(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -675,7 +675,7 @@ async fn test_data_client_subscribe_book_deltas() {
         None,
         None,
     );
-    client.subscribe_book_deltas(&cmd).unwrap();
+    client.subscribe_book_deltas(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await

--- a/crates/adapters/hyperliquid/tests/exec_client.rs
+++ b/crates/adapters/hyperliquid/tests/exec_client.rs
@@ -806,9 +806,10 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("HYPERLIQUID-001"),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    let result = client.query_account(&cmd);
+    let result = client.query_account(cmd);
     assert!(result.is_ok());
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -896,7 +897,7 @@ async fn test_submit_order_inner_error_cleans_up_dispatch_state() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Identity is registered synchronously inside submit_order before the
     // spawn_task fires.
@@ -961,7 +962,7 @@ async fn test_modify_order_success_marks_pending_modify() {
         None,
     );
 
-    client.modify_order(&cmd).unwrap();
+    client.modify_order(cmd).unwrap();
 
     let dispatch = client.ws_dispatch_state().clone();
     let cid = order.client_order_id();
@@ -1018,7 +1019,7 @@ async fn test_modify_order_rejection_does_not_mark_pending_modify() {
         None,
     );
 
-    client.modify_order(&cmd).unwrap();
+    client.modify_order(cmd).unwrap();
 
     // Wait for the spawn task to drain fully so we know the HTTP round-trip
     // AND the client's response-handling continuation have both run. Only

--- a/crates/adapters/kraken/src/data/futures.rs
+++ b/crates/adapters/kraken/src/data/futures.rs
@@ -566,17 +566,17 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!("subscribe_instruments: Kraken instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log::debug!("subscribe_instrument: Kraken instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let depth = cmd.depth;
 
@@ -604,7 +604,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -623,7 +623,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -640,7 +640,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -657,7 +657,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -674,7 +674,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -691,7 +691,7 @@ impl DataClient for KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         log::warn!(
             "Cannot subscribe to {} bars: Kraken Futures does not support EXTERNAL bar streaming",
             cmd.bar_type
@@ -701,7 +701,7 @@ impl DataClient for KrakenFuturesDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::info!(
             "subscribe_instrument_status: {} (status changes detected via periodic instrument polling)",

--- a/crates/adapters/kraken/src/data/spot.rs
+++ b/crates/adapters/kraken/src/data/spot.rs
@@ -469,17 +469,17 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!("subscribe_instruments: Kraken instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log::debug!("subscribe_instrument: Kraken instruments are fetched via HTTP on connect");
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let depth = cmd.depth;
 
@@ -513,7 +513,7 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -530,7 +530,7 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let ws = self.ws.clone();
 
@@ -547,7 +547,7 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         log::warn!(
             "Mark price subscription not supported for Spot instrument {}",
             cmd.instrument_id
@@ -555,7 +555,7 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         log::warn!(
             "Index price subscription not supported for Spot instrument {}",
             cmd.instrument_id
@@ -563,7 +563,7 @@ impl DataClient for KrakenSpotDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let bar_type = cmd.bar_type;
 
         if bar_type.aggregation_source() != AggregationSource::External {
@@ -592,7 +592,7 @@ impl DataClient for KrakenSpotDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log::info!(
             "subscribe_instrument_status: {} (status changes detected via periodic instrument polling)",

--- a/crates/adapters/kraken/src/execution/futures.rs
+++ b/crates/adapters/kraken/src/execution/futures.rs
@@ -762,7 +762,7 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn query_account(&self, cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, cmd: QueryAccount) -> anyhow::Result<()> {
         log::debug!("Querying account: {cmd:?}");
 
         let account_id = self.core.account_id;
@@ -783,7 +783,7 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("Querying order: {cmd:?}");
 
         let venue_order_id = cmd
@@ -811,7 +811,7 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -822,7 +822,7 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let orders = self.core.get_orders_for_list(&cmd.order_list)?;
 
         log::info!(
@@ -937,17 +937,17 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
-        self.modify_single_order(cmd);
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
+        self.modify_single_order(&cmd);
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        self.cancel_single_order(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        self.cancel_single_order(&cmd);
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         if cmd.order_side == OrderSide::NoOrderSide {
@@ -1025,7 +1025,7 @@ impl ExecutionClient for KrakenFuturesExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         log::info!(
             "Batch canceling orders: instrument_id={}, count={}",
             cmd.instrument_id,

--- a/crates/adapters/kraken/src/execution/spot.rs
+++ b/crates/adapters/kraken/src/execution/spot.rs
@@ -790,7 +790,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn query_account(&self, cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, cmd: QueryAccount) -> anyhow::Result<()> {
         log::debug!("Querying account: {cmd:?}");
 
         let account_id = self.core.account_id;
@@ -811,7 +811,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("Querying order: {cmd:?}");
 
         let venue_order_id = cmd
@@ -839,7 +839,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -850,7 +850,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let orders = self.core.get_orders_for_list(&cmd.order_list)?;
 
         log::info!(
@@ -989,17 +989,17 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
-        self.modify_single_order(cmd);
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
+        self.modify_single_order(&cmd);
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        self.cancel_single_order(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        self.cancel_single_order(&cmd);
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
 
         if cmd.order_side == OrderSide::NoOrderSide {
@@ -1076,7 +1076,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         log::info!(
             "Batch canceling orders: instrument_id={}, count={}",
             cmd.instrument_id,

--- a/crates/adapters/okx/src/data.rs
+++ b/crates/adapters/okx/src/data.rs
@@ -911,7 +911,7 @@ impl DataClient for OKXDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         for inst_type in &self.config.instrument_types {
             let ws = self.public_ws()?.clone();
             let inst_type = *inst_type;
@@ -929,7 +929,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         // OKX instruments channel doesn't support subscribing to individual instruments via instId
         // Instead, subscribe to the instrument type if not already subscribed
         let instrument_id = cmd.instrument_id;
@@ -947,7 +947,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!("OKX only supports L2_MBP order book deltas");
         }
@@ -1009,7 +1009,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1024,7 +1024,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1039,7 +1039,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1054,7 +1054,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;
         let symbol = instrument_id.symbol.inner();
@@ -1076,7 +1076,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         let ws = self.business_ws()?.clone();
         let bar_type = cmd.bar_type;
 
@@ -1091,7 +1091,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;
 
@@ -1106,7 +1106,7 @@ impl DataClient for OKXDataClient {
         Ok(())
     }
 
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         self.option_greeks_subs.insert(instrument_id);
 
@@ -1129,7 +1129,7 @@ impl DataClient for OKXDataClient {
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         let ws = self.public_ws()?.clone();
         let instrument_id = cmd.instrument_id;

--- a/crates/adapters/okx/src/execution.rs
+++ b/crates/adapters/okx/src/execution.rs
@@ -1008,12 +1008,12 @@ impl ExecutionClient for OKXExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         self.update_account_state();
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!(
             "query_order not implemented for OKX execution client (client_order_id={})",
             cmd.client_order_id
@@ -1390,7 +1390,7 @@ impl ExecutionClient for OKXExecutionClient {
         Ok(Some(mass_status))
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order_type = {
             let cache = self.core.cache();
             let order = cache
@@ -1423,13 +1423,13 @@ impl ExecutionClient for OKXExecutionClient {
         };
 
         if self.is_conditional_order(order_type) {
-            self.submit_conditional_order(cmd)
+            self.submit_conditional_order(&cmd)
         } else {
-            self.submit_regular_order(cmd)
+            self.submit_regular_order(&cmd)
         }
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let inst_type = okx_instrument_type_from_symbol(cmd.instrument_id.symbol.as_str());
 
         // Validate all orders before emitting any submitted events
@@ -1494,7 +1494,7 @@ impl ExecutionClient for OKXExecutionClient {
         let clock = self.clock;
         let instrument_id = cmd.instrument_id;
         let strategy_id = cmd.strategy_id;
-        let client_order_ids: Vec<_> = cmd.order_list.client_order_ids.clone();
+        let client_order_ids: Vec<_> = cmd.order_list.client_order_ids;
         let dispatch_state = Arc::clone(&self.ws_dispatch_state);
 
         self.spawn_task("batch_submit_orders", async move {
@@ -1526,7 +1526,7 @@ impl ExecutionClient for OKXExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         self.ensure_order_identity(cmd.client_order_id, cmd.strategy_id, cmd.instrument_id);
 
         let ws_private = self.ws_private.clone();
@@ -1573,7 +1573,7 @@ impl ExecutionClient for OKXExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let cache = self.core.cache();
         let is_pending_algo = cache.order(&cmd.client_order_id).is_some_and(|o| {
             self.is_conditional_order(o.order_type()) && o.is_triggered() != Some(true)
@@ -1581,14 +1581,14 @@ impl ExecutionClient for OKXExecutionClient {
         drop(cache);
 
         if is_pending_algo {
-            self.cancel_algo_order(cmd);
+            self.cancel_algo_order(&cmd);
         } else {
-            self.cancel_ws_order(cmd);
+            self.cancel_ws_order(&cmd);
         }
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         if self.config.use_mm_mass_cancel {
             // Use OKX's mass-cancel endpoint (requires market maker permissions)
             self.mass_cancel_instrument(cmd.instrument_id);
@@ -1717,7 +1717,7 @@ impl ExecutionClient for OKXExecutionClient {
         }
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         let cache = self.core.cache();
 
         let mut regular_payload = Vec::new();

--- a/crates/adapters/okx/tests/exec_client.rs
+++ b/crates/adapters/okx/tests/exec_client.rs
@@ -962,9 +962,10 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("OKX-001"),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
-    let result = client.query_account(&cmd);
+    let result = client.query_account(cmd);
     assert!(result.is_ok());
 
     wait_until_async(

--- a/crates/adapters/polymarket/src/data.rs
+++ b/crates/adapters/polymarket/src/data.rs
@@ -1043,12 +1043,12 @@ impl DataClient for PolymarketDataClient {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log::debug!("subscribe_instruments: subscribed individually via data subscription methods");
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if cmd.book_type != BookType::L2_MBP {
             anyhow::bail!(
                 "Polymarket only supports L2_MBP order book deltas, received {:?}",
@@ -1074,7 +1074,7 @@ impl DataClient for PolymarketDataClient {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let token_id = self.resolve_token_id(instrument_id)?;
 
@@ -1089,7 +1089,7 @@ impl DataClient for PolymarketDataClient {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let token_id = self.resolve_token_id(instrument_id)?;
 

--- a/crates/adapters/polymarket/src/execution/mod.rs
+++ b/crates/adapters/polymarket/src/execution/mod.rs
@@ -734,7 +734,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let order = self
             .core
             .cache()
@@ -765,7 +765,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         for (i, order_init) in cmd.order_inits.iter().enumerate() {
             let submit = SubmitOrder::new(
                 cmd.trader_id,
@@ -781,7 +781,7 @@ impl ExecutionClient for PolymarketExecutionClient {
                 self.clock.get_time_ns(),
             );
 
-            if let Err(e) = self.submit_order(&submit) {
+            if let Err(e) = self.submit_order(submit) {
                 log::warn!(
                     "Failed to submit order {} from list: {e}",
                     order_init.client_order_id
@@ -791,7 +791,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let order = self.core.cache().order(&cmd.client_order_id).cloned();
         if let Some(order) = order {
             let venue_order_id = order.venue_order_id();
@@ -806,7 +806,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let order = self.core.cache().order(&cmd.client_order_id).cloned();
         let order_ref = match &order {
             Some(o) => o,
@@ -894,7 +894,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let cache = self.core.cache();
         let open_orders = cache.orders_open(
             Some(&self.core.venue),
@@ -945,7 +945,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         if cmd.cancels.is_empty() {
             return Ok(());
         }
@@ -989,7 +989,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let http_client = self.http_client.clone();
         let emitter = self.emitter.clone();
         let clock = self.clock;
@@ -1001,7 +1001,7 @@ impl ExecutionClient for PolymarketExecutionClient {
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("Querying order: client_order_id={}", cmd.client_order_id);
 
         let venue_order_id = match &cmd.venue_order_id {

--- a/crates/adapters/polymarket/tests/exec_client.rs
+++ b/crates/adapters/polymarket/tests/exec_client.rs
@@ -615,7 +615,7 @@ async fn test_modify_order_emits_rejection() {
         params: None,
     };
 
-    client.modify_order(&cmd).unwrap();
+    client.modify_order(cmd).unwrap();
 
     // Should receive an order modify rejected event
     let event = rx.try_recv().unwrap();
@@ -683,7 +683,7 @@ async fn test_submit_market_order_denied_buy_without_quote_quantity() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let event = rx.try_recv().unwrap();
     assert_order_event(event, "Denied");
@@ -742,7 +742,7 @@ async fn test_submit_market_order_denied_sell_with_quote_quantity() {
         UnixNanos::default(),
     );
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let event = rx.try_recv().unwrap();
     assert_order_event(event, "Denied");
@@ -795,7 +795,7 @@ async fn test_submit_market_order_buy_accepted() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Market orders: Submitted comes from the async task (after book fetch)
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -843,7 +843,7 @@ async fn test_submit_market_order_buy_quote_to_base_conversion() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -898,7 +898,7 @@ async fn test_submit_market_order_sell_no_updated_event() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -935,7 +935,7 @@ async fn test_submit_market_order_rejected_empty_book() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Empty book should cause rejection
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -997,7 +997,7 @@ async fn test_fok_deferred_check_emits_rejected_for_unmatched() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -1189,7 +1189,7 @@ async fn test_submit_order_denied_for_reduce_only() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let event = rx.try_recv().unwrap();
     assert_order_event(event, "Denied");
@@ -1219,7 +1219,7 @@ async fn test_submit_order_denied_for_quote_quantity() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let event = rx.try_recv().unwrap();
     assert_order_event(event, "Denied");
@@ -1249,7 +1249,7 @@ async fn test_submit_order_denied_for_post_only_with_ioc() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     let event = rx.try_recv().unwrap();
     assert_order_event(event, "Denied");
@@ -1281,7 +1281,7 @@ async fn test_submit_order_post_only_with_gtc_allowed() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // First event should be Submitted (not Denied)
     let event = rx.try_recv().unwrap();
@@ -1314,7 +1314,7 @@ async fn test_submit_order_accepted_on_http_success() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted event
     let event = rx.try_recv().unwrap();
@@ -1355,7 +1355,7 @@ async fn test_submit_order_rejected_on_http_failure_response() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted
     let event = rx.try_recv().unwrap();
@@ -1397,7 +1397,7 @@ async fn test_submit_order_rejected_on_http_error() {
         .unwrap();
     let cmd = make_submit_cmd(&order, instrument_id);
 
-    client.submit_order(&cmd).unwrap();
+    client.submit_order(cmd).unwrap();
 
     // Submitted
     let event = rx.try_recv().unwrap();
@@ -1437,7 +1437,7 @@ async fn test_cancel_order_skips_non_open_order() {
         .unwrap();
 
     let cmd = make_cancel_cmd("O-CANCEL-INIT", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // CancelRejected is emitted synchronously for non-open orders
     let event = rx.try_recv().expect("Expected CancelRejected event");
@@ -1470,7 +1470,7 @@ async fn test_cancel_order_success_no_rejection_event() {
     submit_and_accept_order(&cache, &mut order, "0xvenue-cancel-ok");
 
     let cmd = make_cancel_cmd("O-CANCEL-OK", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // Wait briefly and verify no rejection event is emitted for a successful cancel
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1504,7 +1504,7 @@ async fn test_cancel_order_already_done_suppresses_rejection() {
     submit_and_accept_order(&cache, &mut order, "0xvenue-cancel-done");
 
     let cmd = make_cancel_cmd("O-CANCEL-DONE", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // CANCEL_ALREADY_DONE should suppress the rejection event
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1540,7 +1540,7 @@ async fn test_cancel_order_other_reason_emits_cancel_rejected() {
     submit_and_accept_order(&cache, &mut order, "0xvenue-cancel-fail");
 
     let cmd = make_cancel_cmd("O-CANCEL-FAIL", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -1636,7 +1636,7 @@ async fn test_batch_cancel_orders_with_partial_failure() {
         None,
     );
 
-    client.batch_cancel_orders(&cmd).unwrap();
+    client.batch_cancel_orders(cmd).unwrap();
 
     // Order 3 has CANCEL_ALREADY_DONE, so it should be suppressed.
     // No CancelRejected events expected.
@@ -1699,7 +1699,7 @@ async fn test_cancel_order_deferred_when_no_venue_order_id() {
 
     // Cancel should be deferred (no venue_order_id available)
     let cmd = make_cancel_cmd("O-DEFERRED-CANCEL", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // No events emitted yet
     assert!(rx.try_recv().is_err());
@@ -1707,7 +1707,7 @@ async fn test_cancel_order_deferred_when_no_venue_order_id() {
     // Submit the order, triggering the HTTP response with a venue_order_id.
     // handle_order_response detects the pending cancel and issues the deferred cancel.
     let submit_cmd = make_submit_cmd(&order, instrument_id);
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     // Submitted event (sync)
     let event = rx.try_recv().unwrap();
@@ -1757,10 +1757,10 @@ async fn test_cancel_order_deferred_with_already_done_response() {
     submit_and_pending_cancel(&cache, &mut order);
 
     let cmd = make_cancel_cmd("O-DEFERRED-DONE", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     let submit_cmd = make_submit_cmd(&order, instrument_id);
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     // Submitted
     let event = rx.try_recv().unwrap();
@@ -1811,10 +1811,10 @@ async fn test_cancel_order_deferred_with_rejection_response() {
     submit_and_pending_cancel(&cache, &mut order);
 
     let cmd = make_cancel_cmd("O-DEFERRED-REJECT", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     let submit_cmd = make_submit_cmd(&order, instrument_id);
-    client.submit_order(&submit_cmd).unwrap();
+    client.submit_order(submit_cmd).unwrap();
 
     // Submitted
     let event = rx.try_recv().unwrap();
@@ -1879,7 +1879,7 @@ async fn test_cancel_order_uses_cache_index_fallback() {
     // cancel_order should find the venue_order_id in the cache index
     // and send the cancel HTTP request directly (no deferred mechanism)
     let cmd = make_cancel_cmd("O-CACHE-FALLBACK", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // A successful cancel via the mock server produces no rejection event
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -1925,7 +1925,7 @@ async fn test_cancel_order_cache_fallback_with_rejection() {
         .unwrap();
 
     let cmd = make_cancel_cmd("O-CACHE-REJECT", instrument_id);
-    client.cancel_order(&cmd).unwrap();
+    client.cancel_order(cmd).unwrap();
 
     // The cancel hit the venue, received "order not found", emits CancelRejected
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -1957,10 +1957,11 @@ async fn test_query_order_does_not_block_within_runtime() {
         )),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
     // This must not panic with "Cannot start a runtime from within a runtime"
-    client.query_order(&cmd).unwrap();
+    client.query_order(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
@@ -1983,10 +1984,11 @@ async fn test_query_account_does_not_block_within_runtime() {
         AccountId::from("POLYMARKET-001"),
         UUID4::new(),
         UnixNanos::default(),
+        None,
     );
 
     // This must not panic with "Cannot start a runtime from within a runtime"
-    client.query_account(&cmd).unwrap();
+    client.query_account(cmd).unwrap();
 
     let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await

--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -665,7 +665,7 @@ impl ExecutionClient for SandboxExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         let mut order = self.get_order(&cmd.client_order_id)?;
 
         if order.is_closed() {
@@ -715,13 +715,13 @@ impl ExecutionClient for SandboxExecutionClient {
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let ts_init = self.clock.borrow().timestamp_ns();
 
         let orders: Vec<OrderAny> = self
             .cache
             .borrow()
-            .orders_for_ids(&cmd.order_list.client_order_ids, cmd);
+            .orders_for_ids(&cmd.order_list.client_order_ids, &cmd);
 
         for order in &orders {
             if order.is_closed() {
@@ -775,40 +775,40 @@ impl ExecutionClient for SandboxExecutionClient {
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let account_id = self.core.borrow().account_id;
 
         let mut inner = self.inner.borrow_mut();
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
-            engine.get_engine_mut().process_modify(cmd, account_id);
+            engine.get_engine_mut().process_modify(&cmd, account_id);
         }
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let account_id = self.core.borrow().account_id;
 
         let mut inner = self.inner.borrow_mut();
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
-            engine.get_engine_mut().process_cancel(cmd, account_id);
+            engine.get_engine_mut().process_cancel(&cmd, account_id);
         }
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let account_id = self.core.borrow().account_id;
 
         let mut inner = self.inner.borrow_mut();
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
-            engine.get_engine_mut().process_cancel_all(cmd, account_id);
+            engine.get_engine_mut().process_cancel_all(&cmd, account_id);
         }
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         let instrument_id = cmd.instrument_id;
         let account_id = self.core.borrow().account_id;
 
@@ -816,19 +816,19 @@ impl ExecutionClient for SandboxExecutionClient {
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
             engine
                 .get_engine_mut()
-                .process_batch_cancel(cmd, account_id);
+                .process_batch_cancel(&cmd, account_id);
         }
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         let balances = self.get_current_account_balances();
         let ts_event = self.clock.borrow().timestamp_ns();
         self.generate_account_state(balances, vec![], false, ts_event)?;
         Ok(())
     }
 
-    fn query_order(&self, _cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, _cmd: QueryOrder) -> anyhow::Result<()> {
         // Orders are tracked in the cache, no external query needed for sandbox
         Ok(())
     }

--- a/crates/adapters/tardis/src/data.rs
+++ b/crates/adapters/tardis/src/data.rs
@@ -472,17 +472,17 @@ impl DataClient for TardisDataClient {
         !self.is_connected()
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         log::info!("Subscribed mark prices for {}", cmd.instrument_id);
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         log::info!("Subscribed index prices for {}", cmd.instrument_id);
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         log::info!("Subscribed funding rates for {}", cmd.instrument_id);
         Ok(())
     }

--- a/crates/backtest/src/data_client.rs
+++ b/crates/backtest/src/data_client.rs
@@ -92,57 +92,54 @@ impl DataClient for BacktestDataClient {
         false
     }
 
-    fn subscribe(&mut self, _cmd: &SubscribeCustomData) -> anyhow::Result<()> {
+    fn subscribe(&mut self, _cmd: SubscribeCustomData) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, _cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, _cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, _cmd: SubscribeInstrument) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, _cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, _cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_book_depth10(&mut self, _cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, _cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, _cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, _cmd: SubscribeQuotes) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, _cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, _cmd: SubscribeTrades) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, _cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, _cmd: SubscribeBars) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, _cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, _cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, _cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, _cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         Ok(())
     }
 
     fn subscribe_instrument_status(
         &mut self,
-        _cmd: &SubscribeInstrumentStatus,
+        _cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn subscribe_instrument_close(
-        &mut self,
-        _cmd: &SubscribeInstrumentClose,
-    ) -> anyhow::Result<()> {
+    fn subscribe_instrument_close(&mut self, _cmd: SubscribeInstrumentClose) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -195,7 +195,7 @@ impl ExecutionClient for BacktestExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
         // Buffer the OrderSubmitted event for deferred processing to avoid
         // RefCell re-entrancy (exec_engine holds a borrow during execute)
         let order = self.get_order(&cmd.client_order_id)?;
@@ -204,22 +204,20 @@ impl ExecutionClient for BacktestExecutionClient {
         self.queued_events.borrow_mut().push(event);
 
         if let Some(exchange) = self.exchange.upgrade() {
-            exchange
-                .borrow_mut()
-                .send(TradingCommand::SubmitOrder(cmd.clone()));
+            exchange.borrow_mut().send(TradingCommand::SubmitOrder(cmd));
         } else {
             log::error!("submit_order: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let ts_init = self.clock.borrow().timestamp_ns();
 
         let orders: Vec<OrderAny> = self
             .cache
             .borrow()
-            .orders_for_ids(&cmd.order_list.client_order_ids, cmd);
+            .orders_for_ids(&cmd.order_list.client_order_ids, &cmd);
 
         // Buffer events for deferred processing
         let mut queued = self.queued_events.borrow_mut();
@@ -233,73 +231,67 @@ impl ExecutionClient for BacktestExecutionClient {
         if let Some(exchange) = self.exchange.upgrade() {
             exchange
                 .borrow_mut()
-                .send(TradingCommand::SubmitOrderList(cmd.clone()));
+                .send(TradingCommand::SubmitOrderList(cmd));
         } else {
             log::error!("submit_order_list: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
-            exchange
-                .borrow_mut()
-                .send(TradingCommand::ModifyOrder(cmd.clone()));
+            exchange.borrow_mut().send(TradingCommand::ModifyOrder(cmd));
         } else {
             log::error!("modify_order: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
-            exchange
-                .borrow_mut()
-                .send(TradingCommand::CancelOrder(cmd.clone()));
+            exchange.borrow_mut().send(TradingCommand::CancelOrder(cmd));
         } else {
             log::error!("cancel_order: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
             exchange
                 .borrow_mut()
-                .send(TradingCommand::CancelAllOrders(cmd.clone()));
+                .send(TradingCommand::CancelAllOrders(cmd));
         } else {
             log::error!("cancel_all_orders: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
             exchange
                 .borrow_mut()
-                .send(TradingCommand::BatchCancelOrders(cmd.clone()));
+                .send(TradingCommand::BatchCancelOrders(cmd));
         } else {
             log::error!("batch_cancel_orders: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn query_account(&self, cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, cmd: QueryAccount) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
             exchange
                 .borrow_mut()
-                .send(TradingCommand::QueryAccount(cmd.clone()));
+                .send(TradingCommand::QueryAccount(cmd));
         } else {
             log::error!("query_account: SimulatedExchange has been dropped");
         }
         Ok(())
     }
 
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         if let Some(exchange) = self.exchange.upgrade() {
-            exchange
-                .borrow_mut()
-                .send(TradingCommand::QueryOrder(cmd.clone()));
+            exchange.borrow_mut().send(TradingCommand::QueryOrder(cmd));
         } else {
             log::error!("query_order: SimulatedExchange has been dropped");
         }

--- a/crates/common/src/actor/data_actor.rs
+++ b/crates/common/src/actor/data_actor.rs
@@ -1376,6 +1376,7 @@ pub trait DataActor:
         strike_range: StrikeRange,
         snapshot_interval_ms: Option<u64>,
         client_id: Option<ClientId>,
+        params: Option<Params>,
     ) where
         Self: 'static + Debug + Sized,
     {
@@ -1398,6 +1399,7 @@ pub trait DataActor:
             strike_range,
             snapshot_interval_ms,
             client_id,
+            params,
         );
     }
 
@@ -3399,6 +3401,7 @@ impl DataActorCore {
     }
 
     /// Helper method for subscribing to option chain snapshots from the trait.
+    #[allow(clippy::too_many_arguments)]
     pub fn subscribe_option_chain(
         &mut self,
         topic: MStr<Topic>,
@@ -3407,6 +3410,7 @@ impl DataActorCore {
         strike_range: StrikeRange,
         snapshot_interval_ms: Option<u64>,
         client_id: Option<ClientId>,
+        params: Option<Params>,
     ) {
         self.check_registered();
 
@@ -3420,6 +3424,7 @@ impl DataActorCore {
             self.timestamp_ns(),
             client_id,
             Some(series_id.venue),
+            params,
         ));
 
         self.send_data_cmd(DataCommand::Subscribe(command));

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -1331,7 +1331,7 @@ fn test_subscribe_and_receive_option_chain(
         strikes_above: 5,
         strikes_below: 5,
     };
-    actor.subscribe_option_chain(series_id, strike_range, None, None);
+    actor.subscribe_option_chain(series_id, strike_range, None, None, None);
 
     let slice = OptionChainSlice {
         series_id,
@@ -1660,7 +1660,7 @@ fn test_unsubscribe_option_chain(
         strikes_above: 5,
         strikes_below: 5,
     };
-    actor.subscribe_option_chain(series_id, strike_range, None, None);
+    actor.subscribe_option_chain(series_id, strike_range, None, None, None);
 
     let slice = OptionChainSlice {
         series_id,

--- a/crates/common/src/clients/data.rs
+++ b/crates/common/src/clients/data.rs
@@ -116,7 +116,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe(&mut self, cmd: &SubscribeCustomData) -> anyhow::Result<()> {
+    fn subscribe(&mut self, cmd: SubscribeCustomData) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -126,7 +126,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_instruments(&mut self, cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, cmd: SubscribeInstruments) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -136,7 +136,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -146,7 +146,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -156,7 +156,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_book_depth10(&mut self, cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -166,7 +166,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -176,7 +176,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -186,7 +186,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -196,7 +196,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -206,7 +206,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -216,7 +216,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscribe operation fails.
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -228,7 +228,7 @@ pub trait DataClient {
     /// Returns an error if the subscribe operation fails.
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
@@ -239,7 +239,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_instrument_close(&mut self, cmd: &SubscribeInstrumentClose) -> anyhow::Result<()> {
+    fn subscribe_instrument_close(&mut self, cmd: SubscribeInstrumentClose) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -249,7 +249,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -260,7 +260,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_blocks(&mut self, cmd: &SubscribeBlocks) -> anyhow::Result<()> {
+    fn subscribe_blocks(&mut self, cmd: SubscribeBlocks) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -271,7 +271,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_pool(&mut self, cmd: &SubscribePool) -> anyhow::Result<()> {
+    fn subscribe_pool(&mut self, cmd: SubscribePool) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -282,7 +282,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_pool_swaps(&mut self, cmd: &SubscribePoolSwaps) -> anyhow::Result<()> {
+    fn subscribe_pool_swaps(&mut self, cmd: SubscribePoolSwaps) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -295,7 +295,7 @@ pub trait DataClient {
     /// Returns an error if the subscription operation fails.
     fn subscribe_pool_liquidity_updates(
         &mut self,
-        cmd: &SubscribePoolLiquidityUpdates,
+        cmd: SubscribePoolLiquidityUpdates,
     ) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
@@ -307,10 +307,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_pool_fee_collects(
-        &mut self,
-        cmd: &SubscribePoolFeeCollects,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_fee_collects(&mut self, cmd: SubscribePoolFeeCollects) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }
@@ -321,10 +318,7 @@ pub trait DataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription operation fails.
-    fn subscribe_pool_flash_events(
-        &mut self,
-        cmd: &SubscribePoolFlashEvents,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_flash_events(&mut self, cmd: SubscribePoolFlashEvents) -> anyhow::Result<()> {
         log_not_implemented(&cmd);
         Ok(())
     }

--- a/crates/common/src/clients/execution.rs
+++ b/crates/common/src/clients/execution.rs
@@ -100,8 +100,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if submission fails.
-    fn submit_order(&self, cmd: &SubmitOrder) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -110,8 +110,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if submission fails.
-    fn submit_order_list(&self, cmd: &SubmitOrderList) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -120,8 +120,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if modification fails.
-    fn modify_order(&self, cmd: &ModifyOrder) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -130,8 +130,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if cancellation fails.
-    fn cancel_order(&self, cmd: &CancelOrder) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -140,8 +140,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if cancellation fails.
-    fn cancel_all_orders(&self, cmd: &CancelAllOrders) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -150,8 +150,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if batch cancellation fails.
-    fn batch_cancel_orders(&self, cmd: &BatchCancelOrders) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn batch_cancel_orders(&self, cmd: BatchCancelOrders) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -160,8 +160,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if the query fails.
-    fn query_account(&self, cmd: &QueryAccount) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn query_account(&self, cmd: QueryAccount) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 
@@ -170,8 +170,8 @@ pub trait ExecutionClient {
     /// # Errors
     ///
     /// Returns an error if the query fails.
-    fn query_order(&self, cmd: &QueryOrder) -> anyhow::Result<()> {
-        log_not_implemented(cmd);
+    fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
+        log_not_implemented(&cmd);
         Ok(())
     }
 

--- a/crates/common/src/messages/data/mod.rs
+++ b/crates/common/src/messages/data/mod.rs
@@ -17,7 +17,7 @@
 
 use std::{any::Any, sync::Arc};
 
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{Params, UUID4, UnixNanos};
 use nautilus_model::{
     data::BarType,
     identifiers::{ClientId, Venue},
@@ -209,6 +209,27 @@ impl SubscribeCommand {
             Self::InstrumentClose(cmd) => cmd.correlation_id,
             Self::OptionGreeks(cmd) => cmd.correlation_id,
             Self::OptionChain(_) => None,
+        }
+    }
+
+    pub fn params(&self) -> Option<&Params> {
+        match self {
+            Self::Data(cmd) => cmd.params.as_ref(),
+            Self::Instrument(cmd) => cmd.params.as_ref(),
+            Self::Instruments(cmd) => cmd.params.as_ref(),
+            Self::BookDeltas(cmd) => cmd.params.as_ref(),
+            Self::BookDepth10(cmd) => cmd.params.as_ref(),
+            Self::BookSnapshots(cmd) => cmd.params.as_ref(),
+            Self::Quotes(cmd) => cmd.params.as_ref(),
+            Self::Trades(cmd) => cmd.params.as_ref(),
+            Self::Bars(cmd) => cmd.params.as_ref(),
+            Self::MarkPrices(cmd) => cmd.params.as_ref(),
+            Self::IndexPrices(cmd) => cmd.params.as_ref(),
+            Self::FundingRates(cmd) => cmd.params.as_ref(),
+            Self::InstrumentStatus(cmd) => cmd.params.as_ref(),
+            Self::InstrumentClose(cmd) => cmd.params.as_ref(),
+            Self::OptionGreeks(cmd) => cmd.params.as_ref(),
+            Self::OptionChain(cmd) => cmd.params.as_ref(),
         }
     }
 }

--- a/crates/common/src/messages/data/subscribe.rs
+++ b/crates/common/src/messages/data/subscribe.rs
@@ -584,10 +584,12 @@ pub struct SubscribeOptionChain {
     pub ts_init: UnixNanos,
     pub client_id: Option<ClientId>,
     pub venue: Option<Venue>,
+    pub params: Option<Params>,
 }
 
 impl SubscribeOptionChain {
     /// Creates a new [`SubscribeOptionChain`] instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         series_id: OptionSeriesId,
         strike_range: StrikeRange,
@@ -596,6 +598,7 @@ impl SubscribeOptionChain {
         ts_init: UnixNanos,
         client_id: Option<ClientId>,
         venue: Option<Venue>,
+        params: Option<Params>,
     ) -> Self {
         check_client_id_or_venue(&client_id, &venue);
         Self {
@@ -606,6 +609,7 @@ impl SubscribeOptionChain {
             ts_init,
             client_id,
             venue,
+            params,
         }
     }
 }

--- a/crates/common/src/messages/execution/mod.rs
+++ b/crates/common/src/messages/execution/mod.rs
@@ -21,7 +21,7 @@ pub mod query;
 pub mod report;
 pub mod submit;
 
-use nautilus_core::UnixNanos;
+use nautilus_core::{Params, UnixNanos};
 use nautilus_model::{
     identifiers::{ClientId, InstrumentId, StrategyId},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
@@ -123,6 +123,20 @@ impl TradingCommand {
             Self::BatchCancelOrders(command) => Some(command.strategy_id),
             Self::QueryOrder(command) => Some(command.strategy_id),
             Self::QueryAccount(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn params(&self) -> Option<&Params> {
+        match self {
+            Self::SubmitOrder(command) => command.params.as_ref(),
+            Self::SubmitOrderList(command) => command.params.as_ref(),
+            Self::ModifyOrder(command) => command.params.as_ref(),
+            Self::CancelOrder(command) => command.params.as_ref(),
+            Self::CancelAllOrders(command) => command.params.as_ref(),
+            Self::BatchCancelOrders(command) => command.params.as_ref(),
+            Self::QueryOrder(command) => command.params.as_ref(),
+            Self::QueryAccount(command) => command.params.as_ref(),
         }
     }
 }

--- a/crates/common/src/messages/execution/query.rs
+++ b/crates/common/src/messages/execution/query.rs
@@ -16,7 +16,7 @@
 use std::fmt::Display;
 
 use derive_builder::Builder;
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{Params, UUID4, UnixNanos};
 use nautilus_model::identifiers::{
     AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId, VenueOrderId,
 };
@@ -30,6 +30,7 @@ pub struct QueryAccount {
     pub account_id: AccountId,
     pub command_id: UUID4,
     pub ts_init: UnixNanos,
+    pub params: Option<Params>,
 }
 
 impl QueryAccount {
@@ -41,6 +42,7 @@ impl QueryAccount {
         account_id: AccountId,
         command_id: UUID4,
         ts_init: UnixNanos,
+        params: Option<Params>,
     ) -> Self {
         Self {
             trader_id,
@@ -48,6 +50,7 @@ impl QueryAccount {
             account_id,
             command_id,
             ts_init,
+            params,
         }
     }
 }
@@ -73,6 +76,7 @@ pub struct QueryOrder {
     pub venue_order_id: Option<VenueOrderId>,
     pub command_id: UUID4,
     pub ts_init: UnixNanos,
+    pub params: Option<Params>,
 }
 
 impl QueryOrder {
@@ -88,6 +92,7 @@ impl QueryOrder {
         venue_order_id: Option<VenueOrderId>,
         command_id: UUID4,
         ts_init: UnixNanos,
+        params: Option<Params>,
     ) -> Self {
         Self {
             trader_id,
@@ -98,6 +103,7 @@ impl QueryOrder {
             venue_order_id,
             command_id,
             ts_init,
+            params,
         }
     }
 }

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -1364,21 +1364,26 @@ impl PyDataActor {
     }
 
     #[pyo3(name = "subscribe_option_chain")]
-    #[pyo3(signature = (series_id, strike_range, snapshot_interval_ms=None, client_id=None))]
+    #[pyo3(signature = (series_id, strike_range, snapshot_interval_ms=None, client_id=None, params=None))]
     fn py_subscribe_option_chain(
         &mut self,
+        py: Python<'_>,
         series_id: OptionSeriesId,
         strike_range: PyStrikeRange,
         snapshot_interval_ms: Option<u64>,
         client_id: Option<ClientId>,
-    ) {
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params = dict_to_params(py, params)?;
         DataActor::subscribe_option_chain(
             self.inner_mut(),
             series_id,
             strike_range.inner,
             snapshot_interval_ms,
             client_id,
+            params,
         );
+        Ok(())
     }
 
     #[pyo3(name = "subscribe_order_fills")]

--- a/crates/common/src/serialization/capnp/trading.rs
+++ b/crates/common/src/serialization/capnp/trading.rs
@@ -602,6 +602,7 @@ mod tests {
             .venue_order_id(None)
             .command_id(command_id)
             .ts_init(ts_init)
+            .params(None)
             .build()
             .unwrap();
 
@@ -630,6 +631,7 @@ mod tests {
             .account_id(AccountId::new("ACC-001"))
             .command_id(command_id)
             .ts_init(ts_init)
+            .params(None)
             .build()
             .unwrap();
 

--- a/crates/data/src/client.rs
+++ b/crates/data/src/client.rs
@@ -194,7 +194,8 @@ impl DataClientAdapter {
     }
 
     #[inline]
-    pub fn execute_subscribe(&mut self, cmd: &SubscribeCommand) {
+    pub fn execute_subscribe(&mut self, cmd: SubscribeCommand) {
+        let cmd_debug = format!("{cmd:?}");
         if let Err(e) = match cmd {
             SubscribeCommand::Data(cmd) => self.subscribe(cmd),
             SubscribeCommand::Instrument(cmd) => self.subscribe_instrument(cmd),
@@ -213,7 +214,7 @@ impl DataClientAdapter {
             SubscribeCommand::OptionGreeks(cmd) => self.subscribe_option_greeks(cmd),
             SubscribeCommand::OptionChain(_) => Ok(()), // Handled internally by engine
         } {
-            log_command_error(&cmd, &e);
+            log_command_error(&cmd_debug, &e);
         }
     }
 
@@ -248,7 +249,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    pub fn subscribe(&mut self, cmd: &SubscribeCustomData) -> anyhow::Result<()> {
+    pub fn subscribe(&mut self, cmd: SubscribeCustomData) -> anyhow::Result<()> {
         if !self.subscriptions_custom.contains(&cmd.data_type) {
             self.subscriptions_custom.insert(cmd.data_type.clone());
             self.client.subscribe(cmd)?;
@@ -274,7 +275,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_instruments(&mut self, cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, cmd: SubscribeInstruments) -> anyhow::Result<()> {
         if !self.subscriptions_instrument_venue.contains(&cmd.venue) {
             self.subscriptions_instrument_venue.insert(cmd.venue);
             self.client.subscribe_instruments(cmd)?;
@@ -302,7 +303,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         if !self.subscriptions_instrument.contains(&cmd.instrument_id) {
             self.subscriptions_instrument.insert(cmd.instrument_id);
             self.client.subscribe_instrument(cmd)?;
@@ -330,7 +331,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if !self.subscriptions_book_deltas.contains(&cmd.instrument_id) {
             self.subscriptions_book_deltas.insert(cmd.instrument_id);
             self.client.subscribe_book_deltas(cmd)?;
@@ -358,7 +359,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_book_depth10(&mut self, cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         if !self.subscriptions_book_depth10.contains(&cmd.instrument_id) {
             self.subscriptions_book_depth10.insert(cmd.instrument_id);
             self.client.subscribe_book_depth10(cmd)?;
@@ -386,7 +387,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         if !self.subscriptions_quotes.contains(&cmd.instrument_id) {
             self.subscriptions_quotes.insert(cmd.instrument_id);
             self.client.subscribe_quotes(cmd)?;
@@ -412,7 +413,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         if !self.subscriptions_trades.contains(&cmd.instrument_id) {
             self.subscriptions_trades.insert(cmd.instrument_id);
             self.client.subscribe_trades(cmd)?;
@@ -438,7 +439,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         if !self.subscriptions_bars.contains(&cmd.bar_type) {
             self.subscriptions_bars.insert(cmd.bar_type);
             self.client.subscribe_bars(cmd)?;
@@ -464,7 +465,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         if !self.subscriptions_mark_prices.contains(&cmd.instrument_id) {
             self.subscriptions_mark_prices.insert(cmd.instrument_id);
             self.client.subscribe_mark_prices(cmd)?;
@@ -490,7 +491,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         if !self.subscriptions_index_prices.contains(&cmd.instrument_id) {
             self.subscriptions_index_prices.insert(cmd.instrument_id);
             self.client.subscribe_index_prices(cmd)?;
@@ -516,7 +517,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         if !self
             .subscriptions_funding_rates
             .contains(&cmd.instrument_id)
@@ -550,7 +551,7 @@ impl DataClientAdapter {
     /// Returns an error if the underlying client subscribe operation fails.
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         if !self
             .subscriptions_instrument_status
@@ -588,7 +589,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_instrument_close(&mut self, cmd: &SubscribeInstrumentClose) -> anyhow::Result<()> {
+    fn subscribe_instrument_close(&mut self, cmd: SubscribeInstrumentClose) -> anyhow::Result<()> {
         if !self
             .subscriptions_instrument_close
             .contains(&cmd.instrument_id)
@@ -625,7 +626,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         if !self
             .subscriptions_option_greeks
             .contains(&cmd.instrument_id)

--- a/crates/data/src/defi/client.rs
+++ b/crates/data/src/defi/client.rs
@@ -33,7 +33,8 @@ use crate::client::DataClientAdapter;
 
 impl DataClientAdapter {
     #[inline]
-    pub fn execute_defi_subscribe(&mut self, cmd: &DefiSubscribeCommand) {
+    pub fn execute_defi_subscribe(&mut self, cmd: DefiSubscribeCommand) {
+        let cmd_debug = format!("{cmd:?}");
         if let Err(e) = match cmd {
             DefiSubscribeCommand::Blocks(cmd) => self.subscribe_blocks(cmd),
             DefiSubscribeCommand::Pool(cmd) => self.subscribe_pool(cmd),
@@ -44,7 +45,7 @@ impl DataClientAdapter {
             DefiSubscribeCommand::PoolFeeCollects(cmd) => self.subscribe_pool_fee_collects(cmd),
             DefiSubscribeCommand::PoolFlashEvents(cmd) => self.subscribe_pool_flash_events(cmd),
         } {
-            log_command_error(&cmd, &e);
+            log_command_error(&cmd_debug, &e);
         }
     }
 
@@ -81,7 +82,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_blocks(&mut self, cmd: &SubscribeBlocks) -> anyhow::Result<()> {
+    fn subscribe_blocks(&mut self, cmd: SubscribeBlocks) -> anyhow::Result<()> {
         if !self.subscriptions_blocks.contains(&cmd.chain) {
             self.subscriptions_blocks.insert(cmd.chain);
             self.client.subscribe_blocks(cmd)?;
@@ -107,7 +108,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_pool(&mut self, cmd: &SubscribePool) -> anyhow::Result<()> {
+    fn subscribe_pool(&mut self, cmd: SubscribePool) -> anyhow::Result<()> {
         if !self.subscriptions_pools.contains(&cmd.instrument_id) {
             self.subscriptions_pools.insert(cmd.instrument_id);
             self.client.subscribe_pool(cmd)?;
@@ -120,7 +121,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_pool_swaps(&mut self, cmd: &SubscribePoolSwaps) -> anyhow::Result<()> {
+    fn subscribe_pool_swaps(&mut self, cmd: SubscribePoolSwaps) -> anyhow::Result<()> {
         if !self.subscriptions_pool_swaps.contains(&cmd.instrument_id) {
             self.subscriptions_pool_swaps.insert(cmd.instrument_id);
             self.client.subscribe_pool_swaps(cmd)?;
@@ -135,7 +136,7 @@ impl DataClientAdapter {
     /// Returns an error if the underlying client subscribe operation fails.
     fn subscribe_pool_liquidity_updates(
         &mut self,
-        cmd: &SubscribePoolLiquidityUpdates,
+        cmd: SubscribePoolLiquidityUpdates,
     ) -> anyhow::Result<()> {
         if !self
             .subscriptions_pool_liquidity_updates
@@ -153,10 +154,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_pool_fee_collects(
-        &mut self,
-        cmd: &SubscribePoolFeeCollects,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_fee_collects(&mut self, cmd: SubscribePoolFeeCollects) -> anyhow::Result<()> {
         if !self
             .subscriptions_pool_fee_collects
             .contains(&cmd.instrument_id)
@@ -173,10 +171,7 @@ impl DataClientAdapter {
     /// # Errors
     ///
     /// Returns an error if the underlying client subscribe operation fails.
-    fn subscribe_pool_flash_events(
-        &mut self,
-        cmd: &SubscribePoolFlashEvents,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_flash_events(&mut self, cmd: SubscribePoolFlashEvents) -> anyhow::Result<()> {
         if !self.subscriptions_pool_flash.contains(&cmd.instrument_id) {
             self.subscriptions_pool_flash.insert(cmd.instrument_id);
             self.client.subscribe_pool_flash_events(cmd)?;

--- a/crates/data/src/defi/engine.rs
+++ b/crates/data/src/defi/engine.rs
@@ -118,7 +118,7 @@ impl DataEngine {
     ///
     /// Returns an error if the subscription is invalid (e.g., synthetic instrument for book data),
     /// or if the underlying client operation fails.
-    pub fn execute_defi_subscribe(&mut self, cmd: &DefiSubscribeCommand) -> anyhow::Result<()> {
+    pub fn execute_defi_subscribe(&mut self, cmd: DefiSubscribeCommand) -> anyhow::Result<()> {
         if let Some(client_id) = cmd.client_id()
             && self.external_clients.contains(client_id)
         {
@@ -130,7 +130,7 @@ impl DataEngine {
 
         if let Some(client) = self.get_client(cmd.client_id(), cmd.venue()) {
             log::info!("Forwarding subscription to client {}", client.client_id);
-            client.execute_defi_subscribe(cmd);
+            client.execute_defi_subscribe(cmd.clone());
         } else {
             log::error!(
                 "Cannot handle command: no client found for client_id={:?}, venue={:?}",

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -737,13 +737,13 @@ impl DataEngine {
     /// Errors during execution are logged.
     pub fn execute(&mut self, cmd: DataCommand) {
         if let Err(e) = match cmd {
-            DataCommand::Subscribe(c) => self.execute_subscribe(&c),
+            DataCommand::Subscribe(c) => self.execute_subscribe(c),
             DataCommand::Unsubscribe(c) => self.execute_unsubscribe(&c),
             DataCommand::Request(c) => self.execute_request(c),
             #[cfg(feature = "defi")]
             DataCommand::DefiRequest(c) => self.execute_defi_request(c),
             #[cfg(feature = "defi")]
-            DataCommand::DefiSubscribe(c) => self.execute_defi_subscribe(&c),
+            DataCommand::DefiSubscribe(c) => self.execute_defi_subscribe(c),
             #[cfg(feature = "defi")]
             DataCommand::DefiUnsubscribe(c) => self.execute_defi_unsubscribe(&c),
             _ => {
@@ -761,7 +761,7 @@ impl DataEngine {
     ///
     /// Returns an error if the subscription is invalid (e.g., synthetic instrument for book data),
     /// or if the underlying client operation fails.
-    pub fn execute_subscribe(&mut self, cmd: &SubscribeCommand) -> anyhow::Result<()> {
+    pub fn execute_subscribe(&mut self, cmd: SubscribeCommand) -> anyhow::Result<()> {
         // Update internal engine state
         match &cmd {
             SubscribeCommand::BookDeltas(cmd) => self.subscribe_book_deltas(cmd)?,
@@ -1278,7 +1278,7 @@ impl DataEngine {
                     DeferredCommand::Subscribe(sub) => {
                         let client = self.get_client(sub.client_id(), sub.venue());
                         if let Some(client) = client {
-                            client.execute_subscribe(&sub);
+                            client.execute_subscribe(sub);
                         }
                     }
                     DeferredCommand::Unsubscribe(unsub) => {
@@ -1396,7 +1396,7 @@ impl DataEngine {
                 "Calling client.execute_subscribe for BookDeltas: {}",
                 cmd.instrument_id
             );
-            client.execute_subscribe(&SubscribeCommand::BookDeltas(deltas_cmd));
+            client.execute_subscribe(SubscribeCommand::BookDeltas(deltas_cmd));
         } else {
             log::error!(
                 "Cannot handle command: no client found for client_id={:?}, venue={:?}",

--- a/crates/data/src/option_chains/manager.rs
+++ b/crates/data/src/option_chains/manager.rs
@@ -246,7 +246,7 @@ impl OptionChainManager {
         };
 
         for instrument_id in instrument_ids {
-            client.execute_subscribe(&SubscribeCommand::Quotes(SubscribeQuotes {
+            client.execute_subscribe(SubscribeCommand::Quotes(SubscribeQuotes {
                 instrument_id: *instrument_id,
                 client_id: cmd.client_id,
                 venue: Some(venue),
@@ -255,7 +255,7 @@ impl OptionChainManager {
                 correlation_id: None,
                 params: None,
             }));
-            client.execute_subscribe(&SubscribeCommand::OptionGreeks(SubscribeOptionGreeks {
+            client.execute_subscribe(SubscribeCommand::OptionGreeks(SubscribeOptionGreeks {
                 instrument_id: *instrument_id,
                 client_id: cmd.client_id,
                 venue: Some(venue),
@@ -264,7 +264,7 @@ impl OptionChainManager {
                 correlation_id: None,
                 params: None,
             }));
-            client.execute_subscribe(&SubscribeCommand::InstrumentStatus(
+            client.execute_subscribe(SubscribeCommand::InstrumentStatus(
                 SubscribeInstrumentStatus {
                     instrument_id: *instrument_id,
                     client_id: cmd.client_id,
@@ -614,7 +614,7 @@ impl OptionChainManager {
 
         let ts_init = clock.borrow().timestamp_ns();
 
-        client.execute_subscribe(&SubscribeCommand::Quotes(SubscribeQuotes {
+        client.execute_subscribe(SubscribeCommand::Quotes(SubscribeQuotes {
             instrument_id,
             client_id: None,
             venue: Some(venue),
@@ -623,7 +623,7 @@ impl OptionChainManager {
             correlation_id: None,
             params: None,
         }));
-        client.execute_subscribe(&SubscribeCommand::OptionGreeks(SubscribeOptionGreeks {
+        client.execute_subscribe(SubscribeCommand::OptionGreeks(SubscribeOptionGreeks {
             instrument_id,
             client_id: None,
             venue: Some(venue),
@@ -632,7 +632,7 @@ impl OptionChainManager {
             correlation_id: None,
             params: None,
         }));
-        client.execute_subscribe(&SubscribeCommand::InstrumentStatus(
+        client.execute_subscribe(SubscribeCommand::InstrumentStatus(
             SubscribeInstrumentStatus {
                 instrument_id,
                 client_id: None,

--- a/crates/data/tests/client.rs
+++ b/crates/data/tests/client.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_clone)]
+
 // -------------------------------------------------------------------------------------------------
 //  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
 //  https://nautechsystems.io
@@ -136,11 +138,11 @@ fn test_custom_data_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_custom.contains(&data_type));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_custom.len(), 1);
 
     let unsub = UnsubscribeCommand::Data(UnsubscribeCustomData::new(
@@ -179,11 +181,11 @@ fn test_instrument_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_instrument.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_instrument.len(), 1);
 
     let unsub = UnsubscribeCommand::Instrument(UnsubscribeInstrument::new(
@@ -217,11 +219,11 @@ fn test_instruments_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_instrument_venue.contains(&venue));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_instrument_venue.len(), 1);
 
     let unsub = UnsubscribeCommand::Instruments(UnsubscribeInstruments::new(
@@ -262,11 +264,11 @@ fn test_book_deltas_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_book_deltas.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_book_deltas.len(), 1);
 
     let unsub = UnsubscribeCommand::BookDeltas(UnsubscribeBookDeltas::new(
@@ -308,11 +310,11 @@ fn test_book_depth10_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_book_depth10.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_book_depth10.len(), 1);
 
     let unsub = UnsubscribeCommand::BookDepth10(UnsubscribeBookDepth10::new(
@@ -350,11 +352,11 @@ fn test_quote_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_quotes.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_quotes.len(), 1);
 
     let unsub = UnsubscribeCommand::Quotes(UnsubscribeQuotes::new(
@@ -392,11 +394,11 @@ fn test_trades_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_trades.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_trades.len(), 1);
 
     let unsub = UnsubscribeCommand::Trades(UnsubscribeTrades::new(
@@ -434,11 +436,11 @@ fn test_mark_price_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_mark_prices.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_mark_prices.len(), 1);
 
     let unsub = UnsubscribeCommand::MarkPrices(UnsubscribeMarkPrices::new(
@@ -476,11 +478,11 @@ fn test_index_price_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_index_prices.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_index_prices.len(), 1);
 
     let unsub = UnsubscribeCommand::IndexPrices(UnsubscribeIndexPrices::new(
@@ -518,11 +520,11 @@ fn test_funding_rate_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_funding_rates.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_funding_rates.len(), 1);
 
     let unsub = UnsubscribeCommand::FundingRates(UnsubscribeFundingRates::new(
@@ -559,11 +561,11 @@ fn test_bars_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_bars.contains(&bar_type));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_bars.len(), 1);
 
     let unsub = UnsubscribeCommand::Bars(UnsubscribeBars::new(
@@ -601,11 +603,11 @@ fn test_instrument_status_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_instrument_status.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_instrument_status.len(), 1);
 
     let unsub = UnsubscribeCommand::InstrumentStatus(UnsubscribeInstrumentStatus::new(
@@ -643,11 +645,11 @@ fn test_instrument_close_subscription(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_instrument_close.contains(&inst_id));
 
     // Idempotency check
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_instrument_close.len(), 1);
 
     let unsub = UnsubscribeCommand::InstrumentClose(UnsubscribeInstrumentClose::new(
@@ -711,7 +713,7 @@ fn test_custom_data_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::Data(UnsubscribeCustomData::new(
         Some(client_id),
         Some(venue),
@@ -774,7 +776,7 @@ fn test_instrument_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::Instrument(UnsubscribeInstrument::new(
         inst_id,
         Some(client_id),
@@ -832,7 +834,7 @@ fn test_instruments_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
 
     let unsub = UnsubscribeCommand::Instruments(UnsubscribeInstruments::new(
         Some(client_id),
@@ -895,7 +897,7 @@ fn test_book_deltas_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
 
     let unsub = UnsubscribeCommand::BookDeltas(UnsubscribeBookDeltas::new(
         inst_id,
@@ -957,7 +959,7 @@ fn test_book_depth10_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::BookDepth10(UnsubscribeBookDepth10::new(
         inst_id,
         Some(client_id),
@@ -1014,7 +1016,7 @@ fn test_quotes_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::Quotes(UnsubscribeQuotes::new(
         inst_id,
         Some(client_id),
@@ -1071,7 +1073,7 @@ fn test_trades_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::Trades(UnsubscribeTrades::new(
         inst_id,
         Some(client_id),
@@ -1128,7 +1130,7 @@ fn test_bars_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::Bars(UnsubscribeBars::new(
         bar_type,
         Some(client_id),
@@ -1185,7 +1187,7 @@ fn test_mark_prices_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::MarkPrices(UnsubscribeMarkPrices::new(
         inst_id,
         Some(client_id),
@@ -1242,7 +1244,7 @@ fn test_index_prices_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::IndexPrices(UnsubscribeIndexPrices::new(
         inst_id,
         Some(client_id),
@@ -1301,7 +1303,7 @@ fn test_funding_rates_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     assert!(adapter.subscriptions_funding_rates.contains(&inst_id));
 
     let unsub = UnsubscribeCommand::FundingRates(UnsubscribeFundingRates::new(
@@ -1362,7 +1364,7 @@ fn test_instrument_status_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
     let unsub = UnsubscribeCommand::InstrumentStatus(UnsubscribeInstrumentStatus::new(
         inst_id,
         Some(client_id),
@@ -1420,7 +1422,7 @@ fn test_instrument_close_unsubscribe_idempotent(
         None,
         None,
     ));
-    adapter.execute_subscribe(&sub);
+    adapter.execute_subscribe(sub.clone());
 
     let unsub = UnsubscribeCommand::InstrumentClose(UnsubscribeInstrumentClose::new(
         inst_id,
@@ -1788,11 +1790,11 @@ fn test_defi_blocks_subscription(
         ts_init: UnixNanos::default(),
         params: None,
     });
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
     assert!(adapter.subscriptions_blocks.contains(&blockchain));
 
     // Idempotency check
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_blocks.len(), 1);
 
     let unsub = DefiUnsubscribeCommand::Blocks(UnsubscribeBlocks {
@@ -1827,11 +1829,11 @@ fn test_defi_pool_swaps_subscription(
         ts_init: UnixNanos::default(),
         params: None,
     });
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
     assert!(adapter.subscriptions_pool_swaps.contains(&instrument_id));
 
     // Idempotency check
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
     assert_eq!(adapter.subscriptions_pool_swaps.len(), 1);
 
     let unsub = DefiUnsubscribeCommand::PoolSwaps(UnsubscribePoolSwaps {
@@ -1890,7 +1892,7 @@ fn test_defi_blocks_unsubscribe_idempotent(
         ts_init: UnixNanos::default(),
         params: None,
     });
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
 
     let unsub = DefiUnsubscribeCommand::Blocks(UnsubscribeBlocks {
         chain: blockchain,
@@ -1955,7 +1957,7 @@ fn test_defi_pool_swaps_unsubscribe_idempotent(
         ts_init: UnixNanos::default(),
         params: None,
     });
-    adapter.execute_defi_subscribe(&sub);
+    adapter.execute_defi_subscribe(sub.clone());
 
     let unsub = DefiUnsubscribeCommand::PoolSwaps(UnsubscribePoolSwaps {
         instrument_id,

--- a/crates/data/tests/common/mocks.rs
+++ b/crates/data/tests/common/mocks.rs
@@ -19,6 +19,7 @@
 
 // Under development
 #![allow(dead_code)]
+#![allow(clippy::redundant_clone)]
 
 use std::{cell::RefCell, rc::Rc};
 
@@ -140,173 +141,151 @@ impl DataClient for MockDataClient {
 
     // -- SUBSCRIPTION HANDLERS -------------------------------------------------------------------
 
-    fn subscribe(&mut self, cmd: &SubscribeCustomData) -> anyhow::Result<()> {
+    fn subscribe(&mut self, cmd: SubscribeCustomData) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Data(cmd.clone())));
+                .push(DataCommand::Subscribe(SubscribeCommand::Data(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_instruments(&mut self, cmd: &SubscribeInstruments) -> anyhow::Result<()> {
+    fn subscribe_instruments(&mut self, cmd: SubscribeInstruments) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Instruments(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::Instruments(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_instrument(&mut self, cmd: &SubscribeInstrument) -> anyhow::Result<()> {
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Instrument(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::Instrument(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_book_deltas(&mut self, cmd: &SubscribeBookDeltas) -> anyhow::Result<()> {
+    fn subscribe_book_deltas(&mut self, cmd: SubscribeBookDeltas) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::BookDeltas(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::BookDeltas(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_book_depth10(&mut self, cmd: &SubscribeBookDepth10) -> anyhow::Result<()> {
+    fn subscribe_book_depth10(&mut self, cmd: SubscribeBookDepth10) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::BookDepth10(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::BookDepth10(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_quotes(&mut self, cmd: &SubscribeQuotes) -> anyhow::Result<()> {
+    fn subscribe_quotes(&mut self, cmd: SubscribeQuotes) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Quotes(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::Quotes(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_trades(&mut self, cmd: &SubscribeTrades) -> anyhow::Result<()> {
+    fn subscribe_trades(&mut self, cmd: SubscribeTrades) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Trades(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::Trades(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+    fn subscribe_bars(&mut self, cmd: SubscribeBars) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::Bars(cmd.clone())));
+                .push(DataCommand::Subscribe(SubscribeCommand::Bars(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_mark_prices(&mut self, cmd: &SubscribeMarkPrices) -> anyhow::Result<()> {
+    fn subscribe_mark_prices(&mut self, cmd: SubscribeMarkPrices) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::MarkPrices(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::MarkPrices(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_index_prices(&mut self, cmd: &SubscribeIndexPrices) -> anyhow::Result<()> {
+    fn subscribe_index_prices(&mut self, cmd: SubscribeIndexPrices) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::IndexPrices(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::IndexPrices(cmd)));
         }
         Ok(())
     }
 
-    fn subscribe_funding_rates(&mut self, cmd: &SubscribeFundingRates) -> anyhow::Result<()> {
+    fn subscribe_funding_rates(&mut self, cmd: SubscribeFundingRates) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::FundingRates(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::FundingRates(cmd)));
         }
         Ok(())
     }
 
     fn subscribe_instrument_status(
         &mut self,
-        cmd: &SubscribeInstrumentStatus,
+        cmd: SubscribeInstrumentStatus,
     ) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
                 .push(DataCommand::Subscribe(SubscribeCommand::InstrumentStatus(
-                    cmd.clone(),
+                    cmd,
                 )));
         }
         Ok(())
     }
 
-    fn subscribe_instrument_close(&mut self, cmd: &SubscribeInstrumentClose) -> anyhow::Result<()> {
+    fn subscribe_instrument_close(&mut self, cmd: SubscribeInstrumentClose) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
                 .push(DataCommand::Subscribe(SubscribeCommand::InstrumentClose(
-                    cmd.clone(),
+                    cmd,
                 )));
         }
         Ok(())
     }
 
-    fn subscribe_option_greeks(&mut self, cmd: &SubscribeOptionGreeks) -> anyhow::Result<()> {
+    fn subscribe_option_greeks(&mut self, cmd: SubscribeOptionGreeks) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::Subscribe(SubscribeCommand::OptionGreeks(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::Subscribe(SubscribeCommand::OptionGreeks(cmd)));
         }
         Ok(())
     }
 
     #[cfg(feature = "defi")]
-    fn subscribe_blocks(&mut self, cmd: &SubscribeBlocks) -> anyhow::Result<()> {
+    fn subscribe_blocks(&mut self, cmd: SubscribeBlocks) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
                 .push(DataCommand::DefiSubscribe(DefiSubscribeCommand::Blocks(
-                    cmd.clone(),
+                    cmd,
                 )));
         }
         Ok(())
     }
 
     #[cfg(feature = "defi")]
-    fn subscribe_pool(&mut self, cmd: &SubscribePool) -> anyhow::Result<()> {
+    fn subscribe_pool(&mut self, cmd: SubscribePool) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
-                .push(DataCommand::DefiSubscribe(DefiSubscribeCommand::Pool(
-                    cmd.clone(),
-                )));
+                .push(DataCommand::DefiSubscribe(DefiSubscribeCommand::Pool(cmd)));
         }
         Ok(())
     }
 
     #[cfg(feature = "defi")]
-    fn subscribe_pool_swaps(&mut self, cmd: &SubscribePoolSwaps) -> anyhow::Result<()> {
+    fn subscribe_pool_swaps(&mut self, cmd: SubscribePoolSwaps) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut()
                 .push(DataCommand::DefiSubscribe(DefiSubscribeCommand::PoolSwaps(
-                    cmd.clone(),
+                    cmd,
                 )));
         }
         Ok(())
@@ -315,37 +294,31 @@ impl DataClient for MockDataClient {
     #[cfg(feature = "defi")]
     fn subscribe_pool_liquidity_updates(
         &mut self,
-        cmd: &SubscribePoolLiquidityUpdates,
+        cmd: SubscribePoolLiquidityUpdates,
     ) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut().push(DataCommand::DefiSubscribe(
-                DefiSubscribeCommand::PoolLiquidityUpdates(cmd.clone()),
+                DefiSubscribeCommand::PoolLiquidityUpdates(cmd),
             ));
         }
         Ok(())
     }
 
     #[cfg(feature = "defi")]
-    fn subscribe_pool_fee_collects(
-        &mut self,
-        cmd: &SubscribePoolFeeCollects,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_fee_collects(&mut self, cmd: SubscribePoolFeeCollects) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut().push(DataCommand::DefiSubscribe(
-                DefiSubscribeCommand::PoolFeeCollects(cmd.clone()),
+                DefiSubscribeCommand::PoolFeeCollects(cmd),
             ));
         }
         Ok(())
     }
 
     #[cfg(feature = "defi")]
-    fn subscribe_pool_flash_events(
-        &mut self,
-        cmd: &SubscribePoolFlashEvents,
-    ) -> anyhow::Result<()> {
+    fn subscribe_pool_flash_events(&mut self, cmd: SubscribePoolFlashEvents) -> anyhow::Result<()> {
         if let Some(rec) = &self.recorder {
             rec.borrow_mut().push(DataCommand::DefiSubscribe(
-                DefiSubscribeCommand::PoolFlashEvents(cmd.clone()),
+                DefiSubscribeCommand::PoolFlashEvents(cmd),
             ));
         }
         Ok(())

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -4490,6 +4490,7 @@ fn make_subscribe_option_chain(
         UnixNanos::default(),
         client_id,
         venue,
+        None,
     )))
 }
 
@@ -4898,6 +4899,7 @@ fn test_subscribe_option_chain_atm_relative_requests_forward_prices(
         UnixNanos::default(),
         Some(client_id),
         Some(venue),
+        None,
     )));
     data_engine.borrow_mut().execute(cmd);
 

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -151,7 +151,7 @@ impl ExecutionEngine {
             MessagingSwitchboard::exec_engine_execute(),
             TypedIntoHandler::from(move |cmd: TradingCommand| {
                 if let Some(rc) = weak1.upgrade() {
-                    rc.borrow().execute(&cmd);
+                    rc.borrow().execute(cmd);
                 }
             }),
         );
@@ -1233,7 +1233,7 @@ impl ExecutionEngine {
     }
 
     /// Executes a trading command by routing it to the appropriate execution client.
-    pub fn execute(&self, command: &TradingCommand) {
+    pub fn execute(&self, command: TradingCommand) {
         self.execute_command(command);
     }
 
@@ -1270,7 +1270,7 @@ impl ExecutionEngine {
         log::info!("Disposed");
     }
 
-    fn execute_command(&self, command: &TradingCommand) {
+    fn execute_command(&self, command: TradingCommand) {
         if self.config.debug {
             log::debug!("{RECV}{CMD} {command:?}");
         }
@@ -1321,7 +1321,7 @@ impl ExecutionEngine {
                     let orders: Vec<OrderAny> = self
                         .cache
                         .borrow()
-                        .orders_for_ids(&cmd.order_list.client_order_ids, cmd);
+                        .orders_for_ids(&cmd.order_list.client_order_ids, &cmd);
 
                     for order in &orders {
                         self.deny_order(order, &reason);
@@ -1345,7 +1345,7 @@ impl ExecutionEngine {
         }
     }
 
-    fn handle_submit_order(&self, client: &dyn ExecutionClient, cmd: &SubmitOrder) {
+    fn handle_submit_order(&self, client: &dyn ExecutionClient, cmd: SubmitOrder) {
         let client_order_id = cmd.client_order_id;
 
         let order = {
@@ -1397,11 +1397,11 @@ impl ExecutionEngine {
         }
     }
 
-    fn handle_submit_order_list(&self, client: &dyn ExecutionClient, cmd: &SubmitOrderList) {
+    fn handle_submit_order_list(&self, client: &dyn ExecutionClient, cmd: SubmitOrderList) {
         let orders: Vec<OrderAny> = self
             .cache
             .borrow()
-            .orders_for_ids(&cmd.order_list.client_order_ids, cmd);
+            .orders_for_ids(&cmd.order_list.client_order_ids, &cmd);
 
         if orders.len() != cmd.order_list.client_order_ids.len() {
             for order in &orders {
@@ -1463,37 +1463,37 @@ impl ExecutionEngine {
         }
     }
 
-    fn handle_modify_order(&self, client: &dyn ExecutionClient, cmd: &ModifyOrder) {
+    fn handle_modify_order(&self, client: &dyn ExecutionClient, cmd: ModifyOrder) {
         if let Err(e) = client.modify_order(cmd) {
             log::error!("Error modifying order: {e}");
         }
     }
 
-    fn handle_cancel_order(&self, client: &dyn ExecutionClient, cmd: &CancelOrder) {
+    fn handle_cancel_order(&self, client: &dyn ExecutionClient, cmd: CancelOrder) {
         if let Err(e) = client.cancel_order(cmd) {
             log::error!("Error canceling order: {e}");
         }
     }
 
-    fn handle_cancel_all_orders(&self, client: &dyn ExecutionClient, cmd: &CancelAllOrders) {
+    fn handle_cancel_all_orders(&self, client: &dyn ExecutionClient, cmd: CancelAllOrders) {
         if let Err(e) = client.cancel_all_orders(cmd) {
             log::error!("Error canceling all orders: {e}");
         }
     }
 
-    fn handle_batch_cancel_orders(&self, client: &dyn ExecutionClient, cmd: &BatchCancelOrders) {
+    fn handle_batch_cancel_orders(&self, client: &dyn ExecutionClient, cmd: BatchCancelOrders) {
         if let Err(e) = client.batch_cancel_orders(cmd) {
             log::error!("Error batch canceling orders: {e}");
         }
     }
 
-    fn handle_query_account(&self, client: &dyn ExecutionClient, cmd: &QueryAccount) {
+    fn handle_query_account(&self, client: &dyn ExecutionClient, cmd: QueryAccount) {
         if let Err(e) = client.query_account(cmd) {
             log::error!("Error querying account: {e}");
         }
     }
 
-    fn handle_query_order(&self, client: &dyn ExecutionClient, cmd: &QueryOrder) {
+    fn handle_query_order(&self, client: &dyn ExecutionClient, cmd: QueryOrder) {
         if let Err(e) = client.query_order(cmd) {
             log::error!("Error querying order: {e}");
         }

--- a/crates/execution/src/engine/stubs.rs
+++ b/crates/execution/src/engine/stubs.rs
@@ -117,35 +117,35 @@ impl ExecutionClient for StubExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, _cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, _cmd: SubmitOrder) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn submit_order_list(&self, _cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, _cmd: SubmitOrderList) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn modify_order(&self, _cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, _cmd: ModifyOrder) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn cancel_order(&self, _cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, _cmd: CancelOrder) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn cancel_all_orders(&self, _cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, _cmd: CancelAllOrders) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn batch_cancel_orders(&self, _cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, _cmd: BatchCancelOrders) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 
-    fn query_order(&self, _cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, _cmd: QueryOrder) -> anyhow::Result<()> {
         Ok(()) // Stub implementation always succeeds
     }
 }

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -333,11 +333,11 @@ fn test_submit_order_with_duplicate_client_order_id_handles_gracefully(
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order.clone()));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order.clone()));
 
     let order_submitted_event = TestOrderEventStubs::submitted(&order, AccountId::test_default());
     execution_engine.process(&order_submitted_event);
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     assert!(
         execution_engine
@@ -421,7 +421,7 @@ fn test_submit_order_for_random_venue_logs(mut execution_engine: ExecutionEngine
         ts_init: UnixNanos::default(),
     };
     // This should find the client by venue routing since instrument is AUD/USD.SIM
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
     let cache = execution_engine.cache().borrow();
     assert!(
         cache.order_exists(&order.client_order_id()),
@@ -605,7 +605,7 @@ fn test_submit_bracket_order_list_with_all_duplicate_client_order_id_logs_does_n
             .unwrap();
     }
 
-    execution_engine.execute(&TradingCommand::SubmitOrderList(submit_order_list.clone()));
+    execution_engine.execute(TradingCommand::SubmitOrderList(submit_order_list.clone()));
     let entry_submitted = TestOrderEventStubs::submitted(&entry, AccountId::test_default());
     execution_engine.process(&entry_submitted);
 
@@ -631,7 +631,7 @@ fn test_submit_bracket_order_list_with_all_duplicate_client_order_id_logs_does_n
         .expect("Take profit order should exist")
         .clone();
     drop(cache);
-    execution_engine.execute(&TradingCommand::SubmitOrderList(submit_order_list));
+    execution_engine.execute(TradingCommand::SubmitOrderList(submit_order_list));
     assert_eq!(
         entry_updated.status(),
         OrderStatus::Submitted,
@@ -718,7 +718,7 @@ fn test_submit_order_successfully_processes_and_caches_order(
         instrument_id: instrument.id,
         exec_algorithm_id: None,
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
     let cache = execution_engine.cache().borrow();
     assert!(
         cache.order_exists(&order.client_order_id()),
@@ -810,7 +810,7 @@ fn test_submit_order_with_cleared_cache_logs_error(mut execution_engine: Executi
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
     assert!(
         execution_engine
             .cache()
@@ -901,7 +901,7 @@ fn test_when_applying_event_to_order_with_invalid_state_trigger_logs(
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
     assert!(
         execution_engine
             .cache()
@@ -1051,7 +1051,7 @@ fn test_cancel_order_for_already_closed_order_logs_and_does_nothing(
     };
 
     // Submit and process order through full lifecycle to FILLED status
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let order_submitted_event = TestOrderEventStubs::submitted(&order, AccountId::test_default());
     execution_engine.process(&order_submitted_event);
@@ -1109,7 +1109,7 @@ fn test_cancel_order_for_already_closed_order_logs_and_does_nothing(
         params: None,
     };
 
-    execution_engine.execute(&TradingCommand::CancelOrder(cancel_order));
+    execution_engine.execute(TradingCommand::CancelOrder(cancel_order));
     let order_status_after_cancel = {
         let cache = execution_engine.cache().borrow();
         let cached_order_after_cancel = cache
@@ -1573,7 +1573,7 @@ fn test_modify_order_for_already_closed_order_logs_and_does_nothing(
         ts_init: UnixNanos::default(),
         params: None,
     };
-    execution_engine.execute(&TradingCommand::ModifyOrder(modify_order));
+    execution_engine.execute(TradingCommand::ModifyOrder(modify_order));
     let cache = execution_engine.cache().borrow();
     let order_after = cache
         .order(&order.client_order_id())
@@ -4767,7 +4767,7 @@ fn test_submit_market_should_not_add_to_own_book() {
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let cache = execution_engine.cache().borrow();
     let own_order_book = cache.own_order_book(&order.instrument_id());
@@ -4846,7 +4846,7 @@ fn test_submit_ioc_fok_should_not_add_to_own_book(#[case] time_in_force: TimeInF
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let cache = execution_engine.cache().borrow();
     let own_order_book = cache.own_order_book(&order.instrument_id());
@@ -4922,7 +4922,7 @@ fn test_submit_order_adds_to_own_book_bid() {
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let cache = execution_engine.cache().borrow();
     let own_book = cache
@@ -5069,7 +5069,7 @@ fn test_submit_order_adds_to_own_book_ask() {
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let cache = execution_engine.cache().borrow();
     let own_book = cache
@@ -5247,8 +5247,8 @@ fn test_cancel_order_removes_from_own_book() {
     };
 
     // Submit orders to create own order books
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_bid));
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_ask));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_bid));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_ask));
     let order_submitted_bid = TestOrderEventStubs::submitted(&order_bid, account_id);
     let order_submitted_ask = TestOrderEventStubs::submitted(&order_ask, account_id);
     execution_engine.process(&order_submitted_bid);
@@ -5285,8 +5285,8 @@ fn test_cancel_order_removes_from_own_book() {
         params: None,
     };
 
-    execution_engine.execute(&TradingCommand::CancelOrder(cancel_order_bid));
-    execution_engine.execute(&TradingCommand::CancelOrder(cancel_order_ask));
+    execution_engine.execute(TradingCommand::CancelOrder(cancel_order_bid));
+    execution_engine.execute(TradingCommand::CancelOrder(cancel_order_ask));
 
     let order_canceled_bid =
         TestOrderEventStubs::canceled(&order_bid, account_id, Some(VenueOrderId::from("V-001")));
@@ -5411,8 +5411,8 @@ fn test_own_book_status_filtering() {
     };
 
     // Submit orders to create own order books
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_bid));
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_ask));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_bid));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_ask));
     let order_submitted_bid = TestOrderEventStubs::submitted(&order_bid, account_id);
     let order_submitted_ask = TestOrderEventStubs::submitted(&order_ask, account_id);
     execution_engine.process(&order_submitted_bid);
@@ -5449,8 +5449,8 @@ fn test_own_book_status_filtering() {
         params: None,
     };
 
-    execution_engine.execute(&TradingCommand::CancelOrder(cancel_order_bid));
-    execution_engine.execute(&TradingCommand::CancelOrder(cancel_order_ask));
+    execution_engine.execute(TradingCommand::CancelOrder(cancel_order_bid));
+    execution_engine.execute(TradingCommand::CancelOrder(cancel_order_ask));
 
     let order_canceled_bid =
         TestOrderEventStubs::canceled(&order_bid, account_id, Some(VenueOrderId::from("V-001")));
@@ -5613,8 +5613,8 @@ fn test_filled_order_removes_from_own_book() {
     };
 
     // Submit orders to create own order books
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_bid));
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_ask));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_bid));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_ask));
     let order_submitted_bid = TestOrderEventStubs::submitted(&order_bid, account_id);
     let order_submitted_ask = TestOrderEventStubs::submitted(&order_ask, account_id);
     execution_engine.process(&order_submitted_bid);
@@ -5813,8 +5813,8 @@ fn test_order_updates_in_own_book() {
     };
 
     // Submit orders to create own order books
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_bid));
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order_ask));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_bid));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order_ask));
     let order_submitted_bid = TestOrderEventStubs::submitted(&order_bid, account_id);
     let order_submitted_ask = TestOrderEventStubs::submitted(&order_ask, account_id);
     execution_engine.process(&order_submitted_bid);
@@ -6023,7 +6023,7 @@ fn test_position_flip_with_own_order_book() {
     };
 
     // Submit buy order to create own order book
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_buy_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_buy_order));
 
     let order_submitted_buy = TestOrderEventStubs::submitted(&buy_order, account_id);
     let order_accepted_buy =
@@ -6113,7 +6113,7 @@ fn test_position_flip_with_own_order_book() {
         ts_init: UnixNanos::default(),
     };
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_sell_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_sell_order));
 
     let order_submitted_sell = TestOrderEventStubs::submitted(&sell_order, account_id);
     let order_accepted_sell =
@@ -6293,8 +6293,8 @@ fn test_own_book_with_crossed_orders() {
     };
 
     // Submit orders to create own order books
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_buy_order));
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_sell_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_buy_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_sell_order));
     let order_submitted_buy = TestOrderEventStubs::submitted(&buy_order, account_id);
     let order_submitted_sell = TestOrderEventStubs::submitted(&sell_order, account_id);
     execution_engine.process(&order_submitted_buy);
@@ -6483,10 +6483,10 @@ fn test_own_book_with_contingent_orders() {
         .add_order(sl_order.clone(), None, Some(ClientId::from("STUB")), true)
         .unwrap();
 
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_entry_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_entry_order));
 
     // Submit TP order (in a real bracket, this would be contingent but for testing we submit it)
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_tp_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_tp_order));
 
     let entry_submitted_event = TestOrderEventStubs::submitted(&entry_order, account_id);
     execution_engine.process(&entry_submitted_event);
@@ -6559,7 +6559,7 @@ fn test_own_book_with_contingent_orders() {
     execution_engine.process(&entry_filled_event);
 
     // Submit and process SL order after entry is filled
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_sl_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_sl_order));
 
     let sl_submitted_event = TestOrderEventStubs::submitted(&sl_order, account_id);
     execution_engine.process(&sl_submitted_event);
@@ -6691,7 +6691,7 @@ fn test_own_book_order_status_filtering_parameterized(
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     for step in process_steps {
         match step {
@@ -6932,7 +6932,7 @@ fn test_own_book_combined_status_filtering() {
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_initialized));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_initialized));
 
     // 2. Submit and process submitted_order (becomes SUBMITTED)
     let submit_submitted = SubmitOrder {
@@ -6948,7 +6948,7 @@ fn test_own_book_combined_status_filtering() {
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_submitted));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_submitted));
     let submitted_event = TestOrderEventStubs::submitted(&submitted_order, account_id);
     execution_engine.process(&submitted_event);
 
@@ -6966,7 +6966,7 @@ fn test_own_book_combined_status_filtering() {
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_accepted));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_accepted));
     let accepted_submitted_event = TestOrderEventStubs::submitted(&accepted_order, account_id);
     execution_engine.process(&accepted_submitted_event);
     let accepted_accepted_event =
@@ -6987,7 +6987,7 @@ fn test_own_book_combined_status_filtering() {
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
     };
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_partial));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_partial));
     let partial_submitted_event =
         TestOrderEventStubs::submitted(&partially_filled_order, account_id);
     execution_engine.process(&partial_submitted_event);
@@ -7164,7 +7164,7 @@ fn test_own_book_status_integrity_during_transitions() {
             command_id: UUID4::new(),
             ts_init: UnixNanos::default(),
         };
-        execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+        execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
         let submitted_event = TestOrderEventStubs::submitted(&order, account_id);
         execution_engine.process(&submitted_event);
@@ -8585,7 +8585,7 @@ fn test_submit_order_with_no_client_denies_order(execution_engine: ExecutionEngi
     };
 
     // No clients registered, no default client: should deny the order
-    execution_engine.execute(&TradingCommand::SubmitOrder(submit_order));
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
 
     let cache = execution_engine.cache().borrow();
     let cached_order = cache.order(&order.client_order_id()).unwrap();
@@ -8687,7 +8687,7 @@ fn test_submit_order_list_with_no_client_denies_all_orders(execution_engine: Exe
     };
 
     // No clients registered: all child orders should be denied
-    execution_engine.execute(&TradingCommand::SubmitOrderList(submit_order_list));
+    execution_engine.execute(TradingCommand::SubmitOrderList(submit_order_list));
 
     let cache = execution_engine.cache().borrow();
     let cached_entry = cache.order(&entry.client_order_id()).unwrap();

--- a/crates/live/src/manager.rs
+++ b/crates/live/src/manager.rs
@@ -881,6 +881,7 @@ impl ExecutionManager {
                         order.venue_order_id(),
                         UUID4::new(),
                         current_time,
+                        None,
                     ));
                     result.queries.push(query);
                 }

--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -1966,6 +1966,7 @@ mod tests {
             AccountId::from("TEST-001"),
             UUID4::new(),
             UnixNanos::default(),
+            None,
         ))
     }
 

--- a/crates/live/src/python/node.rs
+++ b/crates/live/src/python/node.rs
@@ -21,12 +21,12 @@ use nautilus_common::{
     actor::data_actor::ImportableActorConfig, cache::CacheConfig, enums::Environment,
     live::get_runtime, logging::logger::LoggerConfig, python::actor::PyDataActor,
 };
-use nautilus_core::UUID4;
-#[allow(
-    unused_imports,
-    reason = "to_pytype_err used in cfg(feature = examples) methods"
-)]
-use nautilus_core::python::{to_pyruntime_err, to_pytype_err, to_pyvalue_err};
+#[cfg(feature = "examples")]
+use nautilus_core::python::to_pytype_err;
+use nautilus_core::{
+    UUID4,
+    python::{to_pyruntime_err, to_pyvalue_err},
+};
 use nautilus_model::identifiers::{ActorId, ComponentId, ExecAlgorithmId, StrategyId, TraderId};
 use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_system::get_global_pyo3_registry;

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -6469,35 +6469,35 @@ impl ExecutionClient for MockExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, _cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, _cmd: SubmitOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn submit_order_list(&self, _cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, _cmd: SubmitOrderList) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn modify_order(&self, _cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, _cmd: ModifyOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn cancel_order(&self, _cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, _cmd: CancelOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, _cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, _cmd: CancelAllOrders) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, _cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, _cmd: BatchCancelOrders) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn query_order(&self, _cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, _cmd: QueryOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -6928,35 +6928,35 @@ impl ExecutionClient for MockPositionExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, _cmd: &SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, _cmd: SubmitOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn submit_order_list(&self, _cmd: &SubmitOrderList) -> anyhow::Result<()> {
+    fn submit_order_list(&self, _cmd: SubmitOrderList) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn modify_order(&self, _cmd: &ModifyOrder) -> anyhow::Result<()> {
+    fn modify_order(&self, _cmd: ModifyOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn cancel_order(&self, _cmd: &CancelOrder) -> anyhow::Result<()> {
+    fn cancel_order(&self, _cmd: CancelOrder) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn cancel_all_orders(&self, _cmd: &CancelAllOrders) -> anyhow::Result<()> {
+    fn cancel_all_orders(&self, _cmd: CancelAllOrders) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn batch_cancel_orders(&self, _cmd: &BatchCancelOrders) -> anyhow::Result<()> {
+    fn batch_cancel_orders(&self, _cmd: BatchCancelOrders) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn query_account(&self, _cmd: &QueryAccount) -> anyhow::Result<()> {
+    fn query_account(&self, _cmd: QueryAccount) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn query_order(&self, _cmd: &QueryOrder) -> anyhow::Result<()> {
+    fn query_order(&self, _cmd: QueryOrder) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -1500,25 +1500,38 @@ impl PyStrategy {
     }
 
     #[pyo3(name = "query_account")]
-    #[pyo3(signature = (account_id, client_id=None))]
+    #[pyo3(signature = (account_id, client_id=None, params=None))]
     fn py_query_account(
         &mut self,
+        py: Python<'_>,
         account_id: AccountId,
         client_id: Option<ClientId>,
+        params: Option<Py<PyDict>>,
     ) -> PyResult<()> {
-        Strategy::query_account(self.inner_mut(), account_id, client_id).map_err(to_pyruntime_err)
+        let params_map = match params {
+            Some(dict) => from_pydict(py, dict)?,
+            None => None,
+        };
+        Strategy::query_account(self.inner_mut(), account_id, client_id, params_map)
+            .map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "query_order")]
-    #[pyo3(signature = (order, client_id=None))]
+    #[pyo3(signature = (order, client_id=None, params=None))]
     fn py_query_order(
         &mut self,
         py: Python<'_>,
         order: Py<PyAny>,
         client_id: Option<ClientId>,
+        params: Option<Py<PyDict>>,
     ) -> PyResult<()> {
         let order = pyobject_to_order_any(py, order)?;
-        Strategy::query_order(self.inner_mut(), &order, client_id).map_err(to_pyruntime_err)
+        let params_map = match params {
+            Some(dict) => from_pydict(py, dict)?,
+            None => None,
+        };
+        Strategy::query_order(self.inner_mut(), &order, client_id, params_map)
+            .map_err(to_pyruntime_err)
     }
 
     #[pyo3(name = "on_start")]
@@ -2014,21 +2027,29 @@ impl PyStrategy {
     }
 
     #[pyo3(name = "subscribe_option_chain")]
-    #[pyo3(signature = (series_id, strike_range, snapshot_interval_ms=None, client_id=None))]
+    #[pyo3(signature = (series_id, strike_range, snapshot_interval_ms=None, client_id=None, params=None))]
     fn py_subscribe_option_chain(
         &mut self,
+        py: Python<'_>,
         series_id: OptionSeriesId,
         strike_range: PyStrikeRange,
         snapshot_interval_ms: Option<u64>,
         client_id: Option<ClientId>,
-    ) {
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params_map = match params {
+            Some(dict) => from_pydict(py, dict)?,
+            None => None,
+        };
         DataActor::subscribe_option_chain(
             self.inner_mut(),
             series_id,
             strike_range.inner,
             snapshot_interval_ms,
             client_id,
+            params_map,
         );
+        Ok(())
     }
 
     #[pyo3(name = "subscribe_order_fills")]

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -908,13 +908,21 @@ pub trait Strategy: DataActor {
         &mut self,
         account_id: AccountId,
         client_id: Option<ClientId>,
+        params: Option<Params>,
     ) -> anyhow::Result<()> {
         let core = self.core_mut();
 
         let trader_id = core.trader_id().expect("Trader ID not set");
         let ts_init = core.clock().timestamp_ns();
 
-        let command = QueryAccount::new(trader_id, client_id, account_id, UUID4::new(), ts_init);
+        let command = QueryAccount::new(
+            trader_id,
+            client_id,
+            account_id,
+            UUID4::new(),
+            ts_init,
+            params,
+        );
 
         core.order_manager()
             .send_exec_command(TradingCommand::QueryAccount(command));
@@ -929,7 +937,12 @@ pub trait Strategy: DataActor {
     /// # Errors
     ///
     /// Returns an error if the strategy is not registered.
-    fn query_order(&mut self, order: &OrderAny, client_id: Option<ClientId>) -> anyhow::Result<()> {
+    fn query_order(
+        &mut self,
+        order: &OrderAny,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) -> anyhow::Result<()> {
         let core = self.core_mut();
 
         let trader_id = core.trader_id().expect("Trader ID not set");
@@ -945,6 +958,7 @@ pub trait Strategy: DataActor {
             order.venue_order_id(),
             UUID4::new(),
             ts_init,
+            params,
         );
 
         core.order_manager()
@@ -2123,7 +2137,7 @@ mod tests {
 
         let account_id = AccountId::from("ACC-001");
 
-        let result = strategy.query_account(account_id, None);
+        let result = strategy.query_account(account_id, None, None);
 
         assert!(result.is_ok());
     }
@@ -2136,7 +2150,7 @@ mod tests {
         let account_id = AccountId::from("ACC-001");
         let client_id = ClientId::from("BINANCE");
 
-        let result = strategy.query_account(account_id, Some(client_id));
+        let result = strategy.query_account(account_id, Some(client_id), None);
 
         assert!(result.is_ok());
     }
@@ -2148,7 +2162,7 @@ mod tests {
 
         let order = OrderAny::Market(MarketOrder::test_default());
 
-        let result = strategy.query_order(&order, None);
+        let result = strategy.query_order(&order, None, None);
 
         assert!(result.is_ok());
     }
@@ -2161,7 +2175,7 @@ mod tests {
         let order = OrderAny::Market(MarketOrder::test_default());
         let client_id = ClientId::from("BINANCE");
 
-        let result = strategy.query_order(&order, Some(client_id));
+        let result = strategy.query_order(&order, Some(client_id), None);
 
         assert!(result.is_ok());
     }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Convert data subscribe commands to owned values across the engine, adapters, and client traits.
- Convert execution trading commands to owned values across the execution engine and execution client traits.
- Add uniform optional `params` support to the remaining command types that were missing it.
- Update adapters, backtest/live integrations, and tests to match the new ownership model.

## What changed

- Added `params`, `params_mut`, and `ensure_params` helpers on `SubscribeCommand` and `TradingCommand`.
- Added `params: Option<Params>` to `SubscribeOptionChain`, `QueryAccount`, and `QueryOrder`.
- Updated option chain subscription plumbing so params can flow through actor APIs, manager setup, and Python bindings.
- Updated execution query APIs so the main `query_account` and `query_order` methods accept optional params directly, including the Python bindings.
- Propagated the owned-command signatures across the Rust venue adapters and their test suites.
- Preserved the existing DeFi subscribe side-effect order so pool subscriptions are forwarded before snapshot bootstrap requests.

## Why

- Owned commands let routing layers enrich metadata in place before forwarding, instead of cloning or rebuilding command payloads.
- The new params helpers avoid repeated enum-wide `match` blocks whenever generic code needs to inspect or extend command metadata.
- Adding params to the remaining outlier command types makes the data and execution command families consistent.

## Verification

- Ran `cargo check --workspace --features "python,streaming,defi"`.
- Ran `cargo test -p nautilus-common actor -- --nocapture`.
- Ran `cargo test -p nautilus-data --test client -- --nocapture`.
- Ran `cargo test -p nautilus-data --test engine -- --nocapture`.
- Ran `cargo test -p nautilus-execution --test exec_engine -- --nocapture`.
- Ran `cargo test -p nautilus-trading query_account -- --nocapture`.
- Ran `cargo test -p nautilus-trading query_order -- --nocapture`.

## Notes

- The broader Rust test run exposed additional adapter test call sites that still used borrowed command arguments; those were updated to the owned-command API.
- The data engine DeFi subscription ordering was adjusted to keep the existing behavior expected by the engine tests.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
