### PR TITLE
Fix Interactive Brokers market data farm reconnect events

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -36,8 +36,8 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
 
     WARNING_CODES: Final[set[int]] = {1101, 1102, 110, 165, 202, 399, 404, 434, 492, 10167}
     CLIENT_ERRORS: Final[set[int]] = {502, 503, 504, 10038, 10182, 1100, 2110}
-    CONNECTIVITY_LOST_CODES: Final[set[int]] = {326, 1100, 1300, 2110}
-    CONNECTIVITY_RESTORED_CODES: Final[set[int]] = {1101, 1102}
+    CONNECTIVITY_LOST_CODES: Final[set[int]] = {326, 1100, 1300, 2103, 2110}
+    CONNECTIVITY_RESTORED_CODES: Final[set[int]] = {1101, 1102, 2104}
     ORDER_REJECTION_CODES: Final[set[int]] = {201, 203, 321, 10289, 10293}
     SUPPRESS_ERROR_LOGGING_CODES: Final[set[int]] = {200}
 


### PR DESCRIPTION
## Problem

The IBKR adapter has a working `_resubscribe_all()` recovery method (`client/client.py`) that re-issues every active subscription when a connectivity-restored event fires. However, the most common real-world disconnect/reconnect pair — TWS error codes **2103** ("Market data farm connection is broken") and **2104** ("Market data farm connection is OK") — is missing from `CONNECTIVITY_LOST_CODES` / `CONNECTIVITY_RESTORED_CODES` in `client/error.py`. As a result, the adapter logs both events as warnings (via the `2100 <= code < 2200` is_warning branch) and does nothing else, leaving any strategies subscribed at the moment of the blip with permanently dead bar feeds while AccountState heartbeats continue.

## Reproduction

Any node running through a market-data-farm reconnect — common during overnight Globex transitions or normal IBKR maintenance windows. In the environment that caught this, a 3-second 2103→2104 cycle on `usfarm` caused two 5-minute-bar dryrun strategies to silently stop receiving bars while appearing alive. Detection took 8+ hours via a separate watchdog.

## Fix

Two-set membership change. `_resubscribe_all()` already exists and is already plumbed; this PR just makes the trigger fire on the codes that actually occur in production.

## Test plan

- Existing test suite passes (no behaviour changed for codes already in the sets).
- Manual: run a TradingNode with bar subscriptions, force a 2103/2104 cycle (or wait for one — they are frequent), confirm `_resubscribe_all` is invoked and bars resume.

## Possible follow-up

Codes **2105** ("HMDS data farm connection is broken") and **2106** ("HMDS data farm connection is OK") look analogous for historical-market-data farms and may deserve the same treatment. Happy to extend this PR or open a follow-up — flagging here for reviewer guidance.