### PR TITLE
Fix Hyperliquid spurious OrderCanceled on concurrent modifies

### DIFF
--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -814,6 +814,11 @@ class HyperliquidExecutionClient(LiveExecutionClient):
             if trigger_price is not None:
                 pyo3_trigger_price = nautilus_pyo3.Price.from_str(str(trigger_price))
 
+            # Mark in-flight BEFORE the await so the WS cancel handler
+            # sees it regardless of timing. Cleaned up in except if HTTP fails.
+            self._pending_modify_keys[command.client_order_id.value] = venue_order_id.value
+            self._log.info(f"Order modification requested for {command.client_order_id}")
+
             await self._client.modify_order(
                 instrument_id=pyo3_instrument_id,
                 venue_order_id=pyo3_venue_order_id,
@@ -827,11 +832,9 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 time_in_force=pyo3_time_in_force,
                 client_order_id=pyo3_client_order_id,
             )
-            # Mark the old venue_order_id as in-flight only after a successful
-            # HTTP round-trip, so a failing modify never leaves stale race state.
-            self._pending_modify_keys[command.client_order_id.value] = venue_order_id.value
-            self._log.info(f"Order modification requested for {command.client_order_id}")
+
         except Exception as e:
+            self._pending_modify_keys.pop(command.client_order_id.value, None)
             self.generate_order_modify_rejected(
                 strategy_id=command.strategy_id,
                 instrument_id=command.instrument_id,
@@ -1019,6 +1022,19 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         if key in self._terminal_orders:
             self._log.debug(f"Ignoring duplicate OrderCanceled for {event.client_order_id!r}")
+            return
+
+        # Suppress cancel-before-accept leg of a Hyperliquid cancel-replace modify
+        pending_old_voi = self._pending_modify_keys.get(key)
+        if (
+            pending_old_voi is not None
+            and event.venue_order_id is not None
+            and event.venue_order_id.value == pending_old_voi
+        ):
+            self._log.debug(
+                f"Suppressing cancel-before-accept for {event.client_order_id!r} "
+                f"venue_order_id={event.venue_order_id!r}",
+            )
             return
 
         self._terminal_orders.add(key)


### PR DESCRIPTION
# fix(hyperliquid): suppress spurious OrderCanceled on concurrent modifies

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Hyperliquid implements order modification as a cancel-replace operation, emitting two WebSocket messages per modify:
- `CANCELED(old_venue_order_id)` — the old leg being killed
- `ACCEPTED(new_venue_order_id)` — the replacement leg

When multiple modifies are fired concurrently, the WS `CANCELED` messages arrive during the HTTP `await` window before `_pending_modify_keys` is populated. The suppression logic in `_handle_order_status_report_pyo3` is never reached because `_handle_order_canceled_pyo3` — which had no suppression check — processes the cancel first, marks the order terminal, and emits a spurious `OrderCanceled` to the strategy while the exchange holds the order correctly at the new price.

## Related Issues/PRs

None — discovered independently via live testnet testing.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

### Bug discovery

Found by firing 5 concurrent `modify_order` calls on Hyperliquid testnet and observing the log timestamps:

```
07:56:18.718  — 5x HTTP modify requests fired (awaiting)
07:56:20.030  — OrderCanceled O-2 arrives via WS  ← _pending_modify_keys is EMPTY
07:56:20.032  — OrderCanceled O-5 arrives via WS
07:56:20.033  — HTTP returns for O-1, _pending_modify_keys populated ← too late
07:56:20.034  — HTTP returns for O-2, O-5, O-3
07:56:20.035  — OrderCanceled O-4
07:56:20.040  — OrderCanceled O-3, O-1
```

The WS cancel beat the HTTP response by ~1.3 seconds. `_pending_modify_keys` was populated after `OrderCanceled` was already processed and the orders marked terminal.

### Reproduction

Place N limit orders far off-market, then fire concurrent modifies once all are accepted:

```python
# fire all modifies in the same tick — no await between them
for i, client_order_id in enumerate(self._order_ids):
    order = self.cache.order(client_order_id)
    new_price = Price(float(mid - new_offset), precision=1)
    self.modify_order(order=order, price=new_price, quantity=order.quantity)
```

Each `modify_order` call enqueues a coroutine. The event loop runs all HTTP calls concurrently — the later ones queue up behind the earlier ones, widening the window in which WS `CANCELED` messages can arrive before their corresponding HTTP responses return. 

The race is non-deterministic: if the HTTP response returns before the WS `CANCELED` arrives, the bug does not trigger. More concurrent modifies increase the queue depth and make reproduction more reliable.

### What was changed

- **`_modify_order`**: moved `_pending_modify_keys` population to **before** the `await self._client.modify_order(...)` call, so the marker is visible to the WS cancel handler regardless of whether the HTTP response or the WS message arrives first
- **`_modify_order` (except block)**: added `self._pending_modify_keys.pop(command.client_order_id.value, None)` on HTTP failure to prevent a stale marker from incorrectly suppressing a future legitimate cancel on the same order
- **`_handle_order_canceled_pyo3`**: added a `_pending_modify_keys` check before `_terminal_orders.add()` — if the arriving cancel matches the old `venue_order_id` of an in-flight modify, it is suppressed and the order is left alive to receive the replacement `ACCEPTED` which routes through `OrderUpdated`

> **Deterministic reproduction**: intercept the HTTP modify request with a proxy 
> (e.g. Burp Suite) and add a 2s delay before forwarding. The WS `CANCELED` 
> will always arrive before the HTTP response returns, triggering the race on 
> every single modify.