### PR TITLE
Fix Interactive Brokers spread fill races where execDetails arrives before openOrder

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,6 +43,7 @@ Released on TBD (UTC).
 - Fixed Hyperliquid bracket order submission grouping (#3810), thanks for reporting @jindrichsirucek
 - Fixed Hyperliquid modify cancel-replace emitting stale `OrderCanceled` (#3827), thanks for reporting @P1YU5H-50N1
 - Fixed IB Gateway Docker image failing on ARM64 hosts (#3813), thanks for reporting @Baki-0501
+- Fixed Interactive Brokers spread (BAG) order fills silently dropped when `execDetails` arrives before `openOrder` assigns `venue_order_id` (#3957), thanks for reporting @taozle
 - Fixed Kraken Futures limit order `OrderUpdated` panic from wire `stop_price: 0.0` treated as trigger price
 - Fixed Kraken Futures margin-account balance parse violating the `AccountBalance` invariant (`total == locked + free`) when Kraken's `af` field and the derived `amount - af` round independently at the currency precision
 - Fixed Kraken Spot quote-quantity orders never reaching terminal state from base/quote size mismatch

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,7 +43,6 @@ Released on TBD (UTC).
 - Fixed Hyperliquid bracket order submission grouping (#3810), thanks for reporting @jindrichsirucek
 - Fixed Hyperliquid modify cancel-replace emitting stale `OrderCanceled` (#3827), thanks for reporting @P1YU5H-50N1
 - Fixed IB Gateway Docker image failing on ARM64 hosts (#3813), thanks for reporting @Baki-0501
-- Fixed Interactive Brokers spread (BAG) order fills silently dropped when `execDetails` arrives before `openOrder` assigns `venue_order_id` (#3957), thanks for reporting @taozle
 - Fixed Kraken Futures limit order `OrderUpdated` panic from wire `stop_price: 0.0` treated as trigger price
 - Fixed Kraken Futures margin-account balance parse violating the `AccountBalance` invariant (`total == locked + free`) when Kraken's `af` field and the derived `amount - af` round independently at the currency precision
 - Fixed Kraken Spot quote-quantity orders never reaching terminal state from base/quote size mismatch

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1459,6 +1459,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         order: Order,
         ib_order: IBOrder | None = None,
         reason: str = "",
+        venue_order_id: VenueOrderId | None = None,
     ) -> None:
         if status == OrderStatus.SUBMITTED:
             self.generate_order_submitted(
@@ -1494,11 +1495,16 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             self._log.warning(f"Order {order.client_order_id} is {status.name}")
         elif status == OrderStatus.CANCELED:
             if order.status != OrderStatus.CANCELED:
+                # Fall back to the venue_order_id from the orderStatus callback when the
+                # cached order has none yet (openOrder may not have fired before the cancel,
+                # in which case order.venue_order_id is still None and propagating that None
+                # through OrderCanceled would lose the mapping for subsequent FillReports).
+                resolved_venue_order_id = order.venue_order_id or venue_order_id
                 self.generate_order_canceled(
                     strategy_id=order.strategy_id,
                     instrument_id=order.instrument_id,
                     client_order_id=order.client_order_id,
-                    venue_order_id=order.venue_order_id,
+                    venue_order_id=resolved_venue_order_id,
                     ts_event=self._clock.timestamp_ns(),
                 )
         elif status == OrderStatus.REJECTED:
@@ -1720,6 +1726,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                     status=status,
                     order=nautilus_order,
                     reason=reason,
+                    venue_order_id=venue_order_id,
                 )
 
             if status in (

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -243,7 +243,9 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # Queue spread combo fills until orderStatus provides the matching avg fill price chunk.
         self._pending_combo_fills: dict[
             ClientOrderId,
-            deque[tuple[Order, Execution, IBContract, CommissionAndFeesReport, Decimal]],
+            deque[
+                tuple[Order, Execution, IBContract, CommissionAndFeesReport, Decimal, VenueOrderId]
+            ],
         ] = {}
         self._pending_combo_fill_avgs: dict[ClientOrderId, deque[tuple[Decimal, Price]]] = {}
 

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1787,7 +1787,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # this, downstream FillReports during continuous reconciliation cannot map
         # venue_order_id back to client_order_id and are silently dropped.
         if nautilus_order.venue_order_id is None:
-            self._log.info(
+            self._log.warning(
                 f"execDetails arrived before openOrder for {nautilus_order.client_order_id}; "
                 f"synthesizing OrderAccepted with venue_order_id={venue_order_id}",
             )

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1780,6 +1780,25 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
             return
 
+        # IB's execDetails callback can race ahead of openOrder for fast fills (typically
+        # market orders or marketable limit orders on liquid combos). The Execution object
+        # is authoritative for venue_order_id, so backfill the mapping into the cache by
+        # synthesizing an OrderAccepted event when openOrder hasn't fired yet. Without
+        # this, downstream FillReports during continuous reconciliation cannot map
+        # venue_order_id back to client_order_id and are silently dropped.
+        if nautilus_order.venue_order_id is None:
+            self._log.info(
+                f"execDetails arrived before openOrder for {nautilus_order.client_order_id}; "
+                f"synthesizing OrderAccepted with venue_order_id={venue_order_id}",
+            )
+            self.generate_order_accepted(
+                strategy_id=nautilus_order.strategy_id,
+                instrument_id=nautilus_order.instrument_id,
+                client_order_id=nautilus_order.client_order_id,
+                venue_order_id=venue_order_id,
+                ts_event=timestring_to_timestamp(execution.time).value,
+            )
+
         # Check if this is a spread order and handle accordingly
         if is_generic_spread_id(nautilus_order.instrument_id):
             self._handle_spread_execution(
@@ -1787,6 +1806,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 execution,
                 contract,
                 commission_report,
+                venue_order_id,
             )
             return
 
@@ -1809,7 +1829,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             strategy_id=nautilus_order.strategy_id,
             instrument_id=nautilus_order.instrument_id,
             client_order_id=nautilus_order.client_order_id,
-            venue_order_id=nautilus_order.venue_order_id,
+            venue_order_id=venue_order_id,
             venue_position_id=None,
             trade_id=TradeId(execution.execId),
             order_side=OrderSide[ORDER_SIDE_TO_ORDER_ACTION[execution.side]],
@@ -1915,6 +1935,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 contract,
                 commission_report,
                 combo_quantity,
+                venue_order_id,
             ) = pending_combo_fills[0]
             avg_chunk_quantity, avg_px = pending_avg_chunks[0]
 
@@ -1927,6 +1948,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 execution,
                 contract,
                 commission_report,
+                venue_order_id,
                 avg_px_override=avg_px,
             )
 
@@ -1946,6 +1968,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         execution: Execution,
         contract: IBContract,
         commission_report: CommissionAndFeesReport,
+        venue_order_id: VenueOrderId,
     ) -> None:
         """
         Handle spread execution by translating leg fills to combo progress and
@@ -1982,6 +2005,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                         contract,
                         commission_report,
                         combo_quantity,
+                        venue_order_id,
                     ),
                 )
                 self._flush_pending_combo_fills(nautilus_order.client_order_id)
@@ -1992,6 +2016,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 execution,
                 contract,
                 commission_report,
+                venue_order_id,
             )
         except Exception as e:
             self._log.error(f"Error handling spread execution: {e}")
@@ -2002,6 +2027,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         execution: Execution,
         contract: IBContract,
         commission_report: CommissionAndFeesReport,
+        venue_order_id: VenueOrderId,
         avg_px_override: Price | None = None,
     ) -> None:
         """
@@ -2066,7 +2092,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 strategy_id=nautilus_order.strategy_id,
                 instrument_id=nautilus_order.instrument_id,  # Keep spread ID
                 client_order_id=nautilus_order.client_order_id,
-                venue_order_id=nautilus_order.venue_order_id,
+                venue_order_id=venue_order_id,
                 venue_position_id=None,
                 trade_id=TradeId(execution.execId),
                 order_side=combo_order_side,
@@ -2100,6 +2126,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         execution: Execution,
         contract: IBContract,
         commission_report: CommissionAndFeesReport,
+        venue_order_id: VenueOrderId,
     ) -> None:
         """
         Generate individual leg fill for portfolio updates.
@@ -2138,9 +2165,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             leg_trade_id_str = f"{execution.execId}-{leg_position}"
             leg_trade_id = TradeId(leg_trade_id_str)
 
-            # Unique venue_order_id for leg, based on parent order's venue_order_id
-            base_venue_order_id = nautilus_order.venue_order_id
-            leg_venue_order_id = VenueOrderId(f"{base_venue_order_id.value}-LEG-{leg_position}")
+            # Unique venue_order_id for leg, derived from venue_order_id resolved at the
+            # execDetails entry point (defends against execDetails arriving before openOrder
+            # has set nautilus_order.venue_order_id).
+            leg_venue_order_id = VenueOrderId(f"{venue_order_id.value}-LEG-{leg_position}")
 
             price_magnifier = self.instrument_provider.get_price_magnifier(leg_instrument_id)
             converted_execution_price = ib_price_to_nautilus_price(execution.price, price_magnifier)

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -1223,6 +1223,48 @@ async def test_spread_execution_handles_exec_details_before_open_order(mocker, e
 
 
 @pytest.mark.asyncio
+async def test_on_order_status_cancel_propagates_venue_order_id_when_order_unaccepted(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    # Regression test: when an orderStatus(Cancelled) callback arrives before
+    # openOrder has set venue_order_id on the cached Order, the OrderCanceled
+    # event must still carry the venue_order_id from the orderStatus payload.
+    # Otherwise the cache loses the venue_order_id->client_order_id mapping
+    # and subsequent FillReports during reconciliation can't be attributed.
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    client_order_id = ClientOrderId("O-CANCEL-RACE-001")
+    order = TestExecStubs.limit_order(
+        instrument=instrument,
+        client_order_id=client_order_id,
+    )
+    order = TestExecStubs.make_submitted_order(order)
+    cache.add_order(order, None)
+    assert order.venue_order_id is None
+
+    venue_order_id = VenueOrderId("8201")
+    generate_order_canceled = mocker.spy(exec_client, "generate_order_canceled")
+
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Cancelled",
+        venue_order_id=venue_order_id,
+    )
+
+    assert generate_order_canceled.call_count == 1
+    assert generate_order_canceled.call_args.kwargs["venue_order_id"] == venue_order_id
+
+
+@pytest.mark.asyncio
 async def test_on_account_update(mocker, exec_client):
     # TODO:
     pass

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -1151,6 +1151,78 @@ async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
 
 
 @pytest.mark.asyncio
+async def test_spread_execution_handles_exec_details_before_open_order(mocker, exec_client, cache):
+    # Regression test: when IB delivers execDetails before openOrder has assigned
+    # venue_order_id (typical for fast market-order combo fills), the spread fill
+    # paths must derive venue_order_id from the Execution and not crash with
+    # NoneType errors. The cache must also learn the venue_order_id mapping so
+    # subsequent FillReports during reconciliation can be attributed correctly.
+    call = make_option_contract("SPY C400", OptionKind.CALL)
+    put = make_option_contract("SPY P390", OptionKind.PUT)
+    spread = make_option_spread(call, put)
+
+    for instrument in [call, put, spread]:
+        exec_client.instrument_provider.add(instrument)
+        cache.add_instrument(instrument)
+
+    call_contract = IBTestContractStubs.create_contract(
+        conId=9101,
+        symbol="SPY",
+        secType="OPT",
+        exchange="SMART",
+        currency="USD",
+        localSymbol="SPY C400",
+    )
+    exec_client.instrument_provider.contract_id_to_instrument_id[call_contract.conId] = call.id
+
+    client_order_id = ClientOrderId("O-SPREAD-RACE-001")
+    # Order is in SUBMITTED state without venue_order_id — i.e. openOrder has not
+    # fired yet. This is the precondition for the race.
+    order = TestExecStubs.limit_order(
+        instrument=spread,
+        client_order_id=client_order_id,
+        quantity=Quantity.from_int(1),
+        price=Price.from_str("1.00"),
+    )
+    order = TestExecStubs.make_submitted_order(order)
+    cache.add_order(order, None)
+    assert order.venue_order_id is None
+
+    venue_order_id = VenueOrderId("7101")
+    generate_order_accepted = mocker.spy(exec_client, "generate_order_accepted")
+    generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
+
+    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution.orderRef = str(client_order_id)
+    execution.execId = "race-fill-1"
+    execution.shares = Decimal(1)
+    execution.price = 3.30
+    commission_report = IBTestExecStubs.commission()
+    commission_report.execId = execution.execId
+
+    # Should not raise (regression: previously crashed with TypeError /
+    # AttributeError on nautilus_order.venue_order_id == None).
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution,
+        commission_report=commission_report,
+        contract=call_contract,
+    )
+
+    # An OrderAccepted event must be synthesized so the cache learns the
+    # venue_order_id mapping.
+    assert generate_order_accepted.call_count == 1
+    assert generate_order_accepted.call_args.kwargs["venue_order_id"] == venue_order_id
+
+    # The leg fill must be generated with venue_order_id derived from the
+    # execution rather than crashing.
+    assert generate_order_filled.call_count >= 1
+    leg_fill_call = generate_order_filled.call_args_list[0].kwargs
+    assert leg_fill_call["instrument_id"] == call.id
+    assert leg_fill_call["venue_order_id"] == VenueOrderId(f"{venue_order_id.value}-LEG-0")
+
+
+@pytest.mark.asyncio
 async def test_on_account_update(mocker, exec_client):
     # TODO:
     pass


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes a silent failure in the Interactive Brokers adapter where spread (BAG/combo) order fills are dropped when IB delivers `execDetails` before the `openOrder` callback assigns `venue_order_id` on the cached `Order`. Every spread-fill code path that read `nautilus_order.venue_order_id` raised an exception that the surrounding `try/except` swallowed, so the strategy never received `OrderFilled`, the `venue_order_id` mapping never reached the cache, and continuous reconciliation later cancelled the order locally — turning every subsequent `FillReport` into a `FillReport received before OrderStatusReport` warning.

The fix has two layers:

1. **Resolve `venue_order_id` from the `Execution` object.** `Execution.orderId`/`permId` are authoritative regardless of `openOrder` timing. Compute `venue_order_id` once at the `_on_exec_details` entry point and thread it through `_handle_spread_execution`, the `_pending_combo_fills` queue, `_generate_combo_fill`, and `_generate_leg_fill`. The single-leg path also switches to the execution-derived id rather than `nautilus_order.venue_order_id`.
2. **Backfill the cache mapping via a synthesized `OrderAccepted`.** When `_on_exec_details` finds the cached order without `venue_order_id`, generate `OrderAccepted` with the derived id before any fill events. The state transition `SUBMITTED → ACCEPTED → FILLED` is valid, and downstream `FillReport`s during continuous reconciliation can now resolve `venue_order_id` → `client_order_id` correctly.

## Related Issues/PRs

Closes #3949.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A — internal helper signatures (`_handle_spread_execution`, `_generate_combo_fill`, `_generate_leg_fill`) gain a `venue_order_id` parameter, but they are private and only invoked from `_on_exec_details` / `_flush_pending_combo_fills`, which are updated in-tree.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

(No documentation changes in this PR.)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

New regression test `test_spread_execution_handles_exec_details_before_open_order` in `tests/integration_tests/adapters/interactive_brokers/test_execution.py` exercises the race directly: a `SUBMITTED`-only spread order (no `venue_order_id`) receives `execDetails` and must produce a leg fill carrying the derived `venue_order_id` and a synthesized `OrderAccepted`, without raising. Existing spread combo tests (`test_spread_combo_fill_waits_for_order_status_avg_px`, `test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills`) continue to pass — they construct accepted orders, so the new Layer 2 branch does not fire and Layer 1 yields the same `venue_order_id` they were using before.