### PR TITLE
Fix TypeError when priceMagnifier is None during position reconciliation in IB adapter

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/parsing/price_conversion.py
+++ b/nautilus_trader/adapters/interactive_brokers/parsing/price_conversion.py
@@ -24,7 +24,7 @@ price. All prices sent to IB need to be multiplied by the price magnifier.
 from nautilus_trader.model.identifiers import InstrumentId
 
 
-def ib_price_to_nautilus_price(ib_price: float, price_magnifier: int) -> float:
+def ib_price_to_nautilus_price(ib_price: float, price_magnifier: int | None) -> float:
     """
     Convert an Interactive Brokers price to a Nautilus price.
 
@@ -41,13 +41,13 @@ def ib_price_to_nautilus_price(ib_price: float, price_magnifier: int) -> float:
         The real price for use in Nautilus.
 
     """
-    if price_magnifier <= 0:
+    if not price_magnifier or price_magnifier <= 0:
         return ib_price
 
     return ib_price / price_magnifier
 
 
-def nautilus_price_to_ib_price(nautilus_price: float, price_magnifier: int) -> float:
+def nautilus_price_to_ib_price(nautilus_price: float, price_magnifier: int | None) -> float:
     """
     Convert a Nautilus price to an Interactive Brokers price.
 
@@ -64,7 +64,7 @@ def nautilus_price_to_ib_price(nautilus_price: float, price_magnifier: int) -> f
         The scaled price for sending to Interactive Brokers.
 
     """
-    if price_magnifier <= 0:
+    if not price_magnifier or price_magnifier <= 0:
         return nautilus_price
 
     return nautilus_price * price_magnifier

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -242,7 +242,7 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
     def get_price_magnifier(self, instrument_id: InstrumentId) -> int:
         contract_details = self.contract_details.get(instrument_id)
         if contract_details:
-            return contract_details.priceMagnifier
+            return contract_details.priceMagnifier or 1
 
         return 1
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_parsing.py
@@ -46,6 +46,12 @@ from nautilus_trader.adapters.interactive_brokers.parsing.instruments import (
     instrument_id_to_ib_contract,
 )
 from nautilus_trader.adapters.interactive_brokers.parsing.instruments import parse_instrument
+from nautilus_trader.adapters.interactive_brokers.parsing.price_conversion import (
+    ib_price_to_nautilus_price,
+)
+from nautilus_trader.adapters.interactive_brokers.parsing.price_conversion import (
+    nautilus_price_to_ib_price,
+)
 from nautilus_trader.model.data import BarSpecification
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.instruments import OptionContract
@@ -598,3 +604,42 @@ def test_parse_instrument_option_on_index_has_caret_prefix():
     # Assert
     assert isinstance(instrument, OptionContract)
     assert instrument.underlying == "^SPX"
+
+
+class TestIbPriceToNautilusPrice:
+    @pytest.mark.parametrize(
+        ("ib_price", "price_magnifier", "expected"),
+        [
+            (100.0, 1, 100.0),
+            (100.0, 10, 10.0),
+            (100.0, 100, 1.0),
+        ],
+    )
+    def test_valid_magnifier(self, ib_price: float, price_magnifier: int, expected: float) -> None:
+        assert ib_price_to_nautilus_price(ib_price, price_magnifier) == expected
+
+    @pytest.mark.parametrize("price_magnifier", [None, 0, -1])
+    def test_invalid_magnifier_returns_original(self, price_magnifier: int | None) -> None:
+        assert ib_price_to_nautilus_price(50.0, price_magnifier) == 50.0
+
+
+class TestNautilusPriceToIbPrice:
+    @pytest.mark.parametrize(
+        ("nautilus_price", "price_magnifier", "expected"),
+        [
+            (10.0, 1, 10.0),
+            (10.0, 10, 100.0),
+            (1.0, 100, 100.0),
+        ],
+    )
+    def test_valid_magnifier(
+        self,
+        nautilus_price: float,
+        price_magnifier: int,
+        expected: float,
+    ) -> None:
+        assert nautilus_price_to_ib_price(nautilus_price, price_magnifier) == expected
+
+    @pytest.mark.parametrize("price_magnifier", [None, 0, -1])
+    def test_invalid_magnifier_returns_original(self, price_magnifier: int | None) -> None:
+        assert nautilus_price_to_ib_price(50.0, price_magnifier) == 50.0


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

When `ContractDetails.priceMagnifier` is `None` (which can occur for certain IB contract types), the price conversion functions raise `TypeError: '<=' not supported between instances of 'int' and 'NoneType'` during position reconciliation after a connection reset. This fix adds a `None` guard to both `ib_price_to_nautilus_price` and `nautilus_price_to_ib_price`, and ensures `get_price_magnifier` in the instrument provider falls back to `1` when `priceMagnifier` is `None`.

## Related Issues/PRs

<!-- No related issues. -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added parameterized tests in `tests/integration_tests/adapters/interactive_brokers/test_parsing.py` covering `ib_price_to_nautilus_price` and `nautilus_price_to_ib_price` with valid magnifiers (1, 10, 100) and invalid magnifiers (`None`, `0`, `-1`).