### PR TITLE
Add Binance futures liquidation custom data subscriptions

### DIFF
--- a/crates/adapters/binance/src/data_types.rs
+++ b/crates/adapters/binance/src/data_types.rs
@@ -1,0 +1,157 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Binance-specific custom data types.
+//!
+//! These types carry Binance domain data through the Nautilus data engine as
+//! [`CustomData`](nautilus_model::data::CustomData).
+
+use std::sync::Arc;
+
+use nautilus_core::UnixNanos;
+use nautilus_model::{
+    data::{HasTsInit, custom::CustomDataTrait},
+    enums::OrderSide,
+    identifiers::InstrumentId,
+    types::{Price, Quantity},
+};
+use serde::{Deserialize, Serialize};
+
+/// Binance Futures liquidation update from the `forceOrder` stream.
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.binance", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.binance")
+)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BinanceFuturesLiquidation {
+    /// The instrument for this liquidation event.
+    pub instrument_id: InstrumentId,
+    /// The liquidation order side.
+    pub side: OrderSide,
+    /// The order price.
+    pub price: Price,
+    /// The average fill price.
+    pub average_price: Price,
+    /// The last filled quantity.
+    pub last_filled_qty: Quantity,
+    /// The cumulative filled quantity.
+    pub accumulated_qty: Quantity,
+    /// UNIX timestamp (nanoseconds) when the data event occurred.
+    pub ts_event: UnixNanos,
+    /// UNIX timestamp (nanoseconds) when the instance was initialized.
+    pub ts_init: UnixNanos,
+}
+
+impl BinanceFuturesLiquidation {
+    /// Creates a new [`BinanceFuturesLiquidation`] instance.
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        instrument_id: InstrumentId,
+        side: OrderSide,
+        price: Price,
+        average_price: Price,
+        last_filled_qty: Quantity,
+        accumulated_qty: Quantity,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self {
+            instrument_id,
+            side,
+            price,
+            average_price,
+            last_filled_qty,
+            accumulated_qty,
+            ts_event,
+            ts_init,
+        }
+    }
+}
+
+impl HasTsInit for BinanceFuturesLiquidation {
+    fn ts_init(&self) -> UnixNanos {
+        self.ts_init
+    }
+}
+
+impl CustomDataTrait for BinanceFuturesLiquidation {
+    fn type_name(&self) -> &'static str {
+        "BinanceFuturesLiquidation"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn ts_event(&self) -> UnixNanos {
+        self.ts_event
+    }
+
+    fn to_json(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn CustomDataTrait> {
+        Arc::new(self.clone())
+    }
+
+    fn eq_arc(&self, other: &dyn CustomDataTrait) -> bool {
+        if let Some(o) = other.as_any().downcast_ref::<Self>() {
+            self == o
+        } else {
+            false
+        }
+    }
+
+    #[cfg(feature = "python")]
+    fn to_pyobject(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
+        nautilus_model::data::custom::clone_pyclass_to_pyobject(self, py)
+    }
+
+    fn type_name_static() -> &'static str {
+        "BinanceFuturesLiquidation"
+    }
+
+    fn from_json(value: serde_json::Value) -> anyhow::Result<Arc<dyn CustomDataTrait>> {
+        let json_str = serde_json::to_string(&value)?;
+        let parsed: Self = serde_json::from_str(&json_str)?;
+        Ok(Arc::new(parsed))
+    }
+}
+
+/// Registers Binance custom data types.
+///
+/// Safe to call multiple times (idempotent via internal `Once` guards).
+pub fn register_binance_custom_data() {
+    let _ = nautilus_model::data::ensure_custom_data_json_registered::<BinanceFuturesLiquidation>();
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_register_binance_custom_data_is_idempotent() {
+        register_binance_custom_data();
+        register_binance_custom_data();
+    }
+}

--- a/crates/adapters/binance/src/futures/data.rs
+++ b/crates/adapters/binance/src/futures/data.rs
@@ -289,6 +289,18 @@ impl BinanceFuturesDataClient {
         )
     }
 
+    fn liquidation_stream(instrument_id: &InstrumentId) -> String {
+        format!("{}@forceOrder", format_binance_stream_symbol(instrument_id))
+    }
+
+    fn tracked_liquidation_streams(&self) -> Vec<String> {
+        self.force_order_refs
+            .load()
+            .keys()
+            .map(Self::liquidation_stream)
+            .collect()
+    }
+
     #[expect(clippy::too_many_arguments)]
     fn handle_ws_message(
         msg: BinanceFuturesWsStreamsMessage,
@@ -433,22 +445,20 @@ impl BinanceFuturesDataClient {
                                 ts_init,
                             ));
 
-                            let has_specific_subscription =
-                                force_order_refs.load().contains_key(&instrument.id());
                             let has_all_market_subscription =
                                 force_order_all_market_refs.load(Ordering::Relaxed) > 0;
-
-                            if has_specific_subscription {
-                                let data_type = Self::liquidation_data_type(instrument.id());
-                                Self::send_data(
-                                    data_sender,
-                                    Data::Custom(CustomData::new(liquidation.clone(), data_type)),
-                                );
-                            }
+                            let has_specific_subscription =
+                                force_order_refs.load().contains_key(&instrument.id());
 
                             if has_all_market_subscription {
                                 let data_type =
                                     DataType::new("BinanceFuturesLiquidation", None, None);
+                                Self::send_data(
+                                    data_sender,
+                                    Data::Custom(CustomData::new(liquidation, data_type)),
+                                );
+                            } else if has_specific_subscription {
+                                let data_type = Self::liquidation_data_type(instrument.id());
                                 Self::send_data(
                                     data_sender,
                                     Data::Custom(CustomData::new(liquidation, data_type)),
@@ -1313,12 +1323,12 @@ impl DataClient for BinanceFuturesDataClient {
                 prev == 0
             };
 
-            if should_subscribe {
+            let has_all_market_subscription =
+                self.force_order_all_market_refs.load(Ordering::Relaxed) > 0;
+
+            if should_subscribe && !has_all_market_subscription {
                 let ws = self.ws_client.clone();
-                let stream = format!(
-                    "{}@forceOrder",
-                    format_binance_stream_symbol(&instrument_id)
-                );
+                let stream = Self::liquidation_stream(&instrument_id);
                 self.spawn_ws(
                     async move {
                         ws.subscribe(vec![stream])
@@ -1339,8 +1349,14 @@ impl DataClient for BinanceFuturesDataClient {
 
         if should_subscribe {
             let ws = self.ws_client.clone();
+            let specific_streams = self.tracked_liquidation_streams();
             self.spawn_ws(
                 async move {
+                    if !specific_streams.is_empty() {
+                        ws.unsubscribe(specific_streams)
+                            .await
+                            .context("specific forceOrder unsubscribe while enabling all-market")?;
+                    }
                     ws.subscribe(vec!["!forceOrder@arr".to_string()])
                         .await
                         .context("all-market forceOrder subscription")
@@ -1717,12 +1733,12 @@ impl DataClient for BinanceFuturesDataClient {
                 }
             };
 
-            if should_unsubscribe {
+            let has_all_market_subscription =
+                self.force_order_all_market_refs.load(Ordering::Relaxed) > 0;
+
+            if should_unsubscribe && !has_all_market_subscription {
                 let ws = self.ws_client.clone();
-                let stream = format!(
-                    "{}@forceOrder",
-                    format_binance_stream_symbol(&instrument_id)
-                );
+                let stream = Self::liquidation_stream(&instrument_id);
                 self.spawn_ws(
                     async move {
                         ws.unsubscribe(vec![stream])
@@ -1748,11 +1764,19 @@ impl DataClient for BinanceFuturesDataClient {
             .is_ok_and(|prev| prev == 1);
         if should_unsubscribe {
             let ws = self.ws_client.clone();
+            let specific_streams = self.tracked_liquidation_streams();
             self.spawn_ws(
                 async move {
                     ws.unsubscribe(vec!["!forceOrder@arr".to_string()])
                         .await
-                        .context("all-market forceOrder unsubscribe")
+                        .context("all-market forceOrder unsubscribe")?;
+
+                    if !specific_streams.is_empty() {
+                        ws.subscribe(specific_streams).await.context(
+                            "specific forceOrder resubscribe after all-market unsubscribe",
+                        )?;
+                    }
+                    Ok(())
                 },
                 "all-market forceOrder unsubscribe",
             );

--- a/crates/adapters/binance/src/futures/data.rs
+++ b/crates/adapters/binance/src/futures/data.rs
@@ -15,9 +15,10 @@
 
 //! Live market data client implementation for the Binance Futures adapter.
 
+use std::str::FromStr;
 use std::sync::{
     Arc, RwLock,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
 use ahash::AHashMap;
@@ -31,22 +32,25 @@ use nautilus_common::{
         data::{
             BarsResponse, DataResponse, InstrumentResponse, InstrumentsResponse, RequestBars,
             RequestInstrument, RequestInstruments, RequestTrades, SubscribeBars,
-            SubscribeBookDeltas, SubscribeFundingRates, SubscribeIndexPrices, SubscribeInstrument,
-            SubscribeInstruments, SubscribeMarkPrices, SubscribeQuotes, SubscribeTrades,
-            TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeFundingRates,
-            UnsubscribeIndexPrices, UnsubscribeMarkPrices, UnsubscribeQuotes, UnsubscribeTrades,
+            SubscribeBookDeltas, SubscribeCustomData, SubscribeFundingRates, SubscribeIndexPrices,
+            SubscribeInstrument, SubscribeInstruments, SubscribeMarkPrices, SubscribeQuotes,
+            SubscribeTrades, TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas,
+            UnsubscribeCustomData, UnsubscribeFundingRates, UnsubscribeIndexPrices,
+            UnsubscribeMarkPrices, UnsubscribeQuotes, UnsubscribeTrades,
             subscribe::SubscribeInstrumentStatus, unsubscribe::UnsubscribeInstrumentStatus,
         },
     },
 };
 use nautilus_core::{
-    AtomicMap, MUTEX_POISONED,
+    AtomicMap, MUTEX_POISONED, Params,
     datetime::{NANOSECONDS_IN_MILLISECOND, datetime_to_unix_nanos},
     nanos::UnixNanos,
     time::{AtomicTime, get_atomic_clock_realtime},
 };
 use nautilus_model::{
-    data::{BookOrder, Data, OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API},
+    data::{
+        BookOrder, CustomData, Data, DataType, OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API,
+    },
     enums::{BookAction, BookType, MarketStatusAction, OrderSide, RecordFlag},
     identifiers::{ClientId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
@@ -66,6 +70,7 @@ use crate::{
         urls::{get_usdm_ws_route_base_url, get_ws_public_base_url},
     },
     config::BinanceDataClientConfig,
+    data_types::{BinanceFuturesLiquidation, register_binance_custom_data},
     futures::{
         http::{
             client::BinanceFuturesHttpClient, models::BinanceOrderBook, query::BinanceDepthParams,
@@ -123,6 +128,8 @@ pub struct BinanceFuturesDataClient {
     book_buffers: Arc<AtomicMap<InstrumentId, BookBuffer>>,
     book_subscriptions: Arc<AtomicMap<InstrumentId, u32>>,
     mark_price_refs: Arc<AtomicMap<InstrumentId, u32>>,
+    force_order_refs: Arc<AtomicMap<InstrumentId, u32>>,
+    force_order_all_market_refs: Arc<AtomicU32>,
     book_epoch: Arc<RwLock<u64>>,
 }
 
@@ -222,6 +229,8 @@ impl BinanceFuturesDataClient {
             book_buffers: Arc::new(AtomicMap::new()),
             book_subscriptions: Arc::new(AtomicMap::new()),
             mark_price_refs: Arc::new(AtomicMap::new()),
+            force_order_refs: Arc::new(AtomicMap::new()),
+            force_order_all_market_refs: Arc::new(AtomicU32::new(0)),
             book_epoch: Arc::new(RwLock::new(0)),
         })
     }
@@ -247,6 +256,39 @@ impl BinanceFuturesDataClient {
         });
     }
 
+    fn custom_liquidation_instrument_id(
+        data_type: &DataType,
+    ) -> anyhow::Result<Option<InstrumentId>> {
+        let Some(raw_instrument_id) = data_type
+            .metadata()
+            .as_ref()
+            .and_then(|m| m.get("instrument_id"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+
+        let instrument_id = InstrumentId::from_str(raw_instrument_id)
+            .with_context(|| format!("invalid instrument_id metadata `{raw_instrument_id}`"))?;
+
+        Ok(Some(instrument_id))
+    }
+
+    fn liquidation_data_type(instrument_id: InstrumentId) -> DataType {
+        let mut metadata = Params::new();
+        metadata.insert(
+            "instrument_id".to_string(),
+            serde_json::Value::String(instrument_id.to_string()),
+        );
+        DataType::new(
+            "BinanceFuturesLiquidation",
+            Some(metadata),
+            Some(instrument_id.to_string()),
+        )
+    }
+
     #[expect(clippy::too_many_arguments)]
     fn handle_ws_message(
         msg: BinanceFuturesWsStreamsMessage,
@@ -255,6 +297,8 @@ impl BinanceFuturesDataClient {
         ws_instruments: &Arc<AtomicMap<Ustr, InstrumentAny>>,
         book_buffers: &Arc<AtomicMap<InstrumentId, BookBuffer>>,
         book_subscriptions: &Arc<AtomicMap<InstrumentId, u32>>,
+        force_order_refs: &Arc<AtomicMap<InstrumentId, u32>>,
+        force_order_all_market_refs: &Arc<AtomicU32>,
         book_epoch: &Arc<RwLock<u64>>,
         http_client: &BinanceFuturesHttpClient,
         clock: &'static AtomicTime,
@@ -351,14 +395,84 @@ impl BinanceFuturesDataClient {
                 }
             }
             BinanceFuturesWsStreamsMessage::ForceOrder(ref liq_msg) => {
-                log::info!(
-                    "Liquidation: {} {:?} {:?} qty={} at price={}",
-                    liq_msg.order.symbol,
-                    liq_msg.order.side,
-                    liq_msg.order.status,
-                    liq_msg.order.original_qty,
-                    liq_msg.order.average_price,
-                );
+                if let Some(instrument) = cache.get(&liq_msg.order.symbol) {
+                    let parse_price = |value: &str, field: &str| -> anyhow::Result<Price> {
+                        let value_f64 = value
+                            .parse::<f64>()
+                            .with_context(|| format!("invalid {field} value `{value}`"))?;
+                        Ok(Price::new(value_f64, instrument.price_precision()))
+                    };
+
+                    let parse_quantity = |value: &str, field: &str| -> anyhow::Result<Quantity> {
+                        let value_f64 = value
+                            .parse::<f64>()
+                            .with_context(|| format!("invalid {field} value `{value}`"))?;
+                        Ok(Quantity::new(value_f64, instrument.size_precision()))
+                    };
+
+                    match (
+                        parse_price(&liq_msg.order.price, "price"),
+                        parse_price(&liq_msg.order.average_price, "average_price"),
+                        parse_quantity(&liq_msg.order.last_filled_qty, "last_filled_qty"),
+                        parse_quantity(&liq_msg.order.accumulated_qty, "accumulated_qty"),
+                    ) {
+                        (
+                            Ok(price),
+                            Ok(average_price),
+                            Ok(last_filled_qty),
+                            Ok(accumulated_qty),
+                        ) => {
+                            let liquidation = Arc::new(BinanceFuturesLiquidation::new(
+                                instrument.id(),
+                                OrderSide::from(liq_msg.order.side),
+                                price,
+                                average_price,
+                                last_filled_qty,
+                                accumulated_qty,
+                                UnixNanos::from_millis(liq_msg.event_time as u64),
+                                ts_init,
+                            ));
+
+                            let has_specific_subscription =
+                                force_order_refs.load().contains_key(&instrument.id());
+                            let has_all_market_subscription =
+                                force_order_all_market_refs.load(Ordering::Relaxed) > 0;
+
+                            if has_specific_subscription {
+                                let data_type = Self::liquidation_data_type(instrument.id());
+                                Self::send_data(
+                                    data_sender,
+                                    Data::Custom(CustomData::new(liquidation.clone(), data_type)),
+                                );
+                            }
+
+                            if has_all_market_subscription {
+                                let data_type =
+                                    DataType::new("BinanceFuturesLiquidation", None, None);
+                                Self::send_data(
+                                    data_sender,
+                                    Data::Custom(CustomData::new(liquidation, data_type)),
+                                );
+                            }
+                        }
+                        (p, ap, lq, aq) => {
+                            log::warn!(
+                                "Failed to parse Binance liquidation {}: price={:?} avg={:?} \
+                                last_qty={:?} accumulated_qty={:?}",
+                                liq_msg.order.symbol,
+                                p.err(),
+                                ap.err(),
+                                lq.err(),
+                                aq.err(),
+                            );
+                        }
+                    }
+                } else {
+                    log::warn!(
+                        "Received Binance liquidation for uncached symbol {}",
+                        liq_msg.order.symbol
+                    );
+                }
             }
             BinanceFuturesWsStreamsMessage::Ticker(ref ticker_msg) => {
                 log::debug!(
@@ -896,6 +1010,8 @@ impl DataClient for BinanceFuturesDataClient {
 
         // Clear subscription state so resubscribes issue fresh WS subscribes
         self.mark_price_refs.store(AHashMap::new());
+        self.force_order_refs.store(AHashMap::new());
+        self.force_order_all_market_refs.store(0, Ordering::Relaxed);
         self.book_subscriptions.store(AHashMap::new());
         self.book_buffers.store(AHashMap::new());
 
@@ -913,6 +1029,8 @@ impl DataClient for BinanceFuturesDataClient {
         if self.is_connected() {
             return Ok(());
         }
+
+        register_binance_custom_data();
 
         // Reinitialize token in case of reconnection after disconnect
         self.cancellation_token = CancellationToken::new();
@@ -986,6 +1104,8 @@ impl DataClient for BinanceFuturesDataClient {
         let ws_insts = self.ws_client.instruments_cache();
         let buffers = self.book_buffers.clone();
         let book_subs = self.book_subscriptions.clone();
+        let force_order_refs = self.force_order_refs.clone();
+        let force_order_all_market_refs = self.force_order_all_market_refs.clone();
         let book_epoch = self.book_epoch.clone();
         let http = self.http_client.clone();
         let clock = self.clock;
@@ -1004,6 +1124,8 @@ impl DataClient for BinanceFuturesDataClient {
                             &ws_insts,
                             &buffers,
                             &book_subs,
+                            &force_order_refs,
+                            &force_order_all_market_refs,
                             &book_epoch,
                             &http,
                             clock,
@@ -1025,6 +1147,8 @@ impl DataClient for BinanceFuturesDataClient {
         let pub_ws_insts = self.ws_public_client.instruments_cache();
         let pub_buffers = self.book_buffers.clone();
         let pub_book_subs = self.book_subscriptions.clone();
+        let pub_force_order_refs = self.force_order_refs.clone();
+        let pub_force_order_all_market_refs = self.force_order_all_market_refs.clone();
         let pub_book_epoch = self.book_epoch.clone();
         let pub_http = self.http_client.clone();
         let pub_cancel = self.cancellation_token.clone();
@@ -1042,6 +1166,8 @@ impl DataClient for BinanceFuturesDataClient {
                             &pub_ws_insts,
                             &pub_buffers,
                             &pub_book_subs,
+                            &pub_force_order_refs,
+                            &pub_force_order_all_market_refs,
                             &pub_book_epoch,
                             &pub_http,
                             clock,
@@ -1140,6 +1266,8 @@ impl DataClient for BinanceFuturesDataClient {
 
         // Clear subscription state so resubscribes issue fresh WS subscribes
         self.mark_price_refs.store(AHashMap::new());
+        self.force_order_refs.store(AHashMap::new());
+        self.force_order_all_market_refs.store(0, Ordering::Relaxed);
         self.book_subscriptions.store(AHashMap::new());
         self.book_buffers.store(AHashMap::new());
 
@@ -1154,6 +1282,74 @@ impl DataClient for BinanceFuturesDataClient {
 
     fn is_disconnected(&self) -> bool {
         !self.is_connected()
+    }
+
+    fn subscribe(&mut self, cmd: SubscribeCustomData) -> anyhow::Result<()> {
+        let data_type = cmd.data_type.type_name();
+        if data_type != "BinanceFuturesLiquidation" {
+            log::warn!("Unsupported custom data subscription: {data_type}");
+            return Ok(());
+        }
+
+        let instrument_id = Self::custom_liquidation_instrument_id(&cmd.data_type)?;
+        if let Some(instrument_id) = instrument_id {
+            if instrument_id.venue != self.venue() {
+                anyhow::bail!(
+                    "Binance liquidation custom data requires BINANCE venue instrument, received {instrument_id}"
+                );
+            }
+
+            let should_subscribe = {
+                let prev = self
+                    .force_order_refs
+                    .load()
+                    .get(&instrument_id)
+                    .copied()
+                    .unwrap_or(0);
+                self.force_order_refs.rcu(|m| {
+                    let count = m.entry(instrument_id).or_insert(0);
+                    *count += 1;
+                });
+                prev == 0
+            };
+
+            if should_subscribe {
+                let ws = self.ws_client.clone();
+                let stream = format!(
+                    "{}@forceOrder",
+                    format_binance_stream_symbol(&instrument_id)
+                );
+                self.spawn_ws(
+                    async move {
+                        ws.subscribe(vec![stream])
+                            .await
+                            .context("forceOrder subscription")
+                    },
+                    "forceOrder subscription",
+                );
+            }
+
+            return Ok(());
+        }
+
+        let should_subscribe = self
+            .force_order_all_market_refs
+            .fetch_add(1, Ordering::Relaxed)
+            == 0;
+
+        if should_subscribe {
+            let ws = self.ws_client.clone();
+            self.spawn_ws(
+                async move {
+                    ws.subscribe(vec!["!forceOrder@arr".to_string()])
+                        .await
+                        .context("all-market forceOrder subscription")
+                },
+                "all-market forceOrder subscription",
+            );
+        }
+
+        Ok(())
     }
 
     fn subscribe_instruments(&mut self, _cmd: SubscribeInstruments) -> anyhow::Result<()> {
@@ -1484,6 +1680,84 @@ impl DataClient for BinanceFuturesDataClient {
             },
             "trade unsubscribe",
         );
+        Ok(())
+    }
+
+    fn unsubscribe(&mut self, cmd: &UnsubscribeCustomData) -> anyhow::Result<()> {
+        let data_type = cmd.data_type.type_name();
+        if data_type != "BinanceFuturesLiquidation" {
+            log::warn!("Unsupported custom data unsubscription: {data_type}");
+            return Ok(());
+        }
+
+        let instrument_id = Self::custom_liquidation_instrument_id(&cmd.data_type)?;
+        if let Some(instrument_id) = instrument_id {
+            if instrument_id.venue != self.venue() {
+                anyhow::bail!(
+                    "Binance liquidation custom data requires BINANCE venue instrument, received {instrument_id}"
+                );
+            }
+
+            let should_unsubscribe = {
+                let prev = self.force_order_refs.load().get(&instrument_id).copied();
+                match prev {
+                    Some(1) => {
+                        self.force_order_refs.remove(&instrument_id);
+                        true
+                    }
+                    Some(count) if count > 1 => {
+                        self.force_order_refs.rcu(|m| {
+                            if let Some(existing) = m.get_mut(&instrument_id) {
+                                *existing -= 1;
+                            }
+                        });
+                        false
+                    }
+                    _ => false,
+                }
+            };
+
+            if should_unsubscribe {
+                let ws = self.ws_client.clone();
+                let stream = format!(
+                    "{}@forceOrder",
+                    format_binance_stream_symbol(&instrument_id)
+                );
+                self.spawn_ws(
+                    async move {
+                        ws.unsubscribe(vec![stream])
+                            .await
+                            .context("forceOrder unsubscribe")
+                    },
+                    "forceOrder unsubscribe",
+                );
+            }
+
+            return Ok(());
+        }
+
+        let should_unsubscribe = self
+            .force_order_all_market_refs
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                if current == 0 {
+                    None
+                } else {
+                    Some(current - 1)
+                }
+            })
+            .is_ok_and(|prev| prev == 1);
+        if should_unsubscribe {
+            let ws = self.ws_client.clone();
+            self.spawn_ws(
+                async move {
+                    ws.unsubscribe(vec!["!forceOrder@arr".to_string()])
+                        .await
+                        .context("all-market forceOrder unsubscribe")
+                },
+                "all-market forceOrder unsubscribe",
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/adapters/binance/src/lib.rs
+++ b/crates/adapters/binance/src/lib.rs
@@ -60,6 +60,7 @@
 pub mod arrow;
 pub mod common;
 pub mod config;
+pub mod data_types;
 pub mod factories;
 pub mod futures;
 pub mod spot;

--- a/crates/adapters/binance/src/python/mod.rs
+++ b/crates/adapters/binance/src/python/mod.rs
@@ -36,6 +36,7 @@ use crate::{
         enums::{BinanceEnvironment, BinanceMarginType, BinancePositionSide, BinanceProductType},
     },
     config::{BinanceDataClientConfig, BinanceExecClientConfig},
+    data_types::{BinanceFuturesLiquidation, register_binance_custom_data},
     factories::{BinanceDataClientFactory, BinanceExecutionClientFactory},
 };
 
@@ -131,6 +132,7 @@ pub fn binance(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BinanceMarginType>()?;
     m.add_class::<BinancePositionSide>()?;
     m.add_class::<BinanceBar>()?;
+    m.add_class::<BinanceFuturesLiquidation>()?;
     m.add_function(wrap_pyfunction!(arrow::get_binance_arrow_schema_map, m)?)?;
     m.add_function(wrap_pyfunction!(
         arrow::py_binance_bar_to_arrow_record_batch_bytes,
@@ -153,6 +155,8 @@ pub fn binance(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register BinanceBar for Arrow/JSON serialization and Python extraction
     ensure_custom_data_registered::<BinanceBar>();
     let _result = ensure_rust_extractor_registered::<BinanceBar>();
+    register_binance_custom_data();
+    let _result = ensure_rust_extractor_registered::<BinanceFuturesLiquidation>();
 
     let registry = get_global_pyo3_registry();
 

--- a/crates/adapters/binance/src/python/types.rs
+++ b/crates/adapters/binance/src/python/types.rs
@@ -21,12 +21,15 @@ use std::{
 use nautilus_core::python::{IntoPyObjectNautilusExt, serialization::from_dict_pyo3};
 use nautilus_model::{
     data::bar::BarType,
+    enums::OrderSide,
+    identifiers::InstrumentId,
     types::{Price, Quantity},
 };
 use pyo3::{basic::CompareOp, prelude::*, types::PyDict};
 use rust_decimal::Decimal;
 
 use crate::common::bar::BinanceBar;
+use crate::data_types::BinanceFuturesLiquidation;
 
 #[pymethods]
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
@@ -173,5 +176,57 @@ impl BinanceBar {
         dict.set_item("ts_event", self.ts_event.as_u64())?;
         dict.set_item("ts_init", self.ts_init.as_u64())?;
         Ok(dict.into())
+    }
+}
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl BinanceFuturesLiquidation {
+    #[getter]
+    #[pyo3(name = "instrument_id")]
+    fn py_instrument_id(&self) -> InstrumentId {
+        self.instrument_id
+    }
+
+    #[getter]
+    #[pyo3(name = "side")]
+    fn py_side(&self) -> OrderSide {
+        self.side
+    }
+
+    #[getter]
+    #[pyo3(name = "price")]
+    fn py_price(&self) -> Price {
+        self.price
+    }
+
+    #[getter]
+    #[pyo3(name = "average_price")]
+    fn py_average_price(&self) -> Price {
+        self.average_price
+    }
+
+    #[getter]
+    #[pyo3(name = "last_filled_qty")]
+    fn py_last_filled_qty(&self) -> Quantity {
+        self.last_filled_qty
+    }
+
+    #[getter]
+    #[pyo3(name = "accumulated_qty")]
+    fn py_accumulated_qty(&self) -> Quantity {
+        self.accumulated_qty
+    }
+
+    #[getter]
+    #[pyo3(name = "ts_event")]
+    fn py_ts_event(&self) -> u64 {
+        self.ts_event.as_u64()
+    }
+
+    #[getter]
+    #[pyo3(name = "ts_init")]
+    fn py_ts_init(&self) -> u64 {
+        self.ts_init.as_u64()
     }
 }

--- a/crates/adapters/binance/tests/futures/data_client.rs
+++ b/crates/adapters/binance/tests/futures/data_client.rs
@@ -674,6 +674,213 @@ async fn test_subscribe_custom_liquidations_all_market() {
 
 #[rstest]
 #[tokio::test]
+async fn test_subscribe_custom_liquidations_overlap_routes_single_event() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    let specific_data_type = liquidation_data_type_for_instrument(instrument_id);
+    let all_market_data_type = DataType::new("BinanceFuturesLiquidation", None, None);
+
+    client
+        .subscribe(SubscribeCustomData::new(
+            Some(*BINANCE_CLIENT_ID),
+            None,
+            specific_data_type.clone(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+                custom.data_type == specific_data_type
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    client
+        .subscribe(SubscribeCustomData::new(
+            Some(*BINANCE_CLIENT_ID),
+            None,
+            all_market_data_type.clone(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+                custom.data_type == all_market_data_type
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut queued_custom_count = 0_u32;
+
+    while let Ok(event) = rx.try_recv() {
+        if matches!(event, DataEvent::Data(Data::Custom(_))) {
+            queued_custom_count += 1;
+        }
+    }
+
+    assert_eq!(
+        queued_custom_count, 0,
+        "expected overlap subscription to route a single liquidation event",
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unsubscribe_all_market_restores_specific_liquidation_streams() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    let specific_data_type = liquidation_data_type_for_instrument(instrument_id);
+    let all_market_data_type = DataType::new("BinanceFuturesLiquidation", None, None);
+
+    client
+        .subscribe(SubscribeCustomData::new(
+            Some(*BINANCE_CLIENT_ID),
+            None,
+            specific_data_type.clone(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+                custom.data_type == specific_data_type
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    client
+        .subscribe(SubscribeCustomData::new(
+            Some(*BINANCE_CLIENT_ID),
+            None,
+            all_market_data_type.clone(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+                custom.data_type == all_market_data_type
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    client
+        .unsubscribe(&UnsubscribeCustomData::new(
+            Some(*BINANCE_CLIENT_ID),
+            None,
+            all_market_data_type,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+                custom.data_type == specific_data_type
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_unsubscribe_trades() {
     let addr = start_data_test_server().await;
     let base_url_http = format!("http://{addr}");

--- a/crates/adapters/binance/tests/futures/data_client.rs
+++ b/crates/adapters/binance/tests/futures/data_client.rs
@@ -30,6 +30,7 @@ use nautilus_binance::{
         enums::BinanceProductType,
     },
     config::BinanceDataClientConfig,
+    data_types::BinanceFuturesLiquidation,
     futures::BinanceFuturesDataClient,
 };
 use nautilus_common::{
@@ -39,18 +40,36 @@ use nautilus_common::{
         DataEvent,
         data::{
             subscribe::{
-                SubscribeBookDeltas, SubscribeMarkPrices, SubscribeQuotes, SubscribeTrades,
+                SubscribeBookDeltas, SubscribeCustomData, SubscribeMarkPrices, SubscribeQuotes,
+                SubscribeTrades,
             },
-            unsubscribe::{UnsubscribeQuotes, UnsubscribeTrades},
+            unsubscribe::{UnsubscribeCustomData, UnsubscribeQuotes, UnsubscribeTrades},
         },
     },
     testing::wait_until_async,
 };
-use nautilus_core::UnixNanos;
-use nautilus_model::{enums::BookType, identifiers::InstrumentId};
+use nautilus_core::{Params, UUID4, UnixNanos};
+use nautilus_model::{
+    data::{Data, DataType},
+    enums::BookType,
+    identifiers::InstrumentId,
+};
 use nautilus_network::http::HttpClient;
 use rstest::rstest;
 use serde_json::json;
+
+fn liquidation_data_type_for_instrument(instrument_id: InstrumentId) -> DataType {
+    let mut metadata = Params::new();
+    metadata.insert(
+        "instrument_id".to_string(),
+        serde_json::Value::String(instrument_id.to_string()),
+    );
+    DataType::new(
+        "BinanceFuturesLiquidation",
+        Some(metadata),
+        Some(instrument_id.to_string()),
+    )
+}
 
 fn json_response(body: &serde_json::Value) -> Response {
     (
@@ -141,6 +160,30 @@ async fn handle_ws_connection(mut socket: WebSocket) {
                                 tokio::time::sleep(Duration::from_millis(50)).await;
                                 let _result = socket
                                     .send(Message::Text(mark_price.to_string().into()))
+                                    .await;
+                            } else if stream.contains("@forceOrder")
+                                || stream.contains("!forceOrder@arr")
+                            {
+                                let liquidation = json!({
+                                    "e": "forceOrder",
+                                    "E": 1700000000000_i64,
+                                    "o": {
+                                        "s": "BTCUSDT",
+                                        "S": "SELL",
+                                        "o": "LIMIT",
+                                        "f": "IOC",
+                                        "q": "0.003",
+                                        "p": "50000.10",
+                                        "ap": "50000.20",
+                                        "X": "FILLED",
+                                        "l": "0.001",
+                                        "z": "0.003",
+                                        "T": 1700000000000_i64
+                                    }
+                                });
+                                tokio::time::sleep(Duration::from_millis(50)).await;
+                                let _result = socket
+                                    .send(Message::Text(liquidation.to_string().into()))
                                     .await;
                             }
                         }
@@ -512,6 +555,125 @@ async fn test_subscribe_mark_prices() {
 
 #[rstest]
 #[tokio::test]
+async fn test_subscribe_custom_liquidations_for_instrument() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    let data_type = liquidation_data_type_for_instrument(instrument_id);
+    let cmd = SubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type.clone(),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.subscribe(cmd).unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+
+                custom
+                    .data
+                    .as_any()
+                    .downcast_ref::<BinanceFuturesLiquidation>()
+                    .is_some_and(|liq| {
+                        liq.instrument_id == instrument_id
+                            && custom.data_type == data_type
+                            && liq.last_filled_qty.to_string() == "0.001"
+                            && liq.accumulated_qty.to_string() == "0.003"
+                    })
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_subscribe_custom_liquidations_all_market() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let data_type = DataType::new("BinanceFuturesLiquidation", None, None);
+    let cmd = SubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type.clone(),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.subscribe(cmd).unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx.try_recv().is_ok_and(|event| {
+                let DataEvent::Data(Data::Custom(custom)) = event else {
+                    return false;
+                };
+
+                custom
+                    .data
+                    .as_any()
+                    .downcast_ref::<BinanceFuturesLiquidation>()
+                    .is_some_and(|liq| {
+                        liq.instrument_id == InstrumentId::from("BTCUSDT-PERP.BINANCE")
+                            && custom.data_type == data_type
+                    })
+            });
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_unsubscribe_trades() {
     let addr = start_data_test_server().await;
     let base_url_http = format!("http://{addr}");
@@ -632,6 +794,127 @@ async fn test_unsubscribe_quotes() {
     );
     let result = client.unsubscribe_quotes(&unsub_cmd);
     result.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unsubscribe_custom_liquidations_for_instrument() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    let data_type = liquidation_data_type_for_instrument(instrument_id);
+    let sub_cmd = SubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type.clone(),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.subscribe(sub_cmd).unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Data(Data::Custom(_))));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let unsub_cmd = UnsubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.unsubscribe(&unsub_cmd).unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unsubscribe_custom_liquidations_all_market() {
+    let addr = start_data_test_server().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx) = create_test_data_client(base_url_http, base_url_ws);
+    client.connect().await.unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Instrument(_)));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let data_type = DataType::new("BinanceFuturesLiquidation", None, None);
+    let sub_cmd = SubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type.clone(),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.subscribe(sub_cmd).unwrap();
+
+    wait_until_async(
+        || {
+            let found = rx
+                .try_recv()
+                .is_ok_and(|e| matches!(e, DataEvent::Data(Data::Custom(_))));
+            async move { found }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    while rx.try_recv().is_ok() {}
+
+    let unsub_cmd = UnsubscribeCustomData::new(
+        Some(*BINANCE_CLIENT_ID),
+        None,
+        data_type,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+    client.unsubscribe(&unsub_cmd).unwrap();
 }
 
 #[rstest]

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -526,6 +526,10 @@ For instrument-specific subscriptions, `CustomData.data_type` includes
 `metadata={"instrument_id": "<instrument_id>"}`. For all-market subscriptions,
 the data type has no metadata.
 
+When both modes are subscribed concurrently, all-market takes precedence. The
+adapter suspends per-symbol liquidation streams while all-market is active, and
+restores active per-symbol streams after all-market is unsubscribed.
+
 ## Funding rates
 
 The Rust adapter emits `FundingRateUpdate` as a first-class data type through

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -502,22 +502,23 @@ Subscribe to liquidation updates for either:
 - all symbols (`!forceOrder@arr`) by omitting `instrument_id`.
 
 ```python
-from nautilus_trader.adapters.binance import BinanceFuturesLiquidation
-from nautilus_trader.model import DataType, ClientId
+from nautilus_trader.core import nautilus_pyo3 as pyo3
+
+client_id = pyo3.ClientId.from_str("BINANCE")
 
 # Instrument-specific
 self.subscribe_data(
-    data_type=DataType(
-        BinanceFuturesLiquidation,
-        metadata={"instrument_id": self.instrument.id},
+    data_type=pyo3.DataType(
+        "BinanceFuturesLiquidation",
+        {"instrument_id": "BTCUSDT-PERP.BINANCE"},
     ),
-    client_id=ClientId("BINANCE"),
+    client_id=client_id,
 )
 
 # All-market (no instrument_id metadata)
 self.subscribe_data(
-    data_type=DataType(BinanceFuturesLiquidation),
-    client_id=ClientId("BINANCE"),
+    data_type=pyo3.DataType("BinanceFuturesLiquidation"),
+    client_id=client_id,
 )
 ```
 

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -58,6 +58,7 @@ The integration includes several custom data types:
 - `BinanceTicker`: 24-hour ticker data including price and statistical information.
 - `BinanceBar`: Bar data with additional volume metrics for historical and real-time use.
 - `BinanceFuturesMarkPriceUpdate`: Mark price updates for Binance Futures.
+- `BinanceFuturesLiquidation`: Futures liquidation events from the `forceOrder` stream.
 
 See the Binance [API Reference](/docs/python-api-latest/adapters/binance.html) for full definitions.
 
@@ -492,6 +493,37 @@ def on_data(self, data: Data):
     if isinstance(data, BinanceFuturesMarkPriceUpdate):
         # Do something with the data
 ```
+
+### `BinanceFuturesLiquidation`
+
+Subscribe to liquidation updates for either:
+
+- a specific instrument (`<symbol>@forceOrder`), or
+- all symbols (`!forceOrder@arr`) by omitting `instrument_id`.
+
+```python
+from nautilus_trader.adapters.binance import BinanceFuturesLiquidation
+from nautilus_trader.model import DataType, ClientId
+
+# Instrument-specific
+self.subscribe_data(
+    data_type=DataType(
+        BinanceFuturesLiquidation,
+        metadata={"instrument_id": self.instrument.id},
+    ),
+    client_id=ClientId("BINANCE"),
+)
+
+# All-market (no instrument_id metadata)
+self.subscribe_data(
+    data_type=DataType(BinanceFuturesLiquidation),
+    client_id=ClientId("BINANCE"),
+)
+```
+
+For instrument-specific subscriptions, `CustomData.data_type` includes
+`metadata={"instrument_id": "<instrument_id>"}`. For all-market subscriptions,
+the data type has no metadata.
 
 ## Funding rates
 

--- a/nautilus_trader/adapters/binance/__init__.py
+++ b/nautilus_trader/adapters/binance/__init__.py
@@ -69,6 +69,7 @@ register_serializable_type(
 
 
 _binance_mod = nautilus_pyo3.binance  # type: ignore[attr-defined]
+BinanceFuturesLiquidation = _binance_mod.BinanceFuturesLiquidation
 
 
 def _convert_binance_bar_to_pyo3(bar: BinanceBar) -> object:
@@ -120,6 +121,7 @@ __all__ = [
     "BinanceDataClientConfig",
     "BinanceExecClientConfig",
     "BinanceFuturesInstrumentProvider",
+    "BinanceFuturesLiquidation",
     "BinanceFuturesMarkPriceUpdate",
     "BinanceInstrumentProviderConfig",
     "BinanceKeyType",

--- a/python/nautilus_trader/binance/__init__.pyi
+++ b/python/nautilus_trader/binance/__init__.pyi
@@ -13,6 +13,7 @@ __all__ = [
     "BinanceEnvironment",
     "BinanceExecClientConfig",
     "BinanceExecutionClientFactory",
+    "BinanceFuturesLiquidation",
     "BinanceMarginType",
     "BinancePositionSide",
     "BinanceProductType",
@@ -94,6 +95,25 @@ class BinanceExecClientConfig:
 class BinanceExecutionClientFactory:
     def __init__(self) -> None: ...
     def name(self) -> str: ...
+
+@typing.final
+class BinanceFuturesLiquidation:
+    @property
+    def instrument_id(self) -> model.InstrumentId: ...
+    @property
+    def side(self) -> model.OrderSide: ...
+    @property
+    def price(self) -> model.Price: ...
+    @property
+    def average_price(self) -> model.Price: ...
+    @property
+    def last_filled_qty(self) -> model.Quantity: ...
+    @property
+    def accumulated_qty(self) -> model.Quantity: ...
+    @property
+    def ts_event(self) -> int: ...
+    @property
+    def ts_init(self) -> int: ...
 
 @typing.final
 class BinanceEnvironment(enum.Enum):

--- a/tests/integration_tests/adapters/binance/test_core_types.py
+++ b/tests/integration_tests/adapters/binance/test_core_types.py
@@ -18,10 +18,12 @@ from decimal import Decimal
 
 import pytest
 
+from nautilus_trader.adapters.binance import BinanceFuturesLiquidation
 from nautilus_trader.adapters.binance.common.types import BinanceBar
 from nautilus_trader.adapters.binance.common.types import BinanceTicker
 from nautilus_trader.adapters.binance.futures.types import BinanceFuturesMarkPriceUpdate
 from nautilus_trader.model.data import BarType
+from nautilus_trader.model.data import DataType
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.persistence.catalog.parquet import ParquetDataCatalog
@@ -332,6 +334,29 @@ def test_binance_mark_price_pickling():
         "ts_event": 1650000000000000001,
         "ts_init": 1650000000000000000,
     }
+
+
+def test_binance_futures_liquidation_type_is_compatible_with_data_type() -> None:
+    # Arrange, Act
+    data_type = DataType(
+        BinanceFuturesLiquidation,
+        metadata={"instrument_id": "ETHUSDT-PERP.BINANCE"},
+    )
+
+    # Assert
+    assert hasattr(BinanceFuturesLiquidation, "ts_event")
+    assert hasattr(BinanceFuturesLiquidation, "ts_init")
+    assert data_type.type == BinanceFuturesLiquidation
+    assert data_type.metadata["instrument_id"] == "ETHUSDT-PERP.BINANCE"
+
+
+def test_binance_futures_liquidation_type_supports_all_market_subscription() -> None:
+    # Arrange, Act
+    data_type = DataType(BinanceFuturesLiquidation)
+
+    # Assert
+    assert data_type.type == BinanceFuturesLiquidation
+    assert data_type.metadata == {}
 
 
 @pytest.fixture


### PR DESCRIPTION
Implements Binance Futures liquidation custom data subscriptions for both instrument-specific and all-market modes, and wires the data through to Python strategy subscriptions.

# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Binance Futures `forceOrder` liquidation messages were previously log-only in the Rust data client path. This PR emits them as subscribable custom data and supports both subscription modes:

- instrument-specific (`<symbol>@forceOrder`) via `metadata.instrument_id`
- all-market (`!forceOrder@arr`) when `instrument_id` is omitted

## Verification

Live verified with PyO3 strategy + Rust data client:

- all-market mode subscribed and received/parsing liquidation events
- instrument-specific mode (`BTCUSDT-PERP.BINANCE`) subscribed successfully
- exchange subscription confirmations observed:
  - `streams=["!forceOrder@arr"]`
  - `streams=["btcusdt@forceOrder"]`
- zero events in a short single-symbol window is expected when no liquidation occurs

## Changes

- add `BinanceFuturesLiquidation` custom data type and registration
- add subscribe/unsubscribe handling for liquidation custom data in futures data client
- emit liquidation updates as `Data::Custom`
- add Python bindings/getters and re-export for strategy imports
- add Rust tests for subscribe/unsubscribe in both modes
- add Python integration tests for `DataType(BinanceFuturesLiquidation, ...)`
- add Binance integration docs usage examples

## Related Issues/PRs

Closes #4094

## Type of change

- [x] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [x] Documentation update

## Testing

Executed locally:
- `cargo test -p nautilus-binance --test futures -- --nocapture`
- `cargo test -p nautilus-binance --features python --test futures custom_liquidations -- --nocapture`
- `uv run --active --no-sync pytest tests/integration_tests/adapters/binance/test_core_types.py -q`
- `pre-commit run --all-files`
