### PR TITLE
Fix IB SMART stock venue resolution

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -843,6 +843,9 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         contract: IBContract,
         contract_details: IBContractDetails | None = None,
     ) -> str:
+        if contract.secType == "STK":
+            return self._resolve_stock_exchange_from_contract(contract)
+
         if (
             contract.exchange == "SMART"
             and contract.primaryExchange
@@ -853,14 +856,49 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         if contract.exchange != "SMART":
             return contract.exchange
 
-        valid_exchanges = self._resolve_valid_exchanges(contract, contract_details)
-        if valid_exchanges:
-            parts = [part.strip() for part in valid_exchanges.split(",") if part.strip()]
-            chosen = next((part for part in parts if part != "SMART"), parts[0] if parts else None)
-            if chosen:
-                return chosen
+        if contract.secType == "OPT":
+            valid_exchanges = self._resolve_valid_exchanges(contract, contract_details)
+            if valid_exchanges:
+                parts = [part.strip() for part in valid_exchanges.split(",") if part.strip()]
+                chosen = next(
+                    (part for part in parts if part != "SMART"),
+                    parts[0] if parts else None,
+                )
+
+                if chosen:
+                    return chosen
 
         return contract.exchange
+
+    def _resolve_stock_exchange_from_contract(self, contract: IBContract) -> str:
+        venue = self._resolve_cached_symbol_venue(contract)
+        if venue and self._is_compatible_cached_stock_venue(venue, contract.primaryExchange):
+            return venue
+
+        if contract.primaryExchange and contract.primaryExchange != "SMART":
+            return contract.primaryExchange
+
+        if contract.exchange == "SMART" and venue:
+            return venue
+
+        return contract.exchange
+
+    def _is_compatible_cached_stock_venue(self, venue: str, primary_exchange: str) -> bool:
+        if not primary_exchange or primary_exchange == "SMART":
+            return True
+
+        return venue in (primary_exchange, exchange_to_mic_venue(primary_exchange))
+
+    def _resolve_cached_symbol_venue(self, contract: IBContract) -> str | None:
+        for instrument in self.get_all().values():
+            if instrument.id.symbol.value == contract.symbol:
+                return instrument.id.venue.value
+
+        for instrument in self._client._cache.instruments():
+            if instrument.id.symbol.value == contract.symbol:
+                return instrument.id.venue.value
+
+        return None
 
     def _resolve_valid_exchanges(
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -292,6 +292,86 @@ async def test_determine_venue_from_contract_opt_smart_uses_first_non_smart_from
     assert venue == "CBOE"
 
 
+def test_determine_venue_from_contract_stk_uses_primary_exchange_over_fill_exchange(
+    instrument_provider,
+):
+    contract = IBContract(
+        secType="STK",
+        symbol="META",
+        exchange="IBEOS",
+        primaryExchange="NASDAQ",
+        currency="USD",
+    )
+
+    venue = instrument_provider.determine_venue_from_contract(contract)
+
+    assert venue == "NASDAQ"
+
+
+def test_determine_venue_from_contract_stk_reuses_cached_mic_venue_over_primary_exchange(
+    ib_client,
+):
+    from nautilus_trader.common.component import LiveClock
+
+    provider = InteractiveBrokersInstrumentProvider(
+        client=ib_client,
+        clock=LiveClock(),
+        config=InteractiveBrokersInstrumentProviderConfig(
+            convert_exchange_to_mic_venue=True,
+        ),
+    )
+    provider._process_contract_details(
+        [IBTestContractStubs.aapl_equity_contract_details()],
+    )
+    contract = IBContract(
+        secType="STK",
+        symbol="AAPL",
+        exchange="IBEOS",
+        primaryExchange="NASDAQ",
+        currency="USD",
+    )
+
+    venue = provider.determine_venue_from_contract(contract)
+
+    assert venue == "XNAS"
+
+
+@pytest.mark.parametrize(
+    "valid_exchanges",
+    [
+        "SMART,AMEX,NYSE,CBOE,PSX,ARCA",
+        "SMART,ARCA,AMEX,NYSE",
+    ],
+)
+def test_determine_venue_from_contract_stk_smart_reuses_cached_symbol_venue(
+    instrument_provider,
+    valid_exchanges,
+):
+    instrument_provider._process_contract_details(
+        [IBTestContractStubs.aapl_equity_contract_details()],
+    )
+
+    contract = IBContract(
+        secType="STK",
+        symbol="AAPL",
+        exchange="SMART",
+        primaryExchange="",
+        currency="USD",
+    )
+    details = IBContractDetails(
+        contract=contract,
+        validExchanges=valid_exchanges,
+        minTick=0.01,
+    )
+
+    venue = instrument_provider.determine_venue_from_contract(
+        contract,
+        contract_details=details,
+    )
+
+    assert venue == "NASDAQ"
+
+
 @pytest.mark.asyncio
 async def test_determine_venue_from_contract_opt_smart_maps_to_mic_when_convert_enabled(
     ib_client,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Prefer `primaryExchange` for `STK` contracts even when IB reports a fill or execution exchange such as `IBEOS`.
- Reuse an already-loaded or cached compatible symbol venue, including MIC venues such as `XNAS` for Databento-style IDs.
- Restricted `validExchanges` fallback venue selection to `OPT` contracts in `InteractiveBrokersInstrumentProvider`.
- Added regression coverage for fill-exchange STK contracts and SMART STK contracts with `SMART,AMEX,...` and `SMART,ARCA,...` valid exchange orderings.

### Design decisions

- STK contracts are keyed by the primary/listing venue when IB provides it, so fills on ARCA, IBEOS, or another execution venue do not change the canonical instrument ID.
- Cached symbol venue reuse applies when the cached venue is compatible with the IB primary exchange, so `AAPL.XNAS` is preserved when IB reports `primaryExchange="NASDAQ"`.
- The first non-SMART `validExchanges` behavior is kept for options, matching the existing option tests and the original use case for SMART-routed OPT contracts.

### Testing

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_providers.py`.
- `make format`.
- `make pre-commit`.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/discussions/4059

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
