### PR TITLE
Fix Kraken Spot WS dispatch dropping delta-only exec frames

### DIFF
--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -139,6 +139,11 @@ pub struct WsDispatchState {
     /// here from the first frame and look it up when later frames omit it.
     /// Keyed by venue `order_id` because delta frames often lack `cl_ord_id`
     /// as well.
+    ///
+    /// Steady-state eviction happens on terminal exec types
+    /// (`Canceled`/`Filled`/`Expired`). Bounded by `DEDUP_CAPACITY` as a
+    /// safety net so missed terminal frames (reconnects, partial replays)
+    /// cannot leak entries indefinitely.
     pub order_symbol_cache: DashMap<String, String>,
     /// Last snapshot of qty / filled / price / trigger_price seen on a
     /// tracked `OpenOrdersDelta`.
@@ -223,14 +228,19 @@ impl WsDispatchState {
 
     /// Caches the symbol for a venue `order_id` if not already present.
     ///
-    /// First-write-wins so a later frame carrying a stale or differently
-    /// formatted symbol cannot overwrite the value resolved from the original
-    /// `pending_new` frame.
+    /// Atomic via [`DashMap::entry`] so concurrent callers cannot overwrite an
+    /// existing cached value — first writer wins, all later writers no-op.
+    /// The cheap `contains_key` fast path skips the key allocation when the
+    /// entry already exists; the `or_insert_with` covers the race that opens
+    /// between that check and the insert.
     pub fn cache_order_symbol(&self, order_id: &str, symbol: &str) {
-        if !self.order_symbol_cache.contains_key(order_id) {
-            self.order_symbol_cache
-                .insert(order_id.to_string(), symbol.to_string());
+        if self.order_symbol_cache.contains_key(order_id) {
+            return;
         }
+        self.evict_map_if_full(&self.order_symbol_cache);
+        self.order_symbol_cache
+            .entry(order_id.to_string())
+            .or_insert_with(|| symbol.to_string());
     }
 
     /// Returns the symbol previously cached for a venue `order_id`, if any.
@@ -323,6 +333,21 @@ impl WsDispatchState {
                 .is_ok()
         {
             set.clear();
+            self.clearing.store(false, Ordering::Release);
+        }
+    }
+
+    fn evict_map_if_full<K, V>(&self, map: &DashMap<K, V>)
+    where
+        K: Eq + std::hash::Hash,
+    {
+        if map.len() >= DEDUP_CAPACITY
+            && self
+                .clearing
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        {
+            map.clear();
             self.clearing.store(false, Ordering::Release);
         }
     }
@@ -487,6 +512,39 @@ mod tests {
         assert!(
             !state.insert_accepted(cid),
             "second insert must report already present (atomic dedup)",
+        );
+    }
+
+    #[rstest]
+    fn test_cache_order_symbol_first_write_wins() {
+        let state = WsDispatchState::new();
+        state.cache_order_symbol("v-order-1", "BTC/USD");
+        state.cache_order_symbol("v-order-1", "ETH/USD");
+
+        assert_eq!(
+            state.lookup_order_symbol("v-order-1").as_deref(),
+            Some("BTC/USD"),
+            "later writes must not overwrite the original cached symbol",
+        );
+    }
+
+    #[rstest]
+    fn test_cache_order_symbol_bounded_by_capacity() {
+        let state = WsDispatchState::new();
+        for i in 0..DEDUP_CAPACITY {
+            state.cache_order_symbol(format!("v-order-{i}").as_str(), "BTC/USD");
+        }
+        // At capacity; the next insert triggers a `clear()` before insertion.
+        state.cache_order_symbol("v-order-overflow", "BTC/USD");
+
+        assert!(
+            state.order_symbol_cache.len() <= DEDUP_CAPACITY,
+            "cache must stay within DEDUP_CAPACITY after overflow",
+        );
+        assert_eq!(
+            state.lookup_order_symbol("v-order-overflow").as_deref(),
+            Some("BTC/USD"),
+            "the overflow entry was inserted after eviction",
         );
     }
 

--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -130,6 +130,16 @@ pub struct WsDispatchState {
     pub emitted_accepted: DashSet<ClientOrderId>,
     /// Client order IDs that have reached the filled terminal state.
     pub filled_orders: DashSet<ClientOrderId>,
+    /// Symbol captured from the first execution frame for a venue order id.
+    ///
+    /// Kraken's spot v2 executions channel sends a `pending_new` frame with
+    /// full order details, then follow-up frames (`new`, `amended`, `restated`,
+    /// `status`) that omit fields which have not changed — `symbol` included.
+    /// The dispatch needs the symbol to resolve the instrument, so we cache it
+    /// here from the first frame and look it up when later frames omit it.
+    /// Keyed by venue `order_id` because delta frames often lack `cl_ord_id`
+    /// as well.
+    pub order_symbol_cache: DashMap<String, String>,
     /// Last snapshot of qty / filled / price / trigger_price seen on a
     /// tracked `OpenOrdersDelta`.
     ///
@@ -163,6 +173,7 @@ impl Default for WsDispatchState {
             order_identities: DashMap::new(),
             emitted_accepted: DashSet::default(),
             filled_orders: DashSet::default(),
+            order_symbol_cache: DashMap::new(),
             delta_snapshots: DashMap::new(),
             order_filled_qty: DashMap::new(),
             emitted_trades: Mutex::new(IndexSet::with_capacity(DEDUP_CAPACITY)),
@@ -208,6 +219,32 @@ impl WsDispatchState {
     pub fn insert_filled(&self, cid: ClientOrderId) {
         self.evict_if_full(&self.filled_orders);
         self.filled_orders.insert(cid);
+    }
+
+    /// Caches the symbol for a venue `order_id` if not already present.
+    ///
+    /// First-write-wins so a later frame carrying a stale or differently
+    /// formatted symbol cannot overwrite the value resolved from the original
+    /// `pending_new` frame.
+    pub fn cache_order_symbol(&self, order_id: &str, symbol: &str) {
+        if !self.order_symbol_cache.contains_key(order_id) {
+            self.order_symbol_cache
+                .insert(order_id.to_string(), symbol.to_string());
+        }
+    }
+
+    /// Returns the symbol previously cached for a venue `order_id`, if any.
+    #[must_use]
+    pub fn lookup_order_symbol(&self, order_id: &str) -> Option<String> {
+        self.order_symbol_cache
+            .get(order_id)
+            .map(|r| r.value().clone())
+    }
+
+    /// Removes any cached symbol for a venue `order_id`. Called when the order
+    /// reaches a terminal state on the executions stream.
+    pub fn forget_order_symbol(&self, order_id: &str) {
+        self.order_symbol_cache.remove(order_id);
     }
 
     /// Atomically inserts a trade id into the dedup set.

--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -130,15 +130,25 @@ pub struct WsDispatchState {
     pub emitted_accepted: DashSet<ClientOrderId>,
     /// Client order IDs that have reached the filled terminal state.
     pub filled_orders: DashSet<ClientOrderId>,
-    /// Symbol captured from the first execution frame for a venue order id.
+    /// Symbol captured from execution frames for a venue order id.
     ///
     /// Kraken's spot v2 executions channel sends a `pending_new` frame with
-    /// full order details, then follow-up frames (`new`, `amended`, `restated`,
-    /// `status`) that omit fields which have not changed — `symbol` included.
-    /// The dispatch needs the symbol to resolve the instrument, so we cache it
-    /// here from the first frame and look it up when later frames omit it.
-    /// Keyed by venue `order_id` because delta frames often lack `cl_ord_id`
-    /// as well.
+    /// full order details, then follow-up frames (`new`, `amended`,
+    /// `restated`, `status`) that omit fields which have not changed —
+    /// Kraken's docs show `symbol` omitted on the `new` delta. The dispatch
+    /// needs the symbol to resolve the instrument, so we cache it here from
+    /// any frame that carries it (first writer wins). Keyed by venue
+    /// `order_id` because delta frames often lack `cl_ord_id` as well.
+    ///
+    /// Known limitation: the live spot execution client currently subscribes
+    /// with `snap_orders=false` (see `execution/spot.rs`). Orders that were
+    /// already open at the venue before this process connected therefore do
+    /// not receive an in-session `pending_new`, and if their next delta
+    /// frame omits `symbol` it is dropped at symbol resolution. State for
+    /// such orders is recovered via REST reconciliation
+    /// (`request_order_status_reports`). Enabling `snap_orders=true` would
+    /// allow the executions snapshot to seed the cache for pre-existing
+    /// orders.
     ///
     /// Steady-state eviction happens on terminal exec types
     /// (`Canceled`/`Filled`/`Expired`). Bounded by `DEDUP_CAPACITY` as a

--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -155,6 +155,23 @@ pub struct WsDispatchState {
     /// safety net so missed terminal frames (reconnects, partial replays)
     /// cannot leak entries indefinitely.
     pub order_symbol_cache: DashMap<String, String>,
+    /// `ClientOrderId` captured from execution frames for a venue order id.
+    ///
+    /// Kraken's `pending_new` echoes our submitted `cl_ord_id`, but follow-up
+    /// delta frames (`new`, `amended`, `restated`, `status`) routinely omit
+    /// it. Without this mapping the dispatch cannot resolve the tracked
+    /// order from a delta and falls back to the untracked report path,
+    /// which loses the typed `OrderAccepted` event — the symptom behind
+    /// issue #4051.
+    ///
+    /// Populated whenever a frame resolves a `cl_ord_id` (first writer
+    /// wins, keyed by venue `order_id`). Consulted when `exec.cl_ord_id`
+    /// is `None`. Mirrors the `venue_client_map` used by the futures
+    /// dispatch path.
+    ///
+    /// Eviction policy matches `order_symbol_cache`: cleared on terminal
+    /// exec types and bounded by `DEDUP_CAPACITY` as a safety net.
+    pub order_client_id_cache: DashMap<String, ClientOrderId>,
     /// Last snapshot of qty / filled / price / trigger_price seen on a
     /// tracked `OpenOrdersDelta`.
     ///
@@ -189,6 +206,7 @@ impl Default for WsDispatchState {
             emitted_accepted: DashSet::default(),
             filled_orders: DashSet::default(),
             order_symbol_cache: DashMap::new(),
+            order_client_id_cache: DashMap::new(),
             delta_snapshots: DashMap::new(),
             order_filled_qty: DashMap::new(),
             emitted_trades: Mutex::new(IndexSet::with_capacity(DEDUP_CAPACITY)),
@@ -265,6 +283,35 @@ impl WsDispatchState {
     /// reaches a terminal state on the executions stream.
     pub fn forget_order_symbol(&self, order_id: &str) {
         self.order_symbol_cache.remove(order_id);
+    }
+
+    /// Caches the resolved `ClientOrderId` for a venue `order_id` if not
+    /// already present.
+    ///
+    /// Atomic via [`DashMap::entry`] so concurrent callers cannot overwrite an
+    /// existing cached value — first writer wins. The cheap `contains_key`
+    /// fast path skips the key allocation when the entry already exists.
+    pub fn cache_order_client_id(&self, order_id: &str, client_order_id: ClientOrderId) {
+        if self.order_client_id_cache.contains_key(order_id) {
+            return;
+        }
+        self.evict_map_if_full(&self.order_client_id_cache);
+        self.order_client_id_cache
+            .entry(order_id.to_string())
+            .or_insert(client_order_id);
+    }
+
+    /// Returns the `ClientOrderId` previously cached for a venue `order_id`,
+    /// if any.
+    #[must_use]
+    pub fn lookup_order_client_id(&self, order_id: &str) -> Option<ClientOrderId> {
+        self.order_client_id_cache.get(order_id).map(|r| *r)
+    }
+
+    /// Removes any cached `ClientOrderId` for a venue `order_id`. Called when
+    /// the order reaches a terminal state on the executions stream.
+    pub fn forget_order_client_id(&self, order_id: &str) {
+        self.order_client_id_cache.remove(order_id);
     }
 
     /// Atomically inserts a trade id into the dedup set.

--- a/crates/adapters/kraken/src/websocket/dispatch/spot.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot.rs
@@ -179,10 +179,7 @@ pub fn execution(
 
     // Evict the cached symbol on terminal exec types so the cache does not
     // grow unbounded across the lifetime of the connection.
-    if matches!(
-        exec.exec_type,
-        KrakenExecType::Canceled | KrakenExecType::Filled | KrakenExecType::Expired
-    ) {
+    if is_terminal_exec_type(exec.exec_type) {
         state.forget_order_symbol(&exec.order_id);
     }
 }

--- a/crates/adapters/kraken/src/websocket/dispatch/spot.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot.rs
@@ -57,6 +57,38 @@ pub fn execution(
     account_id: AccountId,
     ts_init: UnixNanos,
 ) {
+    execution_inner(
+        exec,
+        state,
+        emitter,
+        instruments,
+        truncated_id_map,
+        order_qty_cache,
+        account_id,
+        ts_init,
+    );
+
+    // Run terminal cache cleanup regardless of which early return the inner
+    // dispatch hit (symbol miss, instrument miss, stale-filled suppression,
+    // parse error). Keying eviction off `exec.order_id` means it does not
+    // depend on `cl_ord_id` or identity resolution succeeding.
+    if is_terminal_exec_type(exec.exec_type) {
+        state.forget_order_symbol(&exec.order_id);
+        state.forget_order_client_id(&exec.order_id);
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn execution_inner(
+    exec: &KrakenWsExecutionData,
+    state: &WsDispatchState,
+    emitter: &ExecutionEventEmitter,
+    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    truncated_id_map: &Arc<AtomicMap<String, ClientOrderId>>,
+    order_qty_cache: &Arc<AtomicMap<String, f64>>,
+    account_id: AccountId,
+    ts_init: UnixNanos,
+) {
     // Resolve the trading symbol. Per Kraken's executions docs, follow-up
     // frames (`new`, `amended`, `restated`, `status`) carry only changed
     // fields and omit `symbol`. We cache the symbol from the first frame for
@@ -98,10 +130,20 @@ pub fn execution(
         order_qty_cache.insert(cl_ord_id.clone(), qty);
     }
 
-    let resolved_id = exec
-        .cl_ord_id
-        .as_ref()
-        .map(|id| resolve_client_order_id(id, truncated_id_map));
+    // Resolve the `ClientOrderId`. When the frame carries `cl_ord_id` we
+    // resolve it through the truncation map and seed the venue-id cache so
+    // later delta frames (which routinely omit `cl_ord_id`) can recover it.
+    // When `cl_ord_id` is absent we consult the cache; without this lookup a
+    // tracked order's delta `new` would fall through to the untracked report
+    // path and the strategy would never see `OrderAccepted` (issue #4051).
+    let resolved_id = match exec.cl_ord_id.as_ref() {
+        Some(id) => {
+            let cid = resolve_client_order_id(id, truncated_id_map);
+            state.cache_order_client_id(&exec.order_id, cid);
+            Some(cid)
+        }
+        None => state.lookup_order_client_id(&exec.order_id),
+    };
 
     // Stale-report suppression for previously-tracked orders that already
     // reached the filled terminal state.
@@ -175,12 +217,6 @@ pub fn execution(
             }
             Err(e) => log::error!("Failed to parse fill report: {e}"),
         }
-    }
-
-    // Evict the cached symbol on terminal exec types so the cache does not
-    // grow unbounded across the lifetime of the connection.
-    if is_terminal_exec_type(exec.exec_type) {
-        state.forget_order_symbol(&exec.order_id);
     }
 }
 

--- a/crates/adapters/kraken/src/websocket/dispatch/spot.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot.rs
@@ -57,16 +57,31 @@ pub fn execution(
     account_id: AccountId,
     ts_init: UnixNanos,
 ) {
-    let symbol = match &exec.symbol {
-        Some(s) => s.as_str(),
-        None => {
-            log::debug!(
-                "Execution message without symbol: exec_type={:?}, order_id={}",
-                exec.exec_type,
-                exec.order_id
-            );
-            return;
+    // Resolve the trading symbol. Per Kraken's executions docs, follow-up
+    // frames (`new`, `amended`, `restated`, `status`) carry only changed
+    // fields and omit `symbol`. We cache the symbol from the first frame for
+    // the venue order id and consult it here when the current frame omits it.
+    let cached_symbol;
+    let symbol = match exec.symbol.as_deref() {
+        Some(s) => {
+            state.cache_order_symbol(&exec.order_id, s);
+            s
         }
+        None => match state.lookup_order_symbol(&exec.order_id) {
+            Some(s) => {
+                cached_symbol = s;
+                cached_symbol.as_str()
+            }
+            None => {
+                log::debug!(
+                    "Execution message without symbol and no cached mapping: \
+                     exec_type={:?}, order_id={}",
+                    exec.exec_type,
+                    exec.order_id
+                );
+                return;
+            }
+        },
     };
     let Some(instrument) = lookup_instrument(instruments, symbol) else {
         log::warn!("No instrument for symbol: {symbol}");
@@ -160,6 +175,15 @@ pub fn execution(
             }
             Err(e) => log::error!("Failed to parse fill report: {e}"),
         }
+    }
+
+    // Evict the cached symbol on terminal exec types so the cache does not
+    // grow unbounded across the lifetime of the connection.
+    if matches!(
+        exec.exec_type,
+        KrakenExecType::Canceled | KrakenExecType::Filled | KrakenExecType::Expired
+    ) {
+        state.forget_order_symbol(&exec.order_id);
     }
 }
 

--- a/crates/adapters/kraken/tests/dispatch_spot.rs
+++ b/crates/adapters/kraken/tests/dispatch_spot.rs
@@ -737,12 +737,160 @@ fn test_spot_delta_without_cached_symbol_is_dropped() {
 }
 
 #[rstest]
+fn test_spot_tracked_pending_new_seeds_caches_no_event_yet() {
+    // Realistic `pending_new` for a tracked order: carries `cl_ord_id` and
+    // `symbol`, parses as `OrderStatus::Submitted` (which `status_tracked`
+    // treats as a no-op since the engine already has the order Submitted
+    // locally). Both venue-id caches must be seeded so the follow-up delta
+    // can resolve the identity.
+    let (emitter, mut rx) = test_emitter();
+    let state = Arc::new(WsDispatchState::new());
+    let cid = ClientOrderId::new("uuid-spot-tracked");
+    state.register_identity(
+        cid,
+        make_identity(SPOT_INSTRUMENT_ID, OrderSide::Buy, OrderType::Limit),
+    );
+    let instruments = instruments_with(make_spot_pair());
+
+    let mut pending = make_spot_execution(
+        KrakenExecType::PendingNew,
+        Some("uuid-spot-tracked"),
+        "v-spot-tracked",
+        None,
+    );
+    pending.order_status = Some(KrakenWsOrderStatus::PendingNew);
+    dispatch::spot::execution(
+        &pending,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+
+    assert!(
+        drain_events(&mut rx).is_empty(),
+        "tracked pending_new parses as Submitted; status_tracked emits nothing"
+    );
+    assert_eq!(
+        state.lookup_order_symbol("v-spot-tracked").as_deref(),
+        Some(SPOT_SYMBOL)
+    );
+    assert_eq!(state.lookup_order_client_id("v-spot-tracked"), Some(cid));
+}
+
+#[rstest]
+fn test_spot_tracked_delta_new_without_cl_ord_id_emits_order_accepted() {
+    // Issue #4051: Kraken's `new` delta lacks both `symbol` and `cl_ord_id`.
+    // With both venue-id caches seeded from the prior `pending_new` the
+    // dispatch must still resolve the tracked identity and emit
+    // `OrderAccepted`. Without the `order_client_id_cache` lookup this
+    // delta falls through to the untracked report path and the strategy
+    // never transitions out of `Submitted`.
+    let (emitter, mut rx) = test_emitter();
+    let state = Arc::new(WsDispatchState::new());
+    let cid = ClientOrderId::new("uuid-spot-tracked-delta");
+    state.register_identity(
+        cid,
+        make_identity(SPOT_INSTRUMENT_ID, OrderSide::Buy, OrderType::Limit),
+    );
+    let instruments = instruments_with(make_spot_pair());
+
+    let mut pending = make_spot_execution(
+        KrakenExecType::PendingNew,
+        Some("uuid-spot-tracked-delta"),
+        "v-spot-tracked-delta",
+        None,
+    );
+    pending.order_status = Some(KrakenWsOrderStatus::PendingNew);
+    dispatch::spot::execution(
+        &pending,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+    let _ = drain_events(&mut rx);
+
+    let delta = make_spot_execution_delta(
+        KrakenExecType::New,
+        "v-spot-tracked-delta",
+        KrakenWsOrderStatus::New,
+    );
+    dispatch::spot::execution(
+        &delta,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+
+    let events = drain_events(&mut rx);
+    assert_eq!(
+        events.len(),
+        1,
+        "delta `new` without cl_ord_id must resolve via the venue-id cache and emit OrderAccepted"
+    );
+    assert!(matches!(
+        events[0],
+        ExecutionEvent::Order(OrderEventAny::Accepted(_))
+    ));
+}
+
+#[rstest]
+fn test_spot_terminal_eviction_runs_on_missing_instrument_early_return() {
+    // Terminal cleanup must run regardless of which early return the inner
+    // dispatch hits. Here `lookup_instrument` bails because no instruments
+    // are registered, but the outer eviction still clears both venue-id
+    // caches for the terminal exec type.
+    let state = Arc::new(WsDispatchState::new());
+    let (emitter, _rx) = test_emitter();
+    let cid = ClientOrderId::new("uuid-spot-orphan");
+
+    state.cache_order_symbol("v-spot-orphan", "FOO/BAR");
+    state.cache_order_client_id("v-spot-orphan", cid);
+
+    let empty_instruments: Arc<AtomicMap<InstrumentId, InstrumentAny>> = Arc::new(AtomicMap::new());
+    let canceled = make_spot_execution_delta(
+        KrakenExecType::Canceled,
+        "v-spot-orphan",
+        KrakenWsOrderStatus::Canceled,
+    );
+    dispatch::spot::execution(
+        &canceled,
+        &state,
+        &emitter,
+        &empty_instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+
+    assert!(state.lookup_order_symbol("v-spot-orphan").is_none());
+    assert!(state.lookup_order_client_id("v-spot-orphan").is_none());
+}
+
+#[rstest]
 fn test_spot_terminal_exec_type_evicts_symbol_cache() {
     let state = Arc::new(WsDispatchState::new());
     let (emitter, _rx) = test_emitter();
     let instruments = instruments_with(make_spot_pair());
 
-    let pending = make_spot_execution(KrakenExecType::PendingNew, None, "v-spot-evict", None);
+    let pending = make_spot_execution(
+        KrakenExecType::PendingNew,
+        Some("uuid-spot-evict"),
+        "v-spot-evict",
+        None,
+    );
     dispatch::spot::execution(
         &pending,
         &state,
@@ -754,6 +902,7 @@ fn test_spot_terminal_exec_type_evicts_symbol_cache() {
         UnixNanos::default(),
     );
     assert!(state.lookup_order_symbol("v-spot-evict").is_some());
+    assert!(state.lookup_order_client_id("v-spot-evict").is_some());
 
     let canceled = make_spot_execution_delta(
         KrakenExecType::Canceled,
@@ -771,4 +920,5 @@ fn test_spot_terminal_exec_type_evicts_symbol_cache() {
         UnixNanos::default(),
     );
     assert!(state.lookup_order_symbol("v-spot-evict").is_none());
+    assert!(state.lookup_order_client_id("v-spot-evict").is_none());
 }

--- a/crates/adapters/kraken/tests/dispatch_spot.rs
+++ b/crates/adapters/kraken/tests/dispatch_spot.rs
@@ -657,11 +657,20 @@ fn make_spot_execution_delta(
 }
 
 #[rstest]
-fn test_spot_pending_new_then_symbolless_new_both_emit_reports() {
+#[case::new(KrakenExecType::New, KrakenWsOrderStatus::New)]
+#[case::amended(KrakenExecType::Amended, KrakenWsOrderStatus::New)]
+#[case::restated(KrakenExecType::Restated, KrakenWsOrderStatus::New)]
+#[case::status(KrakenExecType::Status, KrakenWsOrderStatus::New)]
+fn test_spot_pending_new_then_symbolless_delta_resolves_via_cache(
+    #[case] delta_exec_type: KrakenExecType,
+    #[case] delta_order_status: KrakenWsOrderStatus,
+) {
     // Untracked / external order: `pending_new` arrives with full data and
-    // emits a `Submitted` report, then `new` arrives as a delta (no symbol)
-    // and must still emit an `Accepted` report via the cached symbol
-    // populated from the first frame.
+    // emits an initial report, then a delta frame (no symbol) arrives and
+    // must still emit a report via the cached symbol populated from the
+    // first frame. Covers every delta exec type that omits `symbol`
+    // (`new` / `amended` / `restated` / `status`) per Kraken's executions
+    // docs.
     let (emitter, mut rx) = test_emitter();
     let state = Arc::new(WsDispatchState::new());
     let instruments = instruments_with(make_spot_pair());
@@ -679,13 +688,9 @@ fn test_spot_pending_new_then_symbolless_new_both_emit_reports() {
     );
     assert_eq!(drain_events(&mut rx).len(), 1);
 
-    let new_delta = make_spot_execution_delta(
-        KrakenExecType::New,
-        "v-spot-delta",
-        KrakenWsOrderStatus::New,
-    );
+    let delta = make_spot_execution_delta(delta_exec_type, "v-spot-delta", delta_order_status);
     dispatch::spot::execution(
-        &new_delta,
+        &delta,
         &state,
         &emitter,
         &instruments,
@@ -699,7 +704,7 @@ fn test_spot_pending_new_then_symbolless_new_both_emit_reports() {
     assert_eq!(
         events.len(),
         1,
-        "the delta `new` frame should resolve via the cached symbol and emit a report"
+        "delta frame should resolve via the cached symbol and emit a report"
     );
     assert!(matches!(events[0], ExecutionEvent::Report(_)));
 }

--- a/crates/adapters/kraken/tests/dispatch_spot.rs
+++ b/crates/adapters/kraken/tests/dispatch_spot.rs
@@ -618,3 +618,152 @@ fn test_spot_restated_emits_order_updated() {
         ExecutionEvent::Order(OrderEventAny::Updated(_))
     ));
 }
+
+/// Builds a delta-style execution frame matching what Kraken sends as a
+/// follow-up to `pending_new` (and for `amended` / `restated` / `status`):
+/// only `order_id`, `exec_type`, `order_status`, and `timestamp` are
+/// populated — every other field, including `symbol`, is `None`.
+fn make_spot_execution_delta(
+    exec_type: KrakenExecType,
+    venue_order_id: &str,
+    order_status: KrakenWsOrderStatus,
+) -> KrakenWsExecutionData {
+    KrakenWsExecutionData {
+        exec_type,
+        order_id: venue_order_id.to_string(),
+        cl_ord_id: None,
+        symbol: None,
+        side: None,
+        order_type: None,
+        order_qty: None,
+        limit_price: None,
+        order_status: Some(order_status),
+        cum_qty: None,
+        cum_cost: None,
+        avg_price: None,
+        time_in_force: None,
+        post_only: None,
+        reduce_only: None,
+        timestamp: "2026-04-11T00:00:00.001Z".parse().unwrap(),
+        exec_id: None,
+        last_qty: None,
+        last_price: None,
+        cost: None,
+        liquidity_ind: None,
+        fees: None,
+        fee_usd_equiv: None,
+        reason: None,
+    }
+}
+
+#[rstest]
+fn test_spot_pending_new_then_symbolless_new_both_emit_reports() {
+    // Untracked / external order: `pending_new` arrives with full data and
+    // emits a `Submitted` report, then `new` arrives as a delta (no symbol)
+    // and must still emit an `Accepted` report via the cached symbol
+    // populated from the first frame.
+    let (emitter, mut rx) = test_emitter();
+    let state = Arc::new(WsDispatchState::new());
+    let instruments = instruments_with(make_spot_pair());
+
+    let pending = make_spot_execution(KrakenExecType::PendingNew, None, "v-spot-delta", None);
+    dispatch::spot::execution(
+        &pending,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+    assert_eq!(drain_events(&mut rx).len(), 1);
+
+    let new_delta = make_spot_execution_delta(
+        KrakenExecType::New,
+        "v-spot-delta",
+        KrakenWsOrderStatus::New,
+    );
+    dispatch::spot::execution(
+        &new_delta,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+
+    let events = drain_events(&mut rx);
+    assert_eq!(
+        events.len(),
+        1,
+        "the delta `new` frame should resolve via the cached symbol and emit a report"
+    );
+    assert!(matches!(events[0], ExecutionEvent::Report(_)));
+}
+
+#[rstest]
+fn test_spot_delta_without_cached_symbol_is_dropped() {
+    // No prior `pending_new` -> no cached symbol -> the delta frame must be
+    // skipped (existing behaviour, no panic, no event).
+    let (emitter, mut rx) = test_emitter();
+    let state = Arc::new(WsDispatchState::new());
+    let instruments = instruments_with(make_spot_pair());
+
+    let new_delta = make_spot_execution_delta(
+        KrakenExecType::New,
+        "v-spot-no-prior",
+        KrakenWsOrderStatus::New,
+    );
+    dispatch::spot::execution(
+        &new_delta,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+
+    assert!(drain_events(&mut rx).is_empty());
+}
+
+#[rstest]
+fn test_spot_terminal_exec_type_evicts_symbol_cache() {
+    let state = Arc::new(WsDispatchState::new());
+    let (emitter, _rx) = test_emitter();
+    let instruments = instruments_with(make_spot_pair());
+
+    let pending = make_spot_execution(KrakenExecType::PendingNew, None, "v-spot-evict", None);
+    dispatch::spot::execution(
+        &pending,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+    assert!(state.lookup_order_symbol("v-spot-evict").is_some());
+
+    let canceled = make_spot_execution_delta(
+        KrakenExecType::Canceled,
+        "v-spot-evict",
+        KrakenWsOrderStatus::Canceled,
+    );
+    dispatch::spot::execution(
+        &canceled,
+        &state,
+        &emitter,
+        &instruments,
+        &empty_string_map(),
+        &empty_f64_map(),
+        account_id(),
+        UnixNanos::default(),
+    );
+    assert!(state.lookup_order_symbol("v-spot-evict").is_none());
+}


### PR DESCRIPTION
## Summary

Orders submitted via the Kraken Spot WS that are not instantly executed drop the `symbol` field from the follow-up `new` frame (per Kraken's [executions docs](https://docs.kraken.com/api/docs/websocket-v2/executions/)). The Spot WS dispatch returned early on `exec.symbol.is_none()`, so the order never received `Accepted`. Local state stayed `Submitted`, then the live exec engine resolved it as `OrderRejected(reason=UNKNOWN)` while still open at the venue.

Closes #4051.

## Fix

Cache `order_id → symbol` from frames that carry it, consult on `exec.symbol.is_none()` before bailing, evict on terminal `exec_type`. Mirrors the existing `order_qty_cache` pattern. 
