### PR TITLE
Fix Hyperliquid fill permanently deduped when instrument missing

### DIFF
--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -1414,7 +1414,6 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         instrument = self._cache.instrument(order.instrument_id)
         if instrument is None:
-            self._processed_trade_ids.add(trade_id_str)
             self._log.error(
                 f"Cannot process fill report - instrument {order.instrument_id} not found",
             )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

In `_handle_fill_report_pyo3`, when the instrument is not found in cache, the trade ID was incorrectly added to `_processed_trade_ids` before returning — permanently blacklisting the fill even though nothing was emitted. Fix removes the premature mark of this edge case, making the instrument-missing branch consistent with the order-missing branch directly above it.

Note: if marking the trade as processed on missing instrument is intentional, happy to revert — this fix assumes it was unintentional based on the asymmetry with the order-missing branch.

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] Affected code paths are already covered by the test suite