### PR TITLE
Avoid object materialization in Rust stream Feather conversion to parquet

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -73,7 +73,11 @@ use std::{
 };
 
 use ahash::AHashMap;
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::{
+    array::{Array, UInt64Array},
+    compute::{SortOptions, concat_batches, sort_to_indices, take_record_batch},
+    record_batch::RecordBatch,
+};
 use futures::StreamExt;
 use itertools::Itertools;
 use nautilus_common::live::get_runtime;
@@ -3470,16 +3474,16 @@ impl ParquetDataCatalog {
     /// - The instance ID doesn't exist.
     /// - Feather file listing fails.
     /// - Feather file reading fails.
-    /// - Data deserialization fails.
     /// - Writing to parquet fails.
     ///
     /// # Note
     ///
-    /// This method is currently not fully implemented. It requires:
+    /// This method converts directly between Arrow IPC stream batches and Parquet batches without
+    /// materializing Nautilus data objects. It requires:
     /// - Listing feather files in the specified subdirectory
     /// - Reading feather files (Arrow IPC stream reading)
-    /// - Converting Arrow tables to Nautilus data objects
-    /// - Writing data to the catalog using existing write methods
+    /// - Applying table-only stream conversion transforms
+    /// - Writing Arrow batches to the catalog
     ///
     /// # Examples
     ///
@@ -3529,10 +3533,17 @@ impl ParquetDataCatalog {
                 // Check if this is a subdirectory (per-instrument) or a flat file
                 if let Some(relative_path) = path_str.strip_prefix(&format!("{data_dir}/")) {
                     if relative_path.ends_with(".feather") {
-                        // Flat file format: {data_name}_*.feather
-                        if path_str.contains(&format!("{data_name}_")) {
-                            flat_files.push(path_str);
+                        if let Some(identifiers) = identifiers
+                            && let Some((subdir_name, _)) = relative_path.split_once('/')
+                            && !identifiers.iter().any(|id| {
+                                subdir_name.contains(id)
+                                    || subdir_name.contains(&urisafe_instrument_id(id))
+                            })
+                        {
+                            continue;
                         }
+
+                        flat_files.push(path_str);
                     } else {
                         // This might be a subdirectory - check if it contains feather files
                         let subdir_path = format!("{path_str}/");
@@ -3548,7 +3559,10 @@ impl ParquetDataCatalog {
                                 // Check identifier filter if provided
                                 if let Some(identifiers) = identifiers {
                                     let subdir_name = relative_path.split('/').next().unwrap_or("");
-                                    if !identifiers.iter().any(|id| subdir_name.contains(id)) {
+                                    if !identifiers.iter().any(|id| {
+                                        subdir_name.contains(id)
+                                            || subdir_name.contains(&urisafe_instrument_id(id))
+                                    }) {
                                         continue;
                                     }
                                 }
@@ -3631,24 +3645,22 @@ impl ParquetDataCatalog {
             return Ok(Vec::new());
         }
 
-        // Get schema and metadata from first batch
         let schema = batches[0].schema();
         let mut metadata = schema.metadata().clone();
 
-        // Convert bar_type from INTERNAL to EXTERNAL if requested
         if convert_bar_type_to_external
             && let Some(bar_type_str) = metadata.get("bar_type").cloned()
             && bar_type_str.ends_with("-INTERNAL")
         {
-            let external = bar_type_str.replace("-INTERNAL", "-EXTERNAL");
-            metadata.insert("bar_type".to_string(), external);
+            metadata.insert(
+                "bar_type".to_string(),
+                bar_type_str.replace("-INTERNAL", "-EXTERNAL"),
+            );
         }
 
-        // Process each batch
         let mut all_data = Vec::new();
 
         for mut batch in batches {
-            // Handle ts_event/ts_init replacement if requested
             if use_ts_event_for_ts_init {
                 let column_names: Vec<String> =
                     schema.fields().iter().map(|f| f.name().clone()).collect();
@@ -3662,23 +3674,19 @@ impl ParquetDataCatalog {
                     .position(|n| n == "ts_init")
                     .ok_or_else(|| anyhow::anyhow!("ts_init column not found"))?;
 
-                // Create new arrays with ts_init replaced by ts_event
                 let mut new_columns = batch.columns().to_vec();
                 new_columns[ts_init_idx] = new_columns[ts_event_idx].clone();
 
-                // Create new batch with updated columns
                 batch = RecordBatch::try_new(schema.clone(), new_columns)
                     .map_err(|e| anyhow::anyhow!("Failed to create new batch: {e}"))?;
             }
 
-            // Decode the batch to Data objects
             let data_vec = T::decode_data_batch(&metadata, batch)
                 .map_err(|e| anyhow::anyhow!("Failed to decode batch: {e}"))?;
 
             all_data.extend(data_vec);
         }
 
-        // Convert Data enum to specific type T
         Ok(to_variant::<T>(all_data))
     }
 
@@ -3704,20 +3712,6 @@ impl ParquetDataCatalog {
         }
 
         Ok(all_data)
-    }
-
-    fn write_typed_batches<T>(&self, batches: Vec<RecordBatch>) -> anyhow::Result<()>
-    where
-        T: DecodeTypedFromRecordBatch + EncodeToRecordBatch + CatalogPathPrefix + HasTsInit,
-    {
-        let mut data: Vec<T> = self.convert_record_batches_to_typed(batches)?;
-
-        if !is_monotonically_increasing_by_init(&data) {
-            data.sort_by_key(|item| item.ts_init());
-        }
-
-        self.write_to_parquet(data, None, None, None)?;
-        Ok(())
     }
 
     pub fn convert_stream_to_data(
@@ -3747,205 +3741,299 @@ impl ParquetDataCatalog {
             return Ok(());
         }
 
+        if !Self::is_supported_stream_data_type(&data_name) {
+            anyhow::bail!("Unknown data class: {data_cls}");
+        }
+
         // Process each feather file independently so that each file's identifier
         // (instrument_id or bar_type from schema metadata) is preserved when writing
         // to parquet. This matches the Python _convert_feather_table_to_parquet approach.
-        let convert_bar_type = data_cls == "bars";
-
         for file_path in feather_files {
             let batches = self.read_feather_file(&file_path)?;
-
-            if batches.is_empty() {
-                continue;
-            }
-
-            match data_cls {
-                "quotes" => {
-                    let mut data: Vec<QuoteTick> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "trades" => {
-                    let mut data: Vec<TradeTick> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "order_book_deltas" => {
-                    let mut data: Vec<OrderBookDelta> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "order_book_depths" => {
-                    let mut data: Vec<OrderBookDepth10> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "bars" => {
-                    let mut data: Vec<Bar> = self
-                        .convert_record_batches_to_data_with_bar_type_conversion(
-                            batches,
-                            use_ts_event_for_ts_init,
-                            convert_bar_type,
-                        )?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "index_prices" => {
-                    let mut data: Vec<IndexPriceUpdate> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "mark_prices" => {
-                    let mut data: Vec<MarkPriceUpdate> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "instrument_status" => {
-                    self.write_typed_batches::<InstrumentStatus>(batches)?;
-                }
-                "instrument_closes" => {
-                    let mut data: Vec<InstrumentClose> =
-                        self.convert_record_batches_to_data(batches, use_ts_event_for_ts_init)?;
-
-                    if !is_monotonically_increasing_by_init(&data) {
-                        data.sort_by_key(|d| d.ts_init);
-                    }
-                    self.write_to_parquet(data, None, None, None)?;
-                }
-                "funding_rate_update" => {
-                    self.write_typed_batches::<FundingRateUpdate>(batches)?;
-                }
-                "account_state" => {
-                    self.write_typed_batches::<AccountState>(batches)?;
-                }
-                "order_initialized" => {
-                    self.write_typed_batches::<OrderInitialized>(batches)?;
-                }
-                "order_denied" => {
-                    self.write_typed_batches::<OrderDenied>(batches)?;
-                }
-                "order_emulated" => {
-                    self.write_typed_batches::<OrderEmulated>(batches)?;
-                }
-                "order_submitted" => {
-                    self.write_typed_batches::<OrderSubmitted>(batches)?;
-                }
-                "order_accepted" => {
-                    self.write_typed_batches::<OrderAccepted>(batches)?;
-                }
-                "order_rejected" => {
-                    self.write_typed_batches::<OrderRejected>(batches)?;
-                }
-                "order_pending_cancel" => {
-                    self.write_typed_batches::<OrderPendingCancel>(batches)?;
-                }
-                "order_canceled" => {
-                    self.write_typed_batches::<OrderCanceled>(batches)?;
-                }
-                "order_cancel_rejected" => {
-                    self.write_typed_batches::<OrderCancelRejected>(batches)?;
-                }
-                "order_expired" => {
-                    self.write_typed_batches::<OrderExpired>(batches)?;
-                }
-                "order_triggered" => {
-                    self.write_typed_batches::<OrderTriggered>(batches)?;
-                }
-                "order_pending_update" => {
-                    self.write_typed_batches::<OrderPendingUpdate>(batches)?;
-                }
-                "order_released" => {
-                    self.write_typed_batches::<OrderReleased>(batches)?;
-                }
-                "order_modify_rejected" => {
-                    self.write_typed_batches::<OrderModifyRejected>(batches)?;
-                }
-                "order_updated" => {
-                    self.write_typed_batches::<OrderUpdated>(batches)?;
-                }
-                "order_filled" => {
-                    self.write_typed_batches::<OrderFilled>(batches)?;
-                }
-                "position_opened" => {
-                    self.write_typed_batches::<PositionOpened>(batches)?;
-                }
-                "position_changed" => {
-                    self.write_typed_batches::<PositionChanged>(batches)?;
-                }
-                "position_closed" => {
-                    self.write_typed_batches::<PositionClosed>(batches)?;
-                }
-                "position_adjusted" => {
-                    self.write_typed_batches::<PositionAdjusted>(batches)?;
-                }
-                "order_snapshot" => {
-                    self.write_typed_batches::<OrderSnapshot>(batches)?;
-                }
-                "position_snapshot" => {
-                    self.write_typed_batches::<PositionSnapshot>(batches)?;
-                }
-                "order_status_report" => {
-                    self.write_typed_batches::<OrderStatusReport>(batches)?;
-                }
-                "fill_report" => {
-                    self.write_typed_batches::<FillReport>(batches)?;
-                }
-                "position_status_report" => {
-                    self.write_typed_batches::<PositionStatusReport>(batches)?;
-                }
-                "execution_mass_status" => {
-                    self.write_typed_batches::<ExecutionMassStatus>(batches)?;
-                }
-                _ => {
-                    if data_cls.starts_with("custom/") {
-                        let data =
-                            self.decode_custom_batches_to_data(batches, use_ts_event_for_ts_init)?;
-                        let custom_items: Vec<CustomData> = data
-                            .into_iter()
-                            .filter_map(|d| match d {
-                                Data::Custom(c) => Some(c),
-                                _ => None,
-                            })
-                            .collect();
-
-                        if !custom_items.is_empty() {
-                            self.write_custom_data_batch(custom_items, None, None, None)?;
-                        }
-                    } else {
-                        anyhow::bail!("Unknown data class: {data_cls}");
-                    }
-                }
-            }
+            self.convert_feather_batches_to_parquet(
+                &data_name,
+                &file_path,
+                batches,
+                use_ts_event_for_ts_init,
+            )?;
         }
 
         Ok(())
+    }
+
+    fn convert_feather_batches_to_parquet(
+        &self,
+        data_name: &str,
+        feather_path: &str,
+        batches: Vec<RecordBatch>,
+        use_ts_event_for_ts_init: bool,
+    ) -> anyhow::Result<()> {
+        let Some(batch) = Self::apply_stream_conversion_transforms(
+            batches,
+            use_ts_event_for_ts_init,
+        )
+        .map_err(|e| {
+            anyhow::anyhow!("Failed to apply stream conversion transforms for {feather_path}: {e}")
+        })?
+        else {
+            return Ok(());
+        };
+
+        let (start_ts, end_ts) = Self::ts_init_range(&batch).map_err(|e| {
+            anyhow::anyhow!("Failed to determine ts_init range for {feather_path}: {e}")
+        })?;
+        let identifier = Self::identifier_from_batch_or_path(&batch, data_name, feather_path);
+        let directory = if let Some(type_name) = data_name.strip_prefix("custom/") {
+            self.make_path_custom_data(type_name, identifier.as_deref())?
+        } else {
+            self.make_path(data_name, identifier.as_deref())?
+        };
+        let filename = timestamps_to_filename(UnixNanos::from(start_ts), UnixNanos::from(end_ts));
+        let path = PathBuf::from(format!("{directory}/{filename}"));
+        let object_path = self.to_object_path(&path.to_string_lossy())?;
+
+        let file_exists = self.execute_async(async {
+            let exists = self.object_store.head(&object_path).await.is_ok();
+            Ok::<_, anyhow::Error>(exists)
+        })?;
+
+        if file_exists {
+            log::info!("File {} already exists, skipping write", path.display());
+            return Ok(());
+        }
+
+        let current_intervals = self.get_directory_intervals(&directory)?;
+        let mut new_intervals = current_intervals.clone();
+        new_intervals.push((start_ts, end_ts));
+
+        if !are_intervals_disjoint(&new_intervals) {
+            anyhow::bail!(
+                "Writing file {filename} with interval ({start_ts}, {end_ts}) would create \
+                non-disjoint intervals. Existing intervals: {current_intervals:?}"
+            );
+        }
+
+        let batches = vec![batch];
+        self.execute_async(async {
+            write_batches_to_object_store(
+                &batches,
+                self.object_store.clone(),
+                &object_path,
+                Some(self.compression),
+                Some(self.max_row_group_size),
+                None,
+            )
+            .await
+        })?;
+
+        Ok(())
+    }
+
+    fn apply_stream_conversion_transforms(
+        mut batches: Vec<RecordBatch>,
+        use_ts_event_for_ts_init: bool,
+    ) -> anyhow::Result<Option<RecordBatch>> {
+        if batches.is_empty() {
+            return Ok(None);
+        }
+
+        let schema = batches[0].schema();
+        let mut metadata = schema.metadata().clone();
+        let mut metadata_changed = false;
+
+        if let Some(bar_type_str) = metadata.get("bar_type").cloned()
+            && bar_type_str.ends_with("-INTERNAL")
+        {
+            metadata.insert(
+                "bar_type".to_string(),
+                bar_type_str.replace("-INTERNAL", "-EXTERNAL"),
+            );
+            metadata_changed = true;
+        }
+
+        let schema = if metadata_changed {
+            Arc::new(schema.as_ref().clone().with_metadata(metadata))
+        } else {
+            schema
+        };
+
+        if use_ts_event_for_ts_init {
+            let ts_event_idx = schema
+                .index_of("ts_event")
+                .map_err(|_| anyhow::anyhow!("ts_event column not found"))?;
+            let ts_init_idx = schema
+                .index_of("ts_init")
+                .map_err(|_| anyhow::anyhow!("ts_init column not found"))?;
+
+            for batch in &mut batches {
+                let mut columns = batch.columns().to_vec();
+                columns[ts_init_idx] = columns[ts_event_idx].clone();
+
+                *batch = RecordBatch::try_new(schema.clone(), columns).map_err(|e| {
+                    anyhow::anyhow!("Failed to create stream conversion batch: {e}")
+                })?;
+            }
+        } else if metadata_changed {
+            for batch in &mut batches {
+                *batch = RecordBatch::try_new(schema.clone(), batch.columns().to_vec()).map_err(
+                    |e| anyhow::anyhow!("Failed to create stream conversion batch: {e}"),
+                )?;
+            }
+        }
+
+        let mut batch = concat_batches(&schema, batches.iter())
+            .map_err(|e| anyhow::anyhow!("Failed to concatenate stream batches: {e}"))?;
+
+        if batch.num_rows() == 0 {
+            return Ok(None);
+        }
+
+        if !Self::is_record_batch_monotonic_by_ts_init(&batch)? {
+            let indices = sort_to_indices(
+                Self::ts_init_array(&batch)?,
+                Some(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                None,
+            )
+            .map_err(|e| anyhow::anyhow!("Failed to sort stream conversion batch: {e}"))?;
+            batch = take_record_batch(&batch, &indices)
+                .map_err(|e| anyhow::anyhow!("Failed to reorder stream conversion batch: {e}"))?;
+        }
+
+        let ts_init = Self::ts_init_array(&batch)?;
+        if ts_init.null_count() > 0 {
+            anyhow::bail!("ts_init column contains null values");
+        }
+
+        Ok(Some(batch))
+    }
+
+    fn is_record_batch_monotonic_by_ts_init(batch: &RecordBatch) -> anyhow::Result<bool> {
+        let ts_init = Self::ts_init_array(batch)?;
+        if ts_init.null_count() > 0 {
+            anyhow::bail!("ts_init column contains null values");
+        }
+
+        for idx in 1..ts_init.len() {
+            if ts_init.value(idx) < ts_init.value(idx - 1) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn ts_init_range(batch: &RecordBatch) -> anyhow::Result<(u64, u64)> {
+        let ts_init = Self::ts_init_array(batch)?;
+        if ts_init.is_empty() {
+            anyhow::bail!("Cannot convert empty stream batch to parquet");
+        }
+
+        if ts_init.null_count() > 0 {
+            anyhow::bail!("ts_init column contains null values");
+        }
+
+        Ok((ts_init.value(0), ts_init.value(ts_init.len() - 1)))
+    }
+
+    fn ts_init_array(batch: &RecordBatch) -> anyhow::Result<&UInt64Array> {
+        let ts_init_idx = batch
+            .schema()
+            .index_of("ts_init")
+            .map_err(|_| anyhow::anyhow!("ts_init column not found"))?;
+        batch
+            .column(ts_init_idx)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| anyhow::anyhow!("ts_init column is not UInt64"))
+    }
+
+    fn identifier_from_batch_or_path(
+        batch: &RecordBatch,
+        data_name: &str,
+        feather_path: &str,
+    ) -> Option<String> {
+        let metadata = batch.schema().metadata().clone();
+        if let Some(bar_type) = metadata.get("bar_type") {
+            return Some(bar_type.clone());
+        }
+
+        if let Some(instrument_id) = metadata.get("instrument_id") {
+            return Some(instrument_id.clone());
+        }
+
+        let parts: Vec<&str> = feather_path.trim_matches('/').split('/').collect();
+        if let Some(type_name) = data_name.strip_prefix("custom/") {
+            return Self::custom_identifier_from_path(&parts, type_name);
+        }
+
+        // Stream data currently uses .../{data_name}/{identifier}/{file}.feather.
+        // Keep this fallback explicit because it depends on data_name being one path segment.
+        if parts.len() >= 3 && parts[parts.len() - 3] == data_name {
+            return Some(parts[parts.len() - 2].to_string());
+        }
+
+        None
+    }
+
+    fn custom_identifier_from_path(parts: &[&str], type_name: &str) -> Option<String> {
+        let type_idx = parts
+            .windows(2)
+            .position(|window| window[0] == "custom" && window[1] == type_name)?
+            + 1;
+        let identifier_start = type_idx + 1;
+        let file_idx = parts.len().checked_sub(1)?;
+
+        if identifier_start >= file_idx {
+            return None;
+        }
+
+        Some(parts[identifier_start..file_idx].join("/"))
+    }
+
+    fn is_supported_stream_data_type(data_name: &str) -> bool {
+        data_name.starts_with("custom/")
+            || matches!(
+                data_name,
+                "quotes"
+                    | "trades"
+                    | "order_book_deltas"
+                    | "order_book_depths"
+                    | "bars"
+                    | "index_prices"
+                    | "mark_prices"
+                    | "instrument_status"
+                    | "instrument_closes"
+                    | "funding_rate_update"
+                    | "account_state"
+                    | "order_initialized"
+                    | "order_denied"
+                    | "order_emulated"
+                    | "order_submitted"
+                    | "order_accepted"
+                    | "order_rejected"
+                    | "order_pending_cancel"
+                    | "order_canceled"
+                    | "order_cancel_rejected"
+                    | "order_expired"
+                    | "order_triggered"
+                    | "order_pending_update"
+                    | "order_released"
+                    | "order_modify_rejected"
+                    | "order_updated"
+                    | "order_filled"
+                    | "position_opened"
+                    | "position_changed"
+                    | "position_closed"
+                    | "position_adjusted"
+                    | "order_snapshot"
+                    | "position_snapshot"
+                    | "order_status_report"
+                    | "fill_report"
+                    | "position_status_report"
+                    | "execution_mass_status"
+            )
     }
 }
 

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -3846,6 +3846,229 @@ fn test_convert_stream_to_data_no_files() {
 }
 
 #[rstest]
+fn test_convert_stream_to_data_unknown_type_no_files() {
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let result = catalog.convert_stream_to_data(
+        "test_instance",
+        "unknown_data_type",
+        Some("backtest"),
+        None,
+        false,
+    );
+
+    assert!(
+        result.is_ok(),
+        "Unknown stream data types should be ignored when no files exist",
+    );
+}
+
+#[rstest]
+fn test_convert_stream_to_data_unknown_type_with_files_errors() {
+    let (temp_dir, mut catalog) = create_temp_catalog();
+    let feather_dir = temp_dir
+        .path()
+        .join("backtest")
+        .join("test_instance")
+        .join("unknown_data_type");
+    fs::create_dir_all(&feather_dir).unwrap();
+    fs::File::create(feather_dir.join("unknown_0.feather")).unwrap();
+
+    let result = catalog.convert_stream_to_data(
+        "test_instance",
+        "unknown_data_type",
+        Some("backtest"),
+        None,
+        false,
+    );
+
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown data class"),
+        "Should error once unknown stream files are present",
+    );
+}
+
+#[rstest]
+fn test_convert_stream_to_data_writes_arrow_batches_without_deserializing() {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{Array, StringArray, UInt64Array},
+        datatypes::{DataType, Field, Schema},
+        ipc::writer::StreamWriter,
+        record_batch::RecordBatch,
+    };
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let (temp_dir, mut catalog) = create_temp_catalog();
+    let feather_dir = temp_dir
+        .path()
+        .join("backtest")
+        .join("test_instance")
+        .join("quotes")
+        .join("AUDUSD.SIM");
+    fs::create_dir_all(&feather_dir).unwrap();
+
+    let mut metadata = HashMap::new();
+    metadata.insert("instrument_id".to_string(), "AUD/USD.SIM".to_string());
+    let schema = Arc::new(Schema::new_with_metadata(
+        vec![
+            Field::new("ts_init", DataType::UInt64, false),
+            Field::new("ts_event", DataType::UInt64, false),
+            Field::new("payload", DataType::Utf8, false),
+        ],
+        metadata,
+    ));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt64Array::from(vec![300, 100, 200])),
+            Arc::new(UInt64Array::from(vec![30, 10, 20])),
+            Arc::new(StringArray::from(vec!["c", "a", "b"])),
+        ],
+    )
+    .unwrap();
+
+    let feather_path = feather_dir.join("AUDUSD.SIM_0.feather");
+    let mut feather_file = fs::File::create(feather_path).unwrap();
+    let mut writer = StreamWriter::try_new(&mut feather_file, &schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+
+    catalog
+        .convert_stream_to_data("test_instance", "quotes", Some("backtest"), None, false)
+        .unwrap();
+
+    let files = catalog
+        .query_files("quotes", Some(vec!["AUD/USD.SIM".to_string()]), None, None)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+
+    let parquet_path = std::path::PathBuf::from(&files[0]);
+    let parquet_path = if parquet_path.is_absolute() {
+        parquet_path
+    } else {
+        temp_dir.path().join(parquet_path)
+    };
+    let parquet_file = fs::File::open(parquet_path).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(parquet_file).unwrap();
+    let parquet_schema = builder.schema().clone();
+    assert_eq!(
+        parquet_schema.metadata().get("instrument_id"),
+        Some(&"AUD/USD.SIM".to_string()),
+    );
+
+    let mut reader = builder.build().unwrap();
+    let parquet_batch = reader.next().unwrap().unwrap();
+    assert_eq!(parquet_batch.num_rows(), 3);
+    assert_eq!(parquet_batch.num_columns(), 3);
+
+    let ts_init = parquet_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap();
+    assert_eq!(ts_init.value(0), 100);
+    assert_eq!(ts_init.value(1), 200);
+    assert_eq!(ts_init.value(2), 300);
+
+    let payload = parquet_batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(payload.value(0), "a");
+    assert_eq!(payload.value(1), "b");
+    assert_eq!(payload.value(2), "c");
+}
+
+#[rstest]
+fn test_convert_stream_to_data_converts_bar_type_metadata_to_external() {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{StringArray, UInt64Array},
+        datatypes::{DataType, Field, Schema},
+        ipc::writer::StreamWriter,
+        record_batch::RecordBatch,
+    };
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let (temp_dir, mut catalog) = create_temp_catalog();
+    let bar_type_internal = BarType::new(
+        audusd_sim_id(),
+        BarSpecification::new(1, BarAggregation::Minute, PriceType::Bid),
+        AggregationSource::Internal,
+    )
+    .to_string();
+    let bar_type_external = BarType::new(
+        audusd_sim_id(),
+        BarSpecification::new(1, BarAggregation::Minute, PriceType::Bid),
+        AggregationSource::External,
+    )
+    .to_string();
+    let feather_dir = temp_dir
+        .path()
+        .join("backtest")
+        .join("test_instance_bars")
+        .join("bars")
+        .join(bar_type_internal.replace('/', ""));
+    fs::create_dir_all(&feather_dir).unwrap();
+
+    let mut metadata = HashMap::new();
+    metadata.insert("bar_type".to_string(), bar_type_internal);
+    let schema = Arc::new(Schema::new_with_metadata(
+        vec![
+            Field::new("ts_init", DataType::UInt64, false),
+            Field::new("ts_event", DataType::UInt64, false),
+            Field::new("payload", DataType::Utf8, false),
+        ],
+        metadata,
+    ));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt64Array::from(vec![100])),
+            Arc::new(UInt64Array::from(vec![100])),
+            Arc::new(StringArray::from(vec!["bar"])),
+        ],
+    )
+    .unwrap();
+
+    let feather_path = feather_dir.join("bars_0.feather");
+    let mut feather_file = fs::File::create(feather_path).unwrap();
+    let mut writer = StreamWriter::try_new(&mut feather_file, &schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+
+    catalog
+        .convert_stream_to_data("test_instance_bars", "bars", Some("backtest"), None, false)
+        .unwrap();
+
+    let files = catalog
+        .query_files("bars", Some(vec![bar_type_external.clone()]), None, None)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+
+    let parquet_path = std::path::PathBuf::from(&files[0]);
+    let parquet_path = if parquet_path.is_absolute() {
+        parquet_path
+    } else {
+        temp_dir.path().join(parquet_path)
+    };
+    let parquet_file = fs::File::open(parquet_path).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(parquet_file).unwrap();
+    assert_eq!(
+        builder.schema().metadata().get("bar_type"),
+        Some(&bar_type_external),
+    );
+}
+
+#[rstest]
 fn test_instrument_roundtrip_with_info_params() {
     // Roundtrip an instrument with info (Params) through the Rust catalog to ensure
     // Params serialization/deserialization is correct.

--- a/tests/unit_tests/persistence/test_catalog_pyo3.py
+++ b/tests/unit_tests/persistence/test_catalog_pyo3.py
@@ -15,6 +15,9 @@
 
 import os
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from nautilus_trader.core.nautilus_pyo3 import Bar
 from nautilus_trader.core.nautilus_pyo3 import BarAggregation
 from nautilus_trader.core.nautilus_pyo3 import BarSpecification
@@ -1647,3 +1650,60 @@ def test_convert_stream_to_data_all_data_types(catalog: LegacyParquetDataCatalog
             subdirectory="backtest",
         )
         # Should complete without error for each type
+
+
+def test_convert_stream_to_data_writes_arrow_batches_without_deserializing(
+    catalog: LegacyParquetDataCatalog,
+) -> None:
+    # Arrange
+    pyo3_catalog = ParquetDataCatalog(catalog.path)
+    feather_dir = os.path.join(
+        catalog.path,
+        "backtest",
+        "test_instance_arrow_only",
+        "quotes",
+        "AUDUSD.SIM",
+    )
+    os.makedirs(feather_dir, exist_ok=True)
+
+    schema = pa.schema(
+        [
+            pa.field("ts_init", pa.uint64(), nullable=False),
+            pa.field("ts_event", pa.uint64(), nullable=False),
+            pa.field("payload", pa.string(), nullable=False),
+        ],
+        metadata={b"instrument_id": b"AUD/USD.SIM"},
+    )
+    batch = pa.record_batch(
+        [
+            pa.array([300, 100, 200], type=pa.uint64()),
+            pa.array([30, 10, 20], type=pa.uint64()),
+            pa.array(["c", "a", "b"], type=pa.string()),
+        ],
+        schema=schema,
+    )
+
+    feather_path = os.path.join(feather_dir, "AUDUSD.SIM_0.feather")
+    with (
+        open(feather_path, "wb") as feather_file,
+        pa.ipc.new_stream(feather_file, schema) as writer,
+    ):
+        writer.write_batch(batch)
+
+    # Act
+    pyo3_catalog.convert_stream_to_data(
+        "test_instance_arrow_only",
+        "quotes",
+        subdirectory="backtest",
+    )
+
+    # Assert
+    files = pyo3_catalog.query_files("quotes", ["AUD/USD.SIM"])
+    assert len(files) == 1
+
+    parquet_path = files[0] if os.path.isabs(files[0]) else os.path.join(catalog.path, files[0])
+    parquet_table = pq.read_table(parquet_path)
+    assert parquet_table.schema.metadata[b"instrument_id"] == b"AUD/USD.SIM"
+    assert parquet_table["ts_init"].to_pylist() == [100, 200, 300]
+    assert parquet_table["ts_event"].to_pylist() == [10, 20, 30]
+    assert parquet_table["payload"].to_pylist() == ["a", "b", "c"]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Fix data engine request workflow cleanup

## Summary

- Cleans up `RequestWorkflowState` and request bookkeeping when data engine requests are rejected before a response can be emitted.

- Routes grouped `Instrument` responses through the request-group fan-in path so joins and grouped requests cannot be bypassed by the instrument special case.

- Removes grouped child requests from `_requests` when their responses are merged, matching the existing workflow-state cleanup.

- Validates joined request IDs before cloning join children, aborting stale joins instead of raising on missing request state.

## Tests

- `make build-debug`.

- `uv run --no-sync pytest tests/unit_tests/data/test_engine.py -k "workflow_state or grouped_workflow_state"`.

- `uv run --no-sync pytest tests/unit_tests/data/test_engine.py`.

- `make format`.

- `make pre-commit`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
