### PR TITLE
Add Kraken Spot WebSocket v2 order submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,6 +6037,7 @@ dependencies = [
  "nautilus-tardis",
  "nautilus-testkit",
  "nautilus-trading",
+ "proptest",
  "pyo3",
  "pyo3-async-runtimes",
  "pyo3-stub-gen",

--- a/crates/adapters/kraken/Cargo.toml
+++ b/crates/adapters/kraken/Cargo.toml
@@ -101,6 +101,7 @@ nautilus-trading = { workspace = true }
 axum = { workspace = true }
 criterion = { workspace = true }
 dotenvy = { workspace = true }
+proptest = { workspace = true }
 rstest = { workspace = true }
 
 # Run with `cargo bench -p nautilus-kraken --bench websocket`

--- a/crates/adapters/kraken/src/common/order_params.rs
+++ b/crates/adapters/kraken/src/common/order_params.rs
@@ -1,0 +1,364 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Pure builder functions that convert Nautilus execution commands into Kraken WS param structs.
+
+use chrono::{DateTime, Utc};
+use nautilus_common::messages::execution::{CancelOrder, ModifyOrder, SubmitOrder};
+use nautilus_core::nanos::UnixNanos;
+use nautilus_model::{
+    enums::{OrderSide, OrderType, TimeInForce, TriggerType},
+    orders::{Order, any::OrderAny},
+};
+
+use crate::{
+    common::{
+        enums::{KrakenOrderSide, KrakenOrderType, KrakenSpotTrigger, KrakenTimeInForce},
+        parse::truncate_cl_ord_id,
+    },
+    websocket::spot_v2::messages::{
+        KrakenWsAddOrderParams, KrakenWsAmendOrderParams, KrakenWsCancelOrderParams,
+        KrakenWsTriggerParams,
+    },
+};
+
+/// Builds WebSocket `add_order` parameters from a Nautilus submit command and the cached order.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The order side cannot be mapped to a Kraken side.
+/// - The order type is not supported on the WS path.
+/// - The time in force is not supported for the given order type.
+/// - GTD time in force is missing `expire_time`.
+pub fn build_add_order_params(
+    cmd: &SubmitOrder,
+    order: &OrderAny,
+    token: String,
+    leverage: Option<u16>,
+) -> anyhow::Result<KrakenWsAddOrderParams> {
+    let order_type = order.order_type();
+    let order_side = order.order_side();
+    let time_in_force = order.time_in_force();
+
+    let side = match order_side {
+        OrderSide::Buy => KrakenOrderSide::Buy,
+        OrderSide::Sell => KrakenOrderSide::Sell,
+        _ => anyhow::bail!("Invalid order side: {order_side:?}"),
+    };
+
+    let kraken_order_type = match order_type {
+        OrderType::Market => KrakenOrderType::Market,
+        OrderType::Limit => KrakenOrderType::Limit,
+        OrderType::StopMarket => KrakenOrderType::StopLoss,
+        OrderType::StopLimit => KrakenOrderType::StopLossLimit,
+        OrderType::MarketIfTouched => KrakenOrderType::TakeProfit,
+        OrderType::LimitIfTouched => KrakenOrderType::TakeProfitLimit,
+        OrderType::TrailingStopMarket => KrakenOrderType::TrailingStop,
+        OrderType::TrailingStopLimit => KrakenOrderType::TrailingStopLimit,
+        _ => anyhow::bail!("Unsupported order type for Kraken WS: {order_type:?}"),
+    };
+
+    let is_limit_order = matches!(
+        order_type,
+        OrderType::Limit
+            | OrderType::StopLimit
+            | OrderType::LimitIfTouched
+            | OrderType::TrailingStopLimit
+    );
+
+    if is_limit_order && order.price().is_none() {
+        anyhow::bail!("limit_price is required for order type {order_type:?}");
+    }
+
+    let ws_tif = compute_ws_time_in_force(is_limit_order, time_in_force, order.expire_time())?;
+    let expire_time = match (ws_tif, order.expire_time()) {
+        (Some(KrakenTimeInForce::GoodTilDate), Some(ts)) => Some(format_expire_time(ts)),
+        _ => None,
+    };
+
+    let is_conditional = matches!(
+        order_type,
+        OrderType::StopMarket
+            | OrderType::StopLimit
+            | OrderType::MarketIfTouched
+            | OrderType::LimitIfTouched
+    );
+
+    let limit_price = order.price().map(|p| p.as_f64());
+
+    let trigger = if is_conditional {
+        let trigger_ref = match order.trigger_type() {
+            Some(TriggerType::IndexPrice) => KrakenSpotTrigger::Index,
+            _ => KrakenSpotTrigger::Last,
+        };
+        order.trigger_price().map(|tp| KrakenWsTriggerParams {
+            reference: trigger_ref,
+            price: tp.as_f64(),
+            price_type: None,
+        })
+    } else {
+        None
+    };
+
+    if is_conditional && trigger.is_none() {
+        anyhow::bail!("trigger_price is required for conditional order type {order_type:?}");
+    }
+
+    let symbol = cmd.instrument_id.symbol.inner().to_string();
+    let cl_ord_id = Some(truncate_cl_ord_id(&order.client_order_id()));
+    let post_only = order.is_post_only().then_some(true);
+    let reduce_only = order.is_reduce_only().then_some(true);
+
+    Ok(KrakenWsAddOrderParams {
+        order_type: kraken_order_type,
+        side,
+        order_qty: order.quantity().as_f64(),
+        symbol,
+        token,
+        limit_price,
+        time_in_force: ws_tif,
+        expire_time,
+        cl_ord_id,
+        post_only,
+        reduce_only,
+        leverage,
+        trigger,
+        conditional: None,
+    })
+}
+
+/// Formats a [`UnixNanos`] timestamp as an RFC3339 string suitable for the Kraken
+/// WebSocket v2 `expire_time` field.
+///
+/// `UnixNanos` is a `u64` whose maximum value (`~1.8e19` ns) corresponds to
+/// year 2554, well within both `i64::MAX` seconds and `chrono`'s representable
+/// range, so the conversion cannot fail for any in-range input.
+pub(crate) fn format_expire_time(ts: UnixNanos) -> String {
+    let raw = ts.as_u64();
+    let secs = (raw / 1_000_000_000) as i64;
+    let nanos = (raw % 1_000_000_000) as u32;
+    DateTime::<Utc>::from_timestamp(secs, nanos)
+        .expect("Invariant: UnixNanos always fits a valid DateTime<Utc>")
+        .to_rfc3339()
+}
+
+/// Builds WebSocket `amend_order` parameters from a Nautilus modify command.
+///
+/// Prefers `venue_order_id` (as `order_id`) over `client_order_id` (as `cl_ord_id`);
+/// `cmd.client_order_id` is always set so a fallback is always available.
+pub fn build_amend_order_params(cmd: &ModifyOrder, token: String) -> KrakenWsAmendOrderParams {
+    let order_id = cmd.venue_order_id.as_ref().map(|id| id.to_string());
+    let cl_ord_id = if order_id.is_none() {
+        Some(truncate_cl_ord_id(&cmd.client_order_id))
+    } else {
+        None
+    };
+
+    KrakenWsAmendOrderParams {
+        token,
+        order_id,
+        cl_ord_id,
+        order_qty: cmd.quantity.map(|q| q.as_f64()),
+        limit_price: cmd.price.map(|p| p.as_f64()),
+        trigger_price: cmd.trigger_price.map(|p| p.as_f64()),
+    }
+}
+
+/// Builds WebSocket `cancel_order` parameters from a Nautilus cancel command.
+///
+/// Prefers `venue_order_id` (as `order_id`) over `client_order_id` (as `cl_ord_id`),
+/// mirroring the REST cancel path which prefers the venue identifier since Kraken
+/// always knows it.
+pub fn build_cancel_order_params(cmd: &CancelOrder, token: String) -> KrakenWsCancelOrderParams {
+    if let Some(ref venue_id) = cmd.venue_order_id {
+        KrakenWsCancelOrderParams {
+            token,
+            order_id: Some(vec![venue_id.to_string()]),
+            cl_ord_id: None,
+        }
+    } else {
+        KrakenWsCancelOrderParams {
+            token,
+            order_id: None,
+            cl_ord_id: Some(vec![truncate_cl_ord_id(&cmd.client_order_id)]),
+        }
+    }
+}
+
+pub(crate) fn compute_ws_time_in_force(
+    is_limit_order: bool,
+    time_in_force: TimeInForce,
+    expire_time: Option<UnixNanos>,
+) -> anyhow::Result<Option<KrakenTimeInForce>> {
+    if !is_limit_order {
+        return Ok(None);
+    }
+
+    match time_in_force {
+        TimeInForce::Gtc => Ok(None),
+        TimeInForce::Ioc => Ok(Some(KrakenTimeInForce::ImmediateOrCancel)),
+        TimeInForce::Fok => {
+            anyhow::bail!("FOK time in force is not supported on Kraken WS v2; use REST")
+        }
+        TimeInForce::Gtd => {
+            expire_time.ok_or_else(|| {
+                anyhow::anyhow!("GTD time in force requires expire_time parameter")
+            })?;
+            Ok(Some(KrakenTimeInForce::GoodTilDate))
+        }
+        _ => anyhow::bail!("Unsupported time in force: {time_in_force:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::{UUID4, UnixNanos};
+    use nautilus_model::identifiers::{
+        ClientOrderId, InstrumentId, StrategyId, TraderId, VenueOrderId,
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    fn make_cancel_order(client_order_id: &str, venue_order_id: Option<&str>) -> CancelOrder {
+        CancelOrder {
+            trader_id: TraderId::from("TESTER-001"),
+            client_id: None,
+            strategy_id: StrategyId::from("S-001"),
+            instrument_id: InstrumentId::from("XBT/USD.KRAKEN"),
+            client_order_id: ClientOrderId::from(client_order_id),
+            venue_order_id: venue_order_id.map(VenueOrderId::new),
+            command_id: UUID4::new(),
+            ts_init: UnixNanos::default(),
+            params: None,
+        }
+    }
+
+    #[rstest]
+    fn test_format_expire_time_rfc3339() {
+        let ts = UnixNanos::from(1_767_225_599_000_000_000_u64);
+        assert_eq!(format_expire_time(ts), "2025-12-31T23:59:59+00:00");
+    }
+
+    #[rstest]
+    fn test_format_expire_time_max_unix_nanos_handled() {
+        // u64::MAX nanos ≈ year 2554; chrono accepts it. Documents that the
+        // function never panics for any in-range UnixNanos value.
+        let ts = UnixNanos::from(u64::MAX);
+        let formatted = format_expire_time(ts);
+        assert!(formatted.starts_with("2554-"), "unexpected: {formatted}");
+    }
+
+    #[rstest]
+    fn test_compute_ws_time_in_force_fok_bails() {
+        let result = compute_ws_time_in_force(true, TimeInForce::Fok, None);
+        let err = result.expect_err("FOK should bail on WS path");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("FOK") && msg.contains("REST"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    #[rstest]
+    fn test_build_cancel_order_params_with_venue_id() {
+        let cmd = make_cancel_order("O-20260505-001", Some("OABCDE-12345-FGHIJ"));
+        let params = build_cancel_order_params(&cmd, "TOKEN".to_string());
+
+        let ids = params.order_id.as_ref().unwrap();
+        assert_eq!(ids, &["OABCDE-12345-FGHIJ"]);
+        assert!(params.cl_ord_id.is_none());
+    }
+
+    #[rstest]
+    fn test_build_cancel_order_params_falls_back_to_client_id() {
+        let cmd = make_cancel_order("O-20260505-001", None);
+        let params = build_cancel_order_params(&cmd, "TOKEN".to_string());
+
+        assert!(params.order_id.is_none());
+        let cl_ord_ids = params.cl_ord_id.as_ref().unwrap();
+        assert_eq!(cl_ord_ids, &["O-20260505-001"]);
+    }
+
+    #[rstest]
+    fn test_build_cancel_order_params_long_client_id_is_truncated() {
+        let cmd = make_cancel_order("O202602270023210040011", None);
+        let params = build_cancel_order_params(&cmd, "TOKEN".to_string());
+
+        assert!(params.order_id.is_none());
+        let cl_ord_ids = params.cl_ord_id.as_ref().unwrap();
+        assert_eq!(cl_ord_ids.len(), 1);
+        let cl_ord_id = &cl_ord_ids[0];
+        assert!(
+            cl_ord_id.len() <= 18,
+            "cl_ord_id length was {}",
+            cl_ord_id.len()
+        );
+    }
+
+    #[rstest]
+    fn test_build_amend_order_params_with_venue_id() {
+        use nautilus_model::types::{Price, Quantity};
+
+        let cmd = ModifyOrder {
+            trader_id: TraderId::from("TESTER-001"),
+            client_id: None,
+            strategy_id: StrategyId::from("S-001"),
+            instrument_id: InstrumentId::from("XBT/USD.KRAKEN"),
+            client_order_id: ClientOrderId::from("O-001"),
+            venue_order_id: Some(VenueOrderId::new("OABCDE-12345-FGHIJ")),
+            quantity: Some(Quantity::new(0.1, 1)),
+            price: Some(Price::new(50000.0, 1)),
+            trigger_price: None,
+            command_id: UUID4::new(),
+            ts_init: UnixNanos::default(),
+            params: None,
+        };
+
+        let params = build_amend_order_params(&cmd, "TOKEN".to_string());
+
+        assert_eq!(params.order_id.as_deref(), Some("OABCDE-12345-FGHIJ"));
+        assert!(params.cl_ord_id.is_none());
+        assert!((params.order_qty.unwrap() - 0.1).abs() < 1e-10);
+        assert!((params.limit_price.unwrap() - 50000.0).abs() < 1e-10);
+        assert!(params.trigger_price.is_none());
+    }
+
+    #[rstest]
+    fn test_build_amend_order_params_falls_back_to_client_id() {
+        use nautilus_model::types::Quantity;
+
+        let cmd = ModifyOrder {
+            trader_id: TraderId::from("TESTER-001"),
+            client_id: None,
+            strategy_id: StrategyId::from("S-001"),
+            instrument_id: InstrumentId::from("XBT/USD.KRAKEN"),
+            client_order_id: ClientOrderId::from("O-001"),
+            venue_order_id: None,
+            quantity: Some(Quantity::new(0.2, 1)),
+            price: None,
+            trigger_price: None,
+            command_id: UUID4::new(),
+            ts_init: UnixNanos::default(),
+            params: None,
+        };
+
+        let params = build_amend_order_params(&cmd, "TOKEN".to_string());
+
+        assert!(params.order_id.is_none());
+        assert_eq!(params.cl_ord_id.as_deref(), Some("O-001"));
+    }
+}

--- a/crates/adapters/kraken/src/config.rs
+++ b/crates/adapters/kraken/src/config.rs
@@ -172,6 +172,20 @@ pub struct KrakenExecClientConfig {
     /// Display-only: Kraken converts internally; per-position figures from
     /// `OpenPositions` remain in the traded pair's quote currency.
     pub margin_balance_asset: Option<String>,
+
+    /// Use WebSocket v2 for order submission, modification, and cancellation.
+    ///
+    /// When `true` (default), `submit_order`, `modify_order`, `cancel_order`,
+    /// and `submit_order_list` route through the authenticated WebSocket
+    /// connection when active, falling back to REST when the WebSocket is
+    /// inactive. When `false`, all order operations use REST only.
+    #[builder(default = true)]
+    pub use_ws_trade: bool,
+
+    /// Timeout in seconds for WebSocket order responses before emitting a
+    /// rejection event.
+    #[builder(default = 5)]
+    pub ws_request_timeout_secs: u64,
 }
 
 impl Default for KrakenExecClientConfig {
@@ -219,4 +233,18 @@ fn validate_product_environment(
         anyhow::bail!("Kraken Spot does not support the demo environment");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_exec_config_ws_trade_defaults() {
+        let cfg = KrakenExecClientConfig::default();
+        assert!(cfg.use_ws_trade);
+        assert_eq!(cfg.ws_request_timeout_secs, 5);
+    }
 }

--- a/crates/adapters/kraken/src/data/spot.rs
+++ b/crates/adapters/kraken/src/data/spot.rs
@@ -357,6 +357,7 @@ impl KrakenSpotDataClient {
                 }
             }
             KrakenSpotWsMessage::Execution(_) => {}
+            KrakenSpotWsMessage::OrderResponse(_) => {}
             KrakenSpotWsMessage::Reconnected => {
                 log::info!("Spot WebSocket reconnected");
             }

--- a/crates/adapters/kraken/src/execution/spot.rs
+++ b/crates/adapters/kraken/src/execution/spot.rs
@@ -44,14 +44,16 @@ use nautilus_model::{
     accounts::AccountAny,
     enums::{
         AccountType, OmsType, OrderSide, OrderType, PositionSideSpecified, TimeInForce,
-        TrailingOffsetType,
+        TrailingOffsetType, TriggerType,
     },
-    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, Venue},
+    events::OrderEventAny,
+    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue},
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
-    types::{AccountBalance, MarginBalance, Quantity},
+    types::{AccountBalance, MarginBalance, Price, Quantity},
 };
+use rust_decimal::Decimal;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
@@ -59,14 +61,30 @@ use ustr::Ustr;
 use crate::{
     common::{
         consts::{KRAKEN_SPOT_POST_ONLY_ERROR, KRAKEN_VENUE},
-        enums::{KrakenProductType, product_type_from_symbol},
+        enums::{
+            KrakenOrderSide, KrakenOrderType, KrakenProductType, KrakenSpotTrigger,
+            KrakenTimeInForce, product_type_from_symbol,
+        },
+        order_params::{
+            build_add_order_params, build_amend_order_params, build_cancel_order_params,
+            compute_ws_time_in_force, format_expire_time,
+        },
         parse::truncate_cl_ord_id,
     },
     config::KrakenExecClientConfig,
     http::{KrakenSpotHttpClient, spot::client::KRAKEN_SPOT_DEFAULT_RATE_LIMIT_PER_SECOND},
     websocket::{
-        dispatch::{self, OrderIdentity, WsDispatchState},
-        spot_v2::{client::KrakenSpotWebSocketClient, messages::KrakenSpotWsMessage},
+        dispatch::{
+            self, OrderIdentity, WsDispatchState,
+            spot_orders::{OrderRequestState, PendingOperation, PendingRequest},
+        },
+        spot_v2::{
+            client::KrakenSpotWebSocketClient,
+            messages::{
+                KrakenSpotWsMessage, KrakenWsBatchAddOrder, KrakenWsBatchAddParams,
+                KrakenWsTriggerParams,
+            },
+        },
     },
 };
 
@@ -89,6 +107,8 @@ pub struct KrakenSpotExecutionClient {
     order_qty_cache: Arc<AtomicMap<String, f64>>,
     truncated_id_map: Arc<AtomicMap<String, ClientOrderId>>,
     ws_dispatch_state: Arc<WsDispatchState>,
+    order_request_state: Arc<OrderRequestState>,
+    order_event_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<OrderEventAny>>>,
 }
 
 impl KrakenSpotExecutionClient {
@@ -140,6 +160,22 @@ impl KrakenSpotExecutionClient {
             config.proxy_url.clone(),
         );
 
+        let ws_dispatch_state = Arc::new(WsDispatchState::new());
+        let cmd_tx = get_runtime().block_on(ws.handler_command_sender());
+        let (order_event_tx, order_event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let order_request_state = Arc::new(OrderRequestState::new(
+            cmd_tx,
+            order_event_tx,
+            Arc::clone(&ws_dispatch_state),
+            ws.req_id_counter(),
+            Duration::from_secs(config.ws_request_timeout_secs),
+            core.trader_id,
+            core.account_id,
+            ws.auth_token_handle(),
+            cancellation_token.clone(),
+            clock,
+        ));
+
         Ok(Self {
             core,
             clock,
@@ -153,7 +189,9 @@ impl KrakenSpotExecutionClient {
             instruments: Arc::new(AtomicMap::new()),
             order_qty_cache: Arc::new(AtomicMap::new()),
             truncated_id_map: Arc::new(AtomicMap::new()),
-            ws_dispatch_state: Arc::new(WsDispatchState::new()),
+            ws_dispatch_state,
+            order_request_state,
+            order_event_rx: Mutex::new(Some(order_event_rx)),
         })
     }
 
@@ -209,6 +247,7 @@ impl KrakenSpotExecutionClient {
 
     fn submit_single_order(
         &self,
+        command: &SubmitOrder,
         order: &OrderAny,
         task_name: &'static str,
         leverage: Option<u16>,
@@ -224,7 +263,6 @@ impl KrakenSpotExecutionClient {
         let order_type = order.order_type();
         let time_in_force = order.time_in_force();
 
-        // FOK only supported for plain limit orders on Kraken Spot
         if time_in_force == TimeInForce::Fok && order_type != OrderType::Limit {
             self.emitter.emit_order_denied(
                 order,
@@ -233,7 +271,6 @@ impl KrakenSpotExecutionClient {
             return;
         }
 
-        // Kraken only supports price-based trailing offsets
         if matches!(
             order_type,
             OrderType::TrailingStopMarket | OrderType::TrailingStopLimit
@@ -255,12 +292,56 @@ impl KrakenSpotExecutionClient {
             return;
         }
 
+        let client_order_id = order.client_order_id();
+
+        log::debug!("OrderSubmitted: client_order_id={client_order_id}");
+        self.register_order_identity(order);
+        self.emitter.emit_order_submitted(order);
+
+        let kraken_cl_ord_id = truncate_cl_ord_id(&client_order_id);
+
+        if !order.is_quote_quantity() {
+            self.order_qty_cache
+                .insert(kraken_cl_ord_id.clone(), order.quantity().as_f64());
+        }
+
+        if kraken_cl_ord_id != client_order_id.as_str() {
+            self.truncated_id_map
+                .insert(kraken_cl_ord_id, client_order_id);
+        }
+
+        // Quote-quantity orders submit a quote-currency amount but the venue echoes
+        // fills in base units. The WS dispatch identity is intentionally not
+        // registered for these (see register_order_identity), so a WS round-trip
+        // would never emit OrderAccepted to the strategy. Plus order.quantity()
+        // for quote-qty is a quote amount that would be wrongly sent as `order_qty`
+        // (base units) on the WS path. Force REST.
+        if self.config.use_ws_trade && self.ws.is_active() && !order.is_quote_quantity() {
+            match Self::submit_via_ws(
+                &self.ws,
+                &self.order_request_state,
+                command,
+                order,
+                leverage,
+                self.clock,
+            ) {
+                Ok(()) => return,
+                Err(e) => log::warn!("Kraken WS submit_order fallback to REST: {e}"),
+            }
+        }
+
+        self.submit_via_rest(order, task_name, leverage);
+    }
+
+    fn submit_via_rest(&self, order: &OrderAny, task_name: &'static str, leverage: Option<u16>) {
         let account_id = self.core.account_id;
         let client_order_id = order.client_order_id();
         let strategy_id = order.strategy_id();
         let instrument_id = order.instrument_id();
         let order_side = order.order_side();
+        let order_type = order.order_type();
         let quantity = order.quantity();
+        let time_in_force = order.time_in_force();
         let expire_time = order.expire_time();
         let price = order.price();
         let trigger_price = order.trigger_price();
@@ -271,24 +352,6 @@ impl KrakenSpotExecutionClient {
         let is_post_only = order.is_post_only();
         let is_quote_quantity = order.is_quote_quantity();
         let display_qty = order.display_qty();
-
-        log::debug!("OrderSubmitted: client_order_id={client_order_id}");
-        self.register_order_identity(order);
-        self.emitter.emit_order_submitted(order);
-
-        let kraken_cl_ord_id = truncate_cl_ord_id(&client_order_id);
-
-        // Only cache base-denominated quantities; quote quantities
-        // are not valid for the WS order report fallback path
-        if !is_quote_quantity {
-            self.order_qty_cache
-                .insert(kraken_cl_ord_id.clone(), quantity.as_f64());
-        }
-
-        if kraken_cl_ord_id != client_order_id.as_str() {
-            self.truncated_id_map
-                .insert(kraken_cl_ord_id, client_order_id);
-        }
 
         let http = self.http.clone();
         let emitter = self.emitter.clone();
@@ -326,8 +389,6 @@ impl KrakenSpotExecutionClient {
                 let error_msg = format!("{task_name} error: {e}");
                 let due_post_only = error_msg.contains("POST_ONLY_REJECTED")
                     || error_msg.contains(KRAKEN_SPOT_POST_ONLY_ERROR);
-                // The order will never appear on the wire, so its dispatch
-                // identity has to be cleaned up here.
                 dispatch_state.cleanup_terminal(&client_order_id);
                 emitter.emit_order_rejected_event(
                     strategy_id,
@@ -344,7 +405,44 @@ impl KrakenSpotExecutionClient {
         });
     }
 
+    fn submit_via_ws(
+        ws: &KrakenSpotWebSocketClient,
+        order_request_state: &Arc<OrderRequestState>,
+        command: &SubmitOrder,
+        order: &OrderAny,
+        leverage: Option<u16>,
+        clock: &'static AtomicTime,
+    ) -> anyhow::Result<()> {
+        let token = ws
+            .auth_token_blocking()
+            .ok_or_else(|| anyhow::anyhow!("missing WS auth token"))?;
+
+        let params = build_add_order_params(command, order, token, leverage)?;
+        let identity = PendingRequest {
+            operation: PendingOperation::Submit,
+            client_order_ids: vec![command.client_order_id],
+            venue_order_ids: vec![None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        order_request_state.submit(params, identity, clock.get_time_ns().as_u64())?;
+        Ok(())
+    }
+
     fn cancel_single_order(&self, cmd: &CancelOrder) {
+        if self.config.use_ws_trade && self.ws.is_active() {
+            match Self::cancel_via_ws(&self.ws, &self.order_request_state, cmd, self.clock) {
+                Ok(()) => return,
+                Err(e) => log::warn!("Kraken WS cancel_order fallback to REST: {e}"),
+            }
+        }
+
+        self.cancel_via_rest(cmd);
+    }
+
+    fn cancel_via_rest(&self, cmd: &CancelOrder) {
         let account_id = self.core.account_id;
         let client_order_id = cmd.client_order_id;
         let venue_order_id = cmd.venue_order_id;
@@ -384,6 +482,30 @@ impl KrakenSpotExecutionClient {
         });
     }
 
+    fn cancel_via_ws(
+        ws: &KrakenSpotWebSocketClient,
+        order_request_state: &Arc<OrderRequestState>,
+        cmd: &CancelOrder,
+        clock: &'static AtomicTime,
+    ) -> anyhow::Result<()> {
+        let token = ws
+            .auth_token_blocking()
+            .ok_or_else(|| anyhow::anyhow!("missing WS auth token"))?;
+
+        let params = build_cancel_order_params(cmd, token);
+        let identity = PendingRequest {
+            operation: PendingOperation::Cancel,
+            client_order_ids: vec![cmd.client_order_id],
+            venue_order_ids: vec![cmd.venue_order_id],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        order_request_state.cancel(params, identity, clock.get_time_ns().as_u64())?;
+        Ok(())
+    }
+
     fn spawn_message_handler(&mut self) -> anyhow::Result<()> {
         let stream = self.ws.stream().map_err(|e| anyhow::anyhow!("{e}"))?;
         let emitter = self.emitter.clone();
@@ -391,6 +513,7 @@ impl KrakenSpotExecutionClient {
         let order_qty_cache = self.order_qty_cache.clone();
         let truncated_id_map = self.truncated_id_map.clone();
         let dispatch_state = self.ws_dispatch_state.clone();
+        let order_request_state = self.order_request_state.clone();
         let account_id = self.core.account_id;
         let clock = self.clock;
         let cancellation_token = self.cancellation_token.clone();
@@ -411,6 +534,7 @@ impl KrakenSpotExecutionClient {
                                     ws_msg,
                                     &emitter,
                                     &dispatch_state,
+                                    &order_request_state,
                                     &instruments,
                                     &order_qty_cache,
                                     &truncated_id_map,
@@ -429,10 +553,49 @@ impl KrakenSpotExecutionClient {
         });
 
         self.ws_stream_handle = Some(handle);
+
+        let event_rx = self.order_event_rx.lock().expect(MUTEX_POISONED).take();
+
+        if let Some(mut event_rx) = event_rx {
+            let emitter = self.emitter.clone();
+            let cancellation_token = self.cancellation_token.clone();
+
+            get_runtime().spawn(async move {
+                loop {
+                    tokio::select! {
+                        () = cancellation_token.cancelled() => {
+                            log::debug!("Spot execution order-event forwarder cancelled");
+                            break;
+                        }
+                        event = event_rx.recv() => {
+                            match event {
+                                Some(event) => emitter.send_order_event(event),
+                                None => {
+                                    log::debug!("Spot execution order-event channel closed");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
         Ok(())
     }
 
     fn modify_single_order(&self, cmd: &ModifyOrder) {
+        if self.config.use_ws_trade && self.ws.is_active() {
+            match Self::amend_via_ws(&self.ws, &self.order_request_state, cmd, self.clock) {
+                Ok(()) => return,
+                Err(e) => log::warn!("Kraken WS amend_order fallback to REST: {e}"),
+            }
+        }
+
+        self.amend_via_rest(cmd);
+    }
+
+    fn amend_via_rest(&self, cmd: &ModifyOrder) {
         let client_order_id = cmd.client_order_id;
         let venue_order_id = cmd.venue_order_id;
         let strategy_id = cmd.strategy_id;
@@ -475,6 +638,30 @@ impl KrakenSpotExecutionClient {
         });
     }
 
+    fn amend_via_ws(
+        ws: &KrakenSpotWebSocketClient,
+        order_request_state: &Arc<OrderRequestState>,
+        cmd: &ModifyOrder,
+        clock: &'static AtomicTime,
+    ) -> anyhow::Result<()> {
+        let token = ws
+            .auth_token_blocking()
+            .ok_or_else(|| anyhow::anyhow!("missing WS auth token"))?;
+
+        let params = build_amend_order_params(cmd, token);
+        let identity = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![cmd.client_order_id],
+            venue_order_ids: vec![cmd.venue_order_id],
+            ts_sent_ns: 0,
+            new_quantity: cmd.quantity,
+            new_price: cmd.price,
+            new_trigger_price: cmd.trigger_price,
+        };
+        order_request_state.amend(params, identity, clock.get_time_ns().as_u64())?;
+        Ok(())
+    }
+
     /// Polls the cache until the account is registered or timeout is reached.
     async fn await_account_registered(&self, timeout_secs: f64) -> anyhow::Result<()> {
         let account_id = self.core.account_id;
@@ -509,6 +696,7 @@ impl KrakenSpotExecutionClient {
         msg: KrakenSpotWsMessage,
         emitter: &ExecutionEventEmitter,
         dispatch_state: &Arc<WsDispatchState>,
+        order_request_state: &Arc<OrderRequestState>,
         instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
         order_qty_cache: &Arc<AtomicMap<String, f64>>,
         truncated_id_map: &Arc<AtomicMap<String, ClientOrderId>>,
@@ -531,6 +719,10 @@ impl KrakenSpotExecutionClient {
                         ts_init,
                     );
                 }
+            }
+            KrakenSpotWsMessage::OrderResponse(response) => {
+                let ts_event = clock.get_time_ns().as_u64();
+                order_request_state.handle_response(&response, ts_event);
             }
             KrakenSpotWsMessage::Reconnected => {
                 log::info!("Spot execution WebSocket reconnected");
@@ -585,6 +777,211 @@ impl KrakenSpotExecutionClient {
             ));
         }
     }
+
+    fn batch_add_via_rest(
+        &self,
+        order_tuples: Vec<BatchOrderTuple>,
+        order_meta: Vec<(StrategyId, InstrumentId, ClientOrderId)>,
+    ) {
+        let http = self.http.clone();
+        let emitter = self.emitter.clone();
+        let clock = self.clock;
+        let dispatch_state = self.ws_dispatch_state.clone();
+        let spot_account_type = self.config.spot_account_type;
+
+        self.spawn_task("submit_order_list", async move {
+            match http
+                .submit_orders_batch(order_tuples, spot_account_type)
+                .await
+            {
+                Ok(statuses) => {
+                    for (i, status) in statuses.iter().enumerate() {
+                        if status != "placed"
+                            && let Some((strategy_id, instrument_id, client_order_id)) =
+                                order_meta.get(i)
+                        {
+                            let ts_event = clock.get_time_ns();
+                            let due_post_only = status.contains("POST_ONLY_REJECTED")
+                                || status.contains(KRAKEN_SPOT_POST_ONLY_ERROR);
+                            dispatch_state.cleanup_terminal(client_order_id);
+                            emitter.emit_order_rejected_event(
+                                *strategy_id,
+                                *instrument_id,
+                                *client_order_id,
+                                &format!("submit_order_list batch item rejected: {status}"),
+                                ts_event,
+                                due_post_only,
+                            );
+                        }
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    let ts_event = clock.get_time_ns();
+                    let error_msg = format!("submit_order_list batch error: {e}");
+
+                    for (strategy_id, instrument_id, client_order_id) in &order_meta {
+                        dispatch_state.cleanup_terminal(client_order_id);
+                        emitter.emit_order_rejected_event(
+                            *strategy_id,
+                            *instrument_id,
+                            *client_order_id,
+                            &error_msg,
+                            ts_event,
+                            false,
+                        );
+                    }
+                    Ok(())
+                }
+            }
+        });
+    }
+
+    fn batch_add_via_ws(
+        ws: &KrakenSpotWebSocketClient,
+        order_request_state: &Arc<OrderRequestState>,
+        orders: &[OrderAny],
+        leverage: Option<u16>,
+        clock: &'static AtomicTime,
+    ) -> anyhow::Result<()> {
+        let token = ws
+            .auth_token_blocking()
+            .ok_or_else(|| anyhow::anyhow!("missing WS auth token"))?;
+
+        let first = orders
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("batch_add requires at least one order"))?;
+        let symbol = first.instrument_id().symbol.inner().to_string();
+
+        let mut batch_orders = Vec::with_capacity(orders.len());
+        let mut client_order_ids = Vec::with_capacity(orders.len());
+        for order in orders {
+            batch_orders.push(build_batch_order(order, leverage)?);
+            client_order_ids.push(order.client_order_id());
+        }
+        let venue_order_ids = vec![None; orders.len()];
+
+        let params = KrakenWsBatchAddParams {
+            symbol,
+            orders: batch_orders,
+            token,
+        };
+        let identity = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids,
+            venue_order_ids,
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        order_request_state.batch_add(params, identity, clock.get_time_ns().as_u64())?;
+        Ok(())
+    }
+}
+
+type BatchOrderTuple = (
+    InstrumentId,
+    ClientOrderId,
+    OrderSide,
+    OrderType,
+    Quantity,
+    TimeInForce,
+    Option<UnixNanos>,
+    Option<Price>,
+    Option<Price>,
+    Option<TriggerType>,
+    Option<Decimal>,
+    Option<Decimal>,
+    bool,
+    bool,
+    bool,
+    Option<Quantity>,
+    Option<u16>,
+);
+
+fn build_batch_order(
+    order: &OrderAny,
+    leverage: Option<u16>,
+) -> anyhow::Result<KrakenWsBatchAddOrder> {
+    let order_type = order.order_type();
+    let side = match order.order_side() {
+        OrderSide::Buy => KrakenOrderSide::Buy,
+        OrderSide::Sell => KrakenOrderSide::Sell,
+        side => anyhow::bail!("Invalid order side: {side:?}"),
+    };
+    let kraken_order_type = match order_type {
+        OrderType::Market => KrakenOrderType::Market,
+        OrderType::Limit => KrakenOrderType::Limit,
+        OrderType::StopMarket => KrakenOrderType::StopLoss,
+        OrderType::StopLimit => KrakenOrderType::StopLossLimit,
+        OrderType::MarketIfTouched => KrakenOrderType::TakeProfit,
+        OrderType::LimitIfTouched => KrakenOrderType::TakeProfitLimit,
+        OrderType::TrailingStopMarket => KrakenOrderType::TrailingStop,
+        OrderType::TrailingStopLimit => KrakenOrderType::TrailingStopLimit,
+        ty => anyhow::bail!("Unsupported order type for Kraken WS batch: {ty:?}"),
+    };
+
+    let is_limit_order = matches!(
+        order_type,
+        OrderType::Limit
+            | OrderType::StopLimit
+            | OrderType::LimitIfTouched
+            | OrderType::TrailingStopLimit
+    );
+
+    if is_limit_order && order.price().is_none() {
+        anyhow::bail!("limit_price is required for batch order type {order_type:?}");
+    }
+
+    let ws_tif =
+        compute_ws_time_in_force(is_limit_order, order.time_in_force(), order.expire_time())?;
+    let expire_time = match (ws_tif, order.expire_time()) {
+        (Some(KrakenTimeInForce::GoodTilDate), Some(ts)) => Some(format_expire_time(ts)),
+        _ => None,
+    };
+
+    let is_conditional = matches!(
+        order_type,
+        OrderType::StopMarket
+            | OrderType::StopLimit
+            | OrderType::MarketIfTouched
+            | OrderType::LimitIfTouched
+    );
+
+    let trigger = if is_conditional {
+        let trigger_ref = match order.trigger_type() {
+            Some(TriggerType::IndexPrice) => KrakenSpotTrigger::Index,
+            _ => KrakenSpotTrigger::Last,
+        };
+        order.trigger_price().map(|tp| KrakenWsTriggerParams {
+            reference: trigger_ref,
+            price: tp.as_f64(),
+            price_type: None,
+        })
+    } else {
+        None
+    };
+
+    if is_conditional && trigger.is_none() {
+        anyhow::bail!(
+            "Conditional order type {order_type:?} requires trigger_price for Kraken WS batch",
+        );
+    }
+
+    Ok(KrakenWsBatchAddOrder {
+        order_type: kraken_order_type,
+        side,
+        order_qty: order.quantity().as_f64(),
+        limit_price: order.price().map(|p| p.as_f64()),
+        cl_ord_id: Some(truncate_cl_ord_id(&order.client_order_id())),
+        time_in_force: ws_tif,
+        expire_time,
+        post_only: order.is_post_only().then_some(true),
+        reduce_only: order.is_reduce_only().then_some(true),
+        leverage,
+        trigger,
+    })
 }
 
 #[async_trait(?Send)]
@@ -956,7 +1353,7 @@ impl ExecutionClient for KrakenSpotExecutionClient {
                 return Ok(());
             }
         };
-        self.submit_single_order(&order, "submit_order", leverage);
+        self.submit_single_order(&cmd, &order, "submit_order", leverage);
         Ok(())
     }
 
@@ -969,8 +1366,19 @@ impl ExecutionClient for KrakenSpotExecutionClient {
             orders.len()
         );
 
+        let leverage = match resolve_leverage(cmd.params.as_ref(), self.config.default_leverage) {
+            Ok(lev) => lev,
+            Err(reason) => {
+                for order in &orders {
+                    self.emitter.emit_order_denied(order, &reason);
+                }
+                return Ok(());
+            }
+        };
+
         let mut order_tuples = Vec::with_capacity(orders.len());
         let mut order_meta = Vec::with_capacity(orders.len());
+        let mut prepared_orders = Vec::with_capacity(orders.len());
 
         for order in &orders {
             if order.is_closed() {
@@ -1010,15 +1418,6 @@ impl ExecutionClient for KrakenSpotExecutionClient {
                 continue;
             }
 
-            let leverage = match resolve_leverage(cmd.params.as_ref(), self.config.default_leverage)
-            {
-                Ok(lev) => lev,
-                Err(reason) => {
-                    self.emitter.emit_order_denied(order, &reason);
-                    continue;
-                }
-            };
-
             let client_order_id = order.client_order_id();
             let kraken_cl_ord_id = truncate_cl_ord_id(&client_order_id);
 
@@ -1055,65 +1454,44 @@ impl ExecutionClient for KrakenSpotExecutionClient {
             ));
 
             order_meta.push((order.strategy_id(), order.instrument_id(), client_order_id));
+            prepared_orders.push(order.clone());
         }
 
         if order_tuples.is_empty() {
             return Ok(());
         }
 
-        let http = self.http.clone();
-        let emitter = self.emitter.clone();
-        let clock = self.clock;
-        let dispatch_state = self.ws_dispatch_state.clone();
-        let spot_account_type = self.config.spot_account_type;
+        if self.config.use_ws_trade && self.ws.is_active() {
+            let any_quote_qty = prepared_orders.iter().any(|o| o.is_quote_quantity());
+            let symbols_match = prepared_orders
+                .windows(2)
+                .all(|w| w[0].instrument_id() == w[1].instrument_id());
 
-        self.spawn_task("submit_order_list", async move {
-            match http
-                .submit_orders_batch(order_tuples, spot_account_type)
-                .await
-            {
-                Ok(statuses) => {
-                    // The HTTP helper returns one status per input tuple, including validation failures
-                    for (i, status) in statuses.iter().enumerate() {
-                        if status != "placed"
-                            && let Some((strategy_id, instrument_id, client_order_id)) =
-                                order_meta.get(i)
-                        {
-                            let ts_event = clock.get_time_ns();
-                            let due_post_only = status.contains("POST_ONLY_REJECTED")
-                                || status.contains(KRAKEN_SPOT_POST_ONLY_ERROR);
-                            dispatch_state.cleanup_terminal(client_order_id);
-                            emitter.emit_order_rejected_event(
-                                *strategy_id,
-                                *instrument_id,
-                                *client_order_id,
-                                &format!("submit_order_list batch item rejected: {status}"),
-                                ts_event,
-                                due_post_only,
-                            );
-                        }
-                    }
-                    Ok(())
+            if any_quote_qty {
+                log::warn!(
+                    "Kraken WS batch_add does not support quote-quantity orders, falling back to REST for order_list_id={}",
+                    cmd.order_list.id,
+                );
+            } else if symbols_match {
+                match Self::batch_add_via_ws(
+                    &self.ws,
+                    &self.order_request_state,
+                    &prepared_orders,
+                    leverage,
+                    self.clock,
+                ) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => log::warn!("Kraken WS batch_add fallback to REST: {e}"),
                 }
-                Err(e) => {
-                    let ts_event = clock.get_time_ns();
-                    let error_msg = format!("submit_order_list batch error: {e}");
-
-                    for (strategy_id, instrument_id, client_order_id) in &order_meta {
-                        dispatch_state.cleanup_terminal(client_order_id);
-                        emitter.emit_order_rejected_event(
-                            *strategy_id,
-                            *instrument_id,
-                            *client_order_id,
-                            &error_msg,
-                            ts_event,
-                            false,
-                        );
-                    }
-                    Ok(())
-                }
+            } else {
+                log::warn!(
+                    "Kraken WS batch_add requires single shared symbol, falling back to REST for order_list_id={}",
+                    cmd.order_list.id,
+                );
             }
-        });
+        }
+
+        self.batch_add_via_rest(order_tuples, order_meta);
 
         Ok(())
     }
@@ -1237,11 +1615,18 @@ fn resolve_leverage(params: Option<&Params>, default: Option<u16>) -> Result<Opt
 
 #[cfg(test)]
 mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use nautilus_common::{cache::Cache, clock::TestClock, factories::ExecutionClientFactory};
     use nautilus_core::Params;
     use rstest::rstest;
     use serde_json::json;
 
     use super::resolve_leverage;
+    use crate::{
+        common::enums::KrakenProductType, config::KrakenExecClientConfig,
+        factories::KrakenExecutionClientFactory,
+    };
 
     fn params_with(key: &str, val: serde_json::Value) -> Params {
         let mut map = indexmap::IndexMap::new();
@@ -1275,5 +1660,21 @@ mod tests {
         let p = params_with("leverage", json!(65539u64));
         let err = resolve_leverage(Some(&p), None).unwrap_err();
         assert!(err.contains("exceeds maximum"), "unexpected: {err}");
+    }
+
+    #[rstest]
+    fn test_execution_client_constructs_with_ws_trade_enabled() {
+        let factory = KrakenExecutionClientFactory::new();
+        let config = KrakenExecClientConfig {
+            product_type: KrakenProductType::Spot,
+            use_ws_trade: true,
+            ws_request_timeout_secs: 7,
+            ..Default::default()
+        };
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let _clock = Rc::new(RefCell::new(TestClock::new()));
+
+        let result = factory.create("KRAKEN-WS", &config, cache.into());
+        assert!(result.is_ok(), "construction failed: {:?}", result.err());
     }
 }

--- a/crates/adapters/kraken/src/python/config.rs
+++ b/crates/adapters/kraken/src/python/config.rs
@@ -105,6 +105,8 @@ impl KrakenExecClientConfig {
         use_spot_position_reports = None,
         spot_positions_quote_currency = None,
         margin_balance_asset = None,
+        use_ws_trade = None,
+        ws_request_timeout_secs = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -125,6 +127,8 @@ impl KrakenExecClientConfig {
         use_spot_position_reports: Option<bool>,
         spot_positions_quote_currency: Option<String>,
         margin_balance_asset: Option<String>,
+        use_ws_trade: Option<bool>,
+        ws_request_timeout_secs: Option<u64>,
     ) -> PyResult<Self> {
         let defaults = Self::default();
         let spot_account_type = spot_account_type.unwrap_or(defaults.spot_account_type);
@@ -155,6 +159,9 @@ impl KrakenExecClientConfig {
             spot_positions_quote_currency: spot_positions_quote_currency
                 .unwrap_or(defaults.spot_positions_quote_currency),
             margin_balance_asset,
+            use_ws_trade: use_ws_trade.unwrap_or(defaults.use_ws_trade),
+            ws_request_timeout_secs: ws_request_timeout_secs
+                .unwrap_or(defaults.ws_request_timeout_secs),
         })
     }
 

--- a/crates/adapters/kraken/src/python/websocket_spot.rs
+++ b/crates/adapters/kraken/src/python/websocket_spot.rs
@@ -433,6 +433,7 @@ impl KrakenSpotWebSocketClient {
                         KrakenSpotWsMessage::Reconnected => {
                             log::info!("WebSocket reconnected");
                         }
+                        KrakenSpotWsMessage::OrderResponse(_) => {}
                     }
                 }
             });

--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -34,6 +34,7 @@
 
 pub mod futures;
 pub mod spot;
+pub mod spot_orders;
 
 use std::sync::{
     Arc, Mutex,
@@ -191,10 +192,16 @@ impl WsDispatchState {
             .map(|r| r.clone())
     }
 
-    /// Marks an `OrderAccepted` event as emitted for this order.
-    pub fn insert_accepted(&self, cid: ClientOrderId) {
+    /// Atomically marks an `OrderAccepted` event as emitted for this order.
+    ///
+    /// Returns `true` when the entry was newly inserted (caller should emit the
+    /// event), and `false` when an entry was already present (caller should
+    /// skip emission). Replaces the racier "contains-then-insert" pattern,
+    /// which allowed concurrent emitters to both observe `false` from
+    /// `contains` and then both insert + emit duplicate `OrderAccepted` events.
+    pub fn insert_accepted(&self, cid: ClientOrderId) -> bool {
         self.evict_if_full(&self.emitted_accepted);
-        self.emitted_accepted.insert(cid);
+        self.emitted_accepted.insert(cid)
     }
 
     /// Marks an order as having reached the filled terminal state.
@@ -320,10 +327,9 @@ pub(crate) fn ensure_accepted_emitted(
     ts_event: UnixNanos,
     ts_init: UnixNanos,
 ) {
-    if state.emitted_accepted.contains(&client_order_id) {
+    if !state.insert_accepted(client_order_id) {
         return;
     }
-    state.insert_accepted(client_order_id);
     let accepted = OrderAccepted::new(
         emitter.trader_id(),
         identity.strategy_id,
@@ -430,6 +436,21 @@ mod tests {
         // Second insert is a no-op.
         state.insert_accepted(cid);
         assert!(state.emitted_accepted.contains(&cid));
+    }
+
+    #[rstest]
+    fn test_insert_accepted_returns_true_on_first_insert_false_on_repeat() {
+        let state = WsDispatchState::new();
+        let cid = ClientOrderId::new("uuid-atomic");
+
+        assert!(
+            state.insert_accepted(cid),
+            "first insert must report newly inserted",
+        );
+        assert!(
+            !state.insert_accepted(cid),
+            "second insert must report already present (atomic dedup)",
+        );
     }
 
     #[rstest]

--- a/crates/adapters/kraken/src/websocket/dispatch/spot.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot.rs
@@ -211,12 +211,11 @@ fn status_tracked(
 
     match report.order_status {
         OrderStatus::Accepted => {
-            if state.emitted_accepted.contains(&client_order_id) {
+            if !state.insert_accepted(client_order_id) {
                 // Already accepted; this is a redundant New / Restated / Status
                 // exec. The strategy already saw OrderAccepted; nothing to emit.
                 return;
             }
-            state.insert_accepted(client_order_id);
             let accepted = OrderAccepted::new(
                 trader_id,
                 identity.strategy_id,

--- a/crates/adapters/kraken/src/websocket/dispatch/spot_orders.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot_orders.rs
@@ -1,0 +1,1901 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! WebSocket order-request dispatch state for Kraken Spot v2.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use ahash::AHashMap;
+use dashmap::DashMap;
+use nautilus_common::live::get_runtime;
+use nautilus_core::{UUID4, time::AtomicTime};
+use nautilus_model::{
+    events::{
+        OrderAccepted, OrderCancelRejected, OrderEventAny, OrderModifyRejected, OrderRejected,
+        OrderUpdated,
+    },
+    identifiers::{AccountId, ClientOrderId, TraderId, VenueOrderId},
+    types::{Price, Quantity},
+};
+use tokio_util::sync::CancellationToken;
+use ustr::Ustr;
+
+use super::WsDispatchState;
+use crate::{
+    common::parse::truncate_cl_ord_id,
+    websocket::spot_v2::{
+        enums::KrakenWsMethod,
+        handler::SpotHandlerCommand,
+        messages::{
+            KrakenWsAddOrderParams, KrakenWsAmendOrderParams, KrakenWsBatchAddParams,
+            KrakenWsCancelOrderParams, KrakenWsOrderResponse, KrakenWsOrderResult, KrakenWsParams,
+            KrakenWsRequest,
+        },
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingOperation {
+    /// Pending add_order request.
+    Submit,
+    /// Pending amend_order request.
+    Amend,
+    /// Pending cancel_order request.
+    Cancel,
+    /// Pending batch_add request.
+    BatchAdd,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingRequest {
+    /// The pending operation type.
+    pub operation: PendingOperation,
+    /// Client order IDs associated with this request.
+    pub client_order_ids: Vec<ClientOrderId>,
+    /// Venue order IDs associated with this request, if known.
+    pub venue_order_ids: Vec<Option<VenueOrderId>>,
+    /// UNIX nanosecond timestamp when the request was sent.
+    pub ts_sent_ns: u64,
+    /// New quantity carried for amend operations so the success-path
+    /// `OrderUpdated` event reflects the requested change rather than the
+    /// originally registered quantity. `None` for non-amend operations or
+    /// amends that do not modify quantity.
+    pub new_quantity: Option<Quantity>,
+    /// New limit price carried for amend operations so the success-path
+    /// `OrderUpdated` event surfaces the amended price to strategies.
+    /// `None` for non-amend operations or amends that do not modify price.
+    pub new_price: Option<Price>,
+    /// New trigger price carried for amend operations on conditional orders.
+    /// `None` for non-amend operations or amends that do not modify the
+    /// trigger price.
+    pub new_trigger_price: Option<Price>,
+}
+
+#[derive(Debug)]
+pub struct OrderRequestState {
+    req_id_counter: Arc<AtomicU64>,
+    pending: DashMap<u64, PendingRequest>,
+    timeout: Duration,
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<SpotHandlerCommand>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<OrderEventAny>,
+    dispatch_state: Arc<WsDispatchState>,
+    trader_id: TraderId,
+    account_id: AccountId,
+    /// WS auth token shared with the client; used to build compensating
+    /// cancels when a submit request times out.
+    auth_token: Arc<tokio::sync::RwLock<Option<String>>>,
+    /// Cancellation signal that aborts pending timeout tasks on shutdown so
+    /// the runtime can drop without waiting for in-flight timers.
+    cancellation_token: CancellationToken,
+    /// Clock used to stamp `ts_event` on synthesized timeout-rejection events.
+    /// Sharing the caller's clock keeps test ts_event values consistent with
+    /// the ts_sent_ns the same caller stamped at submit time.
+    clock: &'static AtomicTime,
+}
+
+impl OrderRequestState {
+    /// Creates a new [`OrderRequestState`].
+    #[expect(clippy::too_many_arguments, reason = "all fields are independent")]
+    pub fn new(
+        cmd_tx: tokio::sync::mpsc::UnboundedSender<SpotHandlerCommand>,
+        event_tx: tokio::sync::mpsc::UnboundedSender<OrderEventAny>,
+        dispatch_state: Arc<WsDispatchState>,
+        req_id_counter: Arc<AtomicU64>,
+        timeout: Duration,
+        trader_id: TraderId,
+        account_id: AccountId,
+        auth_token: Arc<tokio::sync::RwLock<Option<String>>>,
+        cancellation_token: CancellationToken,
+        clock: &'static AtomicTime,
+    ) -> Self {
+        Self {
+            req_id_counter,
+            pending: DashMap::new(),
+            timeout,
+            cmd_tx,
+            event_tx,
+            dispatch_state,
+            trader_id,
+            account_id,
+            auth_token,
+            cancellation_token,
+            clock,
+        }
+    }
+
+    /// Returns the next request ID and advances the counter.
+    pub fn next_req_id(&self) -> u64 {
+        self.req_id_counter.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Sends an add_order request over the WebSocket transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON envelope fails to serialise or if the
+    /// handler command channel is closed.
+    pub fn submit(
+        self: &Arc<Self>,
+        params: KrakenWsAddOrderParams,
+        identity: PendingRequest,
+        ts_now_ns: u64,
+    ) -> anyhow::Result<u64> {
+        self.send(
+            KrakenWsRequest {
+                method: KrakenWsMethod::AddOrder,
+                params: Some(KrakenWsParams::AddOrder(params)),
+                req_id: None,
+            },
+            identity,
+            ts_now_ns,
+        )
+    }
+
+    /// Sends an amend_order request over the WebSocket transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialisation fails or the handler command channel is closed.
+    pub fn amend(
+        self: &Arc<Self>,
+        params: KrakenWsAmendOrderParams,
+        identity: PendingRequest,
+        ts_now_ns: u64,
+    ) -> anyhow::Result<u64> {
+        self.send(
+            KrakenWsRequest {
+                method: KrakenWsMethod::AmendOrder,
+                params: Some(KrakenWsParams::AmendOrder(params)),
+                req_id: None,
+            },
+            identity,
+            ts_now_ns,
+        )
+    }
+
+    /// Sends a cancel_order request over the WebSocket transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialisation fails or the handler command channel is closed.
+    pub fn cancel(
+        self: &Arc<Self>,
+        params: KrakenWsCancelOrderParams,
+        identity: PendingRequest,
+        ts_now_ns: u64,
+    ) -> anyhow::Result<u64> {
+        self.send(
+            KrakenWsRequest {
+                method: KrakenWsMethod::CancelOrder,
+                params: Some(KrakenWsParams::CancelOrder(params)),
+                req_id: None,
+            },
+            identity,
+            ts_now_ns,
+        )
+    }
+
+    /// Sends a batch_add request over the WebSocket transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialisation fails or the handler command channel is closed.
+    pub fn batch_add(
+        self: &Arc<Self>,
+        params: KrakenWsBatchAddParams,
+        identity: PendingRequest,
+        ts_now_ns: u64,
+    ) -> anyhow::Result<u64> {
+        self.send(
+            KrakenWsRequest {
+                method: KrakenWsMethod::BatchAdd,
+                params: Some(KrakenWsParams::BatchAdd(params)),
+                req_id: None,
+            },
+            identity,
+            ts_now_ns,
+        )
+    }
+
+    fn send(
+        self: &Arc<Self>,
+        mut envelope: KrakenWsRequest,
+        mut identity: PendingRequest,
+        ts_now_ns: u64,
+    ) -> anyhow::Result<u64> {
+        let req_id = self.next_req_id();
+        envelope.req_id = Some(req_id);
+        identity.ts_sent_ns = ts_now_ns;
+
+        let payload = serde_json::to_string(&envelope)
+            .map_err(|e| anyhow::anyhow!("serialize WS order request: {e}"))?;
+
+        self.pending.insert(req_id, identity);
+
+        if let Err(e) = self
+            .cmd_tx
+            .send(SpotHandlerCommand::SendOrderRequest { req_id, payload })
+        {
+            self.pending.remove(&req_id);
+            anyhow::bail!("handler command channel closed: {e}");
+        }
+
+        let state_for_timeout = Arc::clone(self);
+        let cancel = state_for_timeout.cancellation_token.clone();
+
+        get_runtime().spawn(async move {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    state_for_timeout.pending.remove(&req_id);
+                }
+                () = tokio::time::sleep(state_for_timeout.timeout) => {
+                    if let Some((_, pending)) = state_for_timeout.pending.remove(&req_id) {
+                        log::warn!(
+                            "Kraken WS response timeout req_id={req_id} op={:?} cl_ord_ids={:?}",
+                            pending.operation,
+                            pending.client_order_ids,
+                        );
+                        let ts_event_ns = state_for_timeout.clock.get_time_ns().as_u64();
+                        state_for_timeout.emit_timeout_rejection(req_id, &pending, ts_event_ns);
+                    }
+                }
+            }
+        });
+
+        Ok(req_id)
+    }
+
+    /// Routes an order-method WebSocket response to the correct event emitter.
+    ///
+    /// Removes the matching pending entry and dispatches based on the operation
+    /// kind, success flag, and response method. Late responses (after timeout
+    /// eviction) are logged and dropped.
+    pub fn handle_response(&self, response: &KrakenWsOrderResponse, ts_event_ns: u64) {
+        let req_id = match response.req_id {
+            Some(id) => id,
+            None => {
+                log::warn!(
+                    "Kraken WS order response without req_id method={:?} success={}",
+                    response.method,
+                    response.success,
+                );
+                return;
+            }
+        };
+
+        let Some((_, pending)) = self.pending.remove(&req_id) else {
+            log::debug!("Kraken WS response after eviction (timeout) req_id={req_id}");
+            return;
+        };
+
+        match (pending.operation, response.success, response.method) {
+            (PendingOperation::Submit, true, KrakenWsMethod::AddOrder) => {
+                self.emit_order_accepted(&pending, response, ts_event_ns);
+            }
+            (PendingOperation::Submit, false, KrakenWsMethod::AddOrder) => {
+                self.emit_order_rejected(&pending, response, ts_event_ns);
+            }
+            (PendingOperation::Amend, true, KrakenWsMethod::AmendOrder) => {
+                self.emit_order_updated(&pending, response, ts_event_ns);
+            }
+            (PendingOperation::Amend, false, KrakenWsMethod::AmendOrder) => {
+                self.emit_order_modify_rejected(&pending, response, ts_event_ns);
+            }
+            (PendingOperation::Cancel, true, KrakenWsMethod::CancelOrder) => {
+                log::debug!(
+                    "Kraken WS cancel ack req_id={req_id} cl_ord_ids={:?}",
+                    pending.client_order_ids,
+                );
+            }
+            (PendingOperation::Cancel, false, KrakenWsMethod::CancelOrder) => {
+                self.emit_order_cancel_rejected(&pending, response, ts_event_ns);
+            }
+            (PendingOperation::BatchAdd, _, KrakenWsMethod::BatchAdd) => {
+                self.handle_batch_add_response(&pending, response, ts_event_ns);
+            }
+            (op, ok, method) => {
+                log::error!(
+                    "Kraken WS response method {method:?} mismatched pending op {op:?} success={ok} req_id={req_id}",
+                );
+            }
+        }
+    }
+
+    fn emit_timeout_rejection(&self, req_id: u64, pending: &PendingRequest, ts_event_ns: u64) {
+        let response = KrakenWsOrderResponse {
+            method: pending_op_to_method(pending.operation),
+            req_id: Some(req_id),
+            success: false,
+            time_in: None,
+            time_out: None,
+            error: Some(format!("Kraken WS request timed out req_id={req_id}")),
+            result: None,
+        };
+
+        match pending.operation {
+            PendingOperation::Submit => {
+                self.emit_order_rejected(pending, &response, ts_event_ns);
+                self.send_compensating_cancel(&pending.client_order_ids);
+            }
+            PendingOperation::Amend => {
+                self.emit_order_modify_rejected(pending, &response, ts_event_ns);
+            }
+            PendingOperation::Cancel => {
+                self.emit_order_cancel_rejected(pending, &response, ts_event_ns);
+            }
+            PendingOperation::BatchAdd => {
+                for cl_ord_id in &pending.client_order_ids {
+                    let leg = PendingRequest {
+                        operation: PendingOperation::Submit,
+                        client_order_ids: vec![*cl_ord_id],
+                        venue_order_ids: vec![None],
+                        ts_sent_ns: pending.ts_sent_ns,
+                        new_quantity: None,
+                        new_price: None,
+                        new_trigger_price: None,
+                    };
+                    self.emit_order_rejected(&leg, &response, ts_event_ns);
+                }
+                self.send_compensating_cancel(&pending.client_order_ids);
+            }
+        }
+    }
+
+    /// Sends a best-effort `cancel_order` over the WebSocket after a Submit or
+    /// BatchAdd request has timed out, defending against the case where the
+    /// venue accepted the order but the response was delayed past the
+    /// configured timeout window.
+    ///
+    /// Fire-and-forget: the response is silently dropped because no `pending`
+    /// entry is registered for the cancel `req_id`. If the auth token is not
+    /// available or the command channel is closed the cancel is skipped and
+    /// the engine relies on reconciliation to detect any orphan order.
+    ///
+    /// # Known race
+    ///
+    /// When the timeout fires the dispatch has already emitted an
+    /// `OrderRejected` event, which moves the local cache to `Rejected`. If
+    /// the venue actually accepted the order AND the executions stream
+    /// delivers a fill before the compensating cancel lands at Kraken, the
+    /// fill cannot be applied to a `Rejected` order in the strategy state
+    /// machine. The live execution reconciliation engine
+    /// (`open_check_interval_secs`) is the recovery path: the next reconcile
+    /// poll observes the divergent venue state and emits the missing events.
+    /// Operators who cannot tolerate that recovery latency should set a
+    /// `ws_request_timeout_secs` comfortably above their observed Kraken
+    /// round-trip latency (default `5` is roughly 25× typical) so the timeout
+    /// only fires under genuine network failure.
+    fn send_compensating_cancel(&self, cl_ord_ids: &[ClientOrderId]) {
+        let Some(token) = self.auth_token.try_read().ok().and_then(|g| g.clone()) else {
+            log::warn!(
+                "Submit timeout: no auth token for compensating cancel cl_ord_ids={cl_ord_ids:?}",
+            );
+            return;
+        };
+
+        let req_id = self.next_req_id();
+        let params = KrakenWsCancelOrderParams {
+            token,
+            order_id: None,
+            cl_ord_id: Some(cl_ord_ids.iter().map(truncate_cl_ord_id).collect()),
+        };
+        let envelope = KrakenWsRequest {
+            method: KrakenWsMethod::CancelOrder,
+            params: Some(KrakenWsParams::CancelOrder(params)),
+            req_id: Some(req_id),
+        };
+
+        let payload = match serde_json::to_string(&envelope) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("Submit timeout: compensating cancel serialise failed: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = self
+            .cmd_tx
+            .send(SpotHandlerCommand::SendOrderRequest { req_id, payload })
+        {
+            log::warn!("Submit timeout: compensating cancel channel closed: {e}");
+        } else {
+            log::info!(
+                "Submit timeout: compensating cancel sent req_id={req_id} cl_ord_ids={cl_ord_ids:?}",
+            );
+        }
+    }
+
+    fn emit_order_accepted(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let Some(client_order_id) = pending.client_order_ids.first().copied() else {
+            log::error!("Kraken WS add_order response without client_order_id");
+            return;
+        };
+        let Some(identity) = self.dispatch_state.lookup_identity(&client_order_id) else {
+            log::warn!(
+                "Kraken WS add_order response for untracked order client_order_id={client_order_id}",
+            );
+            return;
+        };
+        let venue_order_id = response
+            .result
+            .as_ref()
+            .and_then(|r| r.order_id.as_deref())
+            .map(VenueOrderId::new);
+        let Some(venue_order_id) = venue_order_id else {
+            log::error!(
+                "Kraken WS add_order success without order_id client_order_id={client_order_id}",
+            );
+            return;
+        };
+
+        if !self.dispatch_state.insert_accepted(client_order_id) {
+            return;
+        }
+
+        let event = OrderAccepted::new(
+            self.trader_id,
+            identity.strategy_id,
+            identity.instrument_id,
+            client_order_id,
+            venue_order_id,
+            self.account_id,
+            UUID4::new(),
+            ts_event_ns.into(),
+            ts_event_ns.into(),
+            false,
+        );
+        self.send_event(OrderEventAny::Accepted(event));
+    }
+
+    fn emit_order_rejected(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let Some(client_order_id) = pending.client_order_ids.first().copied() else {
+            log::error!("Kraken WS add_order rejection without client_order_id");
+            return;
+        };
+        let Some(identity) = self.dispatch_state.lookup_identity(&client_order_id) else {
+            log::warn!(
+                "Kraken WS add_order rejection for untracked order client_order_id={client_order_id}",
+            );
+            return;
+        };
+        let reason = response
+            .error
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("UNKNOWN");
+
+        let event = OrderRejected::new(
+            self.trader_id,
+            identity.strategy_id,
+            identity.instrument_id,
+            client_order_id,
+            self.account_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event_ns.into(),
+            ts_event_ns.into(),
+            false,
+            false,
+        );
+        self.send_event(OrderEventAny::Rejected(event));
+    }
+
+    fn emit_order_updated(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let Some(client_order_id) = pending.client_order_ids.first().copied() else {
+            log::error!("Kraken WS amend_order response without client_order_id");
+            return;
+        };
+        let Some(identity) = self.dispatch_state.lookup_identity(&client_order_id) else {
+            log::warn!(
+                "Kraken WS amend_order response for untracked order client_order_id={client_order_id}",
+            );
+            return;
+        };
+        let venue_order_id = response
+            .result
+            .as_ref()
+            .and_then(|r| r.order_id.as_deref())
+            .map(VenueOrderId::new)
+            .or_else(|| pending.venue_order_ids.first().copied().flatten());
+
+        let quantity = pending.new_quantity.unwrap_or(identity.quantity);
+        if pending.new_quantity.is_some() {
+            self.dispatch_state
+                .update_identity_quantity(&client_order_id, quantity);
+        }
+
+        let event = OrderUpdated::new(
+            self.trader_id,
+            identity.strategy_id,
+            identity.instrument_id,
+            client_order_id,
+            quantity,
+            UUID4::new(),
+            ts_event_ns.into(),
+            ts_event_ns.into(),
+            false,
+            venue_order_id,
+            Some(self.account_id),
+            pending.new_price,
+            pending.new_trigger_price,
+            None,
+            false,
+        );
+        self.send_event(OrderEventAny::Updated(event));
+    }
+
+    fn emit_order_modify_rejected(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let Some(client_order_id) = pending.client_order_ids.first().copied() else {
+            log::error!("Kraken WS amend_order rejection without client_order_id");
+            return;
+        };
+        let Some(identity) = self.dispatch_state.lookup_identity(&client_order_id) else {
+            log::warn!(
+                "Kraken WS amend_order rejection for untracked order client_order_id={client_order_id}",
+            );
+            return;
+        };
+        let venue_order_id = pending.venue_order_ids.first().copied().flatten();
+        let reason = response
+            .error
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("UNKNOWN");
+
+        let event = OrderModifyRejected::new(
+            self.trader_id,
+            identity.strategy_id,
+            identity.instrument_id,
+            client_order_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event_ns.into(),
+            ts_event_ns.into(),
+            false,
+            venue_order_id,
+            Some(self.account_id),
+        );
+        self.send_event(OrderEventAny::ModifyRejected(event));
+    }
+
+    fn emit_order_cancel_rejected(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let Some(client_order_id) = pending.client_order_ids.first().copied() else {
+            log::error!("Kraken WS cancel_order rejection without client_order_id");
+            return;
+        };
+        let Some(identity) = self.dispatch_state.lookup_identity(&client_order_id) else {
+            log::warn!(
+                "Kraken WS cancel_order rejection for untracked order client_order_id={client_order_id}",
+            );
+            return;
+        };
+        let venue_order_id = pending.venue_order_ids.first().copied().flatten();
+        let reason = response
+            .error
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("UNKNOWN");
+
+        let event = OrderCancelRejected::new(
+            self.trader_id,
+            identity.strategy_id,
+            identity.instrument_id,
+            client_order_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event_ns.into(),
+            ts_event_ns.into(),
+            false,
+            venue_order_id,
+            Some(self.account_id),
+        );
+        self.send_event(OrderEventAny::CancelRejected(event));
+    }
+
+    fn handle_batch_add_response(
+        &self,
+        pending: &PendingRequest,
+        response: &KrakenWsOrderResponse,
+        ts_event_ns: u64,
+    ) {
+        let per_order = response
+            .result
+            .as_ref()
+            .and_then(|r| r.orders.as_ref())
+            .map_or(&[][..], Vec::as_slice);
+
+        // Match per-leg results by the cl_ord_id Kraken echoes back rather than
+        // relying purely on positional alignment with the legs we sent. Echoed
+        // matches are robust against the venue reordering or omitting entries
+        // in the response array; positional fallback covers the (currently
+        // dominant) case where the echoed cl_ord_id is missing.
+        let echo_index: AHashMap<&str, usize> = per_order
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| r.cl_ord_id.as_deref().map(|cid| (cid, i)))
+            .collect();
+
+        for (idx, client_order_id) in pending.client_order_ids.iter().copied().enumerate() {
+            let leg_venue = pending.venue_order_ids.get(idx).copied().flatten();
+            let truncated = truncate_cl_ord_id(&client_order_id);
+            let leg_result = echo_index
+                .get(truncated.as_str())
+                .and_then(|&i| per_order.get(i))
+                .or_else(|| per_order.get(idx));
+
+            if leg_result.is_none() {
+                log::error!(
+                    "Kraken WS batch_add response missing per-leg result for client_order_id={client_order_id} idx={idx} \
+                     legs_sent={legs_sent} legs_received={legs_received}; treating as rejection",
+                    legs_sent = pending.client_order_ids.len(),
+                    legs_received = per_order.len(),
+                );
+            }
+
+            let leg_success = leg_result.is_some_and(|r| r.success);
+            let leg_venue_order_id = leg_result
+                .and_then(|r| r.order_id.as_deref())
+                .map(VenueOrderId::new)
+                .or(leg_venue);
+            let leg_error = leg_result.and_then(|r| r.error.clone()).or_else(|| {
+                if leg_result.is_none() {
+                    Some(format!(
+                        "batch_add response missing per-leg result (legs_sent={}, legs_received={})",
+                        pending.client_order_ids.len(),
+                        per_order.len(),
+                    ))
+                } else {
+                    response.error.clone()
+                }
+            });
+
+            let leg_response = KrakenWsOrderResponse {
+                method: KrakenWsMethod::AddOrder,
+                req_id: response.req_id,
+                success: leg_success,
+                time_in: response.time_in.clone(),
+                time_out: response.time_out.clone(),
+                error: leg_error,
+                result: leg_venue_order_id.map(|v| KrakenWsOrderResult {
+                    order_id: Some(v.to_string()),
+                    cl_ord_id: leg_result.and_then(|r| r.cl_ord_id.clone()),
+                    order_userref: None,
+                    warning: None,
+                    orders: None,
+                }),
+            };
+            let leg_pending = PendingRequest {
+                operation: PendingOperation::Submit,
+                client_order_ids: vec![client_order_id],
+                venue_order_ids: vec![leg_venue_order_id],
+                ts_sent_ns: pending.ts_sent_ns,
+                new_quantity: None,
+                new_price: None,
+                new_trigger_price: None,
+            };
+
+            if leg_success {
+                self.emit_order_accepted(&leg_pending, &leg_response, ts_event_ns);
+            } else {
+                self.emit_order_rejected(&leg_pending, &leg_response, ts_event_ns);
+            }
+        }
+    }
+
+    /// Forwards an order event to the execution-engine channel.
+    ///
+    /// A send failure means the receiver has been dropped, which only happens
+    /// during shutdown after the forwarder task has exited. Events lost in
+    /// that window are recovered on the next start by the reconciliation
+    /// engine (`open_check_interval_secs`), which queries the venue for any
+    /// orders or fills the local cache is missing. The error log preserves
+    /// operator visibility for the (rare) shutdown-race case.
+    fn send_event(&self, event: OrderEventAny) {
+        if let Err(e) = self.event_tx.send(event) {
+            log::error!("Kraken WS order-event channel send failed: {e}");
+        }
+    }
+}
+
+fn pending_op_to_method(op: PendingOperation) -> KrakenWsMethod {
+    match op {
+        PendingOperation::Submit => KrakenWsMethod::AddOrder,
+        PendingOperation::Amend => KrakenWsMethod::AmendOrder,
+        PendingOperation::Cancel => KrakenWsMethod::CancelOrder,
+        PendingOperation::BatchAdd => KrakenWsMethod::BatchAdd,
+    }
+}
+
+#[cfg(test)]
+impl OrderRequestState {
+    pub(crate) fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU64;
+
+    use nautilus_model::{
+        enums::{OrderSide, OrderType},
+        identifiers::{AccountId, ClientOrderId, InstrumentId, StrategyId, TraderId},
+        types::{Price, Quantity},
+    };
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{
+        common::enums::{KrakenOrderSide, KrakenOrderType},
+        websocket::{
+            dispatch::OrderIdentity,
+            spot_v2::messages::{
+                KrakenWsAddOrderParams, KrakenWsAmendOrderParams, KrakenWsBatchAddParams,
+                KrakenWsBatchOrderResult, KrakenWsCancelOrderParams, KrakenWsOrderResponse,
+                KrakenWsOrderResult,
+            },
+        },
+    };
+
+    const CLIENT_ORDER_ID: &str = "O-1";
+    const VENUE_ORDER_ID: &str = "O-VENUE";
+    const INSTRUMENT_ID: &str = "BTCUSD.KRAKEN";
+
+    pub(super) struct Harness {
+        pub(super) state: Arc<OrderRequestState>,
+        pub(super) cmd_rx: tokio::sync::mpsc::UnboundedReceiver<SpotHandlerCommand>,
+        pub(super) event_rx: tokio::sync::mpsc::UnboundedReceiver<OrderEventAny>,
+        pub(super) dispatch_state: Arc<WsDispatchState>,
+        pub(super) auth_token: Arc<tokio::sync::RwLock<Option<String>>>,
+        pub(super) cancellation_token: CancellationToken,
+    }
+
+    pub(super) fn make_harness(timeout_ms: u64) -> Harness {
+        let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let counter = Arc::new(AtomicU64::new(0));
+        let dispatch_state = Arc::new(WsDispatchState::new());
+        let auth_token = Arc::new(tokio::sync::RwLock::new(None));
+        let cancellation_token = CancellationToken::new();
+        let state = Arc::new(OrderRequestState::new(
+            cmd_tx,
+            event_tx,
+            Arc::clone(&dispatch_state),
+            counter,
+            Duration::from_millis(timeout_ms),
+            TraderId::new("TESTER-001"),
+            AccountId::new("KRAKEN-001"),
+            Arc::clone(&auth_token),
+            cancellation_token.clone(),
+            nautilus_core::time::get_atomic_clock_realtime(),
+        ));
+        Harness {
+            state,
+            cmd_rx,
+            event_rx,
+            dispatch_state,
+            auth_token,
+            cancellation_token,
+        }
+    }
+
+    fn register_default_identity(dispatch_state: &WsDispatchState, cl_ord_id: ClientOrderId) {
+        dispatch_state.register_identity(
+            cl_ord_id,
+            OrderIdentity {
+                strategy_id: StrategyId::new("S-1"),
+                instrument_id: InstrumentId::from(INSTRUMENT_ID),
+                order_side: OrderSide::Buy,
+                order_type: OrderType::Limit,
+                quantity: Quantity::from("0.001"),
+            },
+        );
+    }
+
+    fn make_state(
+        timeout_ms: u64,
+    ) -> (
+        Arc<OrderRequestState>,
+        tokio::sync::mpsc::UnboundedReceiver<SpotHandlerCommand>,
+    ) {
+        let harness = make_harness(timeout_ms);
+        (harness.state, harness.cmd_rx)
+    }
+
+    fn make_identity(op: PendingOperation) -> PendingRequest {
+        PendingRequest {
+            operation: op,
+            client_order_ids: vec![ClientOrderId::from(CLIENT_ORDER_ID)],
+            venue_order_ids: vec![None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        }
+    }
+
+    #[rstest]
+    fn test_next_req_id_is_monotonic() {
+        let (state, _rx) = make_state(1_000);
+        let a = state.next_req_id();
+        let b = state.next_req_id();
+        let c = state.next_req_id();
+        assert!(b > a && c > b);
+    }
+
+    #[rstest]
+    fn test_submit_registers_pending_and_sends_command() {
+        let (state, mut rx) = make_state(60_000);
+        let identity = make_identity(PendingOperation::Submit);
+
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.001,
+            symbol: "BTC/USD".to_string(),
+            token: "test-token".to_string(),
+            limit_price: Some(50_000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: Some("O-1".to_string()),
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+
+        let req_id = state.submit(params, identity, 1).expect("submit ok");
+        assert_eq!(state.pending_len(), 1);
+
+        let cmd = rx.try_recv().expect("cmd queued");
+        match cmd {
+            SpotHandlerCommand::SendOrderRequest {
+                req_id: rid,
+                payload,
+            } => {
+                assert_eq!(rid, req_id);
+                assert!(payload.contains("\"add_order\""));
+                assert!(payload.contains(&format!("\"req_id\":{req_id}")));
+            }
+            _ => panic!("wrong cmd variant"),
+        }
+    }
+
+    #[rstest]
+    fn test_amend_sends_amend_order_envelope() {
+        let (state, mut rx) = make_state(60_000);
+        let params = KrakenWsAmendOrderParams {
+            order_id: Some("O-VENUE".to_string()),
+            cl_ord_id: None,
+            order_qty: Some(0.005),
+            limit_price: None,
+            trigger_price: None,
+            token: "TKN".to_string(),
+        };
+        let identity = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![ClientOrderId::from("O-1")],
+            venue_order_ids: vec![Some(VenueOrderId::from("O-VENUE"))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        let _ = state.amend(params, identity, 1).expect("amend ok");
+        let cmd = rx.try_recv().unwrap();
+        if let SpotHandlerCommand::SendOrderRequest { payload, .. } = cmd {
+            assert!(payload.contains("\"amend_order\""));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[rstest]
+    fn test_cancel_sends_cancel_order_envelope() {
+        let (state, mut rx) = make_state(60_000);
+        let params = KrakenWsCancelOrderParams {
+            order_id: Some(vec!["O-VENUE".to_string()]),
+            cl_ord_id: None,
+            token: "TKN".to_string(),
+        };
+        let identity = PendingRequest {
+            operation: PendingOperation::Cancel,
+            client_order_ids: vec![ClientOrderId::from("O-1")],
+            venue_order_ids: vec![Some(VenueOrderId::from("O-VENUE"))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        let _ = state.cancel(params, identity, 1).expect("cancel ok");
+        let cmd = rx.try_recv().unwrap();
+        if let SpotHandlerCommand::SendOrderRequest { payload, .. } = cmd {
+            assert!(payload.contains("\"cancel_order\""));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[rstest]
+    fn test_batch_add_sends_batch_add_envelope() {
+        let (state, mut rx) = make_state(60_000);
+        let params = KrakenWsBatchAddParams {
+            symbol: "BTC/USD".to_string(),
+            orders: vec![],
+            token: "TKN".to_string(),
+        };
+        let identity = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids: vec![ClientOrderId::from("O-A"), ClientOrderId::from("O-B")],
+            venue_order_ids: vec![None, None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        let _ = state.batch_add(params, identity, 1).expect("batch ok");
+        let cmd = rx.try_recv().unwrap();
+        if let SpotHandlerCommand::SendOrderRequest { payload, .. } = cmd {
+            assert!(payload.contains("\"batch_add\""));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    fn make_response(
+        method: KrakenWsMethod,
+        success: bool,
+        req_id: u64,
+        order_id: Option<&str>,
+        error: Option<&str>,
+    ) -> KrakenWsOrderResponse {
+        KrakenWsOrderResponse {
+            method,
+            req_id: Some(req_id),
+            success,
+            time_in: None,
+            time_out: None,
+            error: error.map(str::to_string),
+            result: order_id.map(|id| KrakenWsOrderResult {
+                order_id: Some(id.to_string()),
+                cl_ord_id: None,
+                order_userref: None,
+                warning: None,
+                orders: None,
+            }),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_submit_success_emits_order_accepted() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 42;
+        harness
+            .state
+            .pending
+            .insert(req_id, make_identity(PendingOperation::Submit));
+
+        let response = make_response(
+            KrakenWsMethod::AddOrder,
+            true,
+            req_id,
+            Some(VENUE_ORDER_ID),
+            None,
+        );
+        harness.state.handle_response(&response, 1_000);
+
+        assert_eq!(harness.state.pending_len(), 0);
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::Accepted(e) => {
+                assert_eq!(e.client_order_id, cl_ord_id);
+                assert_eq!(e.venue_order_id.as_str(), VENUE_ORDER_ID);
+                assert_eq!(e.account_id.as_str(), "KRAKEN-001");
+            }
+            other => panic!("expected Accepted, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_submit_failure_emits_order_rejected() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 7;
+        harness
+            .state
+            .pending
+            .insert(req_id, make_identity(PendingOperation::Submit));
+
+        let response = make_response(
+            KrakenWsMethod::AddOrder,
+            false,
+            req_id,
+            None,
+            Some("Insufficient funds"),
+        );
+        harness.state.handle_response(&response, 2_000);
+
+        assert_eq!(harness.state.pending_len(), 0);
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::Rejected(e) => {
+                assert_eq!(e.client_order_id, cl_ord_id);
+                assert_eq!(e.reason.as_str(), "Insufficient funds");
+            }
+            other => panic!("expected Rejected, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_amend_success_emits_order_updated() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 11;
+        let pending = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(
+            KrakenWsMethod::AmendOrder,
+            true,
+            req_id,
+            Some(VENUE_ORDER_ID),
+            None,
+        );
+        harness.state.handle_response(&response, 3_000);
+
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::Updated(e) => {
+                assert_eq!(e.client_order_id, cl_ord_id);
+                assert_eq!(
+                    e.venue_order_id.expect("venue id present").as_str(),
+                    VENUE_ORDER_ID
+                );
+                assert_eq!(e.quantity, Quantity::from("0.001"));
+            }
+            other => panic!("expected Updated, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_amend_with_new_quantity_emits_new_quantity() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 11;
+        let new_qty = Quantity::from("0.005");
+        let pending = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: Some(new_qty),
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(
+            KrakenWsMethod::AmendOrder,
+            true,
+            req_id,
+            Some(VENUE_ORDER_ID),
+            None,
+        );
+        harness.state.handle_response(&response, 3_500);
+
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::Updated(e) => {
+                assert_eq!(e.quantity, new_qty, "OrderUpdated must carry new quantity");
+            }
+            other => panic!("expected Updated, was {other:?}"),
+        }
+
+        let identity = harness
+            .dispatch_state
+            .lookup_identity(&cl_ord_id)
+            .expect("identity present");
+        assert_eq!(
+            identity.quantity, new_qty,
+            "dispatch identity must be updated for follow-up ops",
+        );
+    }
+
+    #[rstest]
+    fn test_handle_response_amend_carries_new_price_and_trigger() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 13;
+        let new_price = Price::from("31000.00");
+        let new_trigger = Price::from("30500.00");
+        let pending = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: Some(new_price),
+            new_trigger_price: Some(new_trigger),
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(
+            KrakenWsMethod::AmendOrder,
+            true,
+            req_id,
+            Some(VENUE_ORDER_ID),
+            None,
+        );
+        harness.state.handle_response(&response, 4_500);
+
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::Updated(e) => {
+                assert_eq!(
+                    e.price,
+                    Some(new_price),
+                    "OrderUpdated must carry amended price",
+                );
+                assert_eq!(
+                    e.trigger_price,
+                    Some(new_trigger),
+                    "OrderUpdated must carry amended trigger price",
+                );
+            }
+            other => panic!("expected Updated, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_amend_failure_emits_order_modify_rejected() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 12;
+        let pending = PendingRequest {
+            operation: PendingOperation::Amend,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(
+            KrakenWsMethod::AmendOrder,
+            false,
+            req_id,
+            None,
+            Some("Order not found"),
+        );
+        harness.state.handle_response(&response, 4_000);
+
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::ModifyRejected(e) => {
+                assert_eq!(e.client_order_id, cl_ord_id);
+                assert_eq!(e.reason.as_str(), "Order not found");
+            }
+            other => panic!("expected ModifyRejected, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_cancel_failure_emits_order_cancel_rejected() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 21;
+        let pending = PendingRequest {
+            operation: PendingOperation::Cancel,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(
+            KrakenWsMethod::CancelOrder,
+            false,
+            req_id,
+            None,
+            Some("Unknown order"),
+        );
+        harness.state.handle_response(&response, 5_000);
+
+        let event = harness.event_rx.try_recv().expect("event emitted");
+        match event {
+            OrderEventAny::CancelRejected(e) => {
+                assert_eq!(e.client_order_id, cl_ord_id);
+                assert_eq!(e.reason.as_str(), "Unknown order");
+            }
+            other => panic!("expected CancelRejected, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_cancel_success_is_silent() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 22;
+        let pending = PendingRequest {
+            operation: PendingOperation::Cancel,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![Some(VenueOrderId::from(VENUE_ORDER_ID))],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = make_response(KrakenWsMethod::CancelOrder, true, req_id, None, None);
+        harness.state.handle_response(&response, 6_000);
+
+        assert_eq!(harness.state.pending_len(), 0);
+        assert!(harness.event_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_handle_response_late_after_timeout_is_noop() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 99;
+        harness
+            .state
+            .pending
+            .insert(req_id, make_identity(PendingOperation::Submit));
+        harness.state.pending.remove(&req_id);
+
+        let response = make_response(
+            KrakenWsMethod::AddOrder,
+            true,
+            req_id,
+            Some(VENUE_ORDER_ID),
+            None,
+        );
+        harness.state.handle_response(&response, 7_000);
+
+        assert!(harness.event_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_handle_response_method_op_mismatch_logs_and_drops() {
+        let mut harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let req_id = 33;
+        harness
+            .state
+            .pending
+            .insert(req_id, make_identity(PendingOperation::Submit));
+
+        let response = make_response(KrakenWsMethod::CancelOrder, true, req_id, None, None);
+        harness.state.handle_response(&response, 8_000);
+
+        assert_eq!(harness.state.pending_len(), 0);
+        assert!(harness.event_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_handle_response_batch_add_emits_per_leg_events() {
+        let mut harness = make_harness(60_000);
+        let cl_a = ClientOrderId::from("O-A");
+        let cl_b = ClientOrderId::from("O-B");
+        register_default_identity(&harness.dispatch_state, cl_a);
+        register_default_identity(&harness.dispatch_state, cl_b);
+
+        let req_id = 50;
+        let pending = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids: vec![cl_a, cl_b],
+            venue_order_ids: vec![None, None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        let response = KrakenWsOrderResponse {
+            method: KrakenWsMethod::BatchAdd,
+            req_id: Some(req_id),
+            success: true,
+            time_in: None,
+            time_out: None,
+            error: None,
+            result: Some(KrakenWsOrderResult {
+                order_id: None,
+                cl_ord_id: None,
+                order_userref: None,
+                warning: None,
+                orders: Some(vec![
+                    KrakenWsBatchOrderResult {
+                        success: true,
+                        order_id: Some("V-A".to_string()),
+                        cl_ord_id: Some("O-A".to_string()),
+                        error: None,
+                    },
+                    KrakenWsBatchOrderResult {
+                        success: false,
+                        order_id: None,
+                        cl_ord_id: Some("O-B".to_string()),
+                        error: Some("Bad price".to_string()),
+                    },
+                ]),
+            }),
+        };
+        harness.state.handle_response(&response, 9_000);
+
+        let first = harness.event_rx.try_recv().expect("first event");
+        let second = harness.event_rx.try_recv().expect("second event");
+
+        match first {
+            OrderEventAny::Accepted(e) => {
+                assert_eq!(e.client_order_id, cl_a);
+                assert_eq!(e.venue_order_id.as_str(), "V-A");
+            }
+            other => panic!("expected Accepted, was {other:?}"),
+        }
+
+        match second {
+            OrderEventAny::Rejected(e) => {
+                assert_eq!(e.client_order_id, cl_b);
+                assert_eq!(e.reason.as_str(), "Bad price");
+            }
+            other => panic!("expected Rejected, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_handle_response_batch_add_matches_legs_by_echoed_cl_ord_id() {
+        let mut harness = make_harness(60_000);
+        let cl_a = ClientOrderId::from("O-A");
+        let cl_b = ClientOrderId::from("O-B");
+        register_default_identity(&harness.dispatch_state, cl_a);
+        register_default_identity(&harness.dispatch_state, cl_b);
+
+        let req_id = 60;
+        let pending = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids: vec![cl_a, cl_b],
+            venue_order_ids: vec![None, None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        // Vendor returns per-leg results in REVERSE order vs sent. Echo-based
+        // matching must attribute V-B to cl_b and V-A to cl_a regardless of
+        // index alignment.
+        let response = KrakenWsOrderResponse {
+            method: KrakenWsMethod::BatchAdd,
+            req_id: Some(req_id),
+            success: true,
+            time_in: None,
+            time_out: None,
+            error: None,
+            result: Some(KrakenWsOrderResult {
+                order_id: None,
+                cl_ord_id: None,
+                order_userref: None,
+                warning: None,
+                orders: Some(vec![
+                    KrakenWsBatchOrderResult {
+                        success: true,
+                        order_id: Some("V-B".to_string()),
+                        cl_ord_id: Some("O-B".to_string()),
+                        error: None,
+                    },
+                    KrakenWsBatchOrderResult {
+                        success: true,
+                        order_id: Some("V-A".to_string()),
+                        cl_ord_id: Some("O-A".to_string()),
+                        error: None,
+                    },
+                ]),
+            }),
+        };
+        harness.state.handle_response(&response, 14_000);
+
+        let first = harness.event_rx.try_recv().expect("first event");
+        let second = harness.event_rx.try_recv().expect("second event");
+        let mut by_cl_ord = std::collections::HashMap::new();
+
+        for event in [first, second] {
+            match event {
+                OrderEventAny::Accepted(e) => {
+                    by_cl_ord.insert(e.client_order_id, e.venue_order_id);
+                }
+                other => panic!("expected Accepted, was {other:?}"),
+            }
+        }
+        assert_eq!(
+            by_cl_ord.get(&cl_a).map(|v| v.as_str()),
+            Some("V-A"),
+            "cl_a must be paired with V-A despite reversed response order",
+        );
+        assert_eq!(
+            by_cl_ord.get(&cl_b).map(|v| v.as_str()),
+            Some("V-B"),
+            "cl_b must be paired with V-B despite reversed response order",
+        );
+    }
+
+    #[rstest]
+    fn test_handle_response_batch_add_truncated_per_leg_results_rejects_trailing_legs() {
+        let mut harness = make_harness(60_000);
+        let cl_a = ClientOrderId::from("O-A");
+        let cl_b = ClientOrderId::from("O-B");
+        let cl_c = ClientOrderId::from("O-C");
+        register_default_identity(&harness.dispatch_state, cl_a);
+        register_default_identity(&harness.dispatch_state, cl_b);
+        register_default_identity(&harness.dispatch_state, cl_c);
+
+        let req_id = 51;
+        let pending = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids: vec![cl_a, cl_b, cl_c],
+            venue_order_ids: vec![None, None, None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness.state.pending.insert(req_id, pending);
+
+        // Vendor returns envelope.success=true but only one per-leg entry for three sent.
+        let response = KrakenWsOrderResponse {
+            method: KrakenWsMethod::BatchAdd,
+            req_id: Some(req_id),
+            success: true,
+            time_in: None,
+            time_out: None,
+            error: None,
+            result: Some(KrakenWsOrderResult {
+                order_id: None,
+                cl_ord_id: None,
+                order_userref: None,
+                warning: None,
+                orders: Some(vec![KrakenWsBatchOrderResult {
+                    success: true,
+                    order_id: Some("V-A".to_string()),
+                    cl_ord_id: Some("O-A".to_string()),
+                    error: None,
+                }]),
+            }),
+        };
+        harness.state.handle_response(&response, 12_000);
+
+        let first = harness.event_rx.try_recv().expect("first event");
+        let second = harness.event_rx.try_recv().expect("second event");
+        let third = harness.event_rx.try_recv().expect("third event");
+
+        match first {
+            OrderEventAny::Accepted(e) => assert_eq!(e.client_order_id, cl_a),
+            other => panic!("expected Accepted for present leg, was {other:?}"),
+        }
+
+        for (event, cl_id) in [(second, cl_b), (third, cl_c)] {
+            match event {
+                OrderEventAny::Rejected(e) => {
+                    assert_eq!(
+                        e.client_order_id, cl_id,
+                        "missing-leg rejection cl_ord_id mismatch",
+                    );
+                    assert!(
+                        e.reason.as_str().contains("missing per-leg result"),
+                        "expected truncation reason, was {}",
+                        e.reason,
+                    );
+                }
+                other => panic!(
+                    "missing per-leg result must reject (not inherit envelope.success), was {other:?}",
+                ),
+            }
+        }
+    }
+
+    fn drain_send_payloads(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<SpotHandlerCommand>,
+    ) -> Vec<String> {
+        let mut out = Vec::new();
+
+        while let Ok(cmd) = rx.try_recv() {
+            if let SpotHandlerCommand::SendOrderRequest { payload, .. } = cmd {
+                out.push(payload);
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn test_submit_timeout_sends_compensating_cancel() {
+        let mut harness = make_harness(50);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+        *harness.auth_token.write().await = Some("TEST-TOKEN".to_string());
+
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.001,
+            symbol: "BTC/USD".to_string(),
+            token: "TEST-TOKEN".to_string(),
+            limit_price: Some(50_000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: Some(CLIENT_ORDER_ID.to_string()),
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        let identity = make_identity(PendingOperation::Submit);
+        harness
+            .state
+            .submit(params, identity, 1)
+            .expect("submit ok");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let payloads = drain_send_payloads(&mut harness.cmd_rx);
+        assert!(
+            payloads.iter().any(|p| p.contains("\"add_order\"")),
+            "original add_order missing: {payloads:?}",
+        );
+        let cancel = payloads
+            .iter()
+            .find(|p| p.contains("\"cancel_order\""))
+            .expect("compensating cancel_order missing");
+        assert!(
+            cancel.contains(CLIENT_ORDER_ID),
+            "compensating cancel must reference cl_ord_id, was {cancel}",
+        );
+
+        let event = harness.event_rx.try_recv().expect("rejection event");
+        match event {
+            OrderEventAny::Rejected(_) => {}
+            other => panic!("expected Rejected, was {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_timeout_rejection_uses_fire_time_not_send_time() {
+        let mut harness = make_harness(50);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.001,
+            symbol: "BTC/USD".to_string(),
+            token: String::new(),
+            limit_price: Some(50_000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: Some(CLIENT_ORDER_ID.to_string()),
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        // Use a deliberately ancient ts_sent so we can prove the synthesized
+        // rejection's ts_event is NOT the send time. ts_sent_ns = 1 (1 ns past
+        // epoch) means a successful fix gives ts_event >> 1.
+        let identity = PendingRequest {
+            operation: PendingOperation::Submit,
+            client_order_ids: vec![cl_ord_id],
+            venue_order_ids: vec![None],
+            ts_sent_ns: 1,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness
+            .state
+            .submit(params, identity, 1)
+            .expect("submit ok");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let event = harness.event_rx.try_recv().expect("rejection event");
+        match event {
+            OrderEventAny::Rejected(e) => {
+                let ts_event_ns = e.ts_event.as_u64();
+                assert!(
+                    ts_event_ns > 1,
+                    "ts_event must be the timeout-fire time (clock now), \
+                     not the send time (1 ns); was {ts_event_ns}",
+                );
+            }
+            other => panic!("expected Rejected, was {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_timeout_without_token_skips_compensating_cancel() {
+        let mut harness = make_harness(50);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.001,
+            symbol: "BTC/USD".to_string(),
+            token: String::new(),
+            limit_price: Some(50_000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: Some(CLIENT_ORDER_ID.to_string()),
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        let identity = make_identity(PendingOperation::Submit);
+        harness
+            .state
+            .submit(params, identity, 1)
+            .expect("submit ok");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let payloads = drain_send_payloads(&mut harness.cmd_rx);
+        assert!(
+            payloads.iter().all(|p| !p.contains("\"cancel_order\"")),
+            "no compensating cancel expected without token, was {payloads:?}",
+        );
+
+        let event = harness.event_rx.try_recv().expect("rejection event");
+        assert!(matches!(event, OrderEventAny::Rejected(_)));
+    }
+
+    #[tokio::test]
+    async fn test_batch_add_timeout_sends_compensating_cancel_for_all_legs() {
+        let mut harness = make_harness(50);
+        let cl_a = ClientOrderId::from("O-A");
+        let cl_b = ClientOrderId::from("O-B");
+        register_default_identity(&harness.dispatch_state, cl_a);
+        register_default_identity(&harness.dispatch_state, cl_b);
+        *harness.auth_token.write().await = Some("TEST-TOKEN".to_string());
+
+        let params = KrakenWsBatchAddParams {
+            symbol: "BTC/USD".to_string(),
+            orders: vec![],
+            token: "TEST-TOKEN".to_string(),
+        };
+        let identity = PendingRequest {
+            operation: PendingOperation::BatchAdd,
+            client_order_ids: vec![cl_a, cl_b],
+            venue_order_ids: vec![None, None],
+            ts_sent_ns: 0,
+            new_quantity: None,
+            new_price: None,
+            new_trigger_price: None,
+        };
+        harness
+            .state
+            .batch_add(params, identity, 1)
+            .expect("batch ok");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let payloads = drain_send_payloads(&mut harness.cmd_rx);
+        let cancel = payloads
+            .iter()
+            .find(|p| p.contains("\"cancel_order\""))
+            .expect("compensating cancel missing");
+        assert!(cancel.contains("O-A") && cancel.contains("O-B"));
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_token_aborts_pending_timeout() {
+        let harness = make_harness(60_000);
+        let cl_ord_id = ClientOrderId::from(CLIENT_ORDER_ID);
+        register_default_identity(&harness.dispatch_state, cl_ord_id);
+
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.001,
+            symbol: "BTC/USD".to_string(),
+            token: String::new(),
+            limit_price: Some(50_000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: Some(CLIENT_ORDER_ID.to_string()),
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        let identity = make_identity(PendingOperation::Submit);
+        harness
+            .state
+            .submit(params, identity, 1)
+            .expect("submit ok");
+        assert_eq!(harness.state.pending_len(), 1);
+
+        harness.cancellation_token.cancel();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            harness.state.pending_len(),
+            0,
+            "pending entry must be cleared on cancellation",
+        );
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use nautilus_model::identifiers::ClientOrderId;
+    use proptest::prelude::*;
+
+    use super::{tests::make_harness, *};
+
+    proptest! {
+        fn no_pending_leak_on_random_response_interleaving(
+            ops in proptest::collection::vec(
+                prop_oneof![
+                    Just((PendingOperation::Submit, true)),
+                    Just((PendingOperation::Submit, false)),
+                    Just((PendingOperation::Amend, true)),
+                    Just((PendingOperation::Amend, false)),
+                    Just((PendingOperation::Cancel, true)),
+                    Just((PendingOperation::Cancel, false)),
+                ],
+                1..50usize,
+            )
+        ) {
+            let h = make_harness(60_000);
+            let state = &h.state;
+            let mut req_ids = Vec::new();
+
+            for (op, success) in &ops {
+                let req_id = state.next_req_id();
+                state.pending.insert(req_id, PendingRequest {
+                    operation: *op,
+                    client_order_ids: vec![ClientOrderId::from(
+                        format!("O-{req_id}").as_str(),
+                    )],
+                    venue_order_ids: vec![None],
+                    ts_sent_ns: 0,
+                    new_quantity: None,
+                new_price: None,
+                new_trigger_price: None,
+                });
+                req_ids.push((req_id, *op, *success));
+            }
+            let mut shuffled = req_ids.clone();
+            shuffled.reverse();
+            for (req_id, op, success) in shuffled {
+                let method = match op {
+                    PendingOperation::Submit => KrakenWsMethod::AddOrder,
+                    PendingOperation::Amend => KrakenWsMethod::AmendOrder,
+                    PendingOperation::Cancel => KrakenWsMethod::CancelOrder,
+                    PendingOperation::BatchAdd => KrakenWsMethod::BatchAdd,
+                };
+                let response = KrakenWsOrderResponse {
+                    method,
+                    req_id: Some(req_id),
+                    success,
+                    time_in: None,
+                    time_out: None,
+                    error: if success {
+                        None
+                    } else {
+                        Some("test-error".to_string())
+                    },
+                    result: None,
+                };
+                state.handle_response(&response, 1);
+            }
+            prop_assert_eq!(state.pending_len(), 0);
+        }
+    }
+}

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -19,7 +19,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, RwLock,
-        atomic::{AtomicBool, AtomicU8, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     },
 };
 
@@ -50,7 +50,7 @@ pub const KRAKEN_SPOT_WS_TOPIC_DELIMITER: char = ':';
 use super::{
     enums::{KrakenWsChannel, KrakenWsMethod},
     handler::{SpotFeedHandler, SpotHandlerCommand},
-    messages::{KrakenSpotWsMessage, KrakenWsParams, KrakenWsRequest},
+    messages::{KrakenSpotWsMessage, KrakenWsChannelParams, KrakenWsParams, KrakenWsRequest},
 };
 use crate::{
     common::parse::normalize_spot_symbol,
@@ -83,7 +83,7 @@ pub struct KrakenSpotWebSocketClient {
     subscription_payloads: Arc<tokio::sync::RwLock<HashMap<String, String>>>,
     auth_tracker: AuthTracker,
     cancellation_token: CancellationToken,
-    req_id_counter: Arc<tokio::sync::RwLock<u64>>,
+    req_id_counter: Arc<AtomicU64>,
     auth_token: Arc<tokio::sync::RwLock<Option<String>>>,
     account_id: Arc<RwLock<Option<AccountId>>>,
     truncated_id_map: Arc<AtomicMap<String, ClientOrderId>>,
@@ -153,7 +153,7 @@ impl KrakenSpotWebSocketClient {
             subscription_payloads: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             auth_tracker: AuthTracker::new(),
             cancellation_token,
-            req_id_counter: Arc::new(tokio::sync::RwLock::new(0)),
+            req_id_counter: Arc::new(AtomicU64::new(0)),
             auth_token: Arc::new(tokio::sync::RwLock::new(None)),
             account_id: Arc::new(RwLock::new(None)),
             truncated_id_map: Arc::new(AtomicMap::new()),
@@ -163,10 +163,41 @@ impl KrakenSpotWebSocketClient {
         }
     }
 
-    async fn get_next_req_id(&self) -> u64 {
-        let mut counter = self.req_id_counter.write().await;
-        *counter += 1;
-        *counter
+    fn get_next_req_id(&self) -> u64 {
+        self.req_id_counter.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Returns the shared request-id counter.
+    pub fn req_id_counter(&self) -> Arc<AtomicU64> {
+        self.req_id_counter.clone()
+    }
+
+    /// Returns a clone of the handler command channel sender.
+    pub async fn handler_command_sender(
+        &self,
+    ) -> tokio::sync::mpsc::UnboundedSender<SpotHandlerCommand> {
+        self.cmd_tx.read().await.clone()
+    }
+
+    /// Returns the current cached authentication token, if any.
+    pub async fn auth_token(&self) -> Option<String> {
+        self.auth_token.read().await.clone()
+    }
+
+    /// Returns the current cached authentication token without awaiting.
+    ///
+    /// Returns `None` when the lock is contended or no token is cached. Used by
+    /// the synchronous order-routing path where the auth token is normally
+    /// uncontended; callers fall back to REST when the lock is unavailable.
+    pub fn auth_token_blocking(&self) -> Option<String> {
+        self.auth_token.try_read().ok().and_then(|g| g.clone())
+    }
+
+    /// Returns a clone of the auth token handle for components that need
+    /// non-async, lock-free read access (e.g. compensating cancels triggered
+    /// from the timeout task in `OrderRequestState`).
+    pub fn auth_token_handle(&self) -> Arc<tokio::sync::RwLock<Option<String>>> {
+        self.auth_token.clone()
     }
 
     /// Connects to the WebSocket server.
@@ -510,10 +541,10 @@ impl KrakenSpotWebSocketClient {
             None
         };
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Subscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel,
                 symbol: Some(symbols_to_subscribe.clone()),
                 snapshot: None,
@@ -523,7 +554,7 @@ impl KrakenSpotWebSocketClient {
                 token,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -562,10 +593,10 @@ impl KrakenSpotWebSocketClient {
             return Ok(());
         }
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Subscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel,
                 symbol: Some(symbols_to_subscribe.clone()),
                 snapshot: Some(false),
@@ -575,7 +606,7 @@ impl KrakenSpotWebSocketClient {
                 token: None,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -614,10 +645,10 @@ impl KrakenSpotWebSocketClient {
             return Ok(());
         }
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Unsubscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel,
                 symbol: Some(symbols_to_unsubscribe.clone()),
                 snapshot: None,
@@ -627,7 +658,7 @@ impl KrakenSpotWebSocketClient {
                 token: None,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -681,10 +712,10 @@ impl KrakenSpotWebSocketClient {
             None
         };
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Unsubscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel,
                 symbol: Some(symbols_to_unsubscribe.clone()),
                 snapshot: None,
@@ -694,7 +725,7 @@ impl KrakenSpotWebSocketClient {
                 token,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -711,7 +742,7 @@ impl KrakenSpotWebSocketClient {
 
     /// Sends a ping message to keep the connection alive.
     pub async fn send_ping(&self) -> Result<(), KrakenWsError> {
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
 
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Ping,
@@ -739,6 +770,14 @@ impl KrakenSpotWebSocketClient {
             KrakenWsMethod::Ping | KrakenWsMethod::Pong => SpotHandlerCommand::Ping {
                 payload: payload.clone(),
             },
+            KrakenWsMethod::AddOrder
+            | KrakenWsMethod::AmendOrder
+            | KrakenWsMethod::CancelOrder
+            | KrakenWsMethod::BatchAdd => {
+                return Err(KrakenWsError::InvalidMessage(
+                    "Order methods must not be sent via send_command; use the dedicated order submission path".to_string()
+                ));
+            }
         };
 
         self.cmd_tx
@@ -877,10 +916,10 @@ impl KrakenSpotWebSocketClient {
 
         self.subscriptions.mark_subscribe(&key);
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Subscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel: KrakenWsChannel::Ticker,
                 symbol: Some(vec![symbol]),
                 snapshot: None,
@@ -890,7 +929,7 @@ impl KrakenSpotWebSocketClient {
                 token: None,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -930,7 +969,7 @@ impl KrakenSpotWebSocketClient {
         snap_orders: bool,
         snap_trades: bool,
     ) -> Result<(), KrakenWsError> {
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
 
         let token = self.auth_token.read().await.clone().ok_or_else(|| {
             KrakenWsError::AuthenticationError(
@@ -941,7 +980,7 @@ impl KrakenSpotWebSocketClient {
 
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Subscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel: KrakenWsChannel::Executions,
                 symbol: None,
                 snapshot: None,
@@ -951,7 +990,7 @@ impl KrakenSpotWebSocketClient {
                 token: Some(token),
                 snap_orders: Some(snap_orders),
                 snap_trades: Some(snap_trades),
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -990,10 +1029,10 @@ impl KrakenSpotWebSocketClient {
 
         self.subscriptions.mark_unsubscribe(&key);
 
-        let req_id = self.get_next_req_id().await;
+        let req_id = self.get_next_req_id();
         let request = KrakenWsRequest {
             method: KrakenWsMethod::Unsubscribe,
-            params: Some(KrakenWsParams {
+            params: Some(KrakenWsParams::Channel(KrakenWsChannelParams {
                 channel: KrakenWsChannel::Ticker,
                 symbol: Some(vec![symbol]),
                 snapshot: None,
@@ -1003,7 +1042,7 @@ impl KrakenSpotWebSocketClient {
                 token: None,
                 snap_orders: None,
                 snap_trades: None,
-            }),
+            })),
             req_id: Some(req_id),
         };
 
@@ -1125,9 +1164,27 @@ fn bar_type_to_ws_interval(bar_type: BarType) -> Result<u32, KrakenWsError> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, atomic::Ordering};
+
     use rstest::rstest;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::config::KrakenDataClientConfig;
+
+    #[rstest]
+    fn test_req_id_counter_is_shared_arc_and_monotonic() {
+        let cfg = KrakenDataClientConfig::default();
+        let client = KrakenSpotWebSocketClient::new(cfg, CancellationToken::new(), None);
+        let counter = client.req_id_counter();
+        let a = counter.fetch_add(1, Ordering::Relaxed);
+        let b = counter.fetch_add(1, Ordering::Relaxed);
+        assert!(b > a);
+        #[allow(clippy::redundant_clone)]
+        let cloned = client.clone();
+        let cloned_counter = cloned.req_id_counter();
+        assert!(Arc::ptr_eq(&counter, &cloned_counter));
+    }
 
     #[rstest]
     #[case("XBT/EUR", "BTC/EUR")]

--- a/crates/adapters/kraken/src/websocket/spot_v2/enums.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/enums.rs
@@ -53,6 +53,18 @@ pub enum KrakenWsMethod {
     Unsubscribe,
     Ping,
     Pong,
+    #[serde(rename = "add_order")]
+    #[strum(serialize = "add_order")]
+    AddOrder,
+    #[serde(rename = "amend_order")]
+    #[strum(serialize = "amend_order")]
+    AmendOrder,
+    #[serde(rename = "cancel_order")]
+    #[strum(serialize = "cancel_order")]
+    CancelOrder,
+    #[serde(rename = "batch_add")]
+    #[strum(serialize = "batch_add")]
+    BatchAdd,
 }
 
 #[derive(
@@ -276,5 +288,24 @@ impl From<KrakenLiquidityInd> for LiquiditySide {
             KrakenLiquidityInd::Maker => Self::Maker,
             KrakenLiquidityInd::Taker => Self::Taker,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(KrakenWsMethod::AddOrder, "\"add_order\"")]
+    #[case(KrakenWsMethod::AmendOrder, "\"amend_order\"")]
+    #[case(KrakenWsMethod::CancelOrder, "\"cancel_order\"")]
+    #[case(KrakenWsMethod::BatchAdd, "\"batch_add\"")]
+    fn test_ws_method_order_variants_serde(#[case] m: KrakenWsMethod, #[case] expected: &str) {
+        let json = serde_json::to_string(&m).unwrap();
+        assert_eq!(json, expected);
+        let back: KrakenWsMethod = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, m);
     }
 }

--- a/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
@@ -36,6 +36,7 @@ use super::{
         KrakenSpotWsMessage, KrakenWsBookData, KrakenWsExecutionData, KrakenWsMessage,
         KrakenWsOhlcData, KrakenWsResponse, KrakenWsTickerData, KrakenWsTradeData,
     },
+    parse::parse_order_response,
 };
 
 /// Commands sent from the outer client to the inner message handler.
@@ -46,6 +47,7 @@ pub enum SpotHandlerCommand {
     Subscribe { payload: String },
     Unsubscribe { payload: String },
     Ping { payload: String },
+    SendOrderRequest { req_id: u64, payload: String },
 }
 
 /// WebSocket message handler for Kraken Spot v2.
@@ -112,6 +114,23 @@ impl SpotFeedHandler {
                                 && let Err(e) = client.send_text(payload.clone(), None).await
                             {
                                 log::error!("Failed to send text: {e}");
+                            }
+                        }
+                        SpotHandlerCommand::SendOrderRequest { req_id, payload } => {
+                            if let Some(client) = &self.inner {
+                                if let Err(e) = client.send_text(payload, None).await {
+                                    log::error!(
+                                        "Kraken WS send_order_request failed req_id={req_id}: {e}"
+                                    );
+                                } else {
+                                    log::debug!(
+                                        "Kraken WS send_order_request enqueued req_id={req_id}"
+                                    );
+                                }
+                            } else {
+                                log::error!(
+                                    "Kraken WS send_order_request without active client req_id={req_id}"
+                                );
                             }
                         }
                     }
@@ -203,13 +222,16 @@ impl SpotFeedHandler {
             }
         };
 
-        // Control messages have "method" field
         if value.get("method").is_some() {
+            match parse_order_response(text) {
+                Ok(Some(msg)) => return Some(msg),
+                Ok(None) => {}
+                Err(e) => log::warn!("Failed to parse order response: {e}"),
+            }
             self.handle_control_message(value);
             return None;
         }
 
-        // Data messages have "channel" and "data" fields
         if value.get("channel").is_some() && value.get("data").is_some() {
             match serde_json::from_value::<KrakenWsMessage>(value) {
                 Ok(msg) => return self.handle_data_message(msg),
@@ -570,6 +592,49 @@ mod tests {
     }
 
     #[rstest]
+    fn test_send_order_request_variant_construction() {
+        let cmd = SpotHandlerCommand::SendOrderRequest {
+            req_id: 7,
+            payload: r#"{"method":"add_order","req_id":7}"#.to_string(),
+        };
+
+        match cmd {
+            SpotHandlerCommand::SendOrderRequest { req_id, payload } => {
+                assert_eq!(req_id, 7);
+                assert!(payload.contains("add_order"));
+            }
+            _ => panic!("Expected SendOrderRequest, was a different variant"),
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_send_order_request_without_active_client_does_not_panic() {
+        let signal = Arc::new(AtomicBool::new(false));
+        let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (raw_tx, raw_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let subscriptions = SubscriptionState::new(':');
+
+        let mut handler = SpotFeedHandler::new(signal.clone(), cmd_rx, raw_rx, subscriptions);
+
+        cmd_tx
+            .send(SpotHandlerCommand::SendOrderRequest {
+                req_id: 42,
+                payload: r#"{"method":"add_order","req_id":42}"#.to_string(),
+            })
+            .unwrap();
+
+        drop(cmd_tx);
+        drop(raw_tx);
+
+        let result = handler.next().await;
+        assert!(
+            result.is_none(),
+            "Handler should return None when streams close"
+        );
+    }
+
+    #[rstest]
     fn test_quotes_and_book_subscriptions_independent() {
         let handler = create_test_handler();
         handler.subscriptions.mark_subscribe("quotes:BTC/USD");
@@ -618,5 +683,23 @@ mod tests {
             ticker_result.is_some(),
             "Ticker should pass with quotes subscription"
         );
+    }
+
+    #[rstest]
+    fn test_parse_message_routes_add_order_response_to_order_response_variant() {
+        use super::super::enums::KrakenWsMethod;
+
+        let handler = create_test_handler();
+        let json = r#"{"method":"add_order","req_id":42,"success":true,"time_in":"2026-05-05T10:00:00.123Z","time_out":"2026-05-05T10:00:00.125Z","result":{"order_id":"OABCDE-12345-FGHIJ","cl_ord_id":"O-20260505-000001","order_userref":0}}"#;
+
+        let result = handler.parse_message(json);
+        match result {
+            Some(KrakenSpotWsMessage::OrderResponse(resp)) => {
+                assert_eq!(resp.method, KrakenWsMethod::AddOrder);
+                assert_eq!(resp.req_id, Some(42));
+                assert!(resp.success);
+            }
+            other => panic!("expected OrderResponse, was {other:?}"),
+        }
     }
 }

--- a/crates/adapters/kraken/src/websocket/spot_v2/messages.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/messages.rs
@@ -24,7 +24,9 @@ use super::enums::{
     KrakenExecType, KrakenLiquidityInd, KrakenWsChannel, KrakenWsMessageType, KrakenWsMethod,
     KrakenWsOrderStatus,
 };
-use crate::common::enums::{KrakenOrderSide, KrakenOrderType, KrakenTimeInForce};
+use crate::common::enums::{
+    KrakenOrderSide, KrakenOrderType, KrakenSpotTrigger, KrakenTimeInForce,
+};
 
 /// Output message types from the Kraken Spot v2 WebSocket handler.
 #[derive(Clone, Debug)]
@@ -37,6 +39,7 @@ pub enum KrakenSpotWsMessage {
     },
     Ohlc(Vec<KrakenWsOhlcData>),
     Execution(Vec<KrakenWsExecutionData>),
+    OrderResponse(KrakenWsOrderResponse),
     Reconnected,
 }
 
@@ -49,25 +52,262 @@ pub struct KrakenWsRequest {
     pub req_id: Option<u64>,
 }
 
+/// Parameters for a Kraken WebSocket request, covering both channel subscriptions and order methods.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KrakenWsParams {
+#[serde(untagged)]
+pub enum KrakenWsParams {
+    /// Parameters for subscribe/unsubscribe channel requests.
+    Channel(KrakenWsChannelParams),
+    /// Parameters for the `add_order` method.
+    AddOrder(KrakenWsAddOrderParams),
+    /// Parameters for the `amend_order` method.
+    AmendOrder(KrakenWsAmendOrderParams),
+    /// Parameters for the `cancel_order` method.
+    CancelOrder(KrakenWsCancelOrderParams),
+    /// Parameters for the `batch_add` method.
+    BatchAdd(KrakenWsBatchAddParams),
+}
+
+/// Parameters for channel subscribe/unsubscribe requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsChannelParams {
+    /// Channel to subscribe or unsubscribe.
     pub channel: KrakenWsChannel,
+    /// Symbols to subscribe for (market data channels).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol: Option<Vec<Ustr>>,
+    /// Whether to receive a snapshot on subscribe.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshot: Option<bool>,
+    /// Order book depth (book channel only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depth: Option<u32>,
+    /// OHLC interval in minutes (ohlc channel only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<u32>,
+    /// Event trigger filter (ticker channel, e.g. `"bbo"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_trigger: Option<String>,
+    /// Authentication token (private channels).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+    /// Whether to include a snapshot of open orders (executions channel).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snap_orders: Option<bool>,
+    /// Whether to include a snapshot of recent trades (executions channel).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snap_trades: Option<bool>,
+}
+
+/// Parameters for the `add_order` WebSocket method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsAddOrderParams {
+    /// Order type (limit, market, etc.).
+    pub order_type: KrakenOrderType,
+    /// Order side (buy or sell).
+    pub side: KrakenOrderSide,
+    /// Order quantity in base currency.
+    pub order_qty: f64,
+    /// Trading pair symbol (e.g. `"BTC/USD"`).
+    pub symbol: String,
+    /// Authentication token.
+    pub token: String,
+    /// Limit price (required for limit orders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_price: Option<f64>,
+    /// Time in force policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in_force: Option<KrakenTimeInForce>,
+    /// Expiration timestamp for `GoodTilDate` orders. Required by Kraken whenever
+    /// `time_in_force = GTD`. Accepts an RFC3339 timestamp (`"2026-12-31T23:59:59Z"`)
+    /// or a relative duration (`"+30s"`, `"+1h"`, `"+2D"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expire_time: Option<String>,
+    /// Client-assigned order ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Whether the order must be a passive post-only order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    /// Whether the order may only reduce an existing position.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// Trigger parameters for stop/take-profit orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<KrakenWsTriggerParams>,
+    /// Leverage multiplier for margin orders; omit for non-margin (cash) orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leverage: Option<u16>,
+    /// Conditional close order attached to the parent order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditional: Option<KrakenWsConditionalParams>,
+}
+
+/// Parameters for the `amend_order` WebSocket method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsAmendOrderParams {
+    /// Authentication token.
+    pub token: String,
+    /// Kraken order ID to amend (preferred over `cl_ord_id`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<String>,
+    /// Client-assigned order ID to amend (used when `order_id` is unavailable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// New order quantity (replaces the existing quantity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_qty: Option<f64>,
+    /// New limit price.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_price: Option<f64>,
+    /// New trigger price (for conditional orders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+}
+
+/// Parameters for the `cancel_order` WebSocket method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsCancelOrderParams {
+    /// Authentication token.
+    pub token: String,
+    /// One or more Kraken order IDs to cancel (preferred over `cl_ord_id`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<Vec<String>>,
+    /// One or more client-assigned order IDs to cancel (used when `order_id` is unavailable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<Vec<String>>,
+}
+
+/// Parameters for the `batch_add` WebSocket method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsBatchAddParams {
+    /// Trading pair symbol shared by all orders in the batch.
+    pub symbol: String,
+    /// List of orders to submit.
+    pub orders: Vec<KrakenWsBatchAddOrder>,
+    /// Authentication token.
+    pub token: String,
+}
+
+/// A single order entry within a `batch_add` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsBatchAddOrder {
+    /// Order type.
+    pub order_type: KrakenOrderType,
+    /// Order side.
+    pub side: KrakenOrderSide,
+    /// Order quantity.
+    pub order_qty: f64,
+    /// Limit price (required for limit orders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_price: Option<f64>,
+    /// Client-assigned order ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Time in force policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in_force: Option<KrakenTimeInForce>,
+    /// Expiration timestamp for `GoodTilDate` legs. Required by Kraken whenever
+    /// `time_in_force = GTD`. RFC3339 timestamp or relative duration string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expire_time: Option<String>,
+    /// Whether the order must be a passive post-only order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    /// Whether the order may only reduce an existing position.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// Leverage multiplier for margin orders; omit for non-margin (cash) orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leverage: Option<u16>,
+    /// Trigger parameters for stop-loss and take-profit order types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<KrakenWsTriggerParams>,
+}
+
+/// Trigger parameters for stop/take-profit order types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsTriggerParams {
+    /// Reference price for the trigger.
+    pub reference: KrakenSpotTrigger,
+    /// Trigger price level.
+    pub price: f64,
+    /// Price direction for the trigger (above or below).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_type: Option<String>,
+}
+
+/// Conditional close order attached to a parent order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsConditionalParams {
+    /// Order type for the conditional leg.
+    pub order_type: KrakenOrderType,
+    /// Limit price for the conditional leg.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_price: Option<f64>,
+    /// Stop price for the conditional leg.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+}
+
+/// Response envelope for order-method WebSocket responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsOrderResponse {
+    /// The method that triggered this response.
+    pub method: KrakenWsMethod,
+    /// Echo of the request ID (only present when the client sent one).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub req_id: Option<u64>,
+    /// Whether the request succeeded.
+    pub success: bool,
+    /// ISO 8601 timestamp when the request was received.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in: Option<String>,
+    /// ISO 8601 timestamp when the response was sent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_out: Option<String>,
+    /// Error message when `success` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Result payload when `success` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<KrakenWsOrderResult>,
+}
+
+/// Result payload for single-order responses (`add_order`, `amend_order`, `cancel_order`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsOrderResult {
+    /// Kraken-assigned order ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<String>,
+    /// Client-assigned order ID echoed back.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Integer user reference echoed back.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_userref: Option<i64>,
+    /// Non-fatal warnings associated with the order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<Vec<String>>,
+    /// Per-order results for `batch_add` responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orders: Option<Vec<KrakenWsBatchOrderResult>>,
+}
+
+/// Per-order outcome within a `batch_add` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KrakenWsBatchOrderResult {
+    /// Whether this individual order succeeded.
+    pub success: bool,
+    /// Kraken-assigned order ID (present when `success` is `true`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<String>,
+    /// Client-assigned order ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cl_ord_id: Option<String>,
+    /// Error message (present when `success` is `false`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -235,7 +475,6 @@ pub struct KrakenWsExecutionData {
     pub reduce_only: Option<bool>,
     /// Event timestamp.
     pub timestamp: DateTime<Utc>,
-    // Trade-specific fields (present when exec_type is Trade)
     /// Execution/trade ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exec_id: Option<String>,
@@ -416,5 +655,298 @@ mod tests {
         assert!(ohlc.close.is_finite() && ohlc.close > 0.0);
         assert_eq!(ohlc.interval, 1);
         assert!(ohlc.trades > 0);
+    }
+
+    #[rstest]
+    fn test_serialize_add_order_request() {
+        let request = KrakenWsRequest {
+            method: KrakenWsMethod::AddOrder,
+            params: Some(KrakenWsParams::AddOrder(KrakenWsAddOrderParams {
+                order_type: KrakenOrderType::Limit,
+                side: KrakenOrderSide::Buy,
+                order_qty: 0.01,
+                symbol: "BTC/USD".to_string(),
+                limit_price: Some(30000.0),
+                time_in_force: Some(KrakenTimeInForce::GoodTilCancelled),
+                expire_time: None,
+                cl_ord_id: Some("O-20260505-000001".to_string()),
+                post_only: Some(true),
+                reduce_only: None,
+                leverage: None,
+                trigger: None,
+                conditional: None,
+                token: "TESTTOKEN".to_string(),
+            })),
+            req_id: Some(42),
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Failed to serialize");
+        let expected: serde_json::Value =
+            serde_json::from_str(&load_test_data("ws_add_order_request.json"))
+                .expect("Failed to parse fixture");
+        let actual: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse serialized");
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    fn test_serialize_amend_order_request() {
+        let request = KrakenWsRequest {
+            method: KrakenWsMethod::AmendOrder,
+            params: Some(KrakenWsParams::AmendOrder(KrakenWsAmendOrderParams {
+                order_id: Some("OABCDE-12345-FGHIJ".to_string()),
+                cl_ord_id: None,
+                order_qty: Some(0.005),
+                limit_price: None,
+                trigger_price: None,
+                token: "TESTTOKEN".to_string(),
+            })),
+            req_id: Some(43),
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Failed to serialize");
+        let expected: serde_json::Value =
+            serde_json::from_str(&load_test_data("ws_amend_order_request.json"))
+                .expect("Failed to parse fixture");
+        let actual: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse serialized");
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    fn test_serialize_cancel_order_request() {
+        let request = KrakenWsRequest {
+            method: KrakenWsMethod::CancelOrder,
+            params: Some(KrakenWsParams::CancelOrder(KrakenWsCancelOrderParams {
+                order_id: Some(vec!["OABCDE-12345-FGHIJ".to_string()]),
+                cl_ord_id: None,
+                token: "TESTTOKEN".to_string(),
+            })),
+            req_id: Some(44),
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Failed to serialize");
+        let expected: serde_json::Value =
+            serde_json::from_str(&load_test_data("ws_cancel_order_request.json"))
+                .expect("Failed to parse fixture");
+        let actual: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse serialized");
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    fn test_serialize_batch_add_request() {
+        let request = KrakenWsRequest {
+            method: KrakenWsMethod::BatchAdd,
+            params: Some(KrakenWsParams::BatchAdd(KrakenWsBatchAddParams {
+                symbol: "BTC/USD".to_string(),
+                orders: vec![
+                    KrakenWsBatchAddOrder {
+                        order_type: KrakenOrderType::Limit,
+                        side: KrakenOrderSide::Buy,
+                        order_qty: 0.01,
+                        limit_price: Some(30000.0),
+                        cl_ord_id: Some("O-A".to_string()),
+                        time_in_force: None,
+                        expire_time: None,
+                        post_only: None,
+                        reduce_only: None,
+                        leverage: None,
+                        trigger: None,
+                    },
+                    KrakenWsBatchAddOrder {
+                        order_type: KrakenOrderType::Limit,
+                        side: KrakenOrderSide::Sell,
+                        order_qty: 0.01,
+                        limit_price: Some(31000.0),
+                        cl_ord_id: Some("O-B".to_string()),
+                        time_in_force: None,
+                        expire_time: None,
+                        post_only: None,
+                        reduce_only: None,
+                        leverage: None,
+                        trigger: None,
+                    },
+                ],
+                token: "TESTTOKEN".to_string(),
+            })),
+            req_id: Some(45),
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Failed to serialize");
+        let expected: serde_json::Value =
+            serde_json::from_str(&load_test_data("ws_batch_add_request.json"))
+                .expect("Failed to parse fixture");
+        let actual: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse serialized");
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    fn test_add_order_params_serializes_expire_time_for_gtd() {
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.01,
+            symbol: "BTC/USD".to_string(),
+            token: "TKN".to_string(),
+            limit_price: Some(30000.0),
+            time_in_force: Some(KrakenTimeInForce::GoodTilDate),
+            expire_time: Some("2026-12-31T23:59:59+00:00".to_string()),
+            cl_ord_id: None,
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&params).expect("serialize"))
+                .expect("json");
+
+        assert_eq!(value["time_in_force"], "GTD");
+        assert_eq!(value["expire_time"], "2026-12-31T23:59:59+00:00");
+    }
+
+    #[rstest]
+    fn test_add_order_params_omits_expire_time_when_absent() {
+        let params = KrakenWsAddOrderParams {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.01,
+            symbol: "BTC/USD".to_string(),
+            token: "TKN".to_string(),
+            limit_price: Some(30000.0),
+            time_in_force: None,
+            expire_time: None,
+            cl_ord_id: None,
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+            conditional: None,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&params).expect("serialize"))
+                .expect("json");
+
+        assert!(value.get("expire_time").is_none());
+    }
+
+    #[rstest]
+    fn test_batch_add_order_serializes_leverage_and_trigger() {
+        let order = KrakenWsBatchAddOrder {
+            order_type: KrakenOrderType::StopLossLimit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.01,
+            limit_price: Some(31000.0),
+            cl_ord_id: Some("O-CONDITIONAL".to_string()),
+            time_in_force: None,
+            expire_time: None,
+            post_only: None,
+            reduce_only: None,
+            leverage: Some(2),
+            trigger: Some(KrakenWsTriggerParams {
+                reference: KrakenSpotTrigger::Last,
+                price: 30500.0,
+                price_type: None,
+            }),
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&order).expect("serialize")).expect("json");
+
+        assert_eq!(
+            value["leverage"], 2,
+            "leverage must be serialized for margin batch legs",
+        );
+        assert!(
+            value.get("trigger").is_some(),
+            "trigger must be serialized for conditional batch legs",
+        );
+        assert_eq!(value["trigger"]["reference"], "last");
+        assert_eq!(value["trigger"]["price"], 30500.0);
+    }
+
+    #[rstest]
+    fn test_batch_add_order_omits_leverage_and_trigger_when_absent() {
+        let order = KrakenWsBatchAddOrder {
+            order_type: KrakenOrderType::Limit,
+            side: KrakenOrderSide::Buy,
+            order_qty: 0.01,
+            limit_price: Some(30000.0),
+            cl_ord_id: Some("O-PLAIN".to_string()),
+            time_in_force: None,
+            expire_time: None,
+            post_only: None,
+            reduce_only: None,
+            leverage: None,
+            trigger: None,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&order).expect("serialize")).expect("json");
+
+        assert!(
+            value.get("leverage").is_none(),
+            "leverage must be omitted when None"
+        );
+        assert!(
+            value.get("trigger").is_none(),
+            "trigger must be omitted when None"
+        );
+    }
+
+    #[rstest]
+    fn test_deserialize_add_order_response_success() {
+        let data = load_test_data("ws_add_order_response_success.json");
+        let response: KrakenWsOrderResponse =
+            serde_json::from_str(&data).expect("Failed to parse add_order success response");
+
+        assert_eq!(response.method, KrakenWsMethod::AddOrder);
+        assert_eq!(response.req_id, Some(42));
+        assert!(response.success);
+        assert!(response.error.is_none());
+
+        let result = response.result.expect("Expected result");
+        assert_eq!(result.order_id.as_deref(), Some("OABCDE-12345-FGHIJ"));
+        assert_eq!(result.cl_ord_id.as_deref(), Some("O-20260505-000001"));
+        assert_eq!(result.order_userref, Some(0));
+    }
+
+    #[rstest]
+    fn test_deserialize_add_order_response_failure() {
+        let data = load_test_data("ws_add_order_response_failure.json");
+        let response: KrakenWsOrderResponse =
+            serde_json::from_str(&data).expect("Failed to parse add_order failure response");
+
+        assert_eq!(response.method, KrakenWsMethod::AddOrder);
+        assert_eq!(response.req_id, Some(99));
+        assert!(!response.success);
+        assert_eq!(response.error.as_deref(), Some("EOrder:Insufficient funds"));
+        assert!(response.result.is_none());
+    }
+
+    #[rstest]
+    fn test_deserialize_batch_add_response_partial() {
+        let data = load_test_data("ws_batch_add_response_partial.json");
+        let response: KrakenWsOrderResponse =
+            serde_json::from_str(&data).expect("Failed to parse batch_add partial response");
+
+        assert_eq!(response.method, KrakenWsMethod::BatchAdd);
+        assert_eq!(response.req_id, Some(45));
+        assert!(response.success);
+
+        let result = response.result.expect("Expected result");
+        let orders = result.orders.expect("Expected orders");
+        assert_eq!(orders.len(), 2);
+
+        assert!(orders[0].success);
+        assert_eq!(orders[0].order_id.as_deref(), Some("O1"));
+        assert_eq!(orders[0].cl_ord_id.as_deref(), Some("O-A"));
+        assert!(orders[0].error.is_none());
+
+        assert!(!orders[1].success);
+        assert!(orders[1].order_id.is_none());
+        assert_eq!(orders[1].cl_ord_id.as_deref(), Some("O-B"));
+        assert_eq!(orders[1].error.as_deref(), Some("EOrder:Invalid price"));
     }
 }

--- a/crates/adapters/kraken/src/websocket/spot_v2/parse.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/parse.rs
@@ -33,8 +33,8 @@ use nautilus_model::{
 use super::{
     enums::{KrakenExecType, KrakenLiquidityInd, KrakenWsOrderStatus},
     messages::{
-        KrakenWsBookData, KrakenWsBookLevel, KrakenWsExecutionData, KrakenWsOhlcData,
-        KrakenWsTickerData, KrakenWsTradeData,
+        KrakenSpotWsMessage, KrakenWsBookData, KrakenWsBookLevel, KrakenWsExecutionData,
+        KrakenWsOhlcData, KrakenWsOrderResponse, KrakenWsTickerData, KrakenWsTradeData,
     },
 };
 use crate::common::enums::{KrakenOrderSide, KrakenOrderType, KrakenTimeInForce};
@@ -565,6 +565,34 @@ pub fn parse_ws_fill_report(
     ))
 }
 
+/// Parses a raw WebSocket JSON string and returns [`KrakenSpotWsMessage::OrderResponse`] if the
+/// message is an order-method response envelope, or `Ok(None)` for unrecognised messages.
+///
+/// # Errors
+///
+/// Returns an error if the message appears to be an order response but cannot be deserialized.
+pub fn parse_order_response(text: &str) -> anyhow::Result<Option<KrakenSpotWsMessage>> {
+    let value: serde_json::Value =
+        serde_json::from_str(text).with_context(|| format!("Failed to parse JSON: {text}"))?;
+
+    let method_str = match value.get("method").and_then(|m| m.as_str()) {
+        Some(s) => s.to_owned(),
+        None => return Ok(None),
+    };
+
+    if !matches!(
+        method_str.as_str(),
+        "add_order" | "amend_order" | "cancel_order" | "batch_add"
+    ) {
+        return Ok(None);
+    }
+
+    let response: KrakenWsOrderResponse = serde_json::from_value(value).with_context(|| {
+        format!("Failed to deserialize order response for method '{method_str}'")
+    })?;
+    Ok(Some(KrakenSpotWsMessage::OrderResponse(response)))
+}
+
 #[cfg(test)]
 mod tests {
     use nautilus_model::{identifiers::Symbol, types::Currency};
@@ -792,5 +820,35 @@ mod tests {
     fn test_interval_to_bar_spec_invalid() {
         let result = interval_to_bar_spec(999);
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn test_parse_order_response_envelope_returns_order_response_variant() {
+        use crate::websocket::spot_v2::enums::KrakenWsMethod;
+
+        let raw = load_test_json("ws_add_order_response_success.json");
+        let parsed = parse_order_response(&raw).expect("parse ok");
+        match parsed {
+            Some(KrakenSpotWsMessage::OrderResponse(resp)) => {
+                assert_eq!(resp.method, KrakenWsMethod::AddOrder);
+                assert_eq!(resp.req_id, Some(42));
+                assert!(resp.success);
+            }
+            other => panic!("expected OrderResponse, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn test_parse_order_response_returns_none_for_non_order_method() {
+        let json = r#"{"method":"subscribe","req_id":1,"success":true}"#;
+        let result = parse_order_response(json).expect("parse ok");
+        assert!(result.is_none());
+    }
+
+    #[rstest]
+    fn test_parse_order_response_returns_none_for_data_message() {
+        let json = r#"{"channel":"ticker","type":"snapshot","data":[]}"#;
+        let result = parse_order_response(json).expect("parse ok");
+        assert!(result.is_none());
     }
 }

--- a/crates/adapters/kraken/test_data/ws_add_order_request.json
+++ b/crates/adapters/kraken/test_data/ws_add_order_request.json
@@ -1,0 +1,15 @@
+{
+  "method": "add_order",
+  "params": {
+    "order_type": "limit",
+    "side": "buy",
+    "order_qty": 0.01,
+    "symbol": "BTC/USD",
+    "limit_price": 30000.0,
+    "time_in_force": "GTC",
+    "cl_ord_id": "O-20260505-000001",
+    "post_only": true,
+    "token": "TESTTOKEN"
+  },
+  "req_id": 42
+}

--- a/crates/adapters/kraken/test_data/ws_add_order_response_failure.json
+++ b/crates/adapters/kraken/test_data/ws_add_order_response_failure.json
@@ -1,0 +1,8 @@
+{
+  "method": "add_order",
+  "req_id": 99,
+  "success": false,
+  "error": "EOrder:Insufficient funds",
+  "time_in": "2026-05-05T10:00:00.123Z",
+  "time_out": "2026-05-05T10:00:00.125Z"
+}

--- a/crates/adapters/kraken/test_data/ws_add_order_response_success.json
+++ b/crates/adapters/kraken/test_data/ws_add_order_response_success.json
@@ -1,0 +1,12 @@
+{
+  "method": "add_order",
+  "req_id": 42,
+  "success": true,
+  "time_in": "2026-05-05T10:00:00.123Z",
+  "time_out": "2026-05-05T10:00:00.125Z",
+  "result": {
+    "order_id": "OABCDE-12345-FGHIJ",
+    "cl_ord_id": "O-20260505-000001",
+    "order_userref": 0
+  }
+}

--- a/crates/adapters/kraken/test_data/ws_amend_order_request.json
+++ b/crates/adapters/kraken/test_data/ws_amend_order_request.json
@@ -1,0 +1,9 @@
+{
+  "method": "amend_order",
+  "params": {
+    "order_id": "OABCDE-12345-FGHIJ",
+    "order_qty": 0.005,
+    "token": "TESTTOKEN"
+  },
+  "req_id": 43
+}

--- a/crates/adapters/kraken/test_data/ws_batch_add_request.json
+++ b/crates/adapters/kraken/test_data/ws_batch_add_request.json
@@ -1,0 +1,12 @@
+{
+  "method": "batch_add",
+  "params": {
+    "symbol": "BTC/USD",
+    "orders": [
+      {"order_type": "limit", "side": "buy", "order_qty": 0.01, "limit_price": 30000.0, "cl_ord_id": "O-A"},
+      {"order_type": "limit", "side": "sell", "order_qty": 0.01, "limit_price": 31000.0, "cl_ord_id": "O-B"}
+    ],
+    "token": "TESTTOKEN"
+  },
+  "req_id": 45
+}

--- a/crates/adapters/kraken/test_data/ws_batch_add_response_partial.json
+++ b/crates/adapters/kraken/test_data/ws_batch_add_response_partial.json
@@ -1,0 +1,13 @@
+{
+  "method": "batch_add",
+  "req_id": 45,
+  "success": true,
+  "time_in": "2026-05-05T10:00:00.123Z",
+  "time_out": "2026-05-05T10:00:00.125Z",
+  "result": {
+    "orders": [
+      {"order_id": "O1", "cl_ord_id": "O-A", "success": true},
+      {"cl_ord_id": "O-B", "success": false, "error": "EOrder:Invalid price"}
+    ]
+  }
+}

--- a/crates/adapters/kraken/test_data/ws_cancel_order_request.json
+++ b/crates/adapters/kraken/test_data/ws_cancel_order_request.json
@@ -1,0 +1,8 @@
+{
+  "method": "cancel_order",
+  "params": {
+    "order_id": ["OABCDE-12345-FGHIJ"],
+    "token": "TESTTOKEN"
+  },
+  "req_id": 44
+}

--- a/crates/adapters/kraken/tests/spot.rs
+++ b/crates/adapters/kraken/tests/spot.rs
@@ -13,12 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! Shared primitives and utilities for the Kraken adapter.
+//! Integration tests for Kraken Spot adapter.
 
-pub mod consts;
-pub mod credential;
-pub mod enums;
-pub mod models;
-pub mod order_params;
-pub mod parse;
-pub mod urls;
+#[path = "spot/websocket_orders.rs"]
+mod websocket_orders;

--- a/crates/adapters/kraken/tests/spot/mod.rs
+++ b/crates/adapters/kraken/tests/spot/mod.rs
@@ -13,12 +13,4 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! Shared primitives and utilities for the Kraken adapter.
-
-pub mod consts;
-pub mod credential;
-pub mod enums;
-pub mod models;
-pub mod order_params;
-pub mod parse;
-pub mod urls;
+pub mod websocket_orders;

--- a/crates/adapters/kraken/tests/spot/websocket_orders.rs
+++ b/crates/adapters/kraken/tests/spot/websocket_orders.rs
@@ -1,0 +1,285 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Integration tests for Kraken Spot WebSocket order submission using a mock server.
+//!
+//! These tests verify the WS-trade routing path by:
+//! 1. Spinning up an in-process axum WebSocket server on a random port.
+//! 2. Connecting a [`KrakenSpotWebSocketClient`] to it.
+//! 3. Exercising [`OrderRequestState::submit`] and verifying that the
+//!    `add_order` JSON envelope arrives at the mock server.
+//! 4. Verifying that when the WS connection is not active no message is
+//!    forwarded to the mock server.
+
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use axum::{
+    Router,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::IntoResponse,
+    routing::get,
+};
+use futures_util::StreamExt;
+use nautilus_common::testing::wait_until_async;
+use nautilus_kraken::{
+    KrakenDataClientConfig, KrakenSpotWebSocketClient,
+    common::enums::{KrakenOrderSide, KrakenOrderType},
+    websocket::{
+        dispatch::{
+            WsDispatchState,
+            spot_orders::{OrderRequestState, PendingOperation, PendingRequest},
+        },
+        spot_v2::messages::KrakenWsAddOrderParams,
+    },
+};
+use nautilus_model::identifiers::{AccountId, ClientOrderId, TraderId};
+use rstest::rstest;
+use tokio_util::sync::CancellationToken;
+
+/// Shared state for the mock WebSocket server.
+#[derive(Clone, Default)]
+struct MockServerState {
+    received_messages: Arc<tokio::sync::Mutex<Vec<serde_json::Value>>>,
+    connection_count: Arc<tokio::sync::Mutex<usize>>,
+}
+
+impl MockServerState {
+    async fn messages(&self) -> Vec<serde_json::Value> {
+        self.received_messages.lock().await.clone()
+    }
+}
+
+async fn ws_handler(ws: WebSocketUpgrade, state: Arc<MockServerState>) -> impl IntoResponse {
+    ws.on_upgrade(|socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(socket: WebSocket, state: Arc<MockServerState>) {
+    *state.connection_count.lock().await += 1;
+
+    let (_sender, mut receiver) = socket.split();
+
+    while let Some(Ok(msg)) = receiver.next().await {
+        match msg {
+            Message::Text(text) => {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                    state.received_messages.lock().await.push(value);
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+}
+
+/// Starts a mock WebSocket server and returns its address and shared state.
+async fn start_mock_server() -> (SocketAddr, Arc<MockServerState>) {
+    let state = Arc::new(MockServerState::default());
+    let state_clone = Arc::clone(&state);
+
+    let app = Router::new().route(
+        "/v2",
+        get(move |ws| ws_handler(ws, Arc::clone(&state_clone))),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (addr, state)
+}
+
+fn make_add_order_params(symbol: &str) -> KrakenWsAddOrderParams {
+    KrakenWsAddOrderParams {
+        order_type: KrakenOrderType::Limit,
+        side: KrakenOrderSide::Buy,
+        order_qty: 0.001,
+        symbol: symbol.to_string(),
+        token: "test-token".to_string(),
+        limit_price: Some(50_000.0),
+        time_in_force: None,
+        expire_time: None,
+        cl_ord_id: Some("O-TEST-001".to_string()),
+        post_only: None,
+        reduce_only: None,
+        leverage: None,
+        trigger: None,
+        conditional: None,
+    }
+}
+
+fn make_pending_request() -> PendingRequest {
+    PendingRequest {
+        operation: PendingOperation::Submit,
+        client_order_ids: vec![ClientOrderId::new("O-TEST-001")],
+        venue_order_ids: vec![None],
+        ts_sent_ns: 0,
+        new_quantity: None,
+        new_price: None,
+        new_trigger_price: None,
+    }
+}
+
+fn build_order_request_state(
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<
+        nautilus_kraken::websocket::spot_v2::handler::SpotHandlerCommand,
+    >,
+) -> Arc<OrderRequestState> {
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let dispatch_state = Arc::new(WsDispatchState::new());
+    let req_id_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    Arc::new(OrderRequestState::new(
+        cmd_tx,
+        event_tx,
+        dispatch_state,
+        req_id_counter,
+        Duration::from_secs(5),
+        TraderId::new("TESTER-001"),
+        AccountId::new("KRAKEN-001"),
+        Arc::new(tokio::sync::RwLock::new(None)),
+        tokio_util::sync::CancellationToken::new(),
+        nautilus_core::time::get_atomic_clock_realtime(),
+    ))
+}
+
+/// Verifies that when a [`KrakenSpotWebSocketClient`] is connected and
+/// [`OrderRequestState::submit`] is called, the `add_order` JSON envelope is
+/// forwarded to the mock WebSocket server.
+#[rstest]
+#[tokio::test]
+async fn test_submit_order_via_ws_sends_add_order_message() {
+    let (addr, server_state) = start_mock_server().await;
+    let ws_url = format!("ws://{addr}/v2");
+
+    let config = KrakenDataClientConfig {
+        ws_private_url: Some(ws_url),
+        ..Default::default()
+    };
+
+    let mut ws_client = KrakenSpotWebSocketClient::new(config, CancellationToken::new(), None);
+    ws_client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let state = Arc::clone(&server_state);
+            async move { *state.connection_count.lock().await > 0 }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert!(ws_client.is_active() || ws_client.is_connected());
+
+    let cmd_tx = ws_client.handler_command_sender().await;
+    let order_state = build_order_request_state(cmd_tx);
+
+    let params = make_add_order_params("BTC/USD");
+    let pending = make_pending_request();
+
+    order_state
+        .submit(params, pending, 0)
+        .expect("submit should succeed when WS is connected");
+
+    wait_until_async(
+        || {
+            let state = Arc::clone(&server_state);
+            async move { !state.received_messages.lock().await.is_empty() }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let messages = server_state.messages().await;
+    assert!(
+        !messages.is_empty(),
+        "Mock server should have received at least one message"
+    );
+
+    let first = &messages[0];
+    assert_eq!(
+        first.get("method").and_then(|v| v.as_str()),
+        Some("add_order"),
+        "Expected method 'add_order', was {first}"
+    );
+
+    let params_json = first.get("params").expect("Expected 'params' in message");
+    assert_eq!(
+        params_json.get("symbol").and_then(|v| v.as_str()),
+        Some("BTC/USD"),
+    );
+    assert_eq!(
+        params_json.get("side").and_then(|v| v.as_str()),
+        Some("buy"),
+    );
+    assert_eq!(
+        params_json.get("order_type").and_then(|v| v.as_str()),
+        Some("limit"),
+    );
+
+    ws_client.disconnect().await.unwrap();
+}
+
+/// Verifies that when the WebSocket client is not connected (WS inactive),
+/// [`OrderRequestState::submit`] returns an error because the handler
+/// command channel's receiver is dropped before `connect()` is called.
+/// This is the same observable outcome as `use_ws_trade=false`: the WS
+/// path fails and the execution client falls back to REST.
+#[rstest]
+#[tokio::test]
+async fn test_submit_order_falls_back_to_rest_when_ws_inactive() {
+    let (addr, server_state) = start_mock_server().await;
+    let ws_url = format!("ws://{addr}/v2");
+
+    let config = KrakenDataClientConfig {
+        ws_private_url: Some(ws_url),
+        ..Default::default()
+    };
+
+    let ws_client = KrakenSpotWebSocketClient::new(config, CancellationToken::new(), None);
+
+    assert!(
+        !ws_client.is_active(),
+        "Client should be inactive before connect"
+    );
+    assert!(ws_client.is_closed());
+
+    let cmd_tx = ws_client.handler_command_sender().await;
+    let order_state = build_order_request_state(cmd_tx);
+
+    let params = make_add_order_params("BTC/USD");
+    let pending = make_pending_request();
+
+    let result = order_state.submit(params, pending, 0);
+    assert!(
+        result.is_err(),
+        "submit should fail when WS is not connected (channel closed)"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("channel closed") || err_msg.contains("closed"),
+        "Error should mention channel closed, was: {err_msg}"
+    );
+
+    let messages = server_state.messages().await;
+    assert!(
+        messages.is_empty(),
+        "Mock server should not have received any messages when WS is inactive; was {messages:?}"
+    );
+}

--- a/nautilus_trader/adapters/kraken/config.py
+++ b/nautilus_trader/adapters/kraken/config.py
@@ -172,6 +172,23 @@ class KrakenExecClientConfig(LiveExecClientConfig, frozen=True):
         Display-only: Kraken converts internally; per-position figures from
         ``OpenPositions`` remain in the traded pair's quote currency.
         Only effective when ``spot_account_type=AccountType.MARGIN``.
+    use_ws_trade : bool, default True
+        If ``True``, order submission (add/amend/cancel) uses the Kraken
+        WebSocket v2 trade channel when the connection is authenticated and
+        active. Set to ``False`` to force all order operations through the
+        REST API (useful for testing or when WebSocket trade channel is
+        unavailable).
+    ws_request_timeout_secs : PositiveInt, default 5
+        Seconds to wait for a Kraken WebSocket order-response before
+        synthesising a local rejection event (``OrderRejected`` for submit /
+        batch_add, ``OrderModifyRejected`` for amend, ``OrderCancelRejected``
+        for cancel). Submit and batch_add timeouts also fire a best-effort
+        ``cancel_order`` over the same WebSocket as a safety net against the
+        venue having accepted the order before the response was delivered;
+        any orphan order is otherwise picked up by the live execution
+        reconciliation loop. The timeout does NOT trigger an automatic REST
+        retry — the strategy must resubmit if it wants to try again. Only
+        relevant when ``use_ws_trade`` is ``True``.
 
     Examples
     --------
@@ -224,6 +241,8 @@ class KrakenExecClientConfig(LiveExecClientConfig, frozen=True):
     spot_account_type: AccountType = AccountType.CASH
     default_leverage: int | None = None
     margin_balance_asset: str | None = None
+    use_ws_trade: bool = True
+    ws_request_timeout_secs: PositiveInt = 5
 
     def __post_init__(self) -> None:
         if self.default_leverage is not None and self.spot_account_type != AccountType.MARGIN:

--- a/tests/integration_tests/adapters/kraken/test_config.py
+++ b/tests/integration_tests/adapters/kraken/test_config.py
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.adapters.kraken.config import KrakenExecClientConfig
+
+
+def test_kraken_exec_client_config_defaults_use_ws_trade_true() -> None:
+    cfg = KrakenExecClientConfig()
+    assert cfg.use_ws_trade is True
+    assert cfg.ws_request_timeout_secs == 5
+
+
+def test_kraken_exec_client_config_can_disable_ws_trade() -> None:
+    cfg = KrakenExecClientConfig(use_ws_trade=False, ws_request_timeout_secs=10)
+    assert cfg.use_ws_trade is False
+    assert cfg.ws_request_timeout_secs == 10


### PR DESCRIPTION
Closes #4000

Implements WebSocket v2 order submission for the Kraken Spot adapter, routing `add_order`, `amend_order`, `cancel_order`, and `batch_add` through the authenticated WS connection rather than REST by default.

## Summary

- **Per-call WS routing.** `submit_order`, `modify_order`, `cancel_order`, and `submit_order_list` use the WS v2 trade channel when `use_ws_trade=True` (default) and the socket is active; the per-call `use_ws_trade=False` config flag forces REST.
- **`batch_add` support.** `submit_order_list` dispatches all legs in a single `batch_add` WS message, including leverage, trigger, expire_time, time-in-force, post-only and reduce-only on each leg. The response is matched per-leg by the echoed `cl_ord_id` (with positional fallback) so out-of-order or truncated vendor responses cannot misattribute venue order ids.
- **`req_id` correlation.** Outbound requests carry a monotonic `req_id`; responses are correlated against the pending map before emitting events. Late responses arriving after eviction are logged and dropped.
- **Order types and modifiers.** Limit, market, stop-loss, stop-limit, take-profit, take-profit-limit, trailing-stop, and trailing-stop-limit. Conditional types carry a `trigger` block; `GTD` carries an RFC3339 `expire_time`. `FOK` falls through to REST (Kraken WS v2 has no FOK value in its time-in-force enum). Quote-quantity orders also route via REST since their dispatch identity is intentionally not registered with the WS dispatcher.
- **`ws_request_timeout_secs`.** When the venue does not respond inside the window the dispatch synthesises a local `OrderRejected` (or `OrderModifyRejected` / `OrderCancelRejected`) carrying the timeout-fire timestamp, and for `submit_order` / `batch_add` also fires a best-effort `cancel_order` over the same WebSocket so a delayed venue acceptance is not left as an orphan. Reconciliation is the recovery path if the compensating cancel does not land. Pending timeout tasks are abortable via the client cancellation token so shutdown does not wait for in-flight timers.
- **Margin trading.** `default_leverage` from `KrakenExecClientConfig` (and per-order `params["leverage"]`) flows through both single-submit and `batch_add` WS payloads.

## New files

- `crates/adapters/kraken/src/common/order_params.rs` — pure builder functions for WS request param structs.
- `crates/adapters/kraken/src/websocket/dispatch/spot_orders.rs` — `OrderRequestState` tracking pending WS requests, response correlation, timeout, compensating cancel and event emission.

## Live smoke tests

`./.local-kraken-qualifier/ws_order_smoke.py` exercises the full WS surface against a real Kraken account; the captures below predate a few subsequent code-review fixes and a pair switch from `BTC/USD` to `BTC/USDT` (the test account ran low on `ZUSD`), but each step proves the WS round-trip and event emission for that mode.

Post-run balance diff showed only timestamp and floating-equity drift; no asset balance changes, no open orders, no open positions.

<details>
<summary>Step 1 — Pre-run account snapshot (PASS)</summary>

```
open_orders:    0
open_positions: 0
```

</details>

<details>
<summary>Step 2 — ws-order: add_order + cancel_order via WebSocket (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,370.70
[INFO] Submitted limit buy post_only 80%-of-market coid=O-20260506-062942-001-000-1
[PASS] OrderAccepted via WebSocket
[PASS] OrderCanceled via WebSocket

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 3 — ws-modify: amend_order (price change) via WebSocket (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,373.90
[INFO] Submitted limit buy post_only 80%-of-market coid=O-20260506-063006-001-000-1
[PASS] OrderAccepted (before modify)
[INFO] Amending order to 75%-of-market price=61030.4
[PASS] OrderUpdated via WebSocket amend_order
[PASS] OrderCanceled after amend

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderUpdated': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 4 — ws-modify-qty: amend_order (quantity change) carries new qty in OrderUpdated (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,577.40
[INFO] Submitted limit buy qty=0.0002 post_only 20%-of-market coid=O-20260506-072325-001-000-1
[PASS] OrderAccepted (before modify)
[INFO] Amending order quantity 0.0002 → 0.0001 (price unchanged)
[PASS] OrderUpdated.quantity reflects amend (0.0001)
[PASS] OrderCanceled after amend

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderUpdated': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 5 — ws-fok-fallback: FOK on WS path bails and routes via REST (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,566.50
[INFO] Submitted FOK limit buy at 50%-of-market coid=O-20260506-072340-001-000-1
[INFO] (FOK not supported on Kraken WS v2 → expect REST fallback then exchange-side kill)
[PASS] FOK order reached venue via REST (OrderAccepted); WS path correctly bailed and routing fell back

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1}
```

</details>

<details>
<summary>Step 6 — ws-fallback: use_ws_trade=False routes through REST (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,373.90
[INFO] Submitted limit buy use_ws_trade=False coid=O-20260506-063021-001-000-1
[INFO] (use_ws_trade=False → expect REST add_order path)
[PASS] OrderAccepted via REST fallback (use_ws_trade=False)
[PASS] OrderCanceled via REST fallback

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 7 — ws-batch: batch_add 2-order list via WebSocket (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,338.60
[INFO] Submitting OrderList [BUY, BUY] same-symbol via batch_add WebSocket
[INFO] Submitted 2-order list: ['O-20260506-063037-001-000-1', 'O-20260506-063037-001-000-2']
[PASS] Both orders accepted via batch_add WebSocket (count=2)
[PASS] Both orders canceled (OrderCanceled count=2)

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 2, 'OrderCanceled': 2}
```

</details>

<details>
<summary>Step 8 — ws-timeout: ws_request_timeout_secs=1 accepted, fast response beats timeout (PASS)</summary>

```
[INFO] Oracle BTC/USD.KRAKEN price: 81,338.60
[INFO] ws_request_timeout_secs=1 — submitting order; fast Kraken WS response expected
[INFO] Submitted coid=O-20260506-063056-001-000-1
[PASS] OrderAccepted — fast WS response beat 1s timeout (timeout config accepted)
[PASS] OrderCanceled

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 9 — ws-margin: leveraged add_order via WebSocket (PASS)</summary>

```
[INFO] Oracle ETH/BTC.KRAKEN price: 0.02908000
[INFO] Submitted leveraged limit buy (ETH/BTC, leverage=2, post_only) 80%-of-market coid=O-20260506-063113-001-000-1
[PASS] OrderAccepted via WebSocket margin add_order (leverage field sent)
[PASS] OrderCanceled margin order

────────────────────────────────────────────────────────────
Events captured: {'OrderAccepted': 1, 'OrderCanceled': 1}
```

</details>

<details>
<summary>Step 10 — Post-run account snapshot diff (PASS)</summary>

```diff
  "ts": changed (wall-clock only)
  "trade_balance": eb/tb/e/mf/mfo changed by ~0.02–0.04 USD
```

No asset balance changes. No open orders. No open positions. Trade balance delta is floating equity movement from BTC/ETH market prices during the ~3-minute run window.

</details>
