### PR TITLE
Fully redact DatabaseConfig passwords in repr

### DIFF
--- a/nautilus_trader/common/config.py
+++ b/nautilus_trader/common/config.py
@@ -358,13 +358,8 @@ class DatabaseConfig(NautilusConfig, frozen=True):
     factor: int = 2
 
     def __repr__(self) -> str:
-        redacted_password = "None"
+        redacted_password = "***" if self.password is not None else "None"
 
-        if self.password:
-            if len(self.password) >= 4:
-                redacted_password = f"{self.password[:2]}...{self.password[-2:]}"
-            else:
-                redacted_password = self.password
         return (
             f"{type(self).__name__}("
             f"type={self.type}, "

--- a/tests/unit_tests/config/test_common.py
+++ b/tests/unit_tests/config/test_common.py
@@ -48,14 +48,15 @@ from nautilus_trader.test_kit.providers import TestInstrumentProvider
 from nautilus_trader.trading.config import StrategyConfig
 
 
-def test_repr_with_redacted_password() -> None:
+@pytest.mark.parametrize("password", ["password", "abc", ""])
+def test_repr_with_redacted_password(password: str) -> None:
     # Arrange
-    config = DatabaseConfig(username="username", password="password")
+    config = DatabaseConfig(username="username", password=password)
 
     # Act, Assert
     assert (
         repr(config)
-        == "DatabaseConfig(type=redis, host=None, port=None, username=username, password=pa...rd, "
+        == "DatabaseConfig(type=redis, host=None, port=None, username=username, password=***, "
         "ssl=False, connection_timeout=20, response_timeout=20, number_of_retries=100, "
         "exponent_base=2, max_delay=1000, factor=2)"
     )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Updates `DatabaseConfig.__repr__` to show `password=***` whenever a password value is provided, instead of exposing the first and last characters.
- Preserves `password=None` in the repr when no password is configured.
- Extends the existing config repr test to cover long, short, and empty password values.

### Motivation

Issue #4019 reported that `DatabaseConfig.__repr__` partially leaked database passwords. Reprs are often copied into logs and diagnostics, so any provided password should be treated as sensitive and fully redacted.

### Design notes

- The Python repr now matches the stricter behavior already used by the Rust `DatabaseConfig` debug output, which redacts any present password with `***`.
- The change keeps serialization, equality, hashing, and config IDs unchanged; only the display representation is affected.
- Empty string passwords are treated as explicitly provided values and are therefore redacted.

### Testing

- `uv run --no-sync pytest tests/unit_tests/config/test_common.py -q`
- `make format`
- `prek run --files nautilus_trader/common/config.py tests/unit_tests/config/test_common.py`

### Pre-commit note

`make pre-commit` was also run. It reached `cargo clippy`, but the run failed because hooks reported modified files in unrelated Interactive Brokers changes already present in the working tree. The file-scoped pre-commit run for this config change passed.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

Issue #4019

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
