### PR TITLE
Fix dYdX rate limiter being skipped due to missing keys

### DIFF
--- a/crates/adapters/dydx/src/http/client.rs
+++ b/crates/adapters/dydx/src/http/client.rs
@@ -86,6 +86,7 @@ use nautilus_network::{
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio_util::sync::CancellationToken;
+use ustr::Ustr;
 
 use super::error::DydxHttpError;
 use crate::{
@@ -128,12 +129,18 @@ fn bar_type_to_resolution(bar_type: &BarType) -> anyhow::Result<DydxCandleResolu
 
 /// Default dYdX Indexer REST API rate limit.
 ///
-/// The dYdX Indexer API rate limits are generous for read-only operations:
-/// - General: 100 requests per 10 seconds per IP
-/// - We use a conservative 10 requests per second as the default quota.
+/// The dYdX Indexer API rate limit is 100 requests per 10 seconds per IP.
+/// We use 9 req/s (vs the exact 10) to avoid edge-case 429s from
+/// GCRA vs server sliding-window misalignment at the boundary.
 pub static DYDX_REST_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
-    Quota::per_second(NonZeroU32::new(10).expect("non-zero")).expect("valid constant")
+    Quota::per_second(NonZeroU32::new(9).expect("non-zero")).expect("valid constant")
 });
+
+static DYDX_RATE_LIMIT_KEY: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("dydx:rest"));
+
+fn rate_limit_keys() -> Vec<Ustr> {
+    vec![*DYDX_RATE_LIMIT_KEY]
+}
 
 /// Represents a dYdX HTTP response wrapper.
 ///
@@ -279,11 +286,11 @@ impl DydxRawHttpClient {
                 .request_with_ustr_keys(
                     method.clone(),
                     url.clone(),
-                    None, // No params
-                    None, // No additional headers
-                    None, // No body for GET requests
-                    None, // Use default timeout
-                    None, // No specific rate limit keys (using global quota)
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(rate_limit_keys()),
                 )
                 .await
                 .map_err(|e| DydxHttpError::HttpClientError(e.to_string()))?;
@@ -371,11 +378,11 @@ impl DydxRawHttpClient {
                 .request_with_ustr_keys(
                     Method::POST,
                     url.clone(),
-                    None, // No params
-                    None, // No additional headers (content-type handled by body)
+                    None,
+                    None,
                     Some(body_bytes.clone()),
-                    None, // Use default timeout
-                    None, // No specific rate limit keys (using global quota)
+                    None,
+                    Some(rate_limit_keys()),
                 )
                 .await
                 .map_err(|e| DydxHttpError::HttpClientError(e.to_string()))?;


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

### Problem

When requesting orderbook snapshots for many instruments (~100), the dYdX data client was hitting **HTTP 429 (rate limited)** errors from the dYdX Indexer API within seconds, despite a `DYDX_REST_QUOTA` of 10 req/s being configured.

### Root cause

The `DYDX_REST_QUOTA` was passed as a `default_quota` when constructing the `HttpClient`, which stores it as a `default_gcra` inside the `RateLimiter`. However, both `send_request` (GET) and `send_post_request` (POST) in `DydxRawHttpClient` passed `keys: None` to `request_with_ustr_keys`.

In `nautilus_network`'s `RateLimiter::await_keys_ready()`, when `keys` is `None`, the function returns immediately without ever calling `check_key`. The `default_gcra` only kicks in as a fallback when `check_key` is called with an actual key that has no per-key override. **Passing `None` skips the rate limiter entirely** — all concurrent requests fire with zero throttling.

This was confirmed by comparing behavior before and after the fix:
- **Without fix**: 100 requests dispatched at `t=0`, first 429 at `t+1.6s` (no throttling)
- **With fix**: requests properly throttled, first response at `t+13s` (rate-limited)

### Fix

1. Added a shared `DYDX_RATE_LIMIT_KEY` (`"dydx:rest"`) so all REST requests share a single GCRA bucket
2. Changed both `send_request` and `send_post_request` to pass `Some(rate_limit_keys())` instead of `None`
3. Lowered the quota from 10 to **9 req/s** to avoid boundary 429s

### Why 9 req/s instead of 10

The dYdX Indexer API enforces **100 requests per 10 seconds per IP** using a server-side sliding window. The client-side GCRA (Generic Cell Rate Algorithm) tracks a Theoretical Arrival Time (TAT) and guarantees a long-term average rate.

But the server enforces a **hard count within a sliding window**. Network latency means requests arrive at the server slightly shifted from when the GCRA approved them. The initial burst of 10 at `t=0` is valid by GCRA math, but if the server's 10-second window boundary doesn't perfectly align with the client's, those burst requests can overlap with the tail of a previous window, pushing the count above 100.

At 9 req/s the GCRA approves at most 90 requests per 10s, leaving a 10% margin that absorbs the timing mismatch between client-side GCRA and server-side sliding window. This was observerd in production, where we would hit 429 from time to time.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore