### PR TITLE
Execution/Sandbox: harden market-data update failure paths

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -87,6 +87,12 @@ fn quote_matches_instrument_precision(quote: &QuoteTick, instrument: &Instrument
         && quote.ask_size.precision == size_precision
 }
 
+fn trade_matches_instrument_precision(trade: &TradeTick, instrument: &InstrumentAny) -> bool {
+    let price_precision = instrument.price_precision();
+    let size_precision = instrument.size_precision();
+    trade.price.precision == price_precision && trade.size.precision == size_precision
+}
+
 fn bar_matches_instrument_precision(bar: &Bar, instrument: &InstrumentAny) -> bool {
     let price_precision = instrument.price_precision();
     let size_precision = instrument.size_precision();
@@ -171,6 +177,19 @@ impl SandboxInner {
 
         let instrument = self.cache.borrow().instrument(&instrument_id).cloned();
         if let Some(instrument) = instrument {
+            if !trade_matches_instrument_precision(trade, &instrument) {
+                log::warn!(
+                    "Dropping trade tick for {} due to precision mismatch \
+                     (px={}, sz={}, expected_price={}, expected_size={})",
+                    instrument_id,
+                    trade.price.precision,
+                    trade.size.precision,
+                    instrument.price_precision(),
+                    instrument.size_precision(),
+                );
+                return;
+            }
+
             self.ensure_matching_engine(&instrument);
 
             if let Some(engine) = self.matching_engines.get_mut(&instrument_id) {
@@ -514,6 +533,19 @@ impl SandboxExecutionClient {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Instrument not found: {instrument_id}"))?;
 
+        if !trade_matches_instrument_precision(trade, &instrument) {
+            log::warn!(
+                "Dropping trade tick for {} due to precision mismatch \
+                 (px={}, sz={}, expected_price={}, expected_size={})",
+                instrument_id,
+                trade.price.precision,
+                trade.size.precision,
+                instrument.price_precision(),
+                instrument.size_precision(),
+            );
+            return Ok(());
+        }
+
         let mut inner = self.inner.borrow_mut();
         inner.ensure_matching_engine(&instrument);
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
@@ -792,7 +824,19 @@ impl ExecutionClient for SandboxExecutionClient {
             if self.config.trade_execution
                 && let Some(trade) = cache.trade(&instrument_id)
             {
-                engine.get_engine_mut().process_trade_tick(trade);
+                if trade_matches_instrument_precision(trade, &instrument) {
+                    engine.get_engine_mut().process_trade_tick(trade);
+                } else {
+                    log::warn!(
+                        "Dropping cached trade tick for {} due to precision mismatch \
+                         (px={}, sz={}, expected_price={}, expected_size={})",
+                        instrument_id,
+                        trade.price.precision,
+                        trade.size.precision,
+                        instrument.price_precision(),
+                        instrument.size_precision(),
+                    );
+                }
             }
         }
         drop(cache);
@@ -851,7 +895,19 @@ impl ExecutionClient for SandboxExecutionClient {
                     if self.config.trade_execution
                         && let Some(trade) = cache.trade(&instrument_id)
                     {
-                        engine.get_engine_mut().process_trade_tick(trade);
+                        if trade_matches_instrument_precision(trade, &instrument) {
+                            engine.get_engine_mut().process_trade_tick(trade);
+                        } else {
+                            log::warn!(
+                                "Dropping cached trade tick for {} due to precision mismatch \
+                                 (px={}, sz={}, expected_price={}, expected_size={})",
+                                instrument_id,
+                                trade.price.precision,
+                                trade.size.precision,
+                                instrument.price_precision(),
+                                instrument.size_precision(),
+                            );
+                        }
                     }
                 }
                 drop(cache);

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -1349,10 +1349,6 @@ impl OrderMatchingEngine {
     }
 
     /// Processes a quote tick to update the market state.
-    ///
-    /// # Panics
-    ///
-    /// - If updating the order book with the quote tick fails.
     pub fn process_quote_tick(&mut self, quote: &QuoteTick) {
         log::debug!("Processing {quote}");
 
@@ -1404,7 +1400,10 @@ impl OrderMatchingEngine {
                 self.prev_ask_size_raw = quote.ask_size.raw;
                 self.tob_initialized = true;
             }
-            self.book.update_quote_tick(quote).unwrap();
+
+            if !self.update_quote_tick_or_skip(quote, "quote tick") {
+                return;
+            }
             self.last_quote_bid = Some(quote.bid_price);
             self.last_quote_ask = Some(quote.ask_price);
         }
@@ -1532,13 +1531,19 @@ impl OrderMatchingEngine {
         // Open: fill at market price (gap from previous bar)
         if !self.core.is_last_initialized {
             self.fill_at_market = true;
-            self.book.update_trade_tick(&trade_tick).unwrap();
+
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar open trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
             self.core.set_last_raw(trade_tick.price);
         } else if self.core.last.is_some_and(|last| bar.open != last) {
             // Gap between previous close and this bar's open
             self.fill_at_market = true;
-            self.book.update_trade_tick(&trade_tick).unwrap();
+
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar gap-open trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
             self.core.set_last_raw(trade_tick.price);
         }
@@ -1569,7 +1574,9 @@ impl OrderMatchingEngine {
             }
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(&trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar close trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1585,7 +1592,9 @@ impl OrderMatchingEngine {
             trade_tick.aggressor_side = AggressorSide::Buyer;
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(trade_tick, "bar high trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1599,7 +1608,9 @@ impl OrderMatchingEngine {
             trade_tick.aggressor_side = AggressorSide::Seller;
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(trade_tick, "bar low trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1641,21 +1652,28 @@ impl OrderMatchingEngine {
 
         // Open: fill at market price (gap from previous bar)
         self.fill_at_market = true;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar open quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // High: fill at trigger price (market moving through prices)
         self.fill_at_market = false;
         quote_tick.bid_price = bid_bar.high;
         quote_tick.ask_price = ask_bar.high;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar high quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // Low: fill at trigger price (market moving through prices)
         self.fill_at_market = false;
         quote_tick.bid_price = bid_bar.low;
         quote_tick.ask_price = ask_bar.low;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar low quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // Close: fill at trigger price (market moving through prices)
@@ -1664,7 +1682,9 @@ impl OrderMatchingEngine {
         quote_tick.ask_price = ask_bar.close;
         quote_tick.bid_size = bid_close_size;
         quote_tick.ask_size = ask_close_size;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar close quote tick") {
+            return;
+        }
         self.last_quote_bid = Some(bid_bar.close);
         self.last_quote_ask = Some(ask_bar.close);
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
@@ -1674,16 +1694,36 @@ impl OrderMatchingEngine {
         self.fill_at_market = true;
     }
 
+    fn update_quote_tick_or_skip(&mut self, quote: &QuoteTick, context: &str) -> bool {
+        if let Err(e) = self.book.update_quote_tick(quote) {
+            log::warn!(
+                "Skipping {context} for {}: update_quote_tick failed: {e}",
+                quote.instrument_id,
+            );
+            self.iterate(quote.ts_init, AggressorSide::NoAggressor);
+            return false;
+        }
+        true
+    }
+
+    fn update_trade_tick_or_skip(&mut self, trade: &TradeTick, context: &str) -> bool {
+        if let Err(e) = self.book.update_trade_tick(trade) {
+            log::warn!(
+                "Skipping {context} for {}: update_trade_tick failed: {e}",
+                trade.instrument_id,
+            );
+            self.iterate(trade.ts_init, AggressorSide::NoAggressor);
+            return false;
+        }
+        true
+    }
+
     /// Processes a trade tick to update the market state.
     ///
     /// For L1 books, always updates the order book with the trade tick to maintain
     /// market state. When `trade_execution` is disabled, order matching and maintenance
     /// operations (GTD order expiry, trailing stop activation, instrument expiration)
     /// are skipped. These maintenance operations will run on the next quote tick or bar.
-    ///
-    /// # Panics
-    ///
-    /// - If updating the order book with the trade tick fails.
     pub fn process_trade_tick(&mut self, trade: &TradeTick) {
         log::debug!("Processing {trade}");
 
@@ -1714,7 +1754,9 @@ impl OrderMatchingEngine {
                 return;
             }
 
-            self.book.update_trade_tick(trade).unwrap();
+            if !self.update_trade_tick_or_skip(trade, "trade tick") {
+                return;
+            }
         }
 
         self.core.set_last_raw(trade.price);

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -1499,7 +1499,12 @@ impl OrderMatchingEngine {
                 self.last_bar_ask = Some(bar.to_owned());
                 self.process_quote_ticks_from_bar(bar);
             }
-            PriceType::Mark => panic!("Not implemented"),
+            PriceType::Mark => {
+                log::warn!(
+                    "Skipping bar for {}: `PriceType::Mark` is not supported for matching",
+                    bar.instrument_id()
+                );
+            }
         }
     }
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -8747,3 +8747,30 @@ fn test_process_bar_drops_precision_mismatch_after_instrument_update(
 
     assert!(engine.get_core().last.is_none());
 }
+
+#[rstest]
+fn test_process_bar_ignores_mark_price_type(instrument_eth_usdt: InstrumentAny) {
+    let config = OrderMatchingEngineConfig {
+        bar_execution: true,
+        ..Default::default()
+    };
+    let mut engine = get_order_matching_engine(instrument_eth_usdt, None, None, Some(config), None);
+
+    let mark_bar_type = BarType::from("ETHUSDT-PERP.BINANCE-1-MINUTE-MARK-EXTERNAL");
+    let mark_bar = Bar {
+        bar_type: mark_bar_type,
+        open: Price::from("1000.00"),
+        high: Price::from("1001.00"),
+        low: Price::from("999.00"),
+        close: Price::from("1000.50"),
+        volume: Quantity::from("100.000"),
+        ts_event: UnixNanos::from(1),
+        ts_init: UnixNanos::from(1),
+    };
+
+    // Should not panic; unsupported MARK bars are ignored.
+    engine.process_bar(&mark_bar);
+
+    assert!(engine.get_core().last.is_none());
+    assert!(!engine.get_core().is_last_initialized);
+}

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -4068,17 +4068,48 @@ cdef class OrderMatchingEngine:
         Condition.not_none(instrument, "instrument")
         Condition.equal(instrument.id, self.instrument.id, "instrument.id", "self.instrument.id")
 
-        if (
+        cdef bint changed = (
             instrument.price_increment != self.instrument.price_increment
             or instrument.price_precision != self.instrument.price_precision
-        ):
+            or instrument.size_precision != self.instrument.size_precision
+        )
+
+        if changed:
             self._core.update_price_increment(instrument.price_increment)
+            self._book.reset()
+            self._bid_consumption.clear()
+            self._ask_consumption.clear()
+            self._trade_consumption = 0
+            self._queue_ahead.clear()
+            self._queue_excess.clear()
+            self._queue_pending.clear()
+            self._prev_bid_price_raw = 0
+            self._prev_bid_size_raw = 0
+            self._prev_ask_price_raw = 0
+            self._prev_ask_size_raw = 0
+            self._last_quote_bid_raw = 0
+            self._last_quote_ask_raw = 0
+            self._has_quote_context = False
+            self._tob_initialized = False
+            self._target_bid = 0
+            self._target_ask = 0
+            self._target_last = 0
+            self._has_targets = False
+            self._last_bid_bar = None
+            self._last_ask_bar = None
+            self._core.clear_market_state()
 
         self.instrument = instrument
         self._price_prec = instrument.price_precision
         self._size_prec = instrument.size_precision
 
-        self._log.debug(f"Updated instrument definition for {instrument.id}")
+        if changed:
+            self._log.info(
+                f"Updated instrument {instrument.id} "
+                f"(price_precision={self._price_prec} size_precision={self._size_prec})",
+            )
+        else:
+            self._log.debug(f"Updated instrument definition for {instrument.id}")
 
 # -- QUERIES --------------------------------------------------------------------------------------
 
@@ -4162,13 +4193,6 @@ cdef class OrderMatchingEngine:
         delta : OrderBookDelta
             The order book delta to process.
 
-        Raises
-        ------
-        RuntimeError
-            If the delta price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If the delta size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(delta, "delta")
 
@@ -4178,15 +4202,19 @@ cdef class OrderMatchingEngine:
         # Validate precisions for ADD and UPDATE actions
         if delta._mem.action == BookAction.ADD or delta._mem.action == BookAction.UPDATE:
             if delta._mem.order.price.precision != self._price_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book delta for {delta.instrument_id}: "
                     f"invalid delta price precision={delta._mem.order.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
+                return
             elif delta._mem.order.size.precision != self._size_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book delta for {delta.instrument_id}: "
                     f"invalid delta size precision={delta._mem.order.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
                 )
+                return
 
         # L1 books are driven by top-of-book data only, ignore deltas
         if self.book_type == BookType.L1_MBP:
@@ -4235,13 +4263,6 @@ cdef class OrderMatchingEngine:
         delta : OrderBookDeltas
             The order book deltas to process.
 
-        Raises
-        ------
-        RuntimeError
-            If any delta price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If any delta size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(deltas, "deltas")
 
@@ -4253,15 +4274,19 @@ cdef class OrderMatchingEngine:
         for delta in deltas.deltas:
             if delta._mem.action == BookAction.ADD or delta._mem.action == BookAction.UPDATE:
                 if delta._mem.order.price.precision != self._price_prec:
-                    raise RuntimeError(
+                    self._log.warning(
+                        f"Skipping order book deltas for {deltas.instrument_id}: "
                         f"invalid delta price precision={delta._mem.order.price.precision} "
                         f"did not match instrument.price_precision={self._price_prec}",
                     )
+                    return
                 elif delta._mem.order.size.precision != self._size_prec:
-                    raise RuntimeError(
+                    self._log.warning(
+                        f"Skipping order book deltas for {deltas.instrument_id}: "
                         f"invalid delta size precision={delta._mem.order.size.precision} "
                         f"did not match instrument.size_precision={self._size_prec}",
                     )
+                    return
 
         # L1 books are driven by top-of-book data only, ignore deltas
         if self.book_type == BookType.L1_MBP:
@@ -4310,13 +4335,6 @@ cdef class OrderMatchingEngine:
         depth : OrderBookDepth10
             The order book depth to process.
 
-        Raises
-        ------
-        RuntimeError
-            If any order price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If any order size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(depth, "depth")
 
@@ -4329,29 +4347,37 @@ cdef class OrderMatchingEngine:
             if order._mem.side == OrderSide.NO_ORDER_SIDE:
                 continue  # Skip null orders
             elif order._mem.price.precision != self._price_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book depth for {depth.instrument_id}: "
                     f"invalid depth bid price precision={order._mem.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
+                return
             elif order._mem.size.precision != self._size_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book depth for {depth.instrument_id}: "
                     f"invalid depth bid size precision={order._mem.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
                 )
+                return
 
         for order in depth.asks:
             if order._mem.side == OrderSide.NO_ORDER_SIDE:
                 continue  # Skip null orders
             elif order._mem.price.precision != self._price_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book depth for {depth.instrument_id}: "
                     f"invalid depth ask price precision={order._mem.price.precision} "
                     f"did not match instrument.price_precision={self._price_prec}",
                 )
+                return
             elif order._mem.size.precision != self._size_prec:
-                raise RuntimeError(
+                self._log.warning(
+                    f"Skipping order book depth for {depth.instrument_id}: "
                     f"invalid depth ask size precision={order._mem.size.precision} "
                     f"did not match instrument.size_precision={self._size_prec}",
                 )
+                return
 
         # Reset consumption tracking on snapshot (F_SNAPSHOT = 32)
         if self._liquidity_consumption and (depth._mem.flags & 32):
@@ -4399,13 +4425,6 @@ cdef class OrderMatchingEngine:
         tick : QuoteTick
             The tick to process.
 
-        Raises
-        ------
-        RuntimeError
-            If a price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If a size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(tick, "tick")
 
@@ -4414,21 +4433,33 @@ cdef class OrderMatchingEngine:
 
         # Validate precisions
         if tick._mem.bid_price.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {tick.bid_price.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping quote tick for {tick.instrument_id}: "
+                f"invalid {tick.bid_price.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif tick._mem.ask_price.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {tick.ask_price.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping quote tick for {tick.instrument_id}: "
+                f"invalid {tick.ask_price.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif tick._mem.bid_size.precision != self._size_prec:
-            raise RuntimeError(
-                f"invalid {tick.bid_size.precision=} did not match instrument.size_precision={self._size_prec}",
+            self._log.warning(
+                f"Skipping quote tick for {tick.instrument_id}: "
+                f"invalid {tick.bid_size.precision=} "
+                f"did not match instrument.size_precision={self._size_prec}",
             )
+            return
         elif tick._mem.ask_size.precision != self._size_prec:
-            raise RuntimeError(
-                f"invalid {tick.ask_size.precision=} did not match instrument.size_precision={self._size_prec}",
+            self._log.warning(
+                f"Skipping quote tick for {tick.instrument_id}: "
+                f"invalid {tick.ask_size.precision=} "
+                f"did not match instrument.size_precision={self._size_prec}",
             )
+            return
 
         if self.book_type == BookType.L1_MBP:
             # Stale update: skip book mutation and cache updates
@@ -4476,13 +4507,6 @@ cdef class OrderMatchingEngine:
         tick : TradeTick
             The tick to process.
 
-        Raises
-        ------
-        RuntimeError
-            If the trades price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If the trades size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(tick, "tick")
 
@@ -4491,13 +4515,19 @@ cdef class OrderMatchingEngine:
 
         # Validate precisions
         if tick._mem.price.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {tick.price.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping trade tick for {tick.instrument_id}: "
+                f"invalid {tick.price.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif tick._mem.size.precision != self._size_prec:
-            raise RuntimeError(
-                f"invalid {tick.size.precision=} did not match instrument.size_precision={self._size_prec}",
+            self._log.warning(
+                f"Skipping trade tick for {tick.instrument_id}: "
+                f"invalid {tick.size.precision=} "
+                f"did not match instrument.size_precision={self._size_prec}",
             )
+            return
 
         if self.book_type == BookType.L1_MBP:
             # Stale update: skip book mutation and trade execution
@@ -4619,13 +4649,6 @@ cdef class OrderMatchingEngine:
         bar : Bar
             The bar to process.
 
-        Raises
-        ------
-        RuntimeError
-            If a price precision does not match the instrument for the matching engine.
-        RuntimeError
-            If a size precision does not match the instrument for the matching engine.
-
         """
         Condition.not_none(bar, "bar")
 
@@ -4641,25 +4664,40 @@ cdef class OrderMatchingEngine:
 
         # Validate precisions
         if bar._mem.open.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {bar.open.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping bar for {bar_type.instrument_id}: "
+                f"invalid {bar.open.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif bar._mem.high.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {bar.high.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping bar for {bar_type.instrument_id}: "
+                f"invalid {bar.high.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif bar._mem.low.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {bar.low.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping bar for {bar_type.instrument_id}: "
+                f"invalid {bar.low.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif bar._mem.close.precision != self._price_prec:
-            raise RuntimeError(
-                f"invalid {bar.close.precision=} did not match instrument.price_precision={self._price_prec}",
+            self._log.warning(
+                f"Skipping bar for {bar_type.instrument_id}: "
+                f"invalid {bar.close.precision=} "
+                f"did not match instrument.price_precision={self._price_prec}",
             )
+            return
         elif bar._mem.volume.precision != self._size_prec:
-            raise RuntimeError(
-                f"invalid {bar.volume.precision=} did not match instrument.size_precision={self._size_prec}",
+            self._log.warning(
+                f"Skipping bar for {bar_type.instrument_id}: "
+                f"invalid {bar.volume.precision=} "
+                f"did not match instrument.size_precision={self._size_prec}",
             )
+            return
 
         cdef InstrumentId instrument_id = bar_type.instrument_id
         cdef BarType execution_bar_type = self._execution_bar_types.get(instrument_id)

--- a/nautilus_trader/execution/matching_core.pxd
+++ b/nautilus_trader/execution/matching_core.pxd
@@ -61,6 +61,7 @@ cdef class MatchingCore:
     cdef void set_last_raw(self, PriceRaw last_raw)
 
     cpdef void update_price_increment(self, Price price_increment)
+    cpdef void clear_market_state(self)
 
     cpdef void reset(self)
     cpdef void add_order(self, Order order)

--- a/nautilus_trader/execution/matching_core.pyx
+++ b/nautilus_trader/execution/matching_core.pyx
@@ -206,16 +206,19 @@ cdef class MatchingCore:
         self._price_increment = price_increment
         self._price_precision = price_increment.precision
 
-    cpdef void reset(self):
-        self._orders.clear()
-        self._orders_bid.clear()
-        self._orders_ask.clear()
+    cpdef void clear_market_state(self):
         self.bid_raw = 0
         self.ask_raw = 0
         self.last_raw = 0
         self.is_bid_initialized = False
         self.is_ask_initialized = False
         self.is_last_initialized = False
+
+    cpdef void reset(self):
+        self._orders.clear()
+        self._orders_bid.clear()
+        self._orders_ask.clear()
+        self.clear_market_state()
 
     cpdef void add_order(self, Order order):
         Condition.not_none(order, "order")

--- a/tests/unit_tests/backtest/test_matching_engine.py
+++ b/tests/unit_tests/backtest/test_matching_engine.py
@@ -34,7 +34,10 @@ from nautilus_trader.model.data import BarSpecification
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import BookOrder
 from nautilus_trader.model.data import OrderBookDelta
+from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import OrderBookDepth10
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import AggregationSource
 from nautilus_trader.model.enums import AggressorSide
@@ -58,6 +61,7 @@ from nautilus_trader.model.events import OrderRejected
 from nautilus_trader.model.events import OrderUpdated
 from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import StrategyId
+from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import VenueOrderId
 from nautilus_trader.model.instruments import CryptoPerpetual
 from nautilus_trader.model.objects import Price
@@ -137,6 +141,204 @@ class TestOrderMatchingEngine:
         self.matching_engine.process_status(MarketStatusAction.PRE_OPEN)
         self.matching_engine.process_status(MarketStatusAction.PAUSE)
         self.matching_engine.process_status(MarketStatusAction.TRADING)
+
+    def test_process_order_book_delta_with_precision_mismatch_does_not_raise(self) -> None:
+        # Arrange
+        delta = OrderBookDelta(
+            instrument_id=self.instrument.id,
+            action=BookAction.ADD,
+            order=BookOrder(
+                side=OrderSide.BUY,
+                price=Price.from_str("1000.001"),  # precision=3, instrument expects 2
+                size=Quantity.from_str("1.000"),
+                order_id=1,
+            ),
+            flags=0,
+            sequence=1,
+            ts_event=1,
+            ts_init=1,
+        )
+
+        # Act - Should not raise
+        self.matching_engine.process_order_book_delta(delta)
+
+    def test_process_quote_tick_with_precision_mismatch_does_not_raise(self) -> None:
+        # Arrange
+        quote = QuoteTick(
+            instrument_id=self.instrument.id,
+            bid_price=Price.from_str("1000.001"),  # precision=3, instrument expects 2
+            ask_price=Price.from_str("1000.002"),  # precision=3, instrument expects 2
+            bid_size=Quantity.from_str("1.000"),
+            ask_size=Quantity.from_str("1.000"),
+            ts_event=1,
+            ts_init=1,
+        )
+
+        # Act - Should not raise
+        self.matching_engine.process_quote_tick(quote)
+
+    def test_process_trade_tick_with_precision_mismatch_does_not_raise(self) -> None:
+        # Arrange
+        trade = TradeTick(
+            instrument_id=self.instrument.id,
+            price=Price.from_str("1000.00"),
+            size=Quantity.from_str("1.0000"),  # precision=4, instrument expects 3
+            aggressor_side=AggressorSide.BUYER,
+            trade_id=TradeId("T-1"),
+            ts_event=1,
+            ts_init=1,
+        )
+
+        # Act - Should not raise
+        self.matching_engine.process_trade_tick(trade)
+
+    def test_process_bar_with_precision_mismatch_does_not_raise(self) -> None:
+        # Arrange
+        bar = Bar(
+            bar_type=BarType(
+                instrument_id=self.instrument.id,
+                bar_spec=BarSpecification(
+                    step=1,
+                    aggregation=BarAggregation.MINUTE,
+                    price_type=PriceType.LAST,
+                ),
+                aggregation_source=AggregationSource.EXTERNAL,
+            ),
+            open=Price.from_str("1000.001"),  # precision=3, instrument expects 2
+            high=Price.from_str("1000.002"),
+            low=Price.from_str("999.999"),
+            close=Price.from_str("1000.000"),
+            volume=Quantity.from_str("1.000"),
+            ts_event=1,
+            ts_init=1,
+        )
+
+        # Act - Should not raise
+        self.matching_engine.process_bar(bar)
+
+    def test_process_quote_tick_with_precision_mismatch_preserves_book_state(self) -> None:
+        # Arrange
+        self.matching_engine.process_quote_tick(
+            TestDataStubs.quote_tick(
+                instrument=self.instrument,
+                bid_price=1000.00,
+                ask_price=1000.01,
+                ts_event=1,
+                ts_init=1,
+            ),
+        )
+        bid_before = self.matching_engine.best_bid_price()
+        ask_before = self.matching_engine.best_ask_price()
+
+        mismatched = QuoteTick(
+            instrument_id=self.instrument.id,
+            bid_price=Price.from_str("1001.001"),  # precision=3, instrument expects 2
+            ask_price=Price.from_str("1001.002"),
+            bid_size=Quantity.from_str("1.000"),
+            ask_size=Quantity.from_str("1.000"),
+            ts_event=2,
+            ts_init=2,
+        )
+
+        # Act
+        self.matching_engine.process_quote_tick(mismatched)
+
+        # Assert
+        assert self.matching_engine.best_bid_price() == bid_before
+        assert self.matching_engine.best_ask_price() == ask_before
+        assert self.clock.timestamp_ns() == 1
+
+    def test_process_order_book_deltas_with_precision_mismatch_skips_batch(self) -> None:
+        # Arrange
+        matching_engine_l2 = OrderMatchingEngine(
+            instrument=self.instrument,
+            raw_id=0,
+            fill_model=FillModel(),
+            fee_model=MakerTakerFeeModel(),
+            book_type=BookType.L2_MBP,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            reject_stop_orders=True,
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        deltas = OrderBookDeltas(
+            instrument_id=self.instrument.id,
+            deltas=[
+                OrderBookDelta(
+                    instrument_id=self.instrument.id,
+                    action=BookAction.ADD,
+                    order=BookOrder(
+                        side=OrderSide.BUY,
+                        price=Price.from_str("1000.001"),  # precision=3, expects 2
+                        size=Quantity.from_str("1.000"),
+                        order_id=1,
+                    ),
+                    flags=0,
+                    sequence=1,
+                    ts_event=10,
+                    ts_init=10,
+                ),
+            ],
+        )
+
+        # Act
+        matching_engine_l2.process_order_book_deltas(deltas)
+
+        # Assert
+        assert matching_engine_l2.best_bid_price() is None
+        assert matching_engine_l2.best_ask_price() is None
+        assert self.clock.timestamp_ns() == 0
+
+    def test_process_order_book_depth10_with_precision_mismatch_skips_snapshot(self) -> None:
+        # Arrange
+        matching_engine_l2 = OrderMatchingEngine(
+            instrument=self.instrument,
+            raw_id=0,
+            fill_model=FillModel(),
+            fee_model=MakerTakerFeeModel(),
+            book_type=BookType.L2_MBP,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.MARGIN,
+            reject_stop_orders=True,
+            msgbus=self.msgbus,
+            cache=self.cache,
+            clock=self.clock,
+        )
+        depth = OrderBookDepth10(
+            instrument_id=self.instrument.id,
+            bids=[
+                BookOrder(
+                    side=OrderSide.BUY,
+                    price=Price.from_str("1000.001"),  # precision=3, expects 2
+                    size=Quantity.from_str("1.000"),
+                    order_id=1,
+                ),
+            ],
+            asks=[
+                BookOrder(
+                    side=OrderSide.SELL,
+                    price=Price.from_str("1000.01"),
+                    size=Quantity.from_str("1.000"),
+                    order_id=2,
+                ),
+            ],
+            bid_counts=[1],
+            ask_counts=[1],
+            flags=0,
+            sequence=1,
+            ts_event=11,
+            ts_init=11,
+        )
+
+        # Act
+        matching_engine_l2.process_order_book_depth10(depth)
+
+        # Assert
+        assert matching_engine_l2.best_bid_price() is None
+        assert matching_engine_l2.best_ask_price() is None
+        assert self.clock.timestamp_ns() == 0
 
     def test_process_market_on_close_order(self) -> None:
         order: MarketOrder = TestExecStubs.market_order(
@@ -4066,6 +4268,63 @@ def test_update_instrument_propagates_precision_only_change() -> None:
     assert rejected is not None
     assert "bid=1000.000" in rejected.reason
     assert "ask=1000.010" in rejected.reason
+
+
+def test_update_instrument_clears_stale_core_market_state_before_new_quote() -> None:
+    # Arrange
+    clock = TestClock()
+    account_id = TestIdStubs.account_id()
+    msgbus = MessageBus(trader_id=TestIdStubs.trader_id(), clock=clock)
+    instrument = _ETHUSDT_PERP_BINANCE
+    cache = TestComponentStubs.cache()
+    cache.add_instrument(instrument)
+
+    matching_engine = OrderMatchingEngine(
+        instrument=instrument,
+        raw_id=0,
+        fill_model=FillModel(),
+        fee_model=MakerTakerFeeModel(),
+        book_type=BookType.L1_MBP,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.MARGIN,
+        reject_stop_orders=True,
+        trade_execution=True,
+        msgbus=msgbus,
+        cache=cache,
+        clock=clock,
+    )
+    exec_messages: list[Any] = []
+    msgbus.register("ExecEngine.process", lambda x: exec_messages.append(x))
+
+    matching_engine.process_quote_tick(
+        TestDataStubs.quote_tick(
+            instrument=instrument,
+            bid_price=1000.00,
+            ask_price=1000.01,
+            ts_event=0,
+            ts_init=0,
+        ),
+    )
+
+    repriced = _ethusdt_perp_binance_with_tick(price_precision=3, increment="0.001")
+    cache.add_instrument(repriced)
+
+    # Act: update instrument then submit post-only order before any new quote
+    matching_engine.update_instrument(repriced)
+    post_only = TestExecStubs.limit_order(
+        instrument=repriced,
+        order_side=OrderSide.BUY,
+        price=repriced.make_price(1000.010),
+        post_only=True,
+        client_order_id=ClientOrderId("O-CLEAR-CORE"),
+    )
+    matching_engine.process_order(post_only, account_id)
+
+    # Assert: order is not rejected against stale pre-update quote context
+    accepted = next((m for m in exec_messages if isinstance(m, OrderAccepted)), None)
+    rejected = next((m for m in exec_messages if isinstance(m, OrderRejected)), None)
+    assert accepted is not None
+    assert rejected is None
 
 
 def _create_bar_execution_matching_engine() -> OrderMatchingEngine:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR hardens market-data failure paths across Rust and Cython matching engines so malformed/unsupported data no longer causes process-killing behavior.

It extends the #3994 follow-up in three ways:

1. Removes panic-prone Rust `process_bar` handling for `PriceType::Mark`.
2. Aligns Cython backtest matching-engine precision mismatch handling with Rust fail-soft behavior (`warn + return`, no crash path).
3. Ensures backtest `update_instrument` resets stale market-derived state on precision/tick-size changes.

## Related Issues/PRs

- Related to https://github.com/nautechsystems/nautilus_trader/pull/3994

## Type of change

- [x] Bug fix (non-breaking)
- [x] Improvement (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A.

## Design notes

### Rust (`crates/execution/src/matching_engine/engine.rs`)

- `process_bar` now handles `PriceType::Mark` with warning + skip instead of panic.
- Existing fail-soft precision checks remain unchanged (`warn + return`).

### Cython Backtest Engine (`nautilus_trader/backtest/engine.pyx`)

- Precision mismatches in these market-data entry points now fail-soft instead of raising runtime exceptions:
  - `process_order_book_delta`
  - `process_order_book_deltas`
  - `process_order_book_depth10`
  - `process_quote_tick`
  - `process_trade_tick`
  - `process_bar`
- Behavior is now explicitly `warn + return` for precision mismatch (parity with Rust handling philosophy).
- Removed outdated docstring `Raises RuntimeError` sections for those precision guards.

### Backtest instrument-update state reset (`update_instrument`)

- On tick-size/precision changes, reset stale market-derived state to prevent mixed old/new grid behavior:
  - order book, queue/consumption caches, TOB cache, quote context, execution-bar targets.
- Added `MatchingCore.clear_market_state()` and call it from `update_instrument` to clear bid/ask/last initialization state safely without clearing orders.

## Files changed

- `crates/execution/src/matching_engine/engine.rs`
- `crates/execution/tests/matching_engine.rs`
- `nautilus_trader/backtest/engine.pyx`
- `nautilus_trader/execution/matching_core.pyx`
- `nautilus_trader/execution/matching_core.pxd`
- `tests/unit_tests/backtest/test_matching_engine.py`

## Behavioral impact

- Bad precision market data no longer tears down Cython backtest matching flow.
- Unsupported Rust MARK bars no longer panic.
- Instrument-definition precision updates now avoid stale quote/book state leakage.

## Risk

Low to medium.

- Changes are localized to error/fallback paths and instrument update cache reset behavior.
- Normal-path matching semantics remain unchanged.
- Added explicit regression tests for all modified behaviors.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are covered by tests
- [x] I added/updated tests to cover new or changed logic

### Verification

- `pre-commit run --files crates/execution/src/matching_engine/engine.rs crates/execution/tests/matching_engine.rs nautilus_trader/backtest/engine.pyx nautilus_trader/execution/matching_core.pyx nautilus_trader/execution/matching_core.pxd tests/unit_tests/backtest/test_matching_engine.py`
- `cargo test -q -p nautilus-execution`
- `pytest -q tests/unit_tests/backtest/test_matching_engine.py`
- `pytest -q tests/unit_tests/backtest/test_matching_engine.py -k "precision_mismatch or update_instrument"`
