### PR TITLE
Fix catalog consolidate_data_by_period silently deleting data on repeated calls (#3875)

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -960,6 +960,7 @@ class ParquetDataCatalog(BaseDataCatalog):
         # Track files to remove and maintain existing_files list
         files_to_remove = set()
         existing_files = list(existing_files)  # Make it mutable
+        any_write_happened = False
 
         # Phase 2: Execute queries, write, and delete
         file_start_ns = None  # Track contiguity across periods
@@ -1016,6 +1017,7 @@ class ParquetDataCatalog(BaseDataCatalog):
             )
 
             # Clear the data from memory immediately
+            any_write_happened = True
             del period_data
 
             # Identify files that are completely covered by this period
@@ -1033,8 +1035,9 @@ class ParquetDataCatalog(BaseDataCatalog):
                     files_to_remove.remove(file)
 
         # Remove any remaining files that weren't removed in the loop
-        for file in existing_files:
-            self.fs.rm(file)
+        if any_write_happened:
+            for file in existing_files:
+                self.fs.rm(file)
 
     def _prepare_consolidation_queries(  # noqa: C901
         self,

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -1469,14 +1469,10 @@ class TestConsolidateDataByPeriod:
 
     def test_consolidate_fragment_per_flush_hourly_to_daily(self):
         """
-        Test consolidation groups fragment-per-flush files (one bar per file) by period.
-
-        Regression: the legacy contiguity check required adjacent files to be exactly
-        1 ns apart, causing fragment-per-flush catalogs to be split into single-file
-        groups and pairwise-merged on each run.
-
+        Regression test: fragment-per-flush catalogs (one bar per file) must consolidate
+        correctly into period-sized files without pairwise merging or data loss.
         """
-        # Arrange
+        # Arrange - 168 hourly bars written one-per-file (fragment-per-flush pattern)
         instrument = TestInstrumentProvider.default_fx_ccy("EUR/USD", venue=Venue("SIM"))
         bar_spec = BarSpecification(1, BarAggregation.HOUR, PriceType.MID)
         bar_type = BarType(instrument.id, bar_spec)
@@ -1509,17 +1505,82 @@ class TestConsolidateDataByPeriod:
             ensure_contiguous_files=False,
         )
 
-        # Assert
+        # Assert - should produce exactly 7 daily files, not 84 pairwise merges
         final_intervals = self.catalog.get_intervals(Bar, bar_type_str)
+        assert len(final_intervals) == 7, (
+            f"Expected 7 daily files, got {len(final_intervals)} — "
+            f"pairwise merging bug may have regressed"
+        )
+
+        # Verify all 168 bars are preserved
         all_bars = self.catalog.bars(bar_types=[bar_type_str])
-        assert len(final_intervals) == 7
         assert len(all_bars) == 168
 
+        # Verify one file per day
         for iv in final_intervals:
             start_day = pd.Timestamp(iv[0], unit="ns", tz="UTC").date()
             end_day = pd.Timestamp(iv[1], unit="ns", tz="UTC").date()
             assert start_day == end_day
 
+    def test_consolidate_data_by_period_idempotent(self):
+        # Arrange - 48 hourly bars written one-per-file
+        instrument = TestInstrumentProvider.default_fx_ccy("EUR/USD", venue=Venue("SIM"))
+        bar_spec = BarSpecification(1, BarAggregation.HOUR, PriceType.MID)
+        bar_type = BarType(instrument.id, bar_spec)
+        bar_type_str = str(bar_type)
+
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        hour_ns = int(pd.Timedelta(hours=1).total_seconds() * 1e9)
+
+        for i in range(48):
+            ts = start_ns + i * hour_ns
+            bar = Bar(
+                bar_type=bar_type,
+                open=Price.from_str("1.00000"), high=Price.from_str("1.00010"),
+                low=Price.from_str("0.99990"), close=Price.from_str("1.00005"),
+                volume=Quantity.from_str("1000"), ts_event=ts, ts_init=ts,
+            )
+            self.catalog.write_data([bar], skip_disjoint_check=True)
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar, bar_type_str, period=pd.Timedelta(days=1), ensure_contiguous_files=False
+        )
+        files_after_first = len(self.catalog.get_intervals(Bar, bar_type_str))
+        bars_after_first = len(self.catalog.bars(bar_types=[bar_type_str]))
+
+        self.catalog.consolidate_data_by_period(
+            Bar, bar_type_str, period=pd.Timedelta(days=1), ensure_contiguous_files=False
+        )
+
+        # Assert - second run must not destroy data
+        assert len(self.catalog.get_intervals(Bar, bar_type_str)) == files_after_first
+        assert len(self.catalog.bars(bar_types=[bar_type_str])) == bars_after_first
+
+    def test_consolidate_data_by_period_single_bar_preserved(self):
+        # Arrange - single bar catalog
+        instrument = TestInstrumentProvider.default_fx_ccy("EUR/USD", venue=Venue("SIM"))
+        bar_spec = BarSpecification(1, BarAggregation.HOUR, PriceType.MID)
+        bar_type = BarType(instrument.id, bar_spec)
+        bar_type_str = str(bar_type)
+
+        ts = pd.Timestamp("2024-01-01", tz="UTC").value
+        bar = Bar(
+            bar_type=bar_type,
+            open=Price.from_str("1.00000"), high=Price.from_str("1.00010"),
+            low=Price.from_str("0.99990"), close=Price.from_str("1.00005"),
+            volume=Quantity.from_str("1000"), ts_event=ts, ts_init=ts,
+        )
+        self.catalog.write_data([bar])
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar, bar_type_str, period=pd.Timedelta(days=1), ensure_contiguous_files=False
+        )
+
+        # Assert - single bar must survive consolidation
+        assert len(self.catalog.get_intervals(Bar, bar_type_str)) == 1
+        assert len(self.catalog.bars(bar_types=[bar_type_str])) == 1
 
 def test_consolidate_catalog_by_period(catalog: ParquetDataCatalog) -> None:
     # Arrange


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`consolidate_data_by_period` unconditionally deleted all remaining files in the tail sweep after the query loop, even when no writes occurred. This caused silent data loss on repeated calls (second run deletes already-consolidated files) and on single-file catalogs (the one file is deleted without replacement). The fix guards the tail sweep behind an `any_write_happened` flag so files are only removed when a write actually took place.

## Related Issues/PRs

Closes #3875. Related to #3857.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [x] I added/updated tests to cover new or changed logic

Two regression tests added to `TestConsolidateDataByPeriod` in `tests/unit_tests/persistence/test_catalog.py`:
- `test_consolidate_data_by_period_idempotent` — verifies a second call on an already-consolidated catalog preserves all files and bars
- `test_consolidate_data_by_period_single_bar_preserved` — verifies a single-file catalog survives consolidation without data loss

Both failure modes were also independently reproduced and verified in a local repro script against the installed PyPI wheel before the fix was applied, confirming the root cause and validating the fix end-to-end.