### PR TITLE
Fix consolidation cleanup for skipped targets

### DIFF
--- a/crates/persistence/src/backend/catalog_operations.rs
+++ b/crates/persistence/src/backend/catalog_operations.rs
@@ -886,7 +886,9 @@ impl ParquetDataCatalog {
             );
 
             if self.file_exists(&target_filename)? {
-                // Skip if target file already exists
+                // This period is already consolidated; do not let a later cleanup delete it.
+                let target_object_path = self.to_object_path(&target_filename)?.to_string();
+                existing_files.retain(|f| f != &target_object_path);
                 continue;
             }
 
@@ -1026,7 +1028,9 @@ impl ParquetDataCatalog {
             );
 
             if self.file_exists(&target_filename)? {
-                // Skip if target file already exists
+                // This period is already consolidated; do not let a later cleanup delete it.
+                let target_object_path = self.to_object_path(&target_filename)?.to_string();
+                existing_files.retain(|f| f != &target_object_path);
                 continue;
             }
 

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -1534,6 +1534,53 @@ fn test_generic_consolidate_data_by_period_bars() {
 }
 
 #[rstest]
+fn test_generic_consolidate_data_by_period_keeps_skipped_target() {
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let period = 10;
+    let file1_ts = [3, 6];
+    let file2_ts = [12, 14];
+    let file3_ts = [16];
+
+    for timestamps in [&file1_ts[..], &file2_ts[..], &file3_ts[..]] {
+        let bars: Vec<Bar> = timestamps.iter().copied().map(create_bar).collect();
+        catalog
+            .write_to_parquet(bars, None, None, Some(true))
+            .unwrap();
+    }
+
+    let bar_type = create_bar(file1_ts[0]).bar_type.to_string();
+    catalog
+        .consolidate_data_by_period_generic::<Bar>(
+            Some(bar_type.as_str()),
+            Some(period),
+            None,
+            None,
+            Some(false),
+        )
+        .unwrap();
+
+    let bars = catalog
+        .query_typed_data::<Bar>(Some(vec![bar_type.clone()]), None, None, None, None, true)
+        .unwrap();
+    let timestamps: Vec<u64> = bars.iter().map(|bar| bar.ts_init.as_u64()).collect();
+
+    assert_eq!(
+        timestamps,
+        vec![
+            file1_ts[0],
+            file1_ts[1],
+            file2_ts[0],
+            file2_ts[1],
+            file3_ts[0]
+        ]
+    );
+    let intervals = catalog.get_intervals("bars", Some(&bar_type)).unwrap();
+    assert!(intervals.contains(&(file1_ts[0], file1_ts[1])));
+    assert!(intervals.contains(&(file2_ts[0], file3_ts[0])));
+}
+
+#[rstest]
 fn test_generic_consolidate_data_by_period_empty_catalog() {
     let (_temp_dir, mut catalog) = create_temp_catalog();
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->
Fixes period-based catalog consolidation deleting an existing target file when that period is skipped because the target already exists.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
