### PR TITLE
Add cache instrument status support

### DIFF
--- a/crates/adapters/bybit/src/common/status.rs
+++ b/crates/adapters/bybit/src/common/status.rs
@@ -94,7 +94,7 @@ pub fn diff_and_emit_statuses(
     }
 }
 
-fn emit_status(
+pub fn emit_status(
     sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     instrument_id: InstrumentId,
     action: MarketStatusAction,

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -66,7 +66,7 @@ use crate::{
         consts::{BYBIT_DEFAULT_ORDERBOOK_DEPTH, BYBIT_VENUE},
         enums::BybitProductType,
         parse::{extract_raw_symbol, make_bybit_symbol},
-        status::diff_and_emit_statuses,
+        status::{diff_and_emit_statuses, emit_status},
         symbol::BybitSymbol,
     },
     config::BybitDataClientConfig,
@@ -1407,6 +1407,12 @@ impl DataClient for BybitDataClient {
             id = cmd.instrument_id,
         );
         self.instrument_status_subs.insert(cmd.instrument_id);
+
+        if let Some(action) = self.status_cache.load().get(&cmd.instrument_id) {
+            let ts = self.clock.get_time_ns();
+            emit_status(&self.data_sender, cmd.instrument_id, *action, ts, ts);
+        }
+
         Ok(())
     }
 

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -49,8 +49,8 @@ use nautilus_core::{
 use nautilus_model::{
     accounts::{Account, AccountAny},
     data::{
-        Bar, BarType, FundingRateUpdate, GreeksData, IndexPriceUpdate, MarkPriceUpdate, QuoteTick,
-        TradeTick, YieldCurveData, option_chain::OptionGreeks,
+        Bar, BarType, FundingRateUpdate, GreeksData, IndexPriceUpdate, InstrumentStatus,
+        MarkPriceUpdate, QuoteTick, TradeTick, YieldCurveData, option_chain::OptionGreeks,
     },
     enums::{AggregationSource, OmsType, OrderSide, PositionSide, PriceType, TriggerType},
     identifiers::{
@@ -82,6 +82,7 @@ pub struct Cache {
     general: AHashMap<String, Bytes>,
     currencies: AHashMap<Ustr, Currency>,
     instruments: AHashMap<InstrumentId, InstrumentAny>,
+    instrument_statuses: AHashMap<InstrumentId, InstrumentStatus>,
     synthetics: AHashMap<InstrumentId, SyntheticInstrument>,
     books: AHashMap<InstrumentId, OrderBook>,
     own_books: AHashMap<InstrumentId, OwnOrderBook>,
@@ -112,6 +113,7 @@ impl Debug for Cache {
             .field("general", &self.general)
             .field("currencies", &self.currencies)
             .field("instruments", &self.instruments)
+            .field("instrument_statuses", &self.instrument_statuses)
             .field("synthetics", &self.synthetics)
             .field("books", &self.books)
             .field("own_books", &self.own_books)
@@ -158,6 +160,7 @@ impl Cache {
             general: AHashMap::new(),
             currencies: AHashMap::new(),
             instruments: AHashMap::new(),
+            instrument_statuses: AHashMap::new(),
             synthetics: AHashMap::new(),
             books: AHashMap::new(),
             own_books: AHashMap::new(),
@@ -1274,6 +1277,7 @@ impl Cache {
         self.general.clear();
         self.currencies.clear();
         self.instruments.clear();
+        self.instrument_statuses.clear();
         self.synthetics.clear();
         self.books.clear();
         self.own_books.clear();
@@ -1734,6 +1738,25 @@ impl Cache {
         }
 
         self.instruments.insert(instrument.id(), instrument);
+        Ok(())
+    }
+
+    /// Adds the `instrument status` to the cache.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible, but returns `Result` to allow for future error propagation.
+    pub fn add_instrument_status(
+        &mut self,
+        instrument_status: InstrumentStatus,
+    ) -> anyhow::Result<()> {
+        log::debug!(
+            "Adding `InstrumentStatus` {}",
+            instrument_status.instrument_id
+        );
+
+        self.instrument_statuses
+            .insert(instrument_status.instrument_id, instrument_status);
         Ok(())
     }
 
@@ -3702,6 +3725,12 @@ impl Cache {
     #[must_use]
     pub fn instrument(&self, instrument_id: &InstrumentId) -> Option<&InstrumentAny> {
         self.instruments.get(instrument_id)
+    }
+
+    /// Returns a reference to the instrument status for the `instrument_id` (if found).
+    #[must_use]
+    pub fn instrument_status(&self, instrument_id: &InstrumentId) -> Option<&InstrumentStatus> {
+        self.instrument_statuses.get(instrument_id)
     }
 
     /// Returns references to all instrument IDs for the `venue`.

--- a/crates/common/src/python/cache.rs
+++ b/crates/common/src/python/cache.rs
@@ -23,7 +23,7 @@ use nautilus_core::python::to_pyvalue_err;
 use nautilus_model::defi::{Pool, PoolProfiler};
 use nautilus_model::{
     data::{
-        Bar, BarType, FundingRateUpdate, QuoteTick, TradeTick,
+        Bar, BarType, FundingRateUpdate, InstrumentStatus, QuoteTick, TradeTick,
         prices::{IndexPriceUpdate, MarkPriceUpdate},
     },
     enums::{AggregationSource, OmsType, OrderSide, PositionSide, PriceType},
@@ -271,6 +271,11 @@ impl PyCache {
             Some(instrument) => Ok(Some(instrument_any_to_pyobject(py, instrument.clone())?)),
             None => Ok(None),
         }
+    }
+
+    #[pyo3(name = "instrument_status")]
+    fn py_instrument_status(&self, instrument_id: InstrumentId) -> Option<InstrumentStatus> {
+        self.0.borrow().instrument_status(&instrument_id).copied()
     }
 
     #[pyo3(name = "instrument_ids", signature = (venue=None))]
@@ -1285,6 +1290,12 @@ impl Cache {
             Some(instrument) => Ok(Some(instrument_any_to_pyobject(py, instrument.clone())?)),
             None => Ok(None),
         }
+    }
+
+    /// Returns the instrument status for the `instrument_id` (if found).
+    #[pyo3(name = "instrument_status")]
+    fn py_instrument_status(&self, instrument_id: InstrumentId) -> Option<InstrumentStatus> {
+        self.instrument_status(&instrument_id).copied()
     }
 
     /// Returns references to all instrument IDs for the `venue`.

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -1180,6 +1180,15 @@ impl DataEngine {
     }
 
     fn handle_instrument_status(&mut self, status: InstrumentStatus) {
+        if let Err(e) = self
+            .cache
+            .as_ref()
+            .borrow_mut()
+            .add_instrument_status(status)
+        {
+            log_error_on_cache_insert(&e);
+        }
+
         let topic = switchboard::get_instrument_status_topic(status.instrument_id);
         msgbus::publish_any(topic, &status);
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Cache the current instrument status.

Extra change: when subscribing to Bybit instrument status, emit the current status (follows how other subscriptions return the current value on subscribe).

Note: I'm not too familiar with pyo3 and what bindings are needed, so they might need to be modified/added post-merge with your help @cjdsellers.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
