### PR TITLE
Refine data engine request workflow

### DIFF
--- a/nautilus_trader/data/engine.pxd
+++ b/nautilus_trader/data/engine.pxd
@@ -328,6 +328,7 @@ cdef class DataEngine(Component):
     cdef object _inherit_request_workflows(self, RequestData target, RequestData source)
     cdef dict _request_response_params(self, UUID4 request_id, dict fallback_params = *)
     cdef void _abort_request(self, UUID4 request_id)
+    cdef void _complete_grouped_request_or_abort(self, RequestData request)
     cdef void _emit_empty_request_response(self, UUID4 parent_request_id)
     cdef list _get_bar_types_from_aggregators(self)
     cpdef void _init_historical_aggregators(self, RequestData request)

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -2009,6 +2009,7 @@ cdef class DataEngine(Component):
 
         if client is None:
             self._log_request_warning(request)
+            self._complete_grouped_request_or_abort(request)
             return  # No client to handle request
 
         client.request_instruments(request)
@@ -2023,6 +2024,7 @@ cdef class DataEngine(Component):
 
         if client is None:
             self._log_request_warning(request)
+            self._complete_grouped_request_or_abort(request)
             return  # No client to handle request
 
         client.request_instrument(request)
@@ -2046,6 +2048,7 @@ cdef class DataEngine(Component):
     cpdef void _handle_request_order_book_snapshot(self, DataClient client, RequestOrderBookSnapshot request):
         if client is None:
             self._log_request_warning(request)
+            self._complete_grouped_request_or_abort(request)
             return  # No client to handle request
 
         client.request_order_book_snapshot(request)
@@ -2077,6 +2080,7 @@ cdef class DataEngine(Component):
 
         if start > end:
             self._log.error(f"Cannot handle request: incompatible request dates for {request}")
+            self._complete_grouped_request_or_abort(request)
             return
 
         cdef list query_interval = [(start.value, end.value)]
@@ -2157,6 +2161,7 @@ cdef class DataEngine(Component):
                 client.request(request)
             except:
                 self._log.error(f"Cannot handle request: unrecognized data type {request.data_type}, {request}")
+                self._complete_grouped_request_or_abort(request)
 
     def _log_request_warning(self, RequestData request):
         self._log.warning(f"Cannot handle request: no client registered for '{request.client_id}', {request}")
@@ -2225,6 +2230,7 @@ cdef class DataEngine(Component):
                 bar_type = request.bar_type
                 if bar_type is None:
                     self._log.error("No bar type provided for bars request")
+                    self._complete_grouped_request_or_abort(request)
                     return
 
                 data = catalog.bars(
@@ -2274,6 +2280,7 @@ cdef class DataEngine(Component):
         if isinstance(request, RequestInstrument):
             if len(data) == 0:
                 self._log.error(f"Cannot find instrument for {request.instrument_id}")
+                self._complete_grouped_request_or_abort(request)
                 return
 
         if isinstance(request, RequestInstruments) or isinstance(request, RequestInstrument):
@@ -2450,6 +2457,15 @@ cdef class DataEngine(Component):
 
         for request_id in request.request_ids:
             joined_request = self._requests.get(request_id)
+            if joined_request is None:
+                self._log.error(f"joined_request for {request_id=} not found.")
+                self._parent_join_request_id.pop(request.id, None)
+                self._abort_request(request.id)
+                if request.correlation_id is not None:
+                    self._abort_request(request.correlation_id)
+
+                return
+
             new_request = joined_request.with_dates(state.start, state.end, self._clock.timestamp_ns())
             new_state = self._inherit_request_workflows(new_request, joined_request)
             new_state.join_request = False
@@ -3007,9 +3023,13 @@ cdef class DataEngine(Component):
             self._handle_forward_prices_response(response.correlation_id, response.data)
             return
 
-        # We may need to join responses from a catalog and a client
+        # We may need to join responses from a catalog and a client.
+        # Standalone instruments are processed immediately; grouped instrument children
+        # still need to fan in through the request-group path.
         grouped_response = None
-        if response.data_type.type == Instrument:
+        cdef bint is_grouped_child = response.correlation_id in self._request_group_parent_request_id
+        cdef bint is_standalone_instrument = response.data_type.type == Instrument and not is_grouped_child
+        if is_standalone_instrument:
             grouped_response = response
         else:
             grouped_response = self._handle_request_group(response)
@@ -3122,6 +3142,7 @@ cdef class DataEngine(Component):
                 )
 
             data_result += response.data
+            self._requests.pop(response.correlation_id, None)
             self._request_workflows.pop(response.correlation_id, None)
 
         data_result.sort(key=lambda x: x.ts_init)
@@ -3900,7 +3921,7 @@ cdef class DataEngine(Component):
     cdef tuple _get_bar_aggregator_key(self, BarType bar_type, UUID4 request_id = None):
         return (bar_type.standard(), request_id)
 
-# -- INTERNAL - Spread Quote Aggregators ----------------------------------------------------------
+    # -- INTERNAL - Spread Quote Aggregators ----------------------------------------------------------
 
     cpdef bint _should_request_spread_quote_ticks(self, RequestQuoteTicks request):
         # Check if a spread quote aggregator is running, meaning a request using one is already ongoing, or
@@ -4278,6 +4299,28 @@ cdef class DataEngine(Component):
         # Drop all engine bookkeeping for a request that could not be started.
         self._requests.pop(request_id, None)
         self._request_workflows.pop(request_id, None)
+
+    cdef void _complete_grouped_request_or_abort(self, RequestData request):
+        if request.id not in self._request_group_parent_request_id:
+            self._abort_request(request.id)
+            return
+
+        state = self._ensure_request_workflows(request)
+        response = DataResponse(
+            client_id=request.client_id,
+            venue=request.venue,
+            data_type=request.data_type,
+            data=[],
+            correlation_id=request.id,
+            response_id=UUID4(),
+            start=state.start,
+            end=state.end,
+            ts_init=self._clock.timestamp_ns(),
+            params=self._request_response_params(request.id),
+        )
+        self._handle_response(response)
+
+    # -- INTERNAL - Continuous Futures ----------------------------------------------------------------
 
     cpdef void _handle_subscribe_continuous_future_bars(self, MarketDataClient client, SubscribeBars command):
         # `target_bar_type` keeps the original (possibly composite) shape so source resolution

--- a/tests/unit_tests/data/test_engine.py
+++ b/tests/unit_tests/data/test_engine.py
@@ -39,6 +39,7 @@ from nautilus_trader.data.messages import RequestData
 from nautilus_trader.data.messages import RequestFundingRates
 from nautilus_trader.data.messages import RequestInstrument
 from nautilus_trader.data.messages import RequestInstruments
+from nautilus_trader.data.messages import RequestJoin
 from nautilus_trader.data.messages import RequestOrderBookDeltas
 from nautilus_trader.data.messages import RequestOrderBookDepth
 from nautilus_trader.data.messages import RequestOrderBookSnapshot
@@ -4455,6 +4456,139 @@ class TestDataEngine:
         assert request.id not in self.data_engine._request_workflows
         assert request.id not in self.data_engine._requests
         assert len(handler) == 0
+
+    def test_request_order_book_snapshot_without_client_cleans_up_workflow_state(self):
+        # Arrange
+        handler = []
+        request = RequestOrderBookSnapshot(
+            instrument_id=ETHUSDT_BINANCE.id,
+            limit=1,
+            client_id=None,
+            venue=BINANCE,
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=None,
+        )
+
+        # Act
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Assert
+        assert request.id not in self.data_engine._request_workflows
+        assert request.id not in self.data_engine._requests
+        assert len(handler) == 0
+
+    def test_request_quote_ticks_with_incompatible_dates_cleans_up_workflow_state(self):
+        # Arrange
+        self.clock.advance_time(pd.Timestamp("2024-01-03T00:00:00", tz="UTC").value)
+
+        handler = []
+        request = RequestQuoteTicks(
+            instrument_id=ETHUSDT_BINANCE.id,
+            start=pd.Timestamp("2024-01-02T00:00:00", tz="UTC"),
+            end=pd.Timestamp("2024-01-01T00:00:00", tz="UTC"),
+            limit=0,
+            client_id=None,
+            venue=BINANCE,
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=None,
+        )
+
+        # Act
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Assert
+        assert request.id not in self.data_engine._request_workflows
+        assert request.id not in self.data_engine._requests
+        assert len(handler) == 0
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Failing on windows")
+    def test_request_instrument_catalog_miss_cleans_up_workflow_state(self):
+        # Arrange
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "catalog")
+        catalog.write_data([ETHUSDT_BINANCE])
+        self.data_engine.register_catalog(catalog)
+
+        start = unix_nanos_to_dt(ETHUSDT_BINANCE.ts_init + 1)
+        end = unix_nanos_to_dt(ETHUSDT_BINANCE.ts_init + 2)
+        self.clock.advance_time(ETHUSDT_BINANCE.ts_init + 3)
+
+        handler = []
+        request = RequestInstrument(
+            instrument_id=ETHUSDT_BINANCE.id,
+            start=start,
+            end=end,
+            client_id=None,
+            venue=BINANCE,
+            callback=handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=None,
+        )
+
+        # Act
+        self.msgbus.request(endpoint="DataEngine.request", request=request)
+
+        # Assert
+        assert request.id not in self.data_engine._request_workflows
+        assert request.id not in self.data_engine._requests
+        assert len(handler) == 0
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Failing on windows")
+    def test_request_join_with_instruments_uses_grouped_workflow_state(self):
+        # Arrange
+        catalog = setup_catalog(protocol="file", path=self.tmp_path / "catalog")
+        catalog.write_data([BTCUSDT_BINANCE, ETHUSDT_BINANCE])
+        self.data_engine.register_catalog(catalog)
+        self.clock.advance_time(max(BTCUSDT_BINANCE.ts_init, ETHUSDT_BINANCE.ts_init) + 1)
+
+        join_handler = []
+
+        first_request = RequestInstrument(
+            instrument_id=BTCUSDT_BINANCE.id,
+            start=None,
+            end=None,
+            client_id=None,
+            venue=BINANCE,
+            callback=None,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={"join_request": True},
+        )
+        second_request = RequestInstrument(
+            instrument_id=ETHUSDT_BINANCE.id,
+            start=None,
+            end=None,
+            client_id=None,
+            venue=BINANCE,
+            callback=None,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params={"join_request": True},
+        )
+        join_request = RequestJoin(
+            request_ids=(first_request.id, second_request.id),
+            start=None,
+            end=None,
+            callback=join_handler.append,
+            request_id=UUID4(),
+            ts_init=self.clock.timestamp_ns(),
+            params=None,
+        )
+
+        # Act
+        self.msgbus.request(endpoint="DataEngine.request", request=first_request)
+        self.msgbus.request(endpoint="DataEngine.request", request=second_request)
+        self.msgbus.request(endpoint="DataEngine.request", request=join_request)
+
+        # Assert
+        assert len(join_handler) == 1
+        assert join_handler[0].data == []
+        assert self.data_engine._request_workflows == {}
+        assert self.data_engine._requests == {}
 
     def test_request_aggregated_bars_with_bars(self):
         # Arrange


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Cleans up `RequestWorkflowState` and request bookkeeping when data engine requests are rejected before a response can be emitted.

- Routes grouped `Instrument` responses through the request-group fan-in path so joins and grouped requests cannot be bypassed by the instrument special case.

- Removes grouped child requests from `_requests` when their responses are merged, matching the existing workflow-state cleanup.

- Validates joined request IDs before cloning join children, aborting stale joins instead of raising on missing request state.

## Tests

- `make build-debug`.

- `uv run --no-sync pytest tests/unit_tests/data/test_engine.py -k "workflow_state or grouped_workflow_state"`.

- `uv run --no-sync pytest tests/unit_tests/data/test_engine.py`.

- `make format`.

- `make pre-commit`.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
