### PR TITLE
Fix OKX missing rebase instrument status

### DIFF
--- a/crates/adapters/okx/src/common/enums.rs
+++ b/crates/adapters/okx/src/common/enums.rs
@@ -306,6 +306,7 @@ pub enum OKXInstrumentStatus {
     Preopen,
     Test,
     PostOnly,
+    Rebase,
 }
 
 /// Represents an instrument contract type on OKX.

--- a/crates/adapters/okx/src/common/parse.rs
+++ b/crates/adapters/okx/src/common/parse.rs
@@ -258,6 +258,7 @@ pub fn okx_status_to_market_action(status: OKXInstrumentStatus) -> MarketStatusA
         OKXInstrumentStatus::Preopen => MarketStatusAction::PreOpen,
         OKXInstrumentStatus::Test => MarketStatusAction::NotAvailableForTrading,
         OKXInstrumentStatus::PostOnly => MarketStatusAction::Quoting,
+        OKXInstrumentStatus::Rebase => MarketStatusAction::NotAvailableForTrading,
     }
 }
 
@@ -2811,6 +2812,17 @@ mod tests {
     }
 
     #[rstest]
+    fn test_deserialize_swap_instrument_with_rebase_state() {
+        let json_data = load_test_json("http_get_instruments_swap.json");
+        let mut value: serde_json::Value = serde_json::from_str(&json_data).unwrap();
+        value["data"][0]["state"] = serde_json::Value::String("rebase".to_string());
+
+        let response: OKXResponse<OKXInstrument> = serde_json::from_value(value).unwrap();
+
+        assert_eq!(response.data[0].inst_id, "BTC-USD-SWAP");
+    }
+
+    #[rstest]
     fn test_parse_linear_swap_instrument() {
         let json_data = load_test_json("http_get_instruments_swap.json");
         let response: OKXResponse<OKXInstrument> = serde_json::from_str(&json_data).unwrap();
@@ -5063,6 +5075,10 @@ mod tests {
     #[case(OKXInstrumentStatus::Preopen, MarketStatusAction::PreOpen)]
     #[case(OKXInstrumentStatus::Test, MarketStatusAction::NotAvailableForTrading)]
     #[case(OKXInstrumentStatus::PostOnly, MarketStatusAction::Quoting)]
+    #[case(
+        OKXInstrumentStatus::Rebase,
+        MarketStatusAction::NotAvailableForTrading
+    )]
     fn test_okx_status_to_market_action(
         #[case] status: OKXInstrumentStatus,
         #[case] expected: MarketStatusAction,


### PR DESCRIPTION
OKX demo mode can return a `rebase` instrument state for SWAP instruments, which currently breaks `OKXInstrumentProvider` deserialization with `unknown variant `rebase``. This follows up #3966 and addresses @sumuzhao's comment there: https://github.com/nautechsystems/nautilus_trader/pull/3966#issuecomment-4375676277

I also re-ran the demo-mode state check from the comment on 2026-05-05 and observed `['live', 'preopen', 'rebase']`.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds the missing `rebase` variant to `OKXInstrumentStatus` and maps it to `MarketStatusAction::NotAvailableForTrading`, matching the existing handling for non-tradable OKX states such as `test`.

## Related Issues/PRs

Follow-up to #3966.

Reported by @sumuzhao in https://github.com/nautechsystems/nautilus_trader/pull/3966#issuecomment-4375676277.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No documentation changes were needed.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

Not added, following the scope of #3966 for this small OKX enum compatibility fix.

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added a deserialization regression test for a SWAP instrument with `state: "rebase"`, and extended `test_okx_status_to_market_action` to cover the new variant.

Validation run:

- `cargo test -p nautilus-okx test_deserialize_swap_instrument_with_rebase_state`
- `cargo test -p nautilus-okx test_okx_status_to_market_action`
- `cargo test -p nautilus-okx`
- `cargo fmt --check`
