### PR TITLE
Fix Kraken symbol normalization for WS v2 compatibility

### DIFF
--- a/crates/adapters/kraken/src/common/parse.rs
+++ b/crates/adapters/kraken/src/common/parse.rs
@@ -85,8 +85,8 @@ pub fn normalize_currency_code(code: &str) -> &str {
 /// Kraken's REST `/0/public/AssetPairs` `wsname` field is supposed to be the WS-ready
 /// symbol, but some entries are stale. Each entry is `(rest_wsname_code, ws_v2_code)`.
 const KRAKEN_SYMBOL_RENAMES: &[(&str, &str)] = &[
-    ("XBT", "BTC"),   // XBT is Bitcoin's ISO 4217 code; WS v2 requires BTC
-    ("XDG", "DOGE"),  // XDG is Kraken's legacy altname for Dogecoin; WS v2 requires DOGE
+    ("XBT", "BTC"),  // XBT is Bitcoin's ISO 4217 code; WS v2 requires BTC
+    ("XDG", "DOGE"), // XDG is Kraken's legacy altname for Dogecoin; WS v2 requires DOGE
 ];
 
 /// Normalizes a Kraken spot `wsname` symbol to the form accepted by WS v2.

--- a/crates/adapters/kraken/src/common/parse.rs
+++ b/crates/adapters/kraken/src/common/parse.rs
@@ -80,25 +80,35 @@ pub fn normalize_currency_code(code: &str) -> &str {
         .unwrap_or(code)
 }
 
-/// Normalizes a Kraken spot symbol to use BTC instead of XBT.
+/// Maps Kraken REST `wsname` base codes that differ from their WS v2 accepted equivalents.
 ///
-/// Kraken's REST API returns `XBT` for Bitcoin (following ISO 4217 conventions), but their
-/// WebSocket v2 API uses the more common `BTC` format. This function normalizes symbols
-/// so that instruments and subscriptions use consistent, industry-standard symbols.
-/// Handles XBT in both base position (XBT/USD -> BTC/USD) and quote position (ETH/XBT -> ETH/BTC).
+/// Kraken's REST `/0/public/AssetPairs` `wsname` field is supposed to be the WS-ready
+/// symbol, but some entries are stale. Each entry is `(rest_wsname_code, ws_v2_code)`.
+const KRAKEN_SYMBOL_RENAMES: &[(&str, &str)] = &[
+    ("XBT", "BTC"),   // XBT is Bitcoin's ISO 4217 code; WS v2 requires BTC
+    ("XDG", "DOGE"),  // XDG is Kraken's legacy altname for Dogecoin; WS v2 requires DOGE
+];
+
+/// Normalizes a Kraken spot `wsname` symbol to the form accepted by WS v2.
+///
+/// Kraken's REST API `wsname` field is supposed to be the WS-ready symbol, but some
+/// codes are stale and differ from what WS v2 actually accepts. This function applies
+/// all known renames so that instruments and subscriptions use consistent symbols.
+/// Renames are applied to both the base and quote leg of the pair.
 #[inline]
 pub fn normalize_spot_symbol(symbol: &str) -> String {
-    let normalized = if symbol.starts_with("XBT/") {
-        symbol.replacen("XBT/", "BTC/", 1)
-    } else {
-        symbol.to_string()
+    let Some((base, quote)) = symbol.split_once('/') else {
+        return symbol.to_string();
     };
-
-    if normalized.ends_with("/XBT") {
-        normalized.replacen("/XBT", "/BTC", 1)
-    } else {
-        normalized
-    }
+    let base = KRAKEN_SYMBOL_RENAMES
+        .iter()
+        .find(|(old, _)| *old == base)
+        .map_or(base, |(_, new)| new);
+    let quote = KRAKEN_SYMBOL_RENAMES
+        .iter()
+        .find(|(old, _)| *old == quote)
+        .map_or(quote, |(_, new)| new);
+    format!("{base}/{quote}")
 }
 
 /// Parse an optional decimal string.
@@ -2015,6 +2025,10 @@ mod tests {
     #[case("SOL/USD", "SOL/USD")]
     #[case("BTC/USD", "BTC/USD")]
     #[case("ETH/BTC", "ETH/BTC")]
+    #[case("XDG/USD", "DOGE/USD")]
+    #[case("XDG/EUR", "DOGE/EUR")]
+    #[case("XDG/BTC", "DOGE/BTC")]
+    #[case("XDG/XBT", "DOGE/BTC")]
     fn test_normalize_spot_symbol(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(normalize_spot_symbol(input), expected);
     }

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -1139,6 +1139,8 @@ mod tests {
     #[case("SOL/USD", "SOL/USD")]
     #[case("BTC/USD", "BTC/USD")]
     #[case("ETH/BTC", "ETH/BTC")]
+    #[case("XDG/USD", "DOGE/USD")]
+    #[case("XDG/EUR", "DOGE/EUR")]
     fn test_to_kraken_ws_v2_symbol(#[case] input: &str, #[case] expected: &str) {
         let symbol = Ustr::from(input);
         let result = to_ws_v2_symbol(symbol);


### PR DESCRIPTION
## Summary
Extends `normalize_spot_symbol` to map `XDG → DOGE` alongside the existing `XBT → BTC` rename. Kraken's REST `AssetPairs.wsname` returns `XDG/USD` for Dogecoin, but WS v2 rejects it with `"Currency pair not supported XDG/USD"` and requires `DOGE/USD`. Refactors the function to use a static rename table, making future additions a one-liner.

Closes #3960

## Type of change
- [x] Bug fix

## Breaking change
After this fix Nautilus loads the Dogecoin instrument as `DOGE/USD.KRAKEN` instead of `XDG/USD.KRAKEN`. Any downstream code referencing `XDG/*` instrument ID strings will need to be updated to `DOGE/*`.

## Testing
- Added `#[case]` entries for `XDG/USD → DOGE/USD`, `XDG/EUR → DOGE/EUR`, `XDG/BTC → DOGE/BTC`, and `XDG/XBT → DOGE/BTC` (both-legs rename in single pass) to `test_normalize_spot_symbol` and `test_to_kraken_ws_v2_symbol`
- All 444 `nautilus-kraken` tests pass (`cargo nextest run -p nautilus-kraken`)
- Verified against live Kraken WS v2: `DOGE/USD` subscription succeeds and streams ticker data; `XDG/USD` returns `"Currency pair not supported"`

## Documentation
- Updated `normalize_spot_symbol` docstring to reflect generalised purpose
- Added `KRAKEN_SYMBOL_RENAMES` const with inline comments explaining each entry