### PR TITLE
Harden matching engine and sandbox against stale-precision ticks

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -178,6 +178,19 @@ impl SandboxInner {
 
         let instrument = self.cache.borrow().instrument(&instrument_id).cloned();
         if let Some(instrument) = instrument {
+            if !trade_matches_instrument_precision(trade, &instrument) {
+                log::warn!(
+                    "Dropping trade tick for {} due to precision mismatch \
+                     (px={}, sz={}, expected_price={}, expected_size={})",
+                    instrument_id,
+                    trade.price.precision,
+                    trade.size.precision,
+                    instrument.price_precision(),
+                    instrument.size_precision(),
+                );
+                return;
+            }
+
             self.ensure_matching_engine(&instrument);
 
             if let Some(engine) = self.matching_engines.get_mut(&instrument_id) {
@@ -826,7 +839,19 @@ impl ExecutionClient for SandboxExecutionClient {
             if self.config.trade_execution
                 && let Some(trade) = cache.trade(&instrument_id)
             {
-                engine.get_engine_mut().process_trade_tick(trade);
+                if trade_matches_instrument_precision(trade, &instrument) {
+                    engine.get_engine_mut().process_trade_tick(trade);
+                } else {
+                    log::warn!(
+                        "Dropping cached trade tick for {} due to precision mismatch \
+                         (px={}, sz={}, expected_price={}, expected_size={})",
+                        instrument_id,
+                        trade.price.precision,
+                        trade.size.precision,
+                        instrument.price_precision(),
+                        instrument.size_precision(),
+                    );
+                }
             }
         }
         drop(cache);
@@ -899,7 +924,19 @@ impl ExecutionClient for SandboxExecutionClient {
                     if self.config.trade_execution
                         && let Some(trade) = cache.trade(&instrument_id)
                     {
-                        engine.get_engine_mut().process_trade_tick(trade);
+                        if trade_matches_instrument_precision(trade, &instrument) {
+                            engine.get_engine_mut().process_trade_tick(trade);
+                        } else {
+                            log::warn!(
+                                "Dropping cached trade tick for {} due to precision mismatch \
+                                 (px={}, sz={}, expected_price={}, expected_size={})",
+                                instrument_id,
+                                trade.price.precision,
+                                trade.size.precision,
+                                instrument.price_precision(),
+                                instrument.size_precision(),
+                            );
+                        }
                     }
                 }
                 drop(cache);

--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -87,6 +87,13 @@ fn quote_matches_instrument_precision(quote: &QuoteTick, instrument: &Instrument
         && quote.ask_size.precision == size_precision
 }
 
+fn trade_matches_instrument_precision(trade: &TradeTick, instrument: &InstrumentAny) -> bool {
+    let price_precision = instrument.price_precision();
+    let size_precision = instrument.size_precision();
+
+    trade.price.precision == price_precision && trade.size.precision == size_precision
+}
+
 fn bar_matches_instrument_precision(bar: &Bar, instrument: &InstrumentAny) -> bool {
     let price_precision = instrument.price_precision();
     let size_precision = instrument.size_precision();
@@ -514,6 +521,19 @@ impl SandboxExecutionClient {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Instrument not found: {instrument_id}"))?;
 
+        if !trade_matches_instrument_precision(trade, &instrument) {
+            log::warn!(
+                "Dropping trade tick for {} due to precision mismatch \
+                 (px={}, sz={}, expected_price={}, expected_size={})",
+                instrument_id,
+                trade.price.precision,
+                trade.size.precision,
+                instrument.price_precision(),
+                instrument.size_precision(),
+            );
+            return Ok(());
+        }
+
         let mut inner = self.inner.borrow_mut();
         inner.ensure_matching_engine(&instrument);
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
@@ -786,7 +806,21 @@ impl ExecutionClient for SandboxExecutionClient {
 
         if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
             if let Some(quote) = cache.quote(&instrument_id) {
-                engine.get_engine_mut().process_quote_tick(quote);
+                if quote_matches_instrument_precision(quote, &instrument) {
+                    engine.get_engine_mut().process_quote_tick(quote);
+                } else {
+                    log::warn!(
+                        "Dropping cached quote tick for {} due to precision mismatch \
+                         (bid_px={}, ask_px={}, bid_sz={}, ask_sz={}, expected_price={}, expected_size={})",
+                        instrument_id,
+                        quote.bid_price.precision,
+                        quote.ask_price.precision,
+                        quote.bid_size.precision,
+                        quote.ask_size.precision,
+                        instrument.price_precision(),
+                        instrument.size_precision(),
+                    );
+                }
             }
 
             if self.config.trade_execution
@@ -845,7 +879,21 @@ impl ExecutionClient for SandboxExecutionClient {
 
                 if let Some(engine) = inner.matching_engines.get_mut(&instrument_id) {
                     if let Some(quote) = cache.quote(&instrument_id) {
-                        engine.get_engine_mut().process_quote_tick(quote);
+                        if quote_matches_instrument_precision(quote, &instrument) {
+                            engine.get_engine_mut().process_quote_tick(quote);
+                        } else {
+                            log::warn!(
+                                "Dropping cached quote tick for {} due to precision mismatch \
+                                 (bid_px={}, ask_px={}, bid_sz={}, ask_sz={}, expected_price={}, expected_size={})",
+                                instrument_id,
+                                quote.bid_price.precision,
+                                quote.ask_price.precision,
+                                quote.bid_size.precision,
+                                quote.ask_size.precision,
+                                instrument.price_precision(),
+                                instrument.size_precision(),
+                            );
+                        }
                     }
 
                     if self.config.trade_execution

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -31,10 +31,10 @@ use nautilus_common::{
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_execution::{client::core::ExecutionClientCore, engine::ExecutionEngine};
 use nautilus_model::{
-    data::{Bar, BarType, QuoteTick},
-    enums::{AccountType, BookType, OmsType, OrderSide, OrderType},
+    data::{Bar, BarType, QuoteTick, TradeTick},
+    enums::{AccountType, AggressorSide, BookType, OmsType, OrderSide, OrderType},
     events::OrderEventAny,
-    identifiers::{AccountId, ClientId, InstrumentId, TraderId, Venue},
+    identifiers::{AccountId, ClientId, InstrumentId, TradeId, TraderId, Venue},
     instruments::{CryptoPerpetual, Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt},
     orders::OrderTestBuilder,
     types::{Currency, Money, Price, Quantity},
@@ -133,6 +133,31 @@ fn create_test_context(trader_id: TraderId, account_id: AccountId, venue: Venue)
     TestContext { client, cache }
 }
 
+fn create_test_context_with_trade_execution(
+    trader_id: TraderId,
+    account_id: AccountId,
+    venue: Venue,
+) -> TestContext {
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let mut config = create_config(trader_id, account_id, venue);
+    config.trade_execution = true;
+
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+
+    let client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    TestContext { client, cache }
+}
+
 #[fixture]
 fn test_context(trader_id: TraderId, account_id: AccountId, venue: Venue) -> TestContext {
     create_test_context(trader_id, account_id, venue)
@@ -168,6 +193,29 @@ fn create_quote_tick(instrument_id: InstrumentId, bid: f64, ask: f64) -> QuoteTi
 fn create_mismatched_quote_tick(instrument_id: InstrumentId, bid: f64, ask: f64) -> QuoteTick {
     // Uses price precision 3 (instrument fixture uses 2), should be rejected by sandbox guard.
     create_quote_tick_with_price_precision(instrument_id, bid, ask, 3)
+}
+
+fn create_trade_tick_with_precision(
+    instrument_id: InstrumentId,
+    price: f64,
+    size: f64,
+    price_precision: u8,
+    size_precision: u8,
+) -> TradeTick {
+    TradeTick::new(
+        instrument_id,
+        Price::new(price, price_precision),
+        Quantity::new(size, size_precision),
+        AggressorSide::Buyer,
+        TradeId::new("1"),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
+}
+
+fn create_mismatched_trade_tick(instrument_id: InstrumentId) -> TradeTick {
+    // Uses price precision 3 (instrument fixture uses 2), should be rejected by sandbox guard.
+    create_trade_tick_with_precision(instrument_id, 1000.0, 1.0, 3, 3)
 }
 
 fn updated_instrument_with_price_precision_3(instrument: InstrumentAny) -> InstrumentAny {
@@ -487,8 +535,6 @@ fn test_process_quote_tick_instrument_not_found(execution_client: SandboxExecuti
 
 #[rstest]
 fn test_process_trade_tick_disabled(test_context: TestContext, instrument: InstrumentAny) {
-    use nautilus_model::{data::TradeTick, enums::AggressorSide, identifiers::TradeId};
-
     setup_order_event_handler();
 
     test_context
@@ -513,6 +559,54 @@ fn test_process_trade_tick_disabled(test_context: TestContext, instrument: Instr
     assert!(result.is_ok());
     // No matching engine created because trade_execution is disabled
     assert_eq!(test_context.client.matching_engine_count(), 0);
+}
+
+#[rstest]
+fn test_process_trade_tick_drops_precision_mismatch(
+    trader_id: TraderId,
+    account_id: AccountId,
+    instrument: InstrumentAny,
+) {
+    setup_order_event_handler();
+
+    let venue = instrument.id().venue;
+    let mut test_context = create_test_context_with_trade_execution(trader_id, account_id, venue);
+    test_context.client.start().unwrap();
+    test_context
+        .cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+
+    let trade = create_mismatched_trade_tick(instrument.id());
+    let result = test_context.client.process_trade_tick(&trade);
+
+    assert!(result.is_ok());
+    assert_eq!(test_context.client.matching_engine_count(), 0);
+}
+
+#[rstest]
+fn test_message_handler_drops_precision_mismatched_trade(
+    trader_id: TraderId,
+    account_id: AccountId,
+    instrument: InstrumentAny,
+) {
+    setup_order_event_handler();
+
+    let venue = instrument.id().venue;
+    let mut test_context = create_test_context_with_trade_execution(trader_id, account_id, venue);
+    test_context
+        .cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    test_context.client.start().unwrap();
+
+    let trade = create_mismatched_trade_tick(instrument.id());
+    msgbus::publish_trade(format!("data.trades.{}", instrument.id()).into(), &trade);
+
+    assert_eq!(test_context.client.matching_engine_count(), 0);
+    test_context.client.stop().unwrap();
 }
 
 #[rstest]

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -603,7 +603,10 @@ fn test_message_handler_drops_precision_mismatched_trade(
     test_context.client.start().unwrap();
 
     let trade = create_mismatched_trade_tick(instrument.id());
-    msgbus::publish_trade(format!("data.trades.{}", instrument.id()).into(), &trade);
+    msgbus::publish_trade(
+        format!("data.trades.{}.{}", instrument.id().venue, instrument.id()).into(),
+        &trade,
+    );
 
     assert_eq!(test_context.client.matching_engine_count(), 0);
     test_context.client.stop().unwrap();

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -1346,10 +1346,6 @@ impl OrderMatchingEngine {
     }
 
     /// Processes a quote tick to update the market state.
-    ///
-    /// # Panics
-    ///
-    /// - If updating the order book with the quote tick fails.
     pub fn process_quote_tick(&mut self, quote: &QuoteTick) {
         log::debug!("Processing {quote}");
 

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -1388,6 +1388,10 @@ impl OrderMatchingEngine {
                 return;
             }
 
+            if !self.update_quote_tick_or_skip(quote, "quote tick") {
+                return;
+            }
+
             if self.config.queue_position {
                 self.decrement_l1_queue_on_quote(
                     quote.bid_price.raw,
@@ -1401,7 +1405,6 @@ impl OrderMatchingEngine {
                 self.prev_ask_size_raw = quote.ask_size.raw;
                 self.tob_initialized = true;
             }
-            self.book.update_quote_tick(quote).unwrap();
             self.last_quote_bid = Some(quote.bid_price);
             self.last_quote_ask = Some(quote.ask_price);
         }
@@ -1528,13 +1531,19 @@ impl OrderMatchingEngine {
         // Open: fill at market price (gap from previous bar)
         if self.core.last.is_none() {
             self.fill_at_market = true;
-            self.book.update_trade_tick(&trade_tick).unwrap();
+
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar open trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
             self.core.set_last_raw(trade_tick.price);
         } else if self.core.last.is_some_and(|last| bar.open != last) {
             // Gap between previous close and this bar's open
             self.fill_at_market = true;
-            self.book.update_trade_tick(&trade_tick).unwrap();
+
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar gap-open trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
             self.core.set_last_raw(trade_tick.price);
         }
@@ -1565,7 +1574,9 @@ impl OrderMatchingEngine {
             }
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(&trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(&trade_tick, "bar close trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1581,7 +1592,9 @@ impl OrderMatchingEngine {
             trade_tick.aggressor_side = AggressorSide::Buyer;
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(trade_tick, "bar high trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1595,7 +1608,9 @@ impl OrderMatchingEngine {
             trade_tick.aggressor_side = AggressorSide::Seller;
             trade_tick.trade_id = self.ids_generator.generate_trade_id(trade_tick.ts_init);
 
-            self.book.update_trade_tick(trade_tick).unwrap();
+            if !self.update_trade_tick_or_skip(trade_tick, "bar low trade tick") {
+                return;
+            }
             self.iterate(trade_tick.ts_init, AggressorSide::NoAggressor);
 
             self.core.set_last_raw(trade_tick.price);
@@ -1637,21 +1652,30 @@ impl OrderMatchingEngine {
 
         // Open: fill at market price (gap from previous bar)
         self.fill_at_market = true;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar open quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // High: fill at trigger price (market moving through prices)
         self.fill_at_market = false;
         quote_tick.bid_price = bid_bar.high;
         quote_tick.ask_price = ask_bar.high;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar high quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // Low: fill at trigger price (market moving through prices)
         self.fill_at_market = false;
         quote_tick.bid_price = bid_bar.low;
         quote_tick.ask_price = ask_bar.low;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar low quote tick") {
+            return;
+        }
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
 
         // Close: fill at trigger price (market moving through prices)
@@ -1660,7 +1684,10 @@ impl OrderMatchingEngine {
         quote_tick.ask_price = ask_bar.close;
         quote_tick.bid_size = bid_close_size;
         quote_tick.ask_size = ask_close_size;
-        self.book.update_quote_tick(&quote_tick).unwrap();
+
+        if !self.update_quote_tick_or_skip(&quote_tick, "bar close quote tick") {
+            return;
+        }
         self.last_quote_bid = Some(bid_bar.close);
         self.last_quote_ask = Some(ask_bar.close);
         self.iterate(quote_tick.ts_init, AggressorSide::NoAggressor);
@@ -1670,16 +1697,33 @@ impl OrderMatchingEngine {
         self.fill_at_market = true;
     }
 
+    fn update_quote_tick_or_skip(&mut self, quote: &QuoteTick, context: &str) -> bool {
+        if let Err(e) = self.book.update_quote_tick(quote) {
+            log::warn!(
+                "Skipping {context} for {}: update_quote_tick failed: {e}",
+                quote.instrument_id,
+            );
+            return false;
+        }
+        true
+    }
+
+    fn update_trade_tick_or_skip(&mut self, trade: &TradeTick, context: &str) -> bool {
+        if let Err(e) = self.book.update_trade_tick(trade) {
+            log::warn!(
+                "Skipping {context} for {}: update_trade_tick failed: {e}",
+                trade.instrument_id,
+            );
+            return false;
+        }
+        true
+    }
     /// Processes a trade tick to update the market state.
     ///
     /// For L1 books, always updates the order book with the trade tick to maintain
     /// market state. When `trade_execution` is disabled, order matching and maintenance
     /// operations (GTD order expiry, trailing stop activation, instrument expiration)
     /// are skipped. These maintenance operations will run on the next quote tick or bar.
-    ///
-    /// # Panics
-    ///
-    /// - If updating the order book with the trade tick fails.
     pub fn process_trade_tick(&mut self, trade: &TradeTick) {
         log::debug!("Processing {trade}");
 
@@ -1710,7 +1754,9 @@ impl OrderMatchingEngine {
                 return;
             }
 
-            self.book.update_trade_tick(trade).unwrap();
+            if !self.update_trade_tick_or_skip(trade, "trade tick") {
+                return;
+            }
         }
 
         self.core.set_last_raw(trade.price);


### PR DESCRIPTION
## Summary

This PR is the runtime-focused split from closed #4037.

It hardens market-data handling around `tick_size_change` / `update_instrument` transitions so stale-precision events do not cause panics or invalid cache side-effects.

Scope is intentionally limited to Rust runtime paths (`execution` + `sandbox`) for focused review.

## Context

After instrument precision/tick-size updates, old-precision quote/trade events can still appear briefly from buffers/cache.  
Previously, some paths still used `unwrap()` or updated internal state before confirming book update success.

## Reviewer feedback addressed from #4037

This PR directly addresses prior review concerns:

1. Removed iterate side-effects from failure helpers:
   - `update_quote_tick_or_skip`
   - `update_trade_tick_or_skip`

2. Reordered `process_quote_tick` state writes:
   - book update first
   - TOB/cache updates only after successful update

3. Reduced scope for reviewability:
   - runtime execution/sandbox only
   - backtest/Cython parity work is moved to follow-up PR

## Changes

### 1) Matching engine fail-soft updates
**File:** `crates/execution/src/matching_engine/engine.rs`

- `process_quote_tick` now calls book update first, then updates `tob_initialized` / `prev_*` / `last_quote_*`.
- Replaced direct `unwrap()` book updates in trade/bar synthetic paths with guarded helpers:
  - `update_quote_tick_or_skip(...)`
  - `update_trade_tick_or_skip(...)`
- Failure branches now `warn + return` (no extra `iterate(...)` side-effects).
- Removed outdated quote-tick `# Panics` doc note to match fail-soft behavior.

### 2) Sandbox precision filtering closure (all relevant ingress paths)
**File:** `crates/adapters/sandbox/src/execution.rs`

- Added `trade_matches_instrument_precision(...)`.
- Applied trade precision guards to:
  - message-handler trade path (`SandboxInner::process_trade_tick`)
  - public `process_trade_tick`
  - cached trade replay in `submit_order` and `submit_order_list`
- Also ensured cached quote replay is precision-filtered before engine update.

### 3) Regression coverage
**File:** `crates/adapters/sandbox/tests/execution.rs`

- Added trade precision-mismatch tests for:
  - direct client trade processing
  - message-handler trade processing
- Enabled `trade_execution=true` in dedicated test context where needed.
- Fixed trade publish topic to match subscription pattern:
  - `data.trades.{venue}.{instrument_id}`

## Why this shape

Only fixing engine internals is not enough for this transition window; stale data can still enter from sandbox ingress/cache replay paths.  
This PR keeps runtime protection closed-loop while remaining narrow in scope.

## Risk

Low to medium.

- Changes are concentrated in invalid/stale-data handling paths.
- Valid-data matching behavior is unchanged.

## Validation

- `pre-commit run --files crates/execution/src/matching_engine/engine.rs crates/adapters/sandbox/src/execution.rs crates/adapters/sandbox/tests/execution.rs`
- `cargo test -q -p nautilus-execution -p nautilus-sandbox`
- `cargo test -q -p nautilus-sandbox --test execution`

## Follow-up

Backtest/Cython parity changes (including MARK handling and backtest-side precision/reset behavior) will be submitted in a separate PR.
