### PR TITLE
Remove excessive Deribit funding rate logging

### DIFF
--- a/crates/adapters/deribit/src/data.rs
+++ b/crates/adapters/deribit/src/data.rs
@@ -262,13 +262,7 @@ impl DeribitDataClient {
                 log::debug!("WebSocket authenticated: expires_in={}s", auth.expires_in);
             }
             NautilusWsMessage::FundingRates(funding_rates) => {
-                log::info!(
-                    "Received {} funding rate update(s) from WebSocket",
-                    funding_rates.len()
-                );
-
                 for funding_rate in funding_rates {
-                    log::debug!("Sending funding rate: {funding_rate:?}");
                     if let Err(e) = sender.send(DataEvent::FundingRate(funding_rate)) {
                         log::error!("Failed to send funding rate: {e}");
                     }


### PR DESCRIPTION
Remove info/debug log statements that fired on every funding rate update. Deribit's perpetual channel updates every few seconds, causing excessive log output. Now matches other adapters which only log on send failures.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Remove `log::info!` and `log::debug!` statements that fired on every funding rate update in the Deribit data client
- Deribit's perpetual channel sends updates every few seconds, causing excessive log output
- Now matches the pattern used by all other adapters (Binance, OKX, Hyperliquid, dYdX, BitMEX) which only log `log::error!` on actual send failures

## Changes
- `crates/adapters/deribit/src/data.rs`: Removed 2 log statements (6 lines deleted, 0 added)


## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore