### PR TITLE
Improve IB to allow negative average price for combos

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import json
+import math
 from collections import deque
 from datetime import timedelta
 from decimal import Decimal
@@ -1860,7 +1861,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         avg_fill_price: float,
         filled_decimal: Decimal,
     ) -> None:
-        if not avg_fill_price or avg_fill_price <= 0 or filled_decimal <= 0:
+        is_spread_order = is_generic_spread_id(nautilus_order.instrument_id)
+
+        if (
+            filled_decimal <= 0
+            or not math.isfinite(avg_fill_price)
+            or avg_fill_price == UNSET_DOUBLE
+            or avg_fill_price == 0
+            or (avg_fill_price < 0 and not is_spread_order)
+        ):
             return
 
         instrument = self._cache.instrument(nautilus_order.instrument_id)
@@ -1889,7 +1898,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         self._order_fill_progress[client_order_id] = (filled_decimal, total_notional)
 
-        if fill_delta <= 0 or not is_generic_spread_id(nautilus_order.instrument_id):
+        if fill_delta <= 0 or not is_spread_order:
             return
 
         notional_delta = total_notional - previous_notional

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -1012,6 +1012,80 @@ async def test_spread_combo_fill_waits_for_order_status_avg_px(mocker, exec_clie
 
 
 @pytest.mark.asyncio
+async def test_spread_combo_fill_allows_negative_avg_px_credit(
+    mocker,
+    exec_client,
+    cache,
+):
+    call = make_option_contract("SPY C400", OptionKind.CALL)
+    put = make_option_contract("SPY P390", OptionKind.PUT)
+    spread = make_option_spread(call, put)
+
+    for instrument in [call, put, spread]:
+        exec_client.instrument_provider.add(instrument)
+        cache.add_instrument(instrument)
+
+    call_contract = IBTestContractStubs.create_contract(
+        conId=9011,
+        symbol="SPY",
+        secType="OPT",
+        exchange="SMART",
+        currency="USD",
+        localSymbol="SPY C400",
+    )
+    exec_client.instrument_provider.contract_id_to_instrument_id[call_contract.conId] = call.id
+
+    client_order_id = ClientOrderId("O-SPREAD-CREDIT-001")
+    venue_order_id = VenueOrderId("7011")
+    order = TestExecStubs.limit_order(
+        instrument=spread,
+        client_order_id=client_order_id,
+        quantity=Quantity.from_int(1),
+        price=Price.from_str("-1.00"),
+    )
+    order = TestExecStubs.make_accepted_order(order, venue_order_id=venue_order_id)
+    cache.add_order(order, None)
+    cache.add_venue_order_id(client_order_id, venue_order_id)
+
+    generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
+
+    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution.orderRef = str(client_order_id)
+    execution.execId = "combo-credit-fill-1"
+    execution.shares = Decimal(1)
+    execution.price = 1.25
+
+    commission_report = IBTestExecStubs.commission()
+    commission_report.execId = execution.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution,
+        commission_report=commission_report,
+        contract=call_contract,
+    )
+
+    assert generate_order_filled.call_count == 1
+    assert client_order_id in exec_client._pending_combo_fills
+
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Filled",
+        avg_fill_price=-2.75,
+        filled=Decimal(1),
+        remaining=Decimal(0),
+        venue_order_id=venue_order_id,
+    )
+
+    assert generate_order_filled.call_count == 2
+    combo_fill_call = generate_order_filled.call_args_list[1].kwargs
+    assert combo_fill_call["instrument_id"] == spread.id
+    assert combo_fill_call["info"] == {"avg_px": Price.from_str("-2.75")}
+    assert exec_client._order_avg_prices[client_order_id] == Price.from_str("-2.75")
+    assert client_order_id not in exec_client._pending_combo_fills
+
+
+@pytest.mark.asyncio
 async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
     mocker,
     exec_client,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

This change fixes the IB execution adapter rejecting valid negative average fill prices for spread orders.

  IB can report a negative avg_fill_price when a combo/spread is filled for net credit. The existing guard in _update_order_avg_price treated any non-positive value as invalid, which caused the adapter to
  drop the average price update and prevented queued combo fills from receiving the correct avg_px.

  The fix narrows that validation logic:

  - negative avg_fill_price is now allowed for generic spread instruments
  - 0, UNSET_DOUBLE, and non-finite values are still ignored
  - non-spread orders still reject negative average prices

  A regression test was added covering a spread combo fill where orderStatus.avg_fill_price is negative, asserting that the combo fill is flushed with the expected negative avg_px.

  Why

  Credit spreads and other combo orders can legitimately have negative average fill prices. Rejecting them breaks reconciliation of IB combo fills and loses the spread-level average price.

  Testing

  - Added integration coverage for negative spread avg_px
  - python -m compileall passed on touched files
  - Full targeted pytest execution is currently blocked in this environment by an existing tests/conftest.py import error: ImportError: cannot import name ContFutAdjustmentType

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/pull/3834#pullrequestreview-4126677617

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
