### PR TITLE
Fix custom data Parquet schema registration

### DIFF
--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -466,6 +466,17 @@ fn py_encode_custom_data_to_record_batch(
     })
 }
 
+#[allow(unsafe_code)]
+#[cfg(feature = "python")]
+fn pyarrow_schema_to_arrow_schema(
+    py_schema: &pyo3::Bound<'_, pyo3::PyAny>,
+) -> PyResult<arrow::datatypes::Schema> {
+    let mut ffi_schema = arrow::ffi::FFI_ArrowSchema::empty();
+    py_schema.call_method1("_export_to_c", ((&raw mut ffi_schema as usize),))?;
+    arrow::datatypes::Schema::try_from(&ffi_schema)
+        .map_err(|e| to_pyvalue_err(format!("Failed to import PyArrow schema: {e}")))
+}
+
 /// Decodes `RecordBatch` to `CustomData` via Python `decode_record_batch_py`.
 #[allow(unsafe_code)]
 #[cfg(feature = "python")]
@@ -606,7 +617,13 @@ pub fn register_custom_data_class(data_class: &Bound<'_, PyAny>) -> PyResult<()>
         ))
     })?;
 
-    let schema = Arc::new(arrow::datatypes::Schema::empty());
+    let schema = if let Ok(py_schema) = data_class.getattr("_schema") {
+        Arc::new(pyarrow_schema_to_arrow_schema(&py_schema)?)
+    } else if let Some(schema) = registry::get_arrow_schema(&type_name) {
+        schema
+    } else {
+        Arc::new(arrow::datatypes::Schema::empty())
+    };
 
     let encoder = Box::new(
         move |items: &[Arc<dyn crate::data::CustomDataTrait>]| -> Result<

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -64,7 +64,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     io::Cursor,
     ops::Bound as RangeBound,
@@ -103,8 +103,8 @@ use nautilus_model::{
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
 };
 use nautilus_serialization::arrow::{
-    DecodeDataFromRecordBatch, DecodeTypedFromRecordBatch, EncodeToRecordBatch,
-    custom::CustomDataDecoder,
+    ArrowSchemaProvider, DecodeDataFromRecordBatch, DecodeTypedFromRecordBatch,
+    EncodeToRecordBatch, custom::CustomDataDecoder,
 };
 use object_store::{ObjectStore, ObjectStoreExt, path::Path as ObjectPath};
 use serde::Serialize;
@@ -114,7 +114,7 @@ use super::{
     custom::{
         custom_data_path_components, decode_batch_to_data as orchestration_decode_batch_to_data,
         decode_custom_batches_to_data as orchestration_decode_custom_batches_to_data,
-        prepare_custom_data_batch,
+        prepare_custom_data_batch, schema_with_data_type_column,
     },
     session::{self, DataBackendSession, QueryResult, build_query},
 };
@@ -1894,21 +1894,37 @@ impl ParquetDataCatalog {
             return Ok(Vec::new());
         }
 
-        let table_name = "custom_data_table";
-
         // Use CustomDataDecoder for all custom data. Pass type_name so decode can look up
         // the type when Parquet/DataFusion does not preserve schema metadata. Callers must
         // ensure Rust custom types are registered via ensure_custom_data_registered::<T>().
+        let mut custom_metadata = HashMap::new();
+        custom_metadata.insert("type_name".to_string(), type_name.to_string());
+        let base_schema = CustomDataDecoder::get_schema(Some(custom_metadata));
+        base_schema.field_with_name("ts_init").map_err(|_| {
+            anyhow::anyhow!(
+                "custom data type '{type_name}' is not registered with an Arrow schema containing ts_init; \
+                 call ensure_custom_data_registered::<T>() before querying"
+            )
+        })?;
+        let custom_schema = schema_with_data_type_column(&base_schema, type_name);
+
         for file in files {
+            let identifier = extract_identifier_from_path(&file);
+            let safe_type_name = make_sql_safe_identifier(type_name);
+            let safe_sql_identifier = make_sql_safe_identifier(&identifier);
+            let safe_filename = extract_sql_safe_filename(&file);
+            let table_name =
+                format!("custom_{safe_type_name}_{safe_sql_identifier}_{safe_filename}");
             let resolved_path = self.resolve_path_for_datafusion(&file);
-            let sql_query = build_query(table_name, start, end, where_clause);
+            let sql_query = build_query(&table_name, start, end, where_clause);
 
             self.session
-                .add_file::<CustomDataDecoder>(
-                    table_name,
+                .add_file_with_schema::<CustomDataDecoder>(
+                    &table_name,
                     &resolved_path,
                     Some(&sql_query),
                     Some(type_name),
+                    Some(&custom_schema),
                 )
                 .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }

--- a/crates/persistence/src/backend/session.rs
+++ b/crates/persistence/src/backend/session.rs
@@ -17,8 +17,11 @@ use std::{sync::Arc, vec::IntoIter};
 
 use ahash::{AHashMap, AHashSet};
 use datafusion::{
-    arrow::record_batch::RecordBatch, error::Result, logical_expr::expr::Sort,
-    physical_plan::SendableRecordBatchStream, prelude::*,
+    arrow::{datatypes::Schema, record_batch::RecordBatch},
+    error::Result,
+    logical_expr::expr::Sort,
+    physical_plan::SendableRecordBatchStream,
+    prelude::*,
 };
 use futures::StreamExt;
 use nautilus_core::{UnixNanos, ffi::cvec::CVec};
@@ -153,6 +156,24 @@ impl DataBackendSession {
     where
         T: DecodeDataFromRecordBatch,
     {
+        self.add_file_with_schema::<T>(table_name, file_path, sql_query, custom_type_name, None)
+    }
+
+    /// Registers a Parquet file with an explicit Arrow schema and adds a batch stream for decoding.
+    ///
+    /// Use this for dynamically registered custom data so DataFusion sees the registered schema
+    /// while planning the scan, including the `ts_init` column used for sort-order hints.
+    pub fn add_file_with_schema<T>(
+        &mut self,
+        table_name: &str,
+        file_path: &str,
+        sql_query: Option<&str>,
+        custom_type_name: Option<&str>,
+        schema: Option<&Schema>,
+    ) -> Result<()>
+    where
+        T: DecodeDataFromRecordBatch,
+    {
         // Check if table is already registered to avoid duplicates
         let is_new_table = !self.registered_tables.contains(table_name);
 
@@ -160,6 +181,7 @@ impl DataBackendSession {
             // Register the table only if it doesn't exist
             let parquet_options = ParquetReadOptions::<'_> {
                 skip_metadata: Some(false),
+                schema,
                 file_sort_order: vec![vec![Sort {
                     expr: col("ts_init"),
                     asc: true,

--- a/crates/persistence/src/python/backend/session.rs
+++ b/crates/persistence/src/python/backend/session.rs
@@ -23,10 +23,13 @@ use nautilus_model::data::{
     Bar, Data, DataFFI, InstrumentStatus, MarkPriceUpdate, OrderBookDelta, OrderBookDepth10,
     QuoteTick, TradeTick,
 };
-use nautilus_serialization::arrow::custom::CustomDataDecoder;
+use nautilus_serialization::arrow::{ArrowSchemaProvider, custom::CustomDataDecoder};
 use pyo3::{prelude::*, types::PyCapsule};
 
-use crate::backend::session::{DataBackendSession, DataQueryResult};
+use crate::backend::{
+    custom::schema_with_data_type_column,
+    session::{DataBackendSession, DataQueryResult},
+};
 
 /// Wrapper to pass a raw pointer across the GIL release boundary.
 struct SendPtr<T>(*mut T);
@@ -145,8 +148,23 @@ impl DataBackendSession {
         sql_query: Option<&str>,
     ) -> PyResult<()> {
         let _guard = slf.runtime.enter();
-        slf.add_file::<CustomDataDecoder>(table_name, file_path, sql_query, Some(type_name))
-            .map_err(to_pyruntime_err)
+        let mut metadata = HashMap::new();
+        metadata.insert("type_name".to_string(), type_name.to_string());
+        let base_schema = CustomDataDecoder::get_schema(Some(metadata));
+        base_schema.field_with_name("ts_init").map_err(|_| {
+            to_pyruntime_err(format!(
+                "custom data type '{type_name}' is not registered with an Arrow schema containing ts_init"
+            ))
+        })?;
+        let schema = schema_with_data_type_column(&base_schema, type_name);
+        slf.add_file_with_schema::<CustomDataDecoder>(
+            table_name,
+            file_path,
+            sql_query,
+            Some(type_name),
+            Some(&schema),
+        )
+        .map_err(to_pyruntime_err)
     }
 
     fn to_query_result(mut slf: PyRefMut<'_, Self>) -> DataQueryResult {

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -3344,6 +3344,83 @@ fn test_rust_custom_data_roundtrip_with_params_field() {
     }
 }
 
+#[rstest]
+fn test_query_custom_data_dynamic_with_explicit_files() {
+    use std::sync::Arc;
+
+    use nautilus_model::data::{CustomData, Data, DataType};
+
+    ensure_test_custom_data_registered();
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let instrument_id = InstrumentId::from("RUST.EXPLICIT");
+    let data_type = DataType::new("RustTestCustomData", None, Some(instrument_id.to_string()));
+
+    let first = RustTestCustomData {
+        instrument_id,
+        value: 1.0,
+        flag: true,
+        ts_event: UnixNanos::from(1),
+        ts_init: UnixNanos::from(1),
+    };
+    let second = RustTestCustomData {
+        instrument_id,
+        value: 2.0,
+        flag: false,
+        ts_event: UnixNanos::from(2),
+        ts_init: UnixNanos::from(2),
+    };
+
+    let first_path = catalog
+        .write_custom_data_batch(
+            vec![CustomData::new(Arc::new(first), data_type.clone())],
+            None,
+            None,
+            Some(false),
+        )
+        .unwrap();
+    let second_path = catalog
+        .write_custom_data_batch(
+            vec![CustomData::new(Arc::new(second), data_type)],
+            None,
+            None,
+            Some(false),
+        )
+        .unwrap();
+
+    let loaded = catalog
+        .query_custom_data_dynamic(
+            "RustTestCustomData",
+            None,
+            None,
+            None,
+            None,
+            Some(vec![
+                first_path.to_string_lossy().to_string(),
+                second_path.to_string_lossy().to_string(),
+            ]),
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(loaded.len(), 2);
+    let values: Vec<f64> = loaded
+        .iter()
+        .map(|item| match item {
+            Data::Custom(custom) => {
+                custom
+                    .data
+                    .as_any()
+                    .downcast_ref::<RustTestCustomData>()
+                    .expect("Expected RustTestCustomData")
+                    .value
+            }
+            other => panic!("Expected Data::Custom variant, was {other:?}"),
+        })
+        .collect();
+    assert_eq!(values, vec![1.0, 2.0]);
+}
+
 /// Regression: write_data_enum groups custom data by full DataType (type_name + identifier + metadata).
 /// Same type_name with different identifiers must produce separate batches and be readable back.
 #[rstest]


### PR DESCRIPTION
## Summary

Fixes dynamic custom-data Parquet queries so DataFusion receives the registered custom Arrow schema before planning the scan.

`query_custom_data_dynamic` now resolves the schema from `type_name`, verifies it contains `ts_init`, augments it with the persisted `data_type` column, and registers each explicit custom-data file with a unique table name.

## Root Cause

`DataBackendSession::add_file` previously registered Parquet files without an explicit schema. For custom data, the `type_name` was only injected later before batch decoding, which meant DataFusion planning could see the `CustomDataDecoder` dummy fallback schema rather than the real registered custom schema. Since Parquet registration also declares `file_sort_order` on `ts_init`, this can fail with `Schema error: No field named ts_init`.

The dynamic custom-data query path also reused the same `custom_data_table` name for every explicit file, so duplicate-table skipping could cause multi-file queries to under-read.

## Changes

- Added `DataBackendSession::add_file_with_schema` while preserving the existing `add_file` API.
- Updated `ParquetDataCatalog::query_custom_data_dynamic` to pass the registered custom schema into DataFusion registration.
- Added a `ts_init` schema validation error for unregistered or invalid custom data schemas.
- Added unique table names for explicit custom data files.
- Updated the Python `add_custom_file` binding to use the same explicit-schema registration path.
- Added a regression test for querying two explicit Rust custom-data Parquet files.

## Validation

- `cargo fmt --manifest-path nautilus_trader/Cargo.toml --package nautilus-persistence`
- `CARGO_TARGET_DIR=/tmp/nautilus-target-codex-custom-schema cargo test --manifest-path nautilus_trader/Cargo.toml -p nautilus-persistence --test test_catalog test_query_custom_data_dynamic_with_explicit_files -- --nocapture`
- Commit hooks: `cargo fmt`, `cargo clippy`, and `cargo doc` for `nautilus-persistence` passed during commit.

Closes #3923
