### PR TITLE
Fix Kraken Futures AccountBalance invariant panic on margin parse

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -41,6 +41,7 @@ Released on TBD (UTC).
 - Fixed Hyperliquid modify cancel-replace emitting stale `OrderCanceled` (#3827), thanks for reporting @P1YU5H-50N1
 - Fixed IB Gateway Docker image failing on ARM64 hosts (#3813), thanks for reporting @Baki-0501
 - Fixed Kraken Futures limit order `OrderUpdated` panic from wire `stop_price: 0.0` treated as trigger price
+- Fixed Kraken Futures margin-account balance parse violating the `AccountBalance` invariant (`total == locked + free`) when Kraken's `af` field and the derived `amount - af` round independently at the currency precision
 - Fixed Kraken Spot quote-quantity orders never reaching terminal state from base/quote size mismatch
 - Fixed Kraken trade dedup clearing the entire set at capacity instead of evicting the oldest entry
 - Fixed OKX option greeks not forwarded due to inaccessible Cython `cdef` subscription attribute

--- a/crates/adapters/kraken/src/http/futures/client.rs
+++ b/crates/adapters/kraken/src/http/futures/client.rs
@@ -2571,13 +2571,14 @@ fn parse_margin_account_balances(account: &FuturesAccount, balances: &mut Vec<Ac
             .and_then(|aux| aux.af)
             .unwrap_or(amount)
             .min(amount);
-        let locked = amount - available;
+        // Derive `free` from `total - locked` in fixed-point Money arithmetic so
+        // the `AccountBalance` invariant (`total == locked + free`) holds exactly
+        // regardless of f64 rounding at the currency precision. Mirrors the
+        // `parse_multi_collateral_balances` derivation.
+        let locked = Money::new((amount - available).max(0.0), currency);
+        let free = total - locked;
 
-        balances.push(AccountBalance::new(
-            total,
-            Money::new(locked, currency),
-            Money::new(available, currency),
-        ));
+        balances.push(AccountBalance::new(total, locked, free));
     }
 }
 
@@ -2803,6 +2804,55 @@ mod tests {
 
         // BTC balance + USD portfolio balance
         assert_eq!(balances.len(), 2);
+    }
+
+    #[rstest]
+    fn test_parse_margin_account_balances_free_is_derived_from_total_minus_locked() {
+        // Regression: `free` must be derived via Money fixed-point subtraction so
+        // the `AccountBalance` invariant `total == locked + free` holds exactly,
+        // rather than using the raw Kraken `af` (available funds) value which
+        // can drift at the currency precision and violate the invariant in
+        // `AccountBalance::new_checked`.
+        let mut bals = AHashMap::new();
+        // Values chosen so that Kraken's raw `af` rounds independently from
+        // `amount - af` at currency precision 8, producing a drifted sum when
+        // `free` is set directly from `af` instead of derived from `total - locked`.
+        // With these f64 values (constructed via arithmetic to hit precise bit
+        // patterns): round(amount * 1e8) = 1_000_000_003, round(af * 1e8) = 4,
+        // and round((amount - af) * 1e8) = 1_000_000_000, so 4 + 1_000_000_000
+        // != 1_000_000_003 and the old parse path violates the invariant.
+        let af_f = 35.0_f64 * 1e-9;
+        let amount_f = 10.0_f64 + af_f;
+        bals.insert("XBT".to_string(), amount_f);
+
+        let account = FuturesAccount {
+            account_type: KrakenFuturesAccountType::MarginAccount,
+            balances: bals,
+            currencies: AHashMap::new(),
+            auxiliary: Some(FuturesAuxiliary {
+                usd: None,
+                pv: None,
+                pnl: None,
+                af: Some(af_f),
+                funding: None,
+            }),
+            margin_requirements: None,
+            portfolio_value: None,
+            available_margin: None,
+            initial_margin: None,
+            pnl: None,
+        };
+
+        let mut balances = Vec::new();
+        parse_margin_account_balances(&account, &mut balances);
+
+        assert_eq!(balances.len(), 1);
+        let balance = &balances[0];
+        // Invariant: total == locked + free (enforced by AccountBalance::new_checked,
+        // but assert here to pin the derivation property at the parse site).
+        assert_eq!(balance.total, balance.locked + balance.free);
+        // Free is the derived side (total - locked), not the raw `af` value.
+        assert_eq!(balance.free, balance.total - balance.locked);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Fixes a latent `AccountBalance::new_checked` panic in the Kraken Futures margin-account balance parse, where the raw `af` (available funds) value and the derived `amount - af` could round independently at the currency precision and violate the `total == locked + free` invariant.

Closes #3867

## Root cause

`parse_margin_account_balances` constructed `AccountBalance` via three independent `Money::new` calls (one each for `total`, `locked = amount - available`, `free = available`). When `Money::new` rounded the three f64 inputs at currency precision 8, the three raw values were not guaranteed to satisfy `locked + free == total`, tripping the invariant in `AccountBalance::new_checked`.

The sibling `parse_multi_collateral_balances` already handled this correctly by deriving `free` from `total - locked` in fixed-point `Money` arithmetic.

## Change

- Derive `free = total - locked` via `Money` subtraction (fixed-point) in `parse_margin_account_balances`, matching the multi-collateral parse path.
- Add a regression test (`test_parse_margin_account_balances_free_is_derived_from_total_minus_locked`) using f64 values that provably drift at precision 8 (`af = 35.0 * 1e-9`, `amount = 10.0 + af`), so that the previous implementation panics and the new one passes.

## Files changed

- `crates/adapters/kraken/src/http/futures/client.rs` – fix + test
- `RELEASES.md` – changelog entry under `Fixes`

## Test plan

- [ ] `cargo test -p nautilus-kraken` – all green
- [ ] `cargo test -p nautilus-kraken test_parse_margin_account_balances_free_is_derived_from_total_minus_locked` – passes on this branch, fails on `develop` prior to the fix (verified locally via temporary revert of the parse change)
- [ ] `cargo +nightly fmt -p nautilus-kraken` – clean
- [ ] `cargo clippy -p nautilus-kraken --all-targets -- -D warnings` – clean
