### PR TITLE
Fix sandbox race on tick-size precision changes

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -77,6 +77,16 @@ struct SandboxInner {
     event_handler: Option<Rc<dyn Fn(OrderEventAny)>>,
 }
 
+fn quote_matches_instrument_precision(quote: &QuoteTick, instrument: &InstrumentAny) -> bool {
+    let price_precision = instrument.price_precision();
+    let size_precision = instrument.size_precision();
+
+    quote.bid_price.precision == price_precision
+        && quote.ask_price.precision == price_precision
+        && quote.bid_size.precision == size_precision
+        && quote.ask_size.precision == size_precision
+}
+
 impl SandboxInner {
     /// Ensures a matching engine exists for the given instrument.
     fn ensure_matching_engine(&mut self, instrument: &InstrumentAny) {
@@ -117,6 +127,21 @@ impl SandboxInner {
         // Try to get instrument from cache, create engine if found
         let instrument = self.cache.borrow().instrument(&instrument_id).cloned();
         if let Some(instrument) = instrument {
+            if !quote_matches_instrument_precision(quote, &instrument) {
+                log::warn!(
+                    "Dropping quote tick for {} due to precision mismatch \
+                     (bid_px={}, ask_px={}, bid_sz={}, ask_sz={}, expected_price={}, expected_size={})",
+                    instrument_id,
+                    quote.bid_price.precision,
+                    quote.ask_price.precision,
+                    quote.bid_size.precision,
+                    quote.ask_size.precision,
+                    instrument.price_precision(),
+                    instrument.size_precision(),
+                );
+                return;
+            }
+
             self.ensure_matching_engine(&instrument);
 
             if let Some(engine) = self.matching_engines.get_mut(&instrument_id) {
@@ -421,6 +446,21 @@ impl SandboxExecutionClient {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Instrument not found: {instrument_id}"))?;
 
+        if !quote_matches_instrument_precision(quote, &instrument) {
+            log::warn!(
+                "Dropping quote tick for {} due to precision mismatch \
+                 (bid_px={}, ask_px={}, bid_sz={}, ask_sz={}, expected_price={}, expected_size={})",
+                instrument_id,
+                quote.bid_price.precision,
+                quote.ask_price.precision,
+                quote.bid_size.precision,
+                quote.ask_size.precision,
+                instrument.price_precision(),
+                instrument.size_precision(),
+            );
+            return Ok(());
+        }
+
         let mut inner = self.inner.borrow_mut();
         inner.ensure_matching_engine(&instrument);
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
@@ -562,6 +602,16 @@ impl ExecutionClient for SandboxExecutionClient {
 
     fn oms_type(&self) -> OmsType {
         self.config.oms_type
+    }
+
+    fn on_instrument(&mut self, instrument: InstrumentAny) {
+        let instrument_id = instrument.id();
+        let mut inner = self.inner.borrow_mut();
+        if let Some(engine) = inner.matching_engines.get_mut(&instrument_id)
+            && let Err(e) = engine.get_engine_mut().update_instrument(instrument)
+        {
+            log::error!("Failed to update instrument {instrument_id} in sandbox engine: {e}");
+        }
     }
 
     fn get_account(&self) -> Option<AccountAny> {

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -143,17 +143,42 @@ fn execution_client(test_context: TestContext) -> SandboxExecutionClient {
     test_context.client
 }
 
-fn create_quote_tick(instrument_id: InstrumentId, bid: f64, ask: f64) -> QuoteTick {
-    // Use precision 2 to match crypto_perpetual_ethusdt fixture
+fn create_quote_tick_with_price_precision(
+    instrument_id: InstrumentId,
+    bid: f64,
+    ask: f64,
+    price_precision: u8,
+) -> QuoteTick {
     QuoteTick::new(
         instrument_id,
-        Price::new(bid, 2),
-        Price::new(ask, 2),
+        Price::new(bid, price_precision),
+        Price::new(ask, price_precision),
         Quantity::new(100.0, 3),
         Quantity::new(100.0, 3),
         UnixNanos::default(),
         UnixNanos::default(),
     )
+}
+
+fn create_quote_tick(instrument_id: InstrumentId, bid: f64, ask: f64) -> QuoteTick {
+    // Use price precision 2 to match crypto_perpetual_ethusdt fixture.
+    create_quote_tick_with_price_precision(instrument_id, bid, ask, 2)
+}
+
+fn create_mismatched_quote_tick(instrument_id: InstrumentId, bid: f64, ask: f64) -> QuoteTick {
+    // Uses price precision 3 (instrument fixture uses 2), should be rejected by sandbox guard.
+    create_quote_tick_with_price_precision(instrument_id, bid, ask, 3)
+}
+
+fn updated_instrument_with_price_precision_3(instrument: InstrumentAny) -> InstrumentAny {
+    match instrument {
+        InstrumentAny::CryptoPerpetual(mut crypto_perp) => {
+            crypto_perp.price_precision = 3;
+            crypto_perp.price_increment = Price::from("0.001");
+            InstrumentAny::CryptoPerpetual(crypto_perp)
+        }
+        _ => panic!("Test fixture expected CryptoPerpetual instrument"),
+    }
 }
 
 fn setup_order_event_handler() {
@@ -385,6 +410,67 @@ fn test_process_quote_tick_reuses_matching_engine(
     test_context.client.process_quote_tick(&quote1).unwrap();
     test_context.client.process_quote_tick(&quote2).unwrap();
 
+    assert_eq!(test_context.client.matching_engine_count(), 1);
+}
+
+#[rstest]
+fn test_process_quote_tick_drops_precision_mismatch(
+    test_context: TestContext,
+    instrument: InstrumentAny,
+) {
+    setup_order_event_handler();
+
+    test_context
+        .cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+
+    let quote = create_mismatched_quote_tick(instrument.id(), 1000.0, 1001.0);
+    let result = test_context.client.process_quote_tick(&quote);
+
+    assert!(result.is_ok());
+    assert_eq!(test_context.client.matching_engine_count(), 0);
+}
+
+#[rstest]
+fn test_on_instrument_updates_engine_precision(
+    mut test_context: TestContext,
+    instrument: InstrumentAny,
+) {
+    setup_order_event_handler();
+
+    test_context
+        .cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+
+    let quote_before = create_quote_tick(instrument.id(), 1000.0, 1001.0);
+    test_context
+        .client
+        .process_quote_tick(&quote_before)
+        .unwrap();
+    assert_eq!(test_context.client.matching_engine_count(), 1);
+
+    let updated_instrument = updated_instrument_with_price_precision_3(instrument);
+    test_context
+        .cache
+        .borrow_mut()
+        .add_instrument(updated_instrument.clone())
+        .unwrap();
+    test_context
+        .client
+        .on_instrument(updated_instrument.clone());
+
+    let stale_quote = create_quote_tick(updated_instrument.id(), 1000.0, 1001.0);
+    let stale_result = test_context.client.process_quote_tick(&stale_quote);
+    assert!(stale_result.is_ok());
+
+    let updated_quote =
+        create_quote_tick_with_price_precision(updated_instrument.id(), 1000.0, 1001.0, 3);
+    let updated_result = test_context.client.process_quote_tick(&updated_quote);
+    assert!(updated_result.is_ok());
     assert_eq!(test_context.client.matching_engine_count(), 1);
 }
 

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -120,6 +120,7 @@ pub struct OrderMatchingEngine {
     prev_ask_size_raw: QuantityRaw,
     last_quote_bid: Option<Price>,
     last_quote_ask: Option<Price>,
+    precision_mismatch_streak: u32,
     tob_initialized: bool,
     instrument_close: Option<InstrumentClose>,
     settlement_price: Option<Price>,
@@ -202,6 +203,7 @@ impl OrderMatchingEngine {
             prev_ask_size_raw: 0,
             last_quote_bid: None,
             last_quote_ask: None,
+            precision_mismatch_streak: 0,
             tob_initialized: false,
             instrument_close: None,
             settlement_price: None,
@@ -256,6 +258,7 @@ impl OrderMatchingEngine {
         self.prev_ask_size_raw = 0;
         self.last_quote_bid = None;
         self.last_quote_ask = None;
+        self.precision_mismatch_streak = 0;
         self.tob_initialized = false;
         self.instrument_close = None;
         self.settlement_price = None;
@@ -952,6 +955,65 @@ impl OrderMatchingEngine {
         self.fill_at_market = value;
     }
 
+    /// Updates the instrument definition used by this matching engine.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `instrument.id()` does not match this engines instrument ID.
+    pub fn update_instrument(&mut self, instrument: InstrumentAny) -> anyhow::Result<()> {
+        if instrument.id() != self.instrument.id() {
+            anyhow::bail!(
+                "Cannot update instrument {} with {}",
+                self.instrument.id(),
+                instrument.id()
+            );
+        }
+
+        let changed = instrument.price_increment() != self.instrument.price_increment()
+            || instrument.price_precision() != self.instrument.price_precision()
+            || instrument.size_precision() != self.instrument.size_precision();
+
+        if changed {
+            self.core
+                .update_price_increment(instrument.price_increment());
+            self.book.reset();
+            self.bid_consumption.clear();
+            self.ask_consumption.clear();
+            self.trade_consumption = 0;
+            self.queue_ahead.clear();
+            self.queue_excess.clear();
+            self.queue_pending.clear();
+            self.prev_bid_price_raw = 0;
+            self.prev_bid_size_raw = 0;
+            self.prev_ask_price_raw = 0;
+            self.prev_ask_size_raw = 0;
+            self.last_quote_bid = None;
+            self.last_quote_ask = None;
+            self.precision_mismatch_streak = 0;
+            self.tob_initialized = false;
+            self.target_bid = None;
+            self.target_ask = None;
+            self.target_last = None;
+            self.last_bar_bid = None;
+            self.last_bar_ask = None;
+            self.core.bid = None;
+            self.core.ask = None;
+            self.core.last = None;
+            self.core.is_bid_initialized = false;
+            self.core.is_ask_initialized = false;
+            self.core.is_last_initialized = false;
+            log::info!(
+                "Updated instrument {} (price_precision={} size_precision={})",
+                instrument.id(),
+                instrument.price_precision(),
+                instrument.size_precision()
+            );
+        }
+
+        self.instrument = instrument;
+        Ok(())
+    }
+
     fn check_price_precision(&self, actual: u8, field: &str) -> anyhow::Result<()> {
         let expected = self.instrument.price_precision();
         if actual != expected {
@@ -972,6 +1034,30 @@ impl OrderMatchingEngine {
             );
         }
         Ok(())
+    }
+
+    fn log_precision_mismatch(
+        &mut self,
+        data_type: &str,
+        instrument_id: InstrumentId,
+        err: &anyhow::Error,
+    ) {
+        self.precision_mismatch_streak = self.precision_mismatch_streak.saturating_add(1);
+        let streak = self.precision_mismatch_streak;
+
+        if streak <= 3 || streak.is_multiple_of(100) {
+            log::warn!(
+                "Skipping {data_type} for {instrument_id}: {err} \
+                 (consecutive_precision_mismatches={streak})"
+            );
+        }
+
+        if streak == 20 {
+            log::error!(
+                "Precision mismatches reached {streak} consecutive events for \
+                 {instrument_id}; check instrument update flow and upstream market data"
+            );
+        }
     }
 
     /// Process the venues market for the given order book delta.
@@ -1169,19 +1255,30 @@ impl OrderMatchingEngine {
     /// # Panics
     ///
     /// - If updating the order book with the quote tick fails.
-    /// - If bid/ask price precision does not match the instrument.
-    /// - If bid/ask size precision does not match the instrument.
     pub fn process_quote_tick(&mut self, quote: &QuoteTick) {
         log::debug!("Processing {quote}");
 
-        self.check_price_precision(quote.bid_price.precision, "bid_price")
-            .unwrap();
-        self.check_price_precision(quote.ask_price.precision, "ask_price")
-            .unwrap();
-        self.check_size_precision(quote.bid_size.precision, "bid_size")
-            .unwrap();
-        self.check_size_precision(quote.ask_size.precision, "ask_size")
-            .unwrap();
+        if let Err(e) = self.check_price_precision(quote.bid_price.precision, "bid_price") {
+            self.log_precision_mismatch("quote tick", quote.instrument_id, &e);
+            return;
+        }
+
+        if let Err(e) = self.check_price_precision(quote.ask_price.precision, "ask_price") {
+            self.log_precision_mismatch("quote tick", quote.instrument_id, &e);
+            return;
+        }
+
+        if let Err(e) = self.check_size_precision(quote.bid_size.precision, "bid_size") {
+            self.log_precision_mismatch("quote tick", quote.instrument_id, &e);
+            return;
+        }
+
+        if let Err(e) = self.check_size_precision(quote.ask_size.precision, "ask_size") {
+            self.log_precision_mismatch("quote tick", quote.instrument_id, &e);
+            return;
+        }
+
+        self.precision_mismatch_streak = 0;
 
         if self.book_type == BookType::L1_MBP {
             // Stale update: skip book mutation and cache updates
@@ -1475,15 +1572,20 @@ impl OrderMatchingEngine {
     /// # Panics
     ///
     /// - If updating the order book with the trade tick fails.
-    /// - If trade price precision does not match the instrument.
-    /// - If trade size precision does not match the instrument.
     pub fn process_trade_tick(&mut self, trade: &TradeTick) {
         log::debug!("Processing {trade}");
 
-        self.check_price_precision(trade.price.precision, "trade price")
-            .unwrap();
-        self.check_size_precision(trade.size.precision, "trade size")
-            .unwrap();
+        if let Err(e) = self.check_price_precision(trade.price.precision, "trade price") {
+            self.log_precision_mismatch("trade tick", trade.instrument_id, &e);
+            return;
+        }
+
+        if let Err(e) = self.check_size_precision(trade.size.precision, "trade size") {
+            self.log_precision_mismatch("trade tick", trade.instrument_id, &e);
+            return;
+        }
+
+        self.precision_mismatch_streak = 0;
 
         let price_raw = trade.price.raw;
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -8403,3 +8403,96 @@ fn test_trailing_stop_no_recompute_skips_resync(
         "core RestingOrder should be byte-identical when nothing changed",
     );
 }
+
+#[rstest]
+fn test_update_instrument_resets_market_state(instrument_eth_usdt: InstrumentAny) {
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let mut engine = OrderMatchingEngine::new(
+        instrument_eth_usdt.clone(),
+        1,
+        FillModelAny::default(),
+        FeeModelAny::default(),
+        BookType::L1_MBP,
+        OmsType::Netting,
+        AccountType::Cash,
+        clock,
+        cache,
+        OrderMatchingEngineConfig::default(),
+    );
+
+    let quote = QuoteTick::new(
+        instrument_eth_usdt.id(),
+        Price::from("1000.00"),
+        Price::from("1001.00"),
+        Quantity::from("1.000"),
+        Quantity::from("1.000"),
+        UnixNanos::from(2),
+        UnixNanos::from(2),
+    );
+    engine.process_quote_tick(&quote);
+
+    let updated_instrument = match instrument_eth_usdt {
+        InstrumentAny::CryptoPerpetual(mut crypto_perp) => {
+            crypto_perp.price_precision = 3;
+            crypto_perp.price_increment = Price::from("0.001");
+            InstrumentAny::CryptoPerpetual(crypto_perp)
+        }
+        _ => panic!("Test fixture expected CryptoPerpetual instrument"),
+    };
+
+    engine.update_instrument(updated_instrument).unwrap();
+
+    assert!(engine.best_bid_price().is_none());
+    assert!(engine.best_ask_price().is_none());
+    assert_eq!(engine.get_core().price_increment, Price::from("0.001"));
+}
+
+#[rstest]
+fn test_update_instrument_without_precision_change_keeps_market_state(
+    instrument_eth_usdt: InstrumentAny,
+) {
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let mut engine = OrderMatchingEngine::new(
+        instrument_eth_usdt.clone(),
+        1,
+        FillModelAny::default(),
+        FeeModelAny::default(),
+        BookType::L1_MBP,
+        OmsType::Netting,
+        AccountType::Cash,
+        clock,
+        cache,
+        OrderMatchingEngineConfig::default(),
+    );
+
+    let quote = QuoteTick::new(
+        instrument_eth_usdt.id(),
+        Price::from("1000.00"),
+        Price::from("1001.00"),
+        Quantity::from("1.000"),
+        Quantity::from("1.000"),
+        UnixNanos::from(2),
+        UnixNanos::from(2),
+    );
+    engine.process_quote_tick(&quote);
+
+    let best_bid_before = engine.best_bid_price();
+    let best_ask_before = engine.best_ask_price();
+    let increment_before = engine.get_core().price_increment;
+
+    let updated_instrument = match instrument_eth_usdt {
+        InstrumentAny::CryptoPerpetual(mut crypto_perp) => {
+            crypto_perp.ts_event = UnixNanos::from(3);
+            InstrumentAny::CryptoPerpetual(crypto_perp)
+        }
+        _ => panic!("Test fixture expected CryptoPerpetual instrument"),
+    };
+
+    engine.update_instrument(updated_instrument).unwrap();
+
+    assert_eq!(engine.best_bid_price(), best_bid_before);
+    assert_eq!(engine.best_ask_price(), best_ask_before);
+    assert_eq!(engine.get_core().price_increment, increment_before);
+}


### PR DESCRIPTION
## Summary
This PR fixes a race where a stale `QuoteTick` created just before a `tick_size_change` could be dequeued later and crash sandbox matching with a precision mismatch panic.

Handle tick-size changes atomically across book and matching #3942

## Root Cause
- Adapter updates instrument precision and resets local book around `tick_size_change`.
- But a pre-change quote can already be in the async queue.
- `OrderMatchingEngine::process_quote_tick` previously `unwrap()`ed precision checks against current instrument precision.
- On mismatch, this panicked, propagated through PyO3, and could terminate the process.

## What Changed
### 1) Matching engine hardening (`crates/execution/src/matching_engine/engine.rs`)
- Add `update_instrument(instrument)` to update instrument metadata in-place.
- Detect precision/grid changes using the minimal set:
  - `price_increment`
  - `price_precision`
  - `size_precision`
- When changed, atomically reset dependent market/matching state (book + queue/consumption baselines) and update core increment.
- Replace precision-check `unwrap()` in `process_quote_tick` / `process_trade_tick` with guarded early-return + warning logs.
- Add a small consecutive mismatch streak logger to avoid noisy repeated warnings.

### 2) Sandbox execution integration (`crates/adapters/sandbox/src/execution.rs`)
- Implement `on_instrument` to push instrument updates into existing matching engines via `update_instrument`.
- Add a precision pre-guard in sandbox quote handling to drop mismatched stale quotes before entering matching.

### 3) Tests
- `crates/execution/tests/matching_engine.rs`
  - `test_update_instrument_resets_market_state`
  - `test_update_instrument_without_precision_change_keeps_market_state`
- `crates/adapters/sandbox/tests/execution.rs`
  - `test_process_quote_tick_drops_precision_mismatch`
  - `test_on_instrument_updates_engine_precision`

## Why This Shape
- Prevents crash first (no panic on stale precision mismatch).
- Keeps matching engine and instrument precision/grid aligned over time.
- Keeps behavior safe in non-`tick_size_change` markets by only resetting on true precision/grid change.

## Validation
Ran locally:
- `cargo test -p nautilus-execution --test matching_engine -- --nocapture`
- `cargo test -p nautilus-sandbox --test execution -- --nocapture`
- `cargo fmt --check`
- `pre-commit run --files crates/adapters/sandbox/src/execution.rs crates/adapters/sandbox/tests/execution.rs crates/execution/src/matching_engine/engine.rs crates/execution/tests/matching_engine.rs`

## Known Limitation / Follow-up
In live probe logs, post-change recovery (change -> resumed book) can still be slow in some cases (~10s observed) because recovery depends on passive snapshot/stream progression.

Recommended follow-up: after `tick_size_change`, proactively request a fresh snapshot for that market immediately, instead of waiting passively.
