### PR TITLE
 Improve Binance Spot SBE missing credentials error message

### DIFF
--- a/crates/adapters/binance/src/spot/data.rs
+++ b/crates/adapters/binance/src/spot/data.rs
@@ -118,6 +118,14 @@ impl BinanceSpotDataClient {
             config.environment,
             product_type,
         )
+        .map_err(|e| {
+            log::warn!(
+                "Binance API credentials not found ({e}). \
+                 SBE WebSocket streams require an Ed25519 API key \
+                 (set BINANCE_API_KEY and BINANCE_API_SECRET env vars)"
+            );
+            e
+        })
         .ok();
 
         // SBE streams require Ed25519 authentication
@@ -341,6 +349,14 @@ impl DataClient for BinanceSpotDataClient {
         }
 
         self.ws_client.cache_instruments(&instruments);
+
+        if !self.ws_client.has_credential() {
+            anyhow::bail!(
+                "Binance SBE WebSocket requires Ed25519 API credentials. \
+                 Set BINANCE_API_KEY and BINANCE_API_SECRET environment variables, \
+                 or provide api_key/api_secret in the data client config"
+            );
+        }
 
         log::info!("Connecting to Binance SBE WebSocket...");
         self.ws_client.connect().await.map_err(|e| {

--- a/crates/adapters/binance/src/spot/data.rs
+++ b/crates/adapters/binance/src/spot/data.rs
@@ -118,13 +118,13 @@ impl BinanceSpotDataClient {
             config.environment,
             product_type,
         )
-        .map_err(|e| {
+        .inspect_err(|e| {
             log::warn!(
-                "Binance API credentials not found ({e}). \
-                 SBE WebSocket streams require an Ed25519 API key \
-                 (set BINANCE_API_KEY and BINANCE_API_SECRET env vars)"
+                "Failed to resolve Binance API credentials ({e}). \
+                 SBE WebSocket streams require an Ed25519 API key. \
+                 Set the appropriate env vars for your environment, \
+                 or provide api_key/api_secret in the data client config"
             );
-            e
         })
         .ok();
 
@@ -301,6 +301,14 @@ impl DataClient for BinanceSpotDataClient {
             return Ok(());
         }
 
+        if !self.ws_client.has_credentials() {
+            anyhow::bail!(
+                "Binance SBE WebSocket requires Ed25519 API credentials. \
+                 Set the appropriate env vars for your environment, \
+                 or provide api_key/api_secret in the data client config"
+            );
+        }
+
         // Reinitialize token in case of reconnection after disconnect
         self.cancellation_token = CancellationToken::new();
 
@@ -349,14 +357,6 @@ impl DataClient for BinanceSpotDataClient {
         }
 
         self.ws_client.cache_instruments(&instruments);
-
-        if !self.ws_client.has_credential() {
-            anyhow::bail!(
-                "Binance SBE WebSocket requires Ed25519 API credentials. \
-                 Set BINANCE_API_KEY and BINANCE_API_SECRET environment variables, \
-                 or provide api_key/api_secret in the data client config"
-            );
-        }
 
         log::info!("Connecting to Binance SBE WebSocket...");
         self.ws_client.connect().await.map_err(|e| {

--- a/crates/adapters/binance/src/spot/websocket/streams/client.rs
+++ b/crates/adapters/binance/src/spot/websocket/streams/client.rs
@@ -142,7 +142,7 @@ impl BinanceSpotWebSocketClient {
 
     /// Returns whether API credentials are configured.
     #[must_use]
-    pub fn has_credential(&self) -> bool {
+    pub fn has_credentials(&self) -> bool {
         self.credential.is_some()
     }
 

--- a/crates/adapters/binance/src/spot/websocket/streams/client.rs
+++ b/crates/adapters/binance/src/spot/websocket/streams/client.rs
@@ -140,6 +140,12 @@ impl BinanceSpotWebSocketClient {
         })
     }
 
+    /// Returns whether API credentials are configured.
+    #[must_use]
+    pub fn has_credential(&self) -> bool {
+        self.credential.is_some()
+    }
+
     /// Returns whether any connection in the pool is active.
     #[must_use]
     #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]

--- a/crates/adapters/binance/tests/spot/data_client.rs
+++ b/crates/adapters/binance/tests/spot/data_client.rs
@@ -416,6 +416,10 @@ fn create_test_data_client(
     let config = BinanceDataClientConfig {
         base_url_http: Some(base_url_http),
         base_url_ws: Some(base_url_ws),
+        api_key: Some("test-api-key".to_string()),
+        api_secret: Some(
+            "MC4CAQAwBQYDK2VwBCIEIJ1hsZ3v/VpguoRK9JLsLMREScVpezJpGXA7rAMcrn9g".to_string(),
+        ),
         ..Default::default()
     };
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Add early credential check in `BinanceSpotDataClient::connect()` that fails fast with an actionable error message when Ed25519 API keys are not configured, instead of attempting the SBE WebSocket handshake and getting a cryptic `400 Bad Request / No X-MBX-APIKEY header` followed by a 120s connection timeout
- Add `has_credential()` method to `BinanceSpotWebSocketClient` and a warning log during client construction when credentials are missing

## Before

```
[ERROR] Sockudo handshake failed for stream-sbe.binance.com/ws: expected 101 Switching Protocols
  HTTP/1.1 400 Bad Request — No X-MBX-APIKEY header
[ERROR] WebSocket connection failed: handshake failed: expected 101 Switching Protocols
[ERROR] Failed to connect data client: Network error: handshake failed: expected 101 Switching Protocols
[WARN]  Timed out (120s) waiting for engines to connect
        BINANCE │ Data │ false
```

## After

```
[WARN]  Binance API credentials not found. SBE WebSocket streams require an Ed25519 API key
        (set BINANCE_API_KEY and BINANCE_API_SECRET env vars)
[ERROR] Failed to connect data client: Binance SBE WebSocket requires Ed25519 API credentials.
        Set BINANCE_API_KEY and BINANCE_API_SECRET environment variables,
        or provide api_key/api_secret in the data client config
```

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
