### PR TITLE
fix: consolidate_data_by_period pairwise merging in fragment-per-flush catalogs (fixes #3857)

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -19,7 +19,7 @@ import itertools
 import os
 import platform
 import re
-from collections import defaultdict
+from collections import defaultdict, Counter
 from collections.abc import Generator
 from itertools import groupby
 from os import PathLike
@@ -1103,25 +1103,49 @@ class ParquetDataCatalog(BaseDataCatalog):
                 "all files in the consolidation range must have contiguous timestamps."
             )
 
+        
         # Group intervals into contiguous groups to preserve holes between groups
         # but allow consolidation within each contiguous group
-        contiguous_groups = []
-        current_group = [filtered_intervals[0]]
 
+        # Pass 1 - infer dominant rhythm from all interval gaps
+        gaps = []
         for i in range(1, len(filtered_intervals)):
-            prev_interval = filtered_intervals[i - 1]
-            curr_interval = filtered_intervals[i]
+            gap = filtered_intervals[i][0] - filtered_intervals[i - 1][0]
+            gaps.append(gap)
 
-            # Check if current interval is contiguous with previous (end + 1 == start)
-            if prev_interval[1] + 1 == curr_interval[0]:
-                current_group.append(curr_interval)
-            else:
-                # Gap found, start new group
-                contiguous_groups.append(current_group)
-                current_group = [curr_interval]
+        if not gaps:
+            # single interval, nothing to group
+            contiguous_groups = [filtered_intervals]
+        else:
+            gap_counts = Counter(gaps)
+            dominant_gap, dominant_count = gap_counts.most_common(1)[0]
+            total_gaps = len(gaps)
+            dominant_pct = (dominant_count / total_gaps) * 100
 
-        # Add the last group
-        contiguous_groups.append(current_group)
+            rhythm_confidence_threshold = 85.0
+            print(f"[consolidate] standard gap detected: {pd.Timedelta(dominant_gap)} "
+                f"({dominant_pct:.1f}% dominance) — gaps larger than 1.5x standard will start a new group"
+                + (" WARNING: low confidence" if dominant_pct < rhythm_confidence_threshold else ""))
+            
+
+            # Pass 2 - group files into contiguous blocks, splitting only on genuine data holes.
+            # Uses 1.5x dominant gap as threshold to tolerate clock jitter and minor timestamp irregularities
+            gap_threshold = dominant_gap * 1.5
+            contiguous_groups = []
+            current_group = [filtered_intervals[0]]
+
+            for i in range(1, len(filtered_intervals)):
+                prev_interval = filtered_intervals[i - 1]
+                curr_interval = filtered_intervals[i]
+                gap = curr_interval[0] - prev_interval[0]
+
+                if gap > gap_threshold:
+                    contiguous_groups.append(current_group)
+                    current_group = [curr_interval]
+                else:
+                    current_group.append(curr_interval)
+
+            contiguous_groups.append(current_group)
 
         # Convert period to nanoseconds for calculations
         period_in_ns = period.value

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -1467,6 +1467,60 @@ class TestConsolidateDataByPeriod:
         with pytest.raises(ValueError, match="conflicting metadata"):
             self.catalog.consolidate_catalog(ensure_contiguous_files=False)
 
+    def test_consolidate_fragment_per_flush_hourly_to_daily(self):
+        """
+        Regression test: fragment-per-flush catalogs (one bar per file) must consolidate
+        correctly into period-sized files without pairwise merging or data loss.
+        """
+        # Arrange - 168 hourly bars written one-per-file (fragment-per-flush pattern)
+        instrument = TestInstrumentProvider.default_fx_ccy("EUR/USD", venue=Venue("SIM"))
+        bar_spec = BarSpecification(1, BarAggregation.HOUR, PriceType.MID)
+        bar_type = BarType(instrument.id, bar_spec)
+        bar_type_str = str(bar_type)
+
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        hour_ns = int(pd.Timedelta(hours=1).total_seconds() * 1e9)
+
+        for i in range(168):
+            ts = start_ns + i * hour_ns
+            bar = Bar(
+                bar_type=bar_type,
+                open=Price.from_str("1.00000"),
+                high=Price.from_str("1.00010"),
+                low=Price.from_str("0.99990"),
+                close=Price.from_str("1.00005"),
+                volume=Quantity.from_str("1000"),
+                ts_event=ts,
+                ts_init=ts,
+            )
+            self.catalog.write_data([bar], skip_disjoint_check=True)
+
+        assert len(self.catalog.get_intervals(Bar, bar_type_str)) == 168
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            data_cls=Bar,
+            identifier=bar_type_str,
+            period=pd.Timedelta(days=1),
+            ensure_contiguous_files=False,
+        )
+
+        # Assert - should produce exactly 7 daily files, not 84 pairwise merges
+        final_intervals = self.catalog.get_intervals(Bar, bar_type_str)
+        assert len(final_intervals) == 7, (
+            f"Expected 7 daily files, got {len(final_intervals)} — "
+            f"pairwise merging bug may have regressed"
+        )
+
+        # Verify all 168 bars are preserved
+        all_bars = self.catalog.bars(bar_types=[bar_type_str])
+        assert len(all_bars) == 168
+
+        # Verify one file per day
+        for iv in final_intervals:
+            start_day = pd.Timestamp(iv[0], unit="ns", tz="UTC").date()
+            end_day = pd.Timestamp(iv[1], unit="ns", tz="UTC").date()
+            assert start_day == end_day
 
 def test_consolidate_catalog_by_period(catalog: ParquetDataCatalog) -> None:
     # Arrange


### PR DESCRIPTION
# Pull Request
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

**Root cause — hardcoded +1 ns adjacency check**

`_prepare_consolidation_queries` grouped files into contiguous blocks using `prev_interval[1] + 1 == curr_interval[0]`. For fragment-per-flush catalogs where each bar is a separate file, consecutive files are spaced by the bar interval (e.g. 3,600,000,000,000 ns for hourly bars) — never 1 ns apart. Every pair was treated as a genuine data gap, producing N single-file groups instead of 1 and causing pairwise merging that halves the file count on each run and silently destroys originals.

**Intent of the original grouping**

The block was designed to honour:
```python
# Group intervals into contiguous groups to preserve holes between groups
# but allow consolidation within each contiguous group
```
The hardcoded +1 ns assumption broke this for any catalog where files are uniformly spaced but not nanosecond-adjacent.

**Fix — two-pass dominant spacing detection**

- Pass 1: collect all gaps between consecutive file start timestamps, find dominant spacing via `Counter.most_common(1)`, warn if confidence falls below 85%
- Pass 2: group files using `dominant_gap * 1.5` as threshold — only gaps larger than 1.5x the dominant spacing are treated as genuine data holes


Note: this fix introduces new grouping logic rather than a minimal patch. The 1.5x gap threshold and 85% confidence warning are reasonable defaults but are heuristics — both could be exposed as parameters in a future improvement.

## Related Issues/PRs
Closes #3857

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)
N/A

## Documentation
- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes
- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing
**Ensure new or changed logic is covered by tests.**
- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_consolidate_fragment_per_flush_hourly_to_daily` to `TestConsolidateDataByPeriod` in `tests/unit_tests/persistence/test_catalog.py`. The test writes 168 hourly bars one-per-file, consolidates with `period=1d`, and asserts exactly 7 daily files with all 168 bars preserved. The test fails on the unfixed code and passes on the fix. All 17 tests in `TestConsolidateDataByPeriod` pass.

Additionally, 15 standalone scenarios were validated locally covering: minute/second/hourly/daily bar rhythms, real data gaps, intra-period missing bars, multi-instrument isolation, nanosecond jitter tolerance, weekly period boundaries, and idempotency.

