### PR TITLE
Migrate instrument publishing from Any dispatch to typed routing 

### DIFF
--- a/crates/common/src/actor/data_actor.rs
+++ b/crates/common/src/actor/data_actor.rs
@@ -1107,7 +1107,7 @@ pub trait DataActor:
         let actor_id = self.actor_id().inner();
         let pattern = get_instruments_pattern(venue);
 
-        let handler = ShareableMessageHandler::from_typed(move |instrument: &InstrumentAny| {
+        let handler = TypedHandler::from(move |instrument: &InstrumentAny| {
             if let Some(mut actor) = try_get_actor_unchecked::<Self>(&actor_id) {
                 actor.handle_instrument(instrument);
             } else {
@@ -1130,7 +1130,7 @@ pub trait DataActor:
         let actor_id = self.actor_id().inner();
         let topic = get_instrument_topic(instrument_id);
 
-        let handler = ShareableMessageHandler::from_typed(move |instrument: &InstrumentAny| {
+        let handler = TypedHandler::from(move |instrument: &InstrumentAny| {
             if let Some(mut actor) = try_get_actor_unchecked::<Self>(&actor_id) {
                 actor.handle_instrument(instrument);
             } else {
@@ -2247,6 +2247,7 @@ pub struct DataActorCore {
     cache: Option<Rc<RefCell<Cache>>>,     // Wired up on registration
     state: ComponentState,
     topic_handlers: AHashMap<MStr<Pattern>, ShareableMessageHandler>,
+    instrument_handlers: AHashMap<MStr<Pattern>, TypedHandler<InstrumentAny>>,
     deltas_handlers: AHashMap<MStr<Pattern>, TypedHandler<OrderBookDeltas>>,
     depth10_handlers: AHashMap<MStr<Pattern>, TypedHandler<OrderBookDepth10>>,
     book_handlers: AHashMap<MStr<Topic>, TypedHandler<OrderBook>>,
@@ -2464,23 +2465,23 @@ impl DataActorCore {
     pub(crate) fn add_instrument_subscription(
         &mut self,
         pattern: MStr<Pattern>,
-        handler: ShareableMessageHandler,
+        handler: TypedHandler<InstrumentAny>,
     ) {
-        if self.topic_handlers.contains_key(&pattern) {
+        if self.instrument_handlers.contains_key(&pattern) {
             log::warn!(
                 "Actor {} attempted duplicate instrument subscription to '{pattern}'",
                 self.actor_id
             );
             return;
         }
-        self.topic_handlers.insert(pattern, handler.clone());
-        msgbus::subscribe_any(pattern, handler, None);
+        self.instrument_handlers.insert(pattern, handler.clone());
+        msgbus::subscribe_instruments(pattern, handler, None);
     }
 
     #[allow(dead_code)]
     pub(crate) fn remove_instrument_subscription(&mut self, pattern: MStr<Pattern>) {
-        if let Some(handler) = self.topic_handlers.remove(&pattern) {
-            msgbus::unsubscribe_any(pattern, &handler);
+        if let Some(handler) = self.instrument_handlers.remove(&pattern) {
+            msgbus::unsubscribe_instruments(pattern, &handler);
         }
     }
 
@@ -2810,6 +2811,7 @@ impl DataActorCore {
             cache: None,     // None until registered
             state: ComponentState::default(),
             topic_handlers: AHashMap::new(),
+            instrument_handlers: AHashMap::new(),
             deltas_handlers: AHashMap::new(),
             depth10_handlers: AHashMap::new(),
             book_handlers: AHashMap::new(),
@@ -3237,7 +3239,7 @@ impl DataActorCore {
     pub fn subscribe_instruments(
         &mut self,
         pattern: MStr<Pattern>,
-        handler: ShareableMessageHandler,
+        handler: TypedHandler<InstrumentAny>,
         venue: Venue,
         client_id: Option<ClientId>,
         params: Option<Params>,
@@ -3262,7 +3264,7 @@ impl DataActorCore {
     pub fn subscribe_instrument(
         &mut self,
         topic: MStr<Topic>,
-        handler: ShareableMessageHandler,
+        handler: TypedHandler<InstrumentAny>,
         instrument_id: InstrumentId,
         client_id: Option<ClientId>,
         params: Option<Params>,

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -1274,10 +1274,10 @@ fn test_subscribe_and_receive_instruments(
 
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim);
     let topic1 = get_instrument_topic(inst1.id());
-    msgbus::publish_any(topic1, &inst1);
+    msgbus::publish_instrument(topic1, &inst1);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim);
     let topic2 = get_instrument_topic(inst2.id());
-    msgbus::publish_any(topic2, &inst2);
+    msgbus::publish_instrument(topic2, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
     assert_eq!(actor.received_instruments[0], inst1);
@@ -1301,8 +1301,8 @@ fn test_subscribe_and_receive_instrument(
     let topic = get_instrument_topic(audusd_sim.id);
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim);
-    msgbus::publish_any(topic, &inst1);
-    msgbus::publish_any(topic, &inst2);
+    msgbus::publish_instrument(topic, &inst1);
+    msgbus::publish_instrument(topic, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
     assert_eq!(actor.received_instruments[0], inst1);
@@ -1543,19 +1543,19 @@ fn test_unsubscribe_instruments(
 
     let inst1 = InstrumentAny::CurrencyPair(audusd_sim.clone());
     let topic1 = get_instrument_topic(inst1.id());
-    msgbus::publish_any(topic1, &inst1);
+    msgbus::publish_instrument(topic1, &inst1);
     let inst2 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
     let topic2 = get_instrument_topic(inst2.id());
-    msgbus::publish_any(topic2, &inst2);
+    msgbus::publish_instrument(topic2, &inst2);
 
     assert_eq!(actor.received_instruments.len(), 2);
 
     actor.unsubscribe_instruments(venue, None, None);
 
     let inst3 = InstrumentAny::CurrencyPair(audusd_sim);
-    msgbus::publish_any(topic1, &inst3);
+    msgbus::publish_instrument(topic1, &inst3);
     let inst4 = InstrumentAny::CurrencyPair(gbpusd_sim);
-    msgbus::publish_any(topic2, &inst4);
+    msgbus::publish_instrument(topic2, &inst4);
 
     assert_eq!(actor.received_instruments.len(), 2);
 }
@@ -1575,18 +1575,18 @@ fn test_unsubscribe_instrument(
 
     let topic = get_instrument_topic(audusd_sim.id);
     let inst3 = InstrumentAny::CurrencyPair(audusd_sim.clone());
-    msgbus::publish_any(topic, &inst3);
+    msgbus::publish_instrument(topic, &inst3);
     let inst4 = InstrumentAny::CurrencyPair(gbpusd_sim.clone());
-    msgbus::publish_any(topic, &inst4);
+    msgbus::publish_instrument(topic, &inst4);
 
     assert_eq!(actor.received_instruments.len(), 2);
 
     actor.unsubscribe_instrument(audusd_sim.id, None, None);
 
     let inst3 = InstrumentAny::CurrencyPair(audusd_sim);
-    msgbus::publish_any(topic, &inst3);
+    msgbus::publish_instrument(topic, &inst3);
     let inst4 = InstrumentAny::CurrencyPair(gbpusd_sim);
-    msgbus::publish_any(topic, &inst4);
+    msgbus::publish_instrument(topic, &inst4);
 
     assert_eq!(actor.received_instruments.len(), 2);
 }

--- a/crates/common/src/msgbus/api.rs
+++ b/crates/common/src/msgbus/api.rs
@@ -37,6 +37,7 @@ use nautilus_model::{
         option_chain::{OptionChainSlice, OptionGreeks},
     },
     events::{AccountState, OrderEventAny, PortfolioSnapshot, PositionEvent},
+    instruments::InstrumentAny,
     orderbook::OrderBook,
     orders::OrderAny,
     position::Position,
@@ -47,9 +48,9 @@ use ustr::Ustr;
 use super::{
     ACCOUNT_STATE_HANDLERS, ANY_HANDLERS, BAR_HANDLERS, BOOK_HANDLERS, DELTAS_HANDLERS,
     DEPTH10_HANDLERS, FUNDING_RATE_HANDLERS, GREEKS_HANDLERS, HANDLER_BUFFER_CAP,
-    INDEX_PRICE_HANDLERS, MARK_PRICE_HANDLERS, OPTION_CHAIN_HANDLERS, OPTION_GREEKS_HANDLERS,
-    ORDER_EVENT_HANDLERS, PORTFOLIO_SNAPSHOT_HANDLERS, POSITION_EVENT_HANDLERS, QUOTE_HANDLERS,
-    TRADE_HANDLERS,
+    INDEX_PRICE_HANDLERS, INSTRUMENT_HANDLERS, MARK_PRICE_HANDLERS, OPTION_CHAIN_HANDLERS,
+    OPTION_GREEKS_HANDLERS, ORDER_EVENT_HANDLERS, PORTFOLIO_SNAPSHOT_HANDLERS,
+    POSITION_EVENT_HANDLERS, QUOTE_HANDLERS, TRADE_HANDLERS,
     core::{MessageBus, Subscription},
     dispatch_tap_publish, dispatch_tap_response, dispatch_tap_send, get_message_bus,
     matching::is_matching_backtracking,
@@ -255,10 +256,14 @@ pub fn subscribe_any(
 /// Subscribes a handler to instrument messages matching a pattern.
 pub fn subscribe_instruments(
     pattern: MStr<Pattern>,
-    handler: ShareableMessageHandler,
+    handler: TypedHandler<InstrumentAny>,
     priority: Option<u32>,
 ) {
-    subscribe_any(pattern, handler, priority);
+    get_message_bus().borrow_mut().router_instruments.subscribe(
+        pattern,
+        handler,
+        priority.unwrap_or(0),
+    );
 }
 
 /// Subscribes a handler to instrument close messages matching a pattern.
@@ -557,8 +562,11 @@ pub fn subscribe_defi_flash(
 }
 
 /// Unsubscribes a handler from instrument messages.
-pub fn unsubscribe_instruments(pattern: MStr<Pattern>, handler: &ShareableMessageHandler) {
-    unsubscribe_any(pattern, handler);
+pub fn unsubscribe_instruments(pattern: MStr<Pattern>, handler: &TypedHandler<InstrumentAny>) {
+    get_message_bus()
+        .borrow_mut()
+        .router_instruments
+        .unsubscribe(pattern, handler);
 }
 
 /// Unsubscribes a handler from instrument close messages.
@@ -934,6 +942,16 @@ pub fn publish_any(topic: MStr<Topic>, message: &dyn Any) {
 
     handlers.clear(); // Release refs before restore
     ANY_HANDLERS.with_borrow_mut(|buf| *buf = handlers);
+}
+
+/// Publishes an instrument to subscribers on a topic.
+pub fn publish_instrument(topic: MStr<Topic>, instrument: &InstrumentAny) {
+    publish_typed(
+        topic,
+        &INSTRUMENT_HANDLERS,
+        |bus, h| bus.router_instruments.fill_matching_handlers(topic, h),
+        instrument,
+    );
 }
 
 /// Publishes order book deltas to subscribers on a topic.

--- a/crates/common/src/msgbus/core.rs
+++ b/crates/common/src/msgbus/core.rs
@@ -102,6 +102,7 @@ use nautilus_model::{
     },
     events::{AccountState, OrderEventAny, PortfolioSnapshot, PositionEvent},
     identifiers::TraderId,
+    instruments::InstrumentAny,
     orderbook::OrderBook,
     orders::OrderAny,
     position::Position,
@@ -243,6 +244,7 @@ pub struct MessageBus {
     pub(crate) router_greeks: TopicRouter<GreeksData>,
     pub(crate) router_option_greeks: TopicRouter<OptionGreeks>,
     pub(crate) router_option_chain: TopicRouter<OptionChainSlice>,
+    pub(crate) router_instruments: TopicRouter<InstrumentAny>,
     #[cfg(feature = "defi")]
     pub(crate) router_defi_blocks: TopicRouter<nautilus_model::defi::Block>, // nautilus-import-ok
     #[cfg(feature = "defi")]
@@ -319,6 +321,7 @@ impl MessageBus {
             router_greeks: TopicRouter::new(),
             router_option_greeks: TopicRouter::new(),
             router_option_chain: TopicRouter::new(),
+            router_instruments: TopicRouter::new(),
             #[cfg(feature = "defi")]
             router_defi_blocks: TopicRouter::new(),
             #[cfg(feature = "defi")]
@@ -411,6 +414,7 @@ impl MessageBus {
         self.router_greeks.clear();
         self.router_option_greeks.clear();
         self.router_option_chain.clear();
+        self.router_instruments.clear();
 
         #[cfg(feature = "defi")]
         {

--- a/crates/common/src/msgbus/mod.rs
+++ b/crates/common/src/msgbus/mod.rs
@@ -60,6 +60,7 @@ use nautilus_model::{
         option_chain::{OptionChainSlice, OptionGreeks},
     },
     events::{AccountState, OrderEventAny, PortfolioSnapshot, PositionEvent},
+    instruments::InstrumentAny,
     orderbook::OrderBook,
 };
 use smallvec::SmallVec;
@@ -126,6 +127,8 @@ thread_local! {
     pub(super) static ORDER_EVENT_HANDLERS: RefCell<SmallVec<[TypedHandler<OrderEventAny>; HANDLER_BUFFER_CAP]>> =
         RefCell::new(SmallVec::new());
     pub(super) static POSITION_EVENT_HANDLERS: RefCell<SmallVec<[TypedHandler<PositionEvent>; HANDLER_BUFFER_CAP]>> =
+        RefCell::new(SmallVec::new());
+    pub(super) static INSTRUMENT_HANDLERS: RefCell<SmallVec<[TypedHandler<InstrumentAny>; HANDLER_BUFFER_CAP]>> =
         RefCell::new(SmallVec::new());
 
     #[cfg(feature = "defi")]

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -1234,7 +1234,7 @@ impl DataEngine {
 
         let topic = switchboard::get_instrument_topic(instrument.id());
         log::debug!("Publishing instrument to topic: {topic}");
-        msgbus::publish_any(topic, instrument);
+        msgbus::publish_instrument(topic, instrument);
 
         self.update_option_chains(instrument);
     }

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -5377,14 +5377,15 @@ fn test_process_instrument(
 
     data_engine.borrow_mut().execute(cmd);
 
-    let handler = msgbus::stubs::get_message_saving_handler::<InstrumentAny>(None);
+    let (handler, saving_handler) =
+        msgbus::stubs::get_typed_message_saving_handler::<InstrumentAny>(None);
     let topic = switchboard::get_instrument_topic(audusd_sim.id());
-    msgbus::subscribe_any(topic.into(), handler.clone(), None);
+    msgbus::subscribe_instruments(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
     data_engine.process(&audusd_sim as &dyn Any);
     let cache = &data_engine.get_cache();
-    let messages = msgbus::stubs::get_saved_messages::<InstrumentAny>(&handler);
+    let messages = saving_handler.get_messages();
 
     assert_eq!(
         cache.instrument(&audusd_sim.id()),


### PR DESCRIPTION
Migrate InstrumentAny from slow publish_any() (runtime Any dispatch) to typed publish_instrument() using TopicRouter<InstrumentAny>, matching the zero-cost static dispatch pattern used by all other data types.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Add typed `publish_instrument()` / `subscribe_instruments()` routing for `InstrumentAny` through the message bus
- `InstrumentAny` was the only high-traffic data type still using the slow `publish_any()` path (runtime `&dyn Any` dispatch with per-handler downcasting), while every other data type (quotes, trades, bars, deltas, depth10, mark prices, etc.) already had dedicated typed `publish_*()` functions using `TopicRouter<T>` for zero-cost static dispatch

### Changes

- **msgbus infrastructure**: Added `router_instruments: TopicRouter<InstrumentAny>` to `MessageBus`, `INSTRUMENT_HANDLERS` thread-local buffer, and `publish_instrument()` function
- **subscribe/unsubscribe**: Changed `subscribe_instruments()` and `unsubscribe_instruments()` from `ShareableMessageHandler`/`subscribe_any` to `TypedHandler<InstrumentAny>`/typed router
- **DataActorCore**: Added dedicated `instrument_handlers` map (previously shared `topic_handlers`), switched handler creation from `ShareableMessageHandler::from_typed` to `TypedHandler::from`
- **DataEngine**: Single-line change from `publish_any(topic, instrument)` to `publish_instrument(topic, instrument)`
- **Tests**: Updated all instrument publish/subscribe calls to use typed path

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic