### PR TITLE
Fix remote catalog object paths under URI prefix

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -1350,13 +1350,18 @@ impl ParquetDataCatalog {
     /// Helper method to reconstruct full URI for remote object store paths
     #[must_use]
     pub fn reconstruct_full_uri(&self, path_str: &str) -> String {
+        if path_str.contains("://") {
+            return path_str.to_string();
+        }
+
         // Check if this is a remote URI scheme that needs reconstruction
         if self.is_remote_uri() {
             // Extract the base URL (scheme + host) from the original URI
             if let Ok(url) = url::Url::parse(&self.original_uri)
                 && let Some(host) = url.host_str()
             {
-                return format!("{}://{}/{}", url.scheme(), host, path_str);
+                let path = self.path_under_base(path_str);
+                return format!("{}://{}/{}", url.scheme(), host, path);
             }
         }
 
@@ -2637,8 +2642,8 @@ impl ParquetDataCatalog {
     pub fn get_directory_intervals(&self, directory: &str) -> anyhow::Result<Vec<(u64, u64)>> {
         // Use object store for all operations
         // Convert directory to object path format (consistent with how files are written)
-        // For local stores with empty base_path, to_object_path returns path as-is
-        // For remote stores, to_object_path strips the base_path prefix
+        // For local stores with empty base_path, to_object_path returns path as-is.
+        // For remote stores, to_object_path preserves or prepends the catalog base path.
         let object_dir = self.to_object_path(directory);
         let list_result = self.execute_async(async {
             // Ensure trailing slash for directory listing
@@ -2764,8 +2769,8 @@ impl ParquetDataCatalog {
     /// Converts a catalog path string to an [`ObjectPath`] for object store operations.
     ///
     /// This method handles the conversion between catalog-relative paths and object store paths,
-    /// taking into account the catalog's base path configuration. It automatically strips the
-    /// base path prefix when present to create the correct object store path.
+    /// taking into account the catalog's base path configuration. It automatically preserves the
+    /// base path prefix for remote catalogs and strips it for local catalog paths.
     ///
     /// # Parameters
     ///
@@ -2778,7 +2783,8 @@ impl ParquetDataCatalog {
     /// # Path Handling
     ///
     /// - If `base_path` is empty, the path is used as-is.
-    /// - If `base_path` is set, it's stripped from the path if present.
+    /// - If `base_path` is set for a remote catalog, it's preserved or prepended.
+    /// - If `base_path` is set for a local catalog, it's stripped from the path if present.
     /// - Trailing slashes and backslashes are automatically handled.
     /// - The resulting path is relative to the object store root.
     /// - All paths are normalized to use forward slashes (object store convention).
@@ -2792,11 +2798,13 @@ impl ParquetDataCatalog {
     ///
     /// // Convert a full catalog path
     /// let object_path = catalog.to_object_path("/base/data/quotes/file.parquet");
-    /// // Returns: ObjectPath("data/quotes/file.parquet") if base_path is "/base"
+    /// // Returns: ObjectPath("data/quotes/file.parquet") for local catalog paths
+    /// // or ObjectPath("base/data/quotes/file.parquet") for remote catalog paths.
     ///
     /// // Convert a relative path
     /// let object_path = catalog.to_object_path("data/trades/file.parquet");
-    /// // Returns: ObjectPath("data/trades/file.parquet")
+    /// // Returns: ObjectPath("data/trades/file.parquet") for local catalog paths
+    /// // or ObjectPath("base/data/trades/file.parquet") for remote catalog paths.
     /// ```
     #[must_use]
     pub fn to_object_path(&self, path: &str) -> ObjectPath {
@@ -2805,6 +2813,10 @@ impl ParquetDataCatalog {
 
         if self.base_path.is_empty() {
             return ObjectPath::from(normalized_path);
+        }
+
+        if self.is_remote_uri() {
+            return ObjectPath::from(self.path_under_base(&normalized_path));
         }
 
         // Normalize base path separators as well
@@ -2829,7 +2841,9 @@ impl ParquetDataCatalog {
         let normalized_path = path.replace('\\', "/");
 
         let to_parse = if self.base_path.is_empty() {
-            normalized_path.as_str()
+            normalized_path
+        } else if self.is_remote_uri() {
+            self.path_under_base(&normalized_path)
         } else {
             let normalized_base = self.base_path.replace('\\', "/");
             let base = normalized_base.trim_end_matches('/');
@@ -2837,9 +2851,34 @@ impl ParquetDataCatalog {
                 .strip_prefix(&format!("{base}/"))
                 .or_else(|| normalized_path.strip_prefix(base))
                 .unwrap_or(normalized_path.as_str())
+                .to_string()
         };
 
-        ObjectPath::parse(to_parse).map_err(anyhow::Error::from)
+        ObjectPath::parse(&to_parse).map_err(anyhow::Error::from)
+    }
+
+    fn path_under_base(&self, path: &str) -> String {
+        let normalized_path = path.replace('\\', "/");
+        let path = normalized_path
+            .trim_start_matches('/')
+            .trim_end_matches('/');
+
+        if self.base_path.is_empty() {
+            return path.to_string();
+        }
+
+        let normalized_base = self.base_path.replace('\\', "/");
+        let base = normalized_base
+            .trim_start_matches('/')
+            .trim_end_matches('/');
+
+        if base.is_empty() || path == base || path.starts_with(&format!("{base}/")) {
+            path.to_string()
+        } else if path.is_empty() {
+            base.to_string()
+        } else {
+            make_object_store_path(base, &[path])
+        }
     }
 
     #[allow(dead_code)]

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -114,7 +114,10 @@ use super::{
     },
     session::{self, DataBackendSession, QueryResult, build_query},
 };
-use crate::parquet::{read_parquet_from_object_store, write_batches_to_object_store};
+use crate::parquet::{
+    is_remote_uri_scheme, read_parquet_from_object_store, remote_full_uri, remote_store_root_url,
+    write_batches_to_object_store,
+};
 
 /// A high-performance data catalog for storing and retrieving financial market data using Apache Parquet format.
 ///
@@ -306,13 +309,13 @@ impl ParquetDataCatalog {
         let compression = compression.unwrap_or(parquet::basic::Compression::SNAPPY);
         let max_row_group_size = max_row_group_size.unwrap_or(5000);
 
-        let (object_store, base_path, original_uri) =
-            crate::parquet::create_object_store_from_path(uri, storage_options)?;
+        let location =
+            crate::parquet::create_object_store_location_from_path(uri, storage_options)?;
 
         Ok(Self {
-            base_path,
-            original_uri,
-            object_store,
+            base_path: location.base_path,
+            original_uri: location.original_uri,
+            object_store: location.object_store,
             session: session::DataBackendSession::new(batch_size),
             batch_size,
             compression,
@@ -1356,12 +1359,9 @@ impl ParquetDataCatalog {
 
         // Check if this is a remote URI scheme that needs reconstruction
         if self.is_remote_uri() {
-            // Extract the base URL (scheme + host) from the original URI
-            if let Ok(url) = url::Url::parse(&self.original_uri)
-                && let Some(host) = url.host_str()
-            {
-                let path = self.path_under_base(path_str);
-                return format!("{}://{}/{}", url.scheme(), host, path);
+            let path = self.path_under_base(path_str);
+            if let Ok(uri) = remote_full_uri(&self.original_uri, &path) {
+                return uri;
             }
         }
 
@@ -1455,13 +1455,9 @@ impl ParquetDataCatalog {
     /// Helper method to check if the original URI uses a remote object store scheme
     #[must_use]
     pub fn is_remote_uri(&self) -> bool {
-        self.original_uri.starts_with("s3://")
-            || self.original_uri.starts_with("gs://")
-            || self.original_uri.starts_with("gcs://")
-            || self.original_uri.starts_with("az://")
-            || self.original_uri.starts_with("abfs://")
-            || self.original_uri.starts_with("http://")
-            || self.original_uri.starts_with("https://")
+        self.original_uri
+            .split_once("://")
+            .is_some_and(|(scheme, _)| is_remote_uri_scheme(scheme))
     }
 
     /// Executes a query against the catalog to retrieve market data of a specific type.
@@ -1561,11 +1557,7 @@ impl ParquetDataCatalog {
         // so DataFusion's default file provider handles them (avoids path doubling on Windows
         // where a registered store would receive a path that gets prefixed again).
         if self.is_remote_uri() {
-            let url = url::Url::parse(&self.original_uri)?;
-            let host = url
-                .host_str()
-                .ok_or_else(|| anyhow::anyhow!("Remote URI missing host/bucket name"))?;
-            let base_url = url::Url::parse(&format!("{}://{}", url.scheme(), host))?;
+            let base_url = remote_store_root_url(&self.original_uri)?;
             self.session
                 .register_object_store(&base_url, self.object_store.clone());
         }
@@ -1780,11 +1772,7 @@ impl ParquetDataCatalog {
         self.reset_session();
 
         if self.is_remote_uri() {
-            let url = url::Url::parse(&self.original_uri)?;
-            let host = url
-                .host_str()
-                .ok_or_else(|| anyhow::anyhow!("Remote URI missing host/bucket name"))?;
-            let base_url = url::Url::parse(&format!("{}://{}", url.scheme(), host))?;
+            let base_url = remote_store_root_url(&self.original_uri)?;
             self.session
                 .register_object_store(&base_url, self.object_store.clone());
         }
@@ -2808,28 +2796,7 @@ impl ParquetDataCatalog {
     /// ```
     #[must_use]
     pub fn to_object_path(&self, path: &str) -> ObjectPath {
-        // Normalize path separators to forward slashes for object store
-        let normalized_path = path.replace('\\', "/");
-
-        if self.base_path.is_empty() {
-            return ObjectPath::from(normalized_path);
-        }
-
-        if self.is_remote_uri() {
-            return ObjectPath::from(self.path_under_base(&normalized_path));
-        }
-
-        // Normalize base path separators as well
-        let normalized_base = self.base_path.replace('\\', "/");
-        let base = normalized_base.trim_end_matches('/');
-
-        // Remove the catalog base prefix if present
-        let without_base = normalized_path
-            .strip_prefix(&format!("{base}/"))
-            .or_else(|| normalized_path.strip_prefix(base))
-            .unwrap_or(&normalized_path);
-
-        ObjectPath::from(without_base)
+        ObjectPath::from(self.object_store_path(path))
     }
 
     /// Converts a path string to [`ObjectPath`] using parse (no percent-encoding).
@@ -2838,23 +2805,60 @@ impl ParquetDataCatalog {
     /// which may already be percent-encoded. Using [`Self::to_object_path`] (which uses
     /// `Path::from`) on such paths would double-encode (e.g. `%5E` -> `%255E`).
     pub fn to_object_path_parsed(&self, path: &str) -> anyhow::Result<ObjectPath> {
+        let to_parse = self.object_store_path(path);
+        ObjectPath::parse(&to_parse).map_err(anyhow::Error::from)
+    }
+
+    fn object_store_path(&self, path: &str) -> String {
         let normalized_path = path.replace('\\', "/");
 
-        let to_parse = if self.base_path.is_empty() {
-            normalized_path
-        } else if self.is_remote_uri() {
-            self.path_under_base(&normalized_path)
-        } else {
-            let normalized_base = self.base_path.replace('\\', "/");
-            let base = normalized_base.trim_end_matches('/');
-            normalized_path
-                .strip_prefix(&format!("{base}/"))
-                .or_else(|| normalized_path.strip_prefix(base))
-                .unwrap_or(normalized_path.as_str())
-                .to_string()
-        };
+        if self.is_remote_uri() {
+            if normalized_path.contains("://") {
+                return self
+                    .remote_uri_object_path(&normalized_path)
+                    .map(|path| self.path_under_base(&path))
+                    .unwrap_or(normalized_path);
+            }
 
-        ObjectPath::parse(&to_parse).map_err(anyhow::Error::from)
+            return self.path_under_base(&normalized_path);
+        }
+
+        self.path_without_local_base(&normalized_path)
+    }
+
+    fn remote_uri_object_path(&self, path: &str) -> Option<String> {
+        let path_url = url::Url::parse(path).ok()?;
+        if !is_remote_uri_scheme(path_url.scheme()) {
+            return None;
+        }
+
+        let catalog_root = remote_store_root_url(&self.original_uri).ok()?;
+        let path_root = remote_store_root_url(path).ok()?;
+        if catalog_root.as_str().trim_end_matches('/') != path_root.as_str().trim_end_matches('/') {
+            return None;
+        }
+
+        Some(path_url.path().trim_start_matches('/').to_string())
+    }
+
+    fn path_without_local_base(&self, path: &str) -> String {
+        let base_path = if self.base_path.is_empty() {
+            self.native_base_path_string()
+        } else {
+            self.base_path.clone()
+        };
+        let normalized_base = base_path.replace('\\', "/");
+        let base = normalized_base.trim_end_matches('/');
+
+        if base.is_empty() {
+            path.to_string()
+        } else if path == base {
+            String::new()
+        } else if let Some(without_base) = path.strip_prefix(&format!("{base}/")) {
+            without_base.to_string()
+        } else {
+            path.to_string()
+        }
     }
 
     fn path_under_base(&self, path: &str) -> String {

--- a/crates/persistence/src/backend/session.rs
+++ b/crates/persistence/src/backend/session.rs
@@ -106,26 +106,11 @@ impl DataBackendSession {
         uri: &str,
         storage_options: Option<AHashMap<String, String>>,
     ) -> anyhow::Result<()> {
-        // Create object store from URI using the Rust implementation
-        let (object_store, _, _) =
-            crate::parquet::create_object_store_from_path(uri, storage_options)?;
+        let location =
+            crate::parquet::create_object_store_location_from_path(uri, storage_options)?;
 
-        // Parse the URI to get the base URL for registration
-        let parsed_uri = Url::parse(uri)?;
-
-        // Register the object store with the session
-        if matches!(
-            parsed_uri.scheme(),
-            "s3" | "gs" | "gcs" | "az" | "abfs" | "http" | "https"
-        ) {
-            // For cloud storage, register with the base URL (scheme + netloc)
-            let base_url = format!(
-                "{}://{}",
-                parsed_uri.scheme(),
-                parsed_uri.host_str().unwrap_or("")
-            );
-            let base_parsed_url = Url::parse(&base_url)?;
-            self.register_object_store(&base_parsed_url, object_store);
+        if let Some(root_url) = location.store_root_url().cloned() {
+            self.register_object_store(&root_url, location.object_store);
         }
 
         Ok(())

--- a/crates/persistence/src/parquet.rs
+++ b/crates/persistence/src/parquet.rs
@@ -27,6 +27,55 @@ use parquet::{
         statistics::Statistics,
     },
 };
+use url::Url;
+
+pub(crate) fn is_remote_uri_scheme(scheme: &str) -> bool {
+    matches!(
+        scheme,
+        "s3" | "gs" | "gcs" | "az" | "abfs" | "http" | "https"
+    )
+}
+
+pub(crate) fn remote_store_root_url(uri: &str) -> anyhow::Result<Url> {
+    let mut url = Url::parse(uri)?;
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+pub(crate) fn remote_full_uri(uri: &str, object_path: &str) -> anyhow::Result<String> {
+    let root = remote_store_root_url(uri)?;
+    let root = root.as_str().trim_end_matches('/');
+    let object_path = object_path.trim_start_matches('/');
+
+    if object_path.is_empty() {
+        Ok(root.to_string())
+    } else {
+        Ok(format!("{root}/{object_path}"))
+    }
+}
+
+pub(crate) enum ObjectStoreLocationKind {
+    Local,
+    Remote { store_root_url: Url },
+}
+
+pub(crate) struct ObjectStoreLocation {
+    pub object_store: Arc<dyn ObjectStore>,
+    pub base_path: String,
+    pub original_uri: String,
+    pub kind: ObjectStoreLocationKind,
+}
+
+impl ObjectStoreLocation {
+    pub(crate) fn store_root_url(&self) -> Option<&Url> {
+        match &self.kind {
+            ObjectStoreLocationKind::Local => None,
+            ObjectStoreLocationKind::Remote { store_root_url } => Some(store_root_url),
+        }
+    }
+}
 
 /// Writes a `RecordBatch` to a Parquet file using object store, with optional compression.
 ///
@@ -444,9 +493,22 @@ pub fn create_object_store_from_path(
     path: &str,
     storage_options: Option<AHashMap<String, String>>,
 ) -> anyhow::Result<(Arc<dyn ObjectStore>, String, String)> {
+    let location = create_object_store_location_from_path(path, storage_options)?;
+    Ok((
+        location.object_store,
+        location.base_path,
+        location.original_uri,
+    ))
+}
+
+#[allow(unused_variables, clippy::needless_pass_by_value)]
+pub(crate) fn create_object_store_location_from_path(
+    path: &str,
+    storage_options: Option<AHashMap<String, String>>,
+) -> anyhow::Result<ObjectStoreLocation> {
     let uri = normalize_path_to_uri(path);
 
-    match uri.as_str() {
+    let (object_store, base_path, original_uri) = match uri.as_str() {
         #[cfg(feature = "cloud")]
         s if s.starts_with("s3://") => create_s3_store(&uri, storage_options),
         #[cfg(feature = "cloud")]
@@ -474,7 +536,24 @@ pub fn create_object_store_from_path(
         }
         s if s.starts_with("file://") => create_local_store(&uri, true),
         _ => create_local_store(&uri, false), // Fallback: assume local path
-    }
+    }?;
+
+    let kind = Url::parse(&original_uri)
+        .ok()
+        .filter(|url| is_remote_uri_scheme(url.scheme()))
+        .map(|_| {
+            remote_store_root_url(&original_uri)
+                .map(|store_root_url| ObjectStoreLocationKind::Remote { store_root_url })
+        })
+        .transpose()?
+        .unwrap_or(ObjectStoreLocationKind::Local);
+
+    Ok(ObjectStoreLocation {
+        object_store,
+        base_path,
+        original_uri,
+        kind,
+    })
 }
 
 /// Normalizes a path to URI format for consistent object store usage.
@@ -823,8 +902,11 @@ fn create_http_store(
     uri: &str,
     storage_options: Option<AHashMap<String, String>>,
 ) -> anyhow::Result<(Arc<dyn ObjectStore>, String, String)> {
-    let (url, path) = parse_url_and_path(uri)?;
-    let base_url = format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""));
+    let (_, path) = parse_url_and_path(uri)?;
+    let base_url = remote_store_root_url(uri)?
+        .as_str()
+        .trim_end_matches('/')
+        .to_string();
 
     let builder = object_store::http::HttpBuilder::new().with_url(base_url);
 
@@ -965,6 +1047,46 @@ mod tests {
         assert_eq!(url.scheme(), "s3");
         assert_eq!(url.host_str().unwrap(), "bucket");
         assert_eq!(path, "path/to/file");
+    }
+
+    #[rstest]
+    #[cfg(feature = "cloud")]
+    fn test_remote_store_root_url_preserves_authority() {
+        let https_root = remote_store_root_url("https://example.com:9000/base/path").unwrap();
+        assert_eq!(
+            https_root.as_str().trim_end_matches('/'),
+            "https://example.com:9000"
+        );
+
+        let abfs_root =
+            remote_store_root_url("abfs://container@account.dfs.core.windows.net/base/path")
+                .unwrap();
+        assert_eq!(
+            abfs_root.as_str().trim_end_matches('/'),
+            "abfs://container@account.dfs.core.windows.net"
+        );
+
+        let full_uri = remote_full_uri(
+            "https://example.com:9000/base/path",
+            "base/path/data/%5E/file.parquet",
+        )
+        .unwrap();
+        assert_eq!(
+            full_uri,
+            "https://example.com:9000/base/path/data/%5E/file.parquet"
+        );
+
+        let location = create_object_store_location_from_path("s3://test-bucket/path", None)
+            .expect("S3 location should be created");
+        assert_eq!(location.base_path, "path");
+        assert_eq!(
+            location
+                .store_root_url()
+                .expect("S3 should be remote")
+                .as_str()
+                .trim_end_matches('/'),
+            "s3://test-bucket"
+        );
     }
 
     #[rstest]

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -1688,6 +1688,21 @@ fn test_to_object_path_trailing_slash() {
             .as_ref()
             .starts_with(base_dir.to_string_lossy().as_ref())
     );
+    assert_eq!(
+        object_path.as_ref(),
+        "data/quotes/XYZ/2021-01-01T00-00-00-000000000Z_2021-01-01T00-00-01-000000000Z.parquet"
+    );
+
+    let sibling_path = format!(
+        "{}/data/quotes/file.parquet",
+        base_dir.with_file_name("catalog2").display()
+    );
+    let sibling_object_path = catalog.to_object_path(&sibling_path);
+    assert_eq!(
+        sibling_object_path.as_ref(),
+        sibling_path.replace('\\', "/").trim_start_matches('/')
+    );
+    assert!(sibling_object_path.as_ref().contains("catalog2/data"));
 }
 
 #[cfg(feature = "cloud")]
@@ -1702,10 +1717,34 @@ fn test_remote_to_object_path_preserves_base_path() {
     let with_base = catalog.to_object_path("base/path/data/quotes/file.parquet");
     assert_eq!(with_base.as_ref(), "base/path/data/quotes/file.parquet");
 
+    let full_uri = catalog.to_object_path("s3://bucket/base/path/data/quotes/file.parquet");
+    assert_eq!(full_uri.as_ref(), "base/path/data/quotes/file.parquet");
+
     let parsed = catalog
         .to_object_path_parsed("data/quotes/file.parquet")
         .unwrap();
     assert_eq!(parsed.as_ref(), "base/path/data/quotes/file.parquet");
+
+    let parsed_with_base = catalog
+        .to_object_path_parsed("base/path/data/quotes/file.parquet")
+        .unwrap();
+    assert_eq!(
+        parsed_with_base.as_ref(),
+        "base/path/data/quotes/file.parquet"
+    );
+
+    let parsed_full_uri = catalog
+        .to_object_path_parsed("s3://bucket/base/path/data/quotes/file.parquet")
+        .unwrap();
+    assert_eq!(
+        parsed_full_uri.as_ref(),
+        "base/path/data/quotes/file.parquet"
+    );
+
+    let parsed_encoded = catalog
+        .to_object_path_parsed("base/path/data/%5E/file.parquet")
+        .unwrap();
+    assert_eq!(parsed_encoded.as_ref(), "base/path/data/%5E/file.parquet");
 }
 
 #[cfg(feature = "cloud")]
@@ -2048,12 +2087,36 @@ fn test_reconstruct_full_uri_moved() {
 
     // Test HTTP URI reconstruction
     let http_catalog =
-        ParquetDataCatalog::from_uri("https://example.com/base/path", None, None, None, None)
+        ParquetDataCatalog::from_uri("https://example.com:9000/base/path", None, None, None, None)
             .unwrap();
     let reconstructed = http_catalog.reconstruct_full_uri("data/quotes/file.parquet");
     assert_eq!(
         reconstructed,
-        "https://example.com/base/path/data/quotes/file.parquet"
+        "https://example.com:9000/base/path/data/quotes/file.parquet"
+    );
+
+    // Test ABFS URI reconstruction preserves the container in the authority
+    let abfs_catalog = ParquetDataCatalog::from_uri(
+        "abfs://container@account.dfs.core.windows.net/base/path",
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    let reconstructed = abfs_catalog.reconstruct_full_uri("data/quotes/file.parquet");
+    assert_eq!(
+        reconstructed,
+        "abfs://container@account.dfs.core.windows.net/base/path/data/quotes/file.parquet"
+    );
+
+    let reconstructed = s3_catalog.reconstruct_full_uri("data/%5E/file.parquet");
+    assert_eq!(reconstructed, "s3://bucket/base/path/data/%5E/file.parquet");
+
+    let full_uri = "s3://bucket/base/path/data/quotes/file.parquet";
+    assert_eq!(
+        s3_catalog.reconstruct_full_uri(full_uri),
+        "s3://bucket/base/path/data/quotes/file.parquet"
     );
 
     // Test local path (should return full absolute path)

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -1692,6 +1692,24 @@ fn test_to_object_path_trailing_slash() {
 
 #[cfg(feature = "cloud")]
 #[rstest]
+fn test_remote_to_object_path_preserves_base_path() {
+    let catalog =
+        ParquetDataCatalog::from_uri("s3://bucket/base/path", None, None, None, None).unwrap();
+
+    let relative = catalog.to_object_path("data/quotes/file.parquet");
+    assert_eq!(relative.as_ref(), "base/path/data/quotes/file.parquet");
+
+    let with_base = catalog.to_object_path("base/path/data/quotes/file.parquet");
+    assert_eq!(with_base.as_ref(), "base/path/data/quotes/file.parquet");
+
+    let parsed = catalog
+        .to_object_path_parsed("data/quotes/file.parquet")
+        .unwrap();
+    assert_eq!(parsed.as_ref(), "base/path/data/quotes/file.parquet");
+}
+
+#[cfg(feature = "cloud")]
+#[rstest]
 fn test_is_remote_uri() {
     // Test S3 URIs
     let s3_catalog =
@@ -2001,13 +2019,19 @@ fn test_reconstruct_full_uri_moved() {
     let s3_catalog =
         ParquetDataCatalog::from_uri("s3://bucket/base/path", None, None, None, None).unwrap();
     let reconstructed = s3_catalog.reconstruct_full_uri("data/quotes/file.parquet");
-    assert_eq!(reconstructed, "s3://bucket/data/quotes/file.parquet");
+    assert_eq!(
+        reconstructed,
+        "s3://bucket/base/path/data/quotes/file.parquet"
+    );
 
     // Test GCS URI reconstruction
     let gcs_catalog =
         ParquetDataCatalog::from_uri("gs://bucket/base/path", None, None, None, None).unwrap();
     let reconstructed = gcs_catalog.reconstruct_full_uri("data/trades/file.parquet");
-    assert_eq!(reconstructed, "gs://bucket/data/trades/file.parquet");
+    assert_eq!(
+        reconstructed,
+        "gs://bucket/base/path/data/trades/file.parquet"
+    );
 
     // Test Azure URI reconstruction
     let azure_test_options = Some(
@@ -2020,7 +2044,7 @@ fn test_reconstruct_full_uri_moved() {
         ParquetDataCatalog::from_uri("az://container/path", azure_test_options, None, None, None)
             .unwrap();
     let reconstructed = azure_catalog.reconstruct_full_uri("data/bars/file.parquet");
-    assert_eq!(reconstructed, "az://container/data/bars/file.parquet");
+    assert_eq!(reconstructed, "az://container/path/data/bars/file.parquet");
 
     // Test HTTP URI reconstruction
     let http_catalog =
@@ -2029,7 +2053,7 @@ fn test_reconstruct_full_uri_moved() {
     let reconstructed = http_catalog.reconstruct_full_uri("data/quotes/file.parquet");
     assert_eq!(
         reconstructed,
-        "https://example.com/data/quotes/file.parquet"
+        "https://example.com/base/path/data/quotes/file.parquet"
     );
 
     // Test local path (should return full absolute path)


### PR DESCRIPTION
Closes https://github.com/nautechsystems/nautilus_trader/issues/3929

## Summary

- Preserve or prepend the remote catalog URI path prefix when converting catalog paths to `ObjectPath`.
- Avoid duplicating the prefix when the input path already includes the remote catalog base path.
- Keep existing local catalog behavior, where the local filesystem store is already scoped to the catalog directory.
- Reconstruct remote full URIs with the catalog path prefix included.

## Root Cause

Remote object stores are created at the bucket/container root, while the URI path is returned separately as `base_path`. The previous `to_object_path` behavior stripped `base_path` for both local and remote catalogs, so paths like `catalog/data/...` became `data/...` and were addressed at the bucket root.

## Tests

- `cargo test -p nautilus-persistence --features cloud test_remote_to_object_path_preserves_base_path`
- `cargo test -p nautilus-persistence --features cloud test_reconstruct_full_uri_moved`
- `cargo check -p nautilus-persistence --features cloud`
- `cargo test -p nautilus-persistence --features cloud --test test_catalog`
- `make pre-commit`
