### PR TITLE
Scope live position reconciliation by account

### DIFF
--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -96,6 +96,9 @@ from nautilus_trader.model.orders import OrderUnpacker
 from nautilus_trader.model.position import Position
 
 
+PositionReportKey = tuple[InstrumentId, AccountId]
+
+
 class LiveExecutionEngine(ExecutionEngine):
     """
     Provides a high-performance asynchronous live execution engine.
@@ -807,17 +810,18 @@ class LiveExecutionEngine(ExecutionEngine):
                 p for p in open_positions if p.instrument_id in self.reconciliation_instrument_ids
             ]
 
-        # Group positions by instrument_id (for netting)
-        positions_by_instrument: dict[InstrumentId, list[Position]] = {}
+        positions_by_key: dict[PositionReportKey, list[Position]] = {}
 
         for position in open_positions:
-            if position.instrument_id not in positions_by_instrument:
-                positions_by_instrument[position.instrument_id] = []
+            position_key = (position.instrument_id, position.account_id)
+            if position_key not in positions_by_key:
+                positions_by_key[position_key] = []
 
-            positions_by_instrument[position.instrument_id].append(position)
+            positions_by_key[position_key].append(position)
 
         self._log.debug(
-            f"Found {len(positions_by_instrument)} unique instrument(s) with open positions",
+            f"Found {len(positions_by_key)} unique instrument/account combination(s) "
+            "with open positions",
         )
 
         if not self._clients:
@@ -827,25 +831,27 @@ class LiveExecutionEngine(ExecutionEngine):
         venue_positions, failed_position_report_venues = await self._query_position_status_reports()
 
         await self._process_cached_position_discrepancies(
-            positions_by_instrument,
+            positions_by_key,
             venue_positions,
             failed_position_report_venues,
         )
 
         await self._process_venue_reported_positions(
-            positions_by_instrument,
+            positions_by_key,
             venue_positions,
         )
 
         # Prune retry counters for instruments no longer actively discrepant
-        active_instruments = set(positions_by_instrument) | set(venue_positions)
+        active_instruments = {key[0] for key in positions_by_key} | {
+            key[0] for key in venue_positions
+        }
         stale = [iid for iid in self._position_recon_retries if iid not in active_instruments]
         for iid in stale:
             self._position_recon_retries.pop(iid, None)
 
     async def _query_position_status_reports(
         self,
-    ) -> tuple[dict[InstrumentId, PositionStatusReport], set[Venue | None]]:
+    ) -> tuple[dict[PositionReportKey, PositionStatusReport], set[Venue | None]]:
         clients = list(self._clients.values())
 
         tasks = [
@@ -868,8 +874,7 @@ class LiveExecutionEngine(ExecutionEngine):
             self._log.error(f"Failed to gather position status reports: {e}")
             return {}, {client.venue for client in clients}
 
-        # Build mapping: instrument_id -> venue report
-        venue_positions: dict[InstrumentId, PositionStatusReport] = {}
+        venue_positions: dict[PositionReportKey, PositionStatusReport] = {}
         failed_venues: set[Venue | None] = set()
 
         for client, reports_or_exception in zip(clients, position_reports_all, strict=True):
@@ -883,20 +888,20 @@ class LiveExecutionEngine(ExecutionEngine):
 
             reports = cast("list[PositionStatusReport]", reports_or_exception)
             for report in reports:
-                venue_positions[report.instrument_id] = report
+                venue_positions[(report.instrument_id, report.account_id)] = report
 
         return venue_positions, failed_venues
 
     async def _process_cached_position_discrepancies(
         self,
-        positions_by_instrument: dict[InstrumentId, list[Position]],
-        venue_positions: dict[InstrumentId, PositionStatusReport],
+        positions_by_key: dict[PositionReportKey, list[Position]],
+        venue_positions: dict[PositionReportKey, PositionStatusReport],
         failed_position_report_venues: set[Venue | None] | None = None,
     ) -> None:
         clients = self._clients.values()
 
-        for instrument_id, cached_positions in positions_by_instrument.items():
-            venue_report = venue_positions.get(instrument_id)
+        for (instrument_id, account_id), cached_positions in positions_by_key.items():
+            venue_report = venue_positions.get((instrument_id, account_id))
 
             if venue_report is None and self._did_position_status_query_fail(
                 instrument_id,
@@ -950,7 +955,10 @@ class LiveExecutionEngine(ExecutionEngine):
             await self._reconcile_missing_fills(missing_fills, instrument_id)
 
             # Re-read positions from cache (may have changed during reconciliation)
-            current_positions = self._cache.positions_open(instrument_id=instrument_id)
+            current_positions = self._cache.positions_open(
+                instrument_id=instrument_id,
+                account_id=account_id,
+            )
             still_discrepant = self._check_position_discrepancy(
                 current_positions,
                 venue_report,
@@ -968,7 +976,10 @@ class LiveExecutionEngine(ExecutionEngine):
                     and self.generate_missing_orders
                     and self._reconcile_position_report(reconciliation_report)
                 ):
-                    current_positions = self._cache.positions_open(instrument_id=instrument_id)
+                    current_positions = self._cache.positions_open(
+                        instrument_id=instrument_id,
+                        account_id=account_id,
+                    )
                     still_discrepant = self._check_position_discrepancy(
                         current_positions,
                         venue_report,
@@ -1089,13 +1100,13 @@ class LiveExecutionEngine(ExecutionEngine):
 
     async def _process_venue_reported_positions(
         self,
-        positions_by_instrument: dict[InstrumentId, list[Position]],
-        venue_positions: dict[InstrumentId, PositionStatusReport],
+        positions_by_key: dict[PositionReportKey, list[Position]],
+        venue_positions: dict[PositionReportKey, PositionStatusReport],
     ) -> None:
         clients = self._clients.values()
 
-        for instrument_id, venue_report in venue_positions.items():
-            if instrument_id in positions_by_instrument:
+        for (instrument_id, account_id), venue_report in venue_positions.items():
+            if (instrument_id, account_id) in positions_by_key:
                 continue  # Already checked above
 
             # Apply instrument filter
@@ -1139,7 +1150,10 @@ class LiveExecutionEngine(ExecutionEngine):
             await self._reconcile_missing_fills(missing_fills, instrument_id)
 
             # Re-check using tolerance-aware comparison
-            cached_after = self._cache.positions_open(instrument_id=instrument_id)
+            cached_after = self._cache.positions_open(
+                instrument_id=instrument_id,
+                account_id=account_id,
+            )
             still_discrepant = self._check_position_discrepancy(
                 cached_after,
                 venue_report,
@@ -2456,6 +2470,7 @@ class LiveExecutionEngine(ExecutionEngine):
         positions_open: list[Position] = self._cache.positions_open(
             venue=None,  # Faster query filtering
             instrument_id=report.instrument_id,
+            account_id=report.account_id,
         )
 
         position_signed_decimal_qty: Decimal = Decimal()

--- a/tests/unit_tests/live/test_execution_recon.py
+++ b/tests/unit_tests/live/test_execution_recon.py
@@ -3606,8 +3606,8 @@ async def test_query_position_status_reports_success(live_exec_engine, exec_clie
 
     # Assert
     assert len(venue_positions) == 1
-    assert AUDUSD_SIM.id in venue_positions
-    assert venue_positions[AUDUSD_SIM.id].quantity == Quantity.from_int(1000)
+    assert (AUDUSD_SIM.id, account_id) in venue_positions
+    assert venue_positions[(AUDUSD_SIM.id, account_id)].quantity == Quantity.from_int(1000)
     assert failed_venues == set()
 
 
@@ -3672,9 +3672,114 @@ async def test_query_position_status_reports_multiple_instruments(
 
     # Assert
     assert len(venue_positions) == 2
-    assert AUDUSD_SIM.id in venue_positions
-    assert GBPUSD_SIM.id in venue_positions
+    assert (AUDUSD_SIM.id, account_id) in venue_positions
+    assert (GBPUSD_SIM.id, account_id) in venue_positions
     assert failed_venues == set()
+
+
+@pytest.mark.asyncio
+async def test_query_position_status_reports_preserves_accounts_for_same_instrument(
+    live_exec_engine,
+    exec_client,
+):
+    live_exec_engine.register_client(exec_client)
+
+    account1_id = AccountId("SIM-001")
+    account2_id = AccountId("SIM-002")
+    report1 = PositionStatusReport(
+        account_id=account1_id,
+        instrument_id=AUDUSD_SIM.id,
+        position_side=PositionSide.LONG,
+        quantity=Quantity.from_int(1000),
+        report_id=UUID4(),
+        ts_last=live_exec_engine._clock.timestamp_ns(),
+        ts_init=live_exec_engine._clock.timestamp_ns(),
+    )
+    report2 = PositionStatusReport(
+        account_id=account2_id,
+        instrument_id=AUDUSD_SIM.id,
+        position_side=PositionSide.SHORT,
+        quantity=Quantity.from_int(2000),
+        report_id=UUID4(),
+        ts_last=live_exec_engine._clock.timestamp_ns(),
+        ts_init=live_exec_engine._clock.timestamp_ns(),
+    )
+    exec_client.add_position_status_report(report1)
+    exec_client.add_position_status_report(report2)
+
+    venue_positions, failed_venues = await live_exec_engine._query_position_status_reports()
+
+    assert venue_positions[(AUDUSD_SIM.id, account1_id)] is report1
+    assert venue_positions[(AUDUSD_SIM.id, account2_id)] is report2
+    assert len(venue_positions) == 2
+    assert failed_venues == set()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_position_report_netting_scopes_cached_positions_by_account(
+    live_exec_engine,
+    cache,
+):
+    live_exec_engine.generate_missing_orders = True
+
+    account1_id = AccountId("SIM-001")
+    account2_id = AccountId("SIM-002")
+
+    order1 = TestExecStubs.limit_order(
+        instrument=AUDUSD_SIM,
+        order_side=OrderSide.BUY,
+        quantity=Quantity.from_int(1000),
+    )
+    fill1 = TestEventStubs.order_filled(
+        order1,
+        instrument=AUDUSD_SIM,
+        account_id=account1_id,
+        last_qty=Quantity.from_int(1000),
+        last_px=Price.from_str("1.00000"),
+        position_id=PositionId("P-ACC-1"),
+    )
+    position1 = Position(instrument=AUDUSD_SIM, fill=fill1)
+    cache.add_position(position1, OmsType.NETTING)
+
+    order2 = TestExecStubs.limit_order(
+        instrument=AUDUSD_SIM,
+        order_side=OrderSide.BUY,
+        quantity=Quantity.from_int(2000),
+    )
+    fill2 = TestEventStubs.order_filled(
+        order2,
+        instrument=AUDUSD_SIM,
+        account_id=account2_id,
+        last_qty=Quantity.from_int(2000),
+        last_px=Price.from_str("1.00000"),
+        position_id=PositionId("P-ACC-2"),
+    )
+    position2 = Position(instrument=AUDUSD_SIM, fill=fill2)
+    cache.add_position(position2, OmsType.NETTING)
+
+    reconcile_calls = []
+    original_reconcile = live_exec_engine._reconcile_order_report
+
+    def spy_reconcile(order_report, trades, is_external=True):
+        reconcile_calls.append((order_report, trades, is_external))
+        return original_reconcile(order_report, trades, is_external)
+
+    live_exec_engine._reconcile_order_report = spy_reconcile
+
+    report = PositionStatusReport(
+        account_id=account1_id,
+        instrument_id=AUDUSD_SIM.id,
+        position_side=PositionSide.LONG,
+        quantity=Quantity.from_int(1000),
+        report_id=UUID4(),
+        ts_last=live_exec_engine._clock.timestamp_ns(),
+        ts_init=live_exec_engine._clock.timestamp_ns(),
+    )
+
+    result = live_exec_engine._reconcile_position_report_netting(report)
+
+    assert result is True
+    assert reconcile_calls == []
 
 
 # Tests for _query_and_find_missing_fills
@@ -4014,8 +4119,8 @@ async def test_process_cached_position_discrepancies_no_discrepancy(live_exec_en
 
     # Act
     await live_exec_engine._process_cached_position_discrepancies(
-        {AUDUSD_SIM.id: [position]},
-        {AUDUSD_SIM.id: venue_report},
+        {(AUDUSD_SIM.id, position.account_id): [position]},
+        {(AUDUSD_SIM.id, venue_report.account_id): venue_report},
     )
 
     # Assert
@@ -4072,8 +4177,8 @@ async def test_process_cached_position_discrepancies_with_discrepancy(
 
     # Act
     await live_exec_engine._process_cached_position_discrepancies(
-        {AUDUSD_SIM.id: [position]},
-        {AUDUSD_SIM.id: venue_report},
+        {(AUDUSD_SIM.id, position.account_id): [position]},
+        {(AUDUSD_SIM.id, venue_report.account_id): venue_report},
     )
 
     # Assert
@@ -4102,7 +4207,7 @@ async def test_position_check_retries_stops_after_max(live_exec_engine, exec_cli
 
     # Venue reports no position (discrepancy)
     venue_positions = {}
-    positions_by_instrument = {AUDUSD_SIM.id: [position]}
+    positions_by_key = {(AUDUSD_SIM.id, position.account_id): [position]}
 
     query_count = 0
     original_query = live_exec_engine._query_and_find_missing_fills
@@ -4117,7 +4222,7 @@ async def test_position_check_retries_stops_after_max(live_exec_engine, exec_cli
     # Act - call retry_limit + 1 times
     for _ in range(3):
         await live_exec_engine._process_cached_position_discrepancies(
-            positions_by_instrument,
+            positions_by_key,
             venue_positions,
         )
 
@@ -4165,7 +4270,7 @@ async def test_process_cached_position_discrepancies_reconciles_missing_venue_po
 
     # Act
     await live_exec_engine._process_cached_position_discrepancies(
-        {AUDUSD_SIM.id: [position]},
+        {(AUDUSD_SIM.id, position.account_id): [position]},
         {},
     )
 
@@ -4219,7 +4324,7 @@ async def test_process_cached_position_discrepancies_skips_flat_reconciliation_o
 
     # Act
     await live_exec_engine._process_cached_position_discrepancies(
-        {AUDUSD_SIM.id: [position]},
+        {(AUDUSD_SIM.id, position.account_id): [position]},
         {},
         {AUDUSD_SIM.id.venue},
     )
@@ -4250,7 +4355,7 @@ async def test_position_check_retries_clears_on_resolved(live_exec_engine, exec_
     cache.add_position(position, OmsType.HEDGING)
 
     venue_positions_mismatch = {}
-    positions_by_instrument = {AUDUSD_SIM.id: [position]}
+    positions_by_key = {(AUDUSD_SIM.id, position.account_id): [position]}
 
     # Stub out query to return no fills (discrepancy persists)
     async def no_fills_query(instrument_id, clients):
@@ -4260,7 +4365,7 @@ async def test_position_check_retries_clears_on_resolved(live_exec_engine, exec_
 
     # Act - first call increments retry counter
     await live_exec_engine._process_cached_position_discrepancies(
-        positions_by_instrument,
+        positions_by_key,
         venue_positions_mismatch,
     )
     assert AUDUSD_SIM.id in live_exec_engine._position_recon_retries
@@ -4277,8 +4382,8 @@ async def test_position_check_retries_clears_on_resolved(live_exec_engine, exec_
     )
 
     await live_exec_engine._process_cached_position_discrepancies(
-        positions_by_instrument,
-        {AUDUSD_SIM.id: venue_report_matching},
+        positions_by_key,
+        {(AUDUSD_SIM.id, venue_report_matching.account_id): venue_report_matching},
     )
 
     # Assert - counter should be cleared
@@ -4351,7 +4456,7 @@ async def test_venue_reported_position_retries_stop_after_max(
     for _ in range(3):
         await live_exec_engine._process_venue_reported_positions(
             {},  # No cached positions
-            {AUDUSD_SIM.id: venue_report},
+            {(AUDUSD_SIM.id, venue_report.account_id): venue_report},
         )
 
     # Assert - should query exactly 2 times (the max), not 3
@@ -4399,8 +4504,8 @@ async def test_venue_reported_position_tolerance_does_not_consume_retries(
 
     # Act
     await live_exec_engine._process_cached_position_discrepancies(
-        {ethusdt.id: [position]},
-        {ethusdt.id: venue_report},
+        {(ethusdt.id, position.account_id): [position]},
+        {(ethusdt.id, venue_report.account_id): venue_report},
     )
 
     # Assert - within tolerance so no retries consumed
@@ -4452,8 +4557,8 @@ async def test_process_venue_reported_positions_no_discrepancy(live_exec_engine,
 
     # Act
     await live_exec_engine._process_venue_reported_positions(
-        {AUDUSD_SIM.id: [position]},
-        {AUDUSD_SIM.id: venue_report},
+        {(AUDUSD_SIM.id, position.account_id): [position]},
+        {(AUDUSD_SIM.id, venue_report.account_id): venue_report},
     )
 
     # Assert
@@ -4503,7 +4608,7 @@ async def test_process_venue_reported_positions_venue_has_position(
     # Act
     await live_exec_engine._process_venue_reported_positions(
         {},  # No cached positions
-        {AUDUSD_SIM.id: venue_report},
+        {(AUDUSD_SIM.id, venue_report.account_id): venue_report},
     )
 
     # Assert


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixed live position report aggregation so reports for the same instrument but different accounts are preserved instead of overwriting each other.
- Scoped netting position reconciliation to cached positions for the report account, preventing discrepancies from being calculated across accounts.
- Updated reconciliation helper tests to use account-aware report keys.

### Design decisions

- Added a `PositionReportKey` alias for `(InstrumentId, AccountId)` in `nautilus_trader/live/execution_engine.py` to make the report map granularity explicit.
- Kept retry and local activity tracking keyed by `InstrumentId` to avoid expanding the behavioral surface beyond the account-scoping bug fix.
- Reused the existing `Cache.positions_open(..., account_id=...)` filter instead of adding new cache behavior.

### Tests

- Added a regression test proving `_query_position_status_reports` preserves two same-instrument reports from different accounts.
- Added a regression test proving `_reconcile_position_report_netting` ignores another account's cached position.
- Ran `uv run --no-sync pytest tests/unit_tests/live/test_execution_recon.py`.
- Ran `uv run --no-sync ruff check nautilus_trader/live/execution_engine.py tests/unit_tests/live/test_execution_recon.py`.
- Ran `uv run --no-sync ruff format --check nautilus_trader/live/execution_engine.py tests/unit_tests/live/test_execution_recon.py`.
- Ran `make format`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4012
https://github.com/nautechsystems/nautilus_trader/issues/4013

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
