### PR TITLE
Fix IB reconnect before server version handshake

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -400,6 +400,7 @@ class InteractiveBrokersClient(
                 await asyncio.wait_for(self._is_client_ready.wait(), timeout)
         except TimeoutError as e:
             self._log.error(f"Client is not ready: {e}")
+            raise
 
     async def _run_connection_watchdog(self) -> None:
         """
@@ -735,7 +736,7 @@ class InteractiveBrokersClient(
 
             return False
 
-        if self._eclient.serverVersion() >= MIN_SERVER_VER_PROTOBUF:
+        if self._use_raw_int_msg_id():
             sMsgId = msg[:4]
             msgId = int.from_bytes(sMsgId, "big")
             msg = msg[4:]
@@ -840,10 +841,16 @@ class InteractiveBrokersClient(
         """
         Override the logging for ibapi EClient.sendMsg.
         """
-        useRawIntMsgId = self._eclient.serverVersion() >= MIN_SERVER_VER_PROTOBUF
+        useRawIntMsgId = self._use_raw_int_msg_id()
         full_msg = comm.make_msg(msgId, useRawIntMsgId, msg)
         self._log.debug(f"TWS API request sent: function={current_fn_name(1)} msg={full_msg}")
         self._eclient.conn.sendMsg(full_msg)
+
+    def _use_raw_int_msg_id(self) -> bool:
+        server_version = self._eclient.serverVersion()
+
+        # Treat unknown server versions as legacy framing until the handshake completes
+        return server_version is not None and server_version >= MIN_SERVER_VER_PROTOBUF
 
     def logRequest(self, fnName, fnParams):
         """

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from ibapi import comm
 
 from nautilus_trader.test_kit.functions import eventually
 
@@ -187,6 +188,16 @@ async def test_wait_until_ready(ib_client_running):
 
 
 @pytest.mark.asyncio
+async def test_wait_until_ready_raises_on_timeout(ib_client):
+    # Arrange
+    ib_client._is_client_ready.clear()
+
+    # Act, Assert
+    with pytest.raises(TimeoutError):
+        await ib_client.wait_until_ready(timeout=0)
+
+
+@pytest.mark.asyncio
 async def test_run_connection_watchdog_reconnect(ib_client):
     # Arrange
     ib_client._is_ib_connected.clear()
@@ -284,3 +295,32 @@ async def test_run_internal_msg_queue_handles_executor_shutdown_during_processin
     # Assert
     ib_client._process_message.assert_awaited_once()
     assert ib_client._internal_msg_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_process_message_uses_legacy_framing_when_server_version_unknown(ib_client):
+    # Arrange
+    ib_client._eclient.decoder = MagicMock()
+
+    with patch.object(ib_client._eclient, "serverVersion", return_value=None):
+        # Act
+        result = await ib_client._process_message(b"1\0payload\0")
+
+    # Assert
+    assert result is True
+    ib_client._eclient.decoder.interpret.assert_called_once_with((b"payload",), 1)
+    ib_client._eclient.decoder.processProtoBuf.assert_not_called()
+
+
+def test_send_msg_uses_legacy_framing_when_server_version_unknown(ib_client):
+    # Arrange
+    ib_client._eclient.conn = MagicMock()
+
+    with patch.object(ib_client._eclient, "serverVersion", return_value=None):
+        # Act
+        ib_client.sendMsg(1, "payload\0")
+
+    # Assert
+    ib_client._eclient.conn.sendMsg.assert_called_once_with(
+        comm.make_msg(1, False, "payload\0"),
+    )

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -251,6 +251,26 @@ async def test_connect(mocker, exec_client):
 
 
 @pytest.mark.asyncio
+async def test_connect_propagates_client_ready_timeout(mocker, exec_client):
+    # Arrange
+    async def wait_until_ready(timeout):
+        raise TimeoutError
+
+    mocker.patch.object(
+        exec_client._client,
+        "wait_until_ready",
+        side_effect=wait_until_ready,
+    )
+    initialize = mocker.patch.object(exec_client.instrument_provider, "initialize")
+
+    # Act, Assert
+    with pytest.raises(TimeoutError):
+        await exec_client._connect()
+
+    initialize.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_disconnect(mocker, exec_client):
     # Arrange
     mocker.patch.object(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes an Interactive Brokers reconnect crash when `EClient.serverVersion()` returns `None` before the TWS/Gateway handshake completes.
- Adds a shared `_use_raw_int_msg_id()` helper for IB message framing decisions.
- Treats an unknown server version as legacy message framing in both `_process_message()` and `sendMsg()`.
- Changes `wait_until_ready()` to re-raise `TimeoutError` after logging, so data and execution clients do not continue as if the IB client is ready.
- Adds regression coverage for unknown server-version message processing, outbound message framing, readiness timeout propagation, and execution-client connection timeout behavior.

### Design notes

- The `None` server-version case is handled as legacy framing because protobuf framing is only valid once the server version is known and high enough.
- Keeping the server-version check in one helper avoids divergent behavior between inbound and outbound message paths.
- Re-raising the readiness timeout preserves the existing log while making the failure visible to callers such as `IBExecutionClient._connect()`.
- The execution-client regression asserts that instrument initialization does not run after readiness times out.

### Files changed

- `nautilus_trader/adapters/interactive_brokers/client/client.py`.
- `tests/integration_tests/adapters/interactive_brokers/client/test_client.py`.
- `tests/integration_tests/adapters/interactive_brokers/test_execution.py`.

### Verification

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client.py -q`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution.py -q`.
- `uv run --no-sync ruff format nautilus_trader/adapters/interactive_brokers/client/client.py tests/integration_tests/adapters/interactive_brokers/client/test_client.py tests/integration_tests/adapters/interactive_brokers/test_execution.py`.
- `uv run --no-sync ruff check nautilus_trader/adapters/interactive_brokers/client/client.py tests/integration_tests/adapters/interactive_brokers/client/test_client.py tests/integration_tests/adapters/interactive_brokers/test_execution.py --fix`.
- `git diff --check -- nautilus_trader/adapters/interactive_brokers/client/client.py tests/integration_tests/adapters/interactive_brokers/client/test_client.py tests/integration_tests/adapters/interactive_brokers/test_execution.py`.

### Risk

- Low. The change is scoped to Interactive Brokers client readiness and message framing.
- Active protobuf sessions remain unchanged once `serverVersion()` returns a value greater than or equal to `MIN_SERVER_VER_PROTOBUF`.
- Unknown server-version sessions now use the same legacy framing expected before the handshake completes.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4026

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
