### PR TITLE
Harden Polymarket websocket parse-error handling

### DIFF
--- a/nautilus_trader/adapters/polymarket/data.py
+++ b/nautilus_trader/adapters/polymarket/data.py
@@ -489,7 +489,8 @@ class PolymarketDataClient(LiveMarketDataClient):
             else:
                 self._handle_ws_message(msg)
         except Exception as e:
-            self._log.exception(f"Failed to parse websocket message: {raw.decode()} with error", e)
+            raw_text = raw.decode(errors="replace")
+            self._log.exception(f"Failed to parse websocket message: {raw_text}", e)
 
     def _handle_ws_message(self, msg: Any) -> None:
         if isinstance(msg, PolymarketQuotes):

--- a/tests/integration_tests/adapters/polymarket/test_data_client.py
+++ b/tests/integration_tests/adapters/polymarket/test_data_client.py
@@ -135,8 +135,18 @@ def _make_data_client(
     client._ws_client.is_connected = MagicMock(return_value=True)
     client._ws_client.subscribe = AsyncMock()
     client._ws_client.unsubscribe = AsyncMock()
+    client._ws_client.disconnect = AsyncMock()
 
     return client, provider
+
+
+def test_handle_raw_ws_message_with_non_utf8_payload_does_not_raise(event_loop) -> None:
+    client, _ = _make_data_client(event_loop)
+    client._decoder_market_msg = MagicMock()
+    client._decoder_market_msg.decode.side_effect = ValueError("invalid payload")
+
+    # Non-UTF8 bytes should still be safely logged on parser failure.
+    client._handle_raw_ws_message(b"\xff")
 
 
 def test_tick_size_change_clears_book_and_marks_pending(event_loop) -> None:
@@ -366,6 +376,7 @@ def _make_client_for_auto_load(
     client._ws_client.is_connected = MagicMock(return_value=True)
     client._ws_client.subscribe = AsyncMock()
     client._ws_client.add_subscription = MagicMock()
+    client._ws_client.disconnect = AsyncMock()
 
     return client, provider
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR hardens Polymarket websocket parse-error handling so the logging path cannot raise a secondary exception while reporting the original failure.

It also aligns the test mock with the production async interface and adds a regression test for non-UTF8 payload handling.

## Related Issues/PRs

Closes #4036

## Type of change

- [x] Bug fix (non-breaking)
- [x] Improvement (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A.

## Design notes

- Keep the original exception object in the logger call, matching the project logger API.
- Decode raw websocket bytes with `errors="replace"` in the exception path so malformed payloads do not trigger a second failure while formatting the diagnostic.
- Update the websocket disconnect mock to `AsyncMock()` so the tests preserve the production awaitable behavior.
- Add a regression test covering parse failure with a non-UTF8 payload.

## Files changed

- `nautilus_trader/adapters/polymarket/data.py`
- `tests/integration_tests/adapters/polymarket/test_data_client.py`

## Risk

Low.
- Change is limited to exception-handling code and tests.
- No protocol or business-logic behavior changes.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

### Verification

- `pre-commit run --files nautilus_trader/adapters/polymarket/data.py tests/integration_tests/adapters/polymarket/test_data_client.py`
- `pytest -q tests/integration_tests/adapters/polymarket`
