### PR TITLE
Remove closed orders from matching core iteration

### DIFF
--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -3444,6 +3444,7 @@ impl OrderMatchingEngine {
             };
 
             if order.is_closed() {
+                let _ = self.core.delete_order(client_order_id);
                 self.cached_filled_qty.swap_remove(&client_order_id);
                 continue;
             }
@@ -4437,7 +4438,7 @@ impl OrderMatchingEngine {
             .get(&order.client_order_id())
             .is_some_and(|qty| qty >= &order.quantity());
 
-        if order.is_passive() && (order.is_closed() || fully_filled) {
+        if order.is_closed() || fully_filled {
             if self.core.order_exists(order.client_order_id()) {
                 let _ = self.core.delete_order(order.client_order_id());
             }

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -2027,6 +2027,76 @@ fn test_process_cancel_skips_already_canceled_order(
 }
 
 #[rstest]
+fn test_iterate_purges_already_canceled_order_from_core(
+    instrument_eth_usdt: InstrumentAny,
+    account_id: AccountId,
+) {
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let order_event_handler = order_event_handler_with_cache(cache.clone());
+    let mut engine_l2 = get_order_matching_engine_l2(
+        instrument_eth_usdt.clone(),
+        Some(cache.clone()),
+        None,
+        None,
+        None,
+    );
+
+    let orderbook_delta_sell = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .build();
+    engine_l2
+        .process_order_book_delta(&orderbook_delta_sell)
+        .unwrap();
+
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1495.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(client_order_id)
+        .submit(true)
+        .build();
+
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    let cached_order = cache.borrow().order(&client_order_id).unwrap().clone();
+    let canceled_event =
+        TestOrderEventStubs::canceled(&cached_order, account_id, Some(VenueOrderId::from("V1")));
+    cache
+        .borrow_mut()
+        .order_mut(&client_order_id)
+        .unwrap()
+        .apply(canceled_event)
+        .unwrap();
+
+    clear_order_event_handler_messages(&order_event_handler);
+
+    assert!(
+        engine_l2.order_exists(client_order_id),
+        "matching core should still hold the order before iterate runs",
+    );
+
+    engine_l2.iterate(UnixNanos::from(1), AggressorSide::NoAggressor);
+
+    let saved_messages = get_order_event_handler_messages(&order_event_handler);
+    assert!(
+        saved_messages.is_empty(),
+        "expected no events while purging stale closed order, found {saved_messages:?}",
+    );
+    assert!(
+        !engine_l2.order_exists(client_order_id),
+        "stale closed order should be purged during matching iteration",
+    );
+}
+
+#[rstest]
 fn test_process_cancel_all_skips_orders_closed_by_contingent_cascade(
     instrument_eth_usdt: InstrumentAny,
     account_id: AccountId,

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -5768,6 +5768,7 @@ cdef class OrderMatchingEngine:
         cdef Order order
         for order in orders:
             if order.is_closed_c():
+                self._core.delete_order(order)
                 self._cached_filled_qty.pop(order.client_order_id, None)
                 continue
 
@@ -7637,6 +7638,7 @@ cdef class OrderMatchingEngine:
 
         cdef Quantity cached_filled_qty = self._cached_filled_qty.get(order.client_order_id)
         cdef Quantity leaves_qty = None
+        cdef Quantity total_filled_qty = None
         if cached_filled_qty is None:
             # Clamp the first fill to the order quantity to avoid over-filling
             last_qty = Quantity.from_raw_c(min(order.quantity._mem.raw, last_qty._mem.raw), size_prec)
@@ -7644,7 +7646,8 @@ cdef class OrderMatchingEngine:
         else:
             if order.quantity._mem.raw <= cached_filled_qty._mem.raw:
                 self._core.delete_order(order)
-                self._cached_filled_qty.pop(order.client_order_id, None)
+                if order.is_closed_c():
+                    self._cached_filled_qty.pop(order.client_order_id, None)
                 return
 
             leaves_qty = Quantity.from_raw_c(order.quantity._mem.raw - cached_filled_qty._mem.raw, size_prec)
@@ -7676,10 +7679,18 @@ cdef class OrderMatchingEngine:
             liquidity_side=order.liquidity_side,
         )
 
-        if order.is_passive_c() and order.is_closed_c():
+        total_filled_qty = self._cached_filled_qty.get(order.client_order_id)
+        if (
+            order.is_closed_c()
+            or (
+                total_filled_qty is not None
+                and total_filled_qty._mem.raw >= order.quantity._mem.raw
+            )
+        ):
             # Remove order from market
             self._core.delete_order(order)
-            self._cached_filled_qty.pop(order.client_order_id, None)
+            if order.is_closed_c():
+                self._cached_filled_qty.pop(order.client_order_id, None)
 
         if not self._support_contingent_orders:
             return

--- a/tests/unit_tests/backtest/test_matching_engine.py
+++ b/tests/unit_tests/backtest/test_matching_engine.py
@@ -1668,6 +1668,8 @@ class TestOrderMatchingEngine:
         matching_engine_l2.iterate(timestamp_ns=1)
 
         # Assert
+        assert not matching_engine_l2.order_exists(order.client_order_id)
+
         filled_events = [m for m in messages if isinstance(m, OrderFilled)]
         assert len(filled_events) == 1, (
             f"Expected exactly 1 fill (initial), but got {len(filled_events)} "


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Removes closed orders from the Cython backtest matching core during iteration instead of only skipping them.
- Removes fully filled orders from the Cython matching core based on cached fill quantity, covering immediate fills before the order object has been refreshed by events.
- Mirrors the cleanup in the Rust matching engine so closed and fully filled orders do not remain in the active matching core.
- Adds Python and Rust regression coverage for stale matching-core entries.

### Design notes

- The deletion is scoped to the matching core's active resting-order structure only.
- Orders remain available for post-backtest analysis through the cache, closed-order indexes, event stream, and reports.
- The existing `get_orders` name is preserved; the change keeps its practical contract as active orders held by the matching core.
- Cython retains cached filled quantity for fully filled orders until the order object is observed closed, so duplicate direct fill attempts are still suppressed while the matching core no longer retains the order.

### Verification

- `cargo test -p nautilus-execution test_iterate_purges_already_canceled_order_from_core`.
- `cargo test -p nautilus-execution fully_filled`.
- `make build-debug`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_fully_filled_order_not_rematched_on_subsequent_iterate`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_fill_order_with_non_positive_qty_returns_early tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_fully_filled_order_not_rematched_on_subsequent_iterate`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_matching_engine.py -k "fully_filled or market_to_limit or not_rematched"`.
- `uv run --no-sync pytest tests/unit_tests/backtest/test_matching_engine.py -k "fully_filled or market_to_limit or not_rematched or non_positive"`.
- `make format`.
- `make pre-commit`.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
