### PR TITLE
Accept PyO3 IB live client configs in TradingNodeConfig

### DIFF
--- a/nautilus_trader/live/config.py
+++ b/nautilus_trader/live/config.py
@@ -344,7 +344,10 @@ class TradingNodeConfig(NautilusKernelConfig, frozen=True):
         config: Any,
         config_type: type[LiveDataClientConfig | LiveExecClientConfig],
     ) -> ImportableConfig | LiveDataClientConfig | LiveExecClientConfig:
-        if isinstance(config, (ImportableConfig, LiveDataClientConfig, LiveExecClientConfig)):
+        if isinstance(
+            config,
+            (ImportableConfig, LiveDataClientConfig, LiveExecClientConfig),
+        ) or TradingNodeConfig._is_live_client_config(config):
             return config
 
         if not isinstance(config, dict):
@@ -361,3 +364,7 @@ class TradingNodeConfig(NautilusKernelConfig, frozen=True):
             )
 
         return msgspec.json.decode(encoded, type=config_type, dec_hook=msgspec_decoding_hook)
+
+    @staticmethod
+    def _is_live_client_config(config: Any) -> bool:
+        return isinstance(getattr(config, "routing", None), RoutingConfig)

--- a/tests/integration_tests/live/test_live_node.py
+++ b/tests/integration_tests/live/test_live_node.py
@@ -151,6 +151,29 @@ class TestTradingNodeConfiguration:
             == "nautilus_trader.adapters.binance.factories:BinanceLiveExecClientFactory"
         )
 
+    def test_node_config_accepts_pyo3_client_configs(self):
+        # Arrange
+        from nautilus_trader.adapters.interactive_brokers_pyo3 import (
+            InteractiveBrokersDataClientConfig,
+        )
+        from nautilus_trader.adapters.interactive_brokers_pyo3 import (
+            InteractiveBrokersExecClientConfig,
+        )
+
+        data_client_config = InteractiveBrokersDataClientConfig()
+        exec_client_config = InteractiveBrokersExecClientConfig()
+
+        # Act
+        config = TradingNodeConfig(
+            logging=LoggingConfig(bypass_logging=True),
+            data_clients={"IB": data_client_config},
+            exec_clients={"IB": exec_client_config},
+        )
+
+        # Assert
+        assert config.data_clients["IB"] is data_client_config
+        assert config.exec_clients["IB"] is exec_client_config
+
     def test_setting_instance_id(self, monkeypatch, event_loop_for_setup):
         # Arrange
         loop = event_loop_for_setup


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes `TradingNodeConfig` rejecting already-constructed PyO3 Interactive Brokers data and execution client configs with `TypeError`.
- Preserves existing parsing behavior for `ImportableConfig`, `LiveDataClientConfig`, `LiveExecClientConfig`, and dict-based JSON configs.
- Adds a focused integration test covering PyO3 IB data and execution configs passed directly into `TradingNodeConfig`.

## Design decisions

- The node builder only requires live client configs to expose a `RoutingConfig` on `routing`, so `TradingNodeConfig` now treats objects with that interface as live client config instances.
- The change avoids making the PyO3 wrapper classes inherit from the msgspec live config base classes, which is not compatible with their Rust binding base classes.
- Dict inputs continue to decode through the existing `ImportableConfig` or concrete live client config path.

## Verification

- `uv run --no-sync pytest tests/integration_tests/live/test_live_node.py::TestTradingNodeConfiguration::test_node_config_accepts_pyo3_client_configs`.
- `uv run --no-sync pytest tests/integration_tests/live/test_live_node.py`.
- `uv run --no-sync examples/live/interactive_brokers_pyo3/connect_with_dockerized_gateway_pyo3.py`.
- `make format`.
- `make pre-commit`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3959

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
