### PR TITLE
Fix Cython OrderMatchingEngine.reset leaking OrderBook.ts_last on repeated runs

### DIFF
--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -3992,7 +3992,16 @@ cdef class OrderMatchingEngine:
     cpdef void reset(self):
         self._log.debug(f"Resetting OrderMatchingEngine {self.instrument.id}")
 
-        self._book.clear(0, 0)
+        # Use `reset` (not `clear`) so `book.ts_last` is zeroed. `clear(0, 0)`
+        # routes through `OrderBook.increment` whose ts_last/sequence are
+        # high-water marks: `ts_event.max(self.ts_last)` keeps the stale
+        # timestamp, and the L1 stale-event guard added in #3790 then drops
+        # every subsequent quote/trade tick whose ts_event < that residual.
+        # Repeated runs (sweep / param-search) need the engine to accept the
+        # next run's bars even though they predate the previous run's last ts.
+        # The Rust matching engine reset path (`crates/execution/src/
+        # matching_engine/engine.rs::reset`) already calls `book.reset()`.
+        self._book.reset()
         self._account_ids.clear()
         self._execution_bar_types.clear()
         self._execution_bar_deltas.clear()

--- a/tests/unit_tests/backtest/test_matching_engine.py
+++ b/tests/unit_tests/backtest/test_matching_engine.py
@@ -170,6 +170,59 @@ class TestOrderMatchingEngine:
         # Assert
         assert exec_messages
 
+    def test_reset_zeroes_book_ts_last(self) -> None:
+        """
+        Regression for the L1 stale-event guard added in #3790.
+
+        ``OrderMatchingEngine.reset`` previously called ``book.clear(0, 0)``,
+        which routes through ``OrderBook.increment`` whose
+        ``ts_last = ts_event.max(self.ts_last)`` is a high-water mark. Calling
+        ``clear(0, 0)`` therefore leaves the prior run's last timestamp in
+        place. The L1 stale-event guard then drops every subsequent
+        quote/trade whose ``ts_event < ts_last``, leaving the matching core's
+        bid/ask uninitialised — every market order on the next run is
+        rejected with ``"no market for {instrument_id}"``.
+
+        The Rust matching engine ``reset`` (``crates/execution/src/
+        matching_engine/engine.rs``) calls ``book.reset()`` (which zeroes
+        ``ts_last``); this test asserts the Cython path does the same so
+        repeated runs (sweep / param-search) on the same engine instance
+        behave identically to a fresh engine.
+
+        """
+        # Arrange — seed the book with a quote so ts_last advances
+        seed_quote = TestDataStubs.quote_tick(
+            instrument=self.instrument,
+            ts_event=100,
+            ts_init=100,
+        )
+        self.matching_engine.process_quote_tick(seed_quote)
+        assert self.matching_engine.get_book().ts_last == 100
+
+        # Act
+        self.matching_engine.reset()
+
+        # Assert — book ts_last must be zero after reset
+        assert self.matching_engine.get_book().ts_last == 0, (
+            "OrderMatchingEngine.reset leaked book.ts_last; subsequent "
+            "quote/trade events with earlier ts_event will be silently "
+            "dropped by the L1 stale-event guard"
+        )
+
+        # And — a quote with an earlier ts_event than the previous run's
+        # last must be accepted (not dropped as stale) and update the book
+        replay_quote = TestDataStubs.quote_tick(
+            instrument=self.instrument,
+            bid_price=2.0,
+            ask_price=2.0,
+            ts_event=50,  # < the seed quote's ts_event=100
+            ts_init=50,
+        )
+        self.matching_engine.process_quote_tick(replay_quote)
+        assert self.matching_engine.get_book().ts_last == 50
+        assert self.matching_engine.best_bid_price() == self.instrument.make_price(2.0)
+        assert self.matching_engine.best_ask_price() == self.instrument.make_price(2.0)
+
     def test_process_order_book_depth_10(self) -> None:
         # Arrange - Create L2_MBP matching engine for depth10 data
         matching_engine_l2 = OrderMatchingEngine(


### PR DESCRIPTION
## Bug

`OrderMatchingEngine.reset` (Cython) calls `self._book.clear(0, 0)`, which routes through `OrderBook.increment` whose `ts_last`/`sequence` are high-water marks:

```rust
// crates/model/src/orderbook/book.rs:1024-1026
self.sequence = sequence.max(self.sequence);
self.ts_last = ts_event.max(self.ts_last);
```

So `clear(0, 0)` preserves the prior run's last timestamp.

The L1 stale-event guard added in #3790 then drops every subsequent quote/trade whose `ts_event < self.ts_last`:

```rust
// crates/model/src/orderbook/book.rs:1092-1098
if trade.ts_event < self.ts_last {
    log::warn!("Skipping stale trade: ...");
    return Ok(());  // book is not mutated
}
```

In repeated-run scenarios (sweep / parameter-search where one `BacktestEngine` instance is reset and re-run with the same data), this leaves the matching core's bid/ask uninitialised, and every market order on subsequent runs is rejected with reason `"no market for {instrument_id}"`.

The Rust matching engine reset path (`crates/execution/src/matching_engine/engine.rs:237`) already calls `book.reset()` (which zeroes `ts_last`); the Cython path was the outlier.

## Fix

One-line Cython change in `nautilus_trader/backtest/engine.pyx::OrderMatchingEngine.reset`:

```diff
-self._book.clear(0, 0)
+self._book.reset()
```

`OrderBook.reset()` clears bids/asks **and** zeroes `sequence`, `ts_last`, `update_count` — exactly the reset semantics needed so repeated runs behave like a fresh engine, matching the Rust path.

## Regression test

Added `tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_reset_zeroes_book_ts_last`:

1. Seed L1_MBP book with a quote at `ts_event=100` → assert `ts_last == 100`
2. Reset matching engine
3. Assert `ts_last == 0` (the leak)
4. Replay a quote at earlier `ts_event=50` and verify it is accepted (best bid/ask updated)

Pre-fix: assertion 3 fails (`ts_last == 100`); also the replay quote in 4 is silently dropped.
Post-fix: all assertions pass.

## Validation

End-to-end reproducer (running 2 trials back-to-back through one `BacktestSweepEngine` against 2 years of BTCUSDT 1m kline data):

| | Pre-fix | Post-fix |
|---|---|---|
| Trial 1 positions | 2 | 2 |
| Trial 2 positions | **0** | **2** |
| Trial 2 OrderRejected | 266 | 0 |

Test suites: `tests/unit_tests/backtest/` 765/765 PASS (1 unrelated skip).

## Scope

- Affects: any code path that calls `BacktestEngine.reset()` (or per-venue `SimulatedExchange.reset()`) and re-runs with data whose `ts_event` is `<` the prior run's last — i.e. classic repeated-runs / sweep / parameter-search
- Unaffected: single-run backtests (each call builds a fresh engine, never hits this reset path), live trading, Rust matching engine path