### PR TITLE
Fix OKX OKXInstrumentStatus to gracefully handle future schema additions

### DIFF
--- a/crates/adapters/okx/src/common/enums.rs
+++ b/crates/adapters/okx/src/common/enums.rs
@@ -307,6 +307,9 @@ pub enum OKXInstrumentStatus {
     Test,
     PostOnly,
     Rebase,
+    /// Unknown or future state (graceful fallback for venue schema evolution).
+    #[serde(other)]
+    Unknown,
 }
 
 /// Represents an instrument contract type on OKX.

--- a/crates/adapters/okx/src/common/parse.rs
+++ b/crates/adapters/okx/src/common/parse.rs
@@ -259,6 +259,7 @@ pub fn okx_status_to_market_action(status: OKXInstrumentStatus) -> MarketStatusA
         OKXInstrumentStatus::Test => MarketStatusAction::NotAvailableForTrading,
         OKXInstrumentStatus::PostOnly => MarketStatusAction::Quoting,
         OKXInstrumentStatus::Rebase => MarketStatusAction::NotAvailableForTrading,
+        OKXInstrumentStatus::Unknown => MarketStatusAction::NotAvailableForTrading,
     }
 }
 
@@ -5079,10 +5080,27 @@ mod tests {
         OKXInstrumentStatus::Rebase,
         MarketStatusAction::NotAvailableForTrading
     )]
+    #[case(
+        OKXInstrumentStatus::Unknown,
+        MarketStatusAction::NotAvailableForTrading
+    )]
     fn test_okx_status_to_market_action(
         #[case] status: OKXInstrumentStatus,
         #[case] expected: MarketStatusAction,
     ) {
         assert_eq!(okx_status_to_market_action(status), expected);
+    }
+
+    #[rstest]
+    #[case::future_state("\"future_state_xyz\"")]
+    #[case::frozen("\"frozen\"")]
+    #[case::delisting("\"delisting\"")]
+    fn test_okx_unknown_status_falls_back(#[case] json: &str) {
+        let parsed: OKXInstrumentStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed, OKXInstrumentStatus::Unknown);
+        assert_eq!(
+            okx_status_to_market_action(parsed),
+            MarketStatusAction::NotAvailableForTrading
+        );
     }
 }


### PR DESCRIPTION
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds a graceful `#[serde(other)]` `Unknown` fallback variant to `OKXInstrumentStatus` so future OKX schema evolution doesn't break instrument list deserialization.

## Motivation

OKX has been adding new instrument states rapidly, requiring a tracking PR each time:

| OKX state | Added | NT fix |
|---|---|---|
| `post_only` | 2026-04-29 | #3966 |
| `rebase` | ~2026-05-05 | #3998 |
| ? | future | another tracking PR |

Each new state causes downstream users on released NT versions (1.225, 1.226) to hit `unknown variant 'X'` panics on `OKXInstrumentProvider.load_async()`, breaking `_connect()` and preventing any account from registering.

The 1.226 → 1.227 cycle has already required two such tracking PRs in 5 days. As long as `OKXInstrumentStatus` only enumerates known variants, every OKX schema change is a release-blocking incident for downstream users.

## Solution

Mirror the pattern already used by `OKXOrderCategory::Other` in the same file (`crates/adapters/okx/src/common/enums.rs`, line ~245):

```rust
#[serde(rename_all = "snake_case")]
pub enum OKXInstrumentStatus {
    Live, Suspend, Preopen, Test, PostOnly, Rebase,
    /// Unknown or future state (graceful fallback for venue schema evolution).
    #[serde(other)]
    Unknown,
}
```

Mapped to `MarketStatusAction::NotAvailableForTrading` in `okx_status_to_market_action`.

This means:
- ✅ Existing 6 variants behave exactly as before
- ✅ Future OKX states deserialize as `Unknown` and are reported as `NotAvailableForTrading` instead of crashing the entire instrument provider
- ✅ Downstream users no longer need a tracking PR every time OKX adds a state
- ✅ Mirrors NT's own pattern (`OKXOrderCategory::Other`)

## Type of change

- [x] Bug fix (non-breaking) — currently any new OKX state crashes `_connect`
- [x] Improvement (non-breaking)

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

(I did not edit RELEASES.md in this PR — please advise if a one-liner under "Fixes" should be added; I am happy to amend.)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added:
1. New `Unknown` case to existing parametrized `test_okx_status_to_market_action`
2. New parametrized `test_okx_unknown_status_falls_back` verifying that arbitrary unknown serde values (`future_state_xyz`, `frozen`, `delisting`) deserialize to `Unknown` and map to `NotAvailableForTrading`

Verification on this branch:

```
cargo test -p nautilus-okx --lib status_to_market
test common::parse::tests::test_okx_status_to_market_action::case_1 ... ok
... (7 cases) ...
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 445 filtered out

cargo test -p nautilus-okx --lib unknown_status
test common::parse::tests::test_okx_unknown_status_falls_back::case_1_future_state ... ok
test common::parse::tests::test_okx_unknown_status_falls_back::case_2_frozen ... ok
test common::parse::tests::test_okx_unknown_status_falls_back::case_3_delisting ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 449 filtered out
```

## Refs

- #3966 (PostOnly fix)
- #3998 (Rebase fix)
- [OKX V5 API changelog](https://www.okx.com/docs-v5/log_en/)