### PR TITLE
Apply realized price PnL to fill-driven account balances

### DIFF
--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -42,6 +42,7 @@ static RISK_QUEUE_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_PROCESS_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static ORDER_EMULATOR_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static PORTFOLIO_ACCOUNT_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
+static PORTFOLIO_ORDER_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static SHUTDOWN_SYSTEM_TOPIC: OnceLock<MStr<Topic>> = OnceLock::new();
 
 macro_rules! define_switchboard {
@@ -189,6 +190,12 @@ macro_rules! define_switchboard {
             #[must_use]
             pub fn portfolio_update_account() -> MStr<Endpoint> {
                 *PORTFOLIO_ACCOUNT_ENDPOINT.get_or_init(|| "Portfolio.update_account".into())
+            }
+
+            #[inline]
+            #[must_use]
+            pub fn portfolio_update_order() -> MStr<Endpoint> {
+                *PORTFOLIO_ORDER_ENDPOINT.get_or_init(|| "Portfolio.update_order".into())
             }
 
             /// Pub/sub topic carrying `ShutdownSystem` commands published by

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -60,6 +60,7 @@ use nautilus_core::{
     datetime::{mins_to_nanos, mins_to_secs},
 };
 use nautilus_model::{
+    accounts::Account,
     enums::{
         ContingencyType, OmsType, OrderStatus, OrderType, PositionSide, TimeInForce,
         TrailingOffsetType,
@@ -2338,16 +2339,26 @@ impl ExecutionEngine {
                 return;
             };
 
-        if self.cache.borrow().account(&fill.account_id).is_none() {
-            log::error!(
-                "Cannot handle order fill: no account found for {}, {fill}",
-                fill.instrument_id.venue,
-            );
-            return;
-        }
+        let is_margin_account = {
+            let cache = self.cache.borrow();
+            let Some(account) = cache.account(&fill.account_id) else {
+                log::error!(
+                    "Cannot handle order fill: no account found for {}, {fill}",
+                    fill.instrument_id.venue,
+                );
+                return;
+            };
+
+            account.is_margin_account()
+        };
 
         // Skip portfolio position updates for combo fills (spread instruments)
         // Combo fills are only used for order management, not portfolio updates
+        if !instrument.is_spread() && is_margin_account {
+            let portfolio_endpoint = MessagingSwitchboard::portfolio_update_order();
+            msgbus::send_order_event(portfolio_endpoint, OrderEventAny::Filled(fill));
+        }
+
         let position = if instrument.is_spread() {
             None
         } else {

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -24,7 +24,7 @@ use nautilus_common::{
     cache::Cache,
     clock::Clock,
     enums::LogColor,
-    msgbus::{self, MessagingSwitchboard, TypedHandler},
+    msgbus::{self, MessagingSwitchboard, TypedHandler, TypedIntoHandler},
     timer::{TimeEvent, TimeEventCallback},
 };
 use nautilus_core::{UUID4, WeakCell, datetime::NANOSECONDS_IN_MILLISECOND};
@@ -61,12 +61,19 @@ struct PortfolioState {
     venues_missing_price: AHashMap<Venue, AHashSet<InstrumentId>>,
     account_open_positions: AHashMap<AccountId, usize>,
     portfolio_snapshots: AHashMap<AccountId, VecDeque<PortfolioSnapshot>>,
+    pre_position_fill_events: AHashSet<UUID4>,
 }
 
 // Sized for post-run backtest analysis (e.g. ~11 days at 1s cadence, or years
 // at per-minute cadence), long-lived live deployments should consume snapshots
 // via the message bus instead of relying on this buffer.
 const SNAPSHOT_BUFFER_CAP: usize = 1_000_000;
+
+#[derive(Clone, Copy)]
+enum OrderUpdateSource {
+    Endpoint,
+    Topic,
+}
 
 impl PortfolioState {
     fn new(
@@ -96,6 +103,7 @@ impl PortfolioState {
             venues_missing_price: AHashMap::new(),
             account_open_positions: AHashMap::new(),
             portfolio_snapshots: AHashMap::new(),
+            pre_position_fill_events: AHashSet::new(),
         }
     }
 
@@ -114,6 +122,7 @@ impl PortfolioState {
         self.venues_missing_price.clear();
         self.account_open_positions.clear();
         self.portfolio_snapshots.clear();
+        self.pre_position_fill_events.clear();
         self.analyzer.reset();
         self.initialized = false;
         log::debug!("READY");
@@ -247,17 +256,47 @@ impl Portfolio {
         let update_order_handler = {
             let cache = cache.clone();
             let clock = clock.clone();
-            let inner = inner_weak;
+            let inner = inner_weak.clone();
             TypedHandler::from(move |event: &OrderEventAny| {
                 if let Some(inner_rc) = inner.upgrade() {
                     let inner_rc: Rc<RefCell<PortfolioState>> = inner_rc.into();
-                    update_order(&cache, &clock, &inner_rc, config, event);
+                    update_order(
+                        &cache,
+                        &clock,
+                        &inner_rc,
+                        config,
+                        event,
+                        OrderUpdateSource::Topic,
+                    );
                 }
             })
         };
 
         let endpoint = MessagingSwitchboard::portfolio_update_account();
         msgbus::register_account_state_endpoint(endpoint, update_account_handler.clone());
+
+        let update_order_endpoint_handler = {
+            let cache = cache.clone();
+            let clock = clock.clone();
+            let inner = inner_weak;
+            TypedIntoHandler::from(move |event: OrderEventAny| {
+                if let Some(inner_rc) = inner.upgrade() {
+                    let inner_rc: Rc<RefCell<PortfolioState>> = inner_rc.into();
+                    update_order(
+                        &cache,
+                        &clock,
+                        &inner_rc,
+                        config,
+                        &event,
+                        OrderUpdateSource::Endpoint,
+                    );
+                }
+            })
+        };
+        msgbus::register_order_event_endpoint(
+            MessagingSwitchboard::portfolio_update_order(),
+            update_order_endpoint_handler,
+        );
 
         msgbus::subscribe_quotes("data.quotes.*".into(), update_quote_handler, Some(10));
 
@@ -1392,7 +1431,14 @@ impl Portfolio {
     ///
     /// Handles balance updates for order fills and margin calculations for order changes.
     pub fn update_order(&mut self, event: &OrderEventAny) {
-        update_order(&self.cache, &self.clock, &self.inner, self.config, event);
+        update_order(
+            &self.cache,
+            &self.clock,
+            &self.inner,
+            self.config,
+            event,
+            OrderUpdateSource::Topic,
+        );
     }
 
     /// Updates portfolio calculations based on a position event.
@@ -2103,7 +2149,27 @@ fn update_order(
     inner: &Rc<RefCell<PortfolioState>>,
     config: PortfolioConfig,
     event: &OrderEventAny,
+    source: OrderUpdateSource,
 ) {
+    let mut mark_pre_position_fill_event = None;
+
+    if let OrderEventAny::Filled(order_filled) = event {
+        match source {
+            OrderUpdateSource::Endpoint => {
+                mark_pre_position_fill_event = Some(order_filled.event_id);
+            }
+            OrderUpdateSource::Topic => {
+                if inner
+                    .borrow_mut()
+                    .pre_position_fill_events
+                    .remove(&order_filled.event_id)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
     let account_id = match event.account_id() {
         Some(account_id) => account_id,
         None => {
@@ -2248,6 +2314,10 @@ fn update_order(
             .unwrap();
     } else {
         cache.borrow_mut().cache_account_owned(working_account);
+    }
+
+    if let Some(event_id) = mark_pre_position_fill_event {
+        inner.borrow_mut().pre_position_fill_events.insert(event_id);
     }
 
     if let Some(account_state) = account_state {

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -18,10 +18,11 @@ use std::{cell::RefCell, rc::Rc};
 use nautilus_common::{
     cache::Cache,
     clock::{Clock, TestClock},
+    msgbus::{self, MessagingSwitchboard},
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
-    accounts::AccountAny,
+    accounts::{Account, AccountAny},
     data::{Bar, BarType, QuoteTick},
     enums::{AccountType, LiquiditySide, OmsType, OrderSide, OrderType, PositionSide},
     events::{
@@ -192,6 +193,16 @@ fn get_margin_account(accountid: Option<&str>) -> AccountState {
         0.into(),
         None,
     )
+}
+
+fn usd_balance_total(portfolio: &Portfolio, account_id: &AccountId) -> Money {
+    portfolio
+        .cache()
+        .borrow()
+        .account_owned(account_id)
+        .unwrap()
+        .balance_total(Some(Currency::USD()))
+        .unwrap()
 }
 
 fn get_quote_tick(
@@ -2049,6 +2060,281 @@ fn test_closing_position_updates_portfolio(
     assert!(!portfolio.is_net_short(&instrument_audusd.id())); // Not short
     assert!(portfolio.is_flat(&instrument_audusd.id())); // Flat position
     assert!(portfolio.is_completely_flat()); // Portfolio is completely flat
+}
+
+#[rstest]
+fn test_order_fill_endpoint_updates_account_balance_before_position_close(
+    mut portfolio: Portfolio,
+    instrument_audusd: InstrumentAny,
+) {
+    let account_id = AccountId::new("SIM-01234");
+    let account_state = AccountState::new(
+        account_id,
+        AccountType::Margin,
+        vec![AccountBalance::new(
+            Money::new(1_000_000.0, Currency::USD()),
+            Money::new(0.0, Currency::USD()),
+            Money::new(1_000_000.0, Currency::USD()),
+        )],
+        vec![],
+        true,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        Some(Currency::USD()),
+    );
+
+    portfolio.update_account(&account_state);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .account_mut(&account_id)
+        .unwrap()
+        .set_calculate_account_state(true);
+
+    let order1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_audusd.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("100000"))
+        .build();
+    let order2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_audusd.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from("100000"))
+        .build();
+
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_order(order1.clone(), None, None, true)
+        .unwrap();
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_order(order2.clone(), None, None, true)
+        .unwrap();
+
+    let fill1 = OrderFilled::new(
+        order1.trader_id(),
+        order1.strategy_id(),
+        order1.instrument_id(),
+        order1.client_order_id(),
+        VenueOrderId::new("123456"),
+        account_id,
+        TradeId::new("1"),
+        order1.order_side(),
+        order1.order_type(),
+        order1.quantity(),
+        Price::new(1.00000, 5),
+        Currency::USD(),
+        LiquiditySide::Taker,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        false,
+        Some(PositionId::new("P-123456")),
+        Some(Money::new(2.0, Currency::USD())),
+    );
+    let mut position = Position::new(&instrument_audusd, fill1);
+
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Hedging)
+        .unwrap();
+
+    let quote_tick = get_quote_tick(&instrument_audusd, 1.00000, 1.00001, 1.0, 1.0);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_quote(quote_tick)
+        .unwrap();
+    portfolio.update_quote_tick(&quote_tick);
+
+    let fill2 = OrderFilled::new(
+        order2.trader_id(),
+        order2.strategy_id(),
+        order2.instrument_id(),
+        order2.client_order_id(),
+        VenueOrderId::new("789012"),
+        account_id,
+        TradeId::new("2"),
+        order2.order_side(),
+        order2.order_type(),
+        order2.quantity(),
+        Price::new(1.00010, 5),
+        Currency::USD(),
+        LiquiditySide::Taker,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        false,
+        Some(PositionId::new("P-123456")),
+        Some(Money::new(2.0, Currency::USD())),
+    );
+
+    msgbus::send_order_event(
+        MessagingSwitchboard::portfolio_update_order(),
+        OrderEventAny::Filled(fill2),
+    );
+
+    assert_eq!(
+        usd_balance_total(&portfolio, &account_id),
+        Money::new(1_000_008.0, Currency::USD())
+    );
+
+    position.apply(&fill2);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .update_position(&position)
+        .unwrap();
+
+    portfolio.update_order(&OrderEventAny::Filled(fill2));
+
+    assert_eq!(
+        usd_balance_total(&portfolio, &account_id),
+        Money::new(1_000_008.0, Currency::USD())
+    );
+}
+
+#[rstest]
+fn test_order_fill_endpoint_updates_account_balance_before_position_reverse(
+    mut portfolio: Portfolio,
+    instrument_audusd: InstrumentAny,
+) {
+    let account_id = AccountId::new("SIM-01234");
+    let account_state = AccountState::new(
+        account_id,
+        AccountType::Margin,
+        vec![AccountBalance::new(
+            Money::new(1_000_000.0, Currency::USD()),
+            Money::new(0.0, Currency::USD()),
+            Money::new(1_000_000.0, Currency::USD()),
+        )],
+        vec![],
+        true,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        Some(Currency::USD()),
+    );
+
+    portfolio.update_account(&account_state);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .account_mut(&account_id)
+        .unwrap()
+        .set_calculate_account_state(true);
+
+    let order1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_audusd.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("100000"))
+        .build();
+    let order2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_audusd.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from("150000"))
+        .build();
+
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_order(order1.clone(), None, None, true)
+        .unwrap();
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_order(order2.clone(), None, None, true)
+        .unwrap();
+
+    let fill1 = OrderFilled::new(
+        order1.trader_id(),
+        order1.strategy_id(),
+        order1.instrument_id(),
+        order1.client_order_id(),
+        VenueOrderId::new("123456"),
+        account_id,
+        TradeId::new("1"),
+        order1.order_side(),
+        order1.order_type(),
+        order1.quantity(),
+        Price::new(1.00000, 5),
+        Currency::USD(),
+        LiquiditySide::Taker,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        false,
+        Some(PositionId::new("P-123456")),
+        Some(Money::new(2.0, Currency::USD())),
+    );
+    let mut position = Position::new(&instrument_audusd, fill1);
+
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Hedging)
+        .unwrap();
+
+    let quote_tick = get_quote_tick(&instrument_audusd, 1.00000, 1.00001, 1.0, 1.0);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_quote(quote_tick)
+        .unwrap();
+    portfolio.update_quote_tick(&quote_tick);
+
+    let fill2 = OrderFilled::new(
+        order2.trader_id(),
+        order2.strategy_id(),
+        order2.instrument_id(),
+        order2.client_order_id(),
+        VenueOrderId::new("789012"),
+        account_id,
+        TradeId::new("2"),
+        order2.order_side(),
+        order2.order_type(),
+        order2.quantity(),
+        Price::new(1.00010, 5),
+        Currency::USD(),
+        LiquiditySide::Taker,
+        uuid4(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        false,
+        Some(PositionId::new("P-123456")),
+        Some(Money::new(3.0, Currency::USD())),
+    );
+
+    msgbus::send_order_event(
+        MessagingSwitchboard::portfolio_update_order(),
+        OrderEventAny::Filled(fill2),
+    );
+
+    assert_eq!(
+        usd_balance_total(&portfolio, &account_id),
+        Money::new(1_000_007.0, Currency::USD())
+    );
+
+    position.apply(&fill2);
+    assert_eq!(position.side, PositionSide::Short);
+    assert_eq!(position.quantity, Quantity::from("50000"));
+
+    portfolio
+        .cache()
+        .borrow_mut()
+        .update_position(&position)
+        .unwrap();
+
+    portfolio.update_order(&OrderEventAny::Filled(fill2));
+
+    assert_eq!(
+        usd_balance_total(&portfolio, &account_id),
+        Money::new(1_000_007.0, Currency::USD())
+    );
 }
 
 #[rstest]

--- a/nautilus_trader/execution/engine.pxd
+++ b/nautilus_trader/execution/engine.pxd
@@ -175,6 +175,7 @@ cdef class ExecutionEngine(Component):
     cpdef bint _apply_event_to_order(self, Order order, OrderEvent event)
     cpdef void _handle_order_fill(self, Order order, OrderFilled fill, OmsType oms_type)
     cdef bint _is_leg_fill(self, OrderFilled fill)
+    cdef void _send_fill_to_portfolio_before_position_update(self, OrderFilled fill)
     cdef void _handle_position_update(self, Instrument instrument, OrderFilled fill, OmsType oms_type)
     cpdef void _handle_leg_fill_without_order(self, OrderFilled fill)
     cpdef void _open_position(self, Instrument instrument, Position position, OrderFilled fill, OmsType oms_type)

--- a/nautilus_trader/execution/engine.pyx
+++ b/nautilus_trader/execution/engine.pyx
@@ -1352,18 +1352,6 @@ cdef class ExecutionEngine(Component):
                 msg=pos_event,
             )
 
-    cdef bint _is_leg_fill(self, OrderFilled fill):
-        cdef str client_order_id_str = fill.client_order_id.value
-        cdef str venue_order_id_str = fill.venue_order_id.value if fill.venue_order_id else ""
-        if not ("-LEG-" in client_order_id_str or "-LEG-" in venue_order_id_str):
-            return False
-
-        cdef Instrument instrument = self._cache.load_instrument(fill.instrument_id)
-        if instrument is None:
-            return False
-
-        return not instrument.is_spread()
-
     cpdef void _handle_leg_fill_without_order(self, OrderFilled fill):
         """
         Handle leg fills that don't have corresponding orders in the cache.
@@ -1406,16 +1394,9 @@ cdef class ExecutionEngine(Component):
 
         fill.position_id = position_id
 
-        # Also send to portfolio endpoint for leg fills (which don't have orders in cache)
-        # Regular fills go through topic subscription below, so we only send directly for leg fills
-        # We do this BEFORE position update so portfolio can see the open quantity for PnL calcs
         if self._is_leg_fill(fill):
-            self._msgbus.send(
-                endpoint="Portfolio.update_order",
-                msg=fill,
-            )
+            self._send_fill_to_portfolio_before_position_update(fill)
 
-        # Handle position update
         self._handle_position_update(instrument, fill, oms_type)
 
         # Pop position events which are pending publishing to prevent recursion issues
@@ -1434,6 +1415,25 @@ cdef class ExecutionEngine(Component):
                 topic=self._get_position_events_topic(pos_event.strategy_id),
                 msg=pos_event,
             )
+
+    cdef bint _is_leg_fill(self, OrderFilled fill):
+        cdef str client_order_id_str = fill.client_order_id.value
+        cdef str venue_order_id_str = fill.venue_order_id.value if fill.venue_order_id else ""
+        if not ("-LEG-" in client_order_id_str or "-LEG-" in venue_order_id_str):
+            return False
+
+        cdef Instrument instrument = self._cache.load_instrument(fill.instrument_id)
+        if instrument is None:
+            return False
+
+        return not instrument.is_spread()
+
+    cdef void _send_fill_to_portfolio_before_position_update(self, OrderFilled fill):
+        # Account balance PnL needs the pre-fill cached position quantity.
+        self._msgbus.send(
+            endpoint="Portfolio.update_order",
+            msg=fill,
+        )
 
     cpdef OmsType _determine_oms_type(self, OrderFilled fill):
         cdef ExecutionClient client = self._routing_map.get(
@@ -1612,10 +1612,18 @@ cdef class ExecutionEngine(Component):
         if self.snapshot_orders:
             self._create_order_state_snapshot(order)
 
-        self._msgbus.send(
-            endpoint="Portfolio.update_order",
-            msg=event,
-        )
+        cdef bint send_to_portfolio = True
+        cdef Account account = None
+        if isinstance(event, OrderFilled):
+            account = self._cache.account(event.account_id)
+            send_to_portfolio = account is None or not account.is_margin_account
+
+        if send_to_portfolio:
+            self._msgbus.send(
+                endpoint="Portfolio.update_order",
+                msg=event,
+            )
+
         return True
 
     cpdef void _handle_order_fill(self, Order order, OrderFilled fill, OmsType oms_type):
@@ -1642,6 +1650,9 @@ cdef class ExecutionEngine(Component):
             ClientOrderId client_order_id
             Order contingent_order
         if not instrument.is_spread():
+            if account.is_margin_account:
+                self._send_fill_to_portfolio_before_position_update(fill)
+
             self._handle_position_update(instrument, fill, oms_type)
             position = self._cache.position(fill.position_id)
 

--- a/tests/unit_tests/backtest/test_exchange_margin.py
+++ b/tests/unit_tests/backtest/test_exchange_margin.py
@@ -2733,6 +2733,94 @@ class TestSimulatedExchangeMarginAccount:
         assert fill_event3.commission == Money(90, JPY)
         assert Money(999995.00, USD) == self.exchange.get_account().balance_total(USD)
 
+    def test_closing_position_updates_balance_with_realized_price_pnl(self) -> None:
+        # Arrange
+        self.exchange.add_instrument(_AUDUSD_SIM)
+        open_quote = TestDataStubs.quote_tick(
+            instrument=_AUDUSD_SIM,
+            bid_price=1.00000,
+            ask_price=1.00001,
+        )
+        self.data_engine.process(open_quote)
+        self.exchange.process_quote_tick(open_quote)
+
+        order_open = self.strategy.order_factory.market(
+            _AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+        )
+        self.strategy.submit_order(order_open)
+        self.exchange.process(0)
+
+        position_id = self.cache.positions_open()[0].id
+
+        close_quote = TestDataStubs.quote_tick(
+            instrument=_AUDUSD_SIM,
+            bid_price=1.00011,
+            ask_price=1.00012,
+        )
+        self.data_engine.process(close_quote)
+        self.exchange.process_quote_tick(close_quote)
+
+        order_close = self.strategy.order_factory.market(
+            _AUDUSD_SIM.id,
+            OrderSide.SELL,
+            Quantity.from_int(100_000),
+        )
+
+        # Act
+        self.strategy.submit_order(order_close, position_id=position_id)
+        self.exchange.process(0)
+
+        # Assert
+        assert self.cache.positions_open() == []
+        assert self.exchange.get_account().balance_total(USD) == Money(1_000_006.00, USD)
+
+    def test_reversing_position_updates_balance_with_realized_price_pnl(self) -> None:
+        # Arrange
+        self.exchange.add_instrument(_AUDUSD_SIM)
+        open_quote = TestDataStubs.quote_tick(
+            instrument=_AUDUSD_SIM,
+            bid_price=1.00000,
+            ask_price=1.00001,
+        )
+        self.data_engine.process(open_quote)
+        self.exchange.process_quote_tick(open_quote)
+
+        order_open = self.strategy.order_factory.market(
+            _AUDUSD_SIM.id,
+            OrderSide.BUY,
+            Quantity.from_int(100_000),
+        )
+        self.strategy.submit_order(order_open)
+        self.exchange.process(0)
+
+        position_id = self.cache.positions_open()[0].id
+
+        reverse_quote = TestDataStubs.quote_tick(
+            instrument=_AUDUSD_SIM,
+            bid_price=1.00011,
+            ask_price=1.00012,
+        )
+        self.data_engine.process(reverse_quote)
+        self.exchange.process_quote_tick(reverse_quote)
+
+        order_reverse = self.strategy.order_factory.market(
+            _AUDUSD_SIM.id,
+            OrderSide.SELL,
+            Quantity.from_int(150_000),
+        )
+
+        # Act
+        self.strategy.submit_order(order_reverse, position_id=position_id)
+        self.exchange.process(0)
+
+        # Assert
+        position_open = self.cache.positions_open()[0]
+        assert position_open.side == PositionSide.SHORT
+        assert position_open.quantity == Quantity.from_int(50_000)
+        assert self.exchange.get_account().balance_total(USD) == Money(1_000_005.00, USD)
+
     def test_expire_order(self) -> None:
         # Arrange: Prepare market
         tick1 = TestDataStubs.quote_tick(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Margin account balance recalculation for fills depended on the cached position. In the Rust path, the execution engine updated the position before the portfolio received the fill, so a close or reversal saw a post-fill flat or reopened position. `calculate_pnls` therefore could not detect the reducing side and only deducted commissions from the account balance.

The Cython execution engine had a similar ordering risk around fill handling because balance updates and position mutation were split between the regular fill path, the generic order-event path, and a leg-fill-only direct path. The fill balance update needed one common pre-position path for margin accounts so closes, reversals, and leg fills use the same ordering.

The pre-position update is intentionally limited to margin accounts. Cash and betting accounts keep the existing post-order flow because they do not use the same cached-position realized-PnL calculation, and applying the new ordering there changed Betfair cash-account settlement results.

### Rust changes

- Added `MessagingSwitchboard::portfolio_update_order()` for the `Portfolio.update_order` endpoint.
- Registered a Rust portfolio order-event endpoint that can process `OrderFilled` before the position cache is mutated.
- Updated the Rust execution engine to send non-spread margin-account fills to the portfolio endpoint immediately before `handle_position_update`.
- Added a portfolio-side event-id guard so the later `events.order.*` topic publication does not apply the same fill balance update twice.
- Added a Rust regression test covering a close fill where account balance must include realized price PnL and ignore the duplicate topic update.
- Added a Rust regression test covering a reversal fill where the endpoint sees the original long position, applies realized price PnL for the reducing leg, and ignores the later duplicate topic update.

### Cython changes

- Moved Cython fill balance updates into `_send_fill_to_portfolio_before_position_update`.
- Called that helper for regular margin-account fills before `_handle_position_update`.
- Kept the defensive leg-fill check in `_handle_leg_fill_without_order` so only true leg fills use the direct pre-position portfolio send.
- Kept non-margin `OrderFilled` events on the generic order-event path so cash and betting account behavior remains unchanged.
- Preserved the previous missing-account behavior by still sending fills to `Portfolio.update_order` when the execution engine cannot resolve the account; the portfolio continues to own its existing error logging for that case.
- Added a Cython-side backtest regression that opens and closes an AUD/USD margin position and asserts the account balance includes the realized price PnL minus both commissions.
- Added a Cython-side backtest regression that opens and reverses an AUD/USD margin position and asserts the remaining position and account balance include realized price PnL for the reducing leg.

### Design notes

- Rust and Cython now follow the same regular-order-fill account-type decision: margin fills use the pre-position portfolio update, while non-margin fills use the existing order-event timing.
- Cython leg fills without cached orders are still handled before position mutation through the shared helper, but remain gated by `_is_leg_fill` to avoid changing spread-instrument behavior.
- The margin-only scope was validated by the Betfair regression: applying the pre-position update to cash betting accounts changed the expected final balance from `906476.18` to `907256.27`, so the broader behavior was reverted.
- The Rust execution-engine margin endpoint send was flattened into a single `!instrument.is_spread() && is_margin_account` condition before the position-update branch for easier scanning.

### Verification

- `cargo test -p nautilus-portfolio --test portfolio --quiet`.
- `cargo test -p nautilus-portfolio test_order_fill_endpoint_updates_account_balance_before_position`.
- `cargo test -p nautilus-execution`.
- `cargo test -p nautilus-execution test_process_filled_order_publishes_order_fills_topic --quiet`.
- `make build-debug`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_exchange_margin.py::TestSimulatedExchangeMarginAccount::test_order_fills_gets_commissioned_for_fx -q`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_exchange_margin.py::TestSimulatedExchangeMarginAccount::test_position_flipped_when_reduce_order_exceeds_original_quantity -q`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_exchange_margin.py::TestSimulatedExchangeMarginAccount::test_closing_position_updates_balance_with_realized_price_pnl -q`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_exchange_margin.py -k 'closing_position_updates_balance_with_realized_price_pnl or reversing_position_updates_balance_with_realized_price_pnl'`.
- `uv run --no-sync pytest tests/unit_tests/execution/test_engine_leg_fills.py`.
- `uv run --no-sync pytest tests/integration_tests/adapters/betfair/test_betfair_backtest.py::test_betfair_backtest -q --tb=short`.
- `make format`.
- `make pre-commit`.
- `make pytest`.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
