### PR TITLE
Migrate recent IB adapter hardening fixes to Rust

### DIFF
--- a/crates/adapters/interactive_brokers/src/common/parse.rs
+++ b/crates/adapters/interactive_brokers/src/common/parse.rs
@@ -480,14 +480,22 @@ pub fn determine_venue_from_contract(
     }
 
     if convert_exchange_to_mic_venue {
-        for (venue_member, exchanges) in VENUE_MEMBERS.iter() {
-            if exchanges.iter().any(|candidate| *candidate == exchange) {
-                return (*venue_member).to_string();
-            }
+        if let Some(venue) = exchange_to_mic_venue(&exchange) {
+            return venue;
         }
     }
 
     exchange
+}
+
+/// Convert an Interactive Brokers exchange code to a MIC venue when known.
+#[must_use]
+pub fn exchange_to_mic_venue(exchange: &str) -> Option<String> {
+    VENUE_MEMBERS.iter().find_map(|(venue_member, exchanges)| {
+        exchanges
+            .contains(&exchange)
+            .then(|| (*venue_member).to_string())
+    })
 }
 
 /// Convert a NautilusTrader `InstrumentId` to an Interactive Brokers `Contract`.

--- a/crates/adapters/interactive_brokers/src/common/shared_client.rs
+++ b/crates/adapters/interactive_brokers/src/common/shared_client.rs
@@ -129,10 +129,21 @@ pub async fn get_or_connect(
             .map_err(|e| anyhow::anyhow!("Registry mutex poisoned: {e}"))?;
 
         if let Some((client, ref_count)) = guard.get_mut(&key) {
-            *ref_count += 1;
-            let ref_count_val = *ref_count;
-            let client = Arc::clone(client);
-            (Some(client), ref_count_val)
+            if client.is_connected() {
+                *ref_count += 1;
+                let ref_count_val = *ref_count;
+                let client = Arc::clone(client);
+                (Some(client), ref_count_val)
+            } else {
+                tracing::debug!(
+                    "Removing disconnected shared IB client before reconnect (host={}, port={}, client_id={})",
+                    host,
+                    port,
+                    client_id
+                );
+                guard.remove(&key);
+                (None, 0)
+            }
         } else {
             (None, 0)
         }

--- a/crates/adapters/interactive_brokers/src/data/cache.rs
+++ b/crates/adapters/interactive_brokers/src/data/cache.rs
@@ -25,6 +25,28 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 
+fn checked_quantity(size: f64, precision: u8) -> Option<Quantity> {
+    let quantity = match Quantity::new_checked(size, precision) {
+        Ok(quantity) => quantity,
+        Err(e) => {
+            tracing::warn!("Ignoring invalid IB quote size {size}: {e}");
+            return None;
+        }
+    };
+
+    let tolerance = 10_f64.powi(-i32::from(precision)) * 1e-9;
+    if (quantity.as_f64() - size).abs() > tolerance {
+        tracing::warn!(
+            "Ignoring unrepresentable IB quote size {} with precision {}",
+            size,
+            precision
+        );
+        return None;
+    }
+
+    Some(quantity)
+}
+
 /// Quote cache that accumulates IB tick updates to build complete quotes.
 ///
 /// Interactive Brokers sends individual tick price and size updates (bid price,
@@ -161,6 +183,8 @@ impl QuoteCache {
         ts_init: UnixNanos,
         ignore_size_only: bool,
     ) -> Option<QuoteTick> {
+        checked_quantity(size, size_precision)?;
+
         let cached = self
             .quotes
             .entry(instrument_id)
@@ -229,6 +253,8 @@ impl QuoteCache {
         ts_init: UnixNanos,
         ignore_size_only: bool,
     ) -> Option<QuoteTick> {
+        checked_quantity(size, size_precision)?;
+
         let cached = self
             .quotes
             .entry(instrument_id)
@@ -281,13 +307,16 @@ impl QuoteCache {
         let bid_size = cached.bid_size.unwrap_or(0.0);
         let ask_size = cached.ask_size.unwrap_or(0.0);
 
+        let bid_qty = checked_quantity(bid_size, size_precision)?;
+        let ask_qty = checked_quantity(ask_size, size_precision)?;
+
         // Build the quote
         let quote = QuoteTick::new(
             instrument_id,
             Price::new(bid_price, price_precision),
             Price::new(ask_price, price_precision),
-            Quantity::new(bid_size, size_precision),
-            Quantity::new(ask_size, size_precision),
+            bid_qty,
+            ask_qty,
             ts_event,
             ts_init,
         );
@@ -531,6 +560,42 @@ mod tests {
             UnixNanos::new(3),
             UnixNanos::new(3),
             true,
+        );
+
+        assert!(quote.is_none());
+        let last_quote = cache.get_last_quote(&instrument_id).unwrap();
+        assert_eq!(last_quote.bid_size.as_f64(), 0.0);
+    }
+
+    #[rstest]
+    fn test_quote_cache_drops_unrepresentable_size() {
+        let mut cache = QuoteCache::new();
+        let instrument_id = instrument_id();
+
+        cache.update_bid_price(
+            instrument_id,
+            100.0,
+            2,
+            0,
+            UnixNanos::new(1),
+            UnixNanos::new(1),
+        );
+        cache.update_ask_price(
+            instrument_id,
+            101.0,
+            2,
+            0,
+            UnixNanos::new(2),
+            UnixNanos::new(2),
+        );
+
+        let quote = cache.update_bid_size(
+            instrument_id,
+            0.5,
+            2,
+            0,
+            UnixNanos::new(3),
+            UnixNanos::new(3),
         );
 
         assert!(quote.is_none());

--- a/crates/adapters/interactive_brokers/src/data/parse.rs
+++ b/crates/adapters/interactive_brokers/src/data/parse.rs
@@ -27,6 +27,20 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 
+fn checked_quantity(size: f64, precision: u8) -> anyhow::Result<Quantity> {
+    let quantity = Quantity::new_checked(size, precision)
+        .map_err(|e| anyhow::anyhow!("invalid quantity size={size}: {e}"))?;
+    let tolerance = 10_f64.powi(-i32::from(precision)) * 1e-9;
+    if (quantity.as_f64() - size).abs() > tolerance {
+        anyhow::bail!(
+            "quantity size={} cannot be represented with precision={}",
+            size,
+            precision
+        );
+    }
+    Ok(quantity)
+}
+
 /// Parse IB tick price and size data into a QuoteTick.
 ///
 /// This builds a quote from individual tick updates. You typically need to accumulate
@@ -49,8 +63,12 @@ pub fn parse_quote_tick(
 ) -> anyhow::Result<QuoteTick> {
     let bid = bid_price.map(|p| Price::new(p, price_precision));
     let ask = ask_price.map(|p| Price::new(p, price_precision));
-    let bid_qty = bid_size.map(|s| Quantity::new(s, size_precision));
-    let ask_qty = ask_size.map(|s| Quantity::new(s, size_precision));
+    let bid_qty = bid_size
+        .map(|s| checked_quantity(s, size_precision))
+        .transpose()?;
+    let ask_qty = ask_size
+        .map(|s| checked_quantity(s, size_precision))
+        .transpose()?;
 
     Ok(QuoteTick::new(
         instrument_id,
@@ -80,7 +98,7 @@ pub fn parse_trade_tick(
     trade_id: Option<TradeId>,
 ) -> anyhow::Result<TradeTick> {
     let trade_price = Price::new(price, price_precision);
-    let trade_size = Quantity::new(size, size_precision);
+    let trade_size = checked_quantity(size, size_precision)?;
     let aggressor_side = AggressorSide::NoAggressor; // IB doesn't provide this directly
     let trade_id = trade_id
         .unwrap_or_else(|| crate::common::parse::generate_ib_trade_id(ts_event, price, size));
@@ -338,6 +356,41 @@ mod tests {
     }
 
     #[rstest]
+    fn test_parse_trade_tick_rejects_unrepresentable_size() {
+        let instrument_id = create_test_instrument_id();
+        let result = parse_trade_tick(
+            instrument_id,
+            150.25,
+            0.5,
+            2,
+            0,
+            UnixNanos::new(1000),
+            UnixNanos::new(1000),
+            None,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn test_parse_quote_tick_rejects_unrepresentable_size() {
+        let instrument_id = create_test_instrument_id();
+        let result = parse_quote_tick(
+            instrument_id,
+            Some(150.25),
+            Some(150.30),
+            Some(0.5),
+            Some(200.0),
+            2,
+            0,
+            UnixNanos::new(0),
+            UnixNanos::new(0),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[rstest]
     fn test_parse_index_price_with_price_magnifier() {
         let instrument_id = create_test_instrument_id();
         let result = parse_index_price(
@@ -430,8 +483,8 @@ mod tests {
             instrument_id,
             Some(150.255),
             Some(150.305),
-            Some(100.5),
-            Some(200.5),
+            Some(100.0),
+            Some(200.0),
             2, // Price precision: 2 decimal places
             0, // Size precision: 0 decimal places
             UnixNanos::new(0),

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1087,6 +1087,96 @@ async fn test_process_order_update_stream_emits_fill_after_commission_report() {
     assert!(commission_cache.lock().unwrap().is_empty());
 }
 
+#[tokio::test]
+async fn test_process_order_update_stream_learns_order_ref_from_execution() {
+    let instrument_provider = create_test_instrument_provider();
+    let equity = equity_aapl();
+    let order_id = 7004;
+    let contract_id = 12346;
+    let client_order_id = ClientOrderId::from("O-STREAM-EXEC-REF");
+    let venue_order_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let instrument_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let trader_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let strategy_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let order_avg_prices = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fills = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fill_avgs = Arc::new(Mutex::new(AHashMap::new()));
+    let order_fill_progress = Arc::new(Mutex::new(AHashMap::new()));
+    let accepted_orders = Arc::new(Mutex::new(ahash::AHashSet::new()));
+    let pending_cancel_orders = Arc::new(Mutex::new(ahash::AHashSet::new()));
+    let spread_fill_tracking = Arc::new(Mutex::new(AHashMap::new()));
+    let commission_cache = Arc::new(Mutex::new(AHashMap::new()));
+    let order_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let (exec_sender, mut exec_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (update_sender, update_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut subscription = Subscription::new(update_receiver);
+
+    let instrument_id = equity.id();
+    instrument_provider.insert_test_instrument(InstrumentAny::from(equity), contract_id, 1);
+
+    let mut exec_data = create_test_execution_data(order_id, "exec-stream-002", 100.0, 50.0, "BOT");
+    exec_data.contract.contract_id = contract_id;
+    exec_data.contract.security_type = SecurityType::Stock;
+    exec_data.contract.symbol = IBSymbol::from("AAPL");
+    exec_data.contract.exchange = Exchange::from("SMART");
+    exec_data.contract.currency = IBCurrency::from("USD");
+    exec_data.execution.order_reference = client_order_id.to_string();
+
+    update_sender
+        .send(Ok(OrderUpdate::ExecutionData(exec_data)))
+        .unwrap();
+    update_sender
+        .send(Ok(OrderUpdate::CommissionReport(CommissionReport {
+            execution_id: String::from("exec-stream-002"),
+            commission: 1.25,
+            currency: String::from("USD"),
+            realized_pnl: None,
+            yields: None,
+            yield_redemption_date: String::new(),
+        })))
+        .unwrap();
+    drop(update_sender);
+
+    InteractiveBrokersExecutionClient::process_order_update_stream(
+        &mut subscription,
+        &order_id_map,
+        &venue_order_id_map,
+        &instrument_provider,
+        &exec_sender,
+        nautilus_core::time::get_atomic_clock_realtime(),
+        AccountId::from("IB-001"),
+        &commission_cache,
+        &instrument_id_map,
+        &trader_id_map,
+        &strategy_id_map,
+        &spread_fill_tracking,
+        &order_avg_prices,
+        &pending_combo_fills,
+        &pending_combo_fill_avgs,
+        &order_fill_progress,
+        &accepted_orders,
+        &pending_cancel_orders,
+    )
+    .await;
+
+    let fill_event = exec_receiver.try_recv().unwrap();
+    match fill_event {
+        ExecutionEvent::Report(ExecutionReport::Fill(fill)) => {
+            assert_eq!(fill.client_order_id, Some(client_order_id));
+            assert_eq!(fill.instrument_id, instrument_id);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+    assert_eq!(
+        venue_order_id_map.lock().unwrap().get(&order_id),
+        Some(&client_order_id)
+    );
+    assert_eq!(
+        order_id_map.lock().unwrap().get(&client_order_id),
+        Some(&order_id)
+    );
+}
+
 #[rstest]
 fn test_get_leg_position_edge_cases() {
     // Test with single component (no spread)

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -701,7 +701,7 @@ impl InteractiveBrokersExecutionClient {
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn handle_execution_data(
         exec_data: &ExecutionData,
-        _order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
+        order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
         venue_order_id_map: &Arc<Mutex<AHashMap<i32, ClientOrderId>>>,
         instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
         exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
@@ -717,14 +717,27 @@ impl InteractiveBrokersExecutionClient {
         pending_combo_fill_avgs: &Arc<Mutex<AHashMap<ClientOrderId, VecDeque<(Decimal, Price)>>>>,
         order_fill_progress: &Arc<Mutex<AHashMap<ClientOrderId, (Decimal, Decimal)>>>,
     ) -> anyhow::Result<()> {
-        let client_order_id = {
+        let mapped_client_order_id = {
             let map = venue_order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?;
             map.get(&exec_data.execution.order_id).copied()
         };
 
-        let Some(client_order_id) = client_order_id else {
+        let client_order_id = if let Some(client_order_id) = mapped_client_order_id {
+            client_order_id
+        } else if !exec_data.execution.order_reference.is_empty() {
+            let client_order_id = ClientOrderId::from(exec_data.execution.order_reference.as_str());
+            order_id_map
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?
+                .insert(client_order_id, exec_data.execution.order_id);
+            venue_order_id_map
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?
+                .insert(exec_data.execution.order_id, client_order_id);
+            client_order_id
+        } else {
             tracing::debug!(
                 "Execution data for unknown order ID: {}",
                 exec_data.execution.order_id

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -31,7 +31,7 @@ use crate::{
     common::{
         enums::IbAction,
         parse::{
-            create_spread_instrument_id, determine_venue_from_contract,
+            create_spread_instrument_id, determine_venue_from_contract, exchange_to_mic_venue,
             instrument_id_to_ib_contract, is_spread_instrument_id,
             parse_spread_instrument_id_to_legs, possible_exchanges_for_venue,
         },
@@ -167,6 +167,10 @@ impl InteractiveBrokersInstrumentProvider {
         contract: &Contract,
         contract_details: Option<&ibapi::contracts::ContractDetails>,
     ) -> Venue {
+        if matches!(contract.security_type, SecurityType::Stock) {
+            return Venue::from(self.resolve_stock_exchange_from_contract(contract).as_str());
+        }
+
         let valid_exchanges = contract_details.map(|details| details.valid_exchanges.join(","));
         let venue_str = determine_venue_from_contract(
             contract,
@@ -175,6 +179,57 @@ impl InteractiveBrokersInstrumentProvider {
             valid_exchanges.as_deref(),
         );
         Venue::from(venue_str.as_str())
+    }
+
+    fn resolve_stock_exchange_from_contract(&self, contract: &Contract) -> String {
+        let cached_venue = self.resolve_cached_symbol_venue(contract);
+        if let Some(venue) = cached_venue.as_deref()
+            && Self::is_compatible_cached_stock_venue(venue, contract.primary_exchange.as_str())
+        {
+            return venue.to_string();
+        }
+
+        if !contract.primary_exchange.as_str().is_empty()
+            && contract.primary_exchange.as_str() != "SMART"
+        {
+            return if self.config.convert_exchange_to_mic_venue {
+                exchange_to_mic_venue(contract.primary_exchange.as_str())
+                    .unwrap_or_else(|| contract.primary_exchange.as_str().to_string())
+            } else {
+                contract.primary_exchange.as_str().to_string()
+            };
+        }
+
+        if contract.exchange.as_str() == "SMART"
+            && let Some(venue) = cached_venue
+        {
+            return venue;
+        }
+
+        let exchange = contract.exchange.as_str();
+        if self.config.convert_exchange_to_mic_venue {
+            exchange_to_mic_venue(exchange).unwrap_or_else(|| exchange.to_string())
+        } else {
+            exchange.to_string()
+        }
+    }
+
+    fn is_compatible_cached_stock_venue(venue: &str, primary_exchange: &str) -> bool {
+        if primary_exchange.is_empty() || primary_exchange == "SMART" {
+            return true;
+        }
+
+        venue == primary_exchange
+            || exchange_to_mic_venue(primary_exchange).is_some_and(|mic| mic == venue)
+    }
+
+    fn resolve_cached_symbol_venue(&self, contract: &Contract) -> Option<String> {
+        self.instruments.iter().find_map(|entry| {
+            let instrument = entry.value();
+            let instrument_id = instrument.id();
+            (instrument_id.symbol.as_str() == contract.symbol.as_str())
+                .then(|| instrument_id.venue.to_string())
+        })
     }
 
     /// Get the symbology method from the provider configuration.

--- a/crates/adapters/interactive_brokers/src/providers/tests.rs
+++ b/crates/adapters/interactive_brokers/src/providers/tests.rs
@@ -102,6 +102,66 @@ mod tests {
     }
 
     #[rstest]
+    fn test_determine_stock_venue_uses_primary_exchange_over_fill_exchange() {
+        let provider = create_test_provider();
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("META"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("IBEOS"),
+            primary_exchange: Exchange::from("NASDAQ"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let venue = provider.determine_venue(&contract, None);
+
+        assert_eq!(venue.as_str(), "NASDAQ");
+    }
+
+    #[rstest]
+    fn test_determine_stock_venue_reuses_compatible_cached_mic_venue() {
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            convert_exchange_to_mic_venue: true,
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+        provider.insert_test_instrument(InstrumentAny::from(equity_aapl()), 265598, 1);
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("IBEOS"),
+            primary_exchange: Exchange::from("NASDAQ"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let venue = provider.determine_venue(&contract, None);
+
+        assert_eq!(venue.as_str(), "XNAS");
+    }
+
+    #[rstest]
+    fn test_determine_stock_smart_venue_reuses_cached_symbol_venue() {
+        let provider = create_test_provider();
+        provider.insert_test_instrument(InstrumentAny::from(equity_aapl()), 265598, 1);
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            primary_exchange: Exchange::default(),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let venue = provider.determine_venue(&contract, None);
+
+        assert_eq!(venue.as_str(), "XNAS");
+    }
+
+    #[rstest]
     fn test_symbology_method() {
         let provider = create_test_provider();
         let method = provider.symbology_method();


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Ported the recent Interactive Brokers Python adapter fixes for SMART stock venue resolution, callback ordering races, unrepresentable market data sizes, reconnect handling, and shutdown-time reader behavior into the Rust adapter.
- Updated Rust stock venue resolution so `STK` contracts prefer `primaryExchange`, reuse compatible cached MIC venues, and keep SMART-routed symbols on their cached canonical venue when possible.
- Added checked market data quantity conversion for quote and trade ticks so negative, overflowing, or otherwise unrepresentable IB sizes are logged and dropped instead of creating invalid `Quantity` values.
- Hardened shared IB client reuse by discarding disconnected shared clients before reconnecting, which maps the pre-handshake reconnect and shutdown reader fixes to the Rust adapter's `rust-ibapi` connection model.
- Taught execution update handling to learn `ClientOrderId` from execution order references when fills arrive before the normal order ID mapping callback.

### Design decisions

- The Rust adapter does not own the same low-level socket reader or server-version framing path as the Python adapter, so the reconnect and shutdown fixes are represented as stale shared-client detection before reuse.
- Stock venue resolution keeps the canonical listing venue stable for fills reported on execution venues such as `IBEOS`, while retaining the existing option fallback behavior for SMART-routed `OPT` contracts.
- Market data quantity validation uses checked construction and round-trip validation before updating quote cache state or emitting quote and trade ticks.
- Execution handling now accepts a valid execution callback with an order reference as an authoritative late mapping source instead of dropping the fill when IB callbacks arrive out of order.

### Files changed

- `crates/adapters/interactive_brokers/src/common/parse.rs`.
- `crates/adapters/interactive_brokers/src/common/shared_client.rs`.
- `crates/adapters/interactive_brokers/src/data/cache.rs`.
- `crates/adapters/interactive_brokers/src/data/parse.rs`.
- `crates/adapters/interactive_brokers/src/execution/core_updates.rs`.
- `crates/adapters/interactive_brokers/src/execution/core_tests.rs`.
- `crates/adapters/interactive_brokers/src/providers/instruments.rs`.
- `crates/adapters/interactive_brokers/src/providers/tests.rs`.

### Testing

- `cargo fmt -p nautilus-interactive-brokers`.
- `cargo test -p nautilus-interactive-brokers --lib`.

### Risk

- Medium. The changes are scoped to the Rust Interactive Brokers adapter, but they touch instrument identity, market data ingestion, connection reuse, and execution callback handling.
- The venue changes are limited to stock-specific logic and preserve option-specific SMART fallback behavior.
- The market data changes intentionally drop sizes the model cannot represent, matching the Python adapter behavior.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
