### PR TITLE
Fix Hyperliquid pending fills buffer

### DIFF
--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -165,6 +165,10 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         # from the cancel-replace ACCEPTED branch. See GH-3972.
         self._buffered_fills: dict[str, list[nautilus_pyo3.FillReport]] = {}
 
+        # FillReports buffered when fill arrives before order is in cache,
+        # drained on OrderAccepted.
+        self._pending_fills: dict[str, list[nautilus_pyo3.FillReport]] = {}
+
         self._fee_refresh_task: asyncio.Task | None = None
 
         # Get user address from HTTP client for WebSocket subscriptions.
@@ -261,6 +265,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
     def _cleanup_cloid_mapping(self, client_order_id: ClientOrderId) -> None:
         # Drop the cancel-replace fill buffer to avoid stranded entries (GH-3972).
         self._buffered_fills.pop(client_order_id.value, None)
+        self._pending_fills.pop(client_order_id.value, None)
         try:
             pyo3_client_order_id = nautilus_pyo3.ClientOrderId(client_order_id.value)
             cloid = nautilus_pyo3.hyperliquid_cloid_from_client_order_id(pyo3_client_order_id)
@@ -1067,6 +1072,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         self._accepted_orders.add(key)
         self._send_order_event(event)
 
+        # Drain any fills that arrived before order was in cache.
+        buffered = self._pending_fills.pop(key, None)
+        if buffered:
+            for pyo3_buffered in buffered:
+                self._handle_fill_report_pyo3(pyo3_buffered)
+
     def _handle_order_canceled_pyo3(self, msg: nautilus_pyo3.OrderCanceled) -> None:
         event = OrderCanceled.from_dict(msg.to_dict())
         key = event.client_order_id.value
@@ -1257,6 +1268,13 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 venue_order_id=report.venue_order_id,
                 ts_event=report.ts_last,
             )
+
+            # Drain any fills that arrived before order was in cache.
+            buffered = self._pending_fills.pop(key, None)
+            if buffered:
+                for pyo3_buffered in buffered:
+                    self._handle_fill_report_pyo3(pyo3_buffered)
+
         elif report.order_status == OrderStatus.PENDING_CANCEL:
             if order.status == OrderStatus.PENDING_CANCEL:
                 self._log.debug(
@@ -1377,7 +1395,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
         else:
             self._log.warning(f"Received unhandled OrderStatusReport: {report}")
 
-    def _handle_fill_report_pyo3(self, pyo3_report: nautilus_pyo3.FillReport) -> None:
+    def _handle_fill_report_pyo3(self, pyo3_report: nautilus_pyo3.FillReport) -> None:  # noqa: C901 (complexity unavoidable)
         report = FillReport.from_pyo3(pyo3_report)
 
         self._log.debug(
@@ -1406,10 +1424,10 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         order = self._cache.order(client_order_id)
         if order is None:
-            # Don't mark as processed - order may arrive later
             self._log.error(
-                f"Cannot process fill report - order for {client_order_id!r} not found",
+                f"Cannot process fill report - order for {client_order_id!r} not found, buffering fill until order arrives",
             )
+            self._pending_fills.setdefault(client_order_id.value, []).append(pyo3_report)
             return
 
         instrument = self._cache.instrument(order.instrument_id)
@@ -1451,6 +1469,12 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 venue_order_id=report.venue_order_id,
                 ts_event=report.ts_event,
             )
+
+            # Drain any fills that arrived before order was in cache.
+            buffered = self._pending_fills.pop(key, None)
+            if buffered:
+                for pyo3_buffered in buffered:
+                    self._handle_fill_report_pyo3(pyo3_buffered)
 
         self.generate_order_filled(
             strategy_id=order.strategy_id,


### PR DESCRIPTION
# Pull Request
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary
`_handle_fill_report_pyo3` silently drops fills when the order is not yet in cache at the time the WS fill message arrives. The existing comment acknowledged this (`# Don't mark as processed - order may arrive later`) but the buffering was never implemented. This PR adds `_pending_fills` — mirroring the existing `_buffered_fills` pattern (GH-3972) — to buffer the raw pyo3 fill report and drain it once the order is confirmed accepted.

## Related Issues/PRs
Related to GH-3972

## Type of change
- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)
N/A

## Documentation
- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes
- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing
- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

No unit tests added — the logic mirrors the proven `_buffered_fills` pattern already in the codebase. Available to help build tests if needed.

### What was already there
The existing code already handled this partially — the comment `# Don't mark as processed - order may arrive later` lead to conclusion the order might arrive later and intentionally avoided marking the fill as processed to prevent dedup lock-out. 

However the buffering to actually hold the fill until that moment was never implemented, leaving the fill permanently dropped.

### What changed

**Buffer** — when `order is None` in `_handle_fill_report_pyo3`, instead of dropping:
```python
# before: fill permanently lost
self._log.error(f"Cannot process fill report - order for {client_order_id!r} not found")
return

# after: buffered until order arrives
self._pending_fills.setdefault(client_order_id.value, []).append(pyo3_report)
return
```

**Drain** — added at all three points where NT first learns an order is accepted, covering all possible WS message orderings:

1. `_handle_order_accepted_pyo3` — WS delivers a dedicated `OrderAccepted` message
2. ACCEPTED branch of `_handle_order_status_report_pyo3` — WS delivers `OrderStatusReport(status=ACCEPTED)`
3. Inside `_handle_fill_report_pyo3` when auto-generating `OrderAccepted` inline — fill arrives but order was never accepted in NT state machine yet

Missing any one of these three drain points leaves a gap depending on which message type the exchange delivers first.

**Cleanup** — `_pending_fills` cleared in `_cleanup_cloid_mapping` alongside `_buffered_fills` to prevent stranded entries on order close.

Note: this adds a small amount of complexity to `_handle_fill_report_pyo3`, requiring a `# noqa: C901` suppression.