### PR TITLE
Support serialized fields in custom_data macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,6 +6226,7 @@ dependencies = [
  "criterion",
  "datafusion",
  "futures",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "nautilus-common",

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -524,7 +524,7 @@ fn dict_to_params(
     params: Option<Py<PyDict>>,
 ) -> PyResult<Option<nautilus_core::Params>> {
     match params {
-        Some(dict) => from_pydict(py, dict),
+        Some(dict) => from_pydict(py, &dict),
         None => Ok(None),
     }
 }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -146,7 +146,7 @@ impl<'a> IntoIterator for &'a Params {
 /// - the JSON is not a valid object
 pub fn from_pydict(
     py: pyo3::Python<'_>,
-    dict: pyo3::Py<pyo3::types::PyDict>,
+    dict: &pyo3::Py<pyo3::types::PyDict>,
 ) -> pyo3::PyResult<Option<Params>> {
     crate::python::params::pydict_to_params(py, dict)
 }

--- a/crates/core/src/python/params.rs
+++ b/crates/core/src/python/params.rs
@@ -15,7 +15,6 @@
 
 //! Python bindings for [`Params`] type conversion.
 
-use indexmap::IndexMap;
 use pyo3::{
     conversion::IntoPyObjectExt,
     prelude::*,
@@ -23,7 +22,10 @@ use pyo3::{
 };
 use serde_json::Value;
 
-use crate::{params::Params, python::to_pyvalue_err};
+use crate::{
+    params::Params,
+    python::{serialization::from_pyobject_pyo3, to_pyvalue_err},
+};
 
 /// Converts a Python dict to `Params` (IndexMap<String, Value>).
 ///
@@ -32,24 +34,13 @@ use crate::{params::Params, python::to_pyvalue_err};
 /// Returns a `PyErr` if:
 /// - the dict cannot be serialized to JSON
 /// - the JSON is not a valid object
-pub fn pydict_to_params(py: Python<'_>, dict: Py<PyDict>) -> PyResult<Option<Params>> {
+pub fn pydict_to_params(py: Python<'_>, dict: &Py<PyDict>) -> PyResult<Option<Params>> {
     let dict_bound = dict.bind(py);
     if dict_bound.is_empty() {
         return Ok(None);
     }
 
-    let json_str: String = PyModule::import(py, "json")?
-        .call_method("dumps", (dict,), None)?
-        .extract()?;
-    let json_value: Value = serde_json::from_str(&json_str).map_err(to_pyvalue_err)?;
-
-    if let Value::Object(map) = json_value {
-        Ok(Some(Params::from_index_map(
-            map.into_iter().collect::<IndexMap<String, Value>>(),
-        )))
-    } else {
-        Err(to_pyvalue_err("Expected a dictionary"))
-    }
+    from_pyobject_pyo3(py, dict_bound.as_any()).map(Some)
 }
 
 /// Helper function to convert a `serde_json::Value` to a Python object.

--- a/crates/core/src/python/serialization.rs
+++ b/crates/core/src/python/serialization.rs
@@ -15,7 +15,17 @@
 
 //! (De)serialization utilities bridging Rust ↔︎ Python types.
 
-use pyo3::{prelude::*, types::PyDict};
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+};
+
+use indexmap::IndexMap;
+use pyo3::{
+    conversion::{FromPyObjectOwned, IntoPyObject},
+    prelude::*,
+    types::{PyAny, PyDict},
+};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::python::to_pyvalue_err;
@@ -32,16 +42,31 @@ pub fn from_dict_pyo3<T>(py: Python<'_>, values: Py<PyDict>) -> Result<T, PyErr>
 where
     T: DeserializeOwned,
 {
+    let values = values.into_any();
+    from_pyobject_pyo3(py, values.bind(py))
+}
+
+/// Convert a Python object to a Rust type that implements `DeserializeOwned`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The Python object cannot be serialized to JSON.
+/// - The JSON string cannot be deserialized to type `T`.
+/// - The Python `json` module fails to import or execute.
+pub fn from_pyobject_pyo3<T>(py: Python<'_>, value: &Bound<'_, PyAny>) -> Result<T, PyErr>
+where
+    T: DeserializeOwned,
+{
     // `ensure_ascii=False` keeps non-ASCII characters as raw UTF-8 in the JSON output.
     // Without this, `\uXXXX` escapes force `serde_json` onto the owned-string path,
     // which `visit_str`-only visitors like `ustr::Ustr` reject as "expected a borrowed string".
     let kwargs = PyDict::new(py);
     kwargs.set_item("ensure_ascii", false)?;
     let json_str: String = PyModule::import(py, "json")?
-        .call_method("dumps", (values,), Some(&kwargs))?
+        .call_method("dumps", (value,), Some(&kwargs))?
         .extract()?;
 
-    // Deserialize to object
     let instance = serde_json::from_str(&json_str).map_err(to_pyvalue_err)?;
     Ok(instance)
 }
@@ -58,11 +83,177 @@ pub fn to_dict_pyo3<T>(py: Python<'_>, value: &T) -> PyResult<Py<PyDict>>
 where
     T: Serialize,
 {
-    let json_str = serde_json::to_string(value).map_err(to_pyvalue_err)?;
+    let py_object = to_pyobject_pyo3(py, value)?;
+    let py_dict = py_object
+        .bind(py)
+        .cast::<PyDict>()
+        .map_err(Into::<PyErr>::into)?
+        .clone()
+        .unbind();
+    Ok(py_dict)
+}
 
-    // Parse JSON into a Python dictionary
-    let py_dict: Py<PyDict> = PyModule::import(py, "json")?
+/// Convert a Rust type that implements `Serialize` to a Python object.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The Rust value cannot be serialized to JSON.
+/// - The JSON string cannot be parsed into a Python object.
+/// - The Python `json` module fails to import or execute.
+pub fn to_pyobject_pyo3<T>(py: Python<'_>, value: &T) -> PyResult<Py<PyAny>>
+where
+    T: Serialize,
+{
+    let json_str = serde_json::to_string(value).map_err(to_pyvalue_err)?;
+    let py_object = PyModule::import(py, "json")?
         .call_method("loads", (json_str,), None)?
         .extract()?;
-    Ok(py_dict)
+    Ok(py_object)
+}
+
+/// Convert a Python mapping to an [`IndexMap`] using typed PyO3 objects when possible.
+///
+/// Falls back to the generic JSON bridge when the input is not a Python dict. Individual dict
+/// keys and values first try typed PyO3 extraction, then JSON/Serde extraction. This accepts both
+/// `{InstrumentId(...): Price(...)}` and `{"AUD/USD.SIM": "1.23456"}` style inputs.
+///
+/// # Errors
+///
+/// Returns an error if the Python object cannot be converted to the requested map type.
+pub fn indexmap_from_pyobject_pyo3<K, V>(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<IndexMap<K, V>>
+where
+    K: for<'py> FromPyObjectOwned<'py> + DeserializeOwned + Eq + Hash,
+    V: for<'py> FromPyObjectOwned<'py> + DeserializeOwned,
+    IndexMap<K, V>: DeserializeOwned,
+{
+    let Ok(dict) = value.cast::<PyDict>() else {
+        return from_pyobject_pyo3(py, value);
+    };
+
+    let mut map = IndexMap::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        map.insert(
+            extract_typed_or_json_pyo3(py, &key)?,
+            extract_typed_or_json_pyo3(py, &value)?,
+        );
+    }
+    Ok(map)
+}
+
+/// Convert a Python mapping to a [`HashMap`] using typed PyO3 objects when possible.
+///
+/// Falls back to the generic JSON bridge when the input is not a Python dict. Individual dict
+/// keys and values first try typed PyO3 extraction, then JSON/Serde extraction.
+///
+/// # Errors
+///
+/// Returns an error if the Python object cannot be converted to the requested map type.
+pub fn hashmap_from_pyobject_pyo3<K, V>(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<HashMap<K, V>>
+where
+    K: for<'py> FromPyObjectOwned<'py> + DeserializeOwned + Eq + Hash,
+    V: for<'py> FromPyObjectOwned<'py> + DeserializeOwned,
+    HashMap<K, V>: DeserializeOwned,
+{
+    let Ok(dict) = value.cast::<PyDict>() else {
+        return from_pyobject_pyo3(py, value);
+    };
+
+    let mut map = HashMap::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        map.insert(
+            extract_typed_or_json_pyo3(py, &key)?,
+            extract_typed_or_json_pyo3(py, &value)?,
+        );
+    }
+    Ok(map)
+}
+
+/// Convert an [`IndexMap`] to a Python dict using typed PyO3 keys and values.
+///
+/// # Errors
+///
+/// Returns an error if any key or value cannot be converted to Python.
+pub fn indexmap_to_pydict_pyo3<K, V>(py: Python<'_>, value: &IndexMap<K, V>) -> PyResult<Py<PyAny>>
+where
+    K: for<'py> IntoPyObject<'py> + Clone,
+    V: for<'py> IntoPyObject<'py> + Clone,
+{
+    let dict = PyDict::new(py);
+    for (key, value) in value {
+        dict.set_item(key.clone(), value.clone())?;
+    }
+    Ok(dict.into_any().unbind())
+}
+
+/// Convert a [`HashMap`] to a Python dict using typed PyO3 keys and values.
+///
+/// # Errors
+///
+/// Returns an error if any key or value cannot be converted to Python.
+pub fn hashmap_to_pydict_pyo3<K, V, S>(
+    py: Python<'_>,
+    value: &HashMap<K, V, S>,
+) -> PyResult<Py<PyAny>>
+where
+    K: for<'py> IntoPyObject<'py> + Clone,
+    V: for<'py> IntoPyObject<'py> + Clone,
+    S: BuildHasher,
+{
+    let dict = PyDict::new(py);
+    for (key, value) in value {
+        dict.set_item(key.clone(), value.clone())?;
+    }
+    Ok(dict.into_any().unbind())
+}
+
+fn extract_typed_or_json_pyo3<T>(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<T>
+where
+    T: for<'py> FromPyObjectOwned<'py> + DeserializeOwned,
+{
+    value.extract::<T>().or_else(|typed_err| {
+        let typed_err: PyErr = typed_err.into();
+        from_pyobject_pyo3(py, value).map_err(|json_err| {
+            to_pyvalue_err(format!(
+                "typed extraction failed: {typed_err}; JSON extraction failed: {json_err}"
+            ))
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use pyo3::types::PyDict;
+    use rstest::rstest;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Payload {
+        values: HashMap<String, String>,
+    }
+
+    #[rstest]
+    fn test_from_pyobject_pyo3_preserves_non_ascii_strings() {
+        Python::initialize();
+        Python::attach(|py| {
+            let values = PyDict::new(py);
+            values.set_item("clé", "café").unwrap();
+
+            let dict = PyDict::new(py);
+            dict.set_item("values", values).unwrap();
+
+            let payload: Payload = from_pyobject_pyo3(py, dict.as_any()).unwrap();
+            assert_eq!(payload.values.get("clé").unwrap(), "café");
+        });
+    }
 }

--- a/crates/core/src/serialization.rs
+++ b/crates/core/src/serialization.rs
@@ -428,8 +428,8 @@ pub fn deserialize_decimal_from_str<'de, D>(deserializer: D) -> Result<Decimal, 
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    Decimal::from_str(&s).map_err(D::Error::custom)
+    let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+    Decimal::from_str(s.as_ref()).map_err(D::Error::custom)
 }
 
 /// Deserializes a `Decimal` from a string field that might be empty.
@@ -443,11 +443,11 @@ pub fn deserialize_decimal_or_zero<'de, D>(deserializer: D) -> Result<Decimal, D
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
+    let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
     if s.is_empty() || s == "0" {
         Ok(Decimal::ZERO)
     } else {
-        Decimal::from_str(&s).map_err(D::Error::custom)
+        Decimal::from_str(s.as_ref()).map_err(D::Error::custom)
     }
 }
 
@@ -466,11 +466,13 @@ pub fn deserialize_optional_decimal_str<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
+    let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
     if s.is_empty() || s == "0" {
         Ok(None)
     } else {
-        Decimal::from_str(&s).map(Some).map_err(D::Error::custom)
+        Decimal::from_str(s.as_ref())
+            .map(Some)
+            .map_err(D::Error::custom)
     }
 }
 
@@ -644,11 +646,11 @@ pub fn deserialize_string_to_u8<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
+    let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
     if s.is_empty() {
         return Ok(0);
     }
-    s.parse::<u8>().map_err(D::Error::custom)
+    s.as_ref().parse::<u8>().map_err(D::Error::custom)
 }
 
 /// Deserializes a `u64` from a string field.
@@ -662,11 +664,11 @@ pub fn deserialize_string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Erro
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
+    let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
     if s.is_empty() {
         Ok(0)
     } else {
-        s.parse::<u64>().map_err(D::Error::custom)
+        s.as_ref().parse::<u64>().map_err(D::Error::custom)
     }
 }
 

--- a/crates/core/src/uuid.rs
+++ b/crates/core/src/uuid.rs
@@ -282,8 +282,8 @@ impl<'de> Deserialize<'de> for UUID4 {
     where
         D: Deserializer<'de>,
     {
-        let uuid4_str: &str = Deserialize::deserialize(deserializer)?;
-        uuid4_str.parse().map_err(serde::de::Error::custom)
+        let uuid4_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        uuid4_str.as_ref().parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -476,6 +476,15 @@ mod tests {
         let serialized = format!("\"{uuid_string}\"");
 
         let deserialized: UUID4 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.to_string(), uuid_string);
+    }
+
+    #[rstest]
+    fn test_deserialize_from_owned_value() {
+        let uuid_string = "2d89666b-1a1e-4a75-b193-4eb3b454c757";
+        let value = serde_json::Value::String(uuid_string.to_string());
+
+        let deserialized: UUID4 = serde_json::from_value(value).unwrap();
         assert_eq!(deserialized.to_string(), uuid_string);
     }
 

--- a/crates/model/src/data/bar.rs
+++ b/crates/model/src/data/bar.rs
@@ -858,8 +858,8 @@ impl<'de> Deserialize<'de> for BarType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = Deserialize::deserialize(deserializer)?;
-        Self::from_str(&s).map_err(serde::de::Error::custom)
+        let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::from_str(s.as_ref()).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/model/src/defi/data/transaction.rs
+++ b/crates/model/src/defi/data/transaction.rs
@@ -95,7 +95,7 @@ pub fn deserialize_chain<'de, D>(deserializer: D) -> Result<Chain, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hex_string = String::deserialize(deserializer)?;
+    let hex_string: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
     let without_prefix = hex_string.trim_start_matches("0x");
     let chain_id = u32::from_str_radix(without_prefix, 16).map_err(serde::de::Error::custom)?;
 

--- a/crates/model/src/defi/hex.rs
+++ b/crates/model/src/defi/hex.rs
@@ -60,8 +60,8 @@ pub fn deserialize_hex_number<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let hex_string = String::deserialize(deserializer)?;
-    from_str_hex_to_u64(hex_string.as_str()).map_err(serde::de::Error::custom)
+    let hex_string: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+    from_str_hex_to_u64(hex_string.as_ref()).map_err(serde::de::Error::custom)
 }
 
 /// Custom deserializer that converts an optional hexadecimal string into an `Option<u64>`.
@@ -127,8 +127,8 @@ pub fn deserialize_hex_timestamp<'de, D>(deserializer: D) -> Result<UnixNanos, D
 where
     D: Deserializer<'de>,
 {
-    let hex_string = String::deserialize(deserializer)?;
-    let seconds = from_str_hex_to_u64(hex_string.as_str()).map_err(serde::de::Error::custom)?;
+    let hex_string: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+    let seconds = from_str_hex_to_u64(hex_string.as_ref()).map_err(serde::de::Error::custom)?;
 
     // Protect against multiplication overflow (extremely far future dates or malicious input).
     seconds

--- a/crates/model/src/defi/pool_identifier.rs
+++ b/crates/model/src/defi/pool_identifier.rs
@@ -280,8 +280,8 @@ impl<'de> Deserialize<'de> for PoolIdentifier {
     where
         D: Deserializer<'de>,
     {
-        let value_str: &str = Deserialize::deserialize(deserializer)?;
-        Self::new_checked(value_str).map_err(serde::de::Error::custom)
+        let value_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::new_checked(value_str.as_ref()).map_err(serde::de::Error::custom)
     }
 }
 
@@ -405,6 +405,18 @@ mod tests {
         let deserialized: PoolIdentifier = serde_json::from_str(&json).unwrap();
 
         assert_eq!(original, deserialized);
+    }
+
+    #[rstest]
+    fn test_deserialize_from_owned_value() {
+        let value =
+            serde_json::Value::String("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string());
+
+        let deserialized: PoolIdentifier = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            deserialized,
+            PoolIdentifier::new("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+        );
     }
 
     #[rstest]

--- a/crates/model/src/identifiers/client_id.rs
+++ b/crates/model/src/identifiers/client_id.rs
@@ -108,6 +108,14 @@ mod tests {
     }
 
     #[rstest]
+    fn test_deserialize_from_owned_value() {
+        let value = serde_json::Value::String("BINANCE".to_string());
+
+        let deserialized: ClientId = serde_json::from_value(value).unwrap();
+        assert_eq!(deserialized, ClientId::new("BINANCE"));
+    }
+
+    #[rstest]
     #[should_panic(expected = "Condition failed: invalid string for 'value', was empty")]
     fn test_new_with_empty_string_panics_with_display_format() {
         let _ = ClientId::new("");

--- a/crates/model/src/identifiers/instrument_id.rs
+++ b/crates/model/src/identifiers/instrument_id.rs
@@ -149,8 +149,8 @@ impl<'de> Deserialize<'de> for InstrumentId {
     where
         D: Deserializer<'de>,
     {
-        let instrument_id_str: String = Deserialize::deserialize(deserializer)?;
-        Self::from_str(&instrument_id_str).map_err(serde::de::Error::custom)
+        let instrument_id_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::from_str(instrument_id_str.as_ref()).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/model/src/identifiers/macros.rs
+++ b/crates/model/src/identifiers/macros.rs
@@ -31,8 +31,8 @@ macro_rules! impl_serialization_for_identifier {
             where
                 D: Deserializer<'de>,
             {
-                let value_str: &str = Deserialize::deserialize(deserializer)?;
-                Self::new_checked(value_str).map_err(serde::de::Error::custom)
+                let value_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+                Self::new_checked(value_str.as_ref()).map_err(serde::de::Error::custom)
             }
         }
     };

--- a/crates/model/src/identifiers/option_series_id.rs
+++ b/crates/model/src/identifiers/option_series_id.rs
@@ -187,8 +187,8 @@ impl<'de> Deserialize<'de> for OptionSeriesId {
     where
         D: serde::Deserializer<'de>,
     {
-        let s: &str = Deserialize::deserialize(deserializer)?;
-        Self::from_str(s).map_err(serde::de::Error::custom)
+        let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::from_str(s.as_ref()).map_err(serde::de::Error::custom)
     }
 }
 
@@ -328,6 +328,15 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         let deserialized: OptionSeriesId = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(id, deserialized);
+    }
+
+    #[rstest]
+    fn test_option_series_id_deserialize_from_owned_value() {
+        let id = test_series_id();
+        let value = serde_json::Value::String(id.to_wire_string());
+
+        let deserialized: OptionSeriesId = serde_json::from_value(value).unwrap();
         assert_eq!(id, deserialized);
     }
 

--- a/crates/model/src/macros.rs
+++ b/crates/model/src/macros.rs
@@ -32,8 +32,8 @@ macro_rules! enum_strum_serde {
             where
                 D: Deserializer<'de>,
             {
-                let s = String::deserialize(deserializer)?;
-                <$type>::from_str(&s).map_err(serde::de::Error::custom)
+                let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+                <$type>::from_str(s.as_ref()).map_err(serde::de::Error::custom)
             }
         }
     };

--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -68,7 +68,7 @@ impl DataType {
     ) -> PyResult<Self> {
         let params = match metadata {
             None => None,
-            Some(d) => pydict_to_params(py, d)?,
+            Some(d) => pydict_to_params(py, &d)?,
         };
         Ok(Self::new(type_name, params, identifier))
     }

--- a/crates/model/src/python/instruments/betting.rs
+++ b/crates/model/src/python/instruments/betting.rs
@@ -80,7 +80,7 @@ impl BettingInstrument {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/binary_option.rs
+++ b/crates/model/src/python/instruments/binary_option.rs
@@ -69,7 +69,7 @@ impl BinaryOption {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/cfd.rs
+++ b/crates/model/src/python/instruments/cfd.rs
@@ -67,7 +67,7 @@ impl Cfd {
         info: Option<Py<PyDict>>,
     ) -> PyResult<Self> {
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/commodity.rs
+++ b/crates/model/src/python/instruments/commodity.rs
@@ -64,7 +64,7 @@ impl Commodity {
         info: Option<Py<PyDict>>,
     ) -> PyResult<Self> {
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/crypto_future.rs
+++ b/crates/model/src/python/instruments/crypto_future.rs
@@ -70,7 +70,7 @@ impl CryptoFuture {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/crypto_option.rs
+++ b/crates/model/src/python/instruments/crypto_option.rs
@@ -73,7 +73,7 @@ impl CryptoOption {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/crypto_perpetual.rs
+++ b/crates/model/src/python/instruments/crypto_perpetual.rs
@@ -68,7 +68,7 @@ impl CryptoPerpetual {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/currency_pair.rs
+++ b/crates/model/src/python/instruments/currency_pair.rs
@@ -67,7 +67,7 @@ impl CurrencyPair {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/equity.rs
+++ b/crates/model/src/python/instruments/equity.rs
@@ -61,7 +61,7 @@ impl Equity {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/futures_contract.rs
+++ b/crates/model/src/python/instruments/futures_contract.rs
@@ -67,7 +67,7 @@ impl FuturesContract {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/futures_spread.rs
+++ b/crates/model/src/python/instruments/futures_spread.rs
@@ -68,7 +68,7 @@ impl FuturesSpread {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/index_instrument.rs
+++ b/crates/model/src/python/instruments/index_instrument.rs
@@ -52,7 +52,7 @@ impl IndexInstrument {
         info: Option<Py<PyDict>>,
     ) -> PyResult<Self> {
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/option_contract.rs
+++ b/crates/model/src/python/instruments/option_contract.rs
@@ -69,7 +69,7 @@ impl OptionContract {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/option_spread.rs
+++ b/crates/model/src/python/instruments/option_spread.rs
@@ -68,7 +68,7 @@ impl OptionSpread {
     ) -> PyResult<Self> {
         // Convert Python dict to Params
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/perpetual_contract.rs
+++ b/crates/model/src/python/instruments/perpetual_contract.rs
@@ -73,7 +73,7 @@ impl PerpetualContract {
         info: Option<Py<PyDict>>,
     ) -> PyResult<Self> {
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/python/instruments/tokenized_asset.rs
+++ b/crates/model/src/python/instruments/tokenized_asset.rs
@@ -71,7 +71,7 @@ impl TokenizedAsset {
         info: Option<Py<PyDict>>,
     ) -> PyResult<Self> {
         let info_map = if let Some(info_dict) = info {
-            Python::attach(|py| from_pydict(py, info_dict))?
+            Python::attach(|py| from_pydict(py, &info_dict))?
         } else {
             None
         };

--- a/crates/model/src/types/currency.rs
+++ b/crates/model/src/types/currency.rs
@@ -306,8 +306,8 @@ impl<'de> Deserialize<'de> for Currency {
     where
         D: serde::Deserializer<'de>,
     {
-        let currency_str: String = Deserialize::deserialize(deserializer)?;
-        Self::from_str(&currency_str).map_err(serde::de::Error::custom)
+        let currency_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::from_str(currency_str.as_ref()).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/model/src/types/money.rs
+++ b/crates/model/src/types/money.rs
@@ -716,8 +716,8 @@ impl<'de> Deserialize<'de> for Money {
     where
         D: Deserializer<'de>,
     {
-        let money_str: String = Deserialize::deserialize(deserializer)?;
-        Ok(Self::from(money_str.as_str()))
+        let money_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Ok(Self::from(money_str.as_ref()))
     }
 }
 
@@ -1198,6 +1198,15 @@ mod tests {
         let money = Money::new(123.45, Currency::USD());
         let serialized = serde_json::to_string(&money);
         let deserialized: Money = serde_json::from_str(&serialized.unwrap()).unwrap();
+        assert_eq!(money, deserialized);
+    }
+
+    #[rstest]
+    fn test_money_deserialize_from_owned_value() {
+        let money = Money::new(123.45, Currency::USD());
+        let value = serde_json::to_value(money).unwrap();
+
+        let deserialized: Money = serde_json::from_value(value).unwrap();
         assert_eq!(money, deserialized);
     }
 

--- a/crates/model/src/types/price.rs
+++ b/crates/model/src/types/price.rs
@@ -776,8 +776,8 @@ impl<'de> Deserialize<'de> for Price {
     where
         D: Deserializer<'de>,
     {
-        let price_str: &str = Deserialize::deserialize(deserializer)?;
-        let price: Self = price_str.into();
+        let price_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        let price: Self = price_str.as_ref().into();
         Ok(price)
     }
 }
@@ -1479,6 +1479,16 @@ mod tests {
         let json = serde_json::to_string(&price).unwrap();
         let deserialized: Price = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, price);
+    }
+
+    #[rstest]
+    fn test_price_serde_json_from_value_round_trip() {
+        let price = Price::new(1.0500, 4);
+        let value = serde_json::to_value(price).unwrap();
+
+        let deserialized: Price = serde_json::from_value(value).unwrap();
+        assert_eq!(deserialized, price);
+        assert_eq!(deserialized.precision, 4);
     }
 
     #[rstest]

--- a/crates/model/src/types/quantity.rs
+++ b/crates/model/src/types/quantity.rs
@@ -851,8 +851,8 @@ impl<'de> Deserialize<'de> for Quantity {
     where
         D: Deserializer<'de>,
     {
-        let qty_str: &str = Deserialize::deserialize(deserializer)?;
-        let qty: Self = qty_str.into();
+        let qty_str: std::borrow::Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        let qty: Self = qty_str.as_ref().into();
         Ok(qty)
     }
 }
@@ -1566,6 +1566,17 @@ mod tests {
         assert_eq!(json_str, "\"123.456\"");
 
         let deserialized: Quantity = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(deserialized, original);
+        assert_eq!(deserialized.precision, 3);
+    }
+
+    #[rstest]
+    fn test_quantity_serde_json_from_value_round_trip() {
+        let original = Quantity::new(123.456, 3);
+        let value = serde_json::to_value(original).unwrap();
+        assert_eq!(value, serde_json::json!("123.456"));
+
+        let deserialized: Quantity = serde_json::from_value(value).unwrap();
         assert_eq!(deserialized, original);
         assert_eq!(deserialized.precision, 3);
     }

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -71,6 +71,7 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true }

--- a/crates/persistence/macros/src/custom.rs
+++ b/crates/persistence/macros/src/custom.rs
@@ -41,6 +41,11 @@
 //!   with constructor and getters; Rust and Python both use constructor `new` (Python __init__ forwards to it).
 //!   Python `__repr__` and `__str__` are generated to use the Rust `Display` implementation.
 //! - `no_display`: Do not generate `repr()` or `Display`; the user may implement them manually.
+//! - `#[custom_data_field(json)]` on a field: Stores the field as a JSON-backed Arrow
+//!   `Utf8` column. The field type must implement Serde `Serialize` and `Deserialize`.
+//!   Python access uses typed dict conversion for supported `HashMap<K, V>` and
+//!   `IndexMap<K, V>` field types, and a full JSON conversion for other JSON-backed fields.
+//!   Use this for convenience and persistence rather than hot path fields.
 //!
 //! # Example
 //!
@@ -49,6 +54,8 @@
 //! pub struct MyCustomData {
 //!     pub instrument_id: InstrumentId,
 //!     pub value: f64,
+//!     #[custom_data_field(json)]
+//!     pub prices: IndexMap<InstrumentId, Price>,
 //!     pub ts_event: UnixNanos,
 //!     pub ts_init: UnixNanos,
 //! }
@@ -63,12 +70,17 @@ use syn::{
     parse2,
 };
 
+/// Returns the path for a type, if it is a path type.
+fn type_path(ty: &Type) -> Option<&syn::Path> {
+    match ty {
+        Type::Path(p) => Some(&p.path),
+        _ => None,
+    }
+}
+
 /// Last path segment of a type (e.g. "InstrumentId", "UnixNanos", "f64").
 fn type_last_segment(ty: &Type) -> Option<String> {
-    let path = match ty {
-        Type::Path(p) => &p.path,
-        _ => return None,
-    };
+    let path = type_path(ty)?;
     path.segments.last().map(|s| s.ident.to_string())
 }
 
@@ -112,8 +124,66 @@ fn type_for_macro(ty: &Type) -> Option<(String, String)> {
     Some((seg.clone(), seg))
 }
 
-/// Returns true if the type uses string extraction (Utf8 or Utf8View).
-fn use_string_extract(ty: &Type) -> bool {
+/// Returns (map_type, key_type, value_type) for HashMap<K, V> and IndexMap<K, V>.
+fn map_type_for_macro(ty: &Type) -> Option<(String, String, String)> {
+    let path = type_path(ty)?;
+    let segment = path.segments.last()?;
+    let outer = segment.ident.to_string();
+
+    if outer != "HashMap" && outer != "IndexMap" {
+        return None;
+    }
+
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+
+    let mut types = args.args.iter().filter_map(|arg| match arg {
+        syn::GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    });
+    let key = type_last_segment(types.next()?)?;
+    let value = type_last_segment(types.next()?)?;
+
+    Some((outer, key, value))
+}
+
+/// Returns true when a JSON map element can be converted to/from typed PyO3 objects.
+fn is_typed_json_map_segment(segment: &str) -> bool {
+    matches!(
+        segment,
+        "InstrumentId"
+            | "AccountId"
+            | "Currency"
+            | "BarType"
+            | "Price"
+            | "Quantity"
+            | "Money"
+            | "String"
+            | "f64"
+            | "f32"
+            | "bool"
+            | "u64"
+            | "i64"
+            | "u32"
+            | "i32"
+    )
+}
+
+fn typed_json_map_kind(ty: &Type) -> Option<String> {
+    let (outer, key, value) = map_type_for_macro(ty)?;
+    if is_typed_json_map_segment(&key) && is_typed_json_map_segment(&value) {
+        return Some(outer);
+    }
+    None
+}
+
+/// Returns true if the field uses string extraction (Utf8 or Utf8View).
+fn use_string_extract(ty: &Type, json: bool) -> bool {
+    if json {
+        return true;
+    }
+
     if let Some((outer, inner)) = type_for_macro(ty) {
         matches!(
             (outer.as_str(), inner.as_str()),
@@ -131,7 +201,18 @@ fn use_string_extract(ty: &Type) -> bool {
 
 /// Arrow DataType and array type for encoding/decoding. Emits token streams that reference
 /// arrow::datatypes::DataType and arrow array types.
-fn arrow_type_for_rust_type(ty: &Type) -> Option<(TokenStream, TokenStream, TokenStream)> {
+fn arrow_type_for_rust_type(
+    ty: &Type,
+    json: bool,
+) -> Option<(TokenStream, TokenStream, TokenStream)> {
+    if json {
+        return Some((
+            quote! { arrow::datatypes::DataType::Utf8 },
+            quote! { arrow::array::StringArray },
+            quote! { arrow::array::StringArray },
+        ));
+    }
+
     let (outer, inner) = type_for_macro(ty)?;
     let (arrow_dt, array_type, extract_array_type): (TokenStream, TokenStream, TokenStream) = match (
         outer.as_str(),
@@ -201,9 +282,21 @@ fn arrow_type_for_rust_type(ty: &Type) -> Option<(TokenStream, TokenStream, Toke
 }
 
 /// How to encode a field value into an Arrow builder (append call).
-fn encode_field_expr(field_name: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
+fn encode_field_expr(field_name: &syn::Ident, ty: &Type, json: bool) -> Option<TokenStream> {
     let name = field_name;
+
+    if json {
+        return Some(quote! {
+            let value = serde_json::to_string(&item.#name).map_err(|e| {
+                arrow::error::ArrowError::InvalidArgumentError(
+                    format!("failed to serialize JSON field '{}': {e}", stringify!(#name)),
+                )
+            })?;
+            builder.append_value(value);
+        });
+    }
+
+    let (outer, inner) = type_for_macro(ty)?;
     match (outer.as_str(), inner.as_str()) {
         ("Vec", "u8") => Some(quote! { builder.append_value(item.#name.as_slice()); }),
         ("Vec", "f64") => Some(quote! {
@@ -241,11 +334,24 @@ fn encode_field_expr(field_name: &syn::Ident, ty: &Type) -> Option<TokenStream> 
 fn decode_field_rhs(
     field_name: &syn::Ident,
     ty: &Type,
+    json: bool,
     col_ident: &syn::Ident,
 ) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
     let name = field_name;
     let col = col_ident;
+
+    if json {
+        return Some(quote! {
+            serde_json::from_str::<#ty>(#col.value(i)).map_err(|e| {
+                nautilus_serialization::arrow::EncodingError::ParseError(
+                    stringify!(#name),
+                    format!("row {i}: {e}"),
+                )
+            })?
+        });
+    }
+
+    let (outer, inner) = type_for_macro(ty)?;
     match (outer.as_str(), inner.as_str()) {
         ("Vec", "u8") => Some(quote! { #col.value(i).to_vec() }),
         ("Vec", "f64") => Some(quote! {
@@ -286,7 +392,11 @@ fn decode_field_rhs(
 }
 
 /// Builder type and initialisation for a field (e.g. StringBuilder::new() or Float64Array::builder(len)).
-fn encode_builder_for_field(ty: &Type, len_var: &syn::Ident) -> Option<TokenStream> {
+fn encode_builder_for_field(ty: &Type, json: bool, len_var: &syn::Ident) -> Option<TokenStream> {
+    if json {
+        return Some(quote! { let mut builder = arrow::array::StringBuilder::new(); });
+    }
+
     let (outer, inner) = type_for_macro(ty)?;
     let len = len_var;
 
@@ -314,7 +424,11 @@ fn encode_builder_for_field(ty: &Type, len_var: &syn::Ident) -> Option<TokenStre
 }
 
 /// Python constructor param type: UnixNanos -> u64, Params -> PyDict, Vec<u8> -> Vec<u8>, rest unchanged.
-fn py_param_ty(ty: &Type) -> Option<TokenStream> {
+fn py_param_ty(ty: &Type, json: bool) -> Option<TokenStream> {
+    if json {
+        return Some(quote! { pyo3::Py<pyo3::PyAny> });
+    }
+
     let (outer, inner) = type_for_macro(ty)?;
     if outer == "UnixNanos" {
         return Some(quote! { u64 });
@@ -335,24 +449,54 @@ fn py_param_ty(ty: &Type) -> Option<TokenStream> {
 }
 
 /// Python constructor body RHS: UnixNanos fields use arg.into(), rest use arg.
-fn py_field_init(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
+fn py_field_init(ident: &syn::Ident, ty: &Type, json: bool) -> Option<TokenStream> {
     let name = ident;
 
+    if json {
+        if let Some(map_kind) = typed_json_map_kind(ty) {
+            let helper = if map_kind == "IndexMap" {
+                quote! { indexmap_from_pyobject_pyo3 }
+            } else {
+                quote! { hashmap_from_pyobject_pyo3 }
+            };
+            return Some(quote! {
+                pyo3::Python::attach(|py| -> pyo3::PyResult<#ty> {
+                    let value = #name.bind(py);
+                    nautilus_core::python::serialization::#helper::<_, _>(py, value)
+                        .map_err(|e| nautilus_core::python::to_pyvalue_err(format!("failed to deserialize JSON field '{}': {e}", stringify!(#name))))
+                })?
+            });
+        }
+
+        return Some(quote! {
+            pyo3::Python::attach(|py| -> pyo3::PyResult<#ty> {
+                let value = #name.bind(py);
+                nautilus_core::python::serialization::from_pyobject_pyo3::<#ty>(py, value)
+                    .map_err(|e| nautilus_core::python::to_pyvalue_err(format!("failed to deserialize JSON field '{}': {e}", stringify!(#name))))
+            })?
+        });
+    }
+
+    let (outer, inner) = type_for_macro(ty)?;
     if outer == "UnixNanos" {
         return Some(quote! { #name.into() });
     }
 
     if outer == inner && outer == "Params" {
         return Some(quote! {
-            pyo3::Python::attach(|py| nautilus_core::from_pydict(py, #name))?.unwrap_or_default()
+            pyo3::Python::attach(|py| nautilus_core::from_pydict(py, &#name))?.unwrap_or_default()
         });
     }
+
     Some(quote! { #name })
 }
 
 /// Python getter return type: UnixNanos -> u64, rest unchanged.
-fn py_getter_ret_ty(ty: &Type) -> Option<TokenStream> {
+fn py_getter_ret_ty(ty: &Type, json: bool) -> Option<TokenStream> {
+    if json {
+        return Some(quote! { pyo3::PyResult<pyo3::Py<pyo3::PyAny>> });
+    }
+
     let (outer, inner) = type_for_macro(ty)?;
 
     if outer == "UnixNanos" {
@@ -362,14 +506,38 @@ fn py_getter_ret_ty(ty: &Type) -> Option<TokenStream> {
     if outer == inner && outer == "Params" {
         return Some(quote! { pyo3::PyResult<pyo3::Py<pyo3::types::PyDict>> });
     }
+
     Some(quote! { #ty })
 }
 
 /// Python getter body: UnixNanos -> self.x.as_u64(), Vec -> clone, String -> clone, rest -> self.x.
-fn py_getter_body(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
-    let (outer, inner) = type_for_macro(ty)?;
+fn py_getter_body(ident: &syn::Ident, ty: &Type, json: bool) -> Option<TokenStream> {
     let name = ident;
 
+    if json {
+        if let Some(map_kind) = typed_json_map_kind(ty) {
+            let helper = if map_kind == "IndexMap" {
+                quote! { indexmap_to_pydict_pyo3 }
+            } else {
+                quote! { hashmap_to_pydict_pyo3 }
+            };
+            return Some(quote! {
+                pyo3::Python::attach(|py| {
+                    nautilus_core::python::serialization::#helper(py, &self.#name)
+                        .map_err(|e| nautilus_core::python::to_pyvalue_err(format!("failed to serialize JSON field '{}': {e}", stringify!(#name))))
+                })
+            });
+        }
+
+        return Some(quote! {
+            pyo3::Python::attach(|py| {
+                nautilus_core::python::serialization::to_pyobject_pyo3(py, &self.#name)
+                    .map_err(|e| nautilus_core::python::to_pyvalue_err(format!("failed to serialize JSON field '{}': {e}", stringify!(#name))))
+            })
+        });
+    }
+
+    let (outer, inner) = type_for_macro(ty)?;
     if outer == "UnixNanos" {
         return Some(quote! { self.#name.as_u64() });
     }
@@ -385,7 +553,11 @@ fn py_getter_body(ident: &syn::Ident, ty: &Type) -> Option<TokenStream> {
 }
 
 /// Finish the builder and wrap in Arc for RecordBatch::try_new columns.
-fn encode_finish_builder(ty: &Type) -> Option<TokenStream> {
+fn encode_finish_builder(ty: &Type, json: bool) -> Option<TokenStream> {
+    if json {
+        return Some(quote! { std::sync::Arc::new(builder.finish()) });
+    }
+
     let (outer, inner) = type_for_macro(ty)?;
     match (outer.as_str(), inner.as_str()) {
         ("Vec", "u8" | "f64") => Some(quote! { std::sync::Arc::new(builder.finish()) }),
@@ -406,6 +578,17 @@ fn encode_finish_builder(ty: &Type) -> Option<TokenStream> {
 struct CustomDataOptions {
     pyo3: bool,
     no_display: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct FieldOptions {
+    json: bool,
+}
+
+struct FieldSpec {
+    ident: Ident,
+    ty: Type,
+    options: FieldOptions,
 }
 
 fn parse_option_ident(
@@ -459,13 +642,46 @@ fn parse_options(attr: &TokenStream) -> Result<CustomDataOptions, syn::Error> {
     Ok(options)
 }
 
+fn parse_field_option_ident(
+    ident: &syn::Ident,
+    options: &mut FieldOptions,
+) -> Result<(), syn::Error> {
+    let s = ident.to_string();
+    match s.as_str() {
+        "json" => options.json = true,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "expected `json`; unknown field option",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_field_options(field: &Field) -> Result<FieldOptions, syn::Error> {
+    let mut options = FieldOptions::default();
+
+    for attr in field.attrs.iter().filter(|attr| {
+        attr.path()
+            .get_ident()
+            .is_some_and(|i| *i == "custom_data_field")
+    }) {
+        let option_idents: OptionIdents = attr.parse_args()?;
+        for ident in &option_idents.idents {
+            parse_field_option_ident(ident, &mut options)?;
+        }
+    }
+    Ok(options)
+}
+
 /// Context passed to each expansion generator for readability and testability.
 struct ExpansionContext<'a> {
     name: &'a Ident,
     name_str: &'a str,
     generics: &'a syn::Generics,
     vis: &'a syn::Visibility,
-    field_list: &'a [(Ident, Type)],
+    field_list: &'a [FieldSpec],
     options: &'a CustomDataOptions,
 }
 
@@ -482,8 +698,15 @@ fn gen_new_fn(ctx: &ExpansionContext<'_>) -> TokenStream {
     } else {
         (quote! { new }, quote! { "Constructor." })
     };
-    let constructor_params = field_list.iter().map(|(i, ty)| quote! { #i: #ty });
-    let constructor_fields = field_list.iter().map(|(i, _)| quote! { #i });
+    let constructor_params = field_list.iter().map(|f| {
+        let ident = &f.ident;
+        let ty = &f.ty;
+        quote! { #ident: #ty }
+    });
+    let constructor_fields = field_list.iter().map(|f| {
+        let ident = &f.ident;
+        quote! { #ident }
+    });
     quote! {
         impl #generics #name #generics {
             #[allow(dead_code)]
@@ -506,7 +729,8 @@ fn gen_repr_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let field_list = ctx.field_list;
     let repr_format_parts: Vec<String> = field_list
         .iter()
-        .map(|(ident, _)| {
+        .map(|f| {
+            let ident = &f.ident;
             let s = ident.to_string();
             if s == "ts_event" || s == "ts_init" {
                 format!("{s}={{}}")
@@ -519,7 +743,8 @@ fn gen_repr_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let repr_format_lit = LitStr::new(&repr_format_str, Span::call_site());
     let repr_args: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, _)| {
+        .map(|f| {
+            let ident = &f.ident;
             let s = ident.to_string();
             if s == "ts_event" || s == "ts_init" {
                 quote! { nautilus_core::datetime::unix_nanos_to_iso8601(self.#ident) }
@@ -559,6 +784,16 @@ fn gen_custom_data_trait_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let name = ctx.name;
     let generics = ctx.generics;
     let name_str = ctx.name_str;
+    let to_pyobject_impl = if ctx.options.pyo3 {
+        quote! {
+            #[cfg(feature = "python")]
+            fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+                nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
+            }
+        }
+    } else {
+        quote! {}
+    };
     quote! {
         impl #generics nautilus_model::data::CustomDataTrait for #name #generics {
             fn type_name(&self) -> &'static str {
@@ -590,10 +825,7 @@ fn gen_custom_data_trait_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                     let t: Self = serde_json::from_value(value)?;
                     Ok(std::sync::Arc::new(t))
                 }
-                #[cfg(feature = "python")]
-                fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-                    nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
-                }
+                #to_pyobject_impl
         }
     }
 }
@@ -634,8 +866,10 @@ fn gen_arrow_schema_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let field_list = ctx.field_list;
     let arrow_schema_fields: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, ty)| {
-            let (arrow_dt, _, _) = arrow_type_for_rust_type(ty).unwrap();
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            let (arrow_dt, _, _) = arrow_type_for_rust_type(ty, f.options.json).unwrap();
             let fn_str = ident.to_string();
             quote! {
                 arrow::datatypes::Field::new(#fn_str, #arrow_dt, false)
@@ -664,10 +898,12 @@ fn gen_encode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let mut col_builds = Vec::new();
     let mut col_names = Vec::new();
 
-    for (ident, ty) in field_list {
-        let builder = encode_builder_for_field(ty, &len_var).unwrap();
-        let append = encode_field_expr(ident, ty).unwrap();
-        let finish = encode_finish_builder(ty).unwrap();
+    for f in field_list {
+        let ident = &f.ident;
+        let ty = &f.ty;
+        let builder = encode_builder_for_field(ty, f.options.json, &len_var).unwrap();
+        let append = encode_field_expr(ident, ty, f.options.json).unwrap();
+        let finish = encode_finish_builder(ty, f.options.json).unwrap();
         let col_name = format_ident!("col_{}", col_builds.len());
         col_names.push(col_name.clone());
         col_builds.push(quote! {
@@ -711,20 +947,24 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     let decode_row_fields: Vec<TokenStream> = field_list
         .iter()
         .enumerate()
-        .map(|(idx, (ident, ty))| {
+        .map(|(idx, f)| {
+            let ident = &f.ident;
+            let ty = &f.ty;
             let col_name = format_ident!("col_{}", idx);
-            let rhs = decode_field_rhs(ident, ty, &col_name).unwrap();
+            let rhs = decode_field_rhs(ident, ty, f.options.json, &col_name).unwrap();
             quote! { #ident: #rhs }
         })
         .collect();
     let decode_extracts: Vec<TokenStream> = field_list
         .iter()
         .enumerate()
-        .map(|(idx, (ident, ty))| {
+        .map(|(idx, f)| {
+            let ident = &f.ident;
+            let ty = &f.ty;
             let col_name = format_ident!("col_{}", idx);
             let fn_str = ident.to_string();
 
-            if use_string_extract(ty) {
+            if use_string_extract(ty, f.options.json) {
                 quote! {
                     let #col_name = nautilus_serialization::arrow::extract_column_string(
                         record_batch.columns(),
@@ -733,7 +973,7 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                     )?;
                 }
             } else {
-                let (arrow_dt, _, array_ty) = arrow_type_for_rust_type(ty).unwrap();
+                let (arrow_dt, _, array_ty) = arrow_type_for_rust_type(ty, f.options.json).unwrap();
                 quote! {
                     let #col_name = nautilus_serialization::arrow::extract_column::<#array_ty>(
                         record_batch.columns(),
@@ -816,27 +1056,36 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     }
     let py_new_params: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, ty)| {
-            let py_ty = py_param_ty(ty).unwrap();
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            let py_ty = py_param_ty(ty, f.options.json).unwrap();
             quote! { #ident: #py_ty }
         })
         .collect();
     let py_let_bindings: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, ty)| {
-            let init = py_field_init(ident, ty).unwrap();
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            let init = py_field_init(ident, ty, f.options.json).unwrap();
             quote! { let #ident = #init; }
         })
         .collect();
     let py_new_call_args: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, _)| quote! { #ident })
+        .map(|f| {
+            let ident = &f.ident;
+            quote! { #ident }
+        })
         .collect();
     let getters: Vec<TokenStream> = field_list
         .iter()
-        .map(|(ident, ty)| {
-            let ret_ty = py_getter_ret_ty(ty).unwrap();
-            let body = py_getter_body(ident, ty).unwrap();
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            let ret_ty = py_getter_ret_ty(ty, f.options.json).unwrap();
+            let body = py_getter_body(ident, ty, f.options.json).unwrap();
             quote! {
                 #[getter]
                 fn #ident(&self) -> #ret_ty {
@@ -1011,21 +1260,31 @@ pub fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    let field_list: Vec<_> = fields
+    let field_list: Vec<_> = match fields
         .iter()
         .map(|f| {
             let ident = f.ident.as_ref().expect("named field");
             let ty = &f.ty;
-            (ident.clone(), ty.clone())
+            let options = parse_field_options(f)?;
+            Ok(FieldSpec {
+                ident: ident.clone(),
+                ty: ty.clone(),
+                options,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, syn::Error>>()
+    {
+        Ok(field_list) => field_list,
+        Err(e) => return e.to_compile_error(),
+    };
 
-    for (ident, ty) in &field_list {
-        if arrow_type_for_rust_type(ty).is_none() {
+    for field in &field_list {
+        if arrow_type_for_rust_type(&field.ty, field.options.json).is_none() {
+            let ident = &field.ident;
             return syn::Error::new_spanned(
-                ty,
+                &field.ty,
                 format!(
-                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>"
+                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>, or fields marked #[custom_data_field(json)]"
                 ),
             )
             .to_compile_error();
@@ -1034,12 +1293,12 @@ pub fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let ts_init_field = field_list
         .iter()
-        .find(|(i, _)| *i == "ts_init")
-        .map(|(i, _)| i);
+        .find(|f| f.ident == "ts_init")
+        .map(|f| &f.ident);
     let ts_event_field = field_list
         .iter()
-        .find(|(i, _)| *i == "ts_event")
-        .map(|(i, _)| i);
+        .find(|f| f.ident == "ts_event")
+        .map(|f| &f.ident);
 
     if ts_init_field.is_none() || ts_event_field.is_none() {
         return syn::Error::new_spanned(
@@ -1083,7 +1342,18 @@ pub fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {}
     };
-    let fields_vec: Vec<&Field> = fields.iter().collect();
+    let fields_vec: Vec<Field> = fields
+        .iter()
+        .map(|field| {
+            let mut field = field.clone();
+            field.attrs.retain(|a| {
+                a.path()
+                    .get_ident()
+                    .is_none_or(|i| *i != "custom_data_field")
+            });
+            field
+        })
+        .collect();
 
     let derived_attr = quote! {
         #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]

--- a/crates/persistence/macros/src/lib.rs
+++ b/crates/persistence/macros/src/lib.rs
@@ -28,6 +28,10 @@ use proc_macro::TokenStream;
 /// Requires fields to include `ts_event` and `ts_init` (e.g. `nautilus_core::UnixNanos`).
 /// Supported field types include InstrumentId, AccountId, Currency, BarType, Params, UnixNanos,
 /// f64, f32, bool, String, u64, i64, u32, i32, `Vec<f64>`, and `Vec<u8>`.
+/// Use `#[custom_data_field(json)]` on a field to store any Serde serializable field as a
+/// JSON-backed Arrow `Utf8` column. Python access uses typed dict conversion for supported
+/// `HashMap<K, V>` and `IndexMap<K, V>` field types, and a full JSON conversion for other
+/// JSON-backed fields.
 ///
 /// Use `#[custom_data(pyo3)]` or `#[custom_data(python)]` to also generate Python bindings:
 /// `#[cfg_attr(feature = "python", pyo3::pyclass)]` on the struct and a `#[pymethods]` impl with

--- a/crates/persistence/src/python/mod.rs
+++ b/crates/persistence/src/python/mod.rs
@@ -39,9 +39,15 @@ pub fn persistence(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     ensure_custom_data_registered::<crate::test_data::RustTestCustomData>();
     ensure_custom_data_registered::<crate::test_data::MacroYieldCurveData>();
     ensure_custom_data_registered::<crate::test_data::RustTestParamsCustomData>();
+    ensure_custom_data_registered::<crate::test_data::RustTestPriceMapCustomData>();
+    ensure_custom_data_registered::<crate::test_data::RustTestTypedMapCustomData>();
     let _result = ensure_rust_extractor_registered::<crate::test_data::RustTestCustomData>();
     let _result = ensure_rust_extractor_registered::<crate::test_data::MacroYieldCurveData>();
     let _result = ensure_rust_extractor_registered::<crate::test_data::RustTestParamsCustomData>();
+    let _result =
+        ensure_rust_extractor_registered::<crate::test_data::RustTestPriceMapCustomData>();
+    let _result =
+        ensure_rust_extractor_registered::<crate::test_data::RustTestTypedMapCustomData>();
 
     // Test/example types (RustTestCustomData, MacroYieldCurveData) are exposed so Python tests
     // and examples can use them; they are not gated behind cfg(test) to keep the extension build simple.
@@ -58,5 +64,7 @@ pub fn persistence(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::test_data::RustTestCustomData>()?;
     m.add_class::<crate::test_data::MacroYieldCurveData>()?;
     m.add_class::<crate::test_data::RustTestParamsCustomData>()?;
+    m.add_class::<crate::test_data::RustTestPriceMapCustomData>()?;
+    m.add_class::<crate::test_data::RustTestTypedMapCustomData>()?;
     Ok(())
 }

--- a/crates/persistence/src/test_data.rs
+++ b/crates/persistence/src/test_data.rs
@@ -18,8 +18,15 @@
 //! Exposed to Python via the persistence PyO3 module so Python tests can exercise
 //! custom data write/query roundtrips.
 
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
 use nautilus_core::{Params, UnixNanos};
-use nautilus_model::identifiers::InstrumentId;
+use nautilus_model::{
+    data::BarType,
+    identifiers::{AccountId, InstrumentId},
+    types::{Currency, Money, Price, Quantity},
+};
 use nautilus_persistence_macros::custom_data;
 
 /// A simple Rust custom data type for roundtrip testing.
@@ -56,6 +63,74 @@ pub struct RustTestParamsCustomData {
     pub ts_init: UnixNanos,
 }
 
+/// Rust custom data type that exercises typed map field support in the macro.
+#[custom_data(pyo3)]
+pub struct RustTestPriceMapCustomData {
+    pub name: String,
+    #[custom_data_field(json)]
+    pub prices: IndexMap<InstrumentId, Price>,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
+/// Rust custom data type that exercises typed JSON map values across PyO3-supported types.
+#[custom_data(pyo3)]
+pub struct RustTestTypedMapCustomData {
+    pub name: String,
+    #[custom_data_field(json)]
+    pub instrument_ids: IndexMap<String, InstrumentId>,
+    #[custom_data_field(json)]
+    pub account_ids: IndexMap<String, AccountId>,
+    #[custom_data_field(json)]
+    pub currencies: IndexMap<String, Currency>,
+    #[custom_data_field(json)]
+    pub bar_types: IndexMap<String, BarType>,
+    #[custom_data_field(json)]
+    pub prices: IndexMap<String, Price>,
+    #[custom_data_field(json)]
+    pub quantities: IndexMap<String, Quantity>,
+    #[custom_data_field(json)]
+    pub monies: IndexMap<String, Money>,
+    #[custom_data_field(json)]
+    pub prices_by_instrument: IndexMap<InstrumentId, Price>,
+    #[custom_data_field(json)]
+    pub quantities_by_account: IndexMap<AccountId, Quantity>,
+    #[custom_data_field(json)]
+    pub monies_by_currency: IndexMap<Currency, Money>,
+    #[custom_data_field(json)]
+    pub prices_by_bar_type: IndexMap<BarType, Price>,
+    #[custom_data_field(json)]
+    pub hash_prices_by_instrument: HashMap<InstrumentId, Price>,
+    #[custom_data_field(json)]
+    pub strings: HashMap<String, String>,
+    #[custom_data_field(json)]
+    pub floats_64: HashMap<String, f64>,
+    #[custom_data_field(json)]
+    pub floats_32: HashMap<String, f32>,
+    #[custom_data_field(json)]
+    pub booleans: HashMap<String, bool>,
+    #[custom_data_field(json)]
+    pub integers_u64: HashMap<String, u64>,
+    #[custom_data_field(json)]
+    pub integers_i64: HashMap<String, i64>,
+    #[custom_data_field(json)]
+    pub integers_u32: HashMap<String, u32>,
+    #[custom_data_field(json)]
+    pub integers_i32: HashMap<String, i32>,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
+/// Rust custom data type that exercises generic JSON map field support.
+#[custom_data]
+pub struct RustTestHashMapCustomData {
+    pub name: String,
+    #[custom_data_field(json)]
+    pub prices: HashMap<String, Price>,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
 #[cfg(test)]
 mod tests {
     use arrow::datatypes::DataType;
@@ -84,5 +159,52 @@ mod tests {
         let params_field = schema.field_with_name("params").unwrap();
 
         assert_eq!(params_field.data_type(), &DataType::Utf8);
+    }
+
+    #[rstest]
+    fn test_rust_test_price_map_custom_data_schema_uses_utf8_for_prices() {
+        let schema = RustTestPriceMapCustomData::get_schema(None);
+        let prices_field = schema.field_with_name("prices").unwrap();
+
+        assert_eq!(prices_field.data_type(), &DataType::Utf8);
+    }
+
+    #[rstest]
+    fn test_rust_test_hash_map_custom_data_schema_uses_utf8_for_prices() {
+        let schema = RustTestHashMapCustomData::get_schema(None);
+        let prices_field = schema.field_with_name("prices").unwrap();
+
+        assert_eq!(prices_field.data_type(), &DataType::Utf8);
+    }
+
+    #[rstest]
+    fn test_rust_test_typed_map_custom_data_schema_uses_utf8_for_json_maps() {
+        let schema = RustTestTypedMapCustomData::get_schema(None);
+
+        for field_name in [
+            "instrument_ids",
+            "account_ids",
+            "currencies",
+            "bar_types",
+            "prices",
+            "quantities",
+            "monies",
+            "prices_by_instrument",
+            "quantities_by_account",
+            "monies_by_currency",
+            "prices_by_bar_type",
+            "hash_prices_by_instrument",
+            "strings",
+            "floats_64",
+            "floats_32",
+            "booleans",
+            "integers_u64",
+            "integers_i64",
+            "integers_u32",
+            "integers_i32",
+        ] {
+            let field = schema.field_with_name(field_name).unwrap();
+            assert_eq!(field.data_type(), &DataType::Utf8);
+        }
     }
 }

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -38,7 +38,10 @@ use nautilus_persistence::{
         catalog::ParquetDataCatalog,
         session::{DataBackendSession, QueryResult},
     },
-    test_data::{MacroYieldCurveData, RustTestCustomData, RustTestParamsCustomData},
+    test_data::{
+        MacroYieldCurveData, RustTestCustomData, RustTestHashMapCustomData,
+        RustTestParamsCustomData, RustTestPriceMapCustomData,
+    },
 };
 use nautilus_serialization::{arrow::ArrowSchemaProvider, ensure_custom_data_registered};
 use nautilus_testkit::common::get_nautilus_test_data_file_path;
@@ -60,7 +63,9 @@ fn ensure_test_custom_data_registered() {
     ONCE.call_once(|| {
         ensure_custom_data_registered::<MacroYieldCurveData>();
         ensure_custom_data_registered::<RustTestCustomData>();
+        ensure_custom_data_registered::<RustTestHashMapCustomData>();
         ensure_custom_data_registered::<RustTestParamsCustomData>();
+        ensure_custom_data_registered::<RustTestPriceMapCustomData>();
     });
 }
 
@@ -3337,6 +3342,153 @@ fn test_rust_custom_data_roundtrip_with_params_field() {
                 .as_any()
                 .downcast_ref::<RustTestParamsCustomData>()
                 .expect("Expected RustTestParamsCustomData");
+            assert_eq!(expected, rust);
+        } else {
+            panic!("Expected Data::Custom variant");
+        }
+    }
+}
+
+#[rstest]
+fn test_rust_custom_data_roundtrip_with_indexmap_price_field() {
+    use std::sync::Arc;
+
+    use indexmap::IndexMap;
+    use nautilus_model::data::{CustomData, Data, DataType};
+
+    ensure_test_custom_data_registered();
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let data_type = DataType::new("RustTestPriceMapCustomData", None, None);
+    let audusd = InstrumentId::from("AUD/USD.SIM");
+    let btcusdt = InstrumentId::from("BTCUSDT.BINANCE");
+
+    let mut prices_a = IndexMap::new();
+    prices_a.insert(audusd, Price::from("1.23456"));
+    prices_a.insert(btcusdt, Price::from("65432.10"));
+
+    let mut prices_b = IndexMap::new();
+    prices_b.insert(btcusdt, Price::from("65433.20"));
+    prices_b.insert(audusd, Price::from("1.23457"));
+
+    let original_data = [
+        RustTestPriceMapCustomData {
+            name: "first".to_string(),
+            prices: prices_a,
+            ts_event: UnixNanos::from(10),
+            ts_init: UnixNanos::from(10),
+        },
+        RustTestPriceMapCustomData {
+            name: "second".to_string(),
+            prices: prices_b,
+            ts_event: UnixNanos::from(20),
+            ts_init: UnixNanos::from(20),
+        },
+    ];
+
+    let custom_data: Vec<CustomData> = original_data
+        .iter()
+        .cloned()
+        .map(|item| CustomData::new(Arc::new(item), data_type.clone()))
+        .collect();
+
+    catalog
+        .write_custom_data_batch(custom_data, None, None, Some(false))
+        .unwrap();
+
+    let loaded: Vec<Data> = catalog
+        .query_custom_data_dynamic(
+            "RustTestPriceMapCustomData",
+            None,
+            None,
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(loaded.len(), original_data.len());
+
+    for (expected, actual) in original_data.iter().zip(loaded.iter()) {
+        if let Data::Custom(custom) = actual {
+            assert_eq!(custom.data_type.type_name(), "RustTestPriceMapCustomData");
+            let rust: &RustTestPriceMapCustomData = custom
+                .data
+                .as_any()
+                .downcast_ref::<RustTestPriceMapCustomData>()
+                .expect("Expected RustTestPriceMapCustomData");
+            assert_eq!(expected, rust);
+        } else {
+            panic!("Expected Data::Custom variant");
+        }
+    }
+}
+
+#[rstest]
+fn test_rust_custom_data_roundtrip_with_hashmap_price_field() {
+    use std::sync::Arc;
+
+    use nautilus_model::data::{CustomData, Data, DataType};
+
+    ensure_test_custom_data_registered();
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let data_type = DataType::new("RustTestHashMapCustomData", None, None);
+
+    let original_data = [
+        RustTestHashMapCustomData {
+            name: "first".to_string(),
+            prices: HashMap::from([
+                ("AUD/USD.SIM".to_string(), Price::from("1.23456")),
+                ("BTCUSDT.BINANCE".to_string(), Price::from("65432.10")),
+            ]),
+            ts_event: UnixNanos::from(10),
+            ts_init: UnixNanos::from(10),
+        },
+        RustTestHashMapCustomData {
+            name: "second".to_string(),
+            prices: HashMap::from([
+                ("AUD/USD.SIM".to_string(), Price::from("1.23457")),
+                ("BTCUSDT.BINANCE".to_string(), Price::from("65433.20")),
+            ]),
+            ts_event: UnixNanos::from(20),
+            ts_init: UnixNanos::from(20),
+        },
+    ];
+
+    let custom_data: Vec<CustomData> = original_data
+        .iter()
+        .cloned()
+        .map(|item| CustomData::new(Arc::new(item), data_type.clone()))
+        .collect();
+
+    catalog
+        .write_custom_data_batch(custom_data, None, None, Some(false))
+        .unwrap();
+
+    let loaded: Vec<Data> = catalog
+        .query_custom_data_dynamic(
+            "RustTestHashMapCustomData",
+            None,
+            None,
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(loaded.len(), original_data.len());
+
+    for (expected, actual) in original_data.iter().zip(loaded.iter()) {
+        if let Data::Custom(custom) = actual {
+            assert_eq!(custom.data_type.type_name(), "RustTestHashMapCustomData");
+            let rust: &RustTestHashMapCustomData = custom
+                .data
+                .as_any()
+                .downcast_ref::<RustTestHashMapCustomData>()
+                .expect("Expected RustTestHashMapCustomData");
             assert_eq!(expected, rust);
         } else {
             panic!("Expected Data::Custom variant");

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -1324,7 +1324,7 @@ impl PyStrategy {
         let order = pyobject_to_order_any(py, order)?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1350,7 +1350,7 @@ impl PyStrategy {
         let order = pyobject_to_order_any(py, order)?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1380,7 +1380,7 @@ impl PyStrategy {
         let order = pyobject_to_order_any(py, order)?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1400,7 +1400,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1424,7 +1424,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1499,7 +1499,7 @@ impl PyStrategy {
         params: Option<Py<PyDict>>,
     ) -> PyResult<()> {
         let params_map = match params {
-            Some(dict) => from_pydict(py, dict)?,
+            Some(dict) => from_pydict(py, &dict)?,
             None => None,
         };
         Strategy::query_account(self.inner_mut(), account_id, client_id, params_map)
@@ -1517,7 +1517,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let order = pyobject_to_order_any(py, order)?;
         let params_map = match params {
-            Some(dict) => from_pydict(py, dict)?,
+            Some(dict) => from_pydict(py, &dict)?,
             None => None,
         };
         Strategy::query_order(self.inner_mut(), &order, client_id, params_map)
@@ -1737,7 +1737,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1755,7 +1755,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1773,7 +1773,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1794,7 +1794,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1824,7 +1824,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1854,7 +1854,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1872,7 +1872,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1890,7 +1890,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1908,7 +1908,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1926,7 +1926,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1944,7 +1944,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1962,7 +1962,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -1980,7 +1980,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2003,7 +2003,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2028,7 +2028,7 @@ impl PyStrategy {
         params: Option<Py<PyDict>>,
     ) -> PyResult<()> {
         let params_map = match params {
-            Some(dict) => from_pydict(py, dict)?,
+            Some(dict) => from_pydict(py, &dict)?,
             None => None,
         };
         DataActor::subscribe_option_chain(
@@ -2064,7 +2064,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2082,7 +2082,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2100,7 +2100,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2118,7 +2118,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2137,7 +2137,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2164,7 +2164,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2182,7 +2182,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2200,7 +2200,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2218,7 +2218,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2236,7 +2236,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2254,7 +2254,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2277,7 +2277,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2300,7 +2300,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2323,7 +2323,7 @@ impl PyStrategy {
     ) -> PyResult<()> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2371,7 +2371,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2404,7 +2404,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2435,7 +2435,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2465,7 +2465,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2495,7 +2495,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2529,7 +2529,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2563,7 +2563,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;
@@ -2597,7 +2597,7 @@ impl PyStrategy {
     ) -> PyResult<String> {
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
             match params {
-                Some(dict) => from_pydict(py, dict),
+                Some(dict) => from_pydict(py, &dict),
                 None => Ok(None),
             }
         })?;

--- a/tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py
+++ b/tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py
@@ -261,6 +261,9 @@ def test_rust_params_custom_data_roundtrip(tmp_path):
 
     for item in result:
         assert isinstance(item, CustomData), f"Expected CustomData, found {type(item)}"
+        assert item.data_type.type_name == "RustTestParamsCustomData"
+        assert item.data_type.metadata == metadata
+        assert item.data_type.identifier is None
         inner = item.data
         assert isinstance(inner, RustTestParamsCustomData), (
             f"Expected RustTestParamsCustomData in .data, found {type(inner)}"
@@ -269,11 +272,6 @@ def test_rust_params_custom_data_roundtrip(tmp_path):
         roundtripped.append(inner)
 
     assert len(roundtripped) == len(original_data)
-
-    for item in result:
-        assert item.data_type.type_name == "RustTestParamsCustomData"
-        assert item.data_type.metadata == metadata
-        assert item.data_type.identifier is None
 
     for expected, expected_params, actual in zip(
         original_data,
@@ -297,6 +295,332 @@ def test_rust_params_custom_data_roundtrip(tmp_path):
         RustTestParamsCustomData,
         assert_params_data,
     )
+
+
+def test_rust_price_map_custom_data_roundtrip(tmp_path):
+    """
+    Test RustTestPriceMapCustomData roundtrip via catalog.
+    """
+    from nautilus_trader.core.nautilus_pyo3 import ParquetDataCatalog
+    from nautilus_trader.core.nautilus_pyo3.model import CustomData
+    from nautilus_trader.core.nautilus_pyo3.model import DataType
+    from nautilus_trader.core.nautilus_pyo3.model import InstrumentId
+    from nautilus_trader.core.nautilus_pyo3.model import Price
+    from nautilus_trader.core.nautilus_pyo3.model import register_custom_data_class
+    from nautilus_trader.core.nautilus_pyo3.persistence import RustTestPriceMapCustomData
+
+    register_custom_data_class(RustTestPriceMapCustomData)
+    catalog_path = tmp_path / "catalog_price_map"
+    catalog_path.mkdir(parents=True, exist_ok=True)
+    pyo3_catalog = ParquetDataCatalog(str(catalog_path))
+
+    metadata = {"source": "unit-test", "kind": "price-map"}
+    data_type = DataType("RustTestPriceMapCustomData", metadata, None)
+    original_prices = [
+        {
+            "AUD/USD.SIM": "1.23456",
+            "BTCUSDT.BINANCE": "65432.10",
+        },
+        {
+            "BTCUSDT.BINANCE": "65433.20",
+            "AUD/USD.SIM": "1.23457",
+        },
+    ]
+    typed_prices = [
+        {
+            InstrumentId.from_str("AUD/USD.SIM"): Price.from_str("1.23456"),
+            InstrumentId.from_str("BTCUSDT.BINANCE"): Price.from_str("65432.10"),
+        },
+        {
+            InstrumentId.from_str("BTCUSDT.BINANCE"): Price.from_str("65433.20"),
+            InstrumentId.from_str("AUD/USD.SIM"): Price.from_str("1.23457"),
+        },
+    ]
+    original_data = [
+        RustTestPriceMapCustomData("first", typed_prices[0], 10, 10),
+        RustTestPriceMapCustomData("second", original_prices[1], 20, 20),
+    ]
+    wrapped = [CustomData(data_type, item) for item in original_data]
+
+    for expected, item in zip(original_prices, original_data, strict=True):
+        _assert_typed_price_map(item.prices, expected, InstrumentId, Price)
+
+    pyo3_catalog.write_custom_data(wrapped)
+
+    result = pyo3_catalog.query(
+        "RustTestPriceMapCustomData",
+        None,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+
+    roundtripped = []
+
+    for item in result:
+        assert isinstance(item, CustomData), f"Expected CustomData, found {type(item)}"
+        assert item.data_type.type_name == "RustTestPriceMapCustomData"
+        assert item.data_type.metadata == metadata
+        assert item.data_type.identifier is None
+        inner = item.data
+        assert isinstance(inner, RustTestPriceMapCustomData), (
+            f"Expected RustTestPriceMapCustomData in .data, found {type(inner)}"
+        )
+        assert isinstance(inner.prices, dict)
+        _assert_typed_price_map(
+            inner.prices,
+            original_prices[len(roundtripped)],
+            InstrumentId,
+            Price,
+        )
+        roundtripped.append(inner)
+
+    assert len(roundtripped) == len(original_data)
+
+    for expected, expected_prices, actual in zip(
+        original_data,
+        original_prices,
+        roundtripped,
+        strict=True,
+    ):
+        assert expected.name == actual.name
+        _assert_typed_price_map(actual.prices, expected_prices, InstrumentId, Price)
+        assert expected.ts_event == actual.ts_event
+        assert expected.ts_init == actual.ts_init
+
+    def assert_price_map_data(orig, rt):
+        assert orig.name == rt.name
+        assert rt.prices == orig.prices
+        assert orig.ts_event == rt.ts_event
+        assert orig.ts_init == rt.ts_init
+
+    _assert_custom_data_json_roundtrip(
+        result,
+        RustTestPriceMapCustomData,
+        assert_price_map_data,
+    )
+
+
+def test_rust_typed_map_custom_data_roundtrip(tmp_path):
+    """
+    Test typed JSON map values roundtrip through PyO3, catalog, and JSON.
+    """
+    from nautilus_trader.core.nautilus_pyo3 import ParquetDataCatalog
+    from nautilus_trader.core.nautilus_pyo3.model import AccountId
+    from nautilus_trader.core.nautilus_pyo3.model import BarType
+    from nautilus_trader.core.nautilus_pyo3.model import Currency
+    from nautilus_trader.core.nautilus_pyo3.model import CustomData
+    from nautilus_trader.core.nautilus_pyo3.model import DataType
+    from nautilus_trader.core.nautilus_pyo3.model import InstrumentId
+    from nautilus_trader.core.nautilus_pyo3.model import Money
+    from nautilus_trader.core.nautilus_pyo3.model import Price
+    from nautilus_trader.core.nautilus_pyo3.model import Quantity
+    from nautilus_trader.core.nautilus_pyo3.model import register_custom_data_class
+    from nautilus_trader.core.nautilus_pyo3.persistence import RustTestTypedMapCustomData
+
+    register_custom_data_class(RustTestTypedMapCustomData)
+    catalog_path = tmp_path / "catalog_typed_map"
+    catalog_path.mkdir(parents=True, exist_ok=True)
+    pyo3_catalog = ParquetDataCatalog(str(catalog_path))
+
+    metadata = {"source": "unit-test", "kind": "typed-map"}
+    data_type = DataType("RustTestTypedMapCustomData", metadata, None)
+    bar_type = BarType.from_str("AUD/USD.SIM-1-MINUTE-LAST-EXTERNAL")
+    original = RustTestTypedMapCustomData(
+        "typed",
+        {"primary": InstrumentId.from_str("AUD/USD.SIM")},
+        {"primary": AccountId.from_str("SIM-001")},
+        {"settlement": Currency.from_str("USD")},
+        {"bar": bar_type},
+        {"bid": Price.from_str("1.23456")},
+        {"size": Quantity.from_str("10.500")},
+        {"notional": Money.from_str("123.45 USD")},
+        {InstrumentId.from_str("AUD/USD.SIM"): Price.from_str("1.23456")},
+        {AccountId.from_str("SIM-001"): Quantity.from_str("10.500")},
+        {Currency.from_str("USD"): Money.from_str("123.45 USD")},
+        {bar_type: Price.from_str("1.23456")},
+        {InstrumentId.from_str("AUD/USD.SIM"): Price.from_str("1.23456")},
+        {"label": "alpha"},
+        {"ratio": 1.5},
+        {"ratio": 1.5},
+        {"enabled": True},
+        {"count": 7},
+        {"delta": -7},
+        {"count": 5},
+        {"delta": -5},
+        10,
+        10,
+    )
+    wrapped = [CustomData(data_type, original)]
+
+    _assert_typed_value_map(original.instrument_ids, {"primary": "AUD/USD.SIM"}, InstrumentId)
+    _assert_typed_value_map(original.account_ids, {"primary": "SIM-001"}, AccountId)
+    _assert_typed_value_map(original.currencies, {"settlement": "USD"}, Currency)
+    _assert_typed_value_map(original.bar_types, {"bar": str(bar_type)}, type(bar_type))
+    _assert_typed_value_map(original.prices, {"bid": "1.23456"}, Price)
+    _assert_typed_value_map(original.quantities, {"size": "10.500"}, Quantity)
+    _assert_typed_value_map(original.monies, {"notional": "123.45 USD"}, Money)
+    _assert_typed_map(
+        original.prices_by_instrument,
+        {"AUD/USD.SIM": "1.23456"},
+        InstrumentId,
+        Price,
+    )
+    _assert_typed_map(
+        original.quantities_by_account,
+        {"SIM-001": "10.500"},
+        AccountId,
+        Quantity,
+    )
+    _assert_typed_map(original.monies_by_currency, {"USD": "123.45 USD"}, Currency, Money)
+    _assert_typed_map(
+        original.prices_by_bar_type,
+        {str(bar_type): "1.23456"},
+        type(bar_type),
+        Price,
+    )
+    _assert_typed_map(
+        original.hash_prices_by_instrument,
+        {"AUD/USD.SIM": "1.23456"},
+        InstrumentId,
+        Price,
+    )
+    assert original.strings == {"label": "alpha"}
+    assert original.floats_64 == {"ratio": 1.5}
+    assert original.floats_32 == {"ratio": 1.5}
+    assert original.booleans == {"enabled": True}
+    assert original.integers_u64 == {"count": 7}
+    assert original.integers_i64 == {"delta": -7}
+    assert original.integers_u32 == {"count": 5}
+    assert original.integers_i32 == {"delta": -5}
+
+    pyo3_catalog.write_custom_data(wrapped)
+
+    result = pyo3_catalog.query(
+        "RustTestTypedMapCustomData",
+        None,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+
+    assert len(result) == 1
+    item = result[0]
+    assert isinstance(item, CustomData), f"Expected CustomData, found {type(item)}"
+    assert item.data_type.type_name == "RustTestTypedMapCustomData"
+    assert item.data_type.metadata == metadata
+    assert item.data_type.identifier is None
+
+    roundtripped = item.data
+    assert isinstance(roundtripped, RustTestTypedMapCustomData), (
+        f"Expected RustTestTypedMapCustomData in .data, found {type(roundtripped)}"
+    )
+    assert roundtripped.name == original.name
+    _assert_typed_value_map(roundtripped.instrument_ids, {"primary": "AUD/USD.SIM"}, InstrumentId)
+    _assert_typed_value_map(roundtripped.account_ids, {"primary": "SIM-001"}, AccountId)
+    _assert_typed_value_map(roundtripped.currencies, {"settlement": "USD"}, Currency)
+    _assert_typed_value_map(roundtripped.bar_types, {"bar": str(bar_type)}, type(bar_type))
+    _assert_typed_value_map(roundtripped.prices, {"bid": "1.23456"}, Price)
+    _assert_typed_value_map(roundtripped.quantities, {"size": "10.500"}, Quantity)
+    _assert_typed_value_map(roundtripped.monies, {"notional": "123.45 USD"}, Money)
+    _assert_typed_map(
+        roundtripped.prices_by_instrument,
+        {"AUD/USD.SIM": "1.23456"},
+        InstrumentId,
+        Price,
+    )
+    _assert_typed_map(
+        roundtripped.quantities_by_account,
+        {"SIM-001": "10.500"},
+        AccountId,
+        Quantity,
+    )
+    _assert_typed_map(roundtripped.monies_by_currency, {"USD": "123.45 USD"}, Currency, Money)
+    _assert_typed_map(
+        roundtripped.prices_by_bar_type,
+        {str(bar_type): "1.23456"},
+        type(bar_type),
+        Price,
+    )
+    _assert_typed_map(
+        roundtripped.hash_prices_by_instrument,
+        {"AUD/USD.SIM": "1.23456"},
+        InstrumentId,
+        Price,
+    )
+    assert roundtripped.strings == original.strings
+    assert roundtripped.floats_64 == original.floats_64
+    assert roundtripped.floats_32 == original.floats_32
+    assert roundtripped.booleans == original.booleans
+    assert roundtripped.integers_u64 == original.integers_u64
+    assert roundtripped.integers_i64 == original.integers_i64
+    assert roundtripped.integers_u32 == original.integers_u32
+    assert roundtripped.integers_i32 == original.integers_i32
+    assert roundtripped.ts_event == original.ts_event
+    assert roundtripped.ts_init == original.ts_init
+
+    def assert_typed_map_data(orig, rt):
+        assert rt.name == orig.name
+        _assert_typed_value_map(rt.instrument_ids, {"primary": "AUD/USD.SIM"}, InstrumentId)
+        _assert_typed_value_map(rt.account_ids, {"primary": "SIM-001"}, AccountId)
+        _assert_typed_value_map(rt.currencies, {"settlement": "USD"}, Currency)
+        _assert_typed_value_map(rt.bar_types, {"bar": str(bar_type)}, type(bar_type))
+        _assert_typed_value_map(rt.prices, {"bid": "1.23456"}, Price)
+        _assert_typed_value_map(rt.quantities, {"size": "10.500"}, Quantity)
+        _assert_typed_value_map(rt.monies, {"notional": "123.45 USD"}, Money)
+        _assert_typed_map(rt.prices_by_instrument, {"AUD/USD.SIM": "1.23456"}, InstrumentId, Price)
+        _assert_typed_map(
+            rt.quantities_by_account,
+            {"SIM-001": "10.500"},
+            AccountId,
+            Quantity,
+        )
+        _assert_typed_map(rt.monies_by_currency, {"USD": "123.45 USD"}, Currency, Money)
+        _assert_typed_map(rt.prices_by_bar_type, {str(bar_type): "1.23456"}, type(bar_type), Price)
+        _assert_typed_map(
+            rt.hash_prices_by_instrument,
+            {"AUD/USD.SIM": "1.23456"},
+            InstrumentId,
+            Price,
+        )
+        assert rt.strings == orig.strings
+        assert rt.floats_64 == orig.floats_64
+        assert rt.floats_32 == orig.floats_32
+        assert rt.booleans == orig.booleans
+        assert rt.integers_u64 == orig.integers_u64
+        assert rt.integers_i64 == orig.integers_i64
+        assert rt.integers_u32 == orig.integers_u32
+        assert rt.integers_i32 == orig.integers_i32
+        assert rt.ts_event == orig.ts_event
+        assert rt.ts_init == orig.ts_init
+
+    _assert_custom_data_json_roundtrip(
+        result,
+        RustTestTypedMapCustomData,
+        assert_typed_map_data,
+    )
+
+
+def _assert_typed_price_map(actual, expected, instrument_id_type, price_type):
+    _assert_typed_map(actual, expected, instrument_id_type, price_type)
+
+
+def _assert_typed_map(actual, expected, key_type, value_type):
+    assert {str(key): str(value) for key, value in actual.items()} == expected
+    for key, value in actual.items():
+        assert isinstance(key, key_type)
+        assert isinstance(value, value_type)
+
+
+def _assert_typed_value_map(actual, expected, value_type):
+    assert {key: str(value) for key, value in actual.items()} == expected
+    for key, value in actual.items():
+        assert isinstance(key, str)
+        assert isinstance(value, value_type)
 
 
 def test_python_only_customdataclass_pyo3_roundtrip(tmp_path):


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Added `#[custom_data_field(json)]` for Serde-backed custom data fields.
- Encoded JSON fields as JSON-backed Arrow `Utf8` columns, matching the existing `Params` storage approach while preserving the Rust field type.
- Added generic PyO3 constructor and getter handling for JSON fields via JSON-compatible Python values.
- Added a typed Python dict bridge for supported `IndexMap<K, V>` and `HashMap<K, V>` JSON fields, so custom data can expose typed keys and values such as `InstrumentId` and `Price`.
- Added Rust and Python persistence coverage for `IndexMap<InstrumentId, Price>`, including catalog and JSON roundtrips.
- Added Rust coverage for a second map shape, `HashMap<String, Price>`, to verify the field path is not hard-coded to `IndexMap`.
- Added Python coverage for string-key maps and typed-key maps across supported map element types, including `InstrumentId`, `AccountId`, `Currency`, `BarType`, `Price`, `Quantity`, and `Money`.
- Updated string-backed deserializers to use `Cow<'de, str>` so custom data payloads reconstructed from `serde_json::Value` can roundtrip without losing the borrowed fast path.
- Covered `Price`, `Quantity`, `Money`, identifier types, `OptionSeriesId`, `PoolIdentifier`, `UUID4`, and related string parsing helpers.
- Moved the Python JSON bridge into shared `nautilus_core::python::serialization` helpers and use `ensure_ascii=False` when converting Python objects to Rust Serde values.
- Routed `Params` conversion through the shared Python JSON bridge, preserving its string-key, JSON-value contract while sharing the same non-ASCII-safe conversion path.
- Documented the Python getter/constructor conversion split for JSON fields and added a field-level JSON example to the macro docs.

### Design decisions

- JSON-backed support is opt-in per field through `#[custom_data_field(json)]`, avoiding a growing list of exact type cases in the macro.
- Arrow storage uses `Utf8` JSON for the first implementation. This keeps the change surgical and reuses Serde behavior for map keys and values.
- `Price` values serialize as strings, so precision is preserved by the existing `Price` Serde implementation.
- String-backed Rust types now deserialize through `Cow<'de, str>`, which accepts both borrowed JSON input and owned strings from `serde_json::Value`.
- `Price`, `Quantity`, and `Money` still reuse their existing string parsing paths, so decimal precision behavior is unchanged.
- Python getters return typed Python dicts for supported `HashMap<K, V>` and `IndexMap<K, V>` JSON fields. Constructors accept typed dicts first and fall back to JSON-compatible dicts, so both `{InstrumentId(...): Price(...)}` and `{"AUD/USD.SIM": "1.23456"}` work for `IndexMap<InstrumentId, Price>`.
- Other JSON-backed fields still return JSON-compatible Python values, which keeps the generic Serde path available without requiring type-specific macro branches.
- `Params` remains `IndexMap<String, serde_json::Value>`, so it can share the robust JSON bridge but cannot infer Nautilus domain types like `Price` from plain JSON strings without adding type metadata.
- Python constructor and getter conversion for JSON fields now goes through shared helpers rather than generated per-field dump/load code. This keeps non-ASCII behavior aligned with the existing dictionary bridge.
- The macro now only overrides `CustomDataTrait::to_pyobject` for `#[custom_data(pyo3)]` types. Non-PyO3 custom data uses the trait default under the Python feature.

### Files changed

- `crates/persistence/macros/src/custom.rs`: Added `custom_data_field(json)` parsing, generic Arrow encode/decode, and generic PyO3 JSON conversion.
- `crates/persistence/macros/src/lib.rs`: Updated macro documentation.
- `crates/core/src/python/serialization.rs`: Added shared Python object JSON conversion helpers, typed map conversion helpers, and non-ASCII coverage.
- `crates/core/src/params.rs` and `crates/core/src/python/params.rs`: Reused the shared Python object JSON conversion helper for `Params` and changed the Python dict bridge to borrow the input dict.
- `crates/core/src/serialization.rs` and `crates/core/src/uuid.rs`: Switched string-backed deserializers to `Cow<'de, str>` and added UUID owned-value coverage.
- `crates/model/src/types/price.rs`, `crates/model/src/types/quantity.rs`, and `crates/model/src/types/money.rs`: Switched numeric string deserializers to `Cow<'de, str>` and added owned-value coverage.
- `crates/model/src/identifiers/*`, `crates/model/src/defi/*`, `crates/model/src/data/bar.rs`, `crates/model/src/types/currency.rs`, and `crates/model/src/macros.rs`: Switched remaining string-backed deserializers to `Cow<'de, str>`.
- `crates/common/src/python/actor.rs`, `crates/trading/src/python/strategy.rs`, and `crates/model/src/python/instruments/*`: Updated `from_pydict` call sites for the borrowed dict signature.
- `crates/persistence/src/test_data.rs`: Added `RustTestPriceMapCustomData`, `RustTestHashMapCustomData`, and `RustTestTypedMapCustomData`.
- `crates/persistence/src/python/mod.rs`: Registered the new test custom data types for Python.
- `crates/persistence/tests/test_catalog.rs`: Added catalog roundtrip coverage for `IndexMap<InstrumentId, Price>` and `HashMap<String, Price>`.
- `tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py`: Added Python PyO3 coverage for constructor/getter, catalog roundtrip, and JSON roundtrip.

### Verification

- `cargo test -p nautilus-persistence custom_data_schema_uses_utf8_for_prices`.
- `cargo test -p nautilus-persistence price_field`.
- `cargo test -p nautilus-core test_from_pyobject_pyo3_preserves_non_ascii_strings --features python`.
- `cargo test -p nautilus-model test_price_serde_json_round_trip --lib`.
- `cargo test -p nautilus-model test_from_str_preserves_trailing_zeros --lib`.
- `cargo test -p nautilus-model test_quantity_serde_json_round_trip --lib`.
- `cargo test -p nautilus-model test_quantity_serde_json_from_value_round_trip --lib`.
- `cargo test -p nautilus-core test_deserialize_from_owned_value --lib`.
- `cargo test -p nautilus-model from_owned_value --lib --features defi`.
- `cargo test -p nautilus-model serde_json_from_value --lib`.
- `cargo check -p nautilus-persistence --features python`.
- `cargo check -p nautilus-core -p nautilus-model -p nautilus-persistence -p nautilus-trading -p nautilus-common --features python`.
- `make clean`.
- `make build-debug`.
- `uv run --no-sync pytest -q tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py::test_rust_price_map_custom_data_roundtrip tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py::test_rust_typed_map_custom_data_roundtrip tests/unit_tests/persistence/test_custom_data_roundtrip_pyo3.py::test_rust_params_custom_data_roundtrip`.
- `cargo test -p nautilus-persistence test_rust_test_typed_map_custom_data_schema_uses_utf8_for_json_maps --features python`.
- `cargo fmt --check`.
- `git diff --check`.
- `make pre-commit`.

### Notes

- `cargo fmt --check` passed with the repository's existing stable-rustfmt warnings about nightly-only import options.
- A grep for non-PyO3 `#[custom_data]` users found only the new `RustTestHashMapCustomData` fixture, so the `to_pyobject` trait-default behavior is not changing an existing production custom data type.





## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/pull/3984

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [X] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [X] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
