### PR TITLE
Make arrow support optional

### DIFF
--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["rlib", "staticlib"]
 
 [features]
 default = []
+arrow = ["dep:arrow"]
 extension-module = [
   "nautilus-core/extension-module",
   "python",
@@ -29,6 +30,7 @@ extension-module = [
 ]
 ffi = ["cbindgen", "nautilus-core/ffi"]
 python = ["nautilus-core/python", "pyo3", "pyo3-stub-gen"]
+python-arrow = ["python", "arrow"]
 stubs = ["bon", "rstest"]
 high-precision = []
 # DeFi domain model requires 18-decimal wei precision, implying `high-precision`
@@ -44,7 +46,7 @@ nautilus-core = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
-arrow = { workspace = true }
+arrow = { workspace = true, optional = true }
 chrono = { workspace = true }
 derive_builder = { workspace = true }
 enum_dispatch = { workspace = true }

--- a/crates/model/src/data/mod.rs
+++ b/crates/model/src/data/mod.rs
@@ -74,16 +74,19 @@ pub use option_chain::{OptionChainSlice, OptionGreeks, OptionStrikeData, StrikeR
 pub use order::{BookOrder, NULL_ORDER};
 pub use prices::{IndexPriceUpdate, MarkPriceUpdate};
 pub use quote::QuoteTick;
+#[cfg(feature = "arrow")]
 pub use registry::{
-    ArrowDecoder, ArrowEncoder, decode_custom_from_arrow, deserialize_custom_from_json,
-    encode_custom_to_arrow, ensure_arrow_registered, ensure_json_deserializer_registered,
-    get_arrow_schema, register_arrow, register_json_deserializer,
+    ArrowDecoder, ArrowEncoder, decode_custom_from_arrow, encode_custom_to_arrow,
+    ensure_arrow_registered, get_arrow_schema, register_arrow,
 };
 #[cfg(feature = "python")]
 pub use registry::{
     PyExtractor, ensure_py_extractor_registered, ensure_rust_extractor_factory_registered,
     ensure_rust_extractor_registered, get_rust_extractor, register_py_extractor,
     register_rust_extractor, register_rust_extractor_factory, try_extract_from_py,
+};
+pub use registry::{
+    deserialize_custom_from_json, ensure_json_deserializer_registered, register_json_deserializer,
 };
 pub use status::InstrumentStatus;
 pub use trade::TradeTick;

--- a/crates/model/src/data/registry.rs
+++ b/crates/model/src/data/registry.rs
@@ -19,8 +19,9 @@
 //! The registry only stores type name -> callbacks for lookup; each type provides
 //! its own deserialize/encode/decode via the trait or registration.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
+#[cfg(feature = "arrow")]
 use arrow::{datatypes::Schema, record_batch::RecordBatch};
 use dashmap::{DashMap, mapref::entry::Entry};
 use nautilus_core::Params;
@@ -31,14 +32,22 @@ use crate::data::{CustomData, CustomDataTrait, Data, DataType};
 
 pub type JsonDeserializer =
     Box<dyn Fn(serde_json::Value) -> Result<Arc<dyn CustomDataTrait>, anyhow::Error> + Send + Sync>;
+#[cfg(feature = "arrow")]
 pub type ArrowEncoder =
     Box<dyn Fn(&[Arc<dyn CustomDataTrait>]) -> Result<RecordBatch, anyhow::Error> + Send + Sync>;
+#[cfg(feature = "arrow")]
 pub type ArrowDecoder = Box<
-    dyn Fn(&HashMap<String, String>, RecordBatch) -> Result<Vec<Data>, anyhow::Error> + Send + Sync,
+    dyn Fn(
+            &std::collections::HashMap<String, String>,
+            RecordBatch,
+        ) -> Result<Vec<Data>, anyhow::Error>
+        + Send
+        + Sync,
 >;
 
 struct Registries {
     json: DashMap<String, JsonDeserializer>,
+    #[cfg(feature = "arrow")]
     arrow: DashMap<String, (Arc<Schema>, ArrowEncoder, ArrowDecoder)>,
 }
 
@@ -46,6 +55,7 @@ fn registries() -> &'static Registries {
     static REGISTRIES: std::sync::OnceLock<Registries> = std::sync::OnceLock::new();
     REGISTRIES.get_or_init(|| Registries {
         json: DashMap::new(),
+        #[cfg(feature = "arrow")]
         arrow: DashMap::new(),
     })
 }
@@ -146,6 +156,7 @@ pub fn deserialize_custom_from_json(
 ///
 /// # Errors
 /// Returns an error if the type is already registered for Arrow.
+#[cfg(feature = "arrow")]
 pub fn register_arrow(
     type_name: &str,
     schema: Arc<Schema>,
@@ -170,6 +181,7 @@ pub fn register_arrow(
 ///
 /// # Errors
 /// Does not return an error (idempotent insert into `DashMap`).
+#[cfg(feature = "arrow")]
 pub fn ensure_arrow_registered(
     type_name: &str,
     schema: Arc<Schema>,
@@ -185,6 +197,7 @@ pub fn ensure_arrow_registered(
 
 /// Returns the Arrow schema for the given custom type name, if registered.
 #[must_use]
+#[cfg(feature = "arrow")]
 pub fn get_arrow_schema(type_name: &str) -> Option<Arc<Schema>> {
     let reg = registries();
     reg.arrow
@@ -196,6 +209,7 @@ pub fn get_arrow_schema(type_name: &str) -> Option<Arc<Schema>> {
 ///
 /// # Errors
 /// Returns an error if the type is not registered or encoding fails.
+#[cfg(feature = "arrow")]
 pub fn encode_custom_to_arrow(
     type_name: &str,
     items: &[Arc<dyn CustomDataTrait>],
@@ -217,9 +231,10 @@ pub fn encode_custom_to_arrow(
     clippy::implicit_hasher,
     reason = "callers always use the default hasher"
 )]
+#[cfg(feature = "arrow")]
 pub fn decode_custom_from_arrow(
     type_name: &str,
-    metadata: &HashMap<String, String>,
+    metadata: &std::collections::HashMap<String, String>,
     record_batch: RecordBatch,
 ) -> Result<Option<Vec<Data>>, anyhow::Error> {
     let reg = registries();
@@ -567,6 +582,35 @@ mod tests {
         assert!(
             err_msg.contains("already registered"),
             "expected 'already registered' in error, found: {err_msg}"
+        );
+    }
+
+    #[rstest]
+    #[cfg(feature = "arrow")]
+    fn ensure_arrow_registered_is_idempotent() {
+        let schema = Arc::new(arrow::datatypes::Schema::empty());
+        let encoder: ArrowEncoder = Box::new(|_| {
+            Ok(arrow::record_batch::RecordBatch::new_empty(Arc::new(
+                arrow::datatypes::Schema::empty(),
+            )))
+        });
+        let decoder: ArrowDecoder = Box::new(|_, _| Ok(Vec::new()));
+
+        let r1 = ensure_arrow_registered("IdempotentTestArrow", schema, encoder, decoder);
+        assert!(r1.is_ok(), "first Arrow registration should succeed");
+
+        let schema2 = Arc::new(arrow::datatypes::Schema::empty());
+        let encoder2: ArrowEncoder = Box::new(|_| {
+            Ok(arrow::record_batch::RecordBatch::new_empty(Arc::new(
+                arrow::datatypes::Schema::empty(),
+            )))
+        });
+        let decoder2: ArrowDecoder = Box::new(|_, _| Ok(Vec::new()));
+
+        let r2 = ensure_arrow_registered("IdempotentTestArrow", schema2, encoder2, decoder2);
+        assert!(
+            r2.is_ok(),
+            "second Arrow registration with same type_name should be idempotent"
         );
     }
 }

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -35,6 +35,8 @@
 //!
 //! - `ffi`: Enables the C foreign function interface (FFI) from [cbindgen](https://github.com/mozilla/cbindgen).
 //! - `python`: Enables Python bindings from [PyO3](https://pyo3.rs).
+//! - `arrow`: Enables Apache Arrow schema and `RecordBatch` registries for custom data.
+//! - `python-arrow`: Enables Python bindings together with `PyArrow` `RecordBatch` bridging.
 //! - `stubs`: Enables type stubs for use in testing scenarios.
 //! - `high-precision`: Enables [high-precision mode](https://nautilustrader.io/docs/nightly/getting_started/installation#precision-mode) to use 128-bit value types.
 //! - `defi`: Enables the DeFi (Decentralized Finance) domain model.

--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -415,7 +415,7 @@ fn py_json_deserialize_custom_data(
 
 /// Encodes `CustomData` items to `RecordBatch` via Python `encode_record_batch_py`.
 #[allow(unsafe_code)]
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python", feature = "arrow"))]
 fn py_encode_custom_data_to_record_batch(
     items: &[std::sync::Arc<dyn crate::data::CustomDataTrait>],
 ) -> Result<arrow::record_batch::RecordBatch, anyhow::Error> {
@@ -468,7 +468,7 @@ fn py_encode_custom_data_to_record_batch(
 
 /// Decodes `RecordBatch` to `CustomData` via Python `decode_record_batch_py`.
 #[allow(unsafe_code)]
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python", feature = "arrow"))]
 fn py_decode_record_batch_to_custom_data(
     data_class: &pyo3::Py<pyo3::PyAny>,
     metadata: &std::collections::HashMap<String, String>,
@@ -565,17 +565,18 @@ pub fn register_custom_data_class(data_class: &Bound<'_, PyAny>) -> PyResult<()>
 
     let _py = data_class.py();
 
-    if !data_class.hasattr("decode_record_batch_py")? {
-        return Err(to_pytype_err(
-            "Custom data class must have decode_record_batch_py(metadata, batch) class method",
-        ));
-    }
-
     let type_name: String = if data_class.hasattr("type_name_static")? {
         data_class.call_method0("type_name_static")?.extract()?
     } else {
         data_class.getattr("__name__")?.extract()?
     };
+
+    #[cfg(feature = "arrow")]
+    if !data_class.hasattr("decode_record_batch_py")? {
+        return Err(to_pytype_err(
+            "Custom data class must have decode_record_batch_py(metadata, batch) class method",
+        ));
+    }
 
     if !data_class.hasattr("from_json")? {
         return Err(to_pytype_err(
@@ -590,7 +591,6 @@ pub fn register_custom_data_class(data_class: &Bound<'_, PyAny>) -> PyResult<()>
     }
 
     let data_class_for_json = data_class.clone().unbind();
-    let data_class_for_decode = data_class.clone().unbind();
 
     let json_deserializer = Box::new(
         move |value: serde_json::Value| -> Result<Arc<dyn crate::data::CustomDataTrait>, anyhow::Error> {
@@ -606,34 +606,38 @@ pub fn register_custom_data_class(data_class: &Bound<'_, PyAny>) -> PyResult<()>
         ))
     })?;
 
-    let schema = Arc::new(arrow::datatypes::Schema::empty());
+    #[cfg(feature = "arrow")]
+    {
+        let data_class_for_decode = data_class.clone().unbind();
+        let schema = Arc::new(arrow::datatypes::Schema::empty());
 
-    let encoder = Box::new(
-        move |items: &[Arc<dyn crate::data::CustomDataTrait>]| -> Result<
-            arrow::record_batch::RecordBatch,
-            anyhow::Error,
-        > { py_encode_custom_data_to_record_batch(items) },
-    );
+        let encoder = Box::new(
+            move |items: &[Arc<dyn crate::data::CustomDataTrait>]| -> Result<
+                arrow::record_batch::RecordBatch,
+                anyhow::Error,
+            > { py_encode_custom_data_to_record_batch(items) },
+        );
 
-    let decoder = Box::new(
-        move |metadata: &std::collections::HashMap<String, String>,
-              batch: arrow::record_batch::RecordBatch|
-              -> Result<Vec<crate::data::Data>, anyhow::Error> {
-            pyo3::Python::attach(|py| {
-                py_decode_record_batch_to_custom_data(
-                    &data_class_for_decode.clone_ref(py),
-                    metadata,
-                    batch,
-                )
-            })
-        },
-    );
+        let decoder = Box::new(
+            move |metadata: &std::collections::HashMap<String, String>,
+                  batch: arrow::record_batch::RecordBatch|
+                  -> Result<Vec<crate::data::Data>, anyhow::Error> {
+                pyo3::Python::attach(|py| {
+                    py_decode_record_batch_to_custom_data(
+                        &data_class_for_decode.clone_ref(py),
+                        metadata,
+                        batch,
+                    )
+                })
+            },
+        );
 
-    registry::ensure_arrow_registered(&type_name, schema, encoder, decoder).map_err(|e| {
-        to_pyruntime_err(format!(
-            "Failed to register Arrow encoder/decoder for {type_name}: {e}"
-        ))
-    })?;
+        registry::ensure_arrow_registered(&type_name, schema, encoder, decoder).map_err(|e| {
+            to_pyruntime_err(format!(
+                "Failed to register Arrow encoder/decoder for {type_name}: {e}"
+            ))
+        })?;
+    }
 
     Ok(())
 }

--- a/crates/serialization/Cargo.toml
+++ b/crates/serialization/Cargo.toml
@@ -33,7 +33,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-arrow = ["dep:arrow"]
+arrow = ["dep:arrow", "nautilus-model/arrow"]
 capnp = ["dep:capnp"]
 display = ["arrow"]
 sbe = []


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Downstream users that only need the core model types should not have to compile Arrow and its transitive dependency tree. This change makes Arrow support explicit and opt-in, while preserving existing Arrow-based catalog, serialization, and PyArrow integration paths for crates that need them.

- Make `arrow` an optional dependency of `nautilus-model`.
- Keep Arrow out of the default `nautilus-model` dependency graph to reduce redundant downstream dependencies, build size, and compile time.
- Gate custom data Arrow registry APIs behind `nautilus-model/arrow`.
- Keep Python JSON custom data registration available without Arrow.
- Move PyArrow `RecordBatch` bridging behind `python-arrow`.
- Propagate `nautilus-model/arrow` from `nautilus-serialization/arrow`.

## Type of change

- [x] Improvement (non-breaking)
