### PR TITLE
Enable filesystem JSON logging in the Rust LiveNode

### DIFF
--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -381,7 +381,7 @@ impl Logger {
             use_tracing: _,
             bypass_logging: _,
             file_config: _,
-            clear_log_file: _,
+            clear_log_file,
         } = config;
 
         // Pre-sort module filters by descending path length for O(n) longest-prefix lookup
@@ -399,7 +399,13 @@ impl Logger {
         let mut file_writer_opt = if fileout_level == LevelFilter::Off {
             None
         } else {
-            FileWriter::new(trader_id, instance_id, file_config, fileout_level)
+            FileWriter::new(
+                trader_id,
+                instance_id,
+                file_config,
+                fileout_level,
+                clear_log_file,
+            )
         };
 
         let process_event = |event: LogEvent,

--- a/crates/common/src/logging/writer.rs
+++ b/crates/common/src/logging/writer.rs
@@ -218,6 +218,7 @@ impl FileWriter {
         instance_id: String,
         file_config: FileWriterConfig,
         fileout_level: LevelFilter,
+        clear_log_file: bool,
     ) -> Option<Self> {
         // Set up log file
         let json_format = match file_config.file_format.as_ref().map(|s| s.to_lowercase()) {
@@ -239,6 +240,13 @@ impl FileWriter {
                     return None;
                 }
             };
+
+        if clear_log_file
+            && file_path.exists()
+            && let Err(e) = File::create(&file_path)
+        {
+            eprintln!("{NAUTILUS_PREFIX} Error clearing log file: {e}");
+        }
 
         match File::options()
             .create(true)
@@ -301,7 +309,7 @@ impl FileWriter {
             }
         };
 
-        let suffix = if is_json_format { "json" } else { "log" };
+        let suffix = if is_json_format { "jsonl" } else { "log" };
         let mut file_path = PathBuf::new();
 
         if let Some(directory) = file_config.directory.as_ref() {
@@ -472,6 +480,7 @@ mod tests {
             "instance-123".to_string(),
             config,
             LevelFilter::Info,
+            false,
         )
         .unwrap();
 
@@ -526,6 +535,7 @@ mod tests {
             "instance-123".to_string(),
             config,
             LevelFilter::Info,
+            false,
         );
 
         assert!(writer.is_none());
@@ -549,6 +559,7 @@ mod tests {
             "instance-123".to_string(),
             config,
             LevelFilter::Info,
+            false,
         );
 
         assert!(writer.is_none());
@@ -570,6 +581,7 @@ mod tests {
             "instance-123".to_string(),
             config,
             LevelFilter::Info,
+            false,
         )
         .unwrap();
 
@@ -593,11 +605,12 @@ mod tests {
             "instance-123".to_string(),
             config,
             LevelFilter::Info,
+            false,
         )
         .unwrap();
 
         assert!(writer.json_format);
-        assert!(writer.path.extension().unwrap() == "json");
+        assert!(writer.path.extension().unwrap() == "jsonl");
     }
 
     #[rstest]

--- a/crates/common/src/python/logging.rs
+++ b/crates/common/src/python/logging.rs
@@ -35,6 +35,44 @@ use crate::{
 #[pymethods]
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 impl LoggerConfig {
+    #[new]
+    #[pyo3(signature = (
+        stdout_level=None,
+        fileout_level=None,
+        component_levels=None,
+        is_colored=None,
+        print_config=None,
+        bypass_logging=None,
+        log_components_only=None,
+        file_config=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        stdout_level: Option<LogLevel>,
+        fileout_level: Option<LogLevel>,
+        component_levels: Option<std::collections::HashMap<String, String>>,
+        is_colored: Option<bool>,
+        print_config: Option<bool>,
+        bypass_logging: Option<bool>,
+        log_components_only: Option<bool>,
+        file_config: Option<FileWriterConfig>,
+    ) -> PyResult<Self> {
+        let component_levels = parse_component_levels(component_levels).map_err(to_pyvalue_err)?;
+        Ok(Self::new(
+            stdout_level.map_or(LevelFilter::Info, map_log_level_to_filter),
+            fileout_level.map_or(LevelFilter::Off, map_log_level_to_filter),
+            component_levels,
+            AHashMap::new(),
+            log_components_only.unwrap_or(false),
+            is_colored.unwrap_or(true),
+            print_config.unwrap_or(false),
+            false,
+            bypass_logging.unwrap_or(false),
+            file_config,
+            false,
+        ))
+    }
+
     /// Parses a configuration from a spec string.
     ///
     /// # Format

--- a/crates/live/src/config.rs
+++ b/crates/live/src/config.rs
@@ -623,18 +623,6 @@ impl LiveNodeConfig {
             );
         }
 
-        if self.logging.file_config.is_some() {
-            anyhow::bail!(
-                "LoggerConfig.file_config is not supported by the Rust live runtime yet (use py_init_logging)"
-            );
-        }
-
-        if self.logging.clear_log_file {
-            anyhow::bail!(
-                "LoggerConfig.clear_log_file is not supported by the Rust live runtime yet"
-            );
-        }
-
         self.data_engine.validate_runtime_support()?;
         self.risk_engine.validate_runtime_support()?;
         self.exec_engine.validate_runtime_support()?;
@@ -1224,7 +1212,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_validate_runtime_support_rejects_file_config() {
+    fn test_validate_runtime_support_accepts_file_config() {
         use nautilus_common::logging::writer::FileWriterConfig;
 
         let config = LiveNodeConfig {
@@ -1235,12 +1223,11 @@ mod tests {
             ..Default::default()
         };
 
-        let error = config.validate_runtime_support().unwrap_err().to_string();
-        assert!(error.contains("file_config"));
+        assert!(config.validate_runtime_support().is_ok());
     }
 
     #[rstest]
-    fn test_validate_runtime_support_rejects_clear_log_file() {
+    fn test_validate_runtime_support_accepts_clear_log_file() {
         let config = LiveNodeConfig {
             logging: LoggerConfig {
                 clear_log_file: true,
@@ -1249,8 +1236,7 @@ mod tests {
             ..Default::default()
         };
 
-        let error = config.validate_runtime_support().unwrap_err().to_string();
-        assert!(error.contains("clear_log_file"));
+        assert!(config.validate_runtime_support().is_ok());
     }
 
     #[rstest]

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -27,7 +27,6 @@ use nautilus_common::{
     logging::{
         headers, init_logging,
         logger::{LogGuard, LoggerConfig},
-        writer::FileWriterConfig,
     },
     messages::system::ShutdownSystem,
     msgbus::{
@@ -220,12 +219,8 @@ impl NautilusKernel {
         #[cfg(feature = "tracing-bridge")]
         let use_tracing = config.use_tracing;
 
-        let log_guard = match init_logging(
-            trader_id,
-            instance_id,
-            config,
-            FileWriterConfig::default(), // TODO: Properly incorporate file writer config
-        ) {
+        let file_config = config.file_config.clone().unwrap_or_default();
+        let log_guard = match init_logging(trader_id, instance_id, config, file_config) {
             Ok(guard) => guard,
             Err(e) => {
                 // Only recover from SetLoggerError (logger already registered).

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -183,7 +183,7 @@ class NautilusKernel:
         if logging.clear_log_file and logging.log_directory and logging.log_file_name:
             file_path = Path(
                 logging.log_directory,
-                f"{logging.log_file_name}.{'log' if logging.log_file_format is None else 'json'}",
+                f"{logging.log_file_name}.{'log' if logging.log_file_format is None else 'jsonl'}",
             )
 
             if file_path.exists():

--- a/python/nautilus_trader/common/__init__.pyi
+++ b/python/nautilus_trader/common/__init__.pyi
@@ -190,6 +190,17 @@ class LogGuard: ...
 
 @typing.final
 class LoggerConfig:
+    def __init__(
+        self,
+        stdout_level: LogLevel | None = None,
+        fileout_level: LogLevel | None = None,
+        component_levels: dict[str, str] | None = None,
+        is_colored: bool | None = None,
+        print_config: bool | None = None,
+        bypass_logging: bool | None = None,
+        log_components_only: bool | None = None,
+        file_config: FileWriterConfig | None = None,
+    ) -> None: ...
     @staticmethod
     def from_spec(spec: str) -> LoggerConfig: ...
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The Rust LiveNode runtime previously rejected `LoggerConfig.file_config` and `LoggerConfig.clear_log_file` at validation time, meaning filesystem logging only worked through the Python path. This PR removes those guards and wires both features through the Rust runtime end-to-end.

#### Enable filesystem logging in the Rust runtime

- **Remove validation bails** (`crates/live/src/config.rs`): Deleted the two `anyhow::bail!` blocks that rejected `file_config` and `clear_log_file` in `validate_runtime_support()`. Updated corresponding tests from "rejects" to "accepts".
- **Forward `file_config` through the kernel** (`crates/system/src/kernel.rs`): Replaced `FileWriterConfig::default()` with `config.file_config.clone().unwrap_or_default()` so the user-supplied config actually reaches the `FileWriter`.

#### Wire clear_log_file support

- **`FileWriter::new()` gains a `clear_log_file` parameter** (`crates/common/src/logging/writer.rs`): When `true` and the log file already exists, it is truncated via `File::create()` before opening for append — matching the existing Python-path behavior in `kernel.py`.
- **Forward from `LoggerConfig`** (`crates/common/src/logging/logger.rs`): The `clear_log_file` field is now destructured and passed through to `FileWriter::new()` instead of being discarded with `_`.

#### Add LoggerConfig Python constructor

- **`#[new]` constructor** (`crates/common/src/python/logging.rs`): Exposes a `LoggerConfig.__init__()` with all 8 optional parameters (including `file_config: Optional[FileWriterConfig]`), so Python users can construct configs directly instead of only via `LoggerConfig.from_spec()`.
- **Type stub** (`python/nautilus_trader/common/__init__.pyi`): Added matching `__init__` signature for IDE/type-checker support.

#### Use .jsonl extension for JSON log files

- Changed the file extension from `.json` to `.jsonl` in `FileWriter` (`writer.rs`) and the Python clear path (`kernel.py`), since the output is newline-delimited JSON (one object per line), not a JSON array.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore