### PR TITLE
Fix panic caused by RefCell reentran when execution engine handle_order_fill

### DIFF
--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -2222,19 +2222,31 @@ impl ExecutionEngine {
                 let position_id = pos.id;
 
                 for client_order_id in order.linked_order_ids().unwrap_or_default() {
-                    let mut cache = self.cache.borrow_mut();
-                    let contingent_order = cache.mut_order(client_order_id);
-                    if let Some(contingent_order) = contingent_order
-                        && contingent_order.position_id().is_none()
-                    {
-                        contingent_order.set_position_id(Some(position_id));
-
-                        if let Err(e) = self.cache.borrow_mut().add_position_id(
-                            &position_id,
-                            &contingent_order.instrument_id().venue,
-                            &contingent_order.client_order_id(),
-                            &contingent_order.strategy_id(),
-                        ) {
+                    // Apply contingent-order mutation and index update in two borrows: `mut_order`
+                    // holds `&mut Cache`, so a nested `self.cache.borrow_mut()` would panic.
+                    let maybe_link: Option<(Venue, ClientOrderId, StrategyId)> = {
+                        let mut cache = self.cache.borrow_mut();
+                        match cache.mut_order(client_order_id) {
+                            None => None,
+                            Some(contingent_order) => {
+                                if contingent_order.position_id().is_some() {
+                                    None
+                                } else {
+                                    contingent_order.set_position_id(Some(position_id));
+                                    Some((
+                                        contingent_order.instrument_id().venue,
+                                        contingent_order.client_order_id(),
+                                        contingent_order.strategy_id(),
+                                    ))
+                                }
+                            }
+                        }
+                    };
+                    if let Some((venue, coid, sid)) = maybe_link {
+                        let mut cache = self.cache.borrow_mut();
+                        if let Err(e) =
+                            cache.add_position_id(&position_id, &venue, &coid, &sid)
+                        {
                             log::error!("Failed to add position ID: {e}");
                         }
                     }


### PR DESCRIPTION
ExecutionEngine::handle_order_fill: Calling self.cache.borrow_mut() while holding a borrow_mut on the cache caused a RefCell reentrancy panic. Change to first end the inner borrow before calling add_position_id.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->

fix bug [issues#3981](https://github.com/nautechsystems/nautilus_trader/issues/3981)