### PR TITLE
Harden Interactive Brokers callback ordering races

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -29,6 +29,7 @@ from nautilus_trader.adapters.interactive_brokers.client.common import BaseMixin
 from nautilus_trader.adapters.interactive_brokers.client.common import get_venue_order_id
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
 from nautilus_trader.common.enums import LogColor
+from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import VenueOrderId
 
 
@@ -279,26 +280,16 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         order.contract = IBContract(**contract.__dict__)
         order.order_state = order_state
         order.orderRef = order.orderRef.rsplit(":", 1)[0]
+        venue_order_id = get_venue_order_id(order.orderId, order.permId)
+        self._set_order_id_ref(
+            venue_order_id=venue_order_id,
+            account_id=order.account,
+            order_id=order.orderRef,
+        )
 
         # Handle response to on-demand request
         if request := self._requests.get(name="OpenOrders"):
             request.result.append(order)
-
-            # Validate and add reverse mapping, if not exists
-            venue_order_id = get_venue_order_id(order.orderId, order.permId)
-            if order_ref := self._order_id_to_order_ref.get(venue_order_id):
-                if not (
-                    order_ref.account_id == order.account and order_ref.order_id == order.orderRef
-                ):
-                    self._log.warning(
-                        f"Discrepancy found in order, expected {order_ref}, "
-                        f"was (account={order.account}, order_id={order.orderRef}",
-                    )
-            else:
-                self._order_id_to_order_ref[venue_order_id] = AccountOrderRef(
-                    account_id=order.account,
-                    order_id=order.orderRef,
-                )
             return
 
         # Handle event based response
@@ -342,6 +333,9 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         venue_order_id = get_venue_order_id(order_id, perm_id)
         order_ref = self._order_id_to_order_ref.get(venue_order_id, None)
 
+        if order_ref is None:
+            order_ref = self._resolve_order_ref_from_cache(venue_order_id)
+
         if order_ref:
             name = f"orderStatus-{order_ref.account_id}"
 
@@ -355,6 +349,10 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
                     remaining=remaining,
                     why_held=why_held,
                 )
+        else:
+            self._log.warning(
+                f"OrderStatus callback for {venue_order_id} has no order reference mapping",
+            )
 
     async def process_exec_details(
         self,
@@ -374,6 +372,14 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         cache["contract"] = IBContract(**contract.__dict__)
         cache["order_ref"] = execution.orderRef.rsplit(":", 1)[0]
         cache["req_id"] = req_id
+
+        if cache["order_ref"]:
+            venue_order_id = get_venue_order_id(execution.orderId, execution.permId)
+            self._set_order_id_ref(
+                venue_order_id=venue_order_id,
+                account_id=execution.acctNumber,
+                order_id=cache["order_ref"],
+            )
 
         # Check if this is for a get_executions request
         execution_request_name = f"Executions-{execution.acctNumber}"
@@ -458,3 +464,56 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         # End the request if it exists
         if self._requests.get(req_id=req_id):
             self._end_request(req_id)
+
+    def _set_order_id_ref(
+        self,
+        venue_order_id: VenueOrderId,
+        account_id: str,
+        order_id: str,
+    ) -> None:
+        if order_ref := self._order_id_to_order_ref.get(venue_order_id):
+            if not (order_ref.account_id == account_id and order_ref.order_id == order_id):
+                self._log.warning(
+                    f"Discrepancy found in order, expected {order_ref}, "
+                    f"was (account={account_id}, order_id={order_id})",
+                )
+        else:
+            self._order_id_to_order_ref[venue_order_id] = AccountOrderRef(
+                account_id=account_id,
+                order_id=order_id,
+            )
+
+    def _resolve_order_ref_from_cache(
+        self,
+        venue_order_id: VenueOrderId,
+    ) -> AccountOrderRef | None:
+        client_order_id: ClientOrderId | None = self._cache.client_order_id(venue_order_id)
+        if client_order_id is None:
+            return None
+
+        account_id = self._resolve_order_status_account_id()
+        if account_id is None:
+            self._log.warning(
+                f"Cannot route orderStatus for {venue_order_id}; account ID is ambiguous",
+            )
+            return None
+
+        order_ref = AccountOrderRef(account_id=account_id, order_id=client_order_id.value)
+        self._order_id_to_order_ref[venue_order_id] = order_ref
+        return order_ref
+
+    def _resolve_order_status_account_id(self) -> str | None:
+        accounts = self.accounts()
+        if len(accounts) == 1:
+            return next(iter(accounts))
+
+        subscribed_account_ids = {
+            name.removeprefix("orderStatus-")
+            for name in self._event_subscriptions
+            if name.startswith("orderStatus-")
+        }
+
+        if len(subscribed_account_ids) == 1:
+            return next(iter(subscribed_account_ids))
+
+        return None

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -425,12 +425,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         if report is None:
             self._log.warning(
-                f"Order {command.client_order_id=}, {command.venue_order_id} not found, canceling",
-            )
-            self._on_order_status(
-                order_ref=command.client_order_id.value,
-                order_status="Cancelled",
-                reason="Not found in query",
+                f"Order {command.client_order_id=}, {command.venue_order_id} not found in "
+                "`get_open_orders`; leaving order state unchanged",
             )
 
         return report
@@ -1070,9 +1066,13 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         if ib_order.parentId:
             parent_nautilus_order = self._cache.order(ClientOrderId(ib_order.parentId))
 
-            if parent_nautilus_order:
+            if parent_nautilus_order and parent_nautilus_order.venue_order_id is not None:
                 ib_order.parentId = int(parent_nautilus_order.venue_order_id.value)
             else:
+                self._log.warning(
+                    f"Parent order {ib_order.parentId!r} has no venue order ID yet; "
+                    "modifying child order without parentId",
+                )
                 ib_order.parentId = 0
 
         if command.quantity and command.quantity != ib_order.totalQuantity:
@@ -1793,10 +1793,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # IB's execDetails callback can race ahead of openOrder for fast fills (typically
         # market orders or marketable limit orders on liquid combos). The Execution object
         # is authoritative for venue_order_id, so backfill the mapping into the cache by
-        # synthesizing an OrderAccepted event when openOrder hasn't fired yet. Without
-        # this, downstream FillReports during continuous reconciliation cannot map
-        # venue_order_id back to client_order_id and are silently dropped.
-        if nautilus_order.venue_order_id is None:
+        # synthesizing an OrderAccepted event for a submitted order when openOrder hasn't
+        # fired yet. Without this, downstream FillReports during continuous reconciliation
+        # cannot map venue_order_id back to client_order_id and are silently dropped. If
+        # openOrder arrives later, _handle_order_event skips the duplicate acceptance.
+        if nautilus_order.venue_order_id is None and nautilus_order.status == OrderStatus.SUBMITTED:
             self._log.warning(
                 f"execDetails arrived before openOrder for {nautilus_order.client_order_id}; "
                 f"synthesizing OrderAccepted with venue_order_id={venue_order_id}",

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
@@ -25,6 +25,7 @@ from ibapi.order_cancel import OrderCancel as IBOrderCancel
 from nautilus_trader.adapters.interactive_brokers.client.common import AccountOrderRef
 from nautilus_trader.adapters.interactive_brokers.client.common import get_venue_order_id
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
+from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import VenueOrderId
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestExecStubs
@@ -204,6 +205,11 @@ async def test_process_open_order_when_request_not_present(ib_client):
     assert kwargs["order_ref"] == "O-20240102-1754-001-000-1"
     assert kwargs["order"].contract == IBContract(**contract.__dict__)
     assert kwargs["order"].order_state == order_state
+    venue_order_id = get_venue_order_id(order.orderId, order.permId)
+    assert ib_client._order_id_to_order_ref[venue_order_id] == AccountOrderRef(
+        account_id=order.account,
+        order_id="O-20240102-1754-001-000-1",
+    )
 
 
 @pytest.mark.asyncio
@@ -286,6 +292,47 @@ async def test_orderStatus_with_zero_avg_fill_price(ib_client):
         avg_fill_price=0.0,
         filled=Decimal(50),
         remaining=Decimal(50),
+        why_held="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_orderStatus_falls_back_to_cached_venue_order_id(ib_client):
+    # Arrange
+    venue_order_id = VenueOrderId("2001")
+    client_order_id = ClientOrderId("O-CACHED-ORDER-STATUS-001")
+    ib_client._cache.add_venue_order_id(client_order_id, venue_order_id)
+    ib_client._account_ids = {"DU123456"}
+    handler_func = Mock()
+    ib_client._event_subscriptions = {"orderStatus-DU123456": handler_func}
+
+    # Act
+    await ib_client.process_order_status(
+        order_id=2001,
+        status="Submitted",
+        filled=Decimal(0),
+        remaining=Decimal(100),
+        avg_fill_price=0.0,
+        perm_id=0,
+        parent_id=0,
+        last_fill_price=0.0,
+        client_id=1,
+        why_held="",
+        mkt_cap_price=0.0,
+    )
+
+    # Assert
+    assert ib_client._order_id_to_order_ref[venue_order_id] == AccountOrderRef(
+        account_id="DU123456",
+        order_id=client_order_id.value,
+    )
+    handler_func.assert_called_once_with(
+        venue_order_id=venue_order_id,
+        order_ref=client_order_id.value,
+        order_status="Submitted",
+        avg_fill_price=0.0,
+        filled=Decimal(0),
+        remaining=Decimal(100),
         why_held="",
     )
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -25,6 +25,8 @@ from nautilus_trader.adapters.interactive_brokers.common import IBOrderTags
 from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveExecClientFactory,
 )
+from nautilus_trader.adapters.interactive_brokers.parsing.execution import timestring_to_timestamp
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
 from nautilus_trader.execution.messages import QueryAccount
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OptionKind
@@ -584,6 +586,51 @@ async def test_modify_order_price(
 
 
 @pytest.mark.asyncio
+async def test_modify_order_child_before_parent_acceptance_skips_parent_id(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    parent_client_order_id = ClientOrderId("O-BRACKET-PARENT-001")
+    child_client_order_id = ClientOrderId("O-BRACKET-CHILD-001")
+    order_list = TestExecStubs.limit_with_stop_market(
+        instrument=instrument,
+        entry_client_order_id=parent_client_order_id,
+        sl_client_order_id=child_client_order_id,
+    )
+    parent_order = TestExecStubs.make_submitted_order(order_list.orders[0])
+    child_order = TestExecStubs.make_accepted_order(
+        order_list.orders[1],
+        venue_order_id=VenueOrderId("9102"),
+    )
+    cache.add_order(parent_order, None)
+    cache.add_order(child_order, None)
+
+    place_order = mocker.patch.object(exec_client._client, "place_order")
+
+    command = TestCommandStubs.modify_order_command(
+        quantity=Quantity.from_str("150"),
+        order=child_order,
+    )
+    await exec_client._modify_order(command)
+
+    assert place_order.call_count == 1
+    ib_order = place_order.call_args.args[0]
+    assert ib_order.orderId == 9102
+    assert ib_order.parentId == 0
+    assert ib_order.totalQuantity == 150.0
+
+
+@pytest.mark.asyncio
 async def test_cancel_order(
     mocker,
     exec_client,
@@ -766,6 +813,49 @@ async def test_on_order_status_with_avg_px(
     stored_avg_px = exec_client._order_avg_prices[client_order_id]
     # Price magnifier for AAPL is 1.0, so 125.50 should be stored as Price(125.50)
     assert stored_avg_px == Price.from_str("125.50")
+
+
+@pytest.mark.asyncio
+async def test_generate_order_status_report_open_order_miss_does_not_cancel(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    client_order_id = ClientOrderId("O-STATUS-MISS-001")
+    venue_order_id = VenueOrderId("9301")
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    cache.add_venue_order_id(order.client_order_id, venue_order_id)
+
+    mocker.patch.object(exec_client._client, "get_open_orders", return_value=[])
+    on_order_status = mocker.spy(exec_client, "_on_order_status")
+    command = GenerateOrderStatusReport(
+        instrument_id=instrument.id,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        command_id=TestIdStubs.uuid(),
+        ts_init=0,
+    )
+
+    report = await exec_client.generate_order_status_report(command)
+
+    assert report is None
+    assert on_order_status.call_count == 0
+    assert cache.order(client_order_id).status == OrderStatus.ACCEPTED
 
 
 @pytest.mark.asyncio
@@ -1287,13 +1377,68 @@ async def test_spread_execution_handles_exec_details_before_open_order(mocker, e
     # venue_order_id mapping.
     assert generate_order_accepted.call_count == 1
     assert generate_order_accepted.call_args.kwargs["venue_order_id"] == venue_order_id
+    assert (
+        generate_order_accepted.call_args.kwargs["ts_event"]
+        == timestring_to_timestamp(execution.time).value
+    )
 
     # The leg fill must be generated with venue_order_id derived from the
     # execution rather than crashing.
-    assert generate_order_filled.call_count >= 1
+    assert generate_order_filled.call_count == 1
     leg_fill_call = generate_order_filled.call_args_list[0].kwargs
     assert leg_fill_call["instrument_id"] == call.id
     assert leg_fill_call["venue_order_id"] == VenueOrderId(f"{venue_order_id.value}-LEG-0")
+
+
+@pytest.mark.asyncio
+async def test_exec_details_does_not_accept_rejected_order(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+):
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+
+    client_order_id = ClientOrderId("O-REJECTED-RACE-001")
+    order = TestExecStubs.limit_order(
+        instrument=instrument,
+        client_order_id=client_order_id,
+    )
+    order = TestExecStubs.make_submitted_order(order)
+    cache.add_order(order, None)
+
+    exec_client._handle_order_event(
+        status=OrderStatus.REJECTED,
+        order=order,
+        reason="Rejected before late execDetails",
+    )
+    assert cache.order(client_order_id).status == OrderStatus.REJECTED
+    assert cache.order(client_order_id).venue_order_id is None
+
+    venue_order_id = VenueOrderId("7201")
+    generate_order_accepted = mocker.spy(exec_client, "generate_order_accepted")
+    mocker.patch.object(exec_client, "generate_order_filled")
+
+    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution.orderRef = str(client_order_id)
+    commission_report = IBTestExecStubs.commission()
+    commission_report.execId = execution.execId
+
+    exec_client._on_exec_details(
+        order_ref=str(client_order_id),
+        execution=execution,
+        commission_report=commission_report,
+        contract=contract_details.contract,
+    )
+
+    assert generate_order_accepted.call_count == 0
+    assert cache.order(client_order_id).status == OrderStatus.REJECTED
 
 
 @pytest.mark.asyncio
@@ -1336,6 +1481,15 @@ async def test_on_order_status_cancel_propagates_venue_order_id_when_order_unacc
 
     assert generate_order_canceled.call_count == 1
     assert generate_order_canceled.call_args.kwargs["venue_order_id"] == venue_order_id
+    assert cache.order(client_order_id).status == OrderStatus.CANCELED
+
+    exec_client._on_order_status(
+        order_ref=str(client_order_id),
+        order_status="Cancelled",
+        venue_order_id=venue_order_id,
+    )
+
+    assert generate_order_canceled.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Guard the synthetic `OrderAccepted` generated from early IB `execDetails` so it only fires for orders still in `SUBMITTED` state.
- Keep late `execDetails` from moving terminal rejected orders back to accepted.
- Preserve spread fill attribution when `execDetails` arrives before `openOrder`, including exact leg fill count, venue order ID, and execution-time timestamp coverage.
- Preserve cancel attribution when `orderStatus(Cancelled)` arrives before `openOrder` has assigned the cached `venue_order_id`.
- Stop `generate_order_status_report` from synthesizing a local cancel when a single `get_open_orders` query misses an order.
- Guard bracket child order modification when the cached parent order has not received its IB `venue_order_id` yet.
- Route `orderStatus` callbacks via the cached `venue_order_id` mapping when `_order_id_to_order_ref` has not been populated by `openOrder`.
- Seed the IB order reference map from event-based `openOrder` callbacks and `execDetails` callbacks, not only open-order query responses.
- Add regressions for early `execDetails`, rejected-order late fills, cancel races, open-order misses, bracket child modification before parent acceptance, and fallback routing for out-of-order `orderStatus`.

### Design notes

- The synthetic acceptance remains limited to the race window where `execDetails` arrives before `openOrder` and the cached order has no `venue_order_id`.
- Terminal and non-submitted states are left untouched, preventing invalid state transitions when IB reports a late fill after a rejection.
- A missing open order response is treated as inconclusive because IB may omit `orderStatus` for fast orders and does not guarantee ordering between `openOrder`, `orderStatus`, and `execDetails`.
- Child order modification now drops `parentId` when the parent venue ID is unavailable, allowing the modify request to proceed without raising on `None.value`.
- The order-status fallback only routes through the cache when the account can be resolved unambiguously from a single account or a single `orderStatus-*` subscription.
- The existing warning path remains for callbacks that still cannot be attributed to an order reference.
- No Rust or Cython changes were required.

### Testing

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution.py -k 'exec_details_before_open_order or exec_details_does_not_accept_rejected_order or cancel_propagates_venue_order_id'`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py -k 'process_open_order_when_request_not_present or orderStatus_falls_back_to_cached_venue_order_id'`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution.py -k 'generate_order_status_report_open_order_miss_does_not_cancel or modify_order_child_before_parent_acceptance_skips_parent_id or exec_details_before_open_order or cancel_propagates_venue_order_id'`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py tests/integration_tests/adapters/interactive_brokers/test_execution.py`.
- `make format`.
- `make pre-commit`.
- `git diff --check`.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3958

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
