### PR TITLE
Support user-provided Tokio runtime in live module

### DIFF
--- a/crates/common/src/live/mod.rs
+++ b/crates/common/src/live/mod.rs
@@ -31,5 +31,5 @@ pub use runner::{
     get_data_event_sender, get_exec_event_sender, set_data_event_sender, set_exec_event_sender,
     try_get_data_event_sender, try_get_exec_event_sender,
 };
-pub use runtime::{get_runtime, shutdown_runtime};
+pub use runtime::{get_runtime, set_runtime, shutdown_runtime};
 pub use timer::LiveTimer;

--- a/crates/common/src/live/runtime.rs
+++ b/crates/common/src/live/runtime.rs
@@ -84,10 +84,25 @@ fn initialize_runtime() -> tokio::runtime::Runtime {
         .expect("Failed to create tokio runtime")
 }
 
+/// Sets a custom pre-built Tokio runtime as the global Nautilus runtime.
+///
+/// Must be called before the first [`get_runtime`] invocation (i.e. before
+/// `LiveNode::build()` or any adapter/client usage). This gives callers who
+/// own `main()` full control over worker threads, blocking threads, thread
+/// names, stack sizes, and any other [`tokio::runtime::Builder`] options.
+///
+/// # Errors
+///
+/// Returns `Err` containing the runtime back if one was already initialized.
+pub fn set_runtime(runtime: tokio::runtime::Runtime) -> Result<(), tokio::runtime::Runtime> {
+    RUNTIME.set(runtime)
+}
+
 /// Returns a reference to the global Nautilus Tokio runtime.
 ///
 /// The runtime is lazily initialized on the first call and reused thereafter.
-/// Intended for use cases where passing a runtime around is impractical.
+/// If a custom runtime was previously installed via [`set_runtime`], that
+/// runtime is returned instead.
 pub fn get_runtime() -> &'static tokio::runtime::Runtime {
     RUNTIME.get_or_init(initialize_runtime)
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Add `set_runtime()` function to allow injecting a custom pre-built Tokio runtime as the global Nautilus runtime
- If used must be called before `get_runtime()` (i.e. before `LiveNode::build()` or any adapter usage)
- Gives Rust-native callers who own `main()` full control over worker threads, blocking threads, thread names, stack sizes, and other `tokio::runtime::Builder` options

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore