### PR TITLE
Fix SQL ParserError for symbols containing ampersand

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -4338,11 +4338,11 @@ pub fn extract_identifier_from_path(file_path: &str) -> String {
 
 /// Makes an identifier safe for use in SQL table names.
 ///
-/// Removes forward slashes, replaces dots, hyphens, and spaces with underscores, and converts to lowercase.
+/// Removes forward slashes, replaces dots, hyphens, spaces, percent signs, and ampersands with underscores, and converts to lowercase.
 #[must_use]
 pub fn make_sql_safe_identifier(identifier: &str) -> String {
     urisafe_instrument_id(identifier)
-        .replace(['.', '-', ' ', '%'], "_")
+        .replace(['.', '-', ' ', '%', '&'], "_")
         .to_lowercase()
 }
 

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -4338,12 +4338,19 @@ pub fn extract_identifier_from_path(file_path: &str) -> String {
 
 /// Makes an identifier safe for use in SQL table names.
 ///
-/// Removes forward slashes, replaces dots, hyphens, spaces, percent signs, and ampersands with underscores, and converts to lowercase.
+/// Keeps ASCII alphanumerics and underscores; replaces everything else with `_`, then lowercases.
 #[must_use]
 pub fn make_sql_safe_identifier(identifier: &str) -> String {
     urisafe_instrument_id(identifier)
-        .replace(['.', '-', ' ', '%', '&'], "_")
-        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Extracts the filename from a file path and makes it SQL-safe.

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -2856,6 +2856,10 @@ fn test_make_sql_safe_identifier() {
     // Test identifier with spaces (like option symbols)
     let safe_id = make_sql_safe_identifier("ESM4 P5230.XCME");
     assert_eq!(safe_id, "esm4_p5230_xcme");
+
+    // Test identifier with ampersand
+    let safe_id = make_sql_safe_identifier("M&M.NSE");
+    assert_eq!(safe_id, "m_m_nse");
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->
Fixes the following error when querying data in the `ParquetDataCatalog` for instruments containing an `&`:
```
sql parser error: Expected: end of statement, found: & at Line: 1, Column: 34
```

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
