### PR TITLE
Drop unrepresentable IB market data tick sizes

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -58,6 +58,8 @@ from nautilus_trader.model.enums import AggressorSide
 from nautilus_trader.model.enums import BookAction
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.objects import Quantity
 
 
 # Used to invalidate abnormal tick sizes that can signal data issues
@@ -762,6 +764,10 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
 
         instrument_id = InstrumentId.from_str(subscription.name[0])
         instrument = self._cache.instrument(instrument_id)
+        if instrument is None:
+            self._log.error(f"Cannot find instrument for {instrument_id}")
+            return
+
         ts_event = pd.Timestamp.fromtimestamp(time, tz=pytz.utc).value
 
         price_magnifier = (
@@ -771,13 +777,28 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         )
         converted_bid_price = ib_price_to_nautilus_price(bid_price, price_magnifier)
         converted_ask_price = ib_price_to_nautilus_price(ask_price, price_magnifier)
+        bid_qty = self._make_market_data_qty(
+            instrument=instrument,
+            instrument_id=instrument_id,
+            size=bid_size,
+            size_name="bid_size",
+        )
+        ask_qty = self._make_market_data_qty(
+            instrument=instrument,
+            instrument_id=instrument_id,
+            size=ask_size,
+            size_name="ask_size",
+        )
+
+        if bid_qty is None or ask_qty is None:
+            return
 
         quote_tick = QuoteTick(
             instrument_id=instrument_id,
             bid_price=instrument.make_price(converted_bid_price),
             ask_price=instrument.make_price(converted_ask_price),
-            bid_size=instrument.make_qty(bid_size),
-            ask_size=instrument.make_qty(ask_size),
+            bid_size=bid_qty,
+            ask_size=ask_qty,
             ts_event=ts_event,
             ts_init=max(self._clock.timestamp_ns(), ts_event),  # `ts_event` <= `ts_init`
         )
@@ -808,6 +829,20 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
 
         instrument_id = InstrumentId.from_str(subscription.name[0])
         instrument = self._cache.instrument(instrument_id)
+        if instrument is None:
+            self._log.error(f"Cannot find instrument for {instrument_id}")
+            return
+
+        qty = self._make_market_data_qty(
+            instrument=instrument,
+            instrument_id=instrument_id,
+            size=size,
+            size_name="size",
+        )
+
+        if qty is None:
+            return
+
         ts_event = pd.Timestamp.fromtimestamp(time, tz=pytz.utc).value
 
         price_magnifier = (
@@ -820,7 +855,7 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         trade_tick = TradeTick(
             instrument_id=instrument_id,
             price=instrument.make_price(converted_price),
-            size=instrument.make_qty(size),
+            size=qty,
             aggressor_side=AggressorSide.NO_AGGRESSOR,
             trade_id=generate_trade_id(ts_event=ts_event, price=converted_price, size=size),
             ts_event=ts_event,
@@ -926,6 +961,10 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             # Create quote tick
             instrument_id = InstrumentId.from_str(subscription.name[0])
             instrument = self._cache.instrument(instrument_id)
+            if instrument is None:
+                self._log.error(f"Cannot find instrument for {instrument_id}")
+                return
+
             ts_event = self._clock.timestamp_ns()
             price_magnifier = (
                 self._instrument_provider.get_price_magnifier(instrument_id)
@@ -934,13 +973,28 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             )
             converted_bid_price = ib_price_to_nautilus_price(bid_price, price_magnifier)
             converted_ask_price = ib_price_to_nautilus_price(ask_price, price_magnifier)
+            bid_qty = self._make_market_data_qty(
+                instrument=instrument,
+                instrument_id=instrument_id,
+                size=bid_size,
+                size_name="bid_size",
+            )
+            ask_qty = self._make_market_data_qty(
+                instrument=instrument,
+                instrument_id=instrument_id,
+                size=ask_size,
+                size_name="ask_size",
+            )
+
+            if bid_qty is None or ask_qty is None:
+                return
 
             quote_tick = QuoteTick(
                 instrument_id=instrument_id,
                 bid_price=instrument.make_price(converted_bid_price),
                 ask_price=instrument.make_price(converted_ask_price),
-                bid_size=instrument.make_qty(bid_size),
-                ask_size=instrument.make_qty(ask_size),
+                bid_size=bid_qty,
+                ask_size=ask_qty,
                 ts_event=ts_event,
                 ts_init=ts_event,
             )
@@ -1121,6 +1175,11 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         if request := self._requests.get(req_id=req_id):
             instrument_id = InstrumentId.from_str(request.name[0])
             instrument = self._cache.instrument(instrument_id)
+            if instrument is None:
+                self._log.error(f"Cannot find instrument for {instrument_id}")
+                self._end_request(req_id)
+                return
+
             price_magnifier = (
                 self._instrument_provider.get_price_magnifier(instrument_id)
                 if self._instrument_provider
@@ -1131,13 +1190,28 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
                 ts_event = pd.Timestamp.fromtimestamp(tick.time, tz=pytz.utc).value
                 converted_bid_price = ib_price_to_nautilus_price(tick.priceBid, price_magnifier)
                 converted_ask_price = ib_price_to_nautilus_price(tick.priceAsk, price_magnifier)
+                bid_qty = self._make_market_data_qty(
+                    instrument=instrument,
+                    instrument_id=instrument_id,
+                    size=tick.sizeBid,
+                    size_name="bid_size",
+                )
+                ask_qty = self._make_market_data_qty(
+                    instrument=instrument,
+                    instrument_id=instrument_id,
+                    size=tick.sizeAsk,
+                    size_name="ask_size",
+                )
+
+                if bid_qty is None or ask_qty is None:
+                    continue
 
                 quote_tick = QuoteTick(
                     instrument_id=instrument_id,
                     bid_price=instrument.make_price(converted_bid_price),
                     ask_price=instrument.make_price(converted_ask_price),
-                    bid_size=instrument.make_qty(tick.sizeBid),
-                    ask_size=instrument.make_qty(tick.sizeAsk),
+                    bid_size=bid_qty,
+                    ask_size=ask_qty,
                     ts_event=ts_event,
                     ts_init=ts_event,
                 )
@@ -1364,6 +1438,10 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
         if request := self._requests.get(req_id=req_id):
             instrument_id = InstrumentId.from_str(request.name[0])
             instrument = self._cache.instrument(instrument_id)
+            if instrument is None:
+                self._log.error(f"Cannot find instrument for {instrument_id}")
+                self._end_request(req_id)
+                return
 
             price_magnifier = (
                 self._instrument_provider.get_price_magnifier(instrument_id)
@@ -1374,11 +1452,20 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             for tick in ticks:
                 ts_event = pd.Timestamp.fromtimestamp(tick.time, tz=pytz.utc).value
                 converted_price = ib_price_to_nautilus_price(tick.price, price_magnifier)
+                qty = self._make_market_data_qty(
+                    instrument=instrument,
+                    instrument_id=instrument_id,
+                    size=tick.size,
+                    size_name="size",
+                )
+
+                if qty is None:
+                    continue
 
                 trade_tick = TradeTick(
                     instrument_id=instrument_id,
                     price=instrument.make_price(converted_price),
-                    size=instrument.make_qty(tick.size),
+                    size=qty,
                     aggressor_side=AggressorSide.NO_AGGRESSOR,
                     trade_id=generate_trade_id(
                         ts_event=ts_event,
@@ -1391,6 +1478,23 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
                 request.result.append(trade_tick)
 
             self._end_request(req_id)
+
+    def _make_market_data_qty(
+        self,
+        instrument: Instrument,
+        instrument_id: InstrumentId,
+        size: Decimal,
+        size_name: str,
+    ) -> Quantity | None:
+        try:
+            return instrument.make_qty(size)
+        except ValueError as e:
+            self._log.debug(
+                f"Ignoring market data tick for {instrument_id}: {size_name}={size} cannot be "
+                f"represented with size_precision={instrument.size_precision} and "
+                f"size_increment={instrument.size_increment}: {e}",
+            )
+            return None
 
     async def _handle_data(self, data: Data) -> None:
         """

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 from ibapi.common import BarData
+from ibapi.common import HistoricalTickBidAsk
 from ibapi.common import HistoricalTickLast
 from ibapi.common import TickAttribBidAsk
 from ibapi.common import TickAttribLast
@@ -1025,6 +1026,80 @@ async def test_process_trade_ticks(ib_client):
 
 
 @pytest.mark.asyncio
+async def test_process_trade_ticks_skips_fractional_size_below_increment(ib_client):
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    ib_client._cache.add_instrument(instrument)
+    mock_request = Mock(spec=Request)
+    mock_request.name = [str(instrument.id)]
+    mock_request.result = []
+    ib_client._requests = Mock()
+    ib_client._requests.get.return_value = mock_request
+
+    request_id = 1
+    fractional_tick = HistoricalTickLast()
+    fractional_tick.time = 1704067200
+    fractional_tick.price = 100.01
+    fractional_tick.size = Decimal("0.5")
+    valid_tick = HistoricalTickLast()
+    valid_tick.time = 1704067205
+    valid_tick.price = 105.01
+    valid_tick.size = Decimal(200)
+
+    # Act
+    await ib_client._process_trade_ticks(request_id, [fractional_tick, valid_tick])
+
+    # Assert
+    assert len(mock_request.result) == 1
+    result = mock_request.result[0]
+    assert result.instrument_id == InstrumentId.from_str("AAPL.NASDAQ")
+    assert result.price == Price(105.01, precision=2)
+    assert result.size == Quantity(200, precision=0)
+    assert result.trade_id == TradeId("1704067205-105.01-200")
+
+
+@pytest.mark.asyncio
+async def test_process_historical_ticks_bid_ask_skips_fractional_size_below_increment(ib_client):
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    ib_client._cache.add_instrument(instrument)
+    mock_request = Mock(spec=Request)
+    mock_request.name = [str(instrument.id)]
+    mock_request.result = []
+    ib_client._requests = Mock()
+    ib_client._requests.get.return_value = mock_request
+
+    fractional_tick = HistoricalTickBidAsk()
+    fractional_tick.time = 1704067200
+    fractional_tick.priceBid = 100.01
+    fractional_tick.priceAsk = 100.02
+    fractional_tick.sizeBid = Decimal("0.5")
+    fractional_tick.sizeAsk = Decimal(200)
+    valid_tick = HistoricalTickBidAsk()
+    valid_tick.time = 1704067205
+    valid_tick.priceBid = 105.01
+    valid_tick.priceAsk = 105.02
+    valid_tick.sizeBid = Decimal(100)
+    valid_tick.sizeAsk = Decimal(200)
+
+    # Act
+    await ib_client.process_historical_ticks_bid_ask(
+        req_id=1,
+        ticks=[fractional_tick, valid_tick],
+        done=True,
+    )
+
+    # Assert
+    assert len(mock_request.result) == 1
+    result = mock_request.result[0]
+    assert result.instrument_id == InstrumentId.from_str("AAPL.NASDAQ")
+    assert result.bid_price == Price(105.01, precision=2)
+    assert result.ask_price == Price(105.02, precision=2)
+    assert result.bid_size == Quantity(100, precision=0)
+    assert result.ask_size == Quantity(200, precision=0)
+
+
+@pytest.mark.asyncio
 async def test_tickByTickBidAsk(ib_client):
     # Arrange
     ib_client._clock.set_time(1704067205000000000)
@@ -1056,6 +1131,33 @@ async def test_tickByTickBidAsk(ib_client):
         ts_init=1704067205000000000,
     )
     ib_client._handle_data.assert_called_once_with(quote_tick)
+
+
+@pytest.mark.asyncio
+async def test_tick_by_tick_bid_ask_skips_fractional_size_below_increment(ib_client):
+    # Arrange
+    ib_client._clock.set_time(1704067205000000000)
+    instrument = IBTestContractStubs.aapl_instrument()
+    ib_client._cache.add_instrument(instrument)
+    mock_subscription = Mock(spec=Subscription)
+    mock_subscription.name = [str(instrument.id)]
+    ib_client._subscriptions = Mock()
+    ib_client._subscriptions.get.return_value = mock_subscription
+    ib_client._handle_data = AsyncMock()
+
+    # Act
+    await ib_client.process_tick_by_tick_bid_ask(
+        req_id=1,
+        time=1704067200,
+        bid_price=100.01,
+        ask_price=100.02,
+        bid_size=Decimal("0.5"),
+        ask_size=Decimal(200),
+        tick_attrib_bid_ask=TickAttribBidAsk(),
+    )
+
+    # Assert
+    ib_client._handle_data.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1091,6 +1193,34 @@ async def test_tickByTickAllLast(ib_client):
         ts_init=1704067205000000000,
     )
     ib_client._handle_data.assert_called_once_with(trade_tick)
+
+
+@pytest.mark.asyncio
+async def test_tick_by_tick_all_last_skips_fractional_size_below_increment(ib_client):
+    # Arrange
+    ib_client._clock.set_time(1704067205000000000)
+    instrument = IBTestContractStubs.aapl_instrument()
+    ib_client._cache.add_instrument(instrument)
+    mock_subscription = Mock(spec=Subscription)
+    mock_subscription.name = [str(instrument.id)]
+    ib_client._subscriptions = Mock()
+    ib_client._subscriptions.get.return_value = mock_subscription
+    ib_client._handle_data = AsyncMock()
+
+    # Act
+    await ib_client.process_tick_by_tick_all_last(
+        req_id=1,
+        tick_type="AllLast",
+        time=1704067200,
+        price=100.01,
+        size=Decimal("0.5"),
+        tick_attrib_last=TickAttribLast(),
+        exchange="",
+        special_conditions="",
+    )
+
+    # Assert
+    ib_client._handle_data.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes Interactive Brokers market data dispatch stalling when IB emits fractional tick sizes that cannot be represented by the cached instrument size precision.
- Adds a shared quantity conversion helper for IB market data paths, so invalid sizes are debug-logged and skipped before constructing Nautilus `QuoteTick` or `TradeTick` objects.
- Applies the guard to live tick-by-tick bid/ask data, live tick-by-tick all-last trades, historical bid/ask ticks, and historical trade ticks.
- Adds regression coverage for AAPL-style equity instruments with `size_precision=0` receiving `Decimal("0.5")` sizes.

### Design notes

- The fix follows the Databento adapter pattern of resolving or validating feed precision before constructing Nautilus model values.
- IB differs from Databento because the affected sizes arrive as decimal quantities for instruments that only support whole-share quantities. Databento feed sizes are decoded as integral quantities, so this guard is specific to the IB adapter.
- Dropping unrepresentable market data ticks is preferable to rounding fractional prints into actionable whole-share sizes.
- Missing cached instruments now log an error before returning from the affected conversion paths.

### Files changed

- `nautilus_trader/adapters/interactive_brokers/client/market_data.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py`

### Verification

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py`.
- `uv run --active --no-sync ruff format nautilus_trader/adapters/interactive_brokers/client/market_data.py tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py`.
- `uv run --active --no-sync ruff check nautilus_trader/adapters/interactive_brokers/client/market_data.py tests/integration_tests/adapters/interactive_brokers/client/test_client_market_data.py`.
- `git diff --check`.

### Risk

- Low to medium. The change only affects IB market data conversion and skips ticks that already could not be represented without raising.
- Consumers may see fewer IB trade or quote ticks when the feed contains fractional sizes for whole-share instruments, but this avoids dispatch task failures and preserves valid ticks.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3951

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
