### PR TITLE
Add custom headers support for sockudo-ws

### DIFF
--- a/crates/adapters/okx/src/websocket/client.rs
+++ b/crates/adapters/okx/src/websocket/client.rs
@@ -294,9 +294,6 @@ impl OKXWebSocketClient {
     }
 
     /// Sets the transport backend for the next [`Self::connect`].
-    ///
-    /// When `Sockudo` is selected the OKX `User-Agent` upgrade header is
-    /// dropped because sockudo does not accept custom upgrade headers.
     #[must_use]
     pub fn with_transport_backend(mut self, backend: TransportBackend) -> Self {
         self.transport_backend = backend;
@@ -482,14 +479,7 @@ impl OKXWebSocketClient {
             // Handler responds to pings internally via select! loop
         });
 
-        // Sockudo's HTTP/1.1 client rejects custom upgrade headers, so the OKX
-        // User-Agent is omitted when that backend is selected.
-        let headers = match self.transport_backend {
-            TransportBackend::Sockudo => vec![],
-            TransportBackend::Tungstenite => {
-                vec![(USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string())]
-            }
-        };
+        let headers = vec![(USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string())];
 
         let config = WebSocketConfig {
             url: self.url.clone(),

--- a/crates/network/src/transport/sockudo.rs
+++ b/crates/network/src/transport/sockudo.rs
@@ -23,21 +23,26 @@
 //! The `Message` enums are structurally identical: both carry payloads as `bytes::Bytes`
 //! across all five variants, so conversions are zero-copy and infallible.
 //!
-//! Sockudo's HTTP/1.1 client handshake does not accept custom headers, so the runtime
-//! selector in [`crate::websocket::config::WebSocketConfig`] rejects non-empty headers
-//! when this backend is selected.
+//! sockudo's public HTTP/1.1 client API does not expose custom headers, so this
+//! module provides a small handshake helper for upgrade requests that need them.
 
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
 
+#[cfg(not(feature = "turmoil"))]
+use bytes::{BufMut, Bytes, BytesMut};
 use futures::{Sink, Stream};
+#[cfg(not(feature = "turmoil"))]
+use sockudo_ws::{HandshakeResult, handshake};
 use sockudo_ws::{
     error::{CloseReason as SockudoCloseReason, Error as SockudoError},
     protocol::Message as SockudoMessage,
     stream::WebSocketStream,
 };
+#[cfg(not(feature = "turmoil"))]
+use tokio::io::ReadBuf;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{
@@ -45,6 +50,210 @@ use super::{
     message::{CloseFrame, Message},
     stream::WsTransport,
 };
+
+#[cfg(not(feature = "turmoil"))]
+const MAX_HTTP_HEADER_SIZE: usize = 8192;
+#[cfg(not(feature = "turmoil"))]
+const RESERVED_UPGRADE_HEADERS: &[&str] = &[
+    "host",
+    "upgrade",
+    "connection",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "sec-websocket-extensions",
+];
+
+/// Perform an HTTP/1.1 WebSocket client handshake with custom headers.
+#[cfg(not(feature = "turmoil"))]
+pub(crate) async fn client_handshake_with_headers<S>(
+    stream: &mut S,
+    host: &str,
+    path: &str,
+    protocol: Option<&str>,
+    extra_headers: &[(String, String)],
+) -> Result<HandshakeResult, SockudoError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let key = handshake::generate_key();
+    let request = build_request_with_headers(host, path, &key, protocol, None, extra_headers)?;
+
+    stream.write_all(&request).await?;
+    stream.flush().await?;
+
+    let mut buf = BytesMut::with_capacity(4096);
+
+    loop {
+        if buf.len() > MAX_HTTP_HEADER_SIZE {
+            return Err(SockudoError::InvalidHttp("response too large"));
+        }
+
+        let n = stream.read_buf(&mut buf).await?;
+        if n == 0 {
+            return Err(SockudoError::ConnectionClosed);
+        }
+
+        if let Some((res, consumed)) = handshake::parse_response(&buf)? {
+            let accept = res.accept.ok_or(SockudoError::HandshakeFailed(
+                "missing Sec-WebSocket-Accept",
+            ))?;
+
+            if !handshake::validate_accept_key(&key, accept) {
+                return Err(SockudoError::HandshakeFailed(
+                    "invalid Sec-WebSocket-Accept",
+                ));
+            }
+
+            let res_protocol = res.protocol.map(String::from);
+            let res_extensions = res.extensions.map(String::from);
+            let leftover = if consumed < buf.len() {
+                Some(buf.split_off(consumed).freeze())
+            } else {
+                None
+            };
+
+            return Ok(HandshakeResult {
+                path: path.to_string(),
+                protocol: res_protocol,
+                extensions: res_extensions,
+                leftover,
+            });
+        }
+    }
+}
+
+#[cfg(not(feature = "turmoil"))]
+fn build_request_with_headers(
+    host: &str,
+    path: &str,
+    key: &str,
+    protocol: Option<&str>,
+    extensions: Option<&str>,
+    extra_headers: &[(String, String)],
+) -> Result<Bytes, SockudoError> {
+    let mut buf = BytesMut::with_capacity(512);
+
+    buf.put_slice(b"GET ");
+    buf.put_slice(path.as_bytes());
+    buf.put_slice(b" HTTP/1.1\r\n");
+    buf.put_slice(b"Host: ");
+    buf.put_slice(host.as_bytes());
+    buf.put_slice(b"\r\n");
+    buf.put_slice(b"Upgrade: websocket\r\n");
+    buf.put_slice(b"Connection: Upgrade\r\n");
+    buf.put_slice(b"Sec-WebSocket-Key: ");
+    buf.put_slice(key.as_bytes());
+    buf.put_slice(b"\r\n");
+    buf.put_slice(b"Sec-WebSocket-Version: 13\r\n");
+
+    if let Some(proto) = protocol {
+        buf.put_slice(b"Sec-WebSocket-Protocol: ");
+        buf.put_slice(proto.as_bytes());
+        buf.put_slice(b"\r\n");
+    }
+
+    if let Some(ext) = extensions {
+        buf.put_slice(b"Sec-WebSocket-Extensions: ");
+        buf.put_slice(ext.as_bytes());
+        buf.put_slice(b"\r\n");
+    }
+
+    validate_extra_headers(extra_headers)?;
+    for (name, value) in extra_headers {
+        buf.put_slice(name.as_bytes());
+        buf.put_slice(b": ");
+        buf.put_slice(value.as_bytes());
+        buf.put_slice(b"\r\n");
+    }
+
+    buf.put_slice(b"\r\n");
+    Ok(buf.freeze())
+}
+
+#[cfg(not(feature = "turmoil"))]
+pub(crate) fn validate_extra_headers(headers: &[(String, String)]) -> Result<(), SockudoError> {
+    for (name, value) in headers {
+        validate_extra_header(name, value)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "turmoil"))]
+fn validate_extra_header(name: &str, value: &str) -> Result<(), SockudoError> {
+    let parsed_name = name
+        .parse::<http::HeaderName>()
+        .map_err(|_| SockudoError::InvalidHttp("invalid header name"))?;
+
+    if RESERVED_UPGRADE_HEADERS.contains(&parsed_name.as_str()) {
+        return Err(SockudoError::InvalidHttp(
+            "reserved upgrade header not allowed in extra_headers",
+        ));
+    }
+
+    http::HeaderValue::from_str(value)
+        .map_err(|_| SockudoError::InvalidHttp("invalid header value"))?;
+    Ok(())
+}
+
+/// Replay bytes read during the handshake before forwarding to the inner IO.
+#[cfg(not(feature = "turmoil"))]
+pub(crate) struct PrefixedIo<S> {
+    inner: S,
+    prefix: Bytes,
+}
+
+#[cfg(not(feature = "turmoil"))]
+impl<S> PrefixedIo<S> {
+    pub(crate) const fn new(inner: S, prefix: Bytes) -> Self {
+        Self { inner, prefix }
+    }
+}
+
+#[cfg(not(feature = "turmoil"))]
+impl<S> AsyncRead for PrefixedIo<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if !self.prefix.is_empty() {
+            let n = self.prefix.len().min(buf.remaining());
+            let chunk = self.prefix.split_to(n);
+            buf.put_slice(&chunk);
+            return Poll::Ready(Ok(()));
+        }
+
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+#[cfg(not(feature = "turmoil"))]
+impl<S> AsyncWrite for PrefixedIo<S>
+where
+    S: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
 
 impl From<SockudoMessage> for Message {
     fn from(value: SockudoMessage) -> Self {
@@ -239,8 +448,187 @@ const _: fn() = || {
 mod tests {
     use bytes::Bytes;
     use rstest::rstest;
+    #[cfg(not(feature = "turmoil"))]
+    use sockudo_ws::handshake::generate_accept_key;
+    #[cfg(not(feature = "turmoil"))]
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, duplex};
 
     use super::*;
+
+    #[cfg(not(feature = "turmoil"))]
+    async fn read_http_request<S>(stream: &mut S) -> Vec<u8>
+    where
+        S: AsyncRead + Unpin,
+    {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 256];
+
+        loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "HTTP request closed before headers completed");
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|window| window == b"\r\n\r\n") {
+                return buf;
+            }
+        }
+    }
+
+    #[cfg(not(feature = "turmoil"))]
+    fn build_test_response(sec_websocket_key: &str, extra_bytes: &[u8]) -> Vec<u8> {
+        let accept = generate_accept_key(sec_websocket_key);
+        let mut response = format!(
+            concat!(
+                "HTTP/1.1 101 Switching Protocols\r\n",
+                "Upgrade: websocket\r\n",
+                "Connection: Upgrade\r\n",
+                "Sec-WebSocket-Accept: {}\r\n",
+                "\r\n",
+            ),
+            accept
+        )
+        .into_bytes();
+        response.extend_from_slice(extra_bytes);
+        response
+    }
+
+    #[cfg(not(feature = "turmoil"))]
+    fn extract_header<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+        request.lines().find_map(|line| {
+            let (header_name, header_value) = line.split_once(':')?;
+            if header_name.eq_ignore_ascii_case(name) {
+                Some(header_value.trim())
+            } else {
+                None
+            }
+        })
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "turmoil"))]
+    async fn client_handshake_with_headers_sends_custom_headers() {
+        let (mut client, mut server) = duplex(4096);
+        let headers = vec![
+            ("ok-access-key".to_string(), "key-1".to_string()),
+            ("ok-access-passphrase".to_string(), "pass-1".to_string()),
+        ];
+
+        let server_task = tokio::spawn(async move {
+            let request = read_http_request(&mut server).await;
+            let request = String::from_utf8(request).unwrap();
+
+            assert!(request.starts_with("GET /ws/v5/public-sbe?instId=BTC-USDT HTTP/1.1\r\n"));
+            assert_eq!(extract_header(&request, "Host"), Some("ws.okx.com:8443"));
+            assert_eq!(extract_header(&request, "ok-access-key"), Some("key-1"));
+            assert_eq!(
+                extract_header(&request, "ok-access-passphrase"),
+                Some("pass-1")
+            );
+
+            let sec_websocket_key = extract_header(&request, "Sec-WebSocket-Key").unwrap();
+            let response = build_test_response(sec_websocket_key, &[]);
+            server.write_all(&response).await.unwrap();
+        });
+
+        let handshake = client_handshake_with_headers(
+            &mut client,
+            "ws.okx.com:8443",
+            "/ws/v5/public-sbe?instId=BTC-USDT",
+            None,
+            &headers,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(handshake.path, "/ws/v5/public-sbe?instId=BTC-USDT");
+        assert!(handshake.leftover.is_none());
+        server_task.await.unwrap();
+    }
+
+    #[rstest]
+    #[cfg(not(feature = "turmoil"))]
+    #[case::host("Host")]
+    #[case::upgrade("Upgrade")]
+    #[case::connection("Connection")]
+    #[case::sec_websocket_key("Sec-WebSocket-Key")]
+    #[case::sec_websocket_version("Sec-WebSocket-Version")]
+    #[case::sec_websocket_protocol("Sec-WebSocket-Protocol")]
+    #[case::sec_websocket_extensions("Sec-WebSocket-Extensions")]
+    fn validate_extra_header_rejects_reserved_upgrade_headers(#[case] name: &str) {
+        let err = validate_extra_header(name, "value").unwrap_err();
+
+        assert!(matches!(
+            err,
+            SockudoError::InvalidHttp("reserved upgrade header not allowed in extra_headers")
+        ));
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "turmoil"))]
+    async fn client_handshake_with_headers_rejects_missing_accept() {
+        let (mut client, mut server) = duplex(4096);
+
+        let server_task = tokio::spawn(async move {
+            let _request = read_http_request(&mut server).await;
+            server
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Upgrade: websocket\r\n\
+                      Connection: Upgrade\r\n\
+                      \r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let err = client_handshake_with_headers(&mut client, "example.com", "/ws", None, &[])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SockudoError::HandshakeFailed("missing Sec-WebSocket-Accept")
+        ));
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "turmoil"))]
+    async fn client_handshake_with_headers_returns_leftover_bytes() {
+        let (mut client, mut server) = duplex(4096);
+        let extra = b"\x81\x05hello";
+
+        let server_task = tokio::spawn(async move {
+            let request = read_http_request(&mut server).await;
+            let request = String::from_utf8(request).unwrap();
+            let sec_websocket_key = extract_header(&request, "Sec-WebSocket-Key").unwrap();
+            let response = build_test_response(sec_websocket_key, extra);
+            server.write_all(&response).await.unwrap();
+        });
+
+        let handshake = client_handshake_with_headers(&mut client, "example.com", "/ws", None, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(handshake.leftover.as_deref(), Some(extra.as_slice()));
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "turmoil"))]
+    async fn prefixed_io_replays_leftover_before_socket() {
+        let (client, mut server) = duplex(4096);
+        let mut prefixed = PrefixedIo::new(client, Bytes::from_static(b"abc"));
+
+        let server_task = tokio::spawn(async move {
+            server.write_all(b"def").await.unwrap();
+        });
+
+        let mut buf = [0u8; 6];
+        prefixed.read_exact(&mut buf).await.unwrap();
+
+        assert_eq!(&buf, b"abcdef");
+        server_task.await.unwrap();
+    }
 
     #[rstest]
     fn round_trip_text() {

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -2147,16 +2147,18 @@ mod rust_tests {
     use futures_util::{SinkExt, StreamExt};
     use nautilus_common::testing::wait_until_async;
     use rstest::rstest;
+    #[cfg(feature = "transport-sockudo")]
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
     use tokio::{
-        io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         task::{self, JoinHandle},
         time::{Duration, sleep},
     };
+    use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+    #[cfg(feature = "transport-sockudo")]
     use tokio_tungstenite::{
-        accept_async, accept_hdr_async,
+        accept_hdr_async,
         tungstenite::{
-            Message as WsMessage,
             handshake::server::{self, Callback},
             http::HeaderValue,
         },
@@ -2201,12 +2203,14 @@ mod rust_tests {
         })
     }
 
+    #[cfg(feature = "transport-sockudo")]
     #[derive(Debug, Clone)]
     struct HeaderAssertCallback {
         key: String,
         value: HeaderValue,
     }
 
+    #[cfg(feature = "transport-sockudo")]
     impl Callback for HeaderAssertCallback {
         #[expect(
             clippy::panic_in_result_fn,
@@ -3905,21 +3909,17 @@ mod rust_tests {
 
                 if let Ok(mut ws) = accept_hdr_async(stream, callback).await {
                     while let Some(Ok(msg)) = ws.next().await {
-                        #[expect(
-                            clippy::collapsible_match,
-                            reason = "send consumes msg, so this cannot be a match guard"
-                        )]
-                        match msg {
-                            WsMessage::Text(_) | WsMessage::Binary(_) => {
-                                if ws.send(msg).await.is_err() {
-                                    break;
-                                }
-                            }
-                            WsMessage::Close(_) => {
-                                let _ = ws.close(None).await;
+                        if msg.is_text() || msg.is_binary() {
+                            if ws.send(msg).await.is_err() {
                                 break;
                             }
-                            _ => {}
+
+                            continue;
+                        }
+
+                        if msg.is_close() {
+                            let _ = ws.close(None).await;
+                            break;
                         }
                     }
                 }

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -43,7 +43,12 @@ use nautilus_cryptography::providers::install_cryptographic_provider;
 ))]
 use rustls::ClientConfig;
 #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
-use sockudo_ws::{Config as SockudoConfig, Http1, client::WebSocketClient as SockudoClient};
+use sockudo_ws::{
+    Config as SockudoConfig, Http1, Role, Stream as SockudoStream,
+    WebSocketStream as SockudoWebSocketStream, handshake as sockudo_handshake,
+};
+#[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
+use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
 use tokio::net::TcpStream;
 #[cfg(any(
@@ -72,7 +77,9 @@ use super::{
 #[cfg(feature = "turmoil")]
 use crate::net::TcpConnector;
 #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
-use crate::transport::sockudo::SockudoTransport;
+use crate::transport::sockudo::{
+    PrefixedIo, SockudoTransport, client_handshake_with_headers, validate_extra_headers,
+};
 use crate::{
     RECONNECTED,
     backoff::ExponentialBackoff,
@@ -328,9 +335,8 @@ impl WebSocketClientInner {
     ///
     /// Dispatches on `backend` to the matching backend helper. The
     /// [`TransportBackend::Tungstenite`] backend is always available; the
-    /// [`TransportBackend::Sockudo`] backend requires the `transport-sockudo`
-    /// Cargo feature and rejects non-empty `headers` because sockudo's HTTP/1.1
-    /// client handshake does not accept custom upgrade headers.
+    /// [`TransportBackend::Sockudo`] requires the `transport-sockudo` Cargo
+    /// feature and uses a custom HTTP/1.1 handshake path for upgrade headers.
     ///
     /// # Errors
     ///
@@ -348,16 +354,9 @@ impl WebSocketClientInner {
         match backend {
             TransportBackend::Tungstenite => Self::connect_tungstenite(url, headers).await,
             TransportBackend::Sockudo => {
-                if !headers.is_empty() {
-                    return Err(TransportError::Other(
-                        "sockudo backend does not support custom upgrade headers; \
-                         use the tungstenite backend for adapters that require them"
-                            .to_string(),
-                    ));
-                }
                 #[cfg(feature = "transport-sockudo")]
                 {
-                    Self::connect_sockudo(url).await
+                    Self::connect_sockudo(url, headers).await
                 }
                 #[cfg(not(feature = "transport-sockudo"))]
                 {
@@ -471,13 +470,16 @@ impl WebSocketClientInner {
 
     /// Connects with the server using the sockudo-ws backend.
     ///
-    /// Sockudo's HTTP/1.1 client handshake does not accept custom upgrade
-    /// headers; the caller [`Self::connect_with_server`] rejects non-empty
-    /// `headers` before reaching this helper.
+    /// Uses sockudo's native handshake when no custom headers are required, and
+    /// a local HTTP/1.1 helper only for upgrade requests with custom headers.
     #[inline]
     #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
-    async fn connect_sockudo(url: &str) -> Result<(MessageWriter, MessageReader), TransportError> {
+    async fn connect_sockudo(
+        url: &str,
+        headers: Vec<(String, String)>,
+    ) -> Result<(MessageWriter, MessageReader), TransportError> {
         let target = SockudoTarget::parse(url)?;
+        validate_extra_headers(&headers).map_err(TransportError::from)?;
 
         let tcp_stream = TcpStream::connect((target.host.as_str(), target.port))
             .await
@@ -486,8 +488,6 @@ impl WebSocketClientInner {
         if let Err(e) = tcp_stream.set_nodelay(true) {
             log::warn!("Failed to enable TCP_NODELAY for sockudo client: {e:?}");
         }
-
-        let client = SockudoClient::<Http1>::new(SockudoConfig::default());
 
         if target.is_tls {
             let mut root_store = rustls::RootCertStore::empty();
@@ -502,20 +502,52 @@ impl WebSocketClientInner {
                 .connect(domain, tcp_stream)
                 .await
                 .map_err(TransportError::Io)?;
-            let (ws, _hs) = client
-                .connect(tls_stream, &target.host_header, &target.path, None)
-                .await
-                .map_err(TransportError::from)?;
-            let transport: BoxedWsTransport = Box::pin(SockudoTransport::new(ws));
-            Ok(transport.split())
+            Self::finish_sockudo_handshake(tls_stream, &target, &headers).await
         } else {
-            let (ws, _hs) = client
-                .connect(tcp_stream, &target.host_header, &target.path, None)
-                .await
-                .map_err(TransportError::from)?;
-            let transport: BoxedWsTransport = Box::pin(SockudoTransport::new(ws));
-            Ok(transport.split())
+            Self::finish_sockudo_handshake(tcp_stream, &target, &headers).await
         }
+    }
+
+    #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
+    async fn finish_sockudo_handshake<S>(
+        mut stream: S,
+        target: &SockudoTarget,
+        headers: &[(String, String)],
+    ) -> Result<(MessageWriter, MessageReader), TransportError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        // sockudo's high-level client drops handshake leftover bytes today, so
+        // choose the handshake primitive here and always own stream construction.
+        let handshake = if headers.is_empty() {
+            sockudo_handshake::client_handshake(
+                &mut stream,
+                &target.host_header,
+                &target.path,
+                None,
+            )
+            .await
+        } else {
+            client_handshake_with_headers(
+                &mut stream,
+                &target.host_header,
+                &target.path,
+                None,
+                headers,
+            )
+            .await
+        }
+        .map_err(TransportError::from)?;
+
+        // Reading the HTTP 101 may also read the first WebSocket frame prefix;
+        // replay it only when present so the ordinary path stays unwrapped.
+        let stream = match handshake.leftover {
+            Some(prefix) => SockudoStream::<Http1>::new(PrefixedIo::new(stream, prefix)),
+            None => SockudoStream::<Http1>::new(stream),
+        };
+        let ws = SockudoWebSocketStream::from_raw(stream, Role::Client, SockudoConfig::default());
+        let transport: BoxedWsTransport = Box::pin(SockudoTransport::new(ws));
+        Ok(transport.split())
     }
 
     /// Sockudo backend is unavailable under the turmoil feature (the simulator
@@ -526,7 +558,10 @@ impl WebSocketClientInner {
         clippy::unused_async,
         reason = "signature mirrors the non-turmoil variant; both are awaited in the dispatcher"
     )]
-    async fn connect_sockudo(_url: &str) -> Result<(MessageWriter, MessageReader), TransportError> {
+    async fn connect_sockudo(
+        _url: &str,
+        _headers: Vec<(String, String)>,
+    ) -> Result<(MessageWriter, MessageReader), TransportError> {
         Err(TransportError::Other(
             "sockudo backend is not available under the turmoil simulator".to_string(),
         ))
@@ -2113,11 +2148,19 @@ mod rust_tests {
     use nautilus_common::testing::wait_until_async;
     use rstest::rstest;
     use tokio::{
+        io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         task::{self, JoinHandle},
         time::{Duration, sleep},
     };
-    use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+    use tokio_tungstenite::{
+        accept_async, accept_hdr_async,
+        tungstenite::{
+            Message as WsMessage,
+            handshake::server::{self, Callback},
+            http::HeaderValue,
+        },
+    };
 
     use super::*;
     use crate::websocket::types::channel_message_handler;
@@ -2126,6 +2169,57 @@ mod rust_tests {
         task: JoinHandle<()>,
         port: u16,
         messages: Arc<tokio::sync::Mutex<Vec<String>>>,
+    }
+
+    #[cfg(feature = "transport-sockudo")]
+    async fn read_http_request<S>(stream: &mut S) -> Vec<u8>
+    where
+        S: AsyncRead + Unpin,
+    {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 256];
+
+        loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "HTTP request closed before headers completed");
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|window| window == b"\r\n\r\n") {
+                return buf;
+            }
+        }
+    }
+
+    #[cfg(feature = "transport-sockudo")]
+    fn extract_header<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+        request.lines().find_map(|line| {
+            let (header_name, header_value) = line.split_once(':')?;
+            if header_name.eq_ignore_ascii_case(name) {
+                Some(header_value.trim())
+            } else {
+                None
+            }
+        })
+    }
+
+    #[derive(Debug, Clone)]
+    struct HeaderAssertCallback {
+        key: String,
+        value: HeaderValue,
+    }
+
+    impl Callback for HeaderAssertCallback {
+        #[expect(
+            clippy::panic_in_result_fn,
+            reason = "assertion failures should fail the test"
+        )]
+        fn on_request(
+            self,
+            request: &server::Request,
+            response: server::Response,
+        ) -> Result<server::Response, server::ErrorResponse> {
+            assert_eq!(request.headers().get(&self.key), Some(&self.value));
+            Ok(response)
+        }
     }
 
     impl RecordingServer {
@@ -3693,12 +3787,12 @@ mod rust_tests {
     #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
     #[rstest]
     #[tokio::test]
-    async fn test_sockudo_backend_rejects_custom_headers() {
+    async fn test_sockudo_backend_rejects_reserved_headers_before_connect() {
         let (handler, _rx) = channel_message_handler();
 
         let config = WebSocketConfig {
             url: "ws://127.0.0.1:1".to_string(),
-            headers: vec![("X-Test".to_string(), "value".to_string())],
+            headers: vec![("Host".to_string(), "example.com".to_string())],
             heartbeat: None,
             heartbeat_msg: None,
             reconnect_timeout_ms: None,
@@ -3711,15 +3805,171 @@ mod rust_tests {
             backend: TransportBackend::Sockudo,
         };
 
-        let result =
-            WebSocketClient::connect(config, Some(handler), None, None, vec![], None).await;
+        let err = WebSocketClient::connect(config, Some(handler), None, None, vec![], None)
+            .await
+            .expect_err("reserved header should fail before TCP connect");
 
-        let err = result.expect_err("sockudo backend should reject custom headers");
-        let msg = err.to_string();
         assert!(
-            msg.contains("does not support custom upgrade headers"),
-            "expected upgrade-headers rejection, was: {msg}"
+            err.to_string()
+                .contains("reserved upgrade header not allowed in extra_headers"),
+            "expected reserved-header failure, was: {err}"
         );
+    }
+
+    #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
+    #[rstest]
+    #[tokio::test]
+    async fn test_sockudo_backend_replays_leftover_without_custom_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let server = task::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let request = read_http_request(&mut stream).await;
+                let request = String::from_utf8(request).unwrap();
+                let sec_websocket_key = extract_header(&request, "Sec-WebSocket-Key").unwrap();
+                let accept = sockudo_handshake::generate_accept_key(sec_websocket_key);
+                let mut response = format!(
+                    concat!(
+                        "HTTP/1.1 101 Switching Protocols\r\n",
+                        "Upgrade: websocket\r\n",
+                        "Connection: Upgrade\r\n",
+                        "Sec-WebSocket-Accept: {}\r\n",
+                        "\r\n",
+                    ),
+                    accept
+                )
+                .into_bytes();
+                response.extend_from_slice(b"\x81\x05hello");
+                stream.write_all(&response).await.unwrap();
+            }
+        });
+
+        let (handler, mut rx) = channel_message_handler();
+
+        let config = WebSocketConfig {
+            url: format!("ws://127.0.0.1:{port}/ws"),
+            headers: vec![],
+            heartbeat: None,
+            heartbeat_msg: None,
+            reconnect_timeout_ms: Some(2_000),
+            reconnect_delay_initial_ms: Some(50),
+            reconnect_delay_max_ms: Some(100),
+            reconnect_backoff_factor: Some(1.0),
+            reconnect_jitter_ms: Some(0),
+            reconnect_max_attempts: None,
+            idle_timeout_ms: None,
+            backend: TransportBackend::Sockudo,
+        };
+
+        let client = WebSocketClient::connect(config, Some(handler), None, None, vec![], None)
+            .await
+            .expect("sockudo connect without custom headers");
+
+        let received = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if let Ok(msg) = rx.try_recv() {
+                    return msg;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("did not receive leftover frame before timeout");
+
+        match received {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "hello"),
+            other => panic!("expected text, was {other:?}"),
+        }
+
+        client.disconnect().await;
+        tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("server did not close before timeout")
+            .unwrap();
+    }
+
+    #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]
+    #[rstest]
+    #[tokio::test]
+    async fn test_sockudo_backend_sends_custom_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let server = task::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let callback = HeaderAssertCallback {
+                    key: "X-Test".to_string(),
+                    value: HeaderValue::from_static("value"),
+                };
+
+                if let Ok(mut ws) = accept_hdr_async(stream, callback).await {
+                    while let Some(Ok(msg)) = ws.next().await {
+                        #[expect(
+                            clippy::collapsible_match,
+                            reason = "send consumes msg, so this cannot be a match guard"
+                        )]
+                        match msg {
+                            WsMessage::Text(_) | WsMessage::Binary(_) => {
+                                if ws.send(msg).await.is_err() {
+                                    break;
+                                }
+                            }
+                            WsMessage::Close(_) => {
+                                let _ = ws.close(None).await;
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        });
+
+        let (handler, mut rx) = channel_message_handler();
+
+        let config = WebSocketConfig {
+            url: format!("ws://127.0.0.1:{port}"),
+            headers: vec![("X-Test".to_string(), "value".to_string())],
+            heartbeat: None,
+            heartbeat_msg: None,
+            reconnect_timeout_ms: Some(2_000),
+            reconnect_delay_initial_ms: Some(50),
+            reconnect_delay_max_ms: Some(100),
+            reconnect_backoff_factor: Some(1.0),
+            reconnect_jitter_ms: Some(0),
+            reconnect_max_attempts: None,
+            idle_timeout_ms: None,
+            backend: TransportBackend::Sockudo,
+        };
+
+        let client = WebSocketClient::connect(config, Some(handler), None, None, vec![], None)
+            .await
+            .expect("sockudo connect with custom headers");
+
+        client.send_text("ping".to_string(), None).await.unwrap();
+
+        let received = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if let Ok(msg) = rx.try_recv() {
+                    return msg;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("did not receive echo before timeout");
+
+        match received {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "ping"),
+            other => panic!("expected text, was {other:?}"),
+        }
+
+        client.disconnect().await;
+        tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("server did not close before timeout")
+            .unwrap();
     }
 
     #[cfg(all(feature = "transport-sockudo", not(feature = "turmoil")))]

--- a/crates/network/src/websocket/config.rs
+++ b/crates/network/src/websocket/config.rs
@@ -36,10 +36,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// `Tungstenite` supports custom HTTP upgrade headers on the WebSocket
 /// handshake (see [`WebSocketConfig::headers`]). `Sockudo` is gated on the
-/// `transport-sockudo` Cargo feature; its HTTP/1.1 handshake does not accept
-/// custom upgrade headers, so adapters that authenticate at upgrade time must
-/// select `Tungstenite`. Headers carried inside WebSocket message payloads are
-/// unaffected.
+/// `transport-sockudo` Cargo feature and uses a local HTTP/1.1 handshake helper
+/// to pass the same upgrade headers through.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(
@@ -156,9 +154,8 @@ pub struct WebSocketConfig {
     ///
     /// Defaults to [`TransportBackend::Tungstenite`]. Selecting
     /// [`TransportBackend::Sockudo`] requires the `transport-sockudo` Cargo
-    /// feature; otherwise `connect_with_server` returns an error. Sockudo
-    /// rejects non-empty `headers` because its HTTP/1.1 handshake does not
-    /// accept custom upgrade headers; in-message authentication is unaffected.
+    /// feature; otherwise `connect_with_server` returns an error. Both backends
+    /// pass `headers` into the HTTP upgrade request.
     #[serde(default)]
     #[builder(default)]
     pub backend: TransportBackend,


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Add custom headers support for sockudo-ws
	- Add a sockudo HTTP/1.1 handshake path for custom WebSocket upgrade headers.
	- Reuse sockudo's native handshake when no custom headers are present, while replaying any leftover bytes before WebSocket frame
	parsing.
	- Reject reserved WebSocket upgrade headers before opening the sockudo TCP connection.
	- Keep the OKX User-Agent header when the sockudo backend is selected.
	- Cover custom headers, reserved headers, missing accept keys, and leftover replay with sockudo tests.

## Type of change

- [x] Improvement (non-breaking)