### PR TITLE
Fix OKX missing post_only instrument status

### DIFF
--- a/crates/adapters/okx/src/common/enums.rs
+++ b/crates/adapters/okx/src/common/enums.rs
@@ -305,6 +305,7 @@ pub enum OKXInstrumentStatus {
     Suspend,
     Preopen,
     Test,
+    PostOnly,
 }
 
 /// Represents an instrument contract type on OKX.

--- a/crates/adapters/okx/src/common/parse.rs
+++ b/crates/adapters/okx/src/common/parse.rs
@@ -257,6 +257,7 @@ pub fn okx_status_to_market_action(status: OKXInstrumentStatus) -> MarketStatusA
         OKXInstrumentStatus::Suspend => MarketStatusAction::Suspend,
         OKXInstrumentStatus::Preopen => MarketStatusAction::PreOpen,
         OKXInstrumentStatus::Test => MarketStatusAction::NotAvailableForTrading,
+        OKXInstrumentStatus::PostOnly => MarketStatusAction::Quoting,
     }
 }
 
@@ -5054,5 +5055,18 @@ mod tests {
     #[rstest]
     fn test_extract_inst_family_single_segment_fails() {
         assert!(extract_inst_family("BTC").is_err());
+    }
+
+    #[rstest]
+    #[case(OKXInstrumentStatus::Live, MarketStatusAction::Trading)]
+    #[case(OKXInstrumentStatus::Suspend, MarketStatusAction::Suspend)]
+    #[case(OKXInstrumentStatus::Preopen, MarketStatusAction::PreOpen)]
+    #[case(OKXInstrumentStatus::Test, MarketStatusAction::NotAvailableForTrading)]
+    #[case(OKXInstrumentStatus::PostOnly, MarketStatusAction::Quoting)]
+    fn test_okx_status_to_market_action(
+        #[case] status: OKXInstrumentStatus,
+        #[case] expected: MarketStatusAction,
+    ) {
+        assert_eq!(okx_status_to_market_action(status), expected);
     }
 }


### PR DESCRIPTION
[OKX changelog 2026-04-29](https://www.okx.com/docs-v5/log_en/) introduced a new `post_only` state for SWAP instruments (production May 2026, only post-only limit orders accepted). OKX testnet has already deployed `AAPL-USDT-SWAP` in this state, breaking `OKXInstrumentProvider` deserialization for any user on testnet.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds the missing `post_only` variant to `OKXInstrumentStatus` and maps it to `MarketStatusAction::Quoting`, matching the venue semantics ("only post-only limit orders accepted; existing post-only orders can be amended and cancelled").

## Related Issues/PRs

OKX API changelog 2026-04-29: https://www.okx.com/docs-v5/log_en/

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added a parametrized `test_okx_status_to_market_action` covering all five variants. Reproduces the failure with stock pre-fix code: `cargo test -p nautilus-okx` panics on `unknown variant \`post_only\`` when the OKX testnet response is parsed; with the fix all 446 OKX tests pass.