### PR TITLE
Add Kraken WebSocket rate limiting

### DIFF
--- a/crates/adapters/kraken/src/common/consts.rs
+++ b/crates/adapters/kraken/src/common/consts.rs
@@ -78,9 +78,26 @@ pub static KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA: LazyLock<Quota> = LazyLock::new(||
         .allow_burst(NonZeroU32::new(10).expect("non-zero"))
 });
 
+/// Kraken Spot WebSocket order rate limit (conservative).
+///
+/// Shares the same dynamic connection-level message budget as subscriptions.
+/// The matching engine enforces additional per-pair rate limits with decay
+/// (thresholds: 60 Starter / 125 Intermediate / 180 Pro).
+///
+/// <https://docs.kraken.com/api/docs/guides/spot-ratelimits>
+pub static KRAKEN_SPOT_WS_ORDER_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(10).expect("non-zero"))
+        .expect("valid constant")
+        .allow_burst(NonZeroU32::new(10).expect("non-zero"))
+});
+
 /// Pre-interned rate limit key for WebSocket subscription operations.
 pub static KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION: LazyLock<[Ustr; 1]> =
     LazyLock::new(|| [Ustr::from("subscription")]);
+
+/// Pre-interned rate limit key for WebSocket order operations.
+pub static KRAKEN_RATE_LIMIT_KEY_ORDER: LazyLock<[Ustr; 1]> =
+    LazyLock::new(|| [Ustr::from("order")]);
 
 // Post-only rejection reason strings
 pub const KRAKEN_FUTURES_POST_ONLY_REJECT: &str = "post_order_failed_because_it_would_filled";

--- a/crates/adapters/kraken/src/common/consts.rs
+++ b/crates/adapters/kraken/src/common/consts.rs
@@ -15,9 +15,10 @@
 
 //! Core constants shared across the Kraken adapter components.
 
-use std::sync::LazyLock;
+use std::{num::NonZeroU32, sync::LazyLock};
 
 use nautilus_model::identifiers::{ClientId, Venue};
+use nautilus_network::ratelimiter::quota::Quota;
 use ustr::Ustr;
 
 /// Venue identifier string.
@@ -54,6 +55,32 @@ pub const KRAKEN_FUTURES_DEMO_WS_URL: &str = "wss://demo-futures.kraken.com/ws/v
 // Spot order flags (oflags parameter values)
 pub const KRAKEN_OFLAG_POST_ONLY: &str = "post";
 pub const KRAKEN_OFLAG_QUOTE_QUANTITY: &str = "viqc";
+
+/// Kraken Futures WebSocket request rate limit: 100 requests per 1 second.
+///
+/// Set to 90/sec (10% margin below the documented 100/sec hard cap).
+///
+/// <https://docs.kraken.com/api/docs/guides/futures-rate-limits/#websocket-limits>
+pub static KRAKEN_FUTURES_WS_SUBSCRIPTION_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(90).expect("non-zero")).expect("valid constant")
+});
+
+/// Kraken Spot WebSocket request rate limit (conservative).
+///
+/// The Spot WS message rate limit is dynamic and varies depending on system load.
+/// No fixed number is documented — the server returns `{"Error": "Exceeded msg rate"}`
+/// when exceeded. This conservative quota should avoid hitting the limit under normal use.
+///
+/// <https://docs.kraken.com/api/docs/guides/spot-ratelimits>
+pub static KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
+    Quota::per_second(NonZeroU32::new(20).expect("non-zero"))
+        .expect("valid constant")
+        .allow_burst(NonZeroU32::new(10).expect("non-zero"))
+});
+
+/// Pre-interned rate limit key for WebSocket subscription operations.
+pub static KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION: LazyLock<[Ustr; 1]> =
+    LazyLock::new(|| [Ustr::from("subscription")]);
 
 // Post-only rejection reason strings
 pub const KRAKEN_FUTURES_POST_ONLY_REJECT: &str = "post_order_failed_because_it_would_filled";

--- a/crates/adapters/kraken/src/websocket/futures/client.rs
+++ b/crates/adapters/kraken/src/websocket/futures/client.rs
@@ -49,7 +49,11 @@ use super::{
     },
 };
 use crate::{
-    common::{credential::KrakenCredential, parse::truncate_cl_ord_id},
+    common::{
+        consts::{KRAKEN_FUTURES_WS_SUBSCRIPTION_QUOTA, KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION},
+        credential::KrakenCredential,
+        parse::truncate_cl_ord_id,
+    },
     websocket::error::KrakenWsError,
 };
 
@@ -286,10 +290,21 @@ impl KrakenFuturesWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
-        let ws_client =
-            WebSocketClient::connect(ws_config, Some(raw_handler), None, None, vec![], None)
-                .await
-                .map_err(|e| KrakenWsError::ConnectionError(e.to_string()))?;
+        let keyed_quotas = vec![(
+            KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION[0].to_string(),
+            *KRAKEN_FUTURES_WS_SUBSCRIPTION_QUOTA,
+        )];
+
+        let ws_client = WebSocketClient::connect(
+            ws_config,
+            Some(raw_handler),
+            None,
+            None,
+            keyed_quotas,
+            None,
+        )
+        .await
+        .map_err(|e| KrakenWsError::ConnectionError(e.to_string()))?;
 
         self.connection_mode
             .store(ws_client.connection_mode_atomic());

--- a/crates/adapters/kraken/src/websocket/futures/client.rs
+++ b/crates/adapters/kraken/src/websocket/futures/client.rs
@@ -295,16 +295,10 @@ impl KrakenFuturesWebSocketClient {
             *KRAKEN_FUTURES_WS_SUBSCRIPTION_QUOTA,
         )];
 
-        let ws_client = WebSocketClient::connect(
-            ws_config,
-            Some(raw_handler),
-            None,
-            None,
-            keyed_quotas,
-            None,
-        )
-        .await
-        .map_err(|e| KrakenWsError::ConnectionError(e.to_string()))?;
+        let ws_client =
+            WebSocketClient::connect(ws_config, Some(raw_handler), None, None, keyed_quotas, None)
+                .await
+                .map_err(|e| KrakenWsError::ConnectionError(e.to_string()))?;
 
         self.connection_mode
             .store(ws_client.connection_mode_atomic());

--- a/crates/adapters/kraken/src/websocket/futures/handler.rs
+++ b/crates/adapters/kraken/src/websocket/futures/handler.rs
@@ -38,6 +38,7 @@ use super::messages::{
     KrakenFuturesOpenOrdersDelta, KrakenFuturesTickerData, KrakenFuturesTradeData,
     KrakenFuturesWsMessage, classify_futures_message,
 };
+use crate::common::consts::KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION;
 
 /// Commands sent from the outer client to the inner message handler.
 #[derive(Debug)]
@@ -109,8 +110,14 @@ impl FuturesFeedHandler {
                             return None;
                         }
                         FuturesHandlerCommand::Subscribe { payload }
-                        | FuturesHandlerCommand::Unsubscribe { payload }
-                        | FuturesHandlerCommand::RequestChallenge { payload } => {
+                        | FuturesHandlerCommand::Unsubscribe { payload } => {
+                            if let Some(ref client) = self.inner
+                                && let Err(e) = client.send_text(payload, Some(KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION.as_slice())).await
+                            {
+                                log::error!("Failed to send text: {e}");
+                            }
+                        }
+                        FuturesHandlerCommand::RequestChallenge { payload } => {
                             if let Some(ref client) = self.inner
                                 && let Err(e) = client.send_text(payload, None).await
                             {

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -53,7 +53,10 @@ use super::{
     messages::{KrakenSpotWsMessage, KrakenWsChannelParams, KrakenWsParams, KrakenWsRequest},
 };
 use crate::{
-    common::parse::normalize_spot_symbol,
+    common::{
+        consts::{KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION, KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA},
+        parse::normalize_spot_symbol,
+    },
     config::KrakenDataClientConfig,
     http::{KrakenSpotHttpClient, spot::client::KRAKEN_SPOT_DEFAULT_RATE_LIMIT_PER_SECOND},
     websocket::error::KrakenWsError,
@@ -254,13 +257,18 @@ impl KrakenSpotWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
+        let keyed_quotas = vec![(
+            KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION[0].to_string(),
+            *KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA,
+        )];
+
         let ws_client = WebSocketClient::connect(
             ws_config,
             Some(raw_handler),
-            None,   // ping_handler
-            None,   // post_reconnection
-            vec![], // keyed_quotas
-            None,   // default_quota
+            None, // ping_handler
+            None, // post_reconnection
+            keyed_quotas,
+            None,
         )
         .await
         .map_err(|e| KrakenWsError::ConnectionError(e.to_string()))?;

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -54,7 +54,10 @@ use super::{
 };
 use crate::{
     common::{
-        consts::{KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION, KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA},
+        consts::{
+            KRAKEN_RATE_LIMIT_KEY_ORDER, KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION,
+            KRAKEN_SPOT_WS_ORDER_QUOTA, KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA,
+        },
         parse::normalize_spot_symbol,
     },
     config::KrakenDataClientConfig,
@@ -257,10 +260,16 @@ impl KrakenSpotWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
-        let keyed_quotas = vec![(
-            KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION[0].to_string(),
-            *KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA,
-        )];
+        let keyed_quotas = vec![
+            (
+                KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION[0].to_string(),
+                *KRAKEN_SPOT_WS_SUBSCRIPTION_QUOTA,
+            ),
+            (
+                KRAKEN_RATE_LIMIT_KEY_ORDER[0].to_string(),
+                *KRAKEN_SPOT_WS_ORDER_QUOTA,
+            ),
+        ];
 
         let ws_client = WebSocketClient::connect(
             ws_config,

--- a/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
@@ -39,7 +39,10 @@ use super::{
     },
     parse::parse_order_response,
 };
-use crate::websocket::spot_v2::level_3::messages::{KrakenL3Snapshot, KrakenL3UpdateData};
+use crate::{
+    common::consts::KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION,
+    websocket::spot_v2::level_3::messages::{KrakenL3Snapshot, KrakenL3UpdateData},
+};
 
 /// Commands sent from the outer client to the inner message handler.
 #[derive(Debug)]
@@ -110,10 +113,16 @@ impl SpotFeedHandler {
                             }
                         }
                         SpotHandlerCommand::Subscribe { payload }
-                        | SpotHandlerCommand::Unsubscribe { payload }
-                        | SpotHandlerCommand::Ping { payload } => {
+                        | SpotHandlerCommand::Unsubscribe { payload } => {
                             if let Some(client) = &self.inner
-                                && let Err(e) = client.send_text(payload.clone(), None).await
+                                && let Err(e) = client.send_text(payload, Some(KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION.as_slice())).await
+                            {
+                                log::error!("Failed to send text: {e}");
+                            }
+                        }
+                        SpotHandlerCommand::Ping { payload } => {
+                            if let Some(client) = &self.inner
+                                && let Err(e) = client.send_text(payload, None).await
                             {
                                 log::error!("Failed to send text: {e}");
                             }

--- a/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/handler.rs
@@ -40,7 +40,7 @@ use super::{
     parse::parse_order_response,
 };
 use crate::{
-    common::consts::KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION,
+    common::consts::{KRAKEN_RATE_LIMIT_KEY_ORDER, KRAKEN_RATE_LIMIT_KEY_SUBSCRIPTION},
     websocket::spot_v2::level_3::messages::{KrakenL3Snapshot, KrakenL3UpdateData},
 };
 
@@ -129,7 +129,7 @@ impl SpotFeedHandler {
                         }
                         SpotHandlerCommand::SendOrderRequest { req_id, payload } => {
                             if let Some(client) = &self.inner {
-                                if let Err(e) = client.send_text(payload, None).await {
+                                if let Err(e) = client.send_text(payload, Some(KRAKEN_RATE_LIMIT_KEY_ORDER.as_slice())).await {
                                     log::error!(
                                         "Kraken WS send_order_request failed req_id={req_id}: {e}"
                                     );


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

In production, bulk unsubscribes from 100+ Futures instruments triggered repeated `rate_limited` and `Not subscribed to feed` WebSocket alerts: 
```
[WARN] nautilus_kraken::websocket::futures::handler: Kraken Futures WebSocket alert: Not subscribed to feed
[WARN] nautilus_kraken::websocket::futures::handler: Kraken Futures WebSocket alert: rate_limited
```
All 100+ unsubscribe messages were dispatched within <10ms (~10,000 msg/sec effective rate), far exceeding the Futures documented 100 req/sec WebSocket limit. Once rate-limited, subsequent unsubscribes were silently dropped by Kraken, causing the "Not subscribed to feed" warnings as confirmations arrived for already-rejected requests.
- Root cause: both Kraken Futures and Spot WebSocket clients called `WebSocketClient::connect()` with empty `keyed_quotas` and `None` default quota — completely bypassing the transport-level rate limiter that every other adapter (Binance, Deribit, OKX, Coinbase, dYdX) already uses
- **Futures subscription quota**: 90 req/sec (10% margin below [documented 100/sec cap](https://docs.kraken.com/api/docs/guides/futures-rate-limits/#websocket-limits)); Futures orders use the REST API which is already rate-limited at the HTTP layer (5 req/sec global quota)
- **Spot subscription quota**: 20 req/sec with burst of 10 (conservative — Spot limit is [dynamic and undocumented](https://docs.kraken.com/api/docs/guides/spot-ratelimits), server returns `{"Error": "Exceeded msg rate"}` when exceeded)
- **Spot order quota**: 10 req/sec with burst of 10, separate `"order"` keyed rate limiter matching the pattern used by Binance, Deribit, and OKX adapters. The [matching engine](https://docs.kraken.com/api/docs/guides/spot-ratelimits) enforces additional per-pair rate limits server-side
- Subscribe/Unsubscribe messages use the `"subscription"` keyed rate limiter; Ping and RequestChallenge are excluded
- `SendOrderRequest` (Spot) uses the `"order"` keyed rate limiter

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore