### PR TITLE
Add IB per-order exchange routing params

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -123,6 +123,30 @@ impl InteractiveBrokersExecutionClient {
             .context("Failed to convert instrument ID to IB contract")
     }
 
+    pub(super) fn contract_with_order_exchange_param(
+        mut contract: ibapi::contracts::Contract,
+        params: Option<&nautilus_core::Params>,
+    ) -> anyhow::Result<ibapi::contracts::Contract> {
+        let Some(params) = params else {
+            return Ok(contract);
+        };
+
+        let Some(exchange_value) = params.get("exchange") else {
+            return Ok(contract);
+        };
+
+        let Some(exchange) = exchange_value.as_str() else {
+            anyhow::bail!("`exchange` order param must be a string");
+        };
+
+        if exchange.is_empty() {
+            return Ok(contract);
+        }
+
+        contract.exchange = ibapi::contracts::Exchange::from(exchange);
+        Ok(contract)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn cache_order_tracking(
         ib_order_id: i32,
@@ -172,5 +196,82 @@ impl InteractiveBrokersExecutionClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ibapi::contracts::{Contract, Exchange};
+    use nautilus_core::Params;
+    use rstest::rstest;
+    use serde_json::Value;
+
+    use super::*;
+
+    fn contract_with_exchange(exchange: &str) -> Contract {
+        Contract {
+            exchange: Exchange::from(exchange),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    fn test_contract_with_order_exchange_param_overrides_exchange() {
+        let contract = contract_with_exchange("SMART");
+        let mut params = Params::new();
+        params.insert("exchange".to_string(), Value::String("IEX".to_string()));
+
+        let updated = InteractiveBrokersExecutionClient::contract_with_order_exchange_param(
+            contract.clone(),
+            Some(&params),
+        )
+        .unwrap();
+
+        assert_eq!(updated.exchange.as_str(), "IEX");
+        assert_eq!(contract.exchange.as_str(), "SMART");
+    }
+
+    #[rstest]
+    fn test_contract_with_order_exchange_param_keeps_contract_without_exchange() {
+        let contract = contract_with_exchange("SMART");
+        let params = Params::new();
+
+        let updated = InteractiveBrokersExecutionClient::contract_with_order_exchange_param(
+            contract,
+            Some(&params),
+        )
+        .unwrap();
+
+        assert_eq!(updated.exchange.as_str(), "SMART");
+    }
+
+    #[rstest]
+    fn test_contract_with_order_exchange_param_keeps_contract_with_empty_exchange() {
+        let contract = contract_with_exchange("SMART");
+        let mut params = Params::new();
+        params.insert("exchange".to_string(), Value::String(String::new()));
+
+        let updated = InteractiveBrokersExecutionClient::contract_with_order_exchange_param(
+            contract,
+            Some(&params),
+        )
+        .unwrap();
+
+        assert_eq!(updated.exchange.as_str(), "SMART");
+    }
+
+    #[rstest]
+    fn test_contract_with_order_exchange_param_rejects_non_string_exchange() {
+        let contract = contract_with_exchange("SMART");
+        let mut params = Params::new();
+        params.insert("exchange".to_string(), Value::Bool(true));
+
+        let err = InteractiveBrokersExecutionClient::contract_with_order_exchange_param(
+            contract,
+            Some(&params),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("must be a string"));
     }
 }

--- a/crates/adapters/interactive_brokers/src/execution/core_orders.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_orders.rs
@@ -107,6 +107,7 @@ impl InteractiveBrokersExecutionClient {
 
         let contract =
             Self::resolve_contract_for_instrument(cmd.instrument_id, instrument_provider)?;
+        let contract = Self::contract_with_order_exchange_param(contract, cmd.params.as_ref())?;
 
         let order_any = OrderAny::try_from(cmd.order_init.clone())
             .context("Failed to construct order from `OrderInitialized`")?;
@@ -214,6 +215,7 @@ impl InteractiveBrokersExecutionClient {
             let ib_order_id = target_ib_order_id.context("Order ID not found in mapping")?;
             let contract =
                 Self::resolve_contract_for_instrument(cmd.instrument_id, instrument_provider)?;
+            let contract = Self::contract_with_order_exchange_param(contract, cmd.params.as_ref())?;
 
             let order_ref = original_order.client_order_id().to_string();
             let mut ib_order = nautilus_order_to_ib_order(
@@ -323,6 +325,8 @@ impl InteractiveBrokersExecutionClient {
 
                     let ib_order_id = data.order_id;
                     let contract = data.contract;
+                    let contract =
+                        Self::contract_with_order_exchange_param(contract, cmd.params.as_ref())?;
                     let mut ib_order = data.order;
 
                     Self::apply_modify_fields_to_ib_order(cmd, &mut ib_order, instrument_provider);
@@ -400,6 +404,7 @@ impl InteractiveBrokersExecutionClient {
             first_order.instrument_id(),
             instrument_provider,
         )?;
+        let contract = Self::contract_with_order_exchange_param(contract, cmd.params.as_ref())?;
 
         let _submit_guard = order_submit_lock.lock().await;
 
@@ -577,6 +582,8 @@ impl InteractiveBrokersExecutionClient {
                     order.instrument_id(),
                     instrument_provider,
                 )?;
+                let order_contract =
+                    Self::contract_with_order_exchange_param(order_contract, cmd.params.as_ref())?;
 
                 let order_ref = order.client_order_id().to_string();
                 let mut ib_order = nautilus_order_to_ib_order(

--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -1200,6 +1200,18 @@ exec_config = InteractiveBrokersExecClientConfig(
 )
 ```
 
+#### Order params
+
+The execution adapter supports `params["exchange"]` on order submit, order list submit, and
+order modification commands. Use it to override the IB contract exchange for routing the current
+order while preserving the cached instrument contract:
+
+```python
+self.submit_order(order, params={"exchange": "IEX"})
+```
+
+Leave `exchange` unset, or set it to an empty string, to use the cached contract exchange.
+
 #### Order tags and advanced features
 
 The adapter supports IB-specific order parameters through order tags:

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import Any
 
+import msgspec
 import pandas as pd
 from ibapi.commission_and_fees_report import CommissionAndFeesReport
 from ibapi.const import UNSET_DECIMAL
@@ -980,7 +981,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         PyCondition.type(command, SubmitOrder, "command")
 
         try:
-            ib_order: IBOrder = self._transform_order_to_ib_order(command.order)
+            ib_order: IBOrder = self._transform_order_to_ib_order(
+                command.order,
+                command.params,
+            )
             ib_order.orderId = self._client.next_order_id()
             self._client.place_order(ib_order)
             self._handle_order_event(status=OrderStatus.SUBMITTED, order=command.order)
@@ -1004,7 +1008,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             client_id_to_orders[order.client_order_id.value] = order
 
             try:
-                ib_order = self._transform_order_to_ib_order(order)
+                ib_order = self._transform_order_to_ib_order(order, command.params)
                 ib_order.transmit = False
                 ib_order.orderId = order_id_map[order.client_order_id.value]
                 ib_orders.append(ib_order)
@@ -1052,7 +1056,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         self._log.info(f"Nautilus order status is {nautilus_order.status_string()}")
 
         try:
-            ib_order: IBOrder = self._transform_order_to_ib_order(nautilus_order)
+            ib_order: IBOrder = self._transform_order_to_ib_order(
+                nautilus_order,
+                command.params,
+            )
         except ValueError as e:
             self._handle_order_event(
                 status=OrderStatus.REJECTED,
@@ -1098,7 +1105,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         self._log.info(f"Placing {ib_order!r}")
         self._client.place_order(ib_order)
 
-    def _transform_order_to_ib_order(self, order: Order) -> IBOrder:  # noqa: C901
+    def _transform_order_to_ib_order(  # noqa: C901
+        self,
+        order: Order,
+        params: dict[str, Any] | None = None,
+    ) -> IBOrder:
         if order.is_post_only:
             raise ValueError("`post_only` not supported by Interactive Brokers")
 
@@ -1163,6 +1174,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         else:
             details = self.instrument_provider.contract_details[order.instrument_id]
             ib_order.contract = details.contract
+
+        if routing_exchange := self._routing_exchange_from_params(params):
+            ib_order.contract = self._contract_with_routing_exchange(
+                ib_order.contract,
+                routing_exchange,
+            )
 
         ib_order.account = self.account_id.get_id()
         ib_order.clearingAccount = self.account_id.get_id()
@@ -1233,6 +1250,29 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
 
         return ib_order
+
+    def _routing_exchange_from_params(self, params: dict[str, Any] | None) -> str | None:
+        if not params:
+            return None
+
+        if "exchange" not in params:
+            return None
+
+        value = params["exchange"]
+        if not isinstance(value, str):
+            raise ValueError("`exchange` order param must be a string")
+
+        return value or None
+
+    def _contract_with_routing_exchange(
+        self,
+        contract: IBContract | None,
+        routing_exchange: str,
+    ) -> IBContract:
+        if contract is None:
+            raise ValueError("Cannot override routing exchange without an IB contract")
+
+        return msgspec.structs.replace(contract, exchange=routing_exchange)
 
     def _create_ib_conditions(
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
@@ -15,6 +15,8 @@
 
 import pytest
 
+from nautilus_trader.adapters.interactive_brokers.common import ComboLeg
+from nautilus_trader.adapters.interactive_brokers.common import IBContract
 from nautilus_trader.adapters.interactive_brokers.common import IBOrderTags
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model.enums import ContingencyType
@@ -143,6 +145,45 @@ async def test_transform_order_to_ib_order_limit(
         f"{expected_order_type=}, but got {ib_order.orderType=}"
     )
     assert ib_order.tif == expected_tif, f"{expected_tif=}, but got {ib_order.tif=}"
+
+
+@pytest.mark.asyncio
+async def test_transform_order_to_ib_order_exchange_param(exec_client):
+    # Arrange
+    instrument = _AAPL
+    await exec_client._instrument_provider.load_async(instrument.id)
+
+    cached_contract = exec_client._instrument_provider.contract_details[instrument.id].contract
+    order = TestExecStubs.limit_order(instrument=instrument)
+
+    # Act
+    ib_order = exec_client._transform_order_to_ib_order(order, {"exchange": "IEX"})
+
+    # Assert
+    assert ib_order.contract.exchange == "IEX"
+    assert ib_order.contract.primaryExchange == "NASDAQ"
+    assert ib_order.contract.conId == cached_contract.conId
+    assert cached_contract.exchange == "SMART"
+    assert ib_order.contract is not cached_contract
+
+
+def test_contract_with_routing_exchange_preserves_combo_legs(exec_client):
+    # Arrange
+    combo_legs = [
+        ComboLeg(conId=1001, ratio=1, action="BUY", exchange="SMART"),
+        ComboLeg(conId=1002, ratio=1, action="SELL", exchange="SMART"),
+    ]
+    contract = IBContract(secType="BAG", exchange="SMART", comboLegs=combo_legs)
+
+    # Act
+    updated = exec_client._contract_with_routing_exchange(contract, "CBOE")
+
+    # Assert
+    assert updated.exchange == "CBOE"
+    assert contract.exchange == "SMART"
+    assert updated.comboLegs == combo_legs
+    assert updated.comboLegs is combo_legs
+    assert isinstance(updated.comboLegs[0], ComboLeg)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Added Python Interactive Brokers execution support for overriding the submitted contract exchange with `params={"exchange": "..."}`.
- Added Rust Interactive Brokers execution support for the same `exchange` order param across submit, modify, modify-via-open-order lookup, and order-list submission paths.
- Preserved cached contract state by applying the exchange override only to owned contract values used for the current order submission.
- Preserved Python BAG/combo nested struct types by copying contracts with `msgspec.structs.replace`.
- Added focused Python and Rust tests covering exchange overrides, combo-leg preservation, empty-string no-op behavior, and non-string Rust param rejection.
- Documented the supported IB `exchange` order param and added a release note.

### Design notes

- The param key is `exchange` only, matching the existing spread/filter naming style and avoiding a new custom order tag.
- In Python, the adapter copies the IB contract before changing `exchange` without recursively converting nested combo structs to dictionaries.
- In Rust, `resolve_contract_for_instrument` returns owned contract values cloned from provider caches, and the override helper consumes that owned value before mutating it.
- Empty string exchange values are treated as no override in both adapters.

### Verification

- `cargo test -p nautilus-interactive-brokers contract_with_order_exchange_param` passed.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py -q` passed.
- `make format` passed.
- `make build-debug` passed.
- `make pre-commit` passed.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
