### PR TITLE
Fix Interactive Brokers post-shutdown RuntimeError in TWS reader

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -625,6 +625,11 @@ class InteractiveBrokersClient(
                         break
         except asyncio.CancelledError:
             self._log.debug("Client TWS incoming message reader was cancelled")
+        except RuntimeError as e:
+            if "after shutdown" in str(e):
+                self._log.debug("Client TWS incoming message reader stopping during shutdown")
+            else:
+                self._log.exception("Unhandled exception in Client TWS incoming message reader", e)
         except Exception as e:
             self._log.exception("Unhandled exception in Client TWS incoming message reader", e)
         finally:


### PR DESCRIPTION
Closes #3950. `asyncio.to_thread()` raises `RuntimeError("cannot schedule new futures after shutdown")` once the event loop starts tearing down, so every dispose logs an Unhandled exception. Treat that specific shutdown-window RuntimeError as a debug-level stop signal.