### PR TITLE
Fix Polymarket parse_to_quote_ticks top-of-book using authoritative best_bid/best_ask

### DIFF
--- a/nautilus_trader/adapters/polymarket/schemas/book.py
+++ b/nautilus_trader/adapters/polymarket/schemas/book.py
@@ -219,25 +219,46 @@ class PolymarketQuotes(msgspec.Struct, tag="price_change", tag_field="event_type
         last_quote: QuoteTick,
         ts_init: int,
     ) -> list[QuoteTick]:
+        """Build QuoteTicks from Polymarket `price_change` entries.
+
+        Uses the authoritative `best_bid` / `best_ask` fields that the
+        Polymarket WS payload carries on every entry (the top of book
+        after the change is applied), NOT `change.price` which is the
+        price of the specific level that was added, updated, or
+        removed. The level that changed is frequently not the spread
+        level (for example a `size=0` removal deep in the ladder), so
+        using `change.price` as the new best bid/ask would silently
+        drift the cached top of book away from the live market.
+
+        Sizes intentionally carry from `last_quote`: the WS payload
+        only reports the size at the changed level, never at the top.
+        Callers that need authoritative top of book sizes should
+        drive off `OrderBookDeltas` plus a local `OrderBook`, as
+        `PolymarketDataClient._handle_quote` does.
+
+        See https://github.com/nautechsystems/nautilus_trader/issues/3905.
+        """
         quotes: list[QuoteTick] = []
 
         for change in self.price_changes:
-            if change.side == PolymarketOrderSide.BUY:
-                ask_price = last_quote.ask_price
-                ask_size = last_quote.ask_size
-                bid_price = instrument.make_price(float(change.price))
-                bid_size = instrument.make_qty(float(change.size))
-            else:  # SELL
-                ask_price = instrument.make_price(float(change.price))
-                ask_size = instrument.make_qty(float(change.size))
-                bid_price = last_quote.bid_price
-                bid_size = last_quote.bid_size
+            try:
+                bid_f = float(change.best_bid)
+                ask_f = float(change.best_ask)
+            except (TypeError, ValueError):
+                continue
+            # Skip obviously invalid pairs (empty parse to 0, crossed
+            # book, one-sided). The next change within ms should
+            # arrive with a valid pair; dropping is better than
+            # emitting a bogus tick that downstream consumers (the
+            # OrderEmulator, user cache reads) would treat as truth.
+            if bid_f <= 0 or ask_f <= 0 or bid_f >= ask_f:
+                continue
             quote = QuoteTick(
                 instrument_id=instrument.id,
-                bid_price=bid_price,
-                ask_price=ask_price,
-                bid_size=bid_size,
-                ask_size=ask_size,
+                bid_price=instrument.make_price(bid_f),
+                ask_price=instrument.make_price(ask_f),
+                bid_size=last_quote.bid_size,
+                ask_size=last_quote.ask_size,
                 ts_event=millis_to_nanos(float(self.timestamp)),
                 ts_init=ts_init,
             )

--- a/tests/integration_tests/adapters/polymarket/test_parsing.py
+++ b/tests/integration_tests/adapters/polymarket/test_parsing.py
@@ -267,6 +267,76 @@ def test_parse_quote_ticks() -> None:
         assert price_change.hash is not None
 
 
+def test_parse_to_quote_ticks_uses_best_bid_and_best_ask_not_changed_level_price() -> None:
+    """Regression for https://github.com/nautechsystems/nautilus_trader/issues/3905.
+
+    Each Polymarket `price_change` entry carries the specific level's
+    price in `change.price` AND the authoritative post-change top of
+    book in `change.best_bid` / `change.best_ask`. The two are
+    frequently different (e.g. a `size=0` removal at a deep level).
+    `parse_to_quote_ticks` must build the resulting `QuoteTick` from
+    `best_bid` / `best_ask`; using `change.price` silently drifts the
+    cached top away from the live market.
+    """
+    from nautilus_trader.adapters.polymarket.schemas.book import PolymarketQuote
+    from nautilus_trader.model.data import QuoteTick
+    from nautilus_trader.model.objects import Price
+    from nautilus_trader.model.objects import Quantity
+
+    instrument = TestInstrumentProvider.binary_option()
+
+    # A deep-book BUY removal (level at $0.30 removed, but true top
+    # of book is still around $0.60 / $0.70).
+    deep_buy_removal = PolymarketQuote(
+        asset_id="0x0",
+        price="0.30",
+        side=PolymarketOrderSide.BUY,
+        size="0",
+        hash="a" * 40,
+        best_bid="0.60",
+        best_ask="0.70",
+    )
+    # A deep-book SELL removal (level at $0.95 removed, true top
+    # unchanged).
+    deep_sell_removal = PolymarketQuote(
+        asset_id="0x0",
+        price="0.95",
+        side=PolymarketOrderSide.SELL,
+        size="0",
+        hash="b" * 40,
+        best_bid="0.60",
+        best_ask="0.70",
+    )
+    ws_message = PolymarketQuotes(
+        market="0x0",
+        price_changes=[deep_buy_removal, deep_sell_removal],
+        timestamp="1729084877448",
+    )
+    last_quote = QuoteTick(
+        instrument_id=instrument.id,
+        bid_price=Price.from_str("0.50"),
+        ask_price=Price.from_str("0.80"),
+        bid_size=Quantity.from_int(100),
+        ask_size=Quantity.from_int(100),
+        ts_event=0,
+        ts_init=0,
+    )
+
+    quotes = ws_message.parse_to_quote_ticks(
+        instrument=instrument,
+        last_quote=last_quote,
+        ts_init=1,
+    )
+
+    # Both changes anchor the same authoritative top of book
+    # (`best_bid=0.60`, `best_ask=0.70`), so the top of book after the
+    # batch should not reflect the deep-level prices $0.30 / $0.95.
+    assert len(quotes) == 2
+    for quote in quotes:
+        assert float(quote.bid_price) == 0.60
+        assert float(quote.ask_price) == 0.70
+
+
 def test_parse_trade_tick() -> None:
     # Arrange
     data = pkgutil.get_data(


### PR DESCRIPTION
Fixes #3905.

## Summary

`PolymarketQuotes.parse_to_quote_ticks` in
`nautilus_trader/adapters/polymarket/schemas/book.py` was building each emitted
`QuoteTick` from `change.price`, the price of the specific level that the
`price_change` entry targeted. That is rarely the spread level: a `size=0`
removal at a deep ladder price, or an addition well away from the spread, both
caused the cached `QuoteTick` to drift arbitrarily far from the live top of
book.

The Polymarket WS `price_change` payload already carries the authoritative post
change top of book on every entry via the `best_bid` and `best_ask` fields of
`PolymarketQuote`. This PR switches the parser to use those authoritative
fields.

## Empirical Evidence (from issue #3905)

Captured 14 real `price_change` events over 30 seconds on
`wss://ws-subscriptions-clob.polymarket.com/ws/market`:

- 0/14 had empty or zero `best_bid`/`best_ask`.
- Several entries had `change.price` differing from `best_bid`/`best_ask`
  (typically `size=0` removals at a deep level).

Sample:

```json
{
  "price": "0.156", "size": "0", "side": "SELL",
  "best_bid": "0.009", "best_ask": "0.155"
}
```

Pre fix, `parse_to_quote_ticks` produced `ask_price=0.156` for this entry;
post fix, it correctly produces `ask_price=0.155`.

Production impact observed on a downstream consumer: cached `QuoteTick`
diverged from live CLOB by up to 6.3x on the ask for buckets where
`price_change` events frequently targeted deep levels.

## Why `PolymarketDataClient` was already correct

`PolymarketDataClient._handle_quote` in `data.py` avoided the bug entirely by
maintaining a local `OrderBook` and deriving the `QuoteTick` from
`local_book.best_bid_price()` / `best_ask_price()`. Only downstream users of
the standalone `parse_to_quote_ticks` (custom subscribers, backtest loaders)
were affected.

## Fix details

`parse_to_quote_ticks` now:

- Reads `change.best_bid` / `change.best_ask` instead of `change.price`.
- Carries sizes from `last_quote` (the WS payload only reports the size at the
  changed level, never at the top; callers that need authoritative top of
  book sizes should drive off `OrderBookDeltas` plus a local `OrderBook`, as
  `PolymarketDataClient` already does).
- Skips invalid pairs (empty, zero, crossed book) rather than emit a bogus
  tick that downstream consumers (the `OrderEmulator`, user cache reads)
  would treat as truth; the next change arrives within milliseconds.

## Test

Added `test_parse_to_quote_ticks_uses_best_bid_and_best_ask_not_changed_level_price`
in `tests/integration_tests/adapters/polymarket/test_parsing.py`. Exercises
two deep level removals on opposite sides where `change.price` (0.30 and 0.95)
differs from `best_bid` / `best_ask` (0.60 / 0.70), and asserts the resulting
`QuoteTick`s anchor on `best_bid` / `best_ask`.

## Test plan

- [x] New regression test passes locally with the fix applied.
- [x] Existing `test_parse_order_book_deltas` and `test_parse_quote_ticks`
      continue to pass (no behavioral change for batches where
      `change.price == change.best_bid/ask`).
