### PR TITLE
Fix PyO3 from_dict failure on non-ASCII strings

### DIFF
--- a/crates/core/src/python/serialization.rs
+++ b/crates/core/src/python/serialization.rs
@@ -32,9 +32,13 @@ pub fn from_dict_pyo3<T>(py: Python<'_>, values: Py<PyDict>) -> Result<T, PyErr>
 where
     T: DeserializeOwned,
 {
-    // Extract to JSON bytes
+    // `ensure_ascii=False` keeps non-ASCII characters as raw UTF-8 in the JSON output.
+    // Without this, `\uXXXX` escapes force `serde_json` onto the owned-string path,
+    // which `visit_str`-only visitors like `ustr::Ustr` reject as "expected a borrowed string".
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("ensure_ascii", false)?;
     let json_str: String = PyModule::import(py, "json")?
-        .call_method("dumps", (values,), None)?
+        .call_method("dumps", (values,), Some(&kwargs))?
         .extract()?;
 
     // Deserialize to object

--- a/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_crypto_perpetual_pyo3.py
@@ -96,6 +96,44 @@ def test_to_dict():
     }
 
 
+def test_from_dict_non_ascii_base_currency():
+    # Regression for https://github.com/nautechsystems/nautilus_trader/issues/3893
+    # CJK characters in string fields must not break the PyO3 `from_dict` path.
+    raw_instrument = {
+        "type": "CryptoPerpetual",
+        "id": "\u9f99\u867eUSDT-PERP.BINANCE",
+        "raw_symbol": "\u9f99\u867eUSDT",
+        "base_currency": "\u9f99\u867e",
+        "quote_currency": "USDT",
+        "settlement_currency": "USDT",
+        "is_inverse": False,
+        "price_precision": 6,
+        "size_precision": 0,
+        "price_increment": "0.000001",
+        "size_increment": "1",
+        "multiplier": "1",
+        "lot_size": "1",
+        "max_quantity": None,
+        "min_quantity": "1",
+        "max_notional": None,
+        "min_notional": None,
+        "max_price": None,
+        "min_price": None,
+        "maker_fee": "0.0002",
+        "margin_init": "0",
+        "margin_maint": "0",
+        "taker_fee": "0.0004",
+        "info": {},
+        "ts_event": 1773187200000000000,
+        "ts_init": 1773187200000000000,
+    }
+
+    instrument = nautilus_pyo3.CryptoPerpetual.from_dict(raw_instrument)
+
+    assert str(instrument.id) == "\u9f99\u867eUSDT-PERP.BINANCE"
+    assert instrument.base_currency.code == "\u9f99\u867e"
+
+
 def test_pyo3_cython_conversion():
     crypto_perpetual_pyo3 = TestInstrumentProviderPyo3.ethusdt_perp_binance()
     crypto_perpetual_pyo3_dict = crypto_perpetual_pyo3.to_dict()


### PR DESCRIPTION
## Summary

- Pass `ensure_ascii=False` to `json.dumps` inside `from_dict_pyo3` so non-ASCII characters stay as raw UTF-8 instead of `\uXXXX` escapes.
- Without the fix, escaped Unicode forces `serde_json` onto the owned-string deserialization path, which `visit_str`-only visitors like `ustr::Ustr` (backing `Symbol`) reject as `invalid type: string "…", expected a borrowed string`.
- Adds a regression test that mirrors the issue repro exactly (Chinese characters in `id`, `raw_symbol`, and `base_currency`).

Closes #3893.

## Test plan

- [x] New `test_from_dict_non_ascii_base_currency` fails on `develop` with the exact bug error, passes with the fix.
- [x] Existing `test_to_dict` and `test_pyo3_cython_conversion` still pass.
- [x] `ruff check` / `ruff format --check` clean on the test file.
- [x] `cargo +nightly fmt --check` clean on `nautilus-core`.
- [x] `cargo clippy -p nautilus-core --features python,pyo3` clean.

## Notes

The fix lives in the generic `from_dict_pyo3` helper, so every PyO3 type that round-trips through Python dicts benefits. I considered patching upstream `ustr::Ustr` to add a `visit_string` fallback instead, but that would mean waiting on a new `ustr` release; `ensure_ascii=False` is a one-line local fix that works regardless of the visitor shape.