### PR TITLE
Port IB Rust adapter historical bar replay and Python parity fixes

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -66,8 +66,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use self::streams::{
-    handle_index_price_subscription, handle_market_depth_subscription,
-    handle_option_greeks_subscription, handle_quote_subscription,
+    handle_historical_bars_subscription, handle_index_price_subscription,
+    handle_market_depth_subscription, handle_option_greeks_subscription, handle_quote_subscription,
     handle_realtime_bars_subscription, handle_tick_by_tick_quote_subscription,
     handle_trade_subscription,
 };
@@ -197,6 +197,17 @@ fn u64_to_nonzero_usize(value: u64) -> Option<std::num::NonZeroUsize> {
 #[cfg(feature = "python")]
 fn u16_to_nonzero_usize(value: u16) -> Option<std::num::NonZeroUsize> {
     std::num::NonZeroUsize::new(value as usize)
+}
+
+fn parse_start_ns(params: Option<&nautilus_core::Params>) -> Option<UnixNanos> {
+    params
+        .and_then(|params| params.get_u64("start_ns"))
+        .or_else(|| {
+            params
+                .and_then(|params| params.get_str("start_ns"))
+                .and_then(|value| value.parse::<u64>().ok())
+        })
+        .map(UnixNanos::from)
 }
 
 #[cfg(feature = "python")]
@@ -462,7 +473,11 @@ impl InteractiveBrokersDataClient {
     }
 
     #[cfg(feature = "python")]
-    pub(crate) fn subscribe_bars_for_python(&mut self, bar_type: BarType) -> anyhow::Result<()> {
+    pub(crate) fn subscribe_bars_for_python(
+        &mut self,
+        bar_type: BarType,
+        params: Option<std::collections::HashMap<String, String>>,
+    ) -> anyhow::Result<()> {
         let cmd = SubscribeBars {
             bar_type,
             client_id: Some(self.client_id()),
@@ -470,7 +485,7 @@ impl InteractiveBrokersDataClient {
             command_id: UUID4::new(),
             ts_init: self.clock.get_time_ns(),
             correlation_id: None,
-            params: None,
+            params: string_hash_map_to_params(params),
         };
         DataClient::subscribe_bars(self, cmd)
     }
@@ -1594,6 +1609,8 @@ impl DataClient for InteractiveBrokersDataClient {
         let last_bars = Arc::clone(&self.last_bars);
         let bar_timeout_tasks = Arc::clone(&self.bar_timeout_tasks);
         let handle_revised_bars = self.config.handle_revised_bars;
+        let use_rth = self.config.use_regular_trading_hours;
+        let start_ns = parse_start_ns(cmd.params.as_ref());
 
         // Create subscription-specific cancellation token
         let subscription_token = CancellationToken::new();
@@ -1603,28 +1620,43 @@ impl DataClient for InteractiveBrokersDataClient {
         let subscription_token_clone = subscription_token.clone();
 
         let task = get_runtime().spawn(async move {
-            if let Err(e) = handle_realtime_bars_subscription(
-                client_clone,
-                contract,
-                bar_type,
-                bar_type_str,
-                instrument_id,
-                price_precision,
-                size_precision,
-                data_sender,
-                clock,
-                last_bars,
-                bar_timeout_tasks,
-                handle_revised_bars,
-                subscription_token_clone,
-            )
-            .await
-            {
-                tracing::error!(
-                    "Real-time bars subscription error for {}: {:?}",
+            let result = if bar_type.spec().timedelta().num_seconds() == 5 {
+                handle_realtime_bars_subscription(
+                    client_clone,
+                    contract,
                     bar_type,
-                    e
-                );
+                    bar_type_str,
+                    instrument_id,
+                    price_precision,
+                    size_precision,
+                    data_sender,
+                    clock,
+                    last_bars,
+                    bar_timeout_tasks,
+                    handle_revised_bars,
+                    subscription_token_clone,
+                )
+                .await
+            } else {
+                handle_historical_bars_subscription(
+                    client_clone,
+                    contract,
+                    bar_type,
+                    price_type_to_ib_what_to_show(bar_type.spec().price_type),
+                    price_precision,
+                    size_precision,
+                    use_rth,
+                    start_ns,
+                    data_sender,
+                    handle_revised_bars,
+                    clock,
+                    subscription_token_clone,
+                )
+                .await
+            };
+
+            if let Err(e) = result {
+                tracing::error!("Bars subscription error for {}: {:?}", bar_type, e);
             }
         });
 

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -7,7 +7,7 @@
 //  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
 // -------------------------------------------------------------------------------------------------
 
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use ahash::AHashMap;
 use anyhow::Context;
@@ -15,7 +15,10 @@ use ibapi::{
     contracts::tick_types::TickType,
     market_data::{
         TradingHours,
-        historical::Bar as HistoricalBar,
+        historical::{
+            Bar as HistoricalBar, BarSize as HistoricalBarSize, HistoricalBarUpdate,
+            WhatToShow as HistoricalWhatToShow,
+        },
         realtime::{
             Bar as RealtimeBar, BarSize as RealtimeBarSize, MarketDepths, TickGeneric, TickPrice,
             TickPriceSize, TickSize, TickTypes, WhatToShow as RealtimeWhatToShow,
@@ -26,7 +29,7 @@ use ibapi::{
 use nautilus_common::messages::DataEvent;
 use nautilus_core::{UnixNanos, time::AtomicTime};
 use nautilus_model::{
-    data::{BarType, BookOrder, Data, OrderBookDelta, QuoteTick, option_chain::OptionGreeks},
+    data::{Bar, BarType, BookOrder, Data, OrderBookDelta, QuoteTick, option_chain::OptionGreeks},
     enums::OrderSide,
     identifiers::InstrumentId,
     types::{Price, Quantity},
@@ -45,6 +48,200 @@ use crate::data::{
 enum StreamAction {
     Continue,
     Stop,
+}
+
+const HISTORICAL_BAR_MIN_COUNT: i64 = 300;
+const HISTORICAL_BAR_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+pub(super) fn resolve_historical_bar_start_ns(
+    start_ns: Option<UnixNanos>,
+    now_ns: UnixNanos,
+) -> UnixNanos {
+    start_ns.unwrap_or(now_ns)
+}
+
+pub(super) fn resolve_historical_bar_replay_start_ns(
+    first_start_ns: UnixNanos,
+    last_disconnection_ns: Option<UnixNanos>,
+) -> UnixNanos {
+    match last_disconnection_ns {
+        Some(last_disconnection_ns) if last_disconnection_ns > first_start_ns => {
+            last_disconnection_ns
+        }
+        _ => first_start_ns,
+    }
+}
+
+pub(super) fn calculate_historical_bar_subscription_duration(
+    bar_type: BarType,
+    start_ns: UnixNanos,
+    now_ns: UnixNanos,
+) -> ibapi::market_data::historical::Duration {
+    use ibapi::market_data::historical::ToDuration;
+
+    let bar_seconds = bar_type.spec().timedelta().num_seconds().max(1);
+    let requested_seconds =
+        ((now_ns.as_u64().saturating_sub(start_ns.as_u64())) / 1_000_000_000) as i64;
+    let minimum_seconds = bar_seconds.saturating_mul(HISTORICAL_BAR_MIN_COUNT);
+    let duration_seconds = requested_seconds.max(minimum_seconds).max(bar_seconds);
+
+    if duration_seconds >= 86_400 {
+        let duration_days = ((duration_seconds + 86_399) / 86_400).min(i32::MAX as i64) as i32;
+        duration_days.days()
+    } else {
+        let duration_seconds = duration_seconds.min(i32::MAX as i64) as i32;
+        duration_seconds.seconds()
+    }
+}
+
+fn should_emit_historical_bar(bar: &Bar, start_ns: UnixNanos) -> bool {
+    bar.ts_init >= start_ns
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_historical_bars_subscription(
+    client: Arc<ibapi::Client>,
+    contract: ibapi::contracts::Contract,
+    bar_type: BarType,
+    what_to_show: HistoricalWhatToShow,
+    price_precision: u8,
+    size_precision: u8,
+    use_rth: bool,
+    start_ns: Option<UnixNanos>,
+    data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
+    _handle_revised_bars: bool,
+    clock: &'static AtomicTime,
+    cancellation_token: CancellationToken,
+) -> anyhow::Result<()> {
+    tracing::debug!("Starting historical bars subscription for {}", bar_type);
+
+    let first_start_ns = resolve_historical_bar_start_ns(start_ns, clock.get_time_ns());
+    let mut last_disconnection_ns = None;
+
+    loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+
+        while !client.is_connected() {
+            if cancellation_token.is_cancelled() {
+                tracing::debug!("Historical bars subscription cancelled for {}", bar_type);
+                return Ok(());
+            }
+            tokio::time::sleep(HISTORICAL_BAR_RETRY_DELAY).await;
+        }
+
+        let replay_start_ns =
+            resolve_historical_bar_replay_start_ns(first_start_ns, last_disconnection_ns);
+        let request_duration = calculate_historical_bar_subscription_duration(
+            bar_type,
+            replay_start_ns,
+            clock.get_time_ns(),
+        );
+        let trading_hours = if use_rth {
+            TradingHours::Regular
+        } else {
+            TradingHours::Extended
+        };
+        let mut subscription = match client
+            .historical_data_streaming(
+                &contract,
+                request_duration,
+                bar_type_to_historical_bar_size(bar_type)?,
+                Some(what_to_show),
+                trading_hours,
+                true,
+            )
+            .await
+        {
+            Ok(subscription) => subscription,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to create historical bars subscription for {}: {:?}",
+                    bar_type,
+                    e
+                );
+                last_disconnection_ns = Some(clock.get_time_ns());
+                tokio::time::sleep(HISTORICAL_BAR_RETRY_DELAY).await;
+                continue;
+            }
+        };
+
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::debug!("Historical bars subscription cancelled for {}", bar_type);
+                    subscription.cancel().await;
+                    return Ok(());
+                }
+                update = subscription.next() => {
+                    match update {
+                        Some(HistoricalBarUpdate::Historical(data)) => {
+                            for ib_bar in &data.bars {
+                                let bar = ib_bar_to_nautilus_bar(
+                                    ib_bar,
+                                    bar_type,
+                                    price_precision,
+                                    size_precision,
+                                )?;
+
+                                if should_emit_historical_bar(&bar, replay_start_ns)
+                                    && data_sender.send(DataEvent::Data(Data::Bar(bar))).is_err()
+                                {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        Some(HistoricalBarUpdate::Update(ib_bar)) => {
+                            let bar = ib_bar_to_nautilus_bar(
+                                &ib_bar,
+                                bar_type,
+                                price_precision,
+                                size_precision,
+                            )?;
+
+                            if should_emit_historical_bar(&bar, replay_start_ns)
+                                && data_sender.send(DataEvent::Data(Data::Bar(bar))).is_err()
+                            {
+                                return Ok(());
+                            }
+                        }
+                        Some(HistoricalBarUpdate::End { .. }) => {}
+                        None => {
+                            if cancellation_token.is_cancelled() {
+                                return Ok(());
+                            }
+
+                            if let Some(error) = subscription.error() {
+                                tracing::warn!(
+                                    "Historical bars subscription ended for {}: {:?}",
+                                    bar_type,
+                                    error
+                                );
+                            } else {
+                                tracing::warn!(
+                                    "Historical bars subscription ended unexpectedly for {}",
+                                    bar_type
+                                );
+                            }
+
+                            last_disconnection_ns = Some(clock.get_time_ns());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        tokio::time::sleep(HISTORICAL_BAR_RETRY_DELAY).await;
+    }
+
+    tracing::debug!("Historical bars subscription ended for {}", bar_type);
+    Ok(())
+}
+
+fn bar_type_to_historical_bar_size(bar_type: BarType) -> anyhow::Result<HistoricalBarSize> {
+    crate::data::convert::bar_type_to_ib_bar_size(&bar_type)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1051,7 +1248,7 @@ mod tests {
         subscriptions::Subscription,
     };
     use nautilus_common::messages::DataEvent;
-    use nautilus_core::time::get_atomic_clock_realtime;
+    use nautilus_core::{UnixNanos, time::get_atomic_clock_realtime};
     use nautilus_model::{
         data::{BarType, Data},
         identifiers::{InstrumentId, Symbol, Venue},
@@ -1068,6 +1265,45 @@ mod tests {
 
     fn instrument_id() -> InstrumentId {
         InstrumentId::new(Symbol::from("SPX"), Venue::from("CBOE"))
+    }
+
+    fn minute_bar_type() -> BarType {
+        BarType::from("SPX.CBOE-1-MINUTE-LAST-EXTERNAL")
+    }
+
+    #[rstest]
+    fn test_resolve_historical_bar_start_ns_uses_current_time_when_missing() {
+        let now_ns = UnixNanos::from(2_000);
+
+        let start_ns = super::resolve_historical_bar_start_ns(None, now_ns);
+
+        assert_eq!(start_ns, now_ns);
+    }
+
+    #[rstest]
+    fn test_resolve_historical_bar_replay_start_ns_uses_last_disconnect_when_later() {
+        let first_start_ns = UnixNanos::from(1_000);
+        let last_disconnection_ns = UnixNanos::from(1_500);
+
+        let replay_start_ns = super::resolve_historical_bar_replay_start_ns(
+            first_start_ns,
+            Some(last_disconnection_ns),
+        );
+
+        assert_eq!(replay_start_ns, last_disconnection_ns);
+    }
+
+    #[rstest]
+    fn test_calculate_historical_bar_subscription_duration_requests_at_least_300_bars() {
+        use ibapi::market_data::historical::ToDuration;
+
+        let duration = super::calculate_historical_bar_subscription_duration(
+            minute_bar_type(),
+            UnixNanos::from(9_000_000_000),
+            UnixNanos::from(10_000_000_000),
+        );
+
+        assert_eq!(duration, 18_000.seconds());
     }
 
     #[tokio::test]

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -625,6 +625,54 @@ fn test_flush_pending_combo_fills_emits_report_with_exact_avg_px() {
 }
 
 #[rstest]
+fn test_update_order_avg_price_allows_negative_spread_avg_fill_price() {
+    let instrument_provider = create_test_instrument_provider();
+    let spread = create_test_option_spread();
+    let spread_instrument_id = spread.id;
+    let client_order_id = ClientOrderId::from("O-COMBO-NEG-001");
+    let order_avg_prices = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fill_avgs = Arc::new(Mutex::new(AHashMap::new()));
+    let order_fill_progress = Arc::new(Mutex::new(AHashMap::new()));
+
+    instrument_provider.insert_test_instrument(InstrumentAny::from(spread), 54321, 1);
+
+    InteractiveBrokersExecutionClient::update_order_avg_price(
+        client_order_id,
+        &spread_instrument_id,
+        -2.25,
+        3.0,
+        &instrument_provider,
+        &order_avg_prices,
+        &pending_combo_fill_avgs,
+        &order_fill_progress,
+    )
+    .unwrap();
+
+    let avg_px = order_avg_prices
+        .lock()
+        .unwrap()
+        .get(&client_order_id)
+        .copied()
+        .unwrap();
+    assert_eq!(avg_px, Price::from("-2.25"));
+
+    let avg_chunks = pending_combo_fill_avgs.lock().unwrap();
+    let (fill_delta, partial_avg_px) = avg_chunks
+        .get(&client_order_id)
+        .unwrap()
+        .front()
+        .copied()
+        .unwrap();
+    assert_eq!(fill_delta, Decimal::from(3));
+    assert_eq!(partial_avg_px, Price::from("-2.25"));
+
+    let fill_progress = order_fill_progress.lock().unwrap();
+    let (filled, total_notional) = fill_progress.get(&client_order_id).copied().unwrap();
+    assert_eq!(filled, Decimal::from(3));
+    assert_eq!(total_notional, Decimal::from_str("-6.75").unwrap());
+}
+
+#[rstest]
 fn test_flush_pending_combo_fills_retains_partial_avg_chunk_remainder() {
     let client_order_id = ClientOrderId::from("O-COMBO-002");
     let pending_combo_fills = Arc::new(Mutex::new(AHashMap::new()));

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -8,6 +8,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use super::*;
+use crate::execution::parse;
 
 impl InteractiveBrokersExecutionClient {
     /// Starts the order update subscription stream.
@@ -650,7 +651,8 @@ impl InteractiveBrokersExecutionClient {
         pending_combo_fill_avgs: &Arc<Mutex<AHashMap<ClientOrderId, VecDeque<(Decimal, Price)>>>>,
         order_fill_progress: &Arc<Mutex<AHashMap<ClientOrderId, (Decimal, Decimal)>>>,
     ) -> anyhow::Result<()> {
-        if avg_fill_price <= 0.0 || filled <= 0.0 {
+        let is_spread_order = is_spread_instrument_id(instrument_id);
+        if filled <= 0.0 || !parse::should_use_avg_fill_price(avg_fill_price, instrument_id) {
             return Ok(());
         }
 
@@ -684,7 +686,7 @@ impl InteractiveBrokersExecutionClient {
         drop(progress);
 
         let fill_delta = filled_decimal - previous_filled;
-        if fill_delta <= Decimal::ZERO || !is_spread_instrument_id(instrument_id) {
+        if fill_delta <= Decimal::ZERO || !is_spread_order {
             return Ok(());
         }
 

--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -33,7 +33,17 @@ use nautilus_model::{
 use rust_decimal::Decimal;
 use time::{PrimitiveDateTime, macros::format_description};
 
-use crate::providers::instruments::InteractiveBrokersInstrumentProvider;
+use crate::{
+    common::parse::is_spread_instrument_id,
+    providers::instruments::InteractiveBrokersInstrumentProvider,
+};
+
+pub(crate) fn should_use_avg_fill_price(avg_fill_price: f64, instrument_id: &InstrumentId) -> bool {
+    avg_fill_price.is_finite()
+        && avg_fill_price != f64::MAX
+        && avg_fill_price != 0.0
+        && (avg_fill_price > 0.0 || is_spread_instrument_id(instrument_id))
+}
 
 /// Parse an IB execution to a Nautilus FillReport.
 ///
@@ -207,7 +217,8 @@ pub fn parse_order_status_to_report(
     let filled_qty = Quantity::new(order_status.filled, size_precision);
 
     // Get average price
-    let avg_px_value = if order_status.average_fill_price > 0.0 {
+    let include_avg_px = should_use_avg_fill_price(order_status.average_fill_price, &instrument_id);
+    let avg_px_value = if include_avg_px {
         order_status.average_fill_price * price_magnifier
     } else {
         0.0
@@ -298,7 +309,7 @@ pub fn parse_order_status_to_report(
         }
     }
 
-    if avg_px_value > 0.0 {
+    if include_avg_px {
         report = report.with_avg_px(avg_px_value)?;
     }
 
@@ -605,6 +616,42 @@ mod tests {
                 error_msg
             );
         }
+    }
+
+    #[rstest]
+    fn test_parse_order_status_to_report_spread_allows_negative_avg_fill_price() {
+        let instrument_provider = create_test_instrument_provider();
+        let instrument_id = InstrumentId::new(
+            Symbol::from("(1)SPY C400_((1))SPY C410"),
+            Venue::from("SMART"),
+        );
+        let account_id = AccountId::from("IB-001");
+
+        let order_status = OrderStatus {
+            order_id: 12345,
+            status: String::from("Filled"),
+            filled: 1.0,
+            remaining: 0.0,
+            average_fill_price: -2.25,
+            perm_id: 0,
+            parent_id: 0,
+            last_fill_price: -2.25,
+            client_id: 0,
+            why_held: String::new(),
+            market_cap_price: 0.0,
+        };
+
+        let report = parse_order_status_to_report(
+            &order_status,
+            None,
+            instrument_id,
+            account_id,
+            &instrument_provider,
+            UnixNanos::new(0),
+        )
+        .unwrap();
+
+        assert_eq!(report.avg_px, Some(Decimal::from_str("-2.25").unwrap()));
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -287,12 +287,12 @@ impl InteractiveBrokersInstrumentProvider {
     pub fn get_price_magnifier(&self, instrument_id: &InstrumentId) -> i32 {
         // First try dedicated price magnifier cache for fast lookup
         if let Some(magnifier) = self.price_magnifiers.get(instrument_id) {
-            return *magnifier.value();
+            return normalize_price_magnifier(*magnifier.value());
         }
 
         // Fall back to contract details lookup
         if let Some(details) = self.contract_details.get(instrument_id) {
-            let magnifier = details.value().price_magnifier;
+            let magnifier = normalize_price_magnifier(details.value().price_magnifier);
             // Cache it for future fast lookups
             self.price_magnifiers.insert(*instrument_id, magnifier);
             return magnifier;
@@ -932,6 +932,14 @@ impl InteractiveBrokersInstrumentProvider {
         }
 
         Ok(loaded_ids)
+    }
+}
+
+fn normalize_price_magnifier(price_magnifier: i32) -> i32 {
+    if price_magnifier > 0 {
+        price_magnifier
+    } else {
+        1
     }
 }
 

--- a/crates/adapters/interactive_brokers/src/providers/tests.rs
+++ b/crates/adapters/interactive_brokers/src/providers/tests.rs
@@ -18,7 +18,10 @@
 #[cfg(test)]
 mod tests {
     use ibapi::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
-    use nautilus_model::identifiers::{InstrumentId, Symbol as NautilusSymbol, Venue};
+    use nautilus_model::{
+        identifiers::{InstrumentId, Symbol as NautilusSymbol, Venue},
+        instruments::{Instrument, InstrumentAny, stubs::equity_aapl},
+    };
     use rstest::rstest;
 
     use crate::{
@@ -104,6 +107,17 @@ mod tests {
         let method = provider.symbology_method();
         // Default should be Simplified
         assert!(matches!(method, crate::config::SymbologyMethod::Simplified));
+    }
+
+    #[rstest]
+    fn test_get_price_magnifier_defaults_zero_to_one() {
+        let provider = create_test_provider();
+        let instrument = equity_aapl();
+        let instrument_id = instrument.id();
+
+        provider.insert_test_instrument(InstrumentAny::from(instrument), 265598, 0);
+
+        assert_eq!(provider.get_price_magnifier(&instrument_id), 1);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/python/data.rs
+++ b/crates/adapters/interactive_brokers/src/python/data.rs
@@ -862,9 +862,13 @@ impl InteractiveBrokersDataClient {
     /// # Errors
     ///
     /// Returns an error if the subscription fails.
-    #[pyo3(name = "subscribe_bars")]
-    fn py_subscribe_bars(&mut self, bar_type: BarType) -> PyResult<()> {
-        self.subscribe_bars_for_python(bar_type)
+    #[pyo3(name = "subscribe_bars", signature = (bar_type, params=None))]
+    fn py_subscribe_bars(
+        &mut self,
+        bar_type: BarType,
+        params: Option<std::collections::HashMap<String, String>>,
+    ) -> PyResult<()> {
+        self.subscribe_bars_for_python(bar_type, params)
             .map_err(to_pyruntime_err)
     }
 

--- a/nautilus_trader/adapters/interactive_brokers_pyo3/data.py
+++ b/nautilus_trader/adapters/interactive_brokers_pyo3/data.py
@@ -405,7 +405,16 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
             )
             return
 
-        self._rust_client.subscribe_bars(_to_pyo3_bar_type(command.bar_type))
+        params = None
+        command_params = getattr(command, "params", None)
+        if command_params:
+            params = {key: str(value) for key, value in command_params.items() if value is not None}
+
+        pyo3_bar_type = _to_pyo3_bar_type(command.bar_type)
+        if params is None:
+            self._rust_client.subscribe_bars(pyo3_bar_type)
+        else:
+            self._rust_client.subscribe_bars(pyo3_bar_type, params)
 
     async def _subscribe_instrument_status(self, command: Any) -> None:
         """


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- This change brings the Rust Interactive Brokers adapter closer to the behavior already present in the Python adapter for historical bar subscriptions, spread average price handling, and price magnifier defaults.
- The Rust data client now routes non-5-second bar subscriptions through IB historical keep-up-to-date streaming instead of treating all bar subscriptions as 5-second real-time bars.
- The Rust PyO3 data bridge now forwards subscription params for bar subscriptions so `start_ns` generated by the data engine reaches the Rust adapter.
- The Rust execution and provider layers now match the recent Python-side fixes for negative spread average prices and `priceMagnifier` values that are zero or absent-like.

## Data subscription changes

- Historical bar subscriptions above 5 seconds now use IB historical streaming with `keep_up_to_date=true`, matching the Python adapter’s split between 5-second real-time bars and larger historical bar subscriptions.
- Historical bar subscriptions now derive a replay window from `start_ns` and request at least approximately 300 bars so IB returns enough history to seed the live stream.
- Historical bars are filtered before publication so bars older than the effective replay start are dropped, matching the Python adapter’s `start_ns` filtering behavior.
- When the underlying IB stream drops, the Rust historical bar subscription loop now waits for reconnection and resubscribes from the later of the original `first_start_ns` and the latest observed disconnection time.
- The implementation keeps the reconnect behavior scoped to the historical bar stream task rather than introducing a broader client-wide resubscription framework, which keeps the change lower risk while covering the missing bar replay behavior.

## Execution and provider parity changes

- Spread orders in the Rust execution adapter now accept negative average fill prices when they are valid spread prices instead of discarding them as invalid non-positive values.
- Order status parsing now preserves negative average prices for spread instruments while still rejecting zero, non-finite, and invalid non-spread values.
- Combo fill average-price tracking now preserves negative spread notional deltas so combo reconciliation stays aligned with the Python adapter.
- The IB Rust instrument provider now normalizes non-positive `price_magnifier` values to `1`, matching the Python provider fallback and preventing invalid scaling during reconciliation and order status conversion.

## Testing

- Added Rust unit tests covering historical bar replay start resolution and minimum-duration calculation for subscription backfill.
- Added Rust unit tests covering negative average fill prices for spread order status parsing and combo fill progress tracking.
- Added a Rust unit test covering zero `price_magnifier` fallback to `1`.
- Verified the adapter with `cargo test -p nautilus-interactive-brokers --lib`.
- Verified the repo debug build with `make build-debug`.
- Ran `make pre-commit` after writing this summary.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
