### PR TITLE
Standardize adapter example manifests and trading deps

### DIFF
--- a/crates/adapters/architect_ax/Cargo.toml
+++ b/crates/adapters/architect_ax/Cargo.toml
@@ -51,7 +51,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -84,6 +83,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/betfair/Cargo.toml
+++ b/crates/adapters/betfair/Cargo.toml
@@ -21,6 +21,7 @@ name = "nautilus_betfair"
 crate-type = ["rlib"]
 
 [features]
+examples = ["nautilus-trading/examples"]
 high-precision = ["nautilus-model/high-precision"]
 python = [
   "nautilus-core/python",
@@ -73,7 +74,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 nautilus-backtest = { workspace = true }
 nautilus-execution = { workspace = true }
 nautilus-testkit = { workspace = true }
-nautilus-trading = { workspace = true, features = ["examples"] }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 dotenvy = { workspace = true }
@@ -98,8 +99,9 @@ name = "betfair-load-file"
 path = "examples/load_betfair_file.rs"
 doc = false
 
-# Run with `cargo run -p nautilus-betfair --example betfair-backtest`
+# Run with `cargo run -p nautilus-betfair --features examples --example betfair-backtest`
 [[example]]
 name = "betfair-backtest"
 path = "examples/betfair_backtest.rs"
+required-features = ["examples"]
 doc = false

--- a/crates/adapters/betfair/examples/betfair_backtest.rs
+++ b/crates/adapters/betfair/examples/betfair_backtest.rs
@@ -24,10 +24,10 @@
 //! The actor computes a running bid/ask quoted volume imbalance per runner.
 //! In Betfair terms: bids = "back" orders, asks = "lay" orders.
 //!
-//! Run with: `cargo run -p nautilus-betfair --example betfair-backtest`
+//! Run with: `cargo run -p nautilus-betfair --features examples --example betfair-backtest`
 //!
 //! Or pass a custom file path:
-//!   `cargo run -p nautilus-betfair --example betfair-backtest -- path/to/file.gz`
+//!   `cargo run -p nautilus-betfair --features examples --example betfair-backtest -- path/to/file.gz`
 
 use std::path::PathBuf;
 

--- a/crates/adapters/binance/Cargo.toml
+++ b/crates/adapters/binance/Cargo.toml
@@ -54,7 +54,6 @@ nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-serialization = { workspace = true, features = ["sbe", "arrow"] }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -87,6 +86,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/bitmex/Cargo.toml
+++ b/crates/adapters/bitmex/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["high-precision"]
+examples = ["nautilus-trading/examples"]
 extension-module = [
   "nautilus-common/extension-module",
   "nautilus-core/extension-module",
@@ -85,7 +86,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-nautilus-trading = { workspace = true, features = ["examples"] }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 dotenvy = { workspace = true }
@@ -123,9 +124,9 @@ path = "examples/node_exec_tester.rs"
 required-features = []
 doc = false
 
-# Run with `cargo run --example bitmex-grid-mm --package nautilus-bitmex`
+# Run with `cargo run --example bitmex-grid-mm --package nautilus-bitmex --features examples`
 [[example]]
 name = "bitmex-grid-mm"
 path = "examples/node_grid_mm.rs"
-required-features = []
+required-features = ["examples"]
 doc = false

--- a/crates/adapters/bitmex/examples/node_grid_mm.rs
+++ b/crates/adapters/bitmex/examples/node_grid_mm.rs
@@ -23,7 +23,7 @@
 //! - Testnet: `BITMEX_TESTNET_API_KEY` / `BITMEX_TESTNET_API_SECRET`
 //! - Mainnet: `BITMEX_API_KEY` / `BITMEX_API_SECRET`
 //!
-//! Run with: `cargo run --example bitmex-grid-mm --package nautilus-bitmex`
+//! Run with: `cargo run --example bitmex-grid-mm --package nautilus-bitmex --features examples`
 
 use log::LevelFilter;
 use nautilus_bitmex::{

--- a/crates/adapters/bybit/Cargo.toml
+++ b/crates/adapters/bybit/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["high-precision"]
+examples = ["nautilus-trading/examples"]
 python = [
   "nautilus-common/python",
   "nautilus-core/python",
@@ -53,7 +54,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true, features = ["examples"] }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -87,6 +87,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }
@@ -140,9 +141,9 @@ path = "examples/node_option_chain.rs"
 required-features = []
 doc = false
 
-# Run with `cargo run --example bybit-delta-neutral --package nautilus-bybit`.
+# Run with `cargo run --example bybit-delta-neutral --package nautilus-bybit --features examples`.
 [[example]]
 name = "bybit-delta-neutral"
 path = "examples/node_delta_neutral.rs"
-required-features = []
+required-features = ["examples"]
 doc = false

--- a/crates/adapters/bybit/examples/node_delta_neutral.rs
+++ b/crates/adapters/bybit/examples/node_delta_neutral.rs
@@ -32,7 +32,7 @@
 //! - Rehedge check every 30 seconds
 //! - Entry disabled by default (set `enter_strangle` to enable live orders)
 //!
-//! Run with: `cargo run --example bybit-delta-neutral --package nautilus-bybit`
+//! Run with: `cargo run --example bybit-delta-neutral --package nautilus-bybit --features examples`
 
 use nautilus_bybit::{
     common::enums::BybitProductType,

--- a/crates/adapters/deribit/Cargo.toml
+++ b/crates/adapters/deribit/Cargo.toml
@@ -53,7 +53,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -84,6 +83,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/dydx/Cargo.toml
+++ b/crates/adapters/dydx/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["high-precision"]
+examples = ["nautilus-trading/examples"]
 extension-module = [
   "nautilus-common/extension-module",
   "nautilus-core/extension-module",
@@ -90,7 +91,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-nautilus-trading = { workspace = true, features = ["examples"] }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 rstest = { workspace = true }
@@ -140,9 +141,9 @@ path = "examples/node_exec_tester.rs"
 required-features = []
 doc = false
 
-# Run with `cargo run --example dydx-grid-mm --package nautilus-dydx`
+# Run with `cargo run --example dydx-grid-mm --package nautilus-dydx --features examples`
 [[example]]
 name = "dydx-grid-mm"
 path = "examples/node_grid_mm.rs"
-required-features = []
+required-features = ["examples"]
 doc = false

--- a/crates/adapters/dydx/examples/node_grid_mm.rs
+++ b/crates/adapters/dydx/examples/node_grid_mm.rs
@@ -19,7 +19,7 @@
 //! - Set `DYDX_PRIVATE_KEY` (or `DYDX_TESTNET_PRIVATE_KEY` for testnet)
 //! - Optionally set `DYDX_WALLET_ADDRESS` (or `DYDX_TESTNET_WALLET_ADDRESS` for testnet)
 //!
-//! Run with: `cargo run --example dydx-grid-mm --package nautilus-dydx`
+//! Run with: `cargo run --example dydx-grid-mm --package nautilus-dydx --features examples`
 
 use log::LevelFilter;
 use nautilus_common::{enums::Environment, logging::logger::LoggerConfig};

--- a/crates/adapters/hyperliquid/Cargo.toml
+++ b/crates/adapters/hyperliquid/Cargo.toml
@@ -53,7 +53,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 alloy = { workspace = true }
@@ -88,6 +87,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/kraken/Cargo.toml
+++ b/crates/adapters/kraken/Cargo.toml
@@ -55,7 +55,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -94,6 +93,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/okx/Cargo.toml
+++ b/crates/adapters/okx/Cargo.toml
@@ -54,7 +54,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -88,6 +87,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 criterion = { workspace = true }

--- a/crates/adapters/polymarket/Cargo.toml
+++ b/crates/adapters/polymarket/Cargo.toml
@@ -52,7 +52,6 @@ nautilus-live = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-network = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 alloy = { workspace = true, features = ["provider-http", "network", "reqwest"] }
@@ -88,7 +87,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
-nautilus-trading = { workspace = true, features = ["examples"] }
+nautilus-trading = { workspace = true }
 
 axum = { workspace = true }
 rstest = { workspace = true }

--- a/crates/adapters/sandbox/Cargo.toml
+++ b/crates/adapters/sandbox/Cargo.toml
@@ -55,7 +55,6 @@ nautilus-core = { workspace = true }
 nautilus-execution = { workspace = true }
 nautilus-model = { workspace = true }
 nautilus-system = { workspace = true }
-nautilus-trading = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -75,6 +74,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 
 [dev-dependencies]
 nautilus-testkit = { workspace = true }
+nautilus-trading = { workspace = true }
 
 rstest = { workspace = true }
 tokio = { workspace = true }

--- a/docs/tutorials/backtest_book_imbalance_betfair.md
+++ b/docs/tutorials/backtest_book_imbalance_betfair.md
@@ -251,13 +251,13 @@ positive backing imbalance of +0.29 throughout the market lifetime.
 
 ```bash
 # Debug build
-cargo run -p nautilus-betfair --example betfair-backtest
+cargo run -p nautilus-betfair --features examples --example betfair-backtest
 
 # Release build (recommended)
-cargo run -p nautilus-betfair --release --example betfair-backtest
+cargo run -p nautilus-betfair --features examples --release --example betfair-backtest
 
 # Custom data file
-cargo run -p nautilus-betfair --release --example betfair-backtest -- path/to/file.gz
+cargo run -p nautilus-betfair --features examples --release --example betfair-backtest -- path/to/file.gz
 ```
 
 ## Complete source

--- a/docs/tutorials/delta_neutral_options_bybit.md
+++ b/docs/tutorials/delta_neutral_options_bybit.md
@@ -236,7 +236,7 @@ the strangle and hedge requires manual action or a separate exit strategy.
 ## Running the example
 
 ```bash
-cargo run --example bybit-delta-neutral --package nautilus-bybit
+cargo run --example bybit-delta-neutral --package nautilus-bybit --features examples
 ```
 
 The example runs with `enter_strangle: false` by default, so it does not

--- a/docs/tutorials/grid_market_maker_bitmex.md
+++ b/docs/tutorials/grid_market_maker_bitmex.md
@@ -380,7 +380,7 @@ sizing `max_position` and `trade_size`.
 ### Run the example
 
 ```bash
-cargo run --example bitmex-grid-mm --package nautilus-bitmex
+cargo run --example bitmex-grid-mm --package nautilus-bitmex --features examples
 ```
 
 ### Graceful shutdown

--- a/docs/tutorials/grid_market_maker_dydx.md
+++ b/docs/tutorials/grid_market_maker_dydx.md
@@ -219,7 +219,7 @@ DYDX_WALLET_ADDRESS=dydx1...
 ### Run the example
 
 ```bash
-cargo run --example dydx-grid-mm --package nautilus-dydx
+cargo run --example dydx-grid-mm --package nautilus-dydx --features examples
 ```
 
 ### Graceful shutdown


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Standardize adapter example manifests and trading deps
- Align adapter example manifests with the OKX
- Remove redundant non-dev edges and reduce unnecessary build work

## Type of change

- [x] Improvement (non-breaking)