### PR TITLE
Fix IB shutdown reader RuntimeError

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -62,9 +62,20 @@ from nautilus_trader.cache.cache import Cache
 from nautilus_trader.common.component import Component
 from nautilus_trader.common.component import LiveClock
 from nautilus_trader.common.component import MessageBus
+from nautilus_trader.common.enums import ComponentState
 from nautilus_trader.common.enums import LogColor
 from nautilus_trader.model.identifiers import ClientId
 from nautilus_trader.model.identifiers import VenueOrderId
+
+
+_SHUTDOWN_STATES = frozenset(
+    {
+        ComponentState.STOPPING,
+        ComponentState.STOPPED,
+        ComponentState.DISPOSING,
+        ComponentState.DISPOSED,
+    },
+)
 
 
 class InteractiveBrokersClient(
@@ -137,6 +148,7 @@ class InteractiveBrokersClient(
         # Event flags
         self._is_client_ready: asyncio.Event = asyncio.Event()
         self._is_ib_connected: asyncio.Event = asyncio.Event()
+        self._is_shutting_down: bool = False
 
         # Hot caches
         self.registered_nautilus_clients: set = set()
@@ -196,6 +208,8 @@ class InteractiveBrokersClient(
 
     async def _start_async(self):
         self._log.info(f"Starting InteractiveBrokersClient ({self._client_id})...")
+        self._is_shutting_down = False
+
         while not self._is_ib_connected.is_set():
             try:
                 self._connection_attempts += 1
@@ -286,6 +300,7 @@ class InteractiveBrokersClient(
 
     async def _stop_async(self) -> None:
         self._log.info(f"Stopping InteractiveBrokersClient ({self._client_id})...")
+        self._is_shutting_down = True
 
         if self._is_client_ready.is_set():
             self._is_client_ready.clear()
@@ -313,6 +328,10 @@ class InteractiveBrokersClient(
         self._eclient.disconnect()
         self._account_ids = set()
         self.registered_nautilus_clients = set()
+
+    def _dispose(self) -> None:
+        self._is_shutting_down = True
+        super()._dispose()
 
     def _reset(self) -> None:
         """
@@ -609,7 +628,9 @@ class InteractiveBrokersClient(
         buf = b""
 
         try:
-            while self._eclient.conn and self._eclient.conn.isConnected():
+            while not self._is_message_processing_stopping() and (
+                self._eclient.conn and self._eclient.conn.isConnected()
+            ):
                 data = await asyncio.to_thread(self._eclient.conn.recvMsg)
                 buf += data
 
@@ -625,6 +646,11 @@ class InteractiveBrokersClient(
                         break
         except asyncio.CancelledError:
             self._log.debug("Client TWS incoming message reader was cancelled")
+        except RuntimeError as e:
+            if self._is_executor_shutdown_error(e):
+                self._log.debug("Client TWS incoming message reader stopped during shutdown")
+            else:
+                self._log.exception("Unhandled exception in Client TWS incoming message reader", e)
         except Exception as e:
             self._log.exception("Unhandled exception in Client TWS incoming message reader", e)
         finally:
@@ -644,13 +670,24 @@ class InteractiveBrokersClient(
         self._log.debug("Client internal message queue processor started")
 
         try:
-            while (
-                self._eclient.conn and self._eclient.conn.isConnected()
-            ) or not self._internal_msg_queue.empty():
+            while not self._is_message_processing_stopping() and (
+                (self._eclient.conn and self._eclient.conn.isConnected())
+                or not self._internal_msg_queue.empty()
+            ):
                 msg = await self._internal_msg_queue.get()
 
-                if not await self._process_message(msg):
-                    break
+                try:
+                    if not await self._process_message(msg):
+                        break
+                except RuntimeError as e:
+                    if self._is_executor_shutdown_error(e):
+                        self._internal_msg_queue.task_done()
+                        self._log.debug(
+                            "Internal message queue processor stopped during shutdown",
+                        )
+                        break
+
+                    raise
 
                 self._internal_msg_queue.task_done()
         except asyncio.CancelledError:
@@ -664,6 +701,15 @@ class InteractiveBrokersClient(
             )
         finally:
             self._log.debug("Internal message queue processor stopped")
+
+    def _is_message_processing_stopping(self) -> bool:
+        return self._is_shutting_down or self.state in _SHUTDOWN_STATES
+
+    def _is_executor_shutdown_error(self, exc: RuntimeError) -> bool:
+        return (
+            self._is_message_processing_stopping()
+            and "cannot schedule new futures after shutdown" in str(exc)
+        )
 
     async def _process_message(self, msg: bytes) -> bool:
         """

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -74,6 +74,17 @@ async def test_stop(ib_client_running):
     assert len(ib_client_running.registered_nautilus_clients) == 0
 
 
+def test_dispose_sets_shutdown_flag(ib_client):
+    # Arrange
+
+    # Act
+    ib_client.dispose()
+
+    # Assert
+    assert ib_client._is_shutting_down is True
+    assert ib_client.is_disposed is True
+
+
 @pytest.mark.asyncio
 async def test_reset(ib_client_running):
     # Arrange
@@ -209,6 +220,21 @@ async def test_run_tws_incoming_msg_reader(ib_client):
 
 
 @pytest.mark.asyncio
+async def test_run_tws_incoming_msg_reader_stops_before_thread_work_when_shutting_down(ib_client):
+    # Arrange
+    ib_client._eclient.conn = Mock()
+    ib_client._eclient.conn.isConnected.return_value = True
+    ib_client._is_shutting_down = True
+
+    with patch("asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+        # Act
+        await ib_client._run_tws_incoming_msg_reader()
+
+    # Assert
+    to_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_run_internal_msg_queue(ib_client_running):
     # Arrange
     test_messages = [b"test message 1", b"test message 2"]
@@ -221,3 +247,40 @@ async def test_run_internal_msg_queue(ib_client_running):
     # Assert
     await eventually(lambda: ib_client_running._process_message.call_count == len(test_messages))
     assert ib_client_running._internal_msg_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_run_internal_msg_queue_stops_before_processing_when_shutting_down(ib_client):
+    # Arrange
+    ib_client._eclient.conn = Mock()
+    ib_client._eclient.conn.isConnected.return_value = True
+    ib_client._internal_msg_queue.put_nowait(b"test message")
+    ib_client._process_message = AsyncMock()
+    ib_client._is_shutting_down = True
+
+    # Act
+    await ib_client._run_internal_msg_queue_processor()
+
+    # Assert
+    ib_client._process_message.assert_not_awaited()
+    assert ib_client._internal_msg_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_run_internal_msg_queue_handles_executor_shutdown_during_processing(ib_client):
+    # Arrange
+    async def process_message(_):
+        ib_client._is_shutting_down = True
+        raise RuntimeError("cannot schedule new futures after shutdown")
+
+    ib_client._eclient.conn = Mock()
+    ib_client._eclient.conn.isConnected.return_value = True
+    ib_client._internal_msg_queue.put_nowait(b"test message")
+    ib_client._process_message = AsyncMock(side_effect=process_message)
+
+    # Act
+    await ib_client._run_internal_msg_queue_processor()
+
+    # Assert
+    ib_client._process_message.assert_awaited_once()
+    assert ib_client._internal_msg_queue.qsize() == 0


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Fixes Interactive Brokers shutdown log noise where reader tasks could report `RuntimeError("cannot schedule new futures after shutdown")`.
- Adds explicit shutdown tracking to `InteractiveBrokersClient` during stop and dispose.
- Stops the TWS incoming message reader and internal message queue processor before scheduling more threaded work once shutdown begins.
- Handles the narrow race where the executor shuts down after the loop guard but before `asyncio.to_thread()` submits work.
- Adds regression coverage for dispose shutdown state, TWS reader shutdown, queue processor shutdown, and the executor-shutdown race.

### Design notes

- The guard uses the client lifecycle state plus an internal shutdown flag, matching the more robust approach discussed on issue #3950 and PR #3975.
- The executor `RuntimeError` is only treated as graceful when the client is already shutting down and the message matches the Python executor shutdown failure.
- Other `RuntimeError` cases still log through the existing unhandled-exception path.
- The internal queue keeps pending messages untouched when shutdown has already started before processing begins.

### Files changed

- `nautilus_trader/adapters/interactive_brokers/client/client.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client.py`

### Verification

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client.py -q`.
- `make format`.
- `make pre-commit`.

### Risk

- Low. The change is limited to the Interactive Brokers client shutdown path.
- Runtime behavior during active connections is unchanged except for checking shutdown state before reader loop iterations.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/3950

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
