### PR TITLE
Fix quote midpoint raw arithmetic across precision modes

### DIFF
--- a/crates/model/src/data/quote.rs
+++ b/crates/model/src/data/quote.rs
@@ -33,6 +33,8 @@ use crate::{
     types::{
         Price, Quantity,
         fixed::{FIXED_PRECISION, FIXED_SIZE_BINARY},
+        price::PriceRaw,
+        quantity::QuantityRaw,
     },
 };
 
@@ -179,7 +181,7 @@ impl QuoteTick {
                 // Calculate mid avoiding overflow
                 let a = self.bid_price.raw;
                 let b = self.ask_price.raw;
-                let mid_raw = (a / 2) + (b / 2) + i128::midpoint(a % 2, b % 2);
+                let mid_raw = (a / 2) + (b / 2) + PriceRaw::midpoint(a % 2, b % 2);
                 Price::from_raw(
                     mid_raw,
                     cmp::min(self.bid_price.precision + 1, FIXED_PRECISION),
@@ -203,7 +205,7 @@ impl QuoteTick {
                 // Calculate mid avoiding overflow
                 let a = self.bid_size.raw;
                 let b = self.ask_size.raw;
-                let mid_raw = (a / 2) + (b / 2) + u128::midpoint(a % 2, b % 2);
+                let mid_raw = (a / 2) + (b / 2) + QuantityRaw::midpoint(a % 2, b % 2);
                 Quantity::from_raw(
                     mid_raw,
                     cmp::min(self.bid_size.precision + 1, FIXED_PRECISION),
@@ -248,7 +250,7 @@ mod tests {
         data::{HasTsInit, QuoteTick, stubs::quote_ethusdt_binance},
         enums::PriceType,
         identifiers::InstrumentId,
-        types::{Price, Quantity},
+        types::{Price, Quantity, fixed::FIXED_PRECISION, price::PriceRaw, quantity::QuantityRaw},
     };
 
     fn create_test_quote() -> QuoteTick {
@@ -542,6 +544,42 @@ mod tests {
 
         assert_eq!(mid_price, Price::from("1.010"));
         assert_eq!(mid_size, Quantity::from("100.000"));
+    }
+
+    #[rstest]
+    fn test_extract_mid_price_uses_raw_midpoint_for_odd_negative_values() {
+        let quote = QuoteTick::new(
+            InstrumentId::from("TEST.SIM"),
+            Price::from_raw(-3, FIXED_PRECISION),
+            Price::from_raw(-2, FIXED_PRECISION),
+            Quantity::from("1"),
+            Quantity::from("1"),
+            UnixNanos::from(0),
+            UnixNanos::from(0),
+        );
+
+        let mid_price = quote.extract_price(PriceType::Mid);
+
+        assert_eq!(mid_price.raw, PriceRaw::midpoint(-3, -2));
+        assert_eq!(mid_price.precision, FIXED_PRECISION);
+    }
+
+    #[rstest]
+    fn test_extract_mid_size_uses_raw_midpoint_for_odd_values() {
+        let quote = QuoteTick::new(
+            InstrumentId::from("TEST.SIM"),
+            Price::from("1"),
+            Price::from("1"),
+            Quantity::from_raw(1, FIXED_PRECISION),
+            Quantity::from_raw(2, FIXED_PRECISION),
+            UnixNanos::from(0),
+            UnixNanos::from(0),
+        );
+
+        let mid_size = quote.extract_size(PriceType::Mid);
+
+        assert_eq!(mid_size.raw, QuantityRaw::midpoint(1, 2));
+        assert_eq!(mid_size.precision, FIXED_PRECISION);
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This fixes a `nautilus-model` regression in `QuoteTick` midpoint extraction introduced by the recent pedantic cleanup. The code switched to `i128::midpoint(...)` / `u128::midpoint(...)`, which compiles in high-precision mode but fails in standard-precision mode where `PriceRaw` and `QuantityRaw` are `i64` / `u64`.

The fix routes midpoint calculation through the raw type aliases (`PriceRaw::midpoint(...)` and `QuantityRaw::midpoint(...)`) so the implementation matches the active precision mode on every platform. Additional tests cover odd raw values for both signed price and unsigned quantity midpoint extraction.

## Related Issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## What this PR does not do

- It does not change serialized data formats, Arrow schema metadata, or raw value layouts.
- It does not change precision-mode defaults.
- It does not touch generated Cython/PyO3 model artifacts beyond the Rust source fix.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No documentation changes were required for this fix.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validated with:
- `cargo test -p nautilus-model extract_ --lib`
- `cargo test -p nautilus-model extract_ --lib --features high-precision`
- `cargo test -p nautilus-model extract_ --lib --no-default-features`
- `cargo build --lib -p nautilus-backtest -p nautilus-common -p nautilus-core -p nautilus-infrastructure -p nautilus-model -p nautilus-persistence -p nautilus-pyo3 --release --no-default-features --features arrow,cython-compat,extension-module,ffi,postgres,python,tracing-bridge`
- `make pre-commit`
