### PR TITLE
Add Deribit DVOL volatility index CustomData support

### DIFF
--- a/crates/adapters/deribit/src/data.rs
+++ b/crates/adapters/deribit/src/data.rs
@@ -34,13 +34,14 @@ use nautilus_common::{
             BarsResponse, BookResponse, ForwardPricesResponse, InstrumentResponse,
             InstrumentsResponse, RequestBars, RequestBookSnapshot, RequestForwardPrices,
             RequestInstrument, RequestInstruments, RequestTrades, SubscribeBars,
-            SubscribeBookDeltas, SubscribeBookDepth10, SubscribeFundingRates, SubscribeIndexPrices,
-            SubscribeInstrument, SubscribeInstrumentStatus, SubscribeInstruments,
-            SubscribeMarkPrices, SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades,
-            TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeBookDepth10,
-            UnsubscribeFundingRates, UnsubscribeIndexPrices, UnsubscribeInstrument,
-            UnsubscribeInstrumentStatus, UnsubscribeInstruments, UnsubscribeMarkPrices,
-            UnsubscribeOptionGreeks, UnsubscribeQuotes, UnsubscribeTrades,
+            SubscribeBookDeltas, SubscribeBookDepth10, SubscribeCustomData, SubscribeFundingRates,
+            SubscribeIndexPrices, SubscribeInstrument, SubscribeInstrumentStatus,
+            SubscribeInstruments, SubscribeMarkPrices, SubscribeOptionGreeks, SubscribeQuotes,
+            SubscribeTrades, TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas,
+            UnsubscribeBookDepth10, UnsubscribeCustomData, UnsubscribeFundingRates,
+            UnsubscribeIndexPrices, UnsubscribeInstrument, UnsubscribeInstrumentStatus,
+            UnsubscribeInstruments, UnsubscribeMarkPrices, UnsubscribeOptionGreeks,
+            UnsubscribeQuotes, UnsubscribeTrades,
         },
     },
 };
@@ -1230,6 +1231,86 @@ impl DataClient for DeribitDataClient {
         get_runtime().spawn(async move {
             if let Err(e) = ws.unsubscribe_ticker(instrument_id, interval).await {
                 log::error!("Failed to unsubscribe from option greeks for {instrument_id}: {e}");
+            }
+        });
+
+        Ok(())
+    }
+
+    fn subscribe(&mut self, cmd: SubscribeCustomData) -> anyhow::Result<()> {
+        let data_type = cmd.data_type.type_name();
+        if data_type != "DeribitVolatilityIndex" {
+            log::warn!("Unsupported custom data subscription: {data_type}");
+            return Ok(());
+        }
+
+        let Some(index_name) = cmd
+            .data_type
+            .metadata()
+            .as_ref()
+            .and_then(|m| m.get("index_name"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+        else {
+            log::warn!(
+                "Rejected Deribit volatility index subscription: missing required metadata `index_name`"
+            );
+            return Ok(());
+        };
+
+        log::info!("Subscribing to Deribit volatility index: {index_name}");
+
+        let ws = self
+            .ws_client
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("WebSocket client not initialized"))?
+            .clone();
+
+        get_runtime().spawn(async move {
+            if let Err(e) = ws.subscribe_volatility_index(&index_name).await {
+                log::error!("Failed to subscribe to volatility index {index_name}: {e}");
+            }
+        });
+
+        Ok(())
+    }
+
+    fn unsubscribe(&mut self, cmd: &UnsubscribeCustomData) -> anyhow::Result<()> {
+        let data_type = cmd.data_type.type_name();
+        if data_type != "DeribitVolatilityIndex" {
+            log::warn!("Unsupported custom data unsubscription: {data_type}");
+            return Ok(());
+        }
+
+        let Some(index_name) = cmd
+            .data_type
+            .metadata()
+            .as_ref()
+            .and_then(|m| m.get("index_name"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+        else {
+            log::warn!(
+                "Rejected Deribit volatility index unsubscription: missing required metadata `index_name`"
+            );
+            return Ok(());
+        };
+
+        log::info!("Unsubscribing from Deribit volatility index: {index_name}");
+
+        let ws = self
+            .ws_client
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("WebSocket client not initialized"))?
+            .clone();
+
+        get_runtime().spawn(async move {
+            if let Err(e) = ws.unsubscribe_volatility_index(&index_name).await {
+                log::error!("Failed to unsubscribe from volatility index {index_name}: {e}");
             }
         });
 

--- a/crates/adapters/deribit/src/data_types.rs
+++ b/crates/adapters/deribit/src/data_types.rs
@@ -1,0 +1,271 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Deribit-specific custom data types.
+//!
+//! These types carry Deribit domain data through the Nautilus data engine as
+//! [`CustomData`](nautilus_model::data::CustomData).
+
+use std::sync::Arc;
+
+use nautilus_core::UnixNanos;
+use serde::{Deserialize, Serialize};
+
+use nautilus_model::data::{CustomDataTrait, HasTsInit};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Deribit volatility index (DVOL) data.
+///
+/// Emitted from the `deribit_volatility_index.{index_name}` WebSocket channel.
+/// The DVOL index is the market-implied volatility benchmark for BTC and ETH,
+/// calculated from Deribit's options order book.
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.deribit", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.deribit")
+)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeribitVolatilityIndex {
+    /// The index name (e.g. "btc_usd" or "eth_usd").
+    pub index_name: String,
+    /// The DVOL value.
+    pub value: f64,
+    /// UNIX timestamp (nanoseconds) when the data event occurred.
+    pub ts_event: UnixNanos,
+    /// UNIX timestamp (nanoseconds) when the instance was initialized.
+    pub ts_init: UnixNanos,
+}
+
+impl DeribitVolatilityIndex {
+    /// Creates a new [`DeribitVolatilityIndex`] instance.
+    #[must_use]
+    pub fn new(index_name: String, value: f64, ts_event: UnixNanos, ts_init: UnixNanos) -> Self {
+        Self {
+            index_name,
+            value,
+            ts_event,
+            ts_init,
+        }
+    }
+}
+
+impl HasTsInit for DeribitVolatilityIndex {
+    fn ts_init(&self) -> UnixNanos {
+        self.ts_init
+    }
+}
+
+impl CustomDataTrait for DeribitVolatilityIndex {
+    fn type_name(&self) -> &'static str {
+        "DeribitVolatilityIndex"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn ts_event(&self) -> UnixNanos {
+        self.ts_event
+    }
+
+    fn to_json(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn CustomDataTrait> {
+        Arc::new(self.clone())
+    }
+
+    fn eq_arc(&self, other: &dyn CustomDataTrait) -> bool {
+        if let Some(o) = other.as_any().downcast_ref::<Self>() {
+            self == o
+        } else {
+            false
+        }
+    }
+
+    #[cfg(feature = "python")]
+    fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
+    }
+
+    fn type_name_static() -> &'static str {
+        "DeribitVolatilityIndex"
+    }
+
+    fn from_json(value: serde_json::Value) -> anyhow::Result<Arc<dyn CustomDataTrait>> {
+        let parsed: Self = serde_json::from_value(value)?;
+        Ok(Arc::new(parsed))
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl DeribitVolatilityIndex {
+    #[new]
+    fn py_new(index_name: String, value: f64, ts_event: u64, ts_init: u64) -> Self {
+        Self::new(
+            index_name,
+            value,
+            UnixNanos::from(ts_event),
+            UnixNanos::from(ts_init),
+        )
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DeribitVolatilityIndex(index_name={}, value={}, ts_event={}, ts_init={})",
+            self.index_name, self.value, self.ts_event, self.ts_init
+        )
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+
+    #[getter]
+    fn index_name(&self) -> String {
+        self.index_name.clone()
+    }
+
+    #[getter]
+    fn value(&self) -> f64 {
+        self.value
+    }
+
+    #[getter]
+    fn ts_event(&self) -> u64 {
+        self.ts_event.as_u64()
+    }
+
+    #[getter]
+    fn ts_init(&self) -> u64 {
+        self.ts_init.as_u64()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nautilus_model::data::CustomDataTrait;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_deribit_volatility_index_new() {
+        let dvol = DeribitVolatilityIndex::new(
+            "btc_usd".to_string(),
+            72.5,
+            UnixNanos::from(1_000_000_000),
+            UnixNanos::from(1_000_000_001),
+        );
+        assert_eq!(dvol.index_name, "btc_usd");
+        assert_eq!(dvol.value, 72.5);
+        assert_eq!(dvol.ts_event.as_u64(), 1_000_000_000);
+        assert_eq!(dvol.ts_init.as_u64(), 1_000_000_001);
+    }
+
+    #[rstest]
+    fn test_deribit_volatility_index_type_name() {
+        let dvol = DeribitVolatilityIndex::new(
+            "eth_usd".to_string(),
+            65.0,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        assert_eq!(dvol.type_name(), "DeribitVolatilityIndex");
+        assert_eq!(
+            DeribitVolatilityIndex::type_name_static(),
+            "DeribitVolatilityIndex"
+        );
+    }
+
+    #[rstest]
+    fn test_deribit_volatility_index_to_json() {
+        let dvol = DeribitVolatilityIndex::new(
+            "btc_usd".to_string(),
+            72.5,
+            UnixNanos::from(1_000_000_000),
+            UnixNanos::from(1_000_000_001),
+        );
+        let json_str = dvol.to_json().unwrap();
+        assert!(json_str.contains("btc_usd"));
+        assert!(json_str.contains("72.5"));
+    }
+
+    #[rstest]
+    fn test_deribit_volatility_index_from_json() {
+        let json_value = serde_json::json!({
+            "index_name": "btc_usd",
+            "value": 72.5,
+            "ts_event": 1_000_000_000u64,
+            "ts_init": 1_000_000_001u64,
+        });
+        let arc = DeribitVolatilityIndex::from_json(json_value).unwrap();
+        let dvol = arc
+            .as_any()
+            .downcast_ref::<DeribitVolatilityIndex>()
+            .unwrap();
+        assert_eq!(dvol.index_name, "btc_usd");
+        assert_eq!(dvol.value, 72.5);
+        assert_eq!(dvol.ts_event.as_u64(), 1_000_000_000);
+        assert_eq!(dvol.ts_init.as_u64(), 1_000_000_001);
+    }
+
+    #[rstest]
+    fn test_deribit_volatility_index_clone_arc() {
+        let dvol = DeribitVolatilityIndex::new(
+            "btc_usd".to_string(),
+            72.5,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        let cloned = dvol.clone_arc();
+        let downcast = cloned
+            .as_any()
+            .downcast_ref::<DeribitVolatilityIndex>()
+            .unwrap();
+        assert_eq!(downcast.index_name, "btc_usd");
+        assert_eq!(downcast.value, 72.5);
+    }
+
+    #[rstest]
+    fn test_deribit_volatility_index_eq_arc() {
+        let dvol1 = DeribitVolatilityIndex::new(
+            "btc_usd".to_string(),
+            72.5,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        let dvol2 = DeribitVolatilityIndex::new(
+            "btc_usd".to_string(),
+            72.5,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        let dvol3 = DeribitVolatilityIndex::new(
+            "eth_usd".to_string(),
+            65.0,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        assert!(dvol1.eq_arc(&dvol2));
+        assert!(!dvol1.eq_arc(&dvol3));
+    }
+}

--- a/crates/adapters/deribit/src/lib.rs
+++ b/crates/adapters/deribit/src/lib.rs
@@ -54,6 +54,7 @@
 pub mod common;
 pub mod config;
 pub mod data;
+pub mod data_types;
 pub mod execution;
 pub mod factories;
 pub mod http;

--- a/crates/adapters/deribit/src/python/mod.rs
+++ b/crates/adapters/deribit/src/python/mod.rs
@@ -106,6 +106,7 @@ pub fn deribit(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DeribitExecClientConfig>()?;
     m.add_class::<DeribitDataClientFactory>()?;
     m.add_class::<DeribitExecutionClientFactory>()?;
+    m.add_class::<crate::data_types::DeribitVolatilityIndex>()?;
     m.add_function(wrap_pyfunction!(urls::py_get_deribit_http_base_url, m)?)?;
     m.add_function(wrap_pyfunction!(urls::py_get_deribit_ws_url, m)?)?;
 

--- a/crates/adapters/deribit/src/python/websocket.rs
+++ b/crates/adapters/deribit/src/python/websocket.rs
@@ -73,6 +73,13 @@ where
     });
 }
 
+fn ws_data_to_pyobject(py: Python<'_>, data: Data) -> PyResult<Py<PyAny>> {
+    match data {
+        Data::Custom(custom) => Py::new(py, custom).map(|obj| obj.into_any()),
+        other => Ok(data_to_pycapsule(py, other)),
+    }
+}
+
 #[pymethods]
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 impl DeribitWebSocketClient {
@@ -267,8 +274,16 @@ impl DeribitWebSocketClient {
                         }
                         NautilusWsMessage::Data(msg) => Python::attach(|py| {
                             for data in msg {
-                                let py_obj = data_to_pycapsule(py, data);
-                                call_python_threadsafe(py, &call_soon, &callback, py_obj);
+                                match ws_data_to_pyobject(py, data) {
+                                    Ok(py_obj) => {
+                                        call_python_threadsafe(py, &call_soon, &callback, py_obj);
+                                    }
+                                    Err(e) => {
+                                        log::error!(
+                                            "Failed to convert WebSocket data payload: {e}"
+                                        );
+                                    }
+                                }
                             }
                         }),
                         NautilusWsMessage::Deltas(msg) => Python::attach(|py| {
@@ -746,6 +761,42 @@ impl DeribitWebSocketClient {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             client
                 .unsubscribe_ticker(instrument_id, interval)
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    /// Subscribes to volatility index updates for the given index name.
+    ///
+    /// Channel format: `deribit_volatility_index.{index_name}`.
+    #[pyo3(name = "subscribe_volatility_index")]
+    fn py_subscribe_volatility_index<'py>(
+        &self,
+        py: Python<'py>,
+        index_name: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .subscribe_volatility_index(&index_name)
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    /// Unsubscribes from volatility index updates for the given index name.
+    #[pyo3(name = "unsubscribe_volatility_index")]
+    fn py_unsubscribe_volatility_index<'py>(
+        &self,
+        py: Python<'py>,
+        index_name: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .unsubscribe_volatility_index(&index_name)
                 .await
                 .map_err(to_pyvalue_err)
         })

--- a/crates/adapters/deribit/src/websocket/client.rs
+++ b/crates/adapters/deribit/src/websocket/client.rs
@@ -1257,6 +1257,28 @@ impl DeribitWebSocketClient {
         self.send_unsubscribe(vec![channel]).await
     }
 
+    /// Subscribes to volatility index updates for the given index name.
+    ///
+    /// Channel format: `deribit_volatility_index.{index_name}`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if subscription fails.
+    pub async fn subscribe_volatility_index(&self, index_name: &str) -> DeribitWsResult<()> {
+        let channel = DeribitWsChannel::VolatilityIndex.format_channel(index_name, None);
+        self.send_subscribe(vec![channel]).await
+    }
+
+    /// Unsubscribes from volatility index updates for the given index name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if unsubscription fails.
+    pub async fn unsubscribe_volatility_index(&self, index_name: &str) -> DeribitWsResult<()> {
+        let channel = DeribitWsChannel::VolatilityIndex.format_channel(index_name, None);
+        self.send_unsubscribe(vec![channel]).await
+    }
+
     /// Subscribes to perpetual interest rates updates.
     ///
     /// Channel format: `perpetual.{instrument_name}.{interval}`

--- a/crates/adapters/deribit/src/websocket/handler.rs
+++ b/crates/adapters/deribit/src/websocket/handler.rs
@@ -29,9 +29,11 @@ use std::{
 
 use ahash::AHashMap;
 use nautilus_common::cache::fifo::FifoCache;
-use nautilus_core::{AtomicSet, AtomicTime, UUID4, UnixNanos, time::get_atomic_clock_realtime};
+use nautilus_core::{
+    AtomicSet, AtomicTime, UUID4, UnixNanos, params::Params, time::get_atomic_clock_realtime,
+};
 use nautilus_model::{
-    data::{Bar, Data, InstrumentStatus},
+    data::{Bar, CustomData, Data, DataType, InstrumentStatus},
     enums::MarketStatusAction,
     events::{AccountState, OrderCancelRejected, OrderModifyRejected, OrderRejected},
     identifiers::{
@@ -55,8 +57,8 @@ use super::{
         DeribitChartMsg, DeribitEditParams, DeribitHeartbeatParams, DeribitInstrumentStateMsg,
         DeribitJsonRpcRequest, DeribitOrderMsg, DeribitOrderParams, DeribitOrderResponse,
         DeribitPerpetualMsg, DeribitPortfolioMsg, DeribitQuoteMsg, DeribitSubscribeParams,
-        DeribitTickerMsg, DeribitTradeMsg, DeribitUserTradeMsg, DeribitWsMessage,
-        NautilusWsMessage, parse_raw_message,
+        DeribitTickerMsg, DeribitTradeMsg, DeribitUserTradeMsg, DeribitVolatilityIndexMsg,
+        DeribitWsMessage, NautilusWsMessage, parse_raw_message,
     },
     parse::{
         OrderEventType, determine_order_event_type, parse_book_msg, parse_chart_msg,
@@ -66,10 +68,13 @@ use super::{
         parse_user_order_msg, parse_user_trade_msg, resolution_to_bar_type,
     },
 };
-use crate::common::{
-    consts::{DERIBIT_POST_ONLY_ERROR_CODE, DERIBIT_RATE_LIMIT_KEY_ORDER, DERIBIT_VENUE},
-    enums::DeribitInstrumentState,
-    parse::parse_portfolio_to_account_state,
+use crate::{
+    common::{
+        consts::{DERIBIT_POST_ONLY_ERROR_CODE, DERIBIT_RATE_LIMIT_KEY_ORDER, DERIBIT_VENUE},
+        enums::DeribitInstrumentState,
+        parse::parse_portfolio_to_account_state,
+    },
+    data_types::DeribitVolatilityIndex,
 };
 
 /// Type of pending request for request ID correlation.
@@ -1794,6 +1799,36 @@ impl DeribitWsFeedHandler {
                                     Err(e) => {
                                         log::warn!("Failed to parse quote message: {e}");
                                     }
+                                }
+                            }
+                        }
+                        DeribitWsChannel::VolatilityIndex => {
+                            match serde_json::from_value::<DeribitVolatilityIndexMsg>(data.clone())
+                            {
+                                Ok(msg) => {
+                                    let ts_event = UnixNanos::from(msg.timestamp * 1_000_000);
+                                    let mut metadata = Params::new();
+                                    metadata.insert(
+                                        "index_name".to_string(),
+                                        serde_json::Value::String(msg.index_name.clone()),
+                                    );
+                                    let data_type = DataType::new(
+                                        "DeribitVolatilityIndex",
+                                        Some(metadata),
+                                        None,
+                                    );
+                                    let dvol = DeribitVolatilityIndex::new(
+                                        msg.index_name,
+                                        msg.volatility,
+                                        ts_event,
+                                        ts_init,
+                                    );
+                                    return Some(NautilusWsMessage::Data(vec![Data::Custom(
+                                        CustomData::new(Arc::new(dvol), data_type),
+                                    )]));
+                                }
+                                Err(e) => {
+                                    log::warn!("Failed to deserialize volatility index: {e}");
                                 }
                             }
                         }

--- a/crates/adapters/deribit/src/websocket/messages.rs
+++ b/crates/adapters/deribit/src/websocket/messages.rs
@@ -799,6 +799,17 @@ pub enum DeribitWsMessage {
     Reconnected,
 }
 
+/// Volatility index message data from Deribit.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeribitVolatilityIndexMsg {
+    /// The timestamp (milliseconds since the Unix epoch).
+    pub timestamp: u64,
+    /// Value of the corresponding volatility.
+    pub volatility: f64,
+    /// Index identifier supported for DVOL.
+    pub index_name: String,
+}
+
 /// Deribit WebSocket error for external consumers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeribitWebSocketError {

--- a/crates/adapters/deribit/test_data/ws_volatility_index.json
+++ b/crates/adapters/deribit/test_data/ws_volatility_index.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "subscription",
+  "params": {
+    "channel": "deribit_volatility_index.btc_usd",
+    "data": {
+      "timestamp": 1619777946007,
+      "volatility": 129.36,
+      "index_name": "btc_usd"
+    }
+  }
+}

--- a/crates/adapters/deribit/tests/websocket.rs
+++ b/crates/adapters/deribit/tests/websocket.rs
@@ -39,12 +39,14 @@ use nautilus_common::testing::wait_until_async;
 use nautilus_core::{AtomicSet, UnixNanos};
 use nautilus_deribit::{
     common::enums::DeribitEnvironment,
+    data_types::DeribitVolatilityIndex,
     websocket::{
         auth::DERIBIT_DATA_SESSION_NAME, client::DeribitWebSocketClient,
         enums::DeribitUpdateInterval, messages::NautilusWsMessage,
     },
 };
 use nautilus_model::{
+    data::Data,
     identifiers::{InstrumentId, Symbol, Venue},
     instruments::{CryptoPerpetual, InstrumentAny},
     types::{Currency, Price, Quantity},
@@ -162,6 +164,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<TestServerState>) {
     let ticker_payload = load_json("ws_ticker.json");
     let quote_payload = load_json("ws_quote.json");
     let chart_payload = load_json("ws_chart.json");
+    let volatility_index_payload = load_json("ws_volatility_index.json");
 
     // Create a second chart payload with a later timestamp for emit-on-next pattern
     let mut chart_payload_next = chart_payload.clone();
@@ -261,6 +264,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<TestServerState>) {
                                     Some(&ticker_payload)
                                 } else if channel.starts_with("quote.") {
                                     Some(&quote_payload)
+                                } else if channel.starts_with("deribit_volatility_index.") {
+                                    Some(&volatility_index_payload)
                                 } else if channel.starts_with("chart.trades.") {
                                     // For chart subscriptions, send two bars to trigger emit-on-next
                                     if socket
@@ -1891,6 +1896,77 @@ async fn test_user_subscription_failure_leaves_state_clean_for_retry() {
         subs.contains(&"user.portfolio.any".to_string()),
         "user.portfolio should be subscribed on retry"
     );
+
+    client.close().await.expect("close failed");
+}
+
+#[tokio::test]
+async fn test_volatility_index_subscription() {
+    let state = Arc::new(TestServerState::default());
+    let addr = start_ws_server(state.clone()).await;
+    let ws_url = format!("ws://{addr}/ws/api/v2");
+
+    let mut client = create_test_client(&ws_url);
+    client.connect().await.expect("connect failed");
+    client
+        .wait_until_active(5.0)
+        .await
+        .expect("client inactive");
+
+    client
+        .subscribe_volatility_index("btc_usd")
+        .await
+        .expect("subscribe failed");
+
+    // Verify subscription event recorded
+    wait_until_async(
+        || {
+            let state = state.clone();
+            async move {
+                state
+                    .subscription_events()
+                    .await
+                    .iter()
+                    .any(|(ch, ok)| ch.starts_with("deribit_volatility_index.") && *ok)
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Receive volatility index data from stream
+    let stream = client.stream().unwrap();
+    pin_mut!(stream);
+    let message = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("no message received")
+        .expect("stream ended unexpectedly");
+
+    match message {
+        NautilusWsMessage::Data(data) => {
+            assert_eq!(data.len(), 1);
+            if let Data::Custom(custom) = &data[0] {
+                let dvol = custom
+                    .data
+                    .as_any()
+                    .downcast_ref::<DeribitVolatilityIndex>()
+                    .expect("expected DeribitVolatilityIndex");
+                assert_eq!(dvol.index_name, "btc_usd");
+                assert_eq!(dvol.value, 129.36);
+                let metadata = custom
+                    .data_type
+                    .metadata()
+                    .expect("expected metadata for DeribitVolatilityIndex");
+                assert_eq!(
+                    metadata.get("index_name").and_then(|value| value.as_str()),
+                    Some("btc_usd"),
+                );
+            } else {
+                panic!("expected CustomData, found {:?}", data[0]);
+            }
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
 
     client.close().await.expect("close failed");
 }

--- a/nautilus_trader/adapters/deribit/data.py
+++ b/nautilus_trader/adapters/deribit/data.py
@@ -28,6 +28,7 @@ from nautilus_trader.common.component import MessageBus
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.common.secure import mask_api_key
 from nautilus_trader.core import nautilus_pyo3
+from nautilus_trader.core.data import Data
 from nautilus_trader.core.datetime import ensure_pydatetime_utc
 from nautilus_trader.core.nautilus_pyo3 import DeribitCurrency
 from nautilus_trader.core.nautilus_pyo3 import DeribitEnvironment
@@ -39,6 +40,7 @@ from nautilus_trader.data.messages import RequestInstruments
 from nautilus_trader.data.messages import RequestOrderBookSnapshot
 from nautilus_trader.data.messages import RequestTradeTicks
 from nautilus_trader.data.messages import SubscribeBars
+from nautilus_trader.data.messages import SubscribeData
 from nautilus_trader.data.messages import SubscribeFundingRates
 from nautilus_trader.data.messages import SubscribeIndexPrices
 from nautilus_trader.data.messages import SubscribeInstrument
@@ -50,6 +52,7 @@ from nautilus_trader.data.messages import SubscribeOrderBook
 from nautilus_trader.data.messages import SubscribeQuoteTicks
 from nautilus_trader.data.messages import SubscribeTradeTicks
 from nautilus_trader.data.messages import UnsubscribeBars
+from nautilus_trader.data.messages import UnsubscribeData
 from nautilus_trader.data.messages import UnsubscribeFundingRates
 from nautilus_trader.data.messages import UnsubscribeIndexPrices
 from nautilus_trader.data.messages import UnsubscribeInstrument
@@ -65,6 +68,7 @@ from nautilus_trader.live.cancellation import cancel_tasks_with_timeout
 from nautilus_trader.live.data_client import LiveMarketDataClient
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import BookOrder
+from nautilus_trader.model.data import CustomData
 from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import FundingRateUpdate
 from nautilus_trader.model.data import InstrumentStatus
@@ -81,6 +85,35 @@ from nautilus_trader.model.enums import book_type_to_str
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.instruments import Instrument
+
+
+class DeribitVolatilityIndexData(Data):
+    """
+    Python data object for Deribit volatility index custom payload.
+    """
+
+    def __init__(self, index_name: str, value: float, ts_event: int, ts_init: int) -> None:
+        self.index_name = index_name
+        self.value = value
+        self._ts_event = ts_event
+        self._ts_init = ts_init
+
+    @property
+    def ts_event(self) -> int:
+        return self._ts_event
+
+    @property
+    def ts_init(self) -> int:
+        return self._ts_init
+
+    @staticmethod
+    def from_pyo3(pyo3_dvol: Any) -> "DeribitVolatilityIndexData":
+        return DeribitVolatilityIndexData(
+            index_name=pyo3_dvol.index_name,
+            value=pyo3_dvol.value,
+            ts_event=pyo3_dvol.ts_event,
+            ts_init=pyo3_dvol.ts_init,
+        )
 
 
 class DeribitDataClient(LiveMarketDataClient):
@@ -355,6 +388,72 @@ class DeribitDataClient(LiveMarketDataClient):
         pyo3_instrument_id = nautilus_pyo3.InstrumentId.from_str(command.instrument_id.value)
         interval = self._get_interval(command.params)
         await self._ws_client.unsubscribe_option_greeks(pyo3_instrument_id, interval)
+
+    async def _subscribe(self, command: SubscribeData) -> None:
+        data_type = command.data_type
+        data_type_name = data_type.type.__name__
+
+        if data_type_name == "DeribitVolatilityIndex":
+            metadata = data_type.metadata or {}
+            index_name_raw = metadata.get("index_name")
+            index_name = str(index_name_raw).strip() if index_name_raw is not None else ""
+            if not index_name:
+                self._log.warning(
+                    "Rejected Deribit volatility index subscription: "
+                    "missing required metadata `index_name`",
+                )
+                return
+
+            self._log.info(f"Subscribing to Deribit volatility index: {index_name}")
+            subscribe_volatility_index: Any = getattr(
+                self._ws_client,
+                "subscribe_volatility_index",
+                None,
+            )
+
+            if subscribe_volatility_index is None:
+                self._log.warning(
+                    "Rejected Deribit volatility index subscription: "
+                    "WebSocket client does not expose subscribe_volatility_index",
+                )
+                return
+            await subscribe_volatility_index(index_name)
+            return
+
+        self._log.warning(f"Unsupported custom data subscription: {data_type_name}")
+
+    async def _unsubscribe(self, command: UnsubscribeData) -> None:
+        data_type = command.data_type
+        data_type_name = data_type.type.__name__
+
+        if data_type_name == "DeribitVolatilityIndex":
+            metadata = data_type.metadata or {}
+            index_name_raw = metadata.get("index_name")
+            index_name = str(index_name_raw).strip() if index_name_raw is not None else ""
+            if not index_name:
+                self._log.warning(
+                    "Rejected Deribit volatility index unsubscription: "
+                    "missing required metadata `index_name`",
+                )
+                return
+
+            self._log.info(f"Unsubscribing from Deribit volatility index: {index_name}")
+            unsubscribe_volatility_index: Any = getattr(
+                self._ws_client,
+                "unsubscribe_volatility_index",
+                None,
+            )
+
+            if unsubscribe_volatility_index is None:
+                self._log.warning(
+                    "Rejected Deribit volatility index unsubscription: "
+                    "WebSocket client does not expose unsubscribe_volatility_index",
+                )
+                return
+            await unsubscribe_volatility_index(index_name)
+            return
+
+        self._log.warning(f"Unsupported custom data unsubscription: {data_type_name}")
 
     async def _unsubscribe_instruments(self, command: UnsubscribeInstruments) -> None:
         kind = "any"
@@ -712,6 +811,17 @@ class DeribitDataClient(LiveMarketDataClient):
                 # to `Data` is still owned and managed by Rust.
                 data = capsule_to_data(msg)
                 self._handle_data(data)
+            elif isinstance(msg, nautilus_pyo3.CustomData):
+                dvol_cls: Any = getattr(nautilus_pyo3, "DeribitVolatilityIndex", None)
+                if dvol_cls is None or not isinstance(msg.data, dvol_cls):
+                    self._log.error(
+                        f"Unsupported custom payload type for Deribit: {type(msg.data).__name__}",
+                    )
+                    return
+
+                inner = DeribitVolatilityIndexData.from_pyo3(msg.data)
+                data_type = DataType(type(msg.data), metadata=msg.data_type.metadata)
+                self._handle_data(CustomData(data_type=data_type, data=inner))
             elif isinstance(msg, nautilus_pyo3.InstrumentStatus):
                 self._handle_data(InstrumentStatus.from_pyo3(msg))
             elif hasattr(msg, "__class__") and "Instrument" in msg.__class__.__name__:


### PR DESCRIPTION
# Pull Request

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds `DeribitVolatilityIndex` as a new Deribit-specific `CustomData` type emitted from the `deribit_volatility_index.{index_name}` WebSocket channel (DVOL). Includes WebSocket subscribe/unsubscribe support, handler routing into `Data::Custom`, and Python `DataClient` subscription/unsubscription routing (via `DataType.metadata["index_name"]`).

## Related Issues/PRs

Closes #3979

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

- `cargo fmt -p nautilus-deribit`
- `cargo clippy -p nautilus-deribit -- -D warnings`
- `cargo test -p nautilus-deribit --lib`
- `cargo test -p nautilus-deribit --test websocket`
- `PYO3_ONLY=1 BUILD_MODE=debug-pyo3 .venv/bin/python build.py` (verified `nautilus_trader.core.nautilus_pyo3.deribit.DeribitVolatilityIndex` import)
