### PR TITLE
Suppress Hyperliquid cancel/modify rejects on transport failure

### DIFF
--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -855,6 +855,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
             )
 
         except Exception as e:
+            if isinstance(e, (TimeoutError, OSError)):
+                self._log.warning(
+                    f"Modify request timed out for {command.client_order_id} "
+                    f"— cancel-replace may have landed, awaiting WS reconciliation",
+                )
+                return
             self._pending_modify_keys.pop(command.client_order_id.value, None)
             self._pending_modify_target_qty.pop(command.client_order_id.value, None)
             self.generate_order_modify_rejected(

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -890,7 +890,14 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 venue_order_id=pyo3_venue_order_id,
             )
             self._log.info(f"Order cancellation requested for {command.client_order_id}")
+
         except Exception as e:
+            if isinstance(e, (TimeoutError, OSError)):
+                self._log.warning(
+                    f"Cancel request timed out for {command.client_order_id} "
+                    f"— order may be canceled on exchange, awaiting WS reconciliation",
+                )
+                return
             self.generate_order_cancel_rejected(
                 strategy_id=command.strategy_id,
                 instrument_id=command.instrument_id,
@@ -939,6 +946,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                     venue_order_id=pyo3_venue_order_id,
                 )
             except Exception as e:
+                if isinstance(e, (TimeoutError, OSError)):
+                    self._log.warning(
+                        f"Cancel request timed out for {order.client_order_id} "
+                        f"— order may be canceled on exchange, awaiting WS reconciliation",
+                    )
+                    continue
                 self.generate_order_cancel_rejected(
                     strategy_id=order.strategy_id,
                     instrument_id=order.instrument_id,
@@ -978,6 +991,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                     venue_order_id=pyo3_venue_order_id,
                 )
             except Exception as e:
+                if isinstance(e, (TimeoutError, OSError)):
+                    self._log.warning(
+                        f"Cancel request timed out for {order.client_order_id} "
+                        f"— order may be canceled on exchange, awaiting WS reconciliation",
+                    )
+                    continue
                 self.generate_order_cancel_rejected(
                     strategy_id=order.strategy_id,
                     instrument_id=order.instrument_id,


### PR DESCRIPTION
## Summary

In the Hyperliquid adapter, `_cancel_order`, `_cancel_all_orders`, and `_batch_cancel_orders` all caught every exception with a bare `except Exception` and unconditionally emitted `OrderCancelRejected`. This is incorrect for transport-level failures (`TimeoutError`, `OSError`) where the HTTP request may have already reached the exchange before the connection dropped — the cancel outcome is undefined, not confirmed-failed. Emitting `OrderCancelRejected` in that case misleads the strategy into believing the order is still open, causing state desync when WS subsequently delivers `OrderCanceled`. The fix adds an `isinstance` guard matching the existing pattern in `_submit_order`: transport errors log a warning and return, leaving WS reconciliation as the source of truth.

**Failure sequence**

1. Strategy sends `CancelOrder` command
2. `_cancel_order` builds the HTTP request and fires it via `await self._client.cancel_order(...)`
3. Request leaves the machine and hits Hyperliquid ✓
4. Connection drops (timeout/network blip) before response arrives
5. `TimeoutError` or `OSError` is raised on our side
6. `except Exception` catches it → `OrderCancelRejected` emitted → strategy believes cancel failed, order still open
7. Exchange did process the cancel → WS delivers `OrderCanceled`
8. NT receives `OrderCanceled` for an order it believes is still open → state desync, strategy may retry cancel or act on a position that no longer exists

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] Affected code paths are already covered by the test suite

The fix is a small, self-contained guard clause — the same pattern already present in `_submit_order`. No tests added; the correctness is apparent from the diff and the edge case (live transport failure during cancel) is not meaningfully unit-testable without a live node. The goal is to prevent state miscommunication on timeout, not to change any happy-path behavior.

> Note: it's possible this edge case is already handled at a higher level in the reconciliation or execution engine logic that I'm not fully across — happy to defer or close if so.