### PR TITLE
Preserve Databento market data price precision

### DIFF
--- a/crates/adapters/databento/src/live.rs
+++ b/crates/adapters/databento/src/live.rs
@@ -60,6 +60,7 @@ use crate::{
 #[derive(Debug)]
 pub enum HandlerCommand {
     Subscribe(Subscription),
+    SetPricePrecision(Symbol, u8),
     Start,
     Close,
 }
@@ -103,6 +104,7 @@ pub struct DatabentoFeedHandler {
     backoff: ExponentialBackoff,
     subscriptions: Vec<Subscription>,
     buffered_commands: Vec<HandlerCommand>,
+    price_precision_overrides: AHashMap<Symbol, u8>,
     gateway_addr: Option<String>,
     success_threshold: Duration,
 }
@@ -164,6 +166,7 @@ impl DatabentoFeedHandler {
             backoff,
             subscriptions: Vec::new(),
             buffered_commands: Vec::new(),
+            price_precision_overrides: AHashMap::new(),
             gateway_addr: None,
             success_threshold: Duration::from_secs(60),
         }
@@ -343,6 +346,9 @@ impl DatabentoFeedHandler {
                         }
                         self.subscriptions.push(sub);
                     }
+                    HandlerCommand::SetPricePrecision(symbol, precision) => {
+                        self.price_precision_overrides.insert(symbol, precision);
+                    }
                     HandlerCommand::Start => {
                         start_buffered = true;
                     }
@@ -407,6 +413,13 @@ impl DatabentoFeedHandler {
                         self.subscriptions.push(sub_for_reconnect);
                         continue;
                     }
+                    Some(HandlerCommand::SetPricePrecision(symbol, precision)) => {
+                        log::debug!(
+                            "Received command: SetPricePrecision for {symbol} to {precision}"
+                        );
+                        self.price_precision_overrides.insert(symbol, precision);
+                        continue;
+                    }
                     Some(HandlerCommand::Start) => {
                         log::debug!("Received command: Start");
                         buffering_start = if self.replay {
@@ -446,6 +459,13 @@ impl DatabentoFeedHandler {
                         let mut sub_for_reconnect = sub;
                         sub_for_reconnect.start = None;
                         self.subscriptions.push(sub_for_reconnect);
+                        continue;
+                    }
+                    Some(HandlerCommand::SetPricePrecision(symbol, precision)) => {
+                        log::debug!(
+                            "Received command: SetPricePrecision for {symbol} to {precision}"
+                        );
+                        self.price_precision_overrides.insert(symbol, precision);
                         continue;
                     }
                     Some(HandlerCommand::Start) => {
@@ -550,6 +570,7 @@ impl DatabentoFeedHandler {
                         &sym_map,
                         &mut instrument_id_map,
                         &price_precision_map,
+                        &self.price_precision_overrides,
                         ts_init,
                     )?
                 };
@@ -565,6 +586,7 @@ impl DatabentoFeedHandler {
                         &sym_map,
                         &mut instrument_id_map,
                         &price_precision_map,
+                        &self.price_precision_overrides,
                         ts_init,
                     )?
                 };
@@ -580,6 +602,7 @@ impl DatabentoFeedHandler {
                         &sym_map,
                         &mut instrument_id_map,
                         &price_precision_map,
+                        &self.price_precision_overrides,
                         ts_init,
                         &initialized_books,
                         self.bars_timestamp_on_close,
@@ -823,6 +846,7 @@ fn handle_imbalance_msg(
     symbol_venue_map: &AHashMap<Symbol, Venue>,
     instrument_id_map: &mut AHashMap<u32, InstrumentId>,
     price_precision_map: &AHashMap<u32, u8>,
+    price_precision_overrides: &AHashMap<Symbol, u8>,
     ts_init: UnixNanos,
 ) -> anyhow::Result<DatabentoImbalance> {
     let instrument_id = update_instrument_id_map(
@@ -833,10 +857,12 @@ fn handle_imbalance_msg(
         instrument_id_map,
     )?;
 
-    let price_precision = price_precision_map
-        .get(&msg.hd.instrument_id)
-        .copied()
-        .unwrap_or(2);
+    let price_precision = resolve_price_precision(
+        msg.hd.instrument_id,
+        instrument_id,
+        price_precision_map,
+        price_precision_overrides,
+    );
 
     decode_imbalance_msg(msg, instrument_id, price_precision, Some(ts_init))
 }
@@ -850,6 +876,7 @@ fn handle_statistics_msg(
     symbol_venue_map: &AHashMap<Symbol, Venue>,
     instrument_id_map: &mut AHashMap<u32, InstrumentId>,
     price_precision_map: &AHashMap<u32, u8>,
+    price_precision_overrides: &AHashMap<Symbol, u8>,
     ts_init: UnixNanos,
 ) -> anyhow::Result<DatabentoStatistics> {
     let instrument_id = update_instrument_id_map(
@@ -860,10 +887,12 @@ fn handle_statistics_msg(
         instrument_id_map,
     )?;
 
-    let price_precision = price_precision_map
-        .get(&msg.hd.instrument_id)
-        .copied()
-        .unwrap_or(2);
+    let price_precision = resolve_price_precision(
+        msg.hd.instrument_id,
+        instrument_id,
+        price_precision_map,
+        price_precision_overrides,
+    );
 
     decode_statistics_msg(msg, instrument_id, price_precision, Some(ts_init))
 }
@@ -876,6 +905,7 @@ fn handle_record(
     symbol_venue_map: &AHashMap<Symbol, Venue>,
     instrument_id_map: &mut AHashMap<u32, InstrumentId>,
     price_precision_map: &AHashMap<u32, u8>,
+    price_precision_overrides: &AHashMap<Symbol, u8>,
     ts_init: UnixNanos,
     initialized_books: &HashSet<InstrumentId>,
     bars_timestamp_on_close: bool,
@@ -888,10 +918,12 @@ fn handle_record(
         instrument_id_map,
     )?;
 
-    let price_precision = price_precision_map
-        .get(&record.header().instrument_id)
-        .copied()
-        .unwrap_or(2);
+    let price_precision = resolve_price_precision(
+        record.header().instrument_id,
+        instrument_id,
+        price_precision_map,
+        price_precision_overrides,
+    );
 
     // For MBP-1 and quote-based schemas, always include trades since they're integral to the data
     // For MBO, only include trades after the book is initialized to maintain consistency
@@ -912,6 +944,23 @@ fn handle_record(
         include_trades,
         bars_timestamp_on_close,
     )
+}
+
+fn resolve_price_precision(
+    record_instrument_id: u32,
+    instrument_id: InstrumentId,
+    price_precision_map: &AHashMap<u32, u8>,
+    price_precision_overrides: &AHashMap<Symbol, u8>,
+) -> u8 {
+    price_precision_map
+        .get(&record_instrument_id)
+        .copied()
+        .or_else(|| {
+            price_precision_overrides
+                .get(&instrument_id.symbol)
+                .copied()
+        })
+        .unwrap_or(2)
 }
 
 /// Processes an MBO delta through the buffering state machine.

--- a/crates/adapters/databento/src/python/live.rs
+++ b/crates/adapters/databento/src/python/live.rs
@@ -208,7 +208,7 @@ impl DatabentoLiveClient {
     }
 
     #[pyo3(name = "subscribe")]
-    #[pyo3(signature = (schema, instrument_ids, start=None, snapshot=None))]
+    #[pyo3(signature = (schema, instrument_ids, start=None, snapshot=None, price_precisions=None))]
     #[expect(clippy::needless_pass_by_value)]
     fn py_subscribe(
         &mut self,
@@ -216,12 +216,32 @@ impl DatabentoLiveClient {
         instrument_ids: Vec<InstrumentId>,
         start: Option<u64>,
         snapshot: Option<bool>,
+        price_precisions: Option<Vec<Option<u8>>>,
     ) -> PyResult<()> {
         self.symbol_venue_map.rcu(|m| {
             for id in &instrument_ids {
                 m.entry(id.symbol).or_insert(id.venue);
             }
         });
+
+        if let Some(precisions) = price_precisions {
+            if precisions.len() != instrument_ids.len() {
+                return Err(to_pyvalue_err(format!(
+                    "`price_precisions` length ({}) must match `instrument_ids` length ({})",
+                    precisions.len(),
+                    instrument_ids.len()
+                )));
+            }
+
+            for (instrument_id, precision) in instrument_ids.iter().zip(precisions) {
+                if let Some(precision) = precision {
+                    self.send_command(HandlerCommand::SetPricePrecision(
+                        instrument_id.symbol,
+                        precision,
+                    ))?;
+                }
+            }
+        }
         let symbols: Vec<String> = instrument_ids
             .iter()
             .map(|id| id.symbol.to_string())

--- a/crates/adapters/databento/tests/feed_handler.rs
+++ b/crates/adapters/databento/tests/feed_handler.rs
@@ -36,7 +36,12 @@ use databento::{
 };
 use nautilus_common::testing::wait_until_async;
 use nautilus_databento::live::{DatabentoMessage, HandlerCommand};
-use nautilus_model::{data::Data, instruments::Instrument};
+use nautilus_model::{
+    data::Data,
+    identifiers::Symbol,
+    instruments::Instrument,
+    types::{Price, Quantity},
+};
 use rstest::rstest;
 
 const INSTRUMENT_ID: u32 = 1;
@@ -124,11 +129,17 @@ async fn test_subscribe_trades() {
     server.expect_subscription();
     server.start();
     server.send_record(symbol_mapping_msg(INSTRUMENT_ID, RAW_SYMBOL));
-    server.send_record(trade_msg(INSTRUMENT_ID, 100_000_000_000, 50));
+    server.send_record(trade_msg(INSTRUMENT_ID, 1_170_400_000, 50));
     server.disconnect();
 
     let handle = tokio::spawn(async move { handler.run().await });
 
+    cmd_tx
+        .send(HandlerCommand::SetPricePrecision(
+            Symbol::from(RAW_SYMBOL),
+            5,
+        ))
+        .unwrap();
     cmd_tx
         .send(HandlerCommand::Subscribe(subscription(dbn::Schema::Trades)))
         .unwrap();
@@ -138,8 +149,9 @@ async fn test_subscribe_trades() {
     match msg {
         DatabentoMessage::Data(Data::Trade(trade)) => {
             assert_eq!(trade.instrument_id.symbol.as_str(), RAW_SYMBOL);
-            assert!(trade.price.as_f64() > 0.0);
-            assert!(trade.size.as_f64() > 0.0);
+            assert_eq!(trade.price, Price::from("1.17040"));
+            assert_eq!(trade.price.precision, 5);
+            assert_eq!(trade.size, Quantity::from(50));
         }
         other => panic!("expected Data::Trade, was {other:?}"),
     }
@@ -161,14 +173,20 @@ async fn test_subscribe_quotes_mbp1() {
     server.send_record(symbol_mapping_msg(INSTRUMENT_ID, RAW_SYMBOL));
     server.send_record(mbp1_msg(
         INSTRUMENT_ID,
-        100_000_000_000, // bid 100.00
-        101_000_000_000, // ask 101.00
-        b'A',            // Add action
+        1_170_350_000, // bid 1.17035
+        1_170_400_000, // ask 1.17040
+        b'A',          // Add action
     ));
     server.disconnect();
 
     let handle = tokio::spawn(async move { handler.run().await });
 
+    cmd_tx
+        .send(HandlerCommand::SetPricePrecision(
+            Symbol::from(RAW_SYMBOL),
+            5,
+        ))
+        .unwrap();
     cmd_tx
         .send(HandlerCommand::Subscribe(subscription(dbn::Schema::Mbp1)))
         .unwrap();
@@ -178,7 +196,10 @@ async fn test_subscribe_quotes_mbp1() {
     match msg {
         DatabentoMessage::Data(Data::Quote(quote)) => {
             assert_eq!(quote.instrument_id.symbol.as_str(), RAW_SYMBOL);
-            assert!(quote.bid_price.as_f64() < quote.ask_price.as_f64());
+            assert_eq!(quote.bid_price, Price::from("1.17035"));
+            assert_eq!(quote.bid_price.precision, 5);
+            assert_eq!(quote.ask_price, Price::from("1.17040"));
+            assert_eq!(quote.ask_price.precision, 5);
         }
         other => panic!("expected Data::Quote, was {other:?}"),
     }

--- a/nautilus_trader/adapters/databento/data.py
+++ b/nautilus_trader/adapters/databento/data.py
@@ -594,6 +594,7 @@ class DatabentoDataClient(LiveMarketDataClient):
             live_client.subscribe(
                 schema=DatabentoSchema.IMBALANCE.value,
                 instrument_ids=[instrument_id_to_pyo3(instrument_id)],
+                price_precisions=self._price_precisions_for_instrument_ids([instrument_id]),
             )
             await self._check_live_client_started(dataset, live_client)
         except asyncio.CancelledError:
@@ -608,6 +609,7 @@ class DatabentoDataClient(LiveMarketDataClient):
             live_client.subscribe(
                 schema=DatabentoSchema.STATISTICS.value,
                 instrument_ids=[instrument_id_to_pyo3(instrument_id)],
+                price_precisions=self._price_precisions_for_instrument_ids([instrument_id]),
             )
             await self._check_live_client_started(dataset, live_client)
         except asyncio.CancelledError:
@@ -733,6 +735,7 @@ class DatabentoDataClient(LiveMarketDataClient):
                 ],
                 start=start,
                 snapshot=snapshot,
+                price_precisions=self._price_precisions_for_instrument_ids(instrument_ids),
             )
 
             # Add trade tick subscriptions for all instruments (MBO data includes trades)
@@ -779,6 +782,7 @@ class DatabentoDataClient(LiveMarketDataClient):
                 instrument_ids=[
                     instrument_id_to_pyo3(instrument_id) for instrument_id in instrument_ids
                 ],
+                price_precisions=self._price_precisions_for_instrument_ids(instrument_ids),
             )
             await self._check_live_client_started(dataset, live_client)
         except asyncio.CancelledError:
@@ -832,6 +836,7 @@ class DatabentoDataClient(LiveMarketDataClient):
                     instrument_id_to_pyo3(instrument_id) for instrument_id in instrument_ids
                 ],
                 start=start,
+                price_precisions=self._price_precisions_for_instrument_ids(instrument_ids),
             )
 
             # Add trade tick subscriptions for instruments (MBP-1 data includes trades)
@@ -883,10 +888,30 @@ class DatabentoDataClient(LiveMarketDataClient):
                     instrument_id_to_pyo3(instrument_id) for instrument_id in instrument_ids
                 ],
                 start=start,
+                price_precisions=self._price_precisions_for_instrument_ids(instrument_ids),
             )
             await self._check_live_client_started(dataset, live_client)
         except asyncio.CancelledError:
             self._log.warning("Canceled task 'subscribe_trade_ticks'")
+
+    def _price_precisions_for_instrument_ids(
+        self,
+        instrument_ids: list[InstrumentId],
+    ) -> list[int | None]:
+        precisions: list[int | None] = []
+
+        for instrument_id in instrument_ids:
+            instrument = self._instrument_provider.find(instrument_id)
+            if instrument is None:
+                self._log.warning(
+                    f"Cannot resolve instrument {instrument_id} price precision for Databento live subscription",
+                )
+                precisions.append(None)
+                continue
+
+            precisions.append(instrument.price_precision)
+
+        return precisions
 
     async def _subscribe_bars(self, command: SubscribeBars) -> None:
         try:
@@ -961,6 +986,7 @@ class DatabentoDataClient(LiveMarketDataClient):
                     instrument_id_to_pyo3(instrument_id) for instrument_id in instrument_ids
                 ],
                 start=start,
+                price_precisions=self._price_precisions_for_instrument_ids(instrument_ids),
             )
             await self._check_live_client_started(dataset, live_client)
         except asyncio.CancelledError:
@@ -1386,14 +1412,28 @@ class DatabentoDataClient(LiveMarketDataClient):
         ]:
             schema = DatabentoSchema.MBP_1.value
 
-        pyo3_quotes = await self._http_client.get_range_quotes(
-            dataset=dataset,
-            instrument_ids=[instrument_id_to_pyo3(inst_id) for inst_id in instrument_ids],
-            start=start.value,
-            end=end.value,
-            schema=schema,
-        )
+        pyo3_quotes = []
+
+        for price_precision, grouped_instrument_ids in self._quote_precision_groups(
+            instrument_ids,
+        ).items():
+            kwargs = {
+                "dataset": dataset,
+                "instrument_ids": [
+                    instrument_id_to_pyo3(inst_id) for inst_id in grouped_instrument_ids
+                ],
+                "start": start.value,
+                "end": end.value,
+                "schema": schema,
+            }
+
+            if price_precision is not None:
+                kwargs["price_precision"] = price_precision
+
+            pyo3_quotes.extend(await self._http_client.get_range_quotes(**kwargs))
+
         quotes = QuoteTick.from_pyo3_list(pyo3_quotes)
+        quotes.sort(key=lambda quote: (quote.ts_event, quote.ts_init))
 
         self._handle_quote_ticks(
             request.instrument_id,
@@ -1403,6 +1443,25 @@ class DatabentoDataClient(LiveMarketDataClient):
             end=request.end,
             params=request.params,
         )
+
+    def _quote_precision_groups(
+        self,
+        instrument_ids: list[InstrumentId],
+    ) -> dict[int | None, list[InstrumentId]]:
+        precision_groups: dict[int | None, list[InstrumentId]] = defaultdict(list)
+
+        for instrument_id in instrument_ids:
+            instrument = self._instrument_provider.find(instrument_id)
+            if instrument is None:
+                self._log.warning(
+                    f"Cannot resolve instrument {instrument_id} price precision for Databento historical quote request",
+                )
+                precision_groups[None].append(instrument_id)
+                continue
+
+            precision_groups[instrument.price_precision].append(instrument_id)
+
+        return precision_groups
 
     async def _request_trade_ticks(self, request: RequestTradeTicks) -> None:
         # Check if multiple instrument_ids are provided in params

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -7826,6 +7826,7 @@ class DatabentoLiveClient:
         stype_in: str | None = None,
         start: int | None = None,
         snapshot: bool | None = False,
+        price_precisions: list[int | None] | None = None,
     ) -> dict[str, str]: ...
     def start(
         self,

--- a/tests/integration_tests/adapters/databento/conftest.py
+++ b/tests/integration_tests/adapters/databento/conftest.py
@@ -43,6 +43,7 @@ def instrument():
 def instrument_provider():
     mock = MagicMock(spec=DatabentoInstrumentProvider)
     mock.initialize = AsyncMock()
+    mock.find = MagicMock(return_value=None)
     mock.get_all = MagicMock(return_value={})
     return mock
 

--- a/tests/integration_tests/adapters/databento/test_data.py
+++ b/tests/integration_tests/adapters/databento/test_data.py
@@ -13,24 +13,35 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import asyncio
 from datetime import UTC
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 
+from nautilus_trader.adapters.databento.types import DatabentoImbalance
+from nautilus_trader.adapters.databento.types import DatabentoStatistics
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.data.messages import RequestBars
 from nautilus_trader.data.messages import RequestOrderBookDepth
 from nautilus_trader.data.messages import RequestQuoteTicks
 from nautilus_trader.data.messages import RequestTradeTicks
+from nautilus_trader.data.messages import SubscribeBars
+from nautilus_trader.data.messages import SubscribeOrderBook
 from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import BarSpecification
 from nautilus_trader.model.data import BarType
+from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import OrderBookDepth10
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import BarAggregation
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.enums import PriceType
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Venue
@@ -43,6 +54,14 @@ GLBX = Venue("GLBX")
 
 ES_CY = InstrumentId.from_str("ESZ21.GLBX")
 NQ_CY = InstrumentId.from_str("NQZ21.GLBX")
+
+
+def _prepare_live_client(databento_client, instrument_provider):
+    live_client = MagicMock()
+    databento_client._live_clients["GLBX.MDP3"] = live_client
+    databento_client._has_subscribed["GLBX.MDP3"] = True
+    instrument_provider.find.return_value = SimpleNamespace(price_precision=5)
+    return live_client
 
 
 def test_resolve_ids_single_instrument_from_command(databento_client):
@@ -126,11 +145,132 @@ def test_resolve_ids_duplicate_instrument_ids_preserved(databento_client):
 
 
 @pytest.mark.asyncio
+async def test_subscribe_imbalance_passes_price_precision(
+    databento_client,
+    instrument_provider,
+):
+    live_client = _prepare_live_client(databento_client, instrument_provider)
+    data_type = DataType(DatabentoImbalance, metadata={"instrument_id": ES_CY})
+
+    await databento_client._subscribe_imbalance(data_type)
+
+    call_kwargs = live_client.subscribe.call_args.kwargs
+    assert call_kwargs["schema"] == "imbalance"
+    assert [str(instrument_id) for instrument_id in call_kwargs["instrument_ids"]] == [str(ES_ID)]
+    assert call_kwargs["price_precisions"] == [5]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_statistics_passes_price_precision(
+    databento_client,
+    instrument_provider,
+):
+    live_client = _prepare_live_client(databento_client, instrument_provider)
+    data_type = DataType(DatabentoStatistics, metadata={"instrument_id": ES_CY})
+
+    await databento_client._subscribe_statistics(data_type)
+
+    call_kwargs = live_client.subscribe.call_args.kwargs
+    assert call_kwargs["schema"] == "statistics"
+    assert [str(instrument_id) for instrument_id in call_kwargs["instrument_ids"]] == [str(ES_ID)]
+    assert call_kwargs["price_precisions"] == [5]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_order_book_deltas_passes_price_precisions(
+    databento_client,
+    instrument_provider,
+):
+    live_client = MagicMock()
+    live_client.start = AsyncMock()
+    databento_client._live_clients_mbo["GLBX.MDP3"] = live_client
+    instrument_provider.find.return_value = SimpleNamespace(price_precision=5)
+
+    await databento_client._subscribe_order_book_deltas_batch([ES_CY, NQ_CY])
+    await asyncio.gather(*databento_client._live_client_futures)
+
+    call_kwargs = live_client.subscribe.call_args.kwargs
+    assert call_kwargs["schema"] == "mbo"
+    assert [str(instrument_id) for instrument_id in call_kwargs["instrument_ids"]] == [
+        str(ES_ID),
+        str(NQ_ID),
+    ]
+    assert call_kwargs["price_precisions"] == [5, 5]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_order_book_snapshots_passes_price_precisions(
+    databento_client,
+    instrument_provider,
+):
+    live_client = _prepare_live_client(databento_client, instrument_provider)
+    databento_client._instrument_ids["GLBX.MDP3"].update([ES_CY, NQ_CY])
+    command = SubscribeOrderBook(
+        instrument_id=ES_CY,
+        book_data_type=OrderBookDepth10,
+        book_type=BookType.L2_MBP,
+        depth=10,
+        client_id=ClientId("DATABENTO"),
+        venue=GLBX,
+        command_id=UUID4(),
+        ts_init=0,
+        params={"instrument_ids": [ES_CY, NQ_CY]},
+    )
+
+    await databento_client._subscribe_order_book_snapshots(command)
+
+    call_kwargs = live_client.subscribe.call_args.kwargs
+    assert call_kwargs["schema"] == "mbp-10"
+    assert [str(instrument_id) for instrument_id in call_kwargs["instrument_ids"]] == [
+        str(ES_ID),
+        str(NQ_ID),
+    ]
+    assert call_kwargs["price_precisions"] == [5, 5]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_bars_passes_price_precisions(
+    databento_client,
+    instrument_provider,
+):
+    live_client = _prepare_live_client(databento_client, instrument_provider)
+    es_bar_type = BarType(
+        ES_CY,
+        BarSpecification(1, BarAggregation.MINUTE, PriceType.LAST),
+    )
+    nq_bar_type = BarType(
+        NQ_CY,
+        BarSpecification(1, BarAggregation.MINUTE, PriceType.LAST),
+    )
+    command = SubscribeBars(
+        bar_type=es_bar_type,
+        client_id=ClientId("DATABENTO"),
+        venue=GLBX,
+        command_id=UUID4(),
+        ts_init=0,
+        params={"bar_types": [es_bar_type, nq_bar_type]},
+    )
+
+    await databento_client._subscribe_bars(command)
+
+    call_kwargs = live_client.subscribe.call_args.kwargs
+    assert call_kwargs["schema"] == "ohlcv-1m"
+    assert [str(instrument_id) for instrument_id in call_kwargs["instrument_ids"]] == [
+        str(ES_ID),
+        str(NQ_ID),
+    ]
+    assert call_kwargs["price_precisions"] == [5, 5]
+
+
+@pytest.mark.asyncio
 async def test_request_quote_ticks_single_instrument(
     databento_client,
     mock_http_client,
+    instrument_provider,
     data_responses,
 ):
+    instrument_provider.find.return_value = SimpleNamespace(price_precision=5)
+
     pyo3_quotes = [
         TestDataProviderPyo3.quote_tick(instrument_id=ES_ID),
         TestDataProviderPyo3.quote_tick(instrument_id=ES_ID),
@@ -169,6 +309,102 @@ async def test_request_quote_ticks_single_instrument(
     assert str(call_kwargs["instrument_ids"][0]) == str(ES_ID)
     assert call_kwargs["dataset"] == "GLBX.MDP3"
     assert call_kwargs["schema"] == "mbp-1"
+    assert call_kwargs["price_precision"] == 5
+
+
+@pytest.mark.asyncio
+async def test_request_quote_ticks_groups_by_price_precision(
+    databento_client,
+    mock_http_client,
+    instrument_provider,
+    data_responses,
+):
+    instrument_provider.find.side_effect = [
+        SimpleNamespace(price_precision=2),
+        SimpleNamespace(price_precision=5),
+    ]
+    mock_http_client.get_range_quotes = AsyncMock(
+        side_effect=[
+            [TestDataProviderPyo3.quote_tick(instrument_id=ES_ID, ts_event=2, ts_init=2)],
+            [TestDataProviderPyo3.quote_tick(instrument_id=NQ_ID, ts_event=1, ts_init=1)],
+        ],
+    )
+
+    request = RequestQuoteTicks(
+        instrument_id=ES_CY,
+        start=datetime(2024, 1, 1, tzinfo=UTC),
+        end=datetime(2024, 1, 2, tzinfo=UTC),
+        limit=0,
+        client_id=ClientId("DATABENTO"),
+        venue=GLBX,
+        callback=None,
+        request_id=UUID4(),
+        ts_init=0,
+        params={"instrument_ids": [ES_CY, NQ_CY]},
+    )
+
+    await databento_client._request_quote_ticks(request)
+
+    assert mock_http_client.get_range_quotes.await_count == 2
+    first_call = mock_http_client.get_range_quotes.await_args_list[0].kwargs
+    second_call = mock_http_client.get_range_quotes.await_args_list[1].kwargs
+    assert first_call["price_precision"] == 2
+    assert [str(instrument_id) for instrument_id in first_call["instrument_ids"]] == [str(ES_ID)]
+    assert second_call["price_precision"] == 5
+    assert [str(instrument_id) for instrument_id in second_call["instrument_ids"]] == [
+        str(NQ_ID),
+    ]
+
+    assert len(data_responses) == 1
+    response = data_responses[0]
+    assert [quote.ts_event for quote in response.data] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_request_quote_ticks_uses_resolved_precision_when_one_instrument_missing(
+    databento_client,
+    mock_http_client,
+    instrument_provider,
+    data_responses,
+):
+    instrument_provider.find.side_effect = [
+        None,
+        SimpleNamespace(price_precision=5),
+    ]
+    mock_http_client.get_range_quotes = AsyncMock(
+        side_effect=[
+            [TestDataProviderPyo3.quote_tick(instrument_id=ES_ID)],
+            [TestDataProviderPyo3.quote_tick(instrument_id=NQ_ID)],
+        ],
+    )
+
+    request = RequestQuoteTicks(
+        instrument_id=ES_CY,
+        start=datetime(2024, 1, 1, tzinfo=UTC),
+        end=datetime(2024, 1, 2, tzinfo=UTC),
+        limit=0,
+        client_id=ClientId("DATABENTO"),
+        venue=GLBX,
+        callback=None,
+        request_id=UUID4(),
+        ts_init=0,
+        params={"instrument_ids": [ES_CY, NQ_CY]},
+    )
+
+    await databento_client._request_quote_ticks(request)
+
+    assert mock_http_client.get_range_quotes.await_count == 2
+    missing_call = mock_http_client.get_range_quotes.await_args_list[0].kwargs
+    resolved_call = mock_http_client.get_range_quotes.await_args_list[1].kwargs
+    assert "price_precision" not in missing_call
+    assert [str(instrument_id) for instrument_id in missing_call["instrument_ids"]] == [str(ES_ID)]
+    assert resolved_call["price_precision"] == 5
+    assert [str(instrument_id) for instrument_id in resolved_call["instrument_ids"]] == [
+        str(NQ_ID),
+    ]
+
+    assert len(data_responses) == 1
+    assert len(data_responses[0].data) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixed Databento live price decoding so price-bearing subscriptions can pass cached instrument price precision into the Rust feed handler.
- Fixed Databento historical quote requests so they pass cached instrument price precision into the historical decoder.
- Added a `SetPricePrecision` handler command and symbol-level precision overrides, while preserving the existing precedence where live instrument definitions populate `price_precision_map`.
- Wired the PyO3 `DatabentoLiveClient.subscribe` binding and Python `DatabentoDataClient` price-bearing subscriptions to pass instrument precisions when available.
- Grouped multi-instrument historical quote requests by resolved price precision, preserving one response for the original request while avoiding mixed-precision decoding.
- Updated the generated PyO3 stub so mypy accepts the new `price_precisions` keyword.

### Design decisions

- The live decoder cannot infer significant trailing zeros from Databento raw prices alone, so the adapter now uses known instrument metadata from the subscription path.
- Live precision overrides are sent for quotes, trades, bars, order book deltas, order book snapshots, imbalance, and statistics because those paths can decode price fields.
- The historical quote API accepts a single `price_precision` per request, so mixed-precision historical quote batches are split by precision and recombined after decoding.
- Live instrument-definition messages still take precedence over the subscription override. Both sources are instrument metadata; the live message is preferred when available because it is keyed by Databento record instrument id.
- The subscription override is keyed by symbol, matching the live subscription and symbol mapping flow used by the Databento feed handler.
- If an instrument is missing from the provider, the adapter logs a warning and only that instrument group falls back to the existing default precision behavior.

### Testing

- `cargo test -p nautilus-databento`.
- `cargo check -p nautilus-databento --features python`.
- `make build-debug`.
- `uv run --no-sync pytest tests/integration_tests/adapters/databento/test_data.py -q`.
- `make format`.
- `prek run mypy --all-files`.
- `make pre-commit`.

### Related issue

- Fixes https://github.com/nautechsystems/nautilus_trader/issues/3999

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
