### PR TITLE
Fix Bybit funding rate errors for dated futures

### DIFF
--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -424,7 +424,9 @@ fn handle_ws_message(
                 }
             };
 
-            if sub_set.is_some_and(|s| s.contains("funding")) {
+            if sub_set.is_some_and(|s| s.contains("funding"))
+                && matches!(instrument, InstrumentAny::CryptoPerpetual(_))
+            {
                 let cache_entry = funding_cache
                     .entry(msg.data.symbol)
                     .or_insert((None, None, None));
@@ -937,6 +939,13 @@ impl DataClient for BybitDataClient {
 
         if product_type == BybitProductType::Spot || product_type == BybitProductType::Option {
             anyhow::bail!("Funding rates not available for {product_type:?} instruments");
+        }
+
+        let guard = self.instruments.load();
+        if let Some(instrument) = guard.get(&instrument_id)
+            && !matches!(instrument, InstrumentAny::CryptoPerpetual(_))
+        {
+            anyhow::bail!("Funding rates only available for perpetuals, not {instrument_id}");
         }
 
         let mut should_subscribe = false;

--- a/crates/adapters/bybit/src/websocket/parse.rs
+++ b/crates/adapters/bybit/src/websocket/parse.rs
@@ -454,10 +454,18 @@ pub fn parse_ticker_linear_funding(
         .as_ref()
         .context("Bybit ticker missing funding_rate")?;
 
+    if funding_rate_str.is_empty() {
+        anyhow::bail!(
+            "empty funding_rate for {instrument_id} (dated futures do not have funding rates)"
+        );
+    }
+
     let funding_rate = funding_rate_str
         .as_str()
         .parse::<Decimal>()
-        .context("invalid funding_rate value")?;
+        .with_context(|| {
+            format!("invalid funding_rate value '{funding_rate_str}' for {instrument_id}")
+        })?;
 
     let funding_interval = if let Some(funding_interval_hour) = &data.funding_interval_hour {
         let funding_interval_hour = funding_interval_hour


### PR DESCRIPTION
Bybit sends empty funding_rate strings for dated futures on the shared tickers.linear WebSocket topic. Gate funding rate processing to CryptoPerpetual instruments only and improve error context in parser.

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

### Problem

Production logs flooded with unhelpful errors:
```
[ERROR] nautilus_bybit::data: Failed to parse ticker linear funding: invalid funding_rate value
[ERROR] nautilus_bybit::data: Failed to parse ticker linear funding: invalid funding_rate value
```

No instrument ID, no actual value — impossible to diagnose.

**Root cause**: Bybit's `tickers.linear` WebSocket topic uses a single payload shape for **all** linear instruments — both perpetuals and dated futures. When any code subscribes to that topic (for quotes, mark prices, etc.), messages arrive with `fundingRate: ""` for dated futures like `XRPUSDT-05JUN26-LINEAR`. The parser tried to parse the empty string as a `Decimal` and failed.

Funding rates only exist on perpetuals — they tether the contract to spot because it never expires. Dated futures converge naturally at expiry and don't have funding. Other exchanges handle this cleanly (Binance separates endpoints, OKX uses distinct `instType`, Deribit omits the fields entirely). Bybit is the odd one out: same payload, empty strings for fields that don't apply.

### Fix

Three layers of defense:

1. **API boundary** (`subscribe_funding_rates`): Rejects non-`CryptoPerpetual` instruments with a hard error — surfaces caller bugs immediately
2. **Message handler** (`handle_ws_message`): `matches!(instrument, InstrumentAny::CryptoPerpetual(_))` guard skips funding extraction for non-perpetuals on the shared topic — this silences the log spam
3. **Parser defense** (`parse_ticker_linear_funding`): Empty `funding_rate` strings bail with a descriptive message; `Decimal` parse errors now include the instrument ID and actual value

## Changes
- `crates/adapters/bybit/src/data.rs`: Gate funding processing to `CryptoPerpetual` in handler + reject non-perpetuals in `subscribe_funding_rates`
- `crates/adapters/bybit/src/websocket/parse.rs`: Handle empty funding rate strings, improve error context with instrument ID and actual value


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
