### PR TITLE
Add continuous futures support for aggregated bars

### DIFF
--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -60,11 +60,22 @@ cdef class BarBuilder:
     cdef Price _close
     cdef Quantity volume
 
+    # Adjustment state pre-computed at `set_adjustment` time so the hot update path
+    # performs only raw C math (no Decimal allocation per tick).
+    cdef readonly object _adjustment_mode
+    cdef PriceRaw _adjustment_raw
+    cdef double _adjustment_ratio
+    cdef bint _adjustment_active
+    cdef bint _adjustment_is_ratio
+
     cpdef void update(self, Price price, Quantity size, uint64_t ts_init)
     cpdef void update_bar(self, Bar bar, Quantity volume, uint64_t ts_init)
-    cpdef void reset(self)
+    cpdef void set_adjustment(self, object adjustment, object mode = *)
     cpdef Bar build_now(self)
     cpdef Bar build(self, uint64_t ts_event, uint64_t ts_init)
+    cpdef void reset(self)
+
+    cdef Price _apply_adjustment_to_price(self, Price price)
 
 
 cdef class BarAggregator:

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -13,6 +13,7 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from decimal import ROUND_HALF_EVEN
 from decimal import Decimal
 from typing import Callable
 
@@ -39,11 +40,14 @@ from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.datetime cimport dt_to_unix_nanos
 from nautilus_trader.core.rust.core cimport millis_to_nanos
 from nautilus_trader.core.rust.core cimport secs_to_nanos
+from nautilus_trader.core.rust.model cimport FIXED_PRECISION
 from nautilus_trader.core.rust.model cimport FIXED_SCALAR
 from nautilus_trader.core.rust.model cimport AggressorSide
 from nautilus_trader.core.rust.model cimport InstrumentClass
 from nautilus_trader.core.rust.model cimport PriceRaw
 from nautilus_trader.core.rust.model cimport QuantityRaw
+from nautilus_trader.core.rust.model cimport price_as_f64
+from nautilus_trader.core.rust.model cimport price_new
 from nautilus_trader.model.data cimport Bar
 from nautilus_trader.model.data cimport BarAggregation
 from nautilus_trader.model.data cimport BarType
@@ -54,6 +58,7 @@ from nautilus_trader.model.greeks cimport GreeksCalculator
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport generic_spread_id_to_list
 from nautilus_trader.model.identifiers cimport is_generic_spread_id
+from nautilus_trader.model.enums import ContinuousFutureAdjustmentType
 from nautilus_trader.model.instruments.base cimport Instrument
 from nautilus_trader.model.objects cimport Price
 from nautilus_trader.model.objects cimport Quantity
@@ -99,6 +104,11 @@ cdef class BarBuilder:
         self._high = None
         self._low = None
         self._close = None
+        self._adjustment_mode = None
+        self._adjustment_raw = 0
+        self._adjustment_ratio = 1.0
+        self._adjustment_active = False
+        self._adjustment_is_ratio = False
         self.volume = Quantity.zero_c(precision=self.size_precision)
 
     def __repr__(self) -> str:
@@ -132,6 +142,8 @@ cdef class BarBuilder:
         if ts_init < self.ts_last:
             return  # Not applicable
 
+        price = self._apply_adjustment_to_price(price)
+
         if self._open is None:
             # Initialize builder
             self._open = price
@@ -163,37 +175,56 @@ cdef class BarBuilder:
         if ts_init < self.ts_last:
             return  # Not applicable
 
+        cdef Price bar_open = self._apply_adjustment_to_price(bar.open)
+        cdef Price bar_high = self._apply_adjustment_to_price(bar.high)
+        cdef Price bar_low = self._apply_adjustment_to_price(bar.low)
+        cdef Price bar_close = self._apply_adjustment_to_price(bar.close)
+
         if self._open is None:
             # Initialize builder
-            self._open = bar.open
-            self._high = bar.high
-            self._low = bar.low
+            self._open = bar_open
+            self._high = bar_high
+            self._low = bar_low
             self.initialized = True
         else:
-            if bar.high > self._high:
-                self._high = bar.high
+            if bar_high._mem.raw > self._high._mem.raw:
+                self._high = bar_high
 
-            if bar.low < self._low:
-                self._low = bar.low
+            if bar_low._mem.raw < self._low._mem.raw:
+                self._low = bar_low
 
-        self._close = bar.close
+        self._close = bar_close
         self.volume._mem.raw += volume._mem.raw
         self.count += 1
         self.ts_last = ts_init
 
-    cpdef void reset(self):
-        """
-        Reset the bar builder.
+    cpdef void set_adjustment(self, object adjustment, object mode = None):
+        # Adjustment applies at ingress on subsequent update()/update_bar() calls,
+        # so running OHLC state is always in the adjusted (common) frame.
+        # Only the ratio-vs-spread distinction matters here; direction affects only
+        # the sign/magnitude of the cumulative offset, which the caller has already applied.
+        # We pre-compute the adjustment once here so the per-tick hot path is pure C math.
+        Condition.not_none(adjustment, "adjustment")
+        if mode is None:
+            mode = ContinuousFutureAdjustmentType.BACKWARD_SPREAD
 
-        All stateful fields are reset to their initial value.
-        """
-        self._open = None
-        self._high = None
-        self._low = None
-        self._close = None
+        self._adjustment_mode = ContinuousFutureAdjustmentType(mode)
+        cdef object adj_decimal = adjustment if isinstance(adjustment, Decimal) else Decimal(str(adjustment))
 
-        self.volume = Quantity.zero_c(precision=self.size_precision)
-        self.count = 0
+        if self._adjustment_mode.is_ratio:
+            self._adjustment_is_ratio = True
+            self._adjustment_ratio = float(adj_decimal)
+            self._adjustment_active = adj_decimal != 1
+            return
+
+        # Spread mode: scale the Decimal offset to FIXED_PRECISION once so the hot path
+        # can add it straight onto `price._mem.raw` (signed PriceRaw supports negatives).
+        self._adjustment_is_ratio = False
+        cdef object scaled = (adj_decimal * (Decimal(10) ** int(FIXED_PRECISION))).to_integral_value(
+            rounding=ROUND_HALF_EVEN,
+        )
+        self._adjustment_raw = <PriceRaw>int(scaled)
+        self._adjustment_active = self._adjustment_raw != 0
 
     cpdef Bar build_now(self):
         """
@@ -246,6 +277,37 @@ cdef class BarBuilder:
         self.reset()
 
         return bar
+
+    cdef Price _apply_adjustment_to_price(self, Price price):
+        # Hot path: pure C math; no Decimal / str allocations per tick.
+        if not self._adjustment_active:
+            return price
+
+        if self._adjustment_is_ratio:
+            # Multiply in double; Rust's `price_new` rounds to the target precision.
+            return Price.from_mem_c(
+                price_new(price_as_f64(&price._mem) * self._adjustment_ratio, price._mem.precision),
+            )
+
+        # Spread: signed raw addition. `PriceRaw` is int64/int128, so backward-spread
+        # adjustments that push prices below zero are representable (bounded by PRICE_RAW_MIN).
+        return Price.from_raw_c(price._mem.raw + self._adjustment_raw, price._mem.precision)
+
+    cpdef void reset(self):
+        """
+        Reset the bar builder.
+
+        All per-bar OHLCV state is cleared. Adjustment configuration set via
+        `set_adjustment` is retained across resets so it spans subsequent bars
+        within the same continuous-future segment.
+        """
+        self._open = None
+        self._high = None
+        self._low = None
+        self._close = None
+
+        self.volume = Quantity.zero_c(precision=self.size_precision)
+        self.count = 0
 
 
 cdef class BarAggregator:

--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -130,6 +130,7 @@ cdef class DataEngine(Component):
     cdef readonly dict[UUID4, UUID4] _parent_request_id
     cdef readonly bint _disable_historical_cache
     cdef readonly dict[UUID4, dict[str, Any]] _bar_types_params
+    cdef readonly dict[BarType, object] _continuous_future_subscriptions
 
     cdef TopicCache _topic_cache
 
@@ -217,6 +218,7 @@ cdef class DataEngine(Component):
     cpdef void _handle_subscribe_funding_rates(self, MarketDataClient client, SubscribeFundingRates command)
     cpdef void _handle_subscribe_synthetic_trade_ticks(self, InstrumentId instrument_id)
     cpdef void _handle_subscribe_bars(self, MarketDataClient client, SubscribeBars command)
+    cpdef void _handle_subscribe_continuous_future_bars(self, MarketDataClient client, SubscribeBars command)
     cpdef void _handle_subscribe_data(self, DataClient client, SubscribeData command)
     cpdef void _handle_subscribe_instrument_status(self, MarketDataClient client, SubscribeInstrumentStatus command)
     cpdef void _handle_subscribe_instrument_close(self, MarketDataClient client, SubscribeInstrumentClose command)
@@ -231,6 +233,7 @@ cdef class DataEngine(Component):
     cpdef void _handle_unsubscribe_index_prices(self, MarketDataClient client, UnsubscribeIndexPrices command)
     cpdef void _handle_unsubscribe_funding_rates(self, MarketDataClient client, UnsubscribeFundingRates command)
     cpdef void _handle_unsubscribe_bars(self, MarketDataClient client, UnsubscribeBars command)
+    cpdef void _handle_unsubscribe_continuous_future_bars(self, MarketDataClient client, UnsubscribeBars command)
     cpdef void _handle_unsubscribe_data(self, DataClient client, UnsubscribeData command)
     cpdef void _handle_unsubscribe_instrument_status(self, MarketDataClient client, UnsubscribeInstrumentStatus command)
     cpdef void _handle_unsubscribe_instrument_close(self, MarketDataClient client, UnsubscribeInstrumentClose command)
@@ -324,17 +327,50 @@ cdef class DataEngine(Component):
     cdef object _ensure_request_workflows(self, RequestData request)
     cdef object _inherit_request_workflows(self, RequestData target, RequestData source)
     cdef dict _request_response_params(self, UUID4 request_id, dict fallback_params = *)
+    cdef void _abort_request(self, UUID4 request_id)
+    cdef void _emit_empty_request_response(self, UUID4 parent_request_id)
     cdef list _get_bar_types_from_aggregators(self)
     cpdef void _init_historical_aggregators(self, RequestData request)
+    cdef void _init_bar_aggregators_for_request(self, tuple bar_types, dict params, UUID4 request_id = *, bint historical = *, bint disable_time_bars_build_with_no_updates = *)
     cpdef void _start_bar_aggregator(self, MarketDataClient client, SubscribeBars command)
     cpdef void _create_bar_aggregator(self, BarType bar_type, dict params, UUID4 request_id = *)
-    cpdef void _setup_bar_aggregator(self, BarType bar_type, bint historical = *, UUID4 request_id = *)
+    cpdef void _setup_bar_aggregator(self, BarType bar_type, bint historical = *, UUID4 request_id = *, bint subscribe_source = *)
     cpdef void _subscribe_bar_aggregator(self, MarketDataClient client, SubscribeBars command)
     cpdef void _finalize_aggregated_bars_request(self, DataResponse response)
     cpdef void _stop_bar_aggregator(self, MarketDataClient client, UnsubscribeBars command)
     cpdef void _dispose_bar_aggregator(self, BarType bar_type, bint historical = *, UUID4 request_id = *)
     cpdef void _unsubscribe_bar_aggregator(self, MarketDataClient client, UnsubscribeBars command)
     cpdef bint _should_request_aggregated_bars(self, RequestData request)
+
+# -- INTERNAL - Continuous Futures ---------------------------------------------------------------
+
+    # (1) Subscribe / Unsubscribe (entry points `_handle_{subscribe,unsubscribe}_continuous_future_bars`
+    # are declared with the other subscribe/unsubscribe handlers above.)
+    cdef void _continuous_future_activate_segment(self, BarType target_bar_type, InstrumentId segment_instrument_id, int segment_index, object transitions, dict params, ClientId client_id, Venue venue, UUID4 correlation_id, uint64_t ts_init)
+    cdef void _continuous_future_schedule_next_transition(self, BarType target_key)
+    cpdef void _handle_continuous_future_subscription_transition(self, TimeEvent event)
+    cdef void _continuous_future_deactivate_segment(self, BarType target_bar_type, InstrumentId segment_instrument_id, dict params, ClientId client_id, Venue venue, UUID4 correlation_id, uint64_t ts_init)
+    cdef object _continuous_future_build_subscribe_command(self, tuple source, ClientId client_id, Venue venue, dict parent_params, UUID4 correlation_id, InstrumentId segment_instrument_id, uint64_t ts_init, bint subscribe)
+
+    # (2) Request
+    cpdef void _handle_continuous_future_request(self, RequestData request)
+    cdef void _setup_continuous_future_aggregators(self, RequestData request, tuple bar_types)
+    cpdef void _update_continuous_future_data(self, UUID4 parent_id)
+    cdef RequestData _continuous_future_build_child_request(self, RequestData parent, tuple source, InstrumentId segment_instrument_id, uint64_t start_ns, uint64_t end_ns)
+    cpdef void _handle_continuous_future_response(self, DataResponse response)
+
+    # (3) Shared helpers
+    cdef void _continuous_future_ensure_target_instrument(self, BarType target_bar_type, object transitions)
+    cdef bint _continuous_future_validate_transitions(self, BarType target_bar_type, object transitions, dict params)
+    cdef tuple _continuous_future_next_segment(self, object transitions, uint64_t cursor_ns, uint64_t end_ns)
+    cdef void _continuous_future_apply_adjustment(self, BarAggregator aggregator, object transitions, int segment_index, dict params)
+    cdef object _continuous_future_compute_offset(self, object transitions, int segment_index, dict params)
+    cdef tuple _continuous_future_resolve_source(self, BarType target_bar_type, InstrumentId segment_instrument_id)
+    cdef dict _continuous_future_child_params(self, dict parent_params)
+    cdef void _continuous_future_subscribe_source(self, BarAggregator aggregator, tuple source, InstrumentId segment_instrument_id, bint historical = *)
+    cdef void _continuous_future_unsubscribe_source(self, BarAggregator aggregator, tuple source, InstrumentId segment_instrument_id, bint historical = *)
+    cdef str _continuous_future_source_topic(self, tuple source, InstrumentId segment_instrument_id, bint historical = *)
+    cdef object _continuous_future_source_handler(self, BarAggregator aggregator, str source_type)
 
 # -- INTERNAL - Spread Quote Aggregators ----------------------------------------------------------
 

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -30,6 +30,8 @@ just need to override the `execute`, `process`, `send` and `receive` methods.
 """
 
 from dataclasses import dataclass
+from decimal import Decimal
+from decimal import InvalidOperation
 from typing import Any
 from typing import Callable
 from typing import Generator
@@ -58,6 +60,7 @@ from nautilus_trader.common.component cimport Clock
 from nautilus_trader.common.component cimport Component
 from nautilus_trader.common.component cimport MessageBus
 from nautilus_trader.common.component cimport TestClock
+from nautilus_trader.common.component cimport TimeEvent
 from nautilus_trader.common.data_topics cimport TopicCache
 from nautilus_trader.core.correctness cimport Condition
 from nautilus_trader.core.data cimport Data
@@ -150,12 +153,16 @@ from nautilus_trader.model.data cimport OrderBookDepth10
 from nautilus_trader.model.data cimport QuoteTick
 from nautilus_trader.model.data cimport TradeTick
 from nautilus_trader.model.data cimport bar_aggregation_not_implemented_message
+
+from nautilus_trader.model.enums import ContinuousFutureAdjustmentType
+
 from nautilus_trader.model.greeks cimport GreeksCalculator
 from nautilus_trader.model.identifiers cimport ClientId
 from nautilus_trader.model.identifiers cimport ComponentId
 from nautilus_trader.model.identifiers cimport InstrumentId
 from nautilus_trader.model.identifiers cimport Venue
 from nautilus_trader.model.instruments.base cimport Instrument
+from nautilus_trader.model.instruments.futures_contract cimport FuturesContract
 from nautilus_trader.model.instruments.synthetic cimport SyntheticInstrument
 from nautilus_trader.model.objects cimport Price
 from nautilus_trader.model.objects cimport Quantity
@@ -231,6 +238,7 @@ cdef class DataEngine(Component):
         self._parent_request_id: dict[UUID4, UUID4] = {}
         self._disable_historical_cache: bool = False
         self._bar_types_params: dict[UUID4, dict[str, Any]] = {}
+        self._continuous_future_subscriptions: dict[BarType, ContinuousFutureSubscriptionState] = {}
 
         self._topic_cache = TopicCache()
 
@@ -795,6 +803,7 @@ cdef class DataEngine(Component):
         self._parent_join_request_id.clear()
         self._parent_request_id.clear()
         self._bar_types_params.clear()
+        self._continuous_future_subscriptions.clear()
 
         self._topic_cache.clear_cache()
 
@@ -1219,6 +1228,10 @@ cdef class DataEngine(Component):
 
     cpdef void _handle_subscribe_bars(self, MarketDataClient client, SubscribeBars command):
         Condition.not_none(client, "client")
+
+        if command.params.get("continuous_future_transitions"):
+            self._handle_subscribe_continuous_future_bars(client, command)
+            return
 
         if command.bar_type.is_internally_aggregated():
             self._start_bar_aggregator(client, command)
@@ -1810,6 +1823,10 @@ cdef class DataEngine(Component):
         if self._msgbus.has_subscribers(self._topic_cache.get_bars_topic(command.bar_type.standard())):
             return
 
+        if command.bar_type.standard() in self._continuous_future_subscriptions:
+            self._handle_unsubscribe_continuous_future_bars(client, command)
+            return
+
         if command.bar_type.is_internally_aggregated():
             # Internal aggregation
             key = self._get_bar_aggregator_key(command.bar_type)
@@ -1916,6 +1933,18 @@ cdef class DataEngine(Component):
         if client is not None:
             Condition.is_true(isinstance(client, DataClient), "client was not a DataClient")
 
+        self._requests[request.id] = request
+
+        # Continuous future is dispatched before any other aggregated-bar handling so the
+        # continuous-future loop can create its own parent aggregator chain.
+        if request.params.get("continuous_future_transitions"):
+            self._handle_continuous_future_request(request)
+            return
+
+        # Aggregated-bar setup must run BEFORE the spread branch: a spread quote request
+        # carrying `bar_types` (e.g. `request_aggregated_bars` with `aggregate_spread_quotes=True`)
+        # needs its parent aggregator created here so the leg quote requests fired by the spread
+        # handler can inherit `has_aggregated_bars=True` and skip this branch themselves.
         if request.params.get("bar_types") and not state.has_aggregated_bars:
             if self._should_request_aggregated_bars(request):
                 self._init_historical_aggregators(request)
@@ -1925,13 +1954,11 @@ cdef class DataEngine(Component):
                 self._log.error(f"One of the aggregators in {request.params.get('bar_types')} is already running. "
                                 f"Either wait for a request to complete or unsubscribe from a live subscription. "
                                 f"Aborting request {request.id}.")
-                self._request_workflows.pop(request.id, None)
+                self._abort_request(request.id)
                 return
 
-        self._requests[request.id] = request
-
-        # A request involving a spread aggregator will be converted to a request join first
-        # "aggregate_spread_quotes" allows to aggregate spread quotes from component quotes
+        # A request involving a spread aggregator will be converted to a request join first.
+        # "aggregate_spread_quotes" allows to aggregate spread quotes from component quotes.
         if isinstance(request, RequestQuoteTicks) and request.params.get("aggregate_spread_quotes", False):
             instrument = self._cache.instrument(request.instrument_id)
             if instrument and instrument.is_spread():
@@ -1942,8 +1969,7 @@ cdef class DataEngine(Component):
                     self._log.error(f"An aggregator for {request.instrument_id} is already running. "
                                     f"Either wait for a request to complete or unsubscribe from a live subscription. "
                                     f"Aborting request {request.id}.")
-                    self._requests.pop(request.id, None)
-                    self._request_workflows.pop(request.id, None)
+                    self._abort_request(request.id)
                     return
 
         # Long join requests need to be processed as join requests first before the long request starts
@@ -2371,13 +2397,11 @@ cdef class DataEngine(Component):
         self._update_long_request_data(parent_request_id, data_received=data_received)
 
     cpdef void _finalize_long_request(self, UUID4 parent_request_id):
-        cdef RequestData parent_request = self._requests.get(parent_request_id)
-        if parent_request is None:
+        if self._requests.get(parent_request_id) is None:
             self._log.error(f"Cannot finalize long request: no parent request found for {parent_request_id}")
             return
-        parent_state = self._ensure_request_workflows(parent_request)
 
-        # Close the generator
+        # Close the generator so it releases resources held across sends.
         time_range_generator = self._long_request_generator.pop(parent_request_id, None)
         if time_range_generator is not None:
             try:
@@ -2385,8 +2409,20 @@ cdef class DataEngine(Component):
             except (StopIteration, GeneratorExit):
                 pass
 
-        # Send response for the original request to trigger its callback
-        response = DataResponse(
+        # Emit empty response so the parent's registered callback runs and _handle_response
+        # cleans up the workflow state.
+        self._emit_empty_request_response(parent_request_id)
+
+    cdef void _emit_empty_request_response(self, UUID4 parent_request_id):
+        # Fan in: emit a zero-data response so the parent's registered callback fires and
+        # `_handle_response` runs the standard cleanup (workflow state, bar-types params,
+        # aggregator disposal) in the same path as any other request.
+        cdef RequestData parent_request = self._requests.get(parent_request_id)
+        if parent_request is None:
+            return
+
+        cdef object parent_state = self._ensure_request_workflows(parent_request)
+        cdef DataResponse response = DataResponse(
             client_id=parent_request.client_id,
             venue=parent_request.venue,
             data_type=parent_request.data_type,
@@ -3010,7 +3046,7 @@ cdef class DataEngine(Component):
 
                 final_data = []
             else:
-                for data in response_data:
+                for data in grouped_response.data:
                     self.process_historical(data)
 
                 if grouped_response.correlation_id in self._bar_types_params:
@@ -3489,9 +3525,35 @@ cdef class DataEngine(Component):
         used_request_id = request.id if not update_subscriptions else None
 
         bar_types = request.params.get("bar_types", ())
+        self._init_bar_aggregators_for_request(
+            bar_types,
+            request.params,
+            used_request_id,
+            historical=True,
+        )
+
+    cdef void _init_bar_aggregators_for_request(
+        self,
+        tuple bar_types,
+        dict params,
+        UUID4 request_id = None,
+        bint historical = False,
+        bint disable_time_bars_build_with_no_updates = False,
+    ):
+        cdef BarType bar_type
+        cdef BarAggregator aggregator
+        cdef TimeBarAggregator time_aggregator
+
         for bar_type in bar_types:
-            self._create_bar_aggregator(bar_type, request.params, used_request_id)
-            self._setup_bar_aggregator(bar_type, historical=True, request_id=used_request_id)
+            self._create_bar_aggregator(bar_type, params, request_id)
+            self._setup_bar_aggregator(bar_type, historical=historical, request_id=request_id)
+            if disable_time_bars_build_with_no_updates:
+                aggregator = self._bar_aggregators.get(
+                    self._get_bar_aggregator_key(bar_type, request_id),
+                )
+                if isinstance(aggregator, TimeBarAggregator):
+                    time_aggregator = aggregator
+                    time_aggregator._build_with_no_updates = False
 
     cpdef void _finalize_aggregated_bars_request(self, DataResponse response):
         used_params = self._bar_types_params.pop(response.correlation_id, None)
@@ -3658,6 +3720,7 @@ cdef class DataEngine(Component):
         BarType bar_type,
         bint historical = False,
         UUID4 request_id = None,
+        bint subscribe_source = True,
     ):
         key = self._get_bar_aggregator_key(bar_type, request_id)
         aggregator = self._bar_aggregators.get(key)
@@ -3695,24 +3758,25 @@ cdef class DataEngine(Component):
 
             aggregator.set_historical_mode(historical, self.process)
 
-        # Subscribe aggregator to message bus to receive underlying data
-        if bar_type.is_composite():
-            self._msgbus.subscribe(
-                topic=self._topic_cache.get_bars_topic(bar_type.composite(), historical),
-                handler=aggregator.handle_bar,
-            )
-        elif bar_type.spec.price_type == PriceType.LAST:
-            self._msgbus.subscribe(
-                topic=self._topic_cache.get_trades_topic(bar_type.instrument_id, historical),
-                handler=aggregator.handle_trade_tick,
-                priority=5,
-            )
-        else:
-            self._msgbus.subscribe(
-                topic=self._topic_cache.get_quotes_topic(bar_type.instrument_id, historical),
-                handler=aggregator.handle_quote_tick,
-                priority=5,
-            )
+        if subscribe_source:
+            # Subscribe aggregator to message bus to receive underlying data
+            if bar_type.is_composite():
+                self._msgbus.subscribe(
+                    topic=self._topic_cache.get_bars_topic(bar_type.composite(), historical),
+                    handler=aggregator.handle_bar,
+                )
+            elif bar_type.spec.price_type == PriceType.LAST:
+                self._msgbus.subscribe(
+                    topic=self._topic_cache.get_trades_topic(bar_type.instrument_id, historical),
+                    handler=aggregator.handle_trade_tick,
+                    priority=5,
+                )
+            else:
+                self._msgbus.subscribe(
+                    topic=self._topic_cache.get_quotes_topic(bar_type.instrument_id, historical),
+                    handler=aggregator.handle_quote_tick,
+                    priority=5,
+                )
 
         # Start timer if aggregator is a TimeBarAggregator and not in historical mode
         if isinstance(aggregator, TimeBarAggregator) and not historical:
@@ -4211,6 +4275,878 @@ cdef class DataEngine(Component):
 
         return params
 
+    cdef void _abort_request(self, UUID4 request_id):
+        # Drop all engine bookkeeping for a request that could not be started.
+        self._requests.pop(request_id, None)
+        self._request_workflows.pop(request_id, None)
+
+    # -- INTERNAL - Continuous Futures ----------------------------------------------------------------
+    #
+    # A continuous-future request/subscription is driven by a list of segments (contracts) and, between
+    # any two consecutive segments, a transition with the pre/post-transition prices used to compute the
+    # cumulative adjustment. The request side mirrors `_handle_long_request` one level up: each segment
+    # emits one inner request via `_msgbus.request`, and `_handle_continuous_future_response` is its
+    # callback. The inner request itself may be long-looped (if `time_range_generator` is set in params),
+    # so both loops compose: outer iterates segments, inner iterates time ranges within a segment.
+    # The subscription side is a small state machine driven by a time alert at each upcoming transition.
+    #
+    # Methods are grouped as: (1) subscribe/unsubscribe, (2) request, (3) shared helpers.
+
+    # -- (1) Subscribe / Unsubscribe -----------------------------------------------------------------
+
+    cpdef void _handle_subscribe_continuous_future_bars(self, MarketDataClient client, SubscribeBars command):
+        # `target_bar_type` keeps the original (possibly composite) shape so source resolution
+        # can see the composite chain; `target_key` is the standardised form used as dict key
+        # and aggregator key.
+        cdef object transitions = command.params.get("continuous_future_transitions") or []
+        cdef BarType target_bar_type = command.bar_type
+        cdef BarType target_key = target_bar_type.standard()
+
+        if not target_bar_type.is_internally_aggregated():
+            self._log.error(
+                f"Continuous future bar subscriptions require an internally aggregated target, was {target_bar_type}",
+            )
+            return
+
+        if not transitions:
+            self._log.error(f"Continuous future bar subscription requires transitions metadata, was {command}")
+            return
+
+        if not self._continuous_future_validate_transitions(target_bar_type, transitions, command.params):
+            return
+
+        self._continuous_future_ensure_target_instrument(target_bar_type, transitions)
+
+        if target_key in self._continuous_future_subscriptions:
+            return
+
+        cdef tuple key = self._get_bar_aggregator_key(target_bar_type)
+        cdef BarAggregator aggregator = self._bar_aggregators.get(key)
+        if aggregator is not None and aggregator.is_running:
+            self._log.warning(f"Aggregator for {target_bar_type} is currently in use, subscription can't be started.")
+            return
+
+        self._create_bar_aggregator(target_bar_type, command.params)
+        self._setup_bar_aggregator(target_bar_type, subscribe_source=False)
+        aggregator = self._bar_aggregators.get(key)
+        if aggregator is None:
+            self._log.error(f"Cannot start continuous future aggregator for {target_bar_type}")
+            return
+
+        cdef uint64_t now_ns = self._clock.timestamp_ns()
+        cdef tuple segment = self._continuous_future_next_segment(transitions, now_ns, now_ns)
+        if segment is None:
+            self._log.error(f"Cannot determine active continuous future segment for {target_bar_type}")
+            if isinstance(aggregator, TimeBarAggregator):
+                (<TimeBarAggregator>aggregator).stop_timer()
+
+            aggregator.set_running(False)
+            self._bar_aggregators.pop(key, None)
+            return
+
+        cdef int segment_index = segment[0]
+        cdef InstrumentId segment_instrument_id = InstrumentId.from_str(segment[1])
+
+        self._continuous_future_subscriptions[target_key] = ContinuousFutureSubscriptionState(
+            target_bar_type=target_bar_type,
+            client_id=command.client_id,
+            venue=command.venue,
+            params=command.params.copy(),
+            active_segment_instrument_id=segment_instrument_id,
+            next_transition_index=segment_index if segment_index < len(transitions) else None,
+        )
+
+        self._continuous_future_activate_segment(
+            target_bar_type, segment_instrument_id, segment_index,
+            transitions, command.params, command.client_id, command.venue,
+            command.id, now_ns,
+        )
+        self._continuous_future_schedule_next_transition(target_key)
+
+    cdef void _continuous_future_activate_segment(
+        self,
+        BarType target_bar_type,
+        InstrumentId segment_instrument_id,
+        int segment_index,
+        object transitions,
+        dict params,
+        ClientId client_id,
+        Venue venue,
+        UUID4 correlation_id,
+        uint64_t ts_init,
+    ):
+        cdef BarAggregator aggregator = self._bar_aggregators.get(self._get_bar_aggregator_key(target_bar_type))
+        if aggregator is None:
+            self._log.warning(
+                f"Cannot activate continuous future segment: no aggregator for {target_bar_type}",
+            )
+            return
+
+        cdef tuple source = self._continuous_future_resolve_source(target_bar_type, segment_instrument_id)
+        self._continuous_future_apply_adjustment(aggregator, transitions, segment_index, params)
+        self._continuous_future_subscribe_source(aggregator, source, segment_instrument_id)
+
+        cdef object child_command = self._continuous_future_build_subscribe_command(
+            source, client_id, venue, params, correlation_id,
+            segment_instrument_id, ts_init, True,
+        )
+        if child_command is not None:
+            self.execute(child_command)
+
+    cdef void _continuous_future_schedule_next_transition(self, BarType target_key):
+        cdef object state = self._continuous_future_subscriptions.get(target_key)
+        if state is None:
+            self._log.warning(
+                f"Cannot schedule continuous future transition: no subscription state for {target_key}",
+            )
+            return
+
+        if state.timer_name is not None:
+            self._clock.cancel_timer(state.timer_name)
+            state.timer_name = None
+
+        cdef object next_transition_index = state.next_transition_index
+        cdef object transitions = state.params.get("continuous_future_transitions") or []
+        if next_transition_index is None or next_transition_index >= len(transitions):
+            return
+
+        cdef uint64_t transition_ns = transitions[next_transition_index]["transition_time_ns"]
+        cdef str timer_name = f"continuous-future-roll:{target_key}:{next_transition_index}"
+        state.timer_name = timer_name
+        self._clock.set_time_alert(
+            name=timer_name,
+            alert_time=unix_nanos_to_dt(transition_ns),
+            callback=self._handle_continuous_future_subscription_transition,
+            override=True,
+        )
+
+    cpdef void _handle_continuous_future_subscription_transition(self, TimeEvent event):
+        # Timer name format: "continuous-future-roll:{target_key}:{transition_index}".
+        # Parse `target_key` back out for an O(1) dict lookup rather than scanning subscriptions.
+        cdef str name = event.name
+        cdef int prefix_end = name.index(":") + 1
+        cdef int suffix_start = name.rindex(":")
+        cdef BarType target_key = BarType.from_str(name[prefix_end:suffix_start])
+        cdef object state = self._continuous_future_subscriptions.get(target_key)
+        if state is None:
+            self._log.warning(
+                f"Ignoring continuous future transition event {name}: no subscription state for {target_key}",
+            )
+            return
+
+        if state.timer_name != name:
+            # Stale timer (subscription was rescheduled or cancelled between fire and dispatch).
+            return
+
+        cdef object transitions = state.params.get("continuous_future_transitions") or []
+        cdef object next_transition_index = state.next_transition_index
+        state.timer_name = None
+
+        if next_transition_index is None or next_transition_index >= len(transitions):
+            return
+
+        cdef dict row = transitions[next_transition_index]
+        cdef uint64_t ts_init = self._clock.timestamp_ns()
+
+        if state.active_segment_instrument_id is not None:
+            self._continuous_future_deactivate_segment(
+                state.target_bar_type, state.active_segment_instrument_id, state.params,
+                state.client_id, state.venue, UUID4(), ts_init,
+            )
+
+        cdef InstrumentId next_segment_instrument_id = InstrumentId.from_str(row["post_instrument_id"])
+        state.active_segment_instrument_id = next_segment_instrument_id
+        state.next_transition_index = (
+            next_transition_index + 1 if next_transition_index + 1 < len(transitions) else None
+        )
+
+        self._continuous_future_activate_segment(
+            state.target_bar_type, next_segment_instrument_id, next_transition_index + 1,
+            transitions, state.params, state.client_id, state.venue,
+            UUID4(), ts_init,
+        )
+        self._continuous_future_schedule_next_transition(target_key)
+
+    cdef void _continuous_future_deactivate_segment(
+        self,
+        BarType target_bar_type,
+        InstrumentId segment_instrument_id,
+        dict params,
+        ClientId client_id,
+        Venue venue,
+        UUID4 correlation_id,
+        uint64_t ts_init,
+    ):
+        cdef BarAggregator aggregator = self._bar_aggregators.get(self._get_bar_aggregator_key(target_bar_type))
+        if aggregator is None:
+            self._log.warning(
+                f"Cannot deactivate continuous future segment: no aggregator for {target_bar_type}",
+            )
+            return
+
+        cdef tuple source = self._continuous_future_resolve_source(target_bar_type, segment_instrument_id)
+        self._continuous_future_unsubscribe_source(aggregator, source, segment_instrument_id)
+
+        cdef object child_command = self._continuous_future_build_subscribe_command(
+            source, client_id, venue, params, correlation_id,
+            segment_instrument_id, ts_init, False,
+        )
+        if child_command is not None:
+            self.execute(child_command)
+
+    cdef object _continuous_future_build_subscribe_command(
+        self,
+        tuple source,
+        ClientId client_id,
+        Venue venue,
+        dict parent_params,
+        UUID4 correlation_id,
+        InstrumentId segment_instrument_id,
+        uint64_t ts_init,
+        bint subscribe,
+    ):
+        cdef str source_type = source[0]
+        cdef dict child_params = self._continuous_future_child_params(parent_params)
+        cdef UUID4 command_id = UUID4()
+
+        if subscribe:
+            child_params["start_ns"] = ts_init
+
+        cdef BarType source_bar_type
+        if source_type == "bars":
+            source_bar_type = source[1]
+            if subscribe:
+                return SubscribeBars(
+                    bar_type=source_bar_type, client_id=client_id, venue=segment_instrument_id.venue,
+                    command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+                )
+
+            return UnsubscribeBars(
+                bar_type=source_bar_type, client_id=client_id, venue=segment_instrument_id.venue,
+                command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+            )
+
+        if source_type == "trades":
+            if subscribe:
+                return SubscribeTradeTicks(
+                    instrument_id=segment_instrument_id, client_id=client_id, venue=segment_instrument_id.venue,
+                    command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+                )
+
+            return UnsubscribeTradeTicks(
+                instrument_id=segment_instrument_id, client_id=client_id, venue=segment_instrument_id.venue,
+                command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+            )
+
+        if subscribe:
+            return SubscribeQuoteTicks(
+                instrument_id=segment_instrument_id, client_id=client_id, venue=segment_instrument_id.venue,
+                command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+            )
+
+        return UnsubscribeQuoteTicks(
+            instrument_id=segment_instrument_id, client_id=client_id, venue=segment_instrument_id.venue,
+            command_id=command_id, ts_init=ts_init, params=child_params, correlation_id=correlation_id,
+        )
+
+    cpdef void _handle_unsubscribe_continuous_future_bars(self, MarketDataClient client, UnsubscribeBars command):
+        cdef BarType target_key = command.bar_type.standard()
+        cdef object state = self._continuous_future_subscriptions.pop(target_key, None)
+
+        if state is None:
+            self._log.warning(
+                f"Cannot unsubscribe continuous future bars: no subscription state for {target_key}",
+            )
+            return
+
+        if state.timer_name is not None:
+            self._clock.cancel_timer(state.timer_name)
+
+        if state.active_segment_instrument_id is not None:
+            self._continuous_future_deactivate_segment(
+                state.target_bar_type, state.active_segment_instrument_id, state.params,
+                state.client_id, state.venue, command.id,
+                self._clock.timestamp_ns(),
+            )
+
+        cdef tuple key = self._get_bar_aggregator_key(state.target_bar_type)
+        cdef BarAggregator aggregator = self._bar_aggregators.get(key)
+        if aggregator is not None:
+            if isinstance(aggregator, TimeBarAggregator):
+                (<TimeBarAggregator>aggregator).stop_timer()
+
+            aggregator.set_running(False)
+            self._bar_aggregators.pop(key, None)
+
+    # -- (2) Request ---------------------------------------------------------------------------------
+
+    cpdef void _handle_continuous_future_request(self, RequestData request):
+        if not isinstance(request, RequestBars):
+            self._log.error(f"Continuous future requests require `RequestBars`, was {type(request)}")
+            self._abort_request(request.id)
+            return
+
+        cdef RequestBars bars_request = request
+        cdef tuple bounded = self._bound_dates(request)
+        cdef datetime start = bounded[0]
+        cdef datetime end = bounded[1]
+        request.start, request.end = start, end
+
+        cdef tuple bar_types = request.params.get("bar_types") or ()
+        cdef BarType primary_bar_type
+        if bar_types:
+            if not self._should_request_aggregated_bars(request):
+                self._log.error(
+                    f"One of the aggregators in {bar_types} is already running. "
+                    f"Either wait for a request to complete or unsubscribe from a live subscription. "
+                    f"Aborting request {request.id}.",
+                )
+                self._abort_request(request.id)
+                return
+
+            primary_bar_type = bar_types[0]
+        else:
+            primary_bar_type = bars_request.bar_type
+            bar_types = (primary_bar_type,)
+
+        cdef object transitions = request.params.get("continuous_future_transitions") or []
+        if not self._continuous_future_validate_transitions(primary_bar_type, transitions, request.params):
+            self._abort_request(request.id)
+            return
+
+        self._continuous_future_ensure_target_instrument(primary_bar_type, transitions)
+
+        self._setup_continuous_future_aggregators(request, bar_types)
+        if self._bar_aggregators.get(self._get_bar_aggregator_key(primary_bar_type, request.id)) is None:
+            self._log.error(f"Cannot start continuous future aggregator for {primary_bar_type}")
+            self._abort_request(request.id)
+            return
+
+        # Register bar_types under parent.id so _handle_response auto-finalizes the chain.
+        # update_subscriptions is stripped: aggregators are always keyed by parent.id for
+        # continuous future requests, so finalize must dispose using that key.
+        cdef dict stored_params = request.params.copy()
+        stored_params["bar_types"] = bar_types
+        stored_params.pop("update_subscriptions", None)
+        self._bar_types_params[request.id] = stored_params
+
+        # Cursor and primary bar type live on the parent's workflow state so they inherit
+        # the normal request lifecycle (created with the request, popped at _handle_response).
+        state = self._ensure_request_workflows(request)
+        state.continuous_future_cursor_ns = dt_to_unix_nanos(start)
+        state.continuous_future_primary_bar_type = primary_bar_type
+        self._update_continuous_future_data(request.id)
+
+    cdef void _setup_continuous_future_aggregators(self, RequestData request, tuple bar_types):
+        # Create and set up each aggregator in the chain keyed by the parent request id
+        # (so concurrent requests do not clash). Time aggregators skip empty buckets so
+        # no synthetic bars are emitted between segments or after the last segment.
+        self._init_bar_aggregators_for_request(
+            bar_types,
+            request.params,
+            request.id,
+            historical=True,
+            disable_time_bars_build_with_no_updates=True,
+        )
+
+    cpdef void _update_continuous_future_data(self, UUID4 parent_id):
+        cdef RequestData parent = self._requests.get(parent_id)
+        if parent is None:
+            self._log.error(f"No active continuous future request for {parent_id}")
+            return
+
+        state = self._ensure_request_workflows(parent)
+        cdef BarType primary_bar_type = state.continuous_future_primary_bar_type
+        if primary_bar_type is None:
+            self._log.error(f"No primary bar type on state for continuous future request {parent_id}")
+            return
+
+        cdef object transitions = parent.params.get("continuous_future_transitions") or []
+        cdef tuple segment = self._continuous_future_next_segment(
+            transitions, state.continuous_future_cursor_ns, state.end.value,
+        )
+        if segment is None:
+            self._emit_empty_request_response(parent_id)
+            return
+
+        cdef int segment_index = segment[0]
+        cdef InstrumentId segment_instrument_id = InstrumentId.from_str(segment[1])
+        cdef uint64_t seg_start_ns = segment[2]
+        cdef uint64_t seg_end_ns = segment[3]
+
+        cdef BarAggregator aggregator = self._bar_aggregators.get(
+            self._get_bar_aggregator_key(primary_bar_type, parent_id),
+        )
+        if aggregator is None:
+            self._log.error(f"No aggregator for continuous future request {parent_id}")
+            self._emit_empty_request_response(parent_id)
+            return
+
+        cdef tuple source = self._continuous_future_resolve_source(primary_bar_type, segment_instrument_id)
+        self._continuous_future_apply_adjustment(aggregator, transitions, segment_index, parent.params)
+
+        cdef RequestData sub = self._continuous_future_build_child_request(
+            parent, source, segment_instrument_id, seg_start_ns, seg_end_ns,
+        )
+        if sub is None:
+            self._emit_empty_request_response(parent_id)
+            return
+
+        # Route segment source data through the msgbus: subscribe the primary aggregator
+        # to the segment's historical topic so `process_historical` in `_handle_response`
+        # feeds the chain without a bespoke dispatch.
+        self._continuous_future_subscribe_source(aggregator, source, segment_instrument_id, historical=True)
+        state.continuous_future_active_source = source
+        state.continuous_future_active_segment_id = segment_instrument_id
+
+        state.continuous_future_cursor_ns = seg_end_ns + 1
+        self._msgbus.request(endpoint="DataEngine.request", request=sub)
+
+    cdef RequestData _continuous_future_build_child_request(
+        self,
+        RequestData parent,
+        tuple source,
+        InstrumentId segment_instrument_id,
+        uint64_t start_ns,
+        uint64_t end_ns,
+    ):
+        cdef RequestBars bars_parent = parent
+        cdef str source_type = source[0]
+        cdef datetime start = unix_nanos_to_dt(start_ns)
+        cdef datetime end = unix_nanos_to_dt(end_ns)
+        cdef datetime now = self._clock.utc_now()
+        cdef dict child_params = self._continuous_future_child_params(parent.params)
+        cdef UUID4 request_id = UUID4()
+
+        child_params["continuous_future_parent_request_id"] = parent.id
+
+        cdef BarType source_bar_type
+        if source_type == "bars":
+            source_bar_type = source[1]
+            return RequestBars(
+                bar_type=source_bar_type,
+                start=start, end=end, limit=bars_parent.limit,
+                client_id=parent.client_id, venue=segment_instrument_id.venue,
+                callback=self._handle_continuous_future_response,
+                request_id=request_id, ts_init=now.value,
+                params=child_params, correlation_id=parent.id,
+            )
+
+        if source_type == "trades":
+            return RequestTradeTicks(
+                instrument_id=segment_instrument_id,
+                start=start, end=end, limit=bars_parent.limit,
+                client_id=parent.client_id, venue=segment_instrument_id.venue,
+                callback=self._handle_continuous_future_response,
+                request_id=request_id, ts_init=now.value,
+                params=child_params, correlation_id=parent.id,
+            )
+
+        return RequestQuoteTicks(
+            instrument_id=segment_instrument_id,
+            start=start, end=end, limit=bars_parent.limit,
+            client_id=parent.client_id, venue=segment_instrument_id.venue,
+            callback=self._handle_continuous_future_response,
+            request_id=request_id, ts_init=now.value,
+            params=child_params, correlation_id=parent.id,
+        )
+
+    cpdef void _handle_continuous_future_response(self, DataResponse response):
+        # The sub-request carries the parent id in its params (set by
+        # `_continuous_future_build_child_request`); `_request_response_params` forwards that
+        # into the final response, so we read it here instead of maintaining a separate dict.
+        cdef UUID4 parent_id = response.params.get("continuous_future_parent_request_id")
+        if parent_id is None:
+            self._log.error(f"No parent id for continuous future sub response {response.correlation_id}")
+            return
+
+        cdef RequestData parent = self._requests.get(parent_id)
+        cdef BarAggregator aggregator
+        if parent is not None:
+            state = self._ensure_request_workflows(parent)
+            state.data_count += response.params.get("data_count", 0)
+            # Detach the primary aggregator from the segment topic we just consumed
+            # so the next segment's subscribe does not stack.
+            if state.continuous_future_active_source is not None and state.continuous_future_primary_bar_type is not None:
+                aggregator = self._bar_aggregators.get(
+                    self._get_bar_aggregator_key(state.continuous_future_primary_bar_type, parent_id),
+                )
+                if aggregator is not None:
+                    self._continuous_future_unsubscribe_source(
+                        aggregator,
+                        state.continuous_future_active_source,
+                        state.continuous_future_active_segment_id,
+                        historical=True,
+                    )
+
+                state.continuous_future_active_source = None
+                state.continuous_future_active_segment_id = None
+
+        self._update_continuous_future_data(parent_id)
+
+    # -- (3) Shared helpers --------------------------------------------------------------------------
+
+    cdef void _continuous_future_ensure_target_instrument(self, BarType target_bar_type, object transitions):
+        # Continuous-future targets (e.g. `ES.XCME`) are synthetic ids with no market
+        # data of their own, but downstream consumers (aggregators, cache lookups,
+        # serialization) still expect an `Instrument` in the cache. Clone the first
+        # segment's instrument, overriding the id / symbol and clearing the expiration
+        # so the continuous id reads as a perpetual FuturesContract.
+        cdef InstrumentId target_id = target_bar_type.instrument_id
+        if self._cache.instrument(target_id) is not None:
+            return
+
+        cdef object first_row = transitions[0]
+        cdef InstrumentId segment_id = InstrumentId.from_str(first_row["pre_instrument_id"])
+        cdef Instrument segment_instrument = self._cache.instrument(segment_id)
+        if segment_instrument is None:
+            self._log.warning(
+                f"Cannot synthesise continuous future instrument {target_id}: "
+                f"first segment {segment_id} not in cache",
+            )
+            return
+
+        if not isinstance(segment_instrument, FuturesContract):
+            self._log.warning(
+                f"Cannot synthesise continuous future instrument {target_id}: "
+                f"segment {segment_id} is {type(segment_instrument).__name__}, expected FuturesContract",
+            )
+            return
+
+        cdef dict values = FuturesContract.to_dict_c(segment_instrument)
+        values["id"] = target_id.value
+        values["raw_symbol"] = target_id.symbol.value
+        values["activation_ns"] = 0
+        values["expiration_ns"] = 0
+        self._cache.add_instrument(FuturesContract.from_dict_c(values))
+
+    cdef bint _continuous_future_validate_transitions(self, BarType target_bar_type, object transitions, dict params):
+        # Validate the full transition schema before callers allocate aggregators or
+        # subscriptions. Segment venue must match the continuous-future target because
+        # child requests/subscriptions route by segment venue.
+        cdef Venue target_venue = target_bar_type.instrument_id.venue
+        cdef object mode
+
+        try:
+            mode = ContinuousFutureAdjustmentType(
+                params.get("continuous_future_adjustment_mode", ContinuousFutureAdjustmentType.BACKWARD_SPREAD),
+            )
+        except (TypeError, ValueError):
+            self._log.error(
+                f"Invalid continuous future adjustment mode for {target_bar_type}: "
+                f"{params.get('continuous_future_adjustment_mode')}",
+            )
+            return False
+
+        if not isinstance(transitions, (list, tuple)):
+            self._log.error(f"Continuous future transitions must be a list/tuple, was {type(transitions)}")
+            return False
+
+        cdef object last_post_id_str = params.get("last_post_instrument_id")
+        cdef object last_post_id = None
+        cdef bint last_post_id_found = False
+        if last_post_id_str is not None:
+            try:
+                last_post_id = InstrumentId.from_str(str(last_post_id_str))
+            except (TypeError, ValueError) as e:
+                self._log.error(
+                    f"Invalid continuous future last_post_instrument_id for {target_bar_type}: "
+                    f"{e}, was {last_post_id_str}",
+                )
+                return False
+
+            if last_post_id.venue != target_venue:
+                self._log.error(
+                    f"Continuous future last_post_instrument_id venue mismatch for {target_bar_type}: "
+                    f"target venue {target_venue}, last_post_instrument_id venue {last_post_id.venue}",
+                )
+                return False
+
+        cdef object first_pre_id_str = params.get("first_pre_instrument_id")
+        cdef object first_pre_id = None
+        cdef bint first_pre_id_found = False
+        if first_pre_id_str is not None:
+            try:
+                first_pre_id = InstrumentId.from_str(str(first_pre_id_str))
+            except (TypeError, ValueError) as e:
+                self._log.error(
+                    f"Invalid continuous future first_pre_instrument_id for {target_bar_type}: "
+                    f"{e}, was {first_pre_id_str}",
+                )
+                return False
+
+            if first_pre_id.venue != target_venue:
+                self._log.error(
+                    f"Continuous future first_pre_instrument_id venue mismatch for {target_bar_type}: "
+                    f"target venue {target_venue}, first_pre_instrument_id venue {first_pre_id.venue}",
+                )
+                return False
+
+        cdef bint is_ratio = mode.is_ratio
+        cdef object row_obj
+        cdef dict row
+        cdef object transition_ns
+        cdef object previous_transition_ns = None
+        cdef object pre_id_str, post_id_str
+        cdef InstrumentId pre_id, post_id
+        cdef object pre_price, post_price
+        cdef object pre, post
+        for row_obj in transitions:
+            if not isinstance(row_obj, dict):
+                self._log.error(f"Continuous future transition must be a dict, was {row_obj}")
+                return False
+
+            row = row_obj
+            transition_ns = row.get("transition_time_ns")
+            if transition_ns is None:
+                self._log.error(f"Continuous future transition missing transition_time_ns, was {row}")
+                return False
+
+            try:
+                transition_ns = int(transition_ns)
+            except (TypeError, ValueError):
+                self._log.error(f"Invalid continuous future transition_time_ns, was {row}")
+                return False
+
+            if transition_ns < 0:
+                self._log.error(f"Continuous future transition_time_ns must be non-negative, was {row}")
+                return False
+
+            if previous_transition_ns is not None and transition_ns <= previous_transition_ns:
+                self._log.error(
+                    f"Continuous future transition times must be strictly increasing, was {transitions}",
+                )
+                return False
+
+            previous_transition_ns = transition_ns
+
+            pre_id_str = row.get("pre_instrument_id")
+            post_id_str = row.get("post_instrument_id")
+            if pre_id_str is None or post_id_str is None:
+                self._log.error(
+                    f"Continuous future transition missing pre/post_instrument_id, was {row}",
+                )
+                return False
+
+            try:
+                pre_id = InstrumentId.from_str(pre_id_str)
+                post_id = InstrumentId.from_str(post_id_str)
+            except (TypeError, ValueError) as e:
+                self._log.error(
+                    f"Invalid continuous future transition instrument id for {target_bar_type}: {e}, was {row}",
+                )
+                return False
+
+            if pre_id.venue != target_venue or post_id.venue != target_venue:
+                self._log.error(
+                    f"Continuous future segment venue mismatch for {target_bar_type}: "
+                    f"target venue {target_venue}, segment venues "
+                    f"pre={pre_id.venue}, post={post_id.venue}",
+                )
+                return False
+
+            if last_post_id_str is not None and post_id == last_post_id:
+                last_post_id_found = True
+
+            if first_pre_id_str is not None and pre_id == first_pre_id:
+                first_pre_id_found = True
+
+            pre_price = row.get("pre_price")
+            post_price = row.get("post_price")
+            if pre_price is None or post_price is None:
+                self._log.error(f"Continuous future transition missing pre/post price, was {row}")
+                return False
+
+            try:
+                pre = Decimal(str(pre_price))
+                post = Decimal(str(post_price))
+            except (InvalidOperation, ValueError):
+                self._log.error(f"Invalid continuous future transition price, was {row}")
+                return False
+
+            if not pre.is_finite() or not post.is_finite():
+                self._log.error(f"Continuous future transition prices must be finite, was {row}")
+                return False
+
+            if is_ratio and (pre <= 0 or post <= 0):
+                self._log.error(f"Continuous future ratio adjustment requires positive prices, was {row}")
+                return False
+
+        if last_post_id_str is not None and not last_post_id_found:
+            self._log.error(
+                f"Continuous future last_post_instrument_id {last_post_id} was not found in transitions",
+            )
+            return False
+
+        if first_pre_id_str is not None and not first_pre_id_found:
+            self._log.error(
+                f"Continuous future first_pre_instrument_id {first_pre_id} was not found in transitions",
+            )
+            return False
+
+        return True
+
+    cdef tuple _continuous_future_next_segment(self, object transitions, uint64_t cursor_ns, uint64_t end_ns):
+        if cursor_ns > end_ns or not transitions:
+            return None
+
+        cdef int i
+        cdef dict row
+        cdef uint64_t transition_ns
+        for i, row in enumerate(transitions):
+            transition_ns = row.get("transition_time_ns", 0)
+            if cursor_ns < transition_ns:
+                return (i, row["pre_instrument_id"], cursor_ns, min(end_ns, transition_ns - 1))
+
+        row = transitions[-1]
+
+        return (len(transitions), row["post_instrument_id"], cursor_ns, end_ns)
+
+    cdef void _continuous_future_apply_adjustment(
+        self,
+        BarAggregator aggregator,
+        object transitions,
+        int segment_index,
+        dict params,
+    ):
+        aggregator._builder.set_adjustment(
+            self._continuous_future_compute_offset(transitions, segment_index, params),
+            params.get("continuous_future_adjustment_mode", ContinuousFutureAdjustmentType.BACKWARD_SPREAD),
+        )
+
+    cdef object _continuous_future_compute_offset(self, object transitions, int segment_index, dict params):
+        cdef object mode = ContinuousFutureAdjustmentType(
+            params.get("continuous_future_adjustment_mode", ContinuousFutureAdjustmentType.BACKWARD_SPREAD),
+        )
+        cdef bint is_ratio = mode.is_ratio
+        cdef bint is_backward = mode.is_backward
+        cdef object cumulative = Decimal("1") if is_ratio else Decimal("0")
+
+        # `first_pre_instrument_id` and `last_post_instrument_id` bound the active chain:
+        # transitions outside [transition_start_index, transition_stop_index) are not part of
+        # the continuous future and never contribute to the cumulative offset. Out-of-chain
+        # `segment_index` values are clamped into the chain so the iteration range degenerates
+        # to either the empty range (no adjustment from the anchor side) or the full in-chain
+        # range (the same adjustment as the nearest in-chain segment).
+        cdef object last_post_id_str = params.get("last_post_instrument_id")
+        cdef object first_pre_id_str = params.get("first_pre_instrument_id")
+        cdef int transition_stop_index = len(transitions)
+        cdef int transition_start_index = 0
+        cdef int i
+        cdef dict row
+        if last_post_id_str is not None:
+            last_post_id_str = str(last_post_id_str)
+            for i, row in enumerate(transitions):
+                if row["post_instrument_id"] == last_post_id_str:
+                    transition_stop_index = i + 1
+                    break
+
+        if first_pre_id_str is not None:
+            first_pre_id_str = str(first_pre_id_str)
+            for i, row in enumerate(transitions):
+                if row["pre_instrument_id"] == first_pre_id_str:
+                    transition_start_index = i
+                    break
+
+        cdef int clamped_segment_index = max(
+            transition_start_index, min(segment_index, transition_stop_index),
+        )
+        cdef object rng = (
+            range(clamped_segment_index, transition_stop_index)
+            if is_backward
+            else range(transition_start_index, clamped_segment_index)
+        )
+
+        cdef object pre, post
+        for i in rng:
+            row = transitions[i]
+            pre = Decimal(str(row["pre_price"]))
+            post = Decimal(str(row["post_price"]))
+            if is_ratio:
+                cumulative *= (post / pre) if is_backward else (pre / post)
+            else:
+                cumulative += (post - pre) if is_backward else (pre - post)
+
+        return cumulative
+
+    cdef tuple _continuous_future_resolve_source(self, BarType target_bar_type, InstrumentId segment_instrument_id):
+        cdef BarType reference_bar_type = target_bar_type.composite() if target_bar_type.is_composite() else target_bar_type
+        cdef BarType source_bar_type
+
+        if reference_bar_type.is_externally_aggregated():
+            source_bar_type = BarType.from_str(
+                f"{segment_instrument_id}-{reference_bar_type.spec}-{reference_bar_type.aggregation_source.name}",
+            )
+            return ("bars", source_bar_type)
+
+        if reference_bar_type.spec.price_type == PriceType.LAST:
+            return ("trades", None)
+
+        return ("quotes", None)
+
+    cdef dict _continuous_future_child_params(self, dict parent_params):
+        cdef dict child_params = parent_params.copy()
+        child_params.pop("continuous_future_transitions", None)
+        child_params.pop("continuous_future_adjustment_mode", None)
+        child_params.pop("last_post_instrument_id", None)
+        child_params.pop("first_pre_instrument_id", None)
+        child_params.pop("bar_types", None)
+        return child_params
+
+    cdef void _continuous_future_subscribe_source(
+        self,
+        BarAggregator aggregator,
+        tuple source,
+        InstrumentId segment_instrument_id,
+        bint historical = False,
+    ):
+        cdef str source_type = source[0]
+        cdef str topic = self._continuous_future_source_topic(source, segment_instrument_id, historical)
+        cdef object handler = self._continuous_future_source_handler(aggregator, source_type)
+        if source_type == "bars":
+            self._msgbus.subscribe(topic=topic, handler=handler)
+        else:
+            # Trade/quote-tick handlers run at elevated priority so the aggregator sees ticks
+            # before anything else subscribed at default priority on the same topic.
+            self._msgbus.subscribe(topic=topic, handler=handler, priority=5)
+
+    cdef void _continuous_future_unsubscribe_source(
+        self,
+        BarAggregator aggregator,
+        tuple source,
+        InstrumentId segment_instrument_id,
+        bint historical = False,
+    ):
+        self._msgbus.unsubscribe(
+            topic=self._continuous_future_source_topic(source, segment_instrument_id, historical),
+            handler=self._continuous_future_source_handler(aggregator, source[0]),
+        )
+
+    cdef str _continuous_future_source_topic(
+        self,
+        tuple source,
+        InstrumentId segment_instrument_id,
+        bint historical = False,
+    ):
+        cdef str source_type = source[0]
+        if source_type == "bars":
+            return self._topic_cache.get_bars_topic(source[1], historical)
+
+        if source_type == "trades":
+            return self._topic_cache.get_trades_topic(segment_instrument_id, historical)
+
+        return self._topic_cache.get_quotes_topic(segment_instrument_id, historical)
+
+    cdef object _continuous_future_source_handler(self, BarAggregator aggregator, str source_type):
+        cdef object py_aggregator = aggregator
+        if source_type == "bars":
+            return py_aggregator.handle_bar
+
+        if source_type == "trades":
+            return py_aggregator.handle_trade_tick
+
+        return py_aggregator.handle_quote_tick
+
 
 @dataclass(slots=True)
 class RequestWorkflowState:
@@ -4223,6 +5159,25 @@ class RequestWorkflowState:
     join_request: bool = False
     join_started: bool = False
     time_range_generator_enabled: bool = False
+    # Continuous-future request cursor (unused by other request kinds):
+    # cursor_ns advances per segment; primary_bar_type is the bottom of the chain.
+    # active_source / active_segment_id track the aggregator subscription attached
+    # to the in-flight segment so it can be detached when the sub response arrives.
+    continuous_future_cursor_ns: int = 0
+    continuous_future_primary_bar_type: BarType | None = None
+    continuous_future_active_source: tuple | None = None
+    continuous_future_active_segment_id: InstrumentId | None = None
+
+
+@dataclass(slots=True)
+class ContinuousFutureSubscriptionState:
+    target_bar_type: BarType
+    client_id: ClientId | None
+    venue: Venue | None
+    params: dict
+    active_segment_instrument_id: InstrumentId | None = None
+    next_transition_index: int | None = None
+    timer_name: str | None = None
 
 
 TimeRangeGenerator = Callable[[int, dict[str, Any]], Generator[int, bool, None]]

--- a/nautilus_trader/model/enums.py
+++ b/nautilus_trader/model/enums.py
@@ -112,6 +112,7 @@ __all__ = [
     "BookAction",
     "BookType",
     "ContingencyType",
+    "ContinuousFutureAdjustmentType",
     "CurrencyType",
     "InstrumentClass",
     "InstrumentCloseType",
@@ -189,6 +190,67 @@ __all__ = [
     "trigger_type_from_str",
     "trigger_type_to_str",
 ]
+
+
+@unique
+class ContinuousFutureAdjustmentType(Enum):
+    """
+    Represents the price-adjustment scheme applied when stitching segment contracts into
+    a continuous future series.
+
+    The direction (backward vs. forward) selects the anchor contract:
+
+    - Backward modes anchor on the most recent contract; prices in older
+      segments are shifted into the latest contract's frame.
+    - Forward modes anchor on the first contract; prices in later segments
+      are shifted into the first contract's frame.
+
+    The kind (spread vs. ratio) selects how each transition's offset is
+    combined:
+
+    - Spread modes accumulate additive offsets (`post_price - pre_price`).
+    - Ratio modes accumulate multiplicative factors (`post_price / pre_price`)
+      and require strictly positive prices.
+
+    """
+
+    BACKWARD_SPREAD = "backward_spread"
+    """
+    Additive adjustment, anchored on the most recent contract.
+    """
+    FORWARD_SPREAD = "forward_spread"
+    """
+    Additive adjustment, anchored on the first contract.
+    """
+    BACKWARD_RATIO = "backward_ratio"
+    """
+    Multiplicative adjustment, anchored on the most recent contract.
+    """
+    FORWARD_RATIO = "forward_ratio"
+    """
+    Multiplicative adjustment, anchored on the first contract.
+    """
+
+    @property
+    def is_ratio(self) -> bool:
+        """
+        Return whether this mode accumulates multiplicative factors.
+        """
+        return self in (
+            ContinuousFutureAdjustmentType.BACKWARD_RATIO,
+            ContinuousFutureAdjustmentType.FORWARD_RATIO,
+        )
+
+    @property
+    def is_backward(self) -> bool:
+        """
+        Return whether this mode anchors on the most recent contract.
+        """
+        return self in (
+            ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+            ContinuousFutureAdjustmentType.BACKWARD_RATIO,
+        )
+
 
 # mypy: disable-error-code=no-redef
 

--- a/tests/acceptance_tests/test_backtest.py
+++ b/tests/acceptance_tests/test_backtest.py
@@ -76,7 +76,9 @@ from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.enums import ContinuousFutureAdjustmentType
 from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.events import OrderAccepted
@@ -86,6 +88,7 @@ from nautilus_trader.model.events import PositionEvent
 from nautilus_trader.model.events import PositionOpened
 from nautilus_trader.model.greeks_data import GreeksData
 from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import TraderId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.identifiers import new_generic_spread_id
@@ -93,6 +96,7 @@ from nautilus_trader.model.instruments import CryptoPerpetual
 from nautilus_trader.model.instruments import FuturesContract
 from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.model.instruments.betting import BettingInstrument
+from nautilus_trader.model.objects import Currency
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.tick_scheme import TieredTickScheme
 from nautilus_trader.model.tick_scheme import register_tick_scheme
@@ -2495,3 +2499,257 @@ class OptionStrategy(Strategy):
         self.unsubscribe_data(DataType(GreeksData), instrument_id=self.config.option_id2)
         self.unsubscribe_quote_ticks(self.config.spread_id, params=self.default_data_params)
         self.unsubscribe_quote_ticks(self.config.spread_id2, params=self.default_data_params)
+
+
+class ContFutTransitionStrategyConfig(StrategyConfig, frozen=True):
+    target_bar_type: BarType
+    transitions: list
+    request_start_iso: str
+    backtest_start_iso: str
+
+
+class ContFutTransitionStrategy(Strategy):
+    """
+    Request adjusted continuous-future bars for the history preceding the backtest
+    start, then subscribe for the post-start live segment.
+
+    The roll adjustment is identical across both phases so the resulting series is
+    seamless.
+
+    """
+
+    def __init__(self, config: ContFutTransitionStrategyConfig):
+        super().__init__(config=config)
+        self.historical_bars: list = []
+        self.live_bars: list = []
+
+    def on_start(self):
+        params = {
+            "continuous_future_transitions": list(self.config.transitions),
+            "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+        }
+        # Composite target bar types go through `request_aggregated_bars`; the list is
+        # the chain of `bar_types` the continuous future engine will set up (here just
+        # the single composite target).
+        self.request_aggregated_bars(
+            [self.config.target_bar_type],
+            start=time_object_to_dt(self.config.request_start_iso),
+            end=time_object_to_dt(self.config.backtest_start_iso) - pd.Timedelta(nanoseconds=1),
+            params=params,
+        )
+        self.subscribe_bars(self.config.target_bar_type, params=params)
+
+    def on_historical_data(self, data):
+        if isinstance(data, Bar):
+            self.historical_bars.append(data)
+
+    def on_bar(self, bar):
+        self.live_bars.append(bar)
+
+    def on_stop(self):
+        self.unsubscribe_bars(
+            self.config.target_bar_type,
+            params={"continuous_future_transitions": list(self.config.transitions)},
+        )
+
+
+class TestBacktestContinuousFuture:
+    """
+    Verifies the transition from a historical ``request_bars`` to a live
+    ``subscribe_bars`` for a continuous future.
+
+    Layout:
+        - ESH26 raw 1-min bars 09:00..09:04
+        - transition @ 09:05 (pre=104, post=110)
+        - ESM26 raw 1-min bars 09:05..09:09
+        - transition @ 09:10 (pre=114, post=120)
+        - ESU26 raw 1-min bars 09:10..09:14
+        - backtest runs 09:10..09:15
+
+    Backward-adjusted offsets:
+        - ESH26: (110-104) + (120-114) = +12  → adjusted 112..116
+        - ESM26: (120-114)             = +6   → adjusted 116..120
+        - ESU26: 0                            → unadjusted 120..124
+
+    The full continuous series is a monotone increasing 112..124; the historical
+    phase emits 112..120 (the first 10 adjusted bars) and the live phase emits
+    the tail starting at 120.
+
+    """
+
+    def _futures_contract(self, symbol: str, expiration_ns: int) -> FuturesContract:
+        return FuturesContract(
+            instrument_id=InstrumentId.from_str(f"{symbol}.XCME"),
+            raw_symbol=Symbol(symbol),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=expiration_ns,
+            ts_event=0,
+            ts_init=0,
+        )
+
+    def _build_catalog(self, tmp_path):
+        catalog = setup_catalog(protocol="file", path=tmp_path / "contfut_catalog")
+
+        instruments = [
+            self._futures_contract("ESH26", 1773532800000000000),
+            self._futures_contract("ESM26", 1781308800000000000),
+            self._futures_contract("ESU26", 1789257600000000000),
+        ]
+        catalog.write_data(instruments)
+
+        def make_bars(symbol: str, first_minute_iso: str, close_prices: list[float]) -> list[Bar]:
+            bar_type = BarType.from_str(f"{symbol}.XCME-1-MINUTE-LAST-EXTERNAL")
+            start_ns = pd.Timestamp(first_minute_iso).value
+            minute_ns = 60 * 1_000_000_000
+            bars = []
+
+            for i, close in enumerate(close_prices):
+                ts = start_ns + i * minute_ns
+                bars.append(
+                    Bar(
+                        bar_type,
+                        Price.from_str(f"{close:.2f}"),
+                        Price.from_str(f"{close:.2f}"),
+                        Price.from_str(f"{close:.2f}"),
+                        Price.from_str(f"{close:.2f}"),
+                        Quantity.from_int(1),
+                        ts,
+                        ts,
+                    ),
+                )
+            return bars
+
+        bars = []
+        bars += make_bars("ESH26", "2026-03-16T09:00:00Z", [100, 101, 102, 103, 104])
+        bars += make_bars("ESM26", "2026-03-16T09:05:00Z", [110, 111, 112, 113, 114])
+        bars += make_bars("ESU26", "2026-03-16T09:10:00Z", [120, 121, 122, 123, 124])
+        catalog.write_data(bars)
+
+        return catalog
+
+    def test_continuous_future_transition_from_request_to_subscription(self, tmp_path):
+        catalog = self._build_catalog(tmp_path)
+
+        target_bar_type = BarType.from_str(
+            "ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL",
+        )
+        transitions = [
+            {
+                "transition_time_ns": pd.Timestamp("2026-03-16T09:05:00Z").value,
+                "pre_instrument_id": "ESH26.XCME",
+                "post_instrument_id": "ESM26.XCME",
+                "pre_price": "104.00",
+                "post_price": "110.00",
+            },
+            {
+                "transition_time_ns": pd.Timestamp("2026-03-16T09:10:00Z").value,
+                "pre_instrument_id": "ESM26.XCME",
+                "post_instrument_id": "ESU26.XCME",
+                "pre_price": "114.00",
+                "post_price": "120.00",
+            },
+        ]
+
+        strategies = [
+            ImportableStrategyConfig(
+                strategy_path=ContFutTransitionStrategy.fully_qualified_name(),
+                config_path=ContFutTransitionStrategyConfig.fully_qualified_name(),
+                config={
+                    "target_bar_type": target_bar_type,
+                    "transitions": transitions,
+                    "request_start_iso": "2026-03-16T09:00:00Z",
+                    "backtest_start_iso": "2026-03-16T09:10:00Z",
+                },
+            ),
+        ]
+
+        data = [
+            BacktestDataConfig(
+                data_cls=Bar,
+                catalog_path=str(catalog.path),
+                instrument_id=InstrumentId.from_str(f"{symbol}.XCME"),
+                bar_spec="1-MINUTE-LAST",
+            )
+            for symbol in ("ESH26", "ESM26", "ESU26")
+        ]
+
+        venues = [
+            BacktestVenueConfig(
+                name="XCME",
+                oms_type="NETTING",
+                account_type="MARGIN",
+                base_currency="USD",
+                starting_balances=["1_000_000 USD"],
+            ),
+        ]
+
+        engine_config = BacktestEngineConfig(
+            logging=LoggingConfig(bypass_logging=True),
+            strategies=strategies,
+            catalogs=[DataCatalogConfig(path=str(catalog.path))],
+        )
+
+        run_config = BacktestRunConfig(
+            engine=engine_config,
+            data=data,
+            venues=venues,
+            start="2026-03-16T09:10:00Z",
+            end="2026-03-16T09:15:00Z",
+            raise_exception=True,
+            dispose_on_completion=False,
+        )
+
+        node = BacktestNode(configs=[run_config])
+        node.build()
+        engine = node.get_engine(run_config.id)
+
+        # The continuous root instrument (e.g. ES.XCME) is synthesised automatically by
+        # the data engine from the first segment's properties on the first CF request or
+        # subscription; no manual `add_instrument` call is required.
+
+        node.run()
+        strategy = engine.trader.strategies()[0]
+
+        # Historical phase: 10 adjusted bars spanning segments 0 and 1.
+        # BACKWARD_SPREAD offsets (sum of post-pre across later rolls):
+        #   segment 0 (ESH26) = (110-104) + (120-114) = +12
+        #   segment 1 (ESM26) = (120-114) = +6
+        # ESH26 raw closes 100..104 shift by +12 → 112..116.
+        # ESM26 raw closes 110..114 shift by +6 → 116..120.
+        historical_closes = [float(b.close) for b in strategy.historical_bars]
+        assert historical_closes == [
+            112.0,
+            113.0,
+            114.0,
+            115.0,
+            116.0,
+            116.0,
+            117.0,
+            118.0,
+            119.0,
+            120.0,
+        ]
+
+        # Live phase: ESU26 raw closes 120..124 pass through unadjusted (last segment has offset 0).
+        # The engine pushes five 1-min source bars; the final extra bar at backtest end comes from
+        # the aggregator's default `build_with_no_updates=True` carrying the last close forward.
+        live_closes = [float(b.close) for b in strategy.live_bars]
+        assert live_closes[:5] == [120.0, 121.0, 122.0, 123.0, 124.0]
+
+        # Seam check: the last historical close (adjusted ESM26) joins the first live close
+        # (unadjusted ESU26) at 120.0 — both phases share the same adjusted frame.
+        assert historical_closes[-1] == live_closes[0] == 120.0
+
+        # Every bar must carry the continuous (target) standard bar type, not a segment contract.
+        expected_bar_type = target_bar_type.standard()
+        assert all(b.bar_type == expected_bar_type for b in strategy.historical_bars)
+        assert all(b.bar_type == expected_bar_type for b in strategy.live_bars)
+
+        node.dispose()

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -47,6 +47,7 @@ from nautilus_trader.model.enums import AggregationSource
 from nautilus_trader.model.enums import AggressorSide
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import BarAggregation
+from nautilus_trader.model.enums import ContinuousFutureAdjustmentType
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.enums import PriceType
 from nautilus_trader.model.greeks import GreeksCalculator
@@ -215,8 +216,125 @@ class TestBarBuilder:
         # Assert
         assert builder.count == 5
 
+    def test_bar_builder_applies_offset_to_bar_updates(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+        builder.set_adjustment(Decimal("10.0"), ContinuousFutureAdjustmentType.BACKWARD_SPREAD)
+
+        input_bar = Bar(
+            bar_type=bar_type,
+            open=Price.from_str("100.00000"),
+            high=Price.from_str("101.00000"),
+            low=Price.from_str("99.00000"),
+            close=Price.from_str("100.50000"),
+            volume=Quantity.from_str("2.0"),
+            ts_event=NANOSECONDS_IN_SECOND,
+            ts_init=NANOSECONDS_IN_SECOND,
+        )
+
+        builder.update_bar(input_bar, input_bar.volume, input_bar.ts_init)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("110.00000")
+        assert built_bar.high == Price.from_str("111.00000")
+        assert built_bar.low == Price.from_str("109.00000")
+        assert built_bar.close == Price.from_str("110.50000")
+        assert built_bar.volume == Quantity.from_str("2.0")
+
+    def test_bar_builder_applies_multiplicative_adjustment_to_bar_updates(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+        builder.set_adjustment(Decimal("1.10"), ContinuousFutureAdjustmentType.BACKWARD_RATIO)
+
+        input_bar = Bar(
+            bar_type=bar_type,
+            open=Price.from_str("100.00000"),
+            high=Price.from_str("101.00000"),
+            low=Price.from_str("99.00000"),
+            close=Price.from_str("100.50000"),
+            volume=Quantity.from_str("2.0"),
+            ts_event=NANOSECONDS_IN_SECOND,
+            ts_init=NANOSECONDS_IN_SECOND,
+        )
+
+        builder.update_bar(input_bar, input_bar.volume, input_bar.ts_init)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("110.00000")
+        assert built_bar.high == Price.from_str("111.10000")
+        assert built_bar.low == Price.from_str("108.90000")
+        assert built_bar.close == Price.from_str("110.55000")
+        assert built_bar.volume == Quantity.from_str("2.0")
+
+    def test_bar_builder_mid_bar_adjustment_change_applies_to_subsequent_updates(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+
+        builder.set_adjustment(Decimal(0), ContinuousFutureAdjustmentType.BACKWARD_SPREAD)
+        builder.update(Price.from_str("100.00000"), Quantity.from_str("1"), 1)
+        builder.update(Price.from_str("101.00000"), Quantity.from_str("2"), 2)
+
+        # Change mid-bar: subsequent prices are adjusted, the already-aggregated OHLC is not rewritten
+        builder.set_adjustment(Decimal(10), ContinuousFutureAdjustmentType.BACKWARD_SPREAD)
+        builder.update(Price.from_str("95.00000"), Quantity.from_str("3"), 3)
+        builder.update(Price.from_str("96.00000"), Quantity.from_str("4"), 4)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("100.00000")
+        assert built_bar.high == Price.from_str("106.00000")
+        assert built_bar.low == Price.from_str("100.00000")
+        assert built_bar.close == Price.from_str("106.00000")
+        assert built_bar.volume == Quantity.from_str("10")
+
+    def test_bar_builder_mid_bar_ratio_adjustment_change_applies_to_subsequent_updates(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+
+        builder.set_adjustment(Decimal(1), ContinuousFutureAdjustmentType.BACKWARD_RATIO)
+        builder.update(Price.from_str("100.00000"), Quantity.from_str("1"), 1)
+        builder.update(Price.from_str("101.00000"), Quantity.from_str("2"), 2)
+
+        # Change mid-bar to 1.10x: subsequent prices multiplied, previous OHLC stays
+        builder.set_adjustment(Decimal("1.10"), ContinuousFutureAdjustmentType.BACKWARD_RATIO)
+        builder.update(Price.from_str("95.00000"), Quantity.from_str("3"), 3)
+        builder.update(Price.from_str("96.00000"), Quantity.from_str("4"), 4)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("100.00000")
+        assert built_bar.high == Price.from_str("105.60000")
+        assert built_bar.low == Price.from_str("100.00000")
+        assert built_bar.close == Price.from_str("105.60000")
+        assert built_bar.volume == Quantity.from_str("10")
+
+    def test_bar_builder_spread_zero_adjustment_is_noop(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+        builder.set_adjustment(Decimal(0), ContinuousFutureAdjustmentType.BACKWARD_SPREAD)
+
+        builder.update(Price.from_str("100.00000"), Quantity.from_str("1"), 1)
+        builder.update(Price.from_str("101.00000"), Quantity.from_str("2"), 2)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("100.00000")
+        assert built_bar.high == Price.from_str("101.00000")
+        assert built_bar.low == Price.from_str("100.00000")
+        assert built_bar.close == Price.from_str("101.00000")
+
+    def test_bar_builder_ratio_one_adjustment_is_noop(self):
+        bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
+        builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
+        builder.set_adjustment(Decimal(1), ContinuousFutureAdjustmentType.BACKWARD_RATIO)
+
+        builder.update(Price.from_str("100.00000"), Quantity.from_str("1"), 1)
+        builder.update(Price.from_str("101.00000"), Quantity.from_str("2"), 2)
+        built_bar = builder.build_now()
+
+        assert built_bar.open == Price.from_str("100.00000")
+        assert built_bar.high == Price.from_str("101.00000")
+        assert built_bar.low == Price.from_str("100.00000")
+        assert built_bar.close == Price.from_str("101.00000")
+
     def test_multiple_bar_updates_correctly_increments_count(self):
-        # Arrange
         bar_type = TestDataStubs.bartype_btcusdt_binance_100tick_last()
         builder = BarBuilder(BTCUSDT_BINANCE, bar_type)
 

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -76,7 +76,6 @@ from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import BookOrder
 from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import FundingRateUpdate
-from nautilus_trader.model.data import InstrumentStatus
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import OrderBookDepth10
@@ -88,7 +87,7 @@ from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import BarAggregation
 from nautilus_trader.model.enums import BookAction
 from nautilus_trader.model.enums import BookType
-from nautilus_trader.model.enums import MarketStatusAction
+from nautilus_trader.model.enums import ContinuousFutureAdjustmentType
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import PriceType
@@ -101,6 +100,7 @@ from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.identifiers import new_generic_spread_id
 from nautilus_trader.model.instruments.base import Instrument
 from nautilus_trader.model.instruments.currency_pair import CurrencyPair
+from nautilus_trader.model.instruments.futures_contract import FuturesContract
 from nautilus_trader.model.instruments.option_contract import OptionContract
 from nautilus_trader.model.instruments.option_spread import OptionSpread
 from nautilus_trader.model.objects import Currency
@@ -199,6 +199,101 @@ class TestDataEngine:
         self.data_engine.process(BTCUSDT_BINANCE)
         self.data_engine.process(ETHUSDT_BINANCE)
         self.data_engine.process(XBTUSD_BITMEX)
+
+        self.esm4_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ESM4.XCME"),
+            raw_symbol=Symbol("ESM4"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=1719792000000000000,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.esu4_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ESU4.XCME"),
+            raw_symbol=Symbol("ESU4"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=1727740800000000000,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.es_root_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ES.XCME"),
+            raw_symbol=Symbol("ES"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=0,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.esh26_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ESH26.XCME"),
+            raw_symbol=Symbol("ESH26"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=1773532800000000000,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.esm26_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ESM26.XCME"),
+            raw_symbol=Symbol("ESM26"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=1781308800000000000,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.esu26_xcme = FuturesContract(
+            instrument_id=InstrumentId.from_str("ESU26.XCME"),
+            raw_symbol=Symbol("ESU26"),
+            asset_class=AssetClass.INDEX,
+            currency=Currency.from_str("USD"),
+            price_precision=2,
+            price_increment=Price.from_str("0.25"),
+            multiplier=Quantity.from_int(50),
+            lot_size=Quantity.from_int(1),
+            underlying="ES",
+            activation_ns=0,
+            expiration_ns=1789257600000000000,
+            ts_event=0,
+            ts_init=0,
+        )
+        self.cache.add_instrument(self.es_root_xcme)
+        self.cache.add_instrument(self.esh26_xcme)
+        self.cache.add_instrument(self.esm26_xcme)
+        self.cache.add_instrument(self.esu26_xcme)
 
     def test_registered_venues(self):
         # Arrange, Act, Assert
@@ -1818,76 +1913,6 @@ class TestDataEngine:
         assert self.data_engine.subscribed_instrument_status() == []
         assert self.binance_client.subscribed_instrument_status() == []
 
-    def test_process_instrument_status_when_subscriber_then_caches_and_publishes(self):
-        # Arrange
-        self.data_engine.register_client(self.binance_client)
-        self.binance_client.start()
-
-        handler = []
-        self.msgbus.subscribe(
-            topic=f"data.status.BINANCE.{ETHUSDT_BINANCE.id.symbol}",
-            handler=handler.append,
-        )
-
-        subscribe = SubscribeInstrumentStatus(
-            client_id=None,
-            venue=BINANCE,
-            instrument_id=ETHUSDT_BINANCE.id,
-            command_id=UUID4(),
-            ts_init=self.clock.timestamp_ns(),
-        )
-        self.data_engine.execute(subscribe)
-
-        status = InstrumentStatus(
-            instrument_id=ETHUSDT_BINANCE.id,
-            action=MarketStatusAction.TRADING,
-            ts_event=1,
-            ts_init=2,
-        )
-
-        # Act
-        self.data_engine.process(status)
-
-        # Assert
-        assert handler == [status]
-        assert self.cache.instrument_status(ETHUSDT_BINANCE.id) == status
-        assert self.cache.instrument_statuses(ETHUSDT_BINANCE.id) == [status]
-
-    def test_process_instrument_status_updates_existing_in_cache(self):
-        # Arrange
-        self.data_engine.register_client(self.binance_client)
-        self.binance_client.start()
-
-        subscribe = SubscribeInstrumentStatus(
-            client_id=None,
-            venue=BINANCE,
-            instrument_id=ETHUSDT_BINANCE.id,
-            command_id=UUID4(),
-            ts_init=self.clock.timestamp_ns(),
-        )
-        self.data_engine.execute(subscribe)
-
-        status1 = InstrumentStatus(
-            instrument_id=ETHUSDT_BINANCE.id,
-            action=MarketStatusAction.PRE_OPEN,
-            ts_event=1,
-            ts_init=2,
-        )
-        status2 = InstrumentStatus(
-            instrument_id=ETHUSDT_BINANCE.id,
-            action=MarketStatusAction.TRADING,
-            ts_event=3,
-            ts_init=4,
-        )
-
-        # Act
-        self.data_engine.process(status1)
-        self.data_engine.process(status2)
-
-        # Assert: latest status is returned by the default-index getter
-        assert self.cache.instrument_status(ETHUSDT_BINANCE.id) == status2
-        assert self.cache.instrument_statuses(ETHUSDT_BINANCE.id) == [status2, status1]
-
     def test_subscribe_instrument_close_then_subscribes(self):
         # Arrange
         self.data_engine.register_client(self.binance_client)
@@ -3338,6 +3363,1536 @@ class TestDataEngine:
         # Assert
         assert self.data_engine.request_count == 1
         assert len(handler) == 0
+
+    def test_request_bars_for_continuous_future_adjusts_across_transition(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog")
+
+        # Monday of March 2026 expiry week, then Monday of June 2026 expiry week.
+        march_transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+        june_transition_ns = pd.Timestamp("2026-06-15T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Price.from_str("5999.00"),
+                Price.from_str("6000.50"),
+                Quantity.from_int(10),
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.50"),
+                Price.from_str("6001.50"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Quantity.from_int(11),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Price.from_str("5994.50"),
+                Price.from_str("5995.50"),
+                Quantity.from_int(12),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.50"),
+                Price.from_str("5996.50"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Quantity.from_int(13),
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6100.00"),
+                Price.from_str("6101.00"),
+                Price.from_str("6099.50"),
+                Price.from_str("6100.50"),
+                Quantity.from_int(14),
+                pd.Timestamp("2026-06-15T14:29:00Z").value,
+                pd.Timestamp("2026-06-15T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6100.50"),
+                Price.from_str("6101.50"),
+                Price.from_str("6100.00"),
+                Price.from_str("6101.00"),
+                Quantity.from_int(15),
+                pd.Timestamp("2026-06-15T14:30:00Z").value,
+                pd.Timestamp("2026-06-15T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESU26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6094.50"),
+                Price.from_str("6095.50"),
+                Price.from_str("6094.00"),
+                Price.from_str("6095.00"),
+                Quantity.from_int(16),
+                pd.Timestamp("2026-06-15T14:31:00Z").value,
+                pd.Timestamp("2026-06-15T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESU26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6095.00"),
+                Price.from_str("6096.00"),
+                Price.from_str("6094.50"),
+                Price.from_str("6095.50"),
+                Quantity.from_int(17),
+                pd.Timestamp("2026-06-15T14:32:00Z").value,
+                pd.Timestamp("2026-06-15T14:32:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-06-15T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:29:00Z"),
+            end=pd.Timestamp("2026-06-15T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": march_transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "6001.00",
+                        "post_price": "5995.50",
+                    },
+                    {
+                        "transition_time_ns": june_transition_ns,
+                        "pre_instrument_id": "ESM26.XCME",
+                        "post_instrument_id": "ESU26.XCME",
+                        "pre_price": "6101.00",
+                        "post_price": "6095.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        assert len(handler) == 1
+        assert handler[0].data == []
+        assert handler[0].params["data_count"] == 8
+        assert len(bars_received) == 8
+        first_bar = bars_received[0]
+        last_bar = bars_received[-1]
+        assert first_bar.bar_type == bar_type.standard()
+        assert first_bar.open == Price.from_str("5988.50")
+        assert first_bar.high == Price.from_str("5989.50")
+        assert first_bar.low == Price.from_str("5987.50")
+        assert first_bar.close == Price.from_str("5989.00")
+        assert first_bar.volume == Quantity.from_int(10)
+        assert last_bar.bar_type == bar_type.standard()
+        assert last_bar.open == Price.from_str("6095.00")
+        assert last_bar.high == Price.from_str("6096.00")
+        assert last_bar.low == Price.from_str("6094.50")
+        assert last_bar.close == Price.from_str("6095.50")
+        assert last_bar.volume == Quantity.from_int(17)
+
+    def test_request_bars_for_continuous_future_applies_multiplicative_adjustment(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_mult")
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Price.from_str("5999.00"),
+                Price.from_str("6000.50"),
+                Quantity.from_int(10),
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.50"),
+                Price.from_str("6001.50"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Quantity.from_int(11),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Price.from_str("5994.50"),
+                Price.from_str("5995.50"),
+                Quantity.from_int(12),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.50"),
+                Price.from_str("5996.50"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Quantity.from_int(13),
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:29:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "6001.00",
+                        "post_price": "5995.50",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_RATIO,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        assert len(handler) == 1
+        assert handler[0].params["data_count"] == 4
+        assert len(bars_received) == 4
+        assert bars_received[0].open == Price.from_str("5994.50")
+        assert bars_received[0].high == Price.from_str("5995.50")
+        assert bars_received[0].low == Price.from_str("5993.50")
+        assert bars_received[0].close == Price.from_str("5995.00")
+        assert bars_received[-1].open == Price.from_str("5995.50")
+        assert bars_received[-1].high == Price.from_str("5996.50")
+        assert bars_received[-1].low == Price.from_str("5995.00")
+        assert bars_received[-1].close == Price.from_str("5996.00")
+
+    def test_request_bars_for_continuous_future_preserves_bar_type_chain(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_chain")
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Price.from_str("5999.00"),
+                Price.from_str("6000.50"),
+                Quantity.from_int(10),
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("6000.50"),
+                Price.from_str("6001.50"),
+                Price.from_str("6000.00"),
+                Price.from_str("6001.00"),
+                Quantity.from_int(11),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Price.from_str("5994.50"),
+                Price.from_str("5995.50"),
+                Quantity.from_int(12),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("5995.50"),
+                Price.from_str("5996.50"),
+                Price.from_str("5995.00"),
+                Price.from_str("5996.00"),
+                Quantity.from_int(13),
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type_1 = BarType.from_str("ES.XCME-2-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bar_type_2 = BarType.from_str("ES.XCME-4-MINUTE-LAST-INTERNAL@2-MINUTE-INTERNAL")
+        bars_1_received = []
+        bars_2_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type_1.standard()}",
+            handler=bars_1_received.append,
+        )
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type_2.standard()}",
+            handler=bars_2_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type_2,
+            start=pd.Timestamp("2026-03-16T14:29:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "bar_types": (bar_type_1, bar_type_2),
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "6001.00",
+                        "post_price": "5995.50",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        assert len(handler) == 1
+        assert handler[0].params["data_count"] == 4
+        assert len(bars_1_received) == 2
+        assert len(bars_2_received) == 1
+        assert bars_1_received[0].open == Price.from_str("5994.50")
+        assert bars_1_received[0].high == Price.from_str("5996.00")
+        assert bars_1_received[0].low == Price.from_str("5993.50")
+        assert bars_1_received[0].close == Price.from_str("5995.50")
+        assert bars_1_received[0].volume == Quantity.from_int(21)
+        assert bars_1_received[1].open == Price.from_str("5995.00")
+        assert bars_1_received[1].high == Price.from_str("5996.50")
+        assert bars_1_received[1].low == Price.from_str("5994.50")
+        assert bars_1_received[1].close == Price.from_str("5996.00")
+        assert bars_1_received[1].volume == Quantity.from_int(25)
+        assert bars_2_received[0].open == Price.from_str("5994.50")
+        assert bars_2_received[0].high == Price.from_str("5996.50")
+        assert bars_2_received[0].low == Price.from_str("5993.50")
+        assert bars_2_received[0].close == Price.from_str("5996.00")
+        assert bars_2_received[0].volume == Quantity.from_int(46)
+
+    def test_subscribe_bars_for_continuous_future_rolls_subscription_at_transition(self):
+        xcme_client = BacktestMarketDataClient(
+            client_id=ClientId("XCME"),
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        self.data_engine.register_client(xcme_client)
+        xcme_client.start()
+
+        transition_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:30:01Z").value)
+
+        subscribe = SubscribeBars(
+            client_id=ClientId("XCME"),
+            venue=Venue("XCME"),
+            bar_type=bar_type,
+            command_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "6001.00",
+                        "post_price": "5995.50",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+            },
+        )
+
+        self.data_engine.execute(subscribe)
+
+        assert xcme_client.subscribed_trade_ticks() == [self.esh26_xcme.id]
+
+        self.data_engine.process(
+            TradeTick(
+                instrument_id=self.esh26_xcme.id,
+                price=Price.from_str("6000.00"),
+                size=Quantity.from_int(1),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESH26-1"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:10Z").value,
+            ),
+        )
+        self.data_engine.process(
+            TradeTick(
+                instrument_id=self.esh26_xcme.id,
+                price=Price.from_str("6001.00"),
+                size=Quantity.from_int(2),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESH26-2"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:20Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:20Z").value,
+            ),
+        )
+
+        events = self.clock.advance_time(transition_ns)
+        for event in events:
+            event.handle()
+
+        assert xcme_client.subscribed_trade_ticks() == [self.esm26_xcme.id]
+
+        self.data_engine.process(
+            TradeTick(
+                instrument_id=self.esh26_xcme.id,
+                price=Price.from_str("7000.00"),
+                size=Quantity.from_int(10),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESH26-IGNORED"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:35Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:35Z").value,
+            ),
+        )
+        self.data_engine.process(
+            TradeTick(
+                instrument_id=self.esm26_xcme.id,
+                price=Price.from_str("5995.00"),
+                size=Quantity.from_int(3),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESM26-1"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:40Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:40Z").value,
+            ),
+        )
+        self.data_engine.process(
+            TradeTick(
+                instrument_id=self.esm26_xcme.id,
+                price=Price.from_str("5996.00"),
+                size=Quantity.from_int(4),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESM26-2"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:50Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:50Z").value,
+            ),
+        )
+
+        events = self.clock.advance_time(pd.Timestamp("2026-03-16T14:31:00Z").value)
+
+        for event in events:
+            event.handle()
+
+        assert len(bars_received) == 1
+        assert bars_received[0].bar_type == bar_type.standard()
+        assert bars_received[0].open == Price.from_str("5994.50")
+        assert bars_received[0].high == Price.from_str("5996.00")
+        assert bars_received[0].low == Price.from_str("5994.50")
+        assert bars_received[0].close == Price.from_str("5996.00")
+        assert bars_received[0].volume == Quantity.from_int(10)
+
+        self.msgbus.unsubscribe(
+            topic=f"data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+        self.data_engine.execute(
+            UnsubscribeBars(
+                client_id=ClientId("XCME"),
+                venue=Venue("XCME"),
+                bar_type=bar_type,
+                command_id=UUID4(),
+                ts_init=self.clock.timestamp_ns(),
+                params=subscribe.params.copy(),
+            ),
+        )
+
+        assert xcme_client.subscribed_trade_ticks() == []
+
+    def test_request_bars_for_continuous_future_forward_direction(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_forward")
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Price.from_str("99.00"),
+                Price.from_str("100.50"),
+                Quantity.from_int(1),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("95.00"),
+                Price.from_str("96.00"),
+                Price.from_str("94.50"),
+                Price.from_str("95.50"),
+                Quantity.from_int(2),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.00",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.FORWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Forward: pre-transition segment unadjusted, post-transition segment shifted by (pre - post) = +5
+        assert len(bars_received) == 2
+        assert bars_received[0].open == Price.from_str("100.00")
+        assert bars_received[0].close == Price.from_str("100.50")
+        assert bars_received[1].open == Price.from_str("100.00")
+        assert bars_received[1].high == Price.from_str("101.00")
+        assert bars_received[1].low == Price.from_str("99.50")
+        assert bars_received[1].close == Price.from_str("100.50")
+
+    def test_request_bars_for_continuous_future_composes_with_time_range_generator(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_trg")
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+
+        # Three 1-minute bars per contract so the inner request is chunked by durations_seconds.
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("100.50"),
+                Price.from_str("99.50"),
+                Price.from_str("100.00"),
+                Quantity.from_int(1),
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Price.from_str("99.00"),
+                Price.from_str("100.50"),
+                Quantity.from_int(2),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("95.00"),
+                Price.from_str("96.00"),
+                Price.from_str("94.50"),
+                Price.from_str("95.50"),
+                Quantity.from_int(3),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("95.50"),
+                Price.from_str("96.50"),
+                Price.from_str("95.00"),
+                Price.from_str("96.00"),
+                Quantity.from_int(4),
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+                pd.Timestamp("2026-03-16T14:32:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:33:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:29:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.50",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                # Each segment's inner request chunks into ~60s sub-requests via the long-request loop
+                "time_range_generator": "",
+                "durations_seconds": [60],
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Backward offset = post - pre = -5.5 → pre-transition bars shifted down by 5.5
+        # Inner requests were chunked but the final adjusted series is identical
+        assert len(handler) == 1
+        assert len(bars_received) == 4
+        assert bars_received[0].open == Price.from_str("94.50")
+        assert bars_received[1].close == Price.from_str("95.00")
+        assert bars_received[2].open == Price.from_str("95.00")
+        assert bars_received[3].close == Price.from_str("96.00")
+
+    def test_request_bars_for_continuous_future_single_segment_no_transition_in_range(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_single")
+        transition_ns = pd.Timestamp("2026-06-15T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Price.from_str("99.00"),
+                Price.from_str("100.50"),
+                Quantity.from_int(1),
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+                pd.Timestamp("2026-03-16T14:29:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.50"),
+                Price.from_str("101.50"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Quantity.from_int(2),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:31:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            # Request range entirely before the only transition
+            start=pd.Timestamp("2026-03-16T14:29:00Z"),
+            end=pd.Timestamp("2026-03-16T14:31:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "101.00",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Single segment before the transition: backward offset = -6 applied
+        assert len(bars_received) == 2
+        assert bars_received[0].open == Price.from_str("94.00")
+        assert bars_received[0].close == Price.from_str("94.50")
+        assert bars_received[1].close == Price.from_str("95.00")
+
+    def test_request_bars_for_continuous_future_stops_adjustment_at_last_post_instrument_id(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_last_post")
+        t1_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+        t2_ns = pd.Timestamp("2026-06-15T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Price.from_str("99.00"),
+                Price.from_str("100.50"),
+                Quantity.from_int(1),
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+                pd.Timestamp("2026-03-16T14:30:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("95.00"),
+                Price.from_str("96.00"),
+                Price.from_str("94.50"),
+                Price.from_str("95.50"),
+                Quantity.from_int(2),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:31:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": t1_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.50",
+                        "post_price": "95.00",
+                    },
+                    {
+                        "transition_time_ns": t2_ns,
+                        "pre_instrument_id": "ESM26.XCME",
+                        "post_instrument_id": "ESU26.XCME",
+                        "pre_price": "105.00",
+                        "post_price": "100.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "last_post_instrument_id": "ESM26.XCME",
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        assert len(handler) == 1
+        assert len(bars_received) == 2
+        assert bars_received[0].open == Price.from_str("94.50")
+        assert bars_received[0].high == Price.from_str("95.50")
+        assert bars_received[0].low == Price.from_str("93.50")
+        assert bars_received[0].close == Price.from_str("95.00")
+        assert bars_received[1].open == Price.from_str("95.00")
+        assert bars_received[1].high == Price.from_str("96.00")
+        assert bars_received[1].low == Price.from_str("94.50")
+        assert bars_received[1].close == Price.from_str("95.50")
+
+    def test_request_bars_for_continuous_future_anchors_forward_at_first_pre_instrument_id(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_first_pre")
+        t1_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+        t2_ns = pd.Timestamp("2026-06-15T14:31:00Z").value
+
+        bars = [
+            Bar(
+                BarType.from_str("ESM26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("95.00"),
+                Price.from_str("96.00"),
+                Price.from_str("94.50"),
+                Price.from_str("95.50"),
+                Quantity.from_int(2),
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+                pd.Timestamp("2026-03-16T14:31:00Z").value,
+            ),
+            Bar(
+                BarType.from_str("ESU26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                Price.from_str("100.00"),
+                Price.from_str("101.00"),
+                Price.from_str("99.50"),
+                Price.from_str("100.50"),
+                Quantity.from_int(3),
+                pd.Timestamp("2026-06-15T14:31:00Z").value,
+                pd.Timestamp("2026-06-15T14:31:00Z").value,
+            ),
+        ]
+        catalog.write_data(bars)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-06-15T14:32:00Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:31:00Z"),
+            end=pd.Timestamp("2026-06-15T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": t1_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.50",
+                        "post_price": "95.00",
+                    },
+                    {
+                        "transition_time_ns": t2_ns,
+                        "pre_instrument_id": "ESM26.XCME",
+                        "post_instrument_id": "ESU26.XCME",
+                        "pre_price": "105.00",
+                        "post_price": "100.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.FORWARD_SPREAD,
+                "first_pre_instrument_id": "ESM26.XCME",
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Forward + first_pre=ESM26 anchors on ESM26: ESM26 segment unadjusted,
+        # ESU26 segment shifted by transitions[1].pre - transitions[1].post = +5.
+        assert len(handler) == 1
+        assert len(bars_received) == 2
+        assert bars_received[0].open == Price.from_str("95.00")
+        assert bars_received[0].high == Price.from_str("96.00")
+        assert bars_received[0].low == Price.from_str("94.50")
+        assert bars_received[0].close == Price.from_str("95.50")
+        assert bars_received[1].open == Price.from_str("105.00")
+        assert bars_received[1].high == Price.from_str("106.00")
+        assert bars_received[1].low == Price.from_str("104.50")
+        assert bars_received[1].close == Price.from_str("105.50")
+
+    def test_request_bars_for_continuous_future_aborts_on_zero_pre_price_ratio(self):
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=(lambda _: None),
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        # Invalid for RATIO mode: division by zero
+                        "pre_price": "0",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_RATIO,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.data_engine._requests[request.id] = request
+        self.data_engine._handle_continuous_future_request(request)
+
+        assert request.id not in self.data_engine._requests
+        assert self.data_engine._bar_aggregators == {}
+
+    @pytest.mark.parametrize(
+        ("transition_overrides", "params_overrides"),
+        [
+            ({"pre_instrument_id": "ESH26"}, {}),
+            ({"transition_time_ns": None}, {}),
+            ({"pre_price": "not-a-price"}, {}),
+            (
+                {"post_price": "0"},
+                {"continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.FORWARD_RATIO},
+            ),
+            ({}, {"last_post_instrument_id": "ESZ26.XCME"}),
+            ({}, {"first_pre_instrument_id": "ESZ26.XCME"}),
+        ],
+    )
+    def test_request_bars_for_continuous_future_aborts_on_invalid_transition_metadata(
+        self,
+        transition_overrides,
+        params_overrides,
+    ):
+        transition = {
+            "transition_time_ns": pd.Timestamp("2026-03-16T14:31:00Z").value,
+            "pre_instrument_id": "ESH26.XCME",
+            "post_instrument_id": "ESM26.XCME",
+            "pre_price": "101.00",
+            "post_price": "95.00",
+        }
+        transition.update(transition_overrides)
+        params = {
+            "continuous_future_transitions": [transition],
+            "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+            "update_catalog": False,
+            "skip_catalog_data": False,
+        }
+        params.update(params_overrides)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+
+        request = RequestBars(
+            bar_type=BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"),
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=(lambda _: None),
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=params,
+        )
+
+        self.data_engine._requests[request.id] = request
+        self.data_engine._handle_continuous_future_request(request)
+
+        assert request.id not in self.data_engine._requests
+        assert self.data_engine._bar_aggregators == {}
+
+    def test_request_bars_for_continuous_future_aborts_on_unsorted_transition_times(self):
+        params = {
+            "continuous_future_transitions": [
+                {
+                    "transition_time_ns": pd.Timestamp("2026-06-15T14:31:00Z").value,
+                    "pre_instrument_id": "ESH26.XCME",
+                    "post_instrument_id": "ESM26.XCME",
+                    "pre_price": "101.00",
+                    "post_price": "95.00",
+                },
+                {
+                    "transition_time_ns": pd.Timestamp("2026-03-16T14:31:00Z").value,
+                    "pre_instrument_id": "ESM26.XCME",
+                    "post_instrument_id": "ESU26.XCME",
+                    "pre_price": "96.00",
+                    "post_price": "92.00",
+                },
+            ],
+            "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+            "update_catalog": False,
+            "skip_catalog_data": False,
+        }
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-06-15T14:32:00Z").value)
+
+        request = RequestBars(
+            bar_type=BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"),
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-06-15T14:32:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=(lambda _: None),
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=params,
+        )
+
+        self.data_engine._requests[request.id] = request
+        self.data_engine._handle_continuous_future_request(request)
+
+        assert request.id not in self.data_engine._requests
+        assert self.data_engine._bar_aggregators == {}
+
+    def test_request_bars_for_continuous_future_synthesizes_target_instrument(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_synth")
+        transition_ns = pd.Timestamp("2026-03-16T14:31:00Z").value
+        catalog.write_data(
+            [
+                Bar(
+                    BarType.from_str("ESH26.XCME-1-MINUTE-LAST-EXTERNAL"),
+                    Price.from_str("100.00"),
+                    Price.from_str("101.00"),
+                    Price.from_str("99.00"),
+                    Price.from_str("100.50"),
+                    Quantity.from_int(1),
+                    pd.Timestamp("2026-03-16T14:30:00Z").value,
+                    pd.Timestamp("2026-03-16T14:30:00Z").value,
+                ),
+            ],
+        )
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:32:00Z").value)
+        cache = TestComponentStubs.cache()
+        cache.add_instrument(self.esh26_xcme)
+        cache.add_instrument(self.esm26_xcme)
+        msgbus = MessageBus(
+            trader_id=self.trader_id,
+            clock=self.clock,
+        )
+        data_engine = DataEngine(
+            msgbus=msgbus,
+            cache=cache,
+            clock=self.clock,
+            config=DataEngineConfig(debug=True),
+        )
+        data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL")
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:30:00Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.50",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        msgbus.request(endpoint="DataEngine.request", request=request)
+
+        target_instrument = cache.instrument(bar_type.instrument_id)
+        assert isinstance(target_instrument, FuturesContract)
+        assert target_instrument.id == bar_type.instrument_id
+        assert target_instrument.raw_symbol == Symbol("ES")
+        assert target_instrument.price_increment == self.esh26_xcme.price_increment
+        assert target_instrument.expiration_ns == 0
+        assert len(handler) == 1
+
+    def test_request_bars_for_continuous_future_trade_tick_source(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_trades")
+        transition_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+
+        trades = [
+            TradeTick(
+                instrument_id=self.esh26_xcme.id,
+                price=Price.from_str("100.00"),
+                size=Quantity.from_int(1),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESH26-A"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:10Z").value,
+            ),
+            TradeTick(
+                instrument_id=self.esh26_xcme.id,
+                price=Price.from_str("101.00"),
+                size=Quantity.from_int(2),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESH26-B"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:20Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:20Z").value,
+            ),
+            TradeTick(
+                instrument_id=self.esm26_xcme.id,
+                price=Price.from_str("95.00"),
+                size=Quantity.from_int(3),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESM26-A"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:40Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:40Z").value,
+            ),
+            TradeTick(
+                instrument_id=self.esm26_xcme.id,
+                price=Price.from_str("96.00"),
+                size=Quantity.from_int(4),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESM26-B"),
+                ts_event=pd.Timestamp("2026-03-16T14:30:50Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:50Z").value,
+            ),
+            # Trailing trade after the 14:30 bucket close to trigger bar emission
+            TradeTick(
+                instrument_id=self.esm26_xcme.id,
+                price=Price.from_str("97.00"),
+                size=Quantity.from_int(5),
+                aggressor_side=AggressorSide.BUYER,
+                trade_id=TradeId("ESM26-C"),
+                ts_event=pd.Timestamp("2026-03-16T14:31:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:31:10Z").value,
+            ),
+        ]
+        catalog.write_data(trades)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:31:30Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:31:30Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "101.00",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Backward offset = -6 on the pre-transition trades.
+        # 14:30 bucket: pre-T 100→94, 101→95; post-T 95, 96 → OHLC(94, 96, 94, 96) vol=10.
+        # The 14:31:10 trade closes the 14:30 bucket and opens a new (incomplete) bucket.
+        assert len(bars_received) == 1
+        assert bars_received[0].open == Price.from_str("94.00")
+        assert bars_received[0].high == Price.from_str("96.00")
+        assert bars_received[0].low == Price.from_str("94.00")
+        assert bars_received[0].close == Price.from_str("96.00")
+        assert bars_received[0].volume == Quantity.from_int(10)
+
+    def test_request_bars_for_continuous_future_quote_tick_source(self):
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "contfut_catalog_quotes")
+        transition_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+
+        quotes = [
+            QuoteTick(
+                instrument_id=self.esh26_xcme.id,
+                bid_price=Price.from_str("100.00"),
+                ask_price=Price.from_str("100.50"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:10Z").value,
+            ),
+            QuoteTick(
+                instrument_id=self.esh26_xcme.id,
+                bid_price=Price.from_str("100.50"),
+                ask_price=Price.from_str("101.00"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:20Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:20Z").value,
+            ),
+            QuoteTick(
+                instrument_id=self.esm26_xcme.id,
+                bid_price=Price.from_str("94.50"),
+                ask_price=Price.from_str("95.00"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:40Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:40Z").value,
+            ),
+            QuoteTick(
+                instrument_id=self.esm26_xcme.id,
+                bid_price=Price.from_str("95.00"),
+                ask_price=Price.from_str("95.50"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:50Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:50Z").value,
+            ),
+            # Trailing quote past the 14:30 bucket close to trigger emission
+            QuoteTick(
+                instrument_id=self.esm26_xcme.id,
+                bid_price=Price.from_str("96.00"),
+                ask_price=Price.from_str("96.50"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:31:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:31:10Z").value,
+            ),
+        ]
+        catalog.write_data(quotes)
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:31:30Z").value)
+        self.data_engine.register_catalog(catalog)
+
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-MID-INTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"historical.data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+
+        handler = []
+        request = RequestBars(
+            bar_type=bar_type,
+            start=pd.Timestamp("2026-03-16T14:30:00Z"),
+            end=pd.Timestamp("2026-03-16T14:31:30Z"),
+            limit=0,
+            client_id=None,
+            venue=Venue("XCME"),
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "100.75",
+                        "post_price": "94.75",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                "update_catalog": False,
+                "skip_catalog_data": False,
+            },
+        )
+
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Backward offset = -6 on the pre-transition quote mids.
+        # Pre-T mids: 100.25, 100.75 → adjusted: 94.25, 94.75.
+        # Post-T mids: 94.75, 95.25 → unchanged.
+        # Trailing 14:31:10 quote closes the 14:30 bucket.
+        assert len(bars_received) == 1
+        assert bars_received[0].open == Price.from_str("94.25")
+        assert bars_received[0].high == Price.from_str("95.25")
+        assert bars_received[0].low == Price.from_str("94.25")
+        assert bars_received[0].close == Price.from_str("95.25")
+
+    def test_subscribe_bars_for_continuous_future_unsubscribe_cancels_pending_timer(self):
+        xcme_client = BacktestMarketDataClient(
+            client_id=ClientId("XCME"),
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        self.data_engine.register_client(xcme_client)
+        xcme_client.start()
+
+        transition_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL")
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:30:01Z").value)
+
+        subscribe = SubscribeBars(
+            client_id=ClientId("XCME"),
+            venue=Venue("XCME"),
+            bar_type=bar_type,
+            command_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={
+                "continuous_future_transitions": [
+                    {
+                        "transition_time_ns": transition_ns,
+                        "pre_instrument_id": "ESH26.XCME",
+                        "post_instrument_id": "ESM26.XCME",
+                        "pre_price": "101.00",
+                        "post_price": "95.00",
+                    },
+                ],
+                "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+            },
+        )
+
+        self.data_engine.execute(subscribe)
+
+        pending_timers = [
+            name for name in self.clock.timer_names if "continuous-future-roll" in name
+        ]
+        assert len(pending_timers) == 1
+
+        # Unsubscribe before the transition fires — timer must be cancelled
+        self.data_engine.execute(
+            UnsubscribeBars(
+                client_id=ClientId("XCME"),
+                venue=Venue("XCME"),
+                bar_type=bar_type,
+                command_id=UUID4(),
+                ts_init=self.clock.timestamp_ns(),
+                params=subscribe.params.copy(),
+            ),
+        )
+
+        pending_timers = [
+            name for name in self.clock.timer_names if "continuous-future-roll" in name
+        ]
+        assert len(pending_timers) == 0
+
+    def test_subscribe_bars_for_continuous_future_rolls_multiple_transitions(self):
+        xcme_client = BacktestMarketDataClient(
+            client_id=ClientId("XCME"),
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        self.data_engine.register_client(xcme_client)
+        xcme_client.start()
+
+        t1_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+        t2_ns = pd.Timestamp("2026-03-16T14:31:30Z").value
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-LAST-INTERNAL")
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:30:01Z").value)
+
+        self.data_engine.execute(
+            SubscribeBars(
+                client_id=ClientId("XCME"),
+                venue=Venue("XCME"),
+                bar_type=bar_type,
+                command_id=UUID4(),
+                ts_init=self.clock.timestamp_ns(),
+                params={
+                    "continuous_future_transitions": [
+                        {
+                            "transition_time_ns": t1_ns,
+                            "pre_instrument_id": "ESH26.XCME",
+                            "post_instrument_id": "ESM26.XCME",
+                            "pre_price": "100.00",
+                            "post_price": "95.00",
+                        },
+                        {
+                            "transition_time_ns": t2_ns,
+                            "pre_instrument_id": "ESM26.XCME",
+                            "post_instrument_id": "ESU26.XCME",
+                            "pre_price": "96.00",
+                            "post_price": "92.00",
+                        },
+                    ],
+                    "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                },
+            ),
+        )
+
+        assert xcme_client.subscribed_trade_ticks() == [self.esh26_xcme.id]
+
+        for event in self.clock.advance_time(t1_ns):
+            event.handle()
+
+        assert xcme_client.subscribed_trade_ticks() == [self.esm26_xcme.id]
+
+        for event in self.clock.advance_time(t2_ns):
+            event.handle()
+
+        assert xcme_client.subscribed_trade_ticks() == [self.esu26_xcme.id]
+
+    def test_subscribe_bars_for_continuous_future_quote_tick_source(self):
+        xcme_client = BacktestMarketDataClient(
+            client_id=ClientId("XCME"),
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        self.data_engine.register_client(xcme_client)
+        xcme_client.start()
+
+        transition_ns = pd.Timestamp("2026-03-16T14:30:30Z").value
+        bar_type = BarType.from_str("ES.XCME-1-MINUTE-MID-INTERNAL")
+        bars_received = []
+        self.msgbus.subscribe(
+            topic=f"data.bars.{bar_type.standard()}",
+            handler=bars_received.append,
+        )
+        self.clock.set_time(to_time_ns=pd.Timestamp("2026-03-16T14:30:01Z").value)
+
+        self.data_engine.execute(
+            SubscribeBars(
+                client_id=ClientId("XCME"),
+                venue=Venue("XCME"),
+                bar_type=bar_type,
+                command_id=UUID4(),
+                ts_init=self.clock.timestamp_ns(),
+                params={
+                    "continuous_future_transitions": [
+                        {
+                            "transition_time_ns": transition_ns,
+                            "pre_instrument_id": "ESH26.XCME",
+                            "post_instrument_id": "ESM26.XCME",
+                            "pre_price": "100.75",
+                            "post_price": "94.75",
+                        },
+                    ],
+                    "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
+                },
+            ),
+        )
+
+        assert xcme_client.subscribed_quote_ticks() == [self.esh26_xcme.id]
+
+        self.data_engine.process(
+            QuoteTick(
+                instrument_id=self.esh26_xcme.id,
+                bid_price=Price.from_str("100.50"),
+                ask_price=Price.from_str("101.00"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:10Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:10Z").value,
+            ),
+        )
+
+        for event in self.clock.advance_time(transition_ns):
+            event.handle()
+
+        assert xcme_client.subscribed_quote_ticks() == [self.esm26_xcme.id]
+
+        self.data_engine.process(
+            QuoteTick(
+                instrument_id=self.esm26_xcme.id,
+                bid_price=Price.from_str("94.50"),
+                ask_price=Price.from_str("95.00"),
+                bid_size=Quantity.from_int(1),
+                ask_size=Quantity.from_int(1),
+                ts_event=pd.Timestamp("2026-03-16T14:30:40Z").value,
+                ts_init=pd.Timestamp("2026-03-16T14:30:40Z").value,
+            ),
+        )
+
+        for event in self.clock.advance_time(pd.Timestamp("2026-03-16T14:31:00Z").value):
+            event.handle()
+
+        # Pre-transition mid = 100.75 adjusted by spread = -6 → 94.75
+        # Post-transition mid = 94.75 unchanged
+        assert len(bars_received) == 1
+        assert bars_received[0].open == Price.from_str("94.75")
+        assert bars_received[0].close == Price.from_str("94.75")
 
     def test_request_bars_reaches_client(self):
         # Arrange


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Adds end-to-end support for continuous-future bar requests and live subscriptions. A continuous future is specified as a target bar type plus a list of roll transitions in `params`; the data engine walks the per-contract segments, applies the cumulative price adjustment at each segment boundary, and re-aggregates source data (bars, trade ticks, or quote ticks) into the continuous series.

- Adds `ContinuousFutureAdjustmentType` enum (`BACKWARD_SPREAD`, `FORWARD_SPREAD`, `BACKWARD_RATIO`, `FORWARD_RATIO`).

- Adds `BarBuilder.set_adjustment` applied at ingress on every `update`/`update_bar` call, so the running OHLC state is always in the adjusted (common) frame. Hot path is pure C math (no `Decimal`/`str` allocation per tick).

- Adds continuous-future request path on `DataEngine`: outer loop over segments fires one inner `RequestBars`/`RequestTradeTicks`/`RequestQuoteTicks` per segment and composes with the existing long-request and aggregated-bars chain setup.

- Adds continuous-future subscription path on `DataEngine`: a small state machine per active subscription, driven by a single pending time alert at each upcoming transition.

- Uses transition schema keys `pre_instrument_id` / `post_instrument_id`, and supports optional `first_pre_instrument_id` and `last_post_instrument_id` to bound the active chain — backward modes anchor on `last_post_instrument_id`, forward modes anchor on `first_pre_instrument_id`, and segments outside the bounded range receive no further adjustment.

- Adds targeted test coverage across `test_aggregation.py` (ingress adjustment, mid-bar adjustment change, no-op), `test_engine.py` (request/subscription permutations, validation aborts, target instrument synthesis, chain aggregators, long-request composition), and `test_backtest.py` (end-to-end acceptance).

## Continuous futures — architecture

This section walks through how the continuous-future bar request and subscription paths work end-to-end. Start with the overview, then jump to whichever subsection you need.

- [What is a continuous future?](#what-is-a-continuous-future)
- [Inputs](#inputs)
- [Validation](#validation)
- [Target instrument auto-synthesis](#target-instrument-auto-synthesis)
- [Overview](#overview)
- [The outer loop — segments](#the-outer-loop--segments)
- [Request flow](#request-flow)
- [Composition with `time_range_generator`](#composition-with-time_range_generator)
- [Subscription flow](#subscription-flow)
- [Source resolution](#source-resolution)
- [`BarBuilder` adjustment](#barbuilder-adjustment)
- [Engine state reference](#engine-state-reference)

### What is a continuous future?

Futures contracts expire. A strategy on "S&P 500 futures" actually trades a succession of contracts — `ESH26`, `ESM26`, `ESU26`, ... — each for a few months. A continuous price series is built by splicing those contracts together. Because consecutive contracts trade at different prices due to roll yield, carry, and interest rates, naive splicing produces a jump at every roll.

A continuous future **adjusts** past (or future) prices so the series is smooth across rolls. One knob, `ContinuousFutureAdjustmentType`, combines direction (backward/forward) with operation (spread/ratio):

- `BACKWARD_SPREAD` (Panama) — additive offset; newest contract unadjusted, past segments shifted by the sum of per-transition spreads that come *after* them.

- `FORWARD_SPREAD` — additive offset; oldest contract unadjusted, newer segments shifted by the sum of per-transition spreads that come *before* them.

- `BACKWARD_RATIO` — multiplicative factor; newest contract unadjusted, cumulative product of per-transition ratios after each segment.

- `FORWARD_RATIO` — multiplicative factor; oldest contract unadjusted, cumulative product of per-transition ratios before each segment.

The cumulative adjustment at segment `k` out of `N` transitions is:

```text
BACKWARD_SPREAD: sum over i in [k, N) of (post_i - pre_i)
FORWARD_SPREAD:  sum over i in [0, k) of (pre_i - post_i)
BACKWARD_RATIO:  product over i in [k, N) of (post_i / pre_i)
FORWARD_RATIO:   product over i in [0, k) of (pre_i / post_i)
```

`_continuous_future_compute_offset` accepts two optional bounds that restrict the active portion of the transition table:

- `last_post_instrument_id` caps the upper end at the first transition whose `post_instrument_id` matches. For backward modes this is the anchor (cumulative adjustment for the anchor segment is zero); for forward modes it caps how far later contracts accumulate.

- `first_pre_instrument_id` caps the lower end at the first transition whose `pre_instrument_id` matches. For forward modes this is the anchor (cumulative adjustment for the anchor segment is zero); for backward modes it caps how far earlier contracts accumulate.

The `segment_index` is clamped into `[transition_start_index, transition_stop_index]` before iterating, so out-of-chain segments collapse to either an empty range (anchor frame, zero cumulative) or the full in-chain range (same cumulative as the nearest in-chain segment). This lets callers request or subscribe using a larger transition table while anchoring the adjusted series to a specific contract on either side.

See [`_continuous_future_compute_offset`](../nautilus_trader/nautilus_trader/data/engine.pyx).

### Inputs

A continuous-future request or subscription is any `RequestBars` / `SubscribeBars` with a `continuous_future_transitions` entry in `params`:

```python
params = {
    "continuous_future_transitions": [
        {
            "transition_time_ns": 1773671460000000000,  # when ESH26 rolls to ESM26
            "pre_instrument_id": "ESH26.XCME",
            "post_instrument_id": "ESM26.XCME",
            "pre_price": "6001.00",                      # last ESH26 price pre-roll
            "post_price": "5995.50",                     # first ESM26 price post-roll
        },
        # ... more transitions ...
    ],
    "continuous_future_adjustment_mode": ContinuousFutureAdjustmentType.BACKWARD_SPREAD,
    # Optional: cap the upper end of cumulative adjustment at the transition whose
    # post_instrument_id matches (the backward-mode anchor).
    # "last_post_instrument_id": "ESM26.XCME",
    # Optional: cap the lower end of cumulative adjustment at the transition whose
    # pre_instrument_id matches (the forward-mode anchor).
    # "first_pre_instrument_id": "ESM26.XCME",
    # Optional chain: bar_types = (bottom, ..., top) for multi-level aggregation
    # Optional: any other param, incl. "time_range_generator" / "durations_seconds"
}
```

The `bar_type` on the request/command is the **target** continuous bar_type, e.g. `"ES.XCME-1-MINUTE-LAST-INTERNAL@1-MINUTE-EXTERNAL"`. Note the root instrument (`ES.XCME`) — that's the continuous identifier, not a real contract. Each segment's raw source data comes from the real contract id listed in the transitions (`ESH26.XCME`, `ESM26.XCME`, ...).

### Validation

Before any aggregator is allocated, both entry points run `_continuous_future_validate_transitions(target_bar_type, transitions, params)`:

- `continuous_future_adjustment_mode` must parse as a valid `ContinuousFutureAdjustmentType`.

- `continuous_future_transitions` must be a list/tuple, and every transition row must be a dict.

- Every transition row must include a non-negative integer `transition_time_ns`, and transition times must be strictly increasing.

- Every `pre_instrument_id` / `post_instrument_id` must parse as a valid `InstrumentId` with a venue equal to `target_bar_type.instrument_id.venue`.

- Every transition row must include finite `pre_price` / `post_price` values. Ratio modes additionally require both prices to be positive, because the cumulative adjustment divides by the roll price.

- If `last_post_instrument_id` is supplied, it must parse as an `InstrumentId`, match the target venue, and appear as a `post_instrument_id` in the transition list.

- If `first_pre_instrument_id` is supplied, it must parse as an `InstrumentId`, match the target venue, and appear as a `pre_instrument_id` in the transition list.

- The continuous-future id's symbol is intentionally arbitrary (e.g. `ES.XCME`), but the venue is load-bearing: child requests and live sub-subscriptions route by `segment_instrument_id.venue`, so a mismatched venue would silently send traffic to the wrong client.

- On validation failure the helper logs a specific error and the subscribe/request returns without allocating anything. `_handle_continuous_future_request` additionally calls `_abort_request` to drop any workflow state it had begun to set up.

See [`_continuous_future_validate_transitions`](../nautilus_trader/nautilus_trader/data/engine.pyx).

### Target instrument auto-synthesis

The continuous root (e.g. `ES.XCME`) is a synthetic id with no market data of its own, but downstream consumers (aggregators, cache lookups, serialization) still expect an `Instrument` in the cache. Right after validation, both entry points call `_continuous_future_ensure_target_instrument(target_bar_type, transitions)`:

- If the target id is already cached, the helper is a no-op (callers can pre-register a custom continuous instrument and the engine will respect it).

- Otherwise it fetches the first segment's instrument (`transitions[0].pre_instrument_id`) from the cache and clones it via `FuturesContract.to_dict_c` / `from_dict_c`, overriding only `id`, `raw_symbol`, and clearing `activation_ns` / `expiration_ns` to `0` so the continuous id can be used as an open-ended aggregation target. Every other field (currency, precision, increment, multiplier, lot size, underlying, fees, margins, exchange, tick scheme, info) is reused from the segment.

- If the first segment is not yet in the cache, or is not a `FuturesContract`, the helper logs a warning and returns; in that case the caller must register the continuous instrument manually as before.

This removes the previous requirement to call `engine.add_instrument(...)` for the continuous root before issuing any CF request or subscription.

See [`_continuous_future_ensure_target_instrument`](../nautilus_trader/nautilus_trader/data/engine.pyx).

### Overview

```mermaid
flowchart TD
    User([User/Strategy]) -->|"params['continuous_future_transitions']"| Entry{"Entry point"}
    Entry -->|RequestBars| ReqPath[Request path]
    Entry -->|SubscribeBars| SubPath[Subscription path]

    ReqPath --> OuterReq[Outer loop: segments]
    SubPath --> OuterSub[Outer loop: segments + time alerts]

    OuterReq -->|per segment| SubReq[Inner Request_ for segment contract]
    OuterSub -->|per segment| LiveSub[Inner SubscribeBars/Trades/Quotes on segment contract]

    SubReq --> Agg[(Primary aggregator<br/>keyed by parent.id<br/>BarBuilder.set_adjustment)]
    LiveSub --> Agg2[(Live aggregator<br/>keyed by target BarType<br/>BarBuilder.set_adjustment)]

    Agg -->|adjusted bars| Chain[Chain aggregators]
    Agg2 -->|adjusted bars| MsgBus[(msgbus: data.bars.*)]
    Chain -->|final bars| HistBus[(msgbus: historical.data.bars.*)]
```

Two entry points, one outer loop shape (walk the segments), two means of fetching per-segment data (historical sub-requests vs live sub-subscriptions), and one adjustment mechanism (`BarBuilder.set_adjustment` at segment boundary).

### The outer loop — segments

A **segment** is a contiguous time slice owned by one real contract. Segments are separated by transitions. Given `transitions[0..N)`:

- Segment 0: `(-∞, transitions[0].time)` on `transitions[0].pre_instrument_id`

- Segment k, for k ∈ [1, N): `[transitions[k-1].time, transitions[k].time)` on `transitions[k].pre_instrument_id`

- Segment N: `[transitions[N-1].time, +∞)` on `transitions[N-1].post_instrument_id`

`_continuous_future_next_segment(transitions, cursor_ns, end_ns)` returns the next segment starting at `cursor_ns`, clamped to `end_ns`:

```mermaid
flowchart TD
    Start[cursor_ns, end_ns] --> Check{"cursor_ns > end_ns<br/>or no transitions?"}
    Check -->|yes| None[return None]
    Check -->|no| Scan[Find first transition i<br/>where cursor_ns &lt; transition_time]
    Scan -->|found| Before["Return segment before transition i<br/>(i, pre_instrument_id, cursor_ns, min(end_ns, transition_time-1))"]
    Scan -->|not found| After["Return final segment<br/>(N, post_instrument_id, cursor_ns, end_ns)"]
```

### Request flow

The request path mirrors `_handle_long_request` one level up: each iteration fires **one** inner request for one segment's worth of data, and the inner's completion callback advances the cursor.

#### Sequence

```mermaid
sequenceDiagram
    participant User
    participant Engine as DataEngine
    participant Agg as Primary Aggregator<br/>(keyed by parent.id)
    participant MsgBus
    participant Client as DataClient

    User->>Engine: msgbus.request(RequestBars w/ transitions)
    Engine->>Engine: _process_request
    Engine->>Engine: _handle_continuous_future_request

    rect rgb(235,245,255)
        Note over Engine,Agg: Setup
        Engine->>Engine: _bound_dates
        Engine->>Agg: _init_bar_aggregators_for_request(chain, parent.id)
        Engine->>Engine: _bar_types_params[parent.id] = {bar_types, ...}
        Engine->>Engine: state.continuous_future_cursor_ns, state.continuous_future_primary_bar_type (on RequestWorkflowState)
        Engine->>Engine: _update_continuous_future_data(parent.id)
    end

    loop one iteration per segment
        rect rgb(245,255,240)
            Engine->>Engine: segment = _continuous_future_next_segment(...)
            alt segment is None
                Engine->>Engine: _emit_empty_request_response
            else
                Engine->>Agg: _continuous_future_apply_adjustment(transitions, segment_index, params)
                Engine->>Engine: sub = _continuous_future_build_child_request(segment_id)
                Engine->>Engine: sub.params["continuous_future_parent_request_id"] = parent.id
                Engine->>MsgBus: subscribe primary aggregator to segment historical topic
                Engine->>Engine: state.continuous_future_active_source / active_segment_id = ...
                Engine->>MsgBus: request(sub)
                MsgBus->>Engine: _process_request(sub)
                Engine->>Client: RequestBars/Trades/Quotes for segment contract
                Client-->>Engine: DataResponse (may fan out via time_range_generator)
                Engine->>Engine: _handle_response(sub_response)

                Note over Engine,Agg: Normal process_historical loop publishes each item on segment topic
                Engine->>MsgBus: publish bar / trade / quote (historical topic)
                MsgBus->>Agg: handle_bar / handle_trade_tick / handle_quote_tick (adjusted at ingress)
                Engine->>Engine: sub_response callback = _handle_continuous_future_response
                Engine->>MsgBus: unsubscribe primary aggregator from segment topic
                Engine->>Engine: state.data_count += response.data_count
                Engine->>Engine: _update_continuous_future_data(parent.id) ↻
            end
        end
    end

    rect rgb(255,245,240)
        Note over Engine: Finalize
        Engine->>Engine: _emit_empty_request_response
        Engine->>Engine: emit empty parent response with correlation_id = parent.id
        Engine->>Engine: _handle_response(parent_response)
        Note over Engine: correlation_id in _bar_types_params → _finalize_aggregated_bars_request disposes chain
        Engine->>User: parent.callback(final response)
    end
```

#### Methods involved

- [`_handle_continuous_future_request`](../nautilus_trader/nautilus_trader/data/engine.pyx) — entry; initializes request-scoped aggregators via `_init_bar_aggregators_for_request`, records state.

- [`_update_continuous_future_data`](../nautilus_trader/nautilus_trader/data/engine.pyx) — one turn of the outer loop: next segment, apply adjustment (via `_continuous_future_apply_adjustment`), subscribe the primary aggregator to the segment's historical msgbus topic, fire inner request.

- [`_continuous_future_build_child_request`](../nautilus_trader/nautilus_trader/data/engine.pyx) — constructs the inner `RequestBars`/`RequestTradeTicks`/`RequestQuoteTicks` with `continuous_future_parent_request_id` in params.

- [`_handle_continuous_future_response`](../nautilus_trader/nautilus_trader/data/engine.pyx) — sub callback; unsubscribes the primary aggregator from the consumed segment topic, then advances the cursor.

- `_handle_response` — for sub-responses carrying `continuous_future_parent_request_id`, the normal `process_historical` loop publishes each item on its segment's historical topic; the primary aggregator receives them through the subscription attached in `_update_continuous_future_data`.

- Terminal call: `_update_continuous_future_data` invokes `_emit_empty_request_response` once `_continuous_future_next_segment` returns `None` (cursor past `state.end`). `_handle_response` then disposes the chain via `_finalize_aggregated_bars_request` because `parent.id` is in `_bar_types_params`.

#### Chain aggregators

If the caller sets `bar_types = (bar_type_1, bar_type_2)` (multi-level internal aggregation), the setup creates all aggregators keyed by `parent.id`. The primary (bottom of the chain, `bar_types[0]`) receives segment source data via a per-segment msgbus subscription: `_update_continuous_future_data` subscribes it to the segment's historical topic before firing each sub-request, and `_handle_continuous_future_response` unsubscribes after the response is consumed. The normal `process_historical` path in `_handle_response` publishes each item on its segment's historical topic, which the primary aggregator picks up. Its emitted bars are published to `historical.data.bars.<bar_type_1>` which `bar_type_2`'s aggregator is subscribed to (via `_setup_bar_aggregator`'s composite subscription), so the chain walks up automatically.

```mermaid
flowchart LR
    SourceData[Raw ESH26 bars / trades / quotes<br/>from segment sub-request]
    -->|"historical.data.*.ESH26<br/>(per-segment subscription)"| Agg1[("bar_types[0]<br/>= bottom aggregator<br/>(composite)<br/>adjusted at ingress")]
    -->|"historical.data.bars.<bar_types[0]>"| Agg2[("bar_types[1]<br/>aggregator")]
    -->|"historical.data.bars.<bar_types[1]>"| Agg3[("bar_types[-1]<br/>top aggregator")]
    -->|"historical.data.bars.<bar_types[-1]>"| User[User callback / subscribers]
```

Only the **primary** (bottom) builder has `set_adjustment` called on it — the data it receives is already adjusted before it reaches the higher levels. Higher levels just re-aggregate.

### Composition with `time_range_generator`

The inner sub-request goes through `_process_request` exactly like any other request. If the caller sets `time_range_generator` and `durations_seconds` in params, those are inherited by the inner request, so the inner itself becomes a **long request** that chunks the segment's time range into N further sub-sub-requests.

```mermaid
flowchart TD
    Outer[Outer loop: segments] --> S1[Segment 1: ESH26<br/>range 10:00–11:00]
    Outer --> S2[Segment 2: ESM26<br/>range 11:00–12:00]

    S1 --> I1["Inner RequestBars for ESH26<br/>params include time_range_generator"]
    I1 --> L1[Long-request loop]
    L1 --> C1a[10:00–10:30]
    L1 --> C1b[10:30–11:00]
    C1a --> Agg[(Primary aggregator)]
    C1b --> Agg

    S2 --> I2["Inner RequestBars for ESM26<br/>params include time_range_generator"]
    I2 --> L2[Long-request loop]
    L2 --> C2a[11:00–11:30]
    L2 --> C2b[11:30–12:00]
    C2a --> Agg
    C2b --> Agg
```

The outer continuous-future loop is oblivious to the inner chunking — each inner `RequestBars` still emits exactly one `DataResponse` back (the long-request path collapses its N sub-requests into one combined response), and that one response triggers the outer loop's next segment.

Covered by `test_request_bars_for_continuous_future_composes_with_time_range_generator`.

### Subscription flow

A small state machine per active subscription, driven by a single pending time alert.

#### State diagram

```mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Active: _handle_subscribe_continuous_future_bars<br/>(segment_i active, timer for transition_i)
    Active --> Active: _handle_continuous_future_subscription_transition<br/>(deactivate segment_i, activate segment_{i+1},<br/>schedule next timer)
    Active --> Tail: last transition fired<br/>(timer_name = None)
    Tail --> [*]: _handle_unsubscribe_continuous_future_bars
    Active --> [*]: _handle_unsubscribe_continuous_future_bars<br/>(cancel timer, deactivate segment)
```

#### Sequence: one roll

```mermaid
sequenceDiagram
    participant User
    participant Engine as DataEngine
    participant Clock as Clock (TimeAlert)
    participant Agg as Live aggregator<br/>(keyed by target BarType)
    participant Client as MarketDataClient

    User->>Engine: execute(SubscribeBars w/ transitions)
    Engine->>Engine: _handle_subscribe_continuous_future_bars
    Engine->>Agg: _create_bar_aggregator + _setup_bar_aggregator(subscribe_source=False)
    Engine->>Engine: _continuous_future_activate_segment(segment_0)
    Engine->>Agg: _continuous_future_apply_adjustment → _builder.set_adjustment(offset_0, mode)
    Engine->>Engine: _continuous_future_subscribe_source → msgbus.subscribe(source topic)
    Engine->>Client: execute(SubscribeTradeTicks/SubscribeBars for ESH26)
    Engine->>Clock: _continuous_future_schedule_next_transition → set_time_alert(transition_0)

    Note over Engine,Agg: Live segment 0: ticks for ESH26 flow through msgbus to aggregator

    Clock->>Engine: _handle_continuous_future_subscription_transition(event)
    Engine->>Engine: parse target_key from event.name ("continuous-future-roll:{target_key}:{idx}") and look up state
    Engine->>Engine: _continuous_future_deactivate_segment(segment_i)
    Engine->>Engine: _continuous_future_unsubscribe_source
    Engine->>Client: execute(UnsubscribeTradeTicks ESH26)
    Engine->>Engine: _continuous_future_activate_segment(segment_{i+1})
    Engine->>Agg: _continuous_future_apply_adjustment → _builder.set_adjustment(offset_{i+1}, mode)
    Engine->>Engine: _continuous_future_subscribe_source
    Engine->>Client: execute(SubscribeTradeTicks ESM26)
    Engine->>Clock: _continuous_future_schedule_next_transition → set_time_alert(transition_{i+1})

    Note over Engine,Agg: Live segment 1: ticks for ESM26 flow through msgbus to aggregator,<br/>now adjusted with the segment 1 offset
```

#### Methods involved

- [`_handle_subscribe_continuous_future_bars`](../nautilus_trader/nautilus_trader/data/engine.pyx) — entry from `_handle_subscribe_bars` when `continuous_future_transitions` is present; reuses `_setup_bar_aggregator` for live mode/timer setup, but disables normal source subscription because segment activation attaches the real contract source.

- [`_handle_unsubscribe_continuous_future_bars`](../nautilus_trader/nautilus_trader/data/engine.pyx) — entry from `_handle_unsubscribe_bars` when the target is in `_continuous_future_subscriptions`.

- [`_handle_continuous_future_subscription_transition`](../nautilus_trader/nautilus_trader/data/engine.pyx) — time-alert callback; orchestrates the roll.

- [`_continuous_future_activate_segment`](../nautilus_trader/nautilus_trader/data/engine.pyx) — resolve source, apply adjustment (via `_continuous_future_apply_adjustment`), subscribe source, execute live sub-subscribe command.

- [`_continuous_future_deactivate_segment`](../nautilus_trader/nautilus_trader/data/engine.pyx) — symmetric teardown: resolve source, unsubscribe source, execute live sub-unsubscribe command.

- [`_continuous_future_schedule_next_transition`](../nautilus_trader/nautilus_trader/data/engine.pyx) — re-arms the timer after each roll.

### Source resolution

For any continuous-future target `BarType`, the raw data feeding the primary aggregator lives on the **segment contract**, not the continuous id. The target's shape decides the source type:

```mermaid
flowchart TD
    Target[target_bar_type] --> Check1{is_composite?}
    Check1 -->|yes| Ref[reference = target.composite]
    Check1 -->|no| RefNo[reference = target]
    Ref --> Check2{"reference.is_externally_aggregated?"}
    RefNo --> Check2
    Check2 -->|yes| Bars["source = ('bars', segment_id-spec-EXTERNAL)<br/>inner = RequestBars / SubscribeBars"]
    Check2 -->|no| Check3{"reference.spec.price_type"}
    Check3 -->|LAST| Trades["source = ('trades', None)<br/>inner = RequestTradeTicks / SubscribeTradeTicks"]
    Check3 -->|MID/BID/ASK| Quotes["source = ('quotes', None)<br/>inner = RequestQuoteTicks / SubscribeQuoteTicks"]
```

See [`_continuous_future_resolve_source`](../nautilus_trader/nautilus_trader/data/engine.pyx).

### `BarBuilder` adjustment

Adjustment is applied **at ingress** on every `update(price, ...)` and `update_bar(bar, ...)` call. The running OHLC state is always in the adjusted (common) frame, so switching adjustment mid-bar just means subsequent prices are adjusted differently — no partial-bar buffering needed.

```mermaid
flowchart LR
    Tick[raw price] --> AdjCheck{adjustment_mode}
    AdjCheck -->|None| Raw[pass through]
    AdjCheck -->|"spread (BACKWARD_SPREAD / FORWARD_SPREAD)"| SpreadBranch{adjustment == 0?}
    SpreadBranch -->|yes| Raw
    SpreadBranch -->|no| SpreadApply[price + adjustment]
    AdjCheck -->|"ratio (BACKWARD_RATIO / FORWARD_RATIO)"| RatioBranch{adjustment == 1?}
    RatioBranch -->|yes| Raw
    RatioBranch -->|no| RatioApply[price * adjustment]
    Raw --> Update[update OHLC state]
    SpreadApply --> Update
    RatioApply --> Update
    Update --> Build[build on trigger]
```

The `BarBuilder` only cares about ratio-vs-spread (to decide add-or-multiply); direction information is collapsed into the sign/magnitude of the cumulative offset computed by the engine before `set_adjustment` is called. The mode enum exposes `is_ratio` and `is_backward` properties for this.

Because a segment boundary arrives as a `set_adjustment(new_offset, mode)` call — and nothing else — the design is:

- Pre-segment-boundary: OHLC reflects raw prices adjusted by old offset (e.g. `pre-transition price + 0` for the newest backward segment).

- Boundary: `set_adjustment` updates the two state fields. Running OHLC stays.

- Post-boundary: new raw prices get the new offset applied on ingress, and merge into the running OHLC (high/low updated as normal). The already aggregated pre-boundary part is already in the same common frame because that's how backward-adjusted (Panama) continuous futures are defined: consecutive contracts are arranged to be seamless at each transition.

`reset()` clears per-bar OHLCV state for the next bar in the series but intentionally preserves the adjustment configuration: rolls happen far less often than bar resets, so the adjustment is treated as segment-scoped state and only changes when the engine calls `set_adjustment` at a segment boundary.

### Engine state reference

Continuous-future state lives in two places: four new fields on the existing `RequestWorkflowState` dataclass (request side), and one dict of `ContinuousFutureSubscriptionState` dataclasses (subscription side).

**Request side** — fields on `RequestWorkflowState` (fetched via `_ensure_request_workflows(request)`), created and popped by the normal request lifecycle so there is nothing bespoke to clean up:

| Field | Type | Role |
|---|---|---|
| `continuous_future_cursor_ns` | `int` | Next segment's start in ns; advances as each sub-request completes. |
| `continuous_future_primary_bar_type` | `BarType \| None` | Bottom of the chain that receives segment source data via its per-segment msgbus subscription. |
| `continuous_future_active_source` | `tuple \| None` | `(source_type, source_bar_type)` for the in-flight segment, used to unsubscribe once the sub-response is consumed. |
| `continuous_future_active_segment_id` | `InstrumentId \| None` | Segment instrument currently attached to the primary aggregator; cleared after unsubscribe. |

The sub-to-parent mapping isn't stored anywhere — `_continuous_future_build_child_request` puts `continuous_future_parent_request_id` in the sub-request's params, and `_request_response_params` forwards it into the response that reaches `_handle_continuous_future_response`.

**Subscription side** — one dict keyed by `BarType`, each entry a typed `ContinuousFutureSubscriptionState`:

| Dict | Key | Value | Lifetime |
|---|---|---|---|
| `_continuous_future_subscriptions` | `target_bar_type.standard(): BarType` | `ContinuousFutureSubscriptionState(target_bar_type, client_id, venue, params, active_segment_instrument_id, next_transition_index, timer_name)` | Active subscription duration |

**Reused engine dicts** (pre-existing, shared with other request kinds):

| Dict | Key | Value | Role in continuous future |
|---|---|---|---|
| `_bar_types_params` | `parent_request_id: UUID4` | stored params incl. `bar_types` tuple | Marks parent for automatic chain cleanup in `_finalize_aggregated_bars_request` at final response time. |
| `_bar_aggregators` | `(bar_type.standard(), parent_request_id): tuple` | `BarAggregator` | Chain aggregators keyed by parent request id (not by `None`), so concurrent continuous-future requests do not clash. |

### Dispatch summary

A compact view of where `continuous_future_transitions` is checked in the engine, what it triggers, and where state flows:

```mermaid
flowchart TD
    Sub[SubscribeBars arrives] --> SD{"params has<br/>continuous_future_transitions?"}
    SD -->|yes| SH[_handle_subscribe_continuous_future_bars]
    SD -->|no| Normal1[normal subscribe path]
    SH --> SValid{"_continuous_future_validate_transitions"}
    SValid -->|validation failure| SAbort[log error + return]
    SValid -->|ok| SEnsure[_continuous_future_ensure_target_instrument<br/>clone first segment if target missing]
    SEnsure --> SOk[proceed to activate segment_0]

    UnSub[UnsubscribeBars arrives] --> UD{"target_bar_type in<br/>_continuous_future_subscriptions?"}
    UD -->|yes| UH[_handle_unsubscribe_continuous_future_bars]
    UD -->|no| Normal2[normal unsubscribe path]

    Req[Request arrives at _process_request] --> RD{"params has<br/>continuous_future_transitions?"}
    RD -->|yes| RH[_handle_continuous_future_request]
    RD -->|no| Normal3[normal request path]
    RH --> RValid{"_continuous_future_validate_transitions"}
    RValid -->|validation failure| RAbort[log error + _abort_request]
    RValid -->|ok| REnsure[_continuous_future_ensure_target_instrument<br/>clone first segment if target missing]
    REnsure --> ROk[init request aggregators<br/>+ _update_continuous_future_data]

    SubResp[Sub-response arrives at _handle_response] --> Normal4["process_historical loop publishes each item<br/>on its segment's historical topic;<br/>primary aggregator receives them via<br/>the per-segment subscription attached in<br/>_update_continuous_future_data"]

    SubResp2[Sub-response msgbus callback] --> Cb{"callback = _handle_continuous_future_response"}
    Cb --> Unsub["Unsubscribe primary aggregator<br/>from segment topic"]
    Unsub --> Update[_update_continuous_future_data]
```

### Test map

| Area | Test |
|---|---|
| Ingress adjustment | `test_bar_builder_applies_offset_to_bar_updates`, `test_bar_builder_applies_multiplicative_adjustment_to_bar_updates` |
| Mid-bar adjustment change | `test_bar_builder_mid_bar_adjustment_change_applies_to_subsequent_updates`, `test_bar_builder_mid_bar_ratio_adjustment_change_applies_to_subsequent_updates` |
| No-op adjustments | `test_bar_builder_spread_zero_adjustment_is_noop`, `test_bar_builder_ratio_one_adjustment_is_noop` |
| Request `BACKWARD_SPREAD`, 2 transitions | `test_request_bars_for_continuous_future_adjusts_across_transition` |
| Request `BACKWARD_RATIO` | `test_request_bars_for_continuous_future_applies_multiplicative_adjustment` |
| Request `FORWARD_SPREAD` | `test_request_bars_for_continuous_future_forward_direction` |
| Request with chain `bar_types` | `test_request_bars_for_continuous_future_preserves_bar_type_chain` |
| Request composes with `time_range_generator` | `test_request_bars_for_continuous_future_composes_with_time_range_generator` |
| Request single segment (no transition in range) | `test_request_bars_for_continuous_future_single_segment_no_transition_in_range` |
| Request caps adjustment at `last_post_instrument_id` | `test_request_bars_for_continuous_future_stops_adjustment_at_last_post_instrument_id` |
| Request anchors forward at `first_pre_instrument_id` | `test_request_bars_for_continuous_future_anchors_forward_at_first_pre_instrument_id` |
| Request aborts on invalid transition metadata | `test_request_bars_for_continuous_future_aborts_on_zero_pre_price_ratio`, `test_request_bars_for_continuous_future_aborts_on_invalid_transition_metadata`, `test_request_bars_for_continuous_future_aborts_on_unsorted_transition_times` |
| Request synthesizes target instrument | `test_request_bars_for_continuous_future_synthesizes_target_instrument` |
| Request trade-tick source | `test_request_bars_for_continuous_future_trade_tick_source` |
| Request quote-tick source | `test_request_bars_for_continuous_future_quote_tick_source` |
| Subscription 1 transition, trades source | `test_subscribe_bars_for_continuous_future_rolls_subscription_at_transition` |
| Subscription unsubscribe cancels timer | `test_subscribe_bars_for_continuous_future_unsubscribe_cancels_pending_timer` |
| Subscription multiple transitions | `test_subscribe_bars_for_continuous_future_rolls_multiple_transitions` |
| Subscription quote-tick source | `test_subscribe_bars_for_continuous_future_quote_tick_source` |

## Files changed

- `nautilus_trader/model/enums.py` — adds `ContinuousFutureAdjustmentType` enum with `is_ratio` / `is_backward` properties.

- `nautilus_trader/data/aggregation.pxd` / `aggregation.pyx` — adds `BarBuilder.set_adjustment`, pre-computed adjustment state, and `_apply_adjustment_to_price` hot-path helper.

- `nautilus_trader/data/engine.pxd` / `engine.pyx` — adds request/subscription handlers, segment walk, adjustment offset computation with optional `first_pre_instrument_id` / `last_post_instrument_id` chain bounds, source resolution, source subscribe/unsubscribe helpers, child-command/request builders with shared child-param cleanup, schema validator for transitions, auto-synthesis of the continuous target `FuturesContract` from the first segment, shared request-scoped bar aggregator initialization, and `ContinuousFutureSubscriptionState` / extended `RequestWorkflowState` fields.

- `tests/unit_tests/data/test_aggregation.py` — ingress and mid-bar adjustment tests.

- `tests/unit_tests/data/test_engine.py` — end-to-end request/subscription tests across modes, sources, chain setups, long-request composition, transition validation, and `first_pre_instrument_id` / `last_post_instrument_id` chain bounding.

- `tests/acceptance_tests/test_backtest.py` — acceptance coverage.

## Test plan

Latest local verification:

- [x] `make build-debug` — clean Cython compile.

- [x] `uv run --no-sync pytest tests/unit_tests/data/test_engine.py -k continuous_future` — 23 passed, 145 deselected.

- [x] `uv run --no-sync pytest tests/acceptance_tests/test_backtest.py::TestBacktestContinuousFuture::test_continuous_future_transition_from_request_to_subscription` — 1 passed.

- [x] `make format` — no changes on the latest run.

- [x] `make pre-commit` — all checks pass.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
