### PR TITLE
Beta weight vega greeks against volatility index instruments

### DIFF
--- a/crates/common/examples/greeks.md
+++ b/crates/common/examples/greeks.md
@@ -26,7 +26,7 @@ use nautilus_common::{
         Actor,
     },
     cache::Cache,
-    greeks::GreeksCalculator,
+    greeks::{GreeksCalculator, InstrumentGreeksParams},
     live::clock::LiveClock,
     msgbus::MessagingSwitchboard,
 };
@@ -63,46 +63,19 @@ impl MyActor {
 
 ```rust
 use nautilus_model::{
-    data::greeks::GreeksData,
+    data::{CustomData, greeks::GreeksData},
     identifiers::InstrumentId,
 };
 
 impl MyActor {
     pub fn calculate_greeks(&self, instrument_id: InstrumentId) -> anyhow::Result<GreeksData> {
-        // Example parameters
-        let flat_interest_rate = 0.0425;
-        let flat_dividend_yield = None;
-        let spot_shock = 0.0;
-        let vol_shock = 0.0;
-        let time_to_expiry_shock = 0.0;
-        let use_cached_greeks = false;
-        let update_vol = false;
-        let cache_greeks = true;
-        let publish_greeks = true;
-        let ts_event = self.core.clock.borrow().timestamp_ns();
-        let position = None;
-        let percent_greeks = false;
-        let index_instrument_id = None;
-        let beta_weights = None;
-
-        // Calculate greeks
-        self.greeks_calculator.instrument_greeks(
-            instrument_id,
-            Some(flat_interest_rate),
-            flat_dividend_yield,
-            Some(spot_shock),
-            Some(vol_shock),
-            Some(time_to_expiry_shock),
-            Some(use_cached_greeks),
-            Some(update_vol),
-            Some(cache_greeks),
-            Some(publish_greeks),
-            Some(ts_event),
-            position,
-            Some(percent_greeks),
-            index_instrument_id,
-            beta_weights,
-        )
+        InstrumentGreeksParams::builder()
+            .instrument_id(instrument_id)
+            .cache_greeks(true)
+            .publish_greeks(true)
+            .ts_event(self.core.clock.borrow().timestamp_ns())
+            .build()
+            .calculate(&self.greeks_calculator)
     }
 }
 ```
@@ -112,8 +85,12 @@ impl MyActor {
 ```rust
 impl MyActor {
     pub fn subscribe_to_greeks(&self, underlying: &str) {
-        // Subscribe to greeks data
-        self.greeks_calculator.subscribe_greeks(underlying, None);
+        self.greeks_calculator
+            .subscribe_greeks(underlying, Some(Self::handle_greeks as fn(&GreeksData)));
+    }
+
+    fn handle_greeks(greeks: &GreeksData) {
+        println!("Received greeks data: {greeks:?}");
     }
 }
 
@@ -124,11 +101,8 @@ impl DataActor for MyActor {
         Ok(())
     }
 
-    fn on_data(&mut self, data: &dyn std::any::Any) -> anyhow::Result<()> {
-        // Handle received data
-        if let Some(greeks_data) = data.downcast_ref::<GreeksData>() {
-            println!("Received greeks data: {:?}", greeks_data);
-        }
+    fn on_data(&mut self, data: &CustomData) -> anyhow::Result<()> {
+        println!("Received custom data: {}", data.data_type);
         Ok(())
     }
 }
@@ -147,5 +121,6 @@ See the complete example in `crates/common/examples/greeks_actor_example.rs` for
 
 ## Notes
 
-- When setting `publish_greeks` to `true`, the calculator will publish the greeks data to the message bus with a topic format of `data.GreeksData.instrument_id={symbol}`.
+- When setting `publish_greeks` to `true`, the calculator publishes typed `GreeksData` to the message bus with a topic format of `data.GreeksData.instrument_id={symbol}`.
+- Greeks subscriptions are handled through `subscribe_greeks`; `DataActor::on_data` receives `CustomData` wrappers and is not the greeks delivery path.
 - When subscribing to greeks data, you can provide a custom handler or use the default handler which caches the received greeks data.

--- a/crates/common/examples/greeks_actor_example.rs
+++ b/crates/common/examples/greeks_actor_example.rs
@@ -21,7 +21,7 @@ use nautilus_common::{
     actor::data_actor::{DataActor, DataActorConfig, DataActorCore},
     cache::Cache,
     component::Component,
-    greeks::GreeksCalculator,
+    greeks::{GreeksCalculator, InstrumentGreeksParams, PortfolioGreeksParams},
     live::clock::LiveClock,
     nautilus_actor,
 };
@@ -64,92 +64,33 @@ impl GreeksActor {
         &self,
         instrument_id: InstrumentId,
     ) -> anyhow::Result<GreeksData> {
-        // Example parameters
-        let flat_interest_rate = 0.0425;
-        let flat_dividend_yield = None;
-        let spot_shock = 0.0;
-        let vol_shock = 0.0;
-        let time_to_expiry_shock = 0.0;
-        let use_cached_greeks = false;
-        let update_vol = false;
-        let cache_greeks = true;
-        let publish_greeks = true;
-        let ts_event = self.core.timestamp_ns();
-        let position = None;
-        let percent_greeks = false;
-        let index_instrument_id = None;
-        let beta_weights = None;
-
-        // Calculate greeks
-        self.greeks_calculator.instrument_greeks(
-            instrument_id,
-            Some(flat_interest_rate),
-            flat_dividend_yield,
-            Some(spot_shock),
-            Some(vol_shock),
-            Some(time_to_expiry_shock),
-            Some(use_cached_greeks),
-            Some(update_vol),
-            Some(cache_greeks),
-            Some(publish_greeks),
-            Some(ts_event),
-            position,
-            Some(percent_greeks),
-            index_instrument_id,
-            beta_weights,
-            None, // vega_time_weight_base
-        )
+        InstrumentGreeksParams::builder()
+            .instrument_id(instrument_id)
+            .cache_greeks(true)
+            .publish_greeks(true)
+            .ts_event(self.core.timestamp_ns())
+            .build()
+            .calculate(&self.greeks_calculator)
     }
 
     /// Calculates portfolio greeks.
     pub(crate) fn calculate_portfolio_greeks(&self) -> anyhow::Result<PortfolioGreeks> {
-        // Example parameters
-        let underlyings = None;
-        let venue = None;
-        let instrument_id = None;
-        let strategy_id = None;
-        let side = Some(PositionSide::NoPositionSide);
-        let flat_interest_rate = 0.0425;
-        let flat_dividend_yield = None;
-        let spot_shock = 0.0;
-        let vol_shock = 0.0;
-        let time_to_expiry_shock = 0.0;
-        let use_cached_greeks = false;
-        let update_vol = false;
-        let cache_greeks = true;
-        let publish_greeks = true;
-        let percent_greeks = false;
-        let index_instrument_id = None;
-        let beta_weights = None;
-        let greeks_filter = None;
-
-        self.greeks_calculator.portfolio_greeks(
-            underlyings,
-            venue,
-            instrument_id,
-            strategy_id,
-            side,
-            Some(flat_interest_rate),
-            flat_dividend_yield,
-            Some(spot_shock),
-            Some(vol_shock),
-            Some(time_to_expiry_shock),
-            Some(use_cached_greeks),
-            Some(update_vol),
-            Some(cache_greeks),
-            Some(publish_greeks),
-            Some(percent_greeks),
-            index_instrument_id,
-            beta_weights,
-            greeks_filter,
-            None, // vega_time_weight_base
-        )
+        PortfolioGreeksParams::builder()
+            .side(PositionSide::NoPositionSide)
+            .cache_greeks(true)
+            .publish_greeks(true)
+            .build()
+            .calculate(&self.greeks_calculator)
     }
 
     /// Subscribes to greeks data for a specific underlying.
     pub(crate) fn subscribe_to_greeks(&self, underlying: &str) {
         self.greeks_calculator
-            .subscribe_greeks::<fn(&GreeksData)>(underlying, None);
+            .subscribe_greeks(underlying, Some(Self::handle_greeks as fn(&GreeksData)));
+    }
+
+    fn handle_greeks(greeks: &GreeksData) {
+        println!("Received greeks data: {greeks:?}");
     }
 }
 
@@ -165,7 +106,8 @@ impl DataActor for GreeksActor {
         Ok(())
     }
 
-    fn on_data(&mut self, _data: &CustomData) -> anyhow::Result<()> {
+    fn on_data(&mut self, data: &CustomData) -> anyhow::Result<()> {
+        println!("Received custom data: {}", data.data_type);
         Ok(())
     }
 }

--- a/crates/common/src/greeks.rs
+++ b/crates/common/src/greeks.rs
@@ -474,6 +474,8 @@ impl GreeksCalculator {
             0.0,
             None,
             None,
+            None,
+            None,
         );
         let mut greeks_data =
             GreeksData::from_delta(instrument_id, delta, multiplier.as_f64(), ts_event);
@@ -557,6 +559,11 @@ impl GreeksCalculator {
             .get_price(&instrument_id)
             .ok_or_else(|| anyhow::anyhow!("No price available for {instrument_id}"))?;
         let underlying_price = self.get_underlying_price(&underlying_instrument_id)?;
+
+        if let Some(vol_index_id) = vol_index_instrument_id {
+            self.get_price(&vol_index_id)
+                .ok_or_else(|| anyhow::anyhow!("No price available for {vol_index_id}"))?;
+        }
         let greeks = if update_vol {
             let cached_greeks = self.cache.borrow().greeks(&instrument_id);
             match cached_greeks {
@@ -607,6 +614,8 @@ impl GreeksCalculator {
             greeks.vol,
             vol_index_instrument_id,
             vol_beta_weights,
+            None,
+            None,
         );
         let greeks_data = GreeksData::new(
             utc_now_ns,
@@ -698,6 +707,8 @@ impl GreeksCalculator {
             greeks_data.vol,
             vol_index_instrument_id,
             vol_beta_weights,
+            None,
+            None,
         );
         GreeksData::new(
             greeks_data.ts_event,
@@ -789,17 +800,20 @@ impl GreeksCalculator {
         unshocked_vol: f64,
         vol_index_instrument_id: Option<InstrumentId>,
         vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
+        index_price: Option<f64>,
+        vol_index_price: Option<f64>,
     ) -> (f64, f64, f64) {
         let mut delta = delta_input;
         let mut gamma = gamma_input;
         let mut vega = vega_input;
 
-        let mut index_price = None;
-        let mut vol_index_price = None;
+        let mut used_index_price = index_price
+            .or_else(|| index_instrument_id.and_then(|index_id| self.get_price(&index_id)));
+        let mut used_index_vol = vol_index_price.or_else(|| {
+            vol_index_instrument_id.and_then(|vol_index_id| self.get_price(&vol_index_id))
+        });
 
-        if let Some(index_id) = index_instrument_id {
-            index_price = Some(self.get_price(&index_id).unwrap_or_default());
-
+        if used_index_price.is_some() {
             let mut beta = 1.0;
 
             if let Some(weights) = beta_weights
@@ -808,7 +822,7 @@ impl GreeksCalculator {
                 beta = weight;
             }
 
-            if let Some(ref mut idx_price) = index_price {
+            if let Some(ref mut idx_price) = used_index_price {
                 #[allow(clippy::float_cmp, reason = "exact-equality baseline check")]
                 if underlying_price != unshocked_underlying_price {
                     *idx_price += 1.0 / beta
@@ -822,10 +836,13 @@ impl GreeksCalculator {
             }
         }
 
-        if let Some(vol_index_id) = vol_index_instrument_id {
-            vol_index_price = Some(self.get_price(&vol_index_id).unwrap_or_default());
-
+        if used_index_vol.is_some() {
             let mut vega_beta = 1.0;
+            let used_vol = if unshocked_vol == 0.0 {
+                vol
+            } else {
+                unshocked_vol
+            };
 
             if let Some(weights) = vol_beta_weights
                 && let Some(&weight) = weights.get(&underlying_instrument_id)
@@ -833,19 +850,23 @@ impl GreeksCalculator {
                 vega_beta = weight;
             }
 
-            if let Some(ref mut idx_price) = vol_index_price {
+            if let Some(ref mut idx_vol) = used_index_vol {
+                *idx_vol *= 0.01;
+
                 #[allow(clippy::float_cmp, reason = "exact-equality baseline check")]
-                if vol != unshocked_vol {
-                    *idx_price +=
-                        1.0 / vega_beta * (*idx_price / unshocked_vol) * (vol - unshocked_vol);
+                if vol != used_vol && used_vol != 0.0 {
+                    *idx_vol += 1.0 / vega_beta * (*idx_vol / used_vol) * (vol - used_vol);
                 }
 
-                vega *= vega_beta * vol / *idx_price;
+                #[allow(clippy::float_cmp, reason = "zero price guard")]
+                if *idx_vol != 0.0 {
+                    vega *= vega_beta * vol / *idx_vol;
+                }
             }
         }
 
         if percent_greeks {
-            if let Some(idx_price) = index_price {
+            if let Some(idx_price) = used_index_price {
                 delta *= idx_price / 100.0;
                 gamma *= (idx_price / 100.0).powi(2);
             } else {
@@ -853,8 +874,8 @@ impl GreeksCalculator {
                 gamma *= (underlying_price / 100.0).powi(2);
             }
 
-            if let Some(idx_price) = vol_index_price {
-                vega *= idx_price / 100.0;
+            if let Some(idx_vol) = used_index_vol {
+                vega *= idx_vol / 100.0;
             } else {
                 vega *= vol / 100.0;
             }
@@ -1156,6 +1177,9 @@ impl GreeksCalculator {
 
     fn get_price_object(&self, instrument_id: &InstrumentId) -> Option<Price> {
         let cache = self.cache.borrow();
+        let price = cache
+            .price(instrument_id, PriceType::Mid)
+            .or_else(|| cache.price(instrument_id, PriceType::Last));
 
         // For index-class futures, prefer tradable quotes over the published index
         // price since index price is the spot level and may diverge from futures basis.
@@ -1163,14 +1187,8 @@ impl GreeksCalculator {
         if let Some(instrument) = cache.instrument(instrument_id)
             && instrument.asset_class() == AssetClass::Index
         {
-            if instrument.instrument_class() == InstrumentClass::Future {
-                let tradable = cache
-                    .price(instrument_id, PriceType::Mid)
-                    .or_else(|| cache.price(instrument_id, PriceType::Last));
-
-                if tradable.is_some() {
-                    return tradable;
-                }
+            if instrument.instrument_class() == InstrumentClass::Future && price.is_some() {
+                return price;
             }
 
             if let Some(index_price) = cache.index_price(instrument_id) {
@@ -1178,9 +1196,7 @@ impl GreeksCalculator {
             }
         }
 
-        cache
-            .price(instrument_id, PriceType::Mid)
-            .or_else(|| cache.price(instrument_id, PriceType::Last))
+        price
     }
 
     fn get_price(&self, instrument_id: &InstrumentId) -> Option<f64> {
@@ -2009,7 +2025,7 @@ mod tests {
             )
             .unwrap();
 
-        let expected_vega = greeks.vega * 0.75 * greeks.vol / 25.0;
+        let expected_vega = greeks.vega * 0.75 * (greeks.vol * 100.0) / 25.0;
         assert_eq!(
             (vol_weighted_greeks.delta * 1e12).round(),
             (greeks.delta * 1e12).round()
@@ -2022,6 +2038,104 @@ mod tests {
             (vol_weighted_greeks.vega * 1e12).round(),
             (expected_vega * 1e12).round()
         );
+    }
+
+    #[rstest]
+    fn test_instrument_greeks_errors_when_vol_index_price_missing() {
+        let now = Utc.with_ymd_and_hms(2025, 3, 8, 12, 0, 0).unwrap();
+        let expiry = now + chrono::Duration::days(30);
+        let now_ns = UnixNanos::from(now);
+        let expiry_ns = UnixNanos::from(expiry);
+        let option = option_with_expiration("AAPL250417C00150000.OPRA", expiry_ns);
+        let option_id = option.id();
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let vol_index_id = InstrumentId::from("VIX.XCBF");
+        let cache = setup_cache_with_option_and_quotes(option, underlying_id, now_ns);
+
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let calculator = GreeksCalculator::new(cache, clock);
+        let error = calculator
+            .instrument_greeks(
+                option_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(vol_index_id),
+                None,
+            )
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "No price available for VIX.XCBF");
+    }
+
+    #[rstest]
+    fn test_modify_greeks_accepts_explicit_index_prices() {
+        let calculator = create_test_calculator();
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let mut beta_weights = HashMap::new();
+        beta_weights.insert(underlying_id, 0.5);
+        let mut vol_beta_weights = HashMap::new();
+        vol_beta_weights.insert(underlying_id, 0.75);
+
+        let (delta, gamma, vega) = calculator.modify_greeks(
+            1.0,
+            2.0,
+            underlying_id,
+            150.0,
+            150.0,
+            false,
+            None,
+            Some(&beta_weights),
+            2.0,
+            0.30,
+            0,
+            None,
+            0.0,
+            None,
+            Some(&vol_beta_weights),
+            Some(200.0),
+            Some(25.0),
+        );
+
+        assert_eq!((delta * 1e12).round(), 375_000_000_000.0);
+        assert_eq!((gamma * 1e12).round(), 281_250_000_000.0);
+        assert_eq!((vega * 1e12).round(), 1_800_000_000_000.0);
+
+        let (delta, gamma, vega) = calculator.modify_greeks(
+            1.0,
+            2.0,
+            underlying_id,
+            150.0,
+            150.0,
+            true,
+            None,
+            Some(&beta_weights),
+            2.0,
+            0.30,
+            0,
+            None,
+            0.0,
+            None,
+            Some(&vol_beta_weights),
+            Some(200.0),
+            Some(25.0),
+        );
+
+        assert_eq!((delta * 1e12).round(), 750_000_000_000.0);
+        assert_eq!((gamma * 1e12).round(), 1_125_000_000_000.0);
+        assert_eq!((vega * 1e12).round(), 4_500_000_000.0);
     }
 
     #[rstest]

--- a/crates/common/src/greeks.rs
+++ b/crates/common/src/greeks.rs
@@ -431,7 +431,7 @@ impl GreeksCalculator {
                 vega_time_weight_base,
                 vol_index_instrument_id,
                 vol_beta_weights,
-            );
+            )?;
         }
 
         if let Some(pos) = position {
@@ -476,7 +476,7 @@ impl GreeksCalculator {
             None,
             None,
             None,
-        );
+        )?;
         let mut greeks_data =
             GreeksData::from_delta(instrument_id, delta, multiplier.as_f64(), ts_event);
 
@@ -616,7 +616,7 @@ impl GreeksCalculator {
             vol_beta_weights,
             None,
             None,
-        );
+        )?;
         let greeks_data = GreeksData::new(
             utc_now_ns,
             utc_now_ns,
@@ -675,7 +675,7 @@ impl GreeksCalculator {
         vega_time_weight_base: Option<i32>,
         vol_index_instrument_id: Option<InstrumentId>,
         vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
-    ) -> GreeksData {
+    ) -> anyhow::Result<GreeksData> {
         let underlying_price = greeks_data.underlying_price;
         let shocked_underlying_price = underlying_price + spot_shock;
         let shocked_vol = greeks_data.vol + vol_shock;
@@ -709,8 +709,8 @@ impl GreeksCalculator {
             vol_beta_weights,
             None,
             None,
-        );
-        GreeksData::new(
+        )?;
+        Ok(GreeksData::new(
             greeks_data.ts_event,
             greeks_data.ts_event,
             greeks_data.instrument_id,
@@ -735,7 +735,7 @@ impl GreeksCalculator {
                 rho: 0.0,
             },
             greeks.itm_prob,
-        )
+        ))
     }
 
     fn get_underlying_price(&self, underlying_instrument_id: &InstrumentId) -> anyhow::Result<f64> {
@@ -782,6 +782,11 @@ impl GreeksCalculator {
     /// Also percent greeks assume a change of variable to percent returns by writing:
     /// V(x = x0 * (1 + `stock_percent_return` / 100))
     /// or V(I = I0 * (1 + `index_percent_return` / 100))
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `vol_index_instrument_id` is supplied and no explicit or cached
+    /// volatility index price is available.
     #[expect(clippy::too_many_arguments)]
     pub fn modify_greeks(
         &self,
@@ -802,16 +807,22 @@ impl GreeksCalculator {
         vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
         index_price: Option<f64>,
         vol_index_price: Option<f64>,
-    ) -> (f64, f64, f64) {
+    ) -> anyhow::Result<(f64, f64, f64)> {
         let mut delta = delta_input;
         let mut gamma = gamma_input;
         let mut vega = vega_input;
 
         let mut used_index_price = index_price
             .or_else(|| index_instrument_id.and_then(|index_id| self.get_price(&index_id)));
-        let mut used_index_vol = vol_index_price.or_else(|| {
-            vol_index_instrument_id.and_then(|vol_index_id| self.get_price(&vol_index_id))
-        });
+        let mut used_index_vol = vol_index_price;
+        if used_index_vol.is_none()
+            && let Some(vol_index_id) = vol_index_instrument_id
+        {
+            used_index_vol = Some(
+                self.get_price(&vol_index_id)
+                    .ok_or_else(|| anyhow::anyhow!("No price available for {vol_index_id}"))?,
+            );
+        }
 
         if used_index_price.is_some() {
             let mut beta = 1.0;
@@ -889,7 +900,7 @@ impl GreeksCalculator {
             vega *= time_weight;
         }
 
-        (delta, gamma, vega)
+        Ok((delta, gamma, vega))
     }
 
     /// Calculates the portfolio Greeks for a given set of positions.
@@ -2081,6 +2092,37 @@ mod tests {
     }
 
     #[rstest]
+    fn test_modify_greeks_errors_when_vol_index_price_missing() {
+        let calculator = create_test_calculator();
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let vol_index_id = InstrumentId::from("VIX.XCBF");
+
+        let error = calculator
+            .modify_greeks(
+                1.0,
+                2.0,
+                underlying_id,
+                150.0,
+                150.0,
+                false,
+                None,
+                None,
+                2.0,
+                0.30,
+                0,
+                None,
+                0.0,
+                Some(vol_index_id),
+                None,
+                None,
+                None,
+            )
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "No price available for VIX.XCBF");
+    }
+
+    #[rstest]
     fn test_modify_greeks_accepts_explicit_index_prices() {
         let calculator = create_test_calculator();
         let underlying_id = InstrumentId::from("AAPL.OPRA");
@@ -2089,49 +2131,53 @@ mod tests {
         let mut vol_beta_weights = HashMap::new();
         vol_beta_weights.insert(underlying_id, 0.75);
 
-        let (delta, gamma, vega) = calculator.modify_greeks(
-            1.0,
-            2.0,
-            underlying_id,
-            150.0,
-            150.0,
-            false,
-            None,
-            Some(&beta_weights),
-            2.0,
-            0.30,
-            0,
-            None,
-            0.0,
-            None,
-            Some(&vol_beta_weights),
-            Some(200.0),
-            Some(25.0),
-        );
+        let (delta, gamma, vega) = calculator
+            .modify_greeks(
+                1.0,
+                2.0,
+                underlying_id,
+                150.0,
+                150.0,
+                false,
+                None,
+                Some(&beta_weights),
+                2.0,
+                0.30,
+                0,
+                None,
+                0.0,
+                None,
+                Some(&vol_beta_weights),
+                Some(200.0),
+                Some(25.0),
+            )
+            .unwrap();
 
         assert_eq!((delta * 1e12).round(), 375_000_000_000.0);
         assert_eq!((gamma * 1e12).round(), 281_250_000_000.0);
         assert_eq!((vega * 1e12).round(), 1_800_000_000_000.0);
 
-        let (delta, gamma, vega) = calculator.modify_greeks(
-            1.0,
-            2.0,
-            underlying_id,
-            150.0,
-            150.0,
-            true,
-            None,
-            Some(&beta_weights),
-            2.0,
-            0.30,
-            0,
-            None,
-            0.0,
-            None,
-            Some(&vol_beta_weights),
-            Some(200.0),
-            Some(25.0),
-        );
+        let (delta, gamma, vega) = calculator
+            .modify_greeks(
+                1.0,
+                2.0,
+                underlying_id,
+                150.0,
+                150.0,
+                true,
+                None,
+                Some(&beta_weights),
+                2.0,
+                0.30,
+                0,
+                None,
+                0.0,
+                None,
+                Some(&vol_beta_weights),
+                Some(200.0),
+                Some(25.0),
+            )
+            .unwrap();
 
         assert_eq!((delta * 1e12).round(), 750_000_000_000.0);
         assert_eq!((gamma * 1e12).round(), 1_125_000_000_000.0);

--- a/crates/common/src/greeks.rs
+++ b/crates/common/src/greeks.rs
@@ -18,7 +18,6 @@
 use std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc};
 
 use ahash::AHashMap;
-use derive_builder::Builder;
 use nautilus_core::UnixNanos;
 use nautilus_model::{
     data::greeks::{
@@ -95,56 +94,53 @@ impl Debug for GreeksFilterCallback {
 }
 
 /// Builder for instrument greeks calculation parameters.
-#[derive(Debug, Builder)]
-#[builder(setter(into), derive(Debug))]
+#[derive(Debug, bon::Builder)]
 pub struct InstrumentGreeksParams {
     /// The instrument ID to calculate greeks for
     pub instrument_id: InstrumentId,
     /// Flat interest rate (default: 0.0425)
-    #[builder(default = "0.0425")]
+    #[builder(default = 0.0425)]
     pub flat_interest_rate: f64,
     /// Flat dividend yield
-    #[builder(default)]
     pub flat_dividend_yield: Option<f64>,
     /// Spot price shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub spot_shock: f64,
     /// Volatility shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub vol_shock: f64,
     /// Time to expiry shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub time_to_expiry_shock: f64,
     /// Whether to use cached greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub use_cached_greeks: bool,
     /// Whether to update vol from cached greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub update_vol: bool,
     /// Whether to cache greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub cache_greeks: bool,
     /// Whether to publish greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub publish_greeks: bool,
     /// Event timestamp
-    #[builder(default)]
     pub ts_event: Option<UnixNanos>,
     /// Position for PnL calculation
-    #[builder(default)]
     pub position: Option<Position>,
     /// Whether to compute percent greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub percent_greeks: bool,
     /// Index instrument ID for beta weighting
-    #[builder(default)]
     pub index_instrument_id: Option<InstrumentId>,
     /// Beta weights for portfolio calculations
-    #[builder(default)]
     pub beta_weights: Option<HashMap<InstrumentId, f64>>,
     /// Base value in days for time-weighting vega
-    #[builder(default)]
     pub vega_time_weight_base: Option<i32>,
+    /// Volatility index instrument ID for vega beta weighting, for example VIX.
+    pub vol_index_instrument_id: Option<InstrumentId>,
+    /// Volatility beta weights for portfolio vega calculations
+    pub vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
 }
 
 impl InstrumentGreeksParams {
@@ -171,71 +167,66 @@ impl InstrumentGreeksParams {
             self.index_instrument_id,
             self.beta_weights.as_ref(),
             self.vega_time_weight_base,
+            self.vol_index_instrument_id,
+            self.vol_beta_weights.as_ref(),
         )
     }
 }
 
 /// Builder for portfolio greeks calculation parameters.
-#[derive(Builder)]
-#[builder(setter(into))]
+#[derive(bon::Builder)]
 pub struct PortfolioGreeksParams {
     /// List of underlying symbols to filter by
-    #[builder(default)]
     pub underlyings: Option<Vec<String>>,
     /// Venue to filter positions by
-    #[builder(default)]
     pub venue: Option<Venue>,
     /// Instrument ID to filter positions by
-    #[builder(default)]
     pub instrument_id: Option<InstrumentId>,
     /// Strategy ID to filter positions by
-    #[builder(default)]
     pub strategy_id: Option<StrategyId>,
     /// Position side to filter by (default: `NoPositionSide`)
-    #[builder(default)]
     pub side: Option<PositionSide>,
     /// Flat interest rate (default: 0.0425)
-    #[builder(default = "0.0425")]
+    #[builder(default = 0.0425)]
     pub flat_interest_rate: f64,
     /// Flat dividend yield
-    #[builder(default)]
     pub flat_dividend_yield: Option<f64>,
     /// Spot price shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub spot_shock: f64,
     /// Volatility shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub vol_shock: f64,
     /// Time to expiry shock (default: 0.0)
-    #[builder(default = "0.0")]
+    #[builder(default = 0.0)]
     pub time_to_expiry_shock: f64,
     /// Whether to use cached greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub use_cached_greeks: bool,
     /// Whether to update vol from cached greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub update_vol: bool,
     /// Whether to cache greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub cache_greeks: bool,
     /// Whether to publish greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub publish_greeks: bool,
     /// Whether to compute percent greeks (default: false)
-    #[builder(default = "false")]
+    #[builder(default = false)]
     pub percent_greeks: bool,
     /// Index instrument ID for beta weighting
-    #[builder(default)]
     pub index_instrument_id: Option<InstrumentId>,
     /// Beta weights for portfolio calculations
-    #[builder(default)]
     pub beta_weights: Option<HashMap<InstrumentId, f64>>,
     /// Filter function for greeks
-    #[builder(default)]
     pub greeks_filter: Option<GreeksFilterCallback>,
     /// Base value in days for time-weighting vega
-    #[builder(default)]
     pub vega_time_weight_base: Option<i32>,
+    /// Volatility index instrument ID for vega beta weighting, for example VIX.
+    pub vol_index_instrument_id: Option<InstrumentId>,
+    /// Volatility beta weights for portfolio vega calculations
+    pub vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
 }
 
 impl Debug for PortfolioGreeksParams {
@@ -259,6 +250,9 @@ impl Debug for PortfolioGreeksParams {
             .field("index_instrument_id", &self.index_instrument_id)
             .field("beta_weights", &self.beta_weights)
             .field("greeks_filter", &self.greeks_filter)
+            .field("vega_time_weight_base", &self.vega_time_weight_base)
+            .field("vol_index_instrument_id", &self.vol_index_instrument_id)
+            .field("vol_beta_weights", &self.vol_beta_weights)
             .finish()
     }
 }
@@ -295,6 +289,8 @@ impl PortfolioGreeksParams {
             self.beta_weights.as_ref(),
             greeks_filter.as_ref(),
             self.vega_time_weight_base,
+            self.vol_index_instrument_id,
+            self.vol_beta_weights.as_ref(),
         )
     }
 }
@@ -336,7 +332,7 @@ impl GreeksCalculator {
     /// Additional features:
     /// - Apply shocks to the spot value of the instrument's underlying, implied volatility or time to expiry.
     /// - Compute percent greeks.
-    /// - Compute beta-weighted delta and gamma with respect to an index.
+    /// - Compute beta-weighted delta, gamma and vega with respect to an index.
     ///
     /// # Errors
     ///
@@ -364,6 +360,8 @@ impl GreeksCalculator {
         index_instrument_id: Option<InstrumentId>,
         beta_weights: Option<&HashMap<InstrumentId, f64>>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
     ) -> anyhow::Result<GreeksData> {
         // Set default values
         let flat_interest_rate = flat_interest_rate.unwrap_or(0.0425);
@@ -416,6 +414,8 @@ impl GreeksCalculator {
             index_instrument_id,
             beta_weights,
             vega_time_weight_base,
+            vol_index_instrument_id,
+            vol_beta_weights,
         )?;
 
         if spot_shock != 0.0 || vol_shock != 0.0 || time_to_expiry_shock != 0.0 {
@@ -429,6 +429,8 @@ impl GreeksCalculator {
                 index_instrument_id,
                 beta_weights,
                 vega_time_weight_base,
+                vol_index_instrument_id,
+                vol_beta_weights,
             );
         }
 
@@ -469,6 +471,9 @@ impl GreeksCalculator {
             0.0,
             0,
             None,
+            0.0,
+            None,
+            None,
         );
         let mut greeks_data =
             GreeksData::from_delta(instrument_id, delta, multiplier.as_f64(), ts_event);
@@ -498,6 +503,8 @@ impl GreeksCalculator {
         index_instrument_id: Option<InstrumentId>,
         beta_weights: Option<&HashMap<InstrumentId, f64>>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
     ) -> anyhow::Result<GreeksData> {
         if use_cached_greeks {
             let cache = self.cache.borrow();
@@ -597,6 +604,9 @@ impl GreeksCalculator {
             greeks.vol,
             expiry_in_days,
             vega_time_weight_base,
+            greeks.vol,
+            vol_index_instrument_id,
+            vol_beta_weights,
         );
         let greeks_data = GreeksData::new(
             utc_now_ns,
@@ -654,6 +664,8 @@ impl GreeksCalculator {
         index_instrument_id: Option<InstrumentId>,
         beta_weights: Option<&HashMap<InstrumentId, f64>>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
     ) -> GreeksData {
         let underlying_price = greeks_data.underlying_price;
         let shocked_underlying_price = underlying_price + spot_shock;
@@ -683,6 +695,9 @@ impl GreeksCalculator {
             shocked_vol,
             shocked_expiry_in_days,
             vega_time_weight_base,
+            greeks_data.vol,
+            vol_index_instrument_id,
+            vol_beta_weights,
         );
         GreeksData::new(
             greeks_data.ts_event,
@@ -736,7 +751,7 @@ impl GreeksCalculator {
         anyhow::bail!("No price available for {underlying_instrument_id}")
     }
 
-    /// Modifies delta and gamma based on beta weighting and percentage calculations.
+    /// Modifies delta, gamma and vega based on beta weighting and percentage calculations.
     ///
     /// The beta weighting of delta and gamma follows this equation linking the returns of a stock x to the ones of an index I:
     /// (x - x0) / x0 = alpha + beta (I - I0) / I0 + epsilon
@@ -750,6 +765,8 @@ impl GreeksCalculator {
     ///
     /// These two last equations explain the beta weighting below, considering the price of an option is V(x) and delta and gamma
     /// are the first and second derivatives respectively of V.
+    ///
+    /// Vega beta weighting follows the same change of variable with implied volatility and a volatility index.
     ///
     /// Also percent greeks assume a change of variable to percent returns by writing:
     /// V(x = x0 * (1 + `stock_percent_return` / 100))
@@ -769,21 +786,19 @@ impl GreeksCalculator {
         vol: f64,
         expiry_in_days: i32,
         vega_time_weight_base: Option<i32>,
+        unshocked_vol: f64,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
     ) -> (f64, f64, f64) {
         let mut delta = delta_input;
         let mut gamma = gamma_input;
         let mut vega = vega_input;
 
         let mut index_price = None;
+        let mut vol_index_price = None;
 
         if let Some(index_id) = index_instrument_id {
-            let cache = self.cache.borrow();
-            index_price = Some(
-                cache
-                    .price(&index_id, PriceType::Last)
-                    .unwrap_or_default()
-                    .as_f64(),
-            );
+            index_price = Some(self.get_price(&index_id).unwrap_or_default());
 
             let mut beta = 1.0;
 
@@ -807,6 +822,28 @@ impl GreeksCalculator {
             }
         }
 
+        if let Some(vol_index_id) = vol_index_instrument_id {
+            vol_index_price = Some(self.get_price(&vol_index_id).unwrap_or_default());
+
+            let mut vega_beta = 1.0;
+
+            if let Some(weights) = vol_beta_weights
+                && let Some(&weight) = weights.get(&underlying_instrument_id)
+            {
+                vega_beta = weight;
+            }
+
+            if let Some(ref mut idx_price) = vol_index_price {
+                #[allow(clippy::float_cmp, reason = "exact-equality baseline check")]
+                if vol != unshocked_vol {
+                    *idx_price +=
+                        1.0 / vega_beta * (*idx_price / unshocked_vol) * (vol - unshocked_vol);
+                }
+
+                vega *= vega_beta * vol / *idx_price;
+            }
+        }
+
         if percent_greeks {
             if let Some(idx_price) = index_price {
                 delta *= idx_price / 100.0;
@@ -816,8 +853,11 @@ impl GreeksCalculator {
                 gamma *= (underlying_price / 100.0).powi(2);
             }
 
-            // Apply percent vega when percent_greeks is True
-            vega *= vol / 100.0;
+            if let Some(idx_price) = vol_index_price {
+                vega *= idx_price / 100.0;
+            } else {
+                vega *= vol / 100.0;
+            }
         }
 
         // Apply time weighting to vega if vega_time_weight_base is provided
@@ -838,7 +878,7 @@ impl GreeksCalculator {
     /// Additional features:
     /// - Apply shocks to the spot value of an instrument's underlying, implied volatility or time to expiry.
     /// - Compute percent greeks.
-    /// - Compute beta-weighted delta and gamma with respect to an index.
+    /// - Compute beta-weighted delta, gamma and vega with respect to an index.
     ///
     /// # Errors
     ///
@@ -867,6 +907,8 @@ impl GreeksCalculator {
         beta_weights: Option<&HashMap<InstrumentId, f64>>,
         greeks_filter: Option<&GreeksFilter>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<&HashMap<InstrumentId, f64>>,
     ) -> anyhow::Result<PortfolioGreeks> {
         let ts_event = self.clock.borrow().timestamp_ns();
         let mut portfolio_greeks =
@@ -935,6 +977,8 @@ impl GreeksCalculator {
                 index_instrument_id,
                 beta_weights,
                 vega_time_weight_base,
+                vol_index_instrument_id,
+                vol_beta_weights,
             )?;
             let position_greeks = quantity * &instrument_greeks;
 
@@ -1220,10 +1264,9 @@ mod tests {
     fn test_instrument_greeks_params_builder_default() {
         let instrument_id = InstrumentId::from("AAPL.NASDAQ");
 
-        let params = InstrumentGreeksParamsBuilder::default()
+        let params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .build();
 
         assert_eq!(params.instrument_id, instrument_id);
         assert_eq!(params.flat_interest_rate, 0.0425);
@@ -1239,19 +1282,24 @@ mod tests {
         assert!(!params.percent_greeks);
         assert_eq!(params.index_instrument_id, None);
         assert_eq!(params.beta_weights, None);
+        assert_eq!(params.vol_index_instrument_id, None);
+        assert_eq!(params.vol_beta_weights, None);
     }
 
     #[rstest]
     fn test_instrument_greeks_params_builder_custom_values() {
         let instrument_id = InstrumentId::from("AAPL.NASDAQ");
         let index_id = InstrumentId::from("SPY.NASDAQ");
+        let vol_index_id = InstrumentId::from("VIX.XCBF");
         let mut beta_weights = HashMap::new();
         beta_weights.insert(instrument_id, 1.2);
+        let mut vol_beta_weights = HashMap::new();
+        vol_beta_weights.insert(instrument_id, 0.8);
 
-        let params = InstrumentGreeksParamsBuilder::default()
+        let params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
             .flat_interest_rate(0.05)
-            .flat_dividend_yield(Some(0.02))
+            .flat_dividend_yield(0.02)
             .spot_shock(0.01)
             .vol_shock(0.05)
             .time_to_expiry_shock(0.1)
@@ -1259,10 +1307,11 @@ mod tests {
             .cache_greeks(true)
             .publish_greeks(true)
             .percent_greeks(true)
-            .index_instrument_id(Some(index_id))
-            .beta_weights(Some(beta_weights.clone()))
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .index_instrument_id(index_id)
+            .beta_weights(beta_weights.clone())
+            .vol_index_instrument_id(vol_index_id)
+            .vol_beta_weights(vol_beta_weights.clone())
+            .build();
 
         assert_eq!(params.instrument_id, instrument_id);
         assert_eq!(params.flat_interest_rate, 0.05);
@@ -1276,16 +1325,17 @@ mod tests {
         assert!(params.percent_greeks);
         assert_eq!(params.index_instrument_id, Some(index_id));
         assert_eq!(params.beta_weights, Some(beta_weights));
+        assert_eq!(params.vol_index_instrument_id, Some(vol_index_id));
+        assert_eq!(params.vol_beta_weights, Some(vol_beta_weights));
     }
 
     #[rstest]
     fn test_instrument_greeks_params_debug() {
         let instrument_id = InstrumentId::from("AAPL.NASDAQ");
 
-        let params = InstrumentGreeksParamsBuilder::default()
+        let params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .build();
 
         let debug_str = format!("{params:?}");
         assert!(debug_str.contains("InstrumentGreeksParams"));
@@ -1294,9 +1344,7 @@ mod tests {
 
     #[rstest]
     fn test_portfolio_greeks_params_builder_default() {
-        let params = PortfolioGreeksParamsBuilder::default()
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+        let params = PortfolioGreeksParams::builder().build();
 
         assert_eq!(params.underlyings, None);
         assert_eq!(params.venue, None);
@@ -1314,6 +1362,8 @@ mod tests {
         assert!(!params.percent_greeks);
         assert_eq!(params.index_instrument_id, None);
         assert_eq!(params.beta_weights, None);
+        assert_eq!(params.vol_index_instrument_id, None);
+        assert_eq!(params.vol_beta_weights, None);
     }
 
     #[rstest]
@@ -1322,18 +1372,21 @@ mod tests {
         let instrument_id = InstrumentId::from("AAPL.NASDAQ");
         let strategy_id = StrategyId::from("test-strategy");
         let index_id = InstrumentId::from("SPY.NASDAQ");
+        let vol_index_id = InstrumentId::from("VIX.XCBF");
         let underlyings = vec!["AAPL".to_string(), "MSFT".to_string()];
         let mut beta_weights = HashMap::new();
         beta_weights.insert(instrument_id, 1.2);
+        let mut vol_beta_weights = HashMap::new();
+        vol_beta_weights.insert(instrument_id, 0.8);
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .underlyings(Some(underlyings.clone()))
-            .venue(Some(venue))
-            .instrument_id(Some(instrument_id))
-            .strategy_id(Some(strategy_id))
-            .side(Some(PositionSide::Long))
+        let params = PortfolioGreeksParams::builder()
+            .underlyings(underlyings.clone())
+            .venue(venue)
+            .instrument_id(instrument_id)
+            .strategy_id(strategy_id)
+            .side(PositionSide::Long)
             .flat_interest_rate(0.05)
-            .flat_dividend_yield(Some(0.02))
+            .flat_dividend_yield(0.02)
             .spot_shock(0.01)
             .vol_shock(0.05)
             .time_to_expiry_shock(0.1)
@@ -1341,10 +1394,11 @@ mod tests {
             .cache_greeks(true)
             .publish_greeks(true)
             .percent_greeks(true)
-            .index_instrument_id(Some(index_id))
-            .beta_weights(Some(beta_weights.clone()))
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .index_instrument_id(index_id)
+            .beta_weights(beta_weights.clone())
+            .vol_index_instrument_id(vol_index_id)
+            .vol_beta_weights(vol_beta_weights.clone())
+            .build();
 
         assert_eq!(params.underlyings, Some(underlyings));
         assert_eq!(params.venue, Some(venue));
@@ -1362,16 +1416,15 @@ mod tests {
         assert!(params.percent_greeks);
         assert_eq!(params.index_instrument_id, Some(index_id));
         assert_eq!(params.beta_weights, Some(beta_weights));
+        assert_eq!(params.vol_index_instrument_id, Some(vol_index_id));
+        assert_eq!(params.vol_beta_weights, Some(vol_beta_weights));
     }
 
     #[rstest]
     fn test_portfolio_greeks_params_debug() {
         let venue = Venue::from("NASDAQ");
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .venue(Some(venue))
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+        let params = PortfolioGreeksParams::builder().venue(venue).build();
 
         let debug_str = format!("{params:?}");
         assert!(debug_str.contains("PortfolioGreeksParams"));
@@ -1379,23 +1432,15 @@ mod tests {
     }
 
     #[rstest]
-    fn test_instrument_greeks_params_builder_missing_required_field() {
-        // Test that building without required instrument_id fails
-        let result = InstrumentGreeksParamsBuilder::default().build();
-        assert!(result.is_err());
-    }
-
-    #[rstest]
     fn test_portfolio_greeks_params_builder_fluent_api() {
         let instrument_id = InstrumentId::from("AAPL.NASDAQ");
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .instrument_id(Some(instrument_id))
+        let params = PortfolioGreeksParams::builder()
+            .instrument_id(instrument_id)
             .flat_interest_rate(0.05)
             .spot_shock(0.01)
             .percent_greeks(true)
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .build();
 
         assert_eq!(params.instrument_id, Some(instrument_id));
         assert_eq!(params.flat_interest_rate, 0.05);
@@ -1408,15 +1453,14 @@ mod tests {
         let instrument_id = InstrumentId::from("TSLA.NASDAQ");
 
         // Test fluent API chaining
-        let params = InstrumentGreeksParamsBuilder::default()
+        let params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
             .flat_interest_rate(0.03)
             .spot_shock(0.02)
             .vol_shock(0.1)
             .use_cached_greeks(true)
             .percent_greeks(true)
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .build();
 
         assert_eq!(params.instrument_id, instrument_id);
         assert_eq!(params.flat_interest_rate, 0.03);
@@ -1430,11 +1474,10 @@ mod tests {
     fn test_portfolio_greeks_params_builder_with_underlyings() {
         let underlyings = vec!["AAPL".to_string(), "MSFT".to_string(), "GOOGL".to_string()];
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .underlyings(Some(underlyings.clone()))
+        let params = PortfolioGreeksParams::builder()
+            .underlyings(underlyings.clone())
             .flat_interest_rate(0.04)
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .build();
 
         assert_eq!(params.underlyings, Some(underlyings));
         assert_eq!(params.flat_interest_rate, 0.04);
@@ -1445,42 +1488,42 @@ mod tests {
         let instrument_id = InstrumentId::from("NVDA.NASDAQ");
         let empty_beta_weights = HashMap::new();
 
-        let instrument_params = InstrumentGreeksParamsBuilder::default()
+        let instrument_params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
-            .beta_weights(Some(empty_beta_weights.clone()))
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .beta_weights(empty_beta_weights.clone())
+            .vol_beta_weights(empty_beta_weights.clone())
+            .build();
 
-        let portfolio_params = PortfolioGreeksParamsBuilder::default()
-            .beta_weights(Some(empty_beta_weights.clone()))
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+        let portfolio_params = PortfolioGreeksParams::builder()
+            .beta_weights(empty_beta_weights.clone())
+            .vol_beta_weights(empty_beta_weights.clone())
+            .build();
 
         assert_eq!(
             instrument_params.beta_weights,
             Some(empty_beta_weights.clone())
         );
         assert_eq!(portfolio_params.beta_weights, Some(empty_beta_weights));
+        assert_eq!(instrument_params.vol_beta_weights, Some(HashMap::new()));
+        assert_eq!(portfolio_params.vol_beta_weights, Some(HashMap::new()));
     }
 
     #[rstest]
     fn test_builders_with_all_shocks() {
         let instrument_id = InstrumentId::from("AMD.NASDAQ");
 
-        let instrument_params = InstrumentGreeksParamsBuilder::default()
+        let instrument_params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
             .spot_shock(0.05)
             .vol_shock(0.1)
             .time_to_expiry_shock(0.01)
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .build();
 
-        let portfolio_params = PortfolioGreeksParamsBuilder::default()
+        let portfolio_params = PortfolioGreeksParams::builder()
             .spot_shock(0.05)
             .vol_shock(0.1)
             .time_to_expiry_shock(0.01)
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .build();
 
         assert_eq!(instrument_params.spot_shock, 0.05);
         assert_eq!(instrument_params.vol_shock, 0.1);
@@ -1495,22 +1538,20 @@ mod tests {
     fn test_builders_with_all_boolean_flags() {
         let instrument_id = InstrumentId::from("META.NASDAQ");
 
-        let instrument_params = InstrumentGreeksParamsBuilder::default()
+        let instrument_params = InstrumentGreeksParams::builder()
             .instrument_id(instrument_id)
             .use_cached_greeks(true)
             .cache_greeks(true)
             .publish_greeks(true)
             .percent_greeks(true)
-            .build()
-            .expect("Failed to build InstrumentGreeksParams");
+            .build();
 
-        let portfolio_params = PortfolioGreeksParamsBuilder::default()
+        let portfolio_params = PortfolioGreeksParams::builder()
             .use_cached_greeks(true)
             .cache_greeks(true)
             .publish_greeks(true)
             .percent_greeks(true)
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .build();
 
         assert!(instrument_params.use_cached_greeks);
         assert!(instrument_params.cache_greeks);
@@ -1597,11 +1638,10 @@ mod tests {
 
         let filter = GreeksFilterCallback::from_fn(filter_high_delta);
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .greeks_filter(Some(filter))
+        let params = PortfolioGreeksParams::builder()
+            .greeks_filter(filter)
             .flat_interest_rate(0.05)
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+            .build();
 
         assert!(params.greeks_filter.is_some());
         assert_eq!(params.flat_interest_rate, 0.05);
@@ -1624,10 +1664,9 @@ mod tests {
         let filter =
             GreeksFilterCallback::from_closure(move |data: &GreeksData| data.gamma > min_gamma);
 
-        let params = PortfolioGreeksParamsBuilder::default()
-            .greeks_filter(Some(filter))
-            .build()
-            .expect("Failed to build PortfolioGreeksParams");
+        let params = PortfolioGreeksParams::builder()
+            .greeks_filter(filter)
+            .build();
 
         assert!(params.greeks_filter.is_some());
 
@@ -1847,6 +1886,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
             )
             .unwrap();
 
@@ -1885,11 +1926,102 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
             )
             .unwrap();
 
         assert_eq!(greeks.expiry_in_days, 1);
         assert!((greeks.expiry_in_years - 1.0 / 365.25).abs() < 1e-9);
+    }
+
+    #[rstest]
+    fn test_instrument_greeks_beta_weights_vega_to_vol_index() {
+        let now = Utc.with_ymd_and_hms(2025, 3, 8, 12, 0, 0).unwrap();
+        let expiry = now + chrono::Duration::days(30);
+        let now_ns = UnixNanos::from(now);
+        let expiry_ns = UnixNanos::from(expiry);
+        let option = option_with_expiration("AAPL250417C00150000.OPRA", expiry_ns);
+        let option_id = option.id();
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let vol_index_id = InstrumentId::from("VIX.XCBF");
+        let cache = setup_cache_with_option_and_quotes(option, underlying_id, now_ns);
+        cache
+            .borrow_mut()
+            .add_quote(QuoteTick::new(
+                vol_index_id,
+                Price::from("25.00"),
+                Price::from("25.00"),
+                Quantity::from(100),
+                Quantity::from(100),
+                now_ns,
+                now_ns,
+            ))
+            .unwrap();
+
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let calculator = GreeksCalculator::new(cache, clock);
+        let greeks = calculator
+            .instrument_greeks(
+                option_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let mut vol_beta_weights = HashMap::new();
+        vol_beta_weights.insert(underlying_id, 0.75);
+        let vol_weighted_greeks = calculator
+            .instrument_greeks(
+                option_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(vol_index_id),
+                Some(&vol_beta_weights),
+            )
+            .unwrap();
+
+        let expected_vega = greeks.vega * 0.75 * greeks.vol / 25.0;
+        assert_eq!(
+            (vol_weighted_greeks.delta * 1e12).round(),
+            (greeks.delta * 1e12).round()
+        );
+        assert_eq!(
+            (vol_weighted_greeks.gamma * 1e12).round(),
+            (greeks.gamma * 1e12).round()
+        );
+        assert_eq!(
+            (vol_weighted_greeks.vega * 1e12).round(),
+            (expected_vega * 1e12).round()
+        );
     }
 
     #[rstest]
@@ -1969,6 +2101,8 @@ mod tests {
                 None,
                 None,
                 Some(now_ns),
+                None,
+                None,
                 None,
                 None,
                 None,
@@ -2200,6 +2334,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
             )
             .unwrap();
 
@@ -2273,6 +2409,8 @@ mod tests {
                 None,
                 None,
                 Some(now_ns),
+                None,
+                None,
                 None,
                 None,
                 None,
@@ -2360,6 +2498,8 @@ mod tests {
                 None,
                 None,
                 Some(now_ns),
+                None,
+                None,
                 None,
                 None,
                 None,

--- a/crates/common/src/python/greeks.rs
+++ b/crates/common/src/python/greeks.rs
@@ -70,7 +70,9 @@ impl PyGreeksCalculator {
             percent_greeks=false,
             index_instrument_id=None,
             beta_weights=None,
-            vega_time_weight_base=None
+            vega_time_weight_base=None,
+            vol_index_instrument_id=None,
+            vol_beta_weights=None
         )
     )]
     fn py_instrument_greeks(
@@ -90,6 +92,8 @@ impl PyGreeksCalculator {
         index_instrument_id: Option<InstrumentId>,
         beta_weights: Option<HashMap<InstrumentId, f64>>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
     ) -> PyResult<GreeksData> {
         self.0
             .instrument_greeks(
@@ -109,6 +113,8 @@ impl PyGreeksCalculator {
                 index_instrument_id,
                 beta_weights.as_ref(),
                 vega_time_weight_base,
+                vol_index_instrument_id,
+                vol_beta_weights.as_ref(),
             )
             .map_err(to_pyvalue_err)
     }
@@ -128,7 +134,10 @@ impl PyGreeksCalculator {
             vega_input=0.0,
             vol=0.0,
             expiry_in_days=0,
-            vega_time_weight_base=None
+            vega_time_weight_base=None,
+            unshocked_vol=0.0,
+            vol_index_instrument_id=None,
+            vol_beta_weights=None
         )
     )]
     fn py_modify_greeks(
@@ -145,6 +154,9 @@ impl PyGreeksCalculator {
         vol: f64,
         expiry_in_days: i32,
         vega_time_weight_base: Option<i32>,
+        unshocked_vol: f64,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
     ) -> (f64, f64, f64) {
         self.0.modify_greeks(
             delta_input,
@@ -159,6 +171,9 @@ impl PyGreeksCalculator {
             vol,
             expiry_in_days,
             vega_time_weight_base,
+            unshocked_vol,
+            vol_index_instrument_id,
+            vol_beta_weights.as_ref(),
         )
     }
 
@@ -183,7 +198,9 @@ impl PyGreeksCalculator {
             index_instrument_id=None,
             beta_weights=None,
             greeks_filter=None,
-            vega_time_weight_base=None
+            vega_time_weight_base=None,
+            vol_index_instrument_id=None,
+            vol_beta_weights=None
         )
     )]
     fn py_portfolio_greeks(
@@ -206,6 +223,8 @@ impl PyGreeksCalculator {
         beta_weights: Option<HashMap<InstrumentId, f64>>,
         greeks_filter: Option<Py<PyAny>>,
         vega_time_weight_base: Option<i32>,
+        vol_index_instrument_id: Option<InstrumentId>,
+        vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
     ) -> PyResult<PortfolioGreeks> {
         let greeks_filter: Option<GreeksFilter> = greeks_filter.map(|callback| {
             Box::new(move |data: &GreeksData| {
@@ -240,6 +259,8 @@ impl PyGreeksCalculator {
                 beta_weights.as_ref(),
                 greeks_filter.as_ref(),
                 vega_time_weight_base,
+                vol_index_instrument_id,
+                vol_beta_weights.as_ref(),
             )
             .map_err(to_pyvalue_err)
     }

--- a/crates/common/src/python/greeks.rs
+++ b/crates/common/src/python/greeks.rs
@@ -137,7 +137,9 @@ impl PyGreeksCalculator {
             vega_time_weight_base=None,
             unshocked_vol=0.0,
             vol_index_instrument_id=None,
-            vol_beta_weights=None
+            vol_beta_weights=None,
+            index_price=None,
+            vol_index_price=None
         )
     )]
     fn py_modify_greeks(
@@ -157,6 +159,8 @@ impl PyGreeksCalculator {
         unshocked_vol: f64,
         vol_index_instrument_id: Option<InstrumentId>,
         vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
+        index_price: Option<f64>,
+        vol_index_price: Option<f64>,
     ) -> (f64, f64, f64) {
         self.0.modify_greeks(
             delta_input,
@@ -174,6 +178,8 @@ impl PyGreeksCalculator {
             unshocked_vol,
             vol_index_instrument_id,
             vol_beta_weights.as_ref(),
+            index_price,
+            vol_index_price,
         )
     }
 

--- a/crates/common/src/python/greeks.rs
+++ b/crates/common/src/python/greeks.rs
@@ -161,26 +161,28 @@ impl PyGreeksCalculator {
         vol_beta_weights: Option<HashMap<InstrumentId, f64>>,
         index_price: Option<f64>,
         vol_index_price: Option<f64>,
-    ) -> (f64, f64, f64) {
-        self.0.modify_greeks(
-            delta_input,
-            gamma_input,
-            underlying_instrument_id,
-            underlying_price,
-            unshocked_underlying_price,
-            percent_greeks,
-            index_instrument_id,
-            beta_weights.as_ref(),
-            vega_input,
-            vol,
-            expiry_in_days,
-            vega_time_weight_base,
-            unshocked_vol,
-            vol_index_instrument_id,
-            vol_beta_weights.as_ref(),
-            index_price,
-            vol_index_price,
-        )
+    ) -> PyResult<(f64, f64, f64)> {
+        self.0
+            .modify_greeks(
+                delta_input,
+                gamma_input,
+                underlying_instrument_id,
+                underlying_price,
+                unshocked_underlying_price,
+                percent_greeks,
+                index_instrument_id,
+                beta_weights.as_ref(),
+                vega_input,
+                vol,
+                expiry_in_days,
+                vega_time_weight_base,
+                unshocked_vol,
+                vol_index_instrument_id,
+                vol_beta_weights.as_ref(),
+                index_price,
+                vol_index_price,
+            )
+            .map_err(to_pyvalue_err)
     }
 
     #[expect(clippy::too_many_arguments, clippy::needless_pass_by_value)]

--- a/nautilus_trader/model/greeks.pxd
+++ b/nautilus_trader/model/greeks.pxd
@@ -29,8 +29,8 @@ cdef class GreeksCalculator:
     cdef dict _cached_futures_spreads
     cdef Price _get_underlying_price(self, InstrumentId underlying_instrument_id)
     cdef object _calculate_non_option_greeks(self, object instrument, InstrumentId instrument_id, double spot_shock, uint64_t ts_event, object position, bint percent_greeks, object index_instrument_id, object beta_weights)
-    cdef object _calculate_option_greeks(self, object instrument, InstrumentId instrument_id, InstrumentId underlying_instrument_id, double flat_interest_rate, object flat_dividend_yield, bint use_cached_greeks, bint update_vol, bint cache_greeks, uint64_t ts_event, bint percent_greeks, object index_instrument_id, object beta_weights, object vega_time_weight_base)
-    cdef object _apply_option_greeks_shocks(self, object greeks_data, InstrumentId underlying_instrument_id, double spot_shock, double vol_shock, double time_to_expiry_shock, bint percent_greeks, object index_instrument_id, object beta_weights, object vega_time_weight_base)
+    cdef object _calculate_option_greeks(self, object instrument, InstrumentId instrument_id, InstrumentId underlying_instrument_id, double flat_interest_rate, object flat_dividend_yield, bint use_cached_greeks, bint update_vol, bint cache_greeks, uint64_t ts_event, bint percent_greeks, object index_instrument_id, object beta_weights, object vega_time_weight_base, object vol_index_instrument_id, object vol_beta_weights)
+    cdef object _apply_option_greeks_shocks(self, object greeks_data, InstrumentId underlying_instrument_id, double spot_shock, double vol_shock, double time_to_expiry_shock, bint percent_greeks, object index_instrument_id, object beta_weights, object vega_time_weight_base, object vol_index_instrument_id, object vol_beta_weights)
     cpdef object get_cached_futures_spread_price(self, InstrumentId underlying_instrument_id)
     cdef double _calculate_implied_future_price(self, object call_instrument, Price call_price, Price put_price)
     cdef Price _get_price(self, InstrumentId instrument_id)

--- a/nautilus_trader/model/greeks.pyx
+++ b/nautilus_trader/model/greeks.pyx
@@ -508,6 +508,8 @@ cdef class GreeksCalculator:
 
         if used_index_vol is None and vol_index_instrument_id is not None:
             used_index_vol = self._get_price(vol_index_instrument_id)
+            if used_index_vol is None:
+                raise ValueError(f"No price available for {vol_index_instrument_id}")
 
         if used_index_vol is not None:
             used_index_vol = float(used_index_vol) * 0.01

--- a/nautilus_trader/model/greeks.pyx
+++ b/nautilus_trader/model/greeks.pyx
@@ -98,6 +98,8 @@ cdef class GreeksCalculator:
         index_instrument_id: InstrumentId | None = None,
         beta_weights: dict[InstrumentId, float] | None = None,
         vega_time_weight_base: int | None = None,
+        vol_index_instrument_id: InstrumentId | None = None,
+        vol_beta_weights: dict[InstrumentId, float] | None = None,
     ) -> GreeksData | None:
         """
         Calculate option or underlying greeks for a given instrument and a quantity of 1.
@@ -105,7 +107,7 @@ cdef class GreeksCalculator:
         Additional features:
         - Apply shocks to the spot value of the instrument's underlying, implied volatility or time to expiry.
         - Compute percent greeks.
-        - Compute beta-weighted delta and gamma with respect to an index.
+        - Compute beta-weighted delta, gamma and vega with respect to an index.
         - Update volatility to a target price from a previously calculated volatility.
 
         Parameters
@@ -145,6 +147,10 @@ cdef class GreeksCalculator:
         vega_time_weight_base : int, optional
             Base value in days for time-weighting vega. When provided, vega is multiplied by sqrt(vega_time_weight_base / expiry_in_days).
             Also enables percent vega calculation where vega is multiplied by vol / 100.
+        vol_index_instrument_id : InstrumentId, optional
+            The reference volatility instrument id vega beta is computed with respect to, for example VIX.
+        vol_beta_weights : dict[InstrumentId, float], optional
+            Dictionary of volatility beta weights used to compute portfolio vega.
 
         Returns
         -------
@@ -168,7 +174,7 @@ cdef class GreeksCalculator:
         cdef object greeks_data = self._calculate_option_greeks(
             instrument, instrument_id, underlying_instrument_id, flat_interest_rate, flat_dividend_yield,
             use_cached_greeks, update_vol, cache_greeks, ts_event, percent_greeks, index_instrument_id,
-            beta_weights, vega_time_weight_base
+            beta_weights, vega_time_weight_base, vol_index_instrument_id, vol_beta_weights
         )
         if greeks_data is None:
             return None
@@ -176,7 +182,8 @@ cdef class GreeksCalculator:
         if spot_shock != 0. or vol_shock != 0. or time_to_expiry_shock != 0.:
             greeks_data = self._apply_option_greeks_shocks(
                 greeks_data, underlying_instrument_id, spot_shock, vol_shock, time_to_expiry_shock, percent_greeks,
-                index_instrument_id, beta_weights, vega_time_weight_base
+                index_instrument_id, beta_weights, vega_time_weight_base, vol_index_instrument_id,
+                vol_beta_weights
             )
 
         if position is not None:
@@ -208,7 +215,7 @@ cdef class GreeksCalculator:
         delta, _, _ = self.modify_greeks(
             1., 0., underlying_instrument_id, underlying_price + spot_shock, underlying_price,
             percent_greeks, index_instrument_id, beta_weights, 0.0, 0.0, 0,
-            None
+            None, 0.0, None, None
         )
         cdef object greeks_data = GreeksData.from_delta(instrument_id, delta, multiplier, ts_event)
 
@@ -233,6 +240,8 @@ cdef class GreeksCalculator:
         object index_instrument_id,
         object beta_weights,
         object vega_time_weight_base,
+        object vol_index_instrument_id,
+        object vol_beta_weights,
     ):
         cdef double cost_of_carry = 0.
         cdef object greeks_data = None
@@ -302,7 +311,8 @@ cdef class GreeksCalculator:
 
         delta, gamma, vega = self.modify_greeks(
             greeks.delta, greeks.gamma, underlying_instrument_id, underlying_price, underlying_price, percent_greeks,
-            index_instrument_id, beta_weights, greeks.vega, greeks.vol, expiry_in_days, vega_time_weight_base
+            index_instrument_id, beta_weights, greeks.vega, greeks.vol, expiry_in_days, vega_time_weight_base,
+            greeks.vol, vol_index_instrument_id, vol_beta_weights
         )
 
         greeks_data = GreeksData(
@@ -327,6 +337,8 @@ cdef class GreeksCalculator:
         object index_instrument_id,
         object beta_weights,
         object vega_time_weight_base,
+        object vol_index_instrument_id,
+        object vol_beta_weights,
     ):
         cdef double underlying_price = greeks_data.underlying_price
         cdef double shocked_underlying_price = underlying_price + spot_shock
@@ -344,7 +356,7 @@ cdef class GreeksCalculator:
         delta, gamma, vega = self.modify_greeks(
             greeks.delta, greeks.gamma, underlying_instrument_id, shocked_underlying_price, underlying_price,
             percent_greeks, index_instrument_id, beta_weights, greeks.vega, shocked_vol, shocked_expiry_in_days,
-            vega_time_weight_base
+            vega_time_weight_base, greeks_data.vol, vol_index_instrument_id, vol_beta_weights
         )
 
         return GreeksData(
@@ -376,36 +388,6 @@ cdef class GreeksCalculator:
         self._log.warning(f"No price available for {underlying_instrument_id}")
         return None
 
-    cdef Price _get_price(self, InstrumentId instrument_id):
-        # For index-class futures, prefer tradable quotes over the published index
-        # price since index price is the spot level and may diverge from futures basis.
-        # For true index instruments (non-futures), prefer the published index price.
-        cdef object instrument = self._cache.instrument(instrument_id)
-        cdef IndexPriceUpdate index_price
-        cdef Price price
-        if instrument is not None and instrument.asset_class is AssetClass.INDEX:
-            if instrument.instrument_class is InstrumentClass.FUTURE:
-                price = self._cache.price(instrument_id, PriceType.MID)
-                if price is not None:
-                    return price
-                price = self._cache.price(instrument_id, PriceType.LAST)
-                if price is not None:
-                    return price
-            index_price = self._cache.index_price(instrument_id)
-            if index_price is not None:
-                return index_price.value
-
-        price = self._cache.price(instrument_id, PriceType.MID)
-        if price is not None:
-            return price
-
-        price = self._cache.price(instrument_id, PriceType.LAST)
-        if price is not None:
-            return price
-
-        self._log.warning(f"No price available for {instrument_id}")
-        return None
-
     def modify_greeks(
         self,
         delta_input: float,
@@ -420,9 +402,12 @@ cdef class GreeksCalculator:
         vol: float = 0.0,
         expiry_in_days: int = 0,
         vega_time_weight_base: int | None = None,
+        unshocked_vol: float = 0.0,
+        vol_index_instrument_id: InstrumentId | None = None,
+        vol_beta_weights: dict[InstrumentId, float] | None = None,
     ) -> tuple[float, float, float]:
         """
-        Modify delta and gamma based on beta weighting and percentage calculations.
+        Modify delta, gamma and vega based on beta weighting and percentage calculations.
 
         Parameters
         ----------
@@ -450,6 +435,12 @@ cdef class GreeksCalculator:
             Days to expiry.
         vega_time_weight_base : int, optional
             Base value in days for time-weighting vega.
+        unshocked_vol : float, default 0.0
+            The base implied volatility before shocks.
+        vol_index_instrument_id : InstrumentId, optional
+            The reference volatility instrument id vega beta is computed with respect to, for example VIX.
+        vol_beta_weights : dict[InstrumentId, float], optional
+            Dictionary of volatility beta weights used to compute portfolio vega.
 
         Returns
         -------
@@ -471,6 +462,8 @@ cdef class GreeksCalculator:
         These two last equations explain the beta weighting below, considering the price of an option is V(x) and delta and gamma
         are the first and second derivatives respectively of V.
 
+        Vega beta weighting follows the same change of variable with implied volatility and a volatility index.
+
         Also percent greeks assume a change of variable to percent returns by writing:
         V(x = x0 * (1 + stock_percent_return / 100))
         or V(I = I0 * (1 + index_percent_return / 100))
@@ -479,11 +472,13 @@ cdef class GreeksCalculator:
         cdef double gamma = gamma_input
         cdef double vega = vega_input
         cdef object index_price = None
+        cdef object vol_index_price = None
         cdef double delta_multiplier = 1.0
         cdef double beta = 1.
+        cdef double vega_beta = 1.
 
         if index_instrument_id is not None:
-            index_price = float(self._cache.price(index_instrument_id, PriceType.LAST))
+            index_price = float(self._get_price(index_instrument_id))
 
             if beta_weights is not None:
                 beta = beta_weights.get(underlying_instrument_id, 1.0)
@@ -495,6 +490,19 @@ cdef class GreeksCalculator:
             delta *= delta_multiplier
             gamma *= delta_multiplier ** 2
 
+        if vol_index_instrument_id is not None:
+            vol_index_price = float(self._get_price(vol_index_instrument_id))
+
+            if vol_beta_weights is not None:
+                vega_beta = vol_beta_weights.get(underlying_instrument_id, 1.0)
+
+            if vol != unshocked_vol:
+                vol_index_price += (
+                    1. / vega_beta * (vol_index_price / unshocked_vol) * (vol - unshocked_vol)
+                )
+
+            vega *= vega_beta * vol / vol_index_price
+
         if percent_greeks:
             if index_price is None:
                 delta *= underlying_price / 100.
@@ -503,15 +511,50 @@ cdef class GreeksCalculator:
                 delta *= index_price / 100.
                 gamma *= (index_price / 100.) ** 2
 
-            vega = vega * vol / 100.0
+            if vol_index_price is None:
+                vega *= vol / 100.0
+            else:
+                vega *= vol_index_price / 100.0
 
-        # Apply time weighting to vega if vega_time_weight_base is provided
         cdef double time_weight
         if vega_time_weight_base is not None and expiry_in_days > 0:
             time_weight = (vega_time_weight_base / expiry_in_days) ** 0.5
             vega *= time_weight
 
         return delta, gamma, vega
+
+    cdef Price _get_price(self, InstrumentId instrument_id):
+        # For index-class futures, prefer tradable quotes over the published index
+        # price since index price is the spot level and may diverge from futures basis.
+        # For true index instruments (non-futures), prefer the published index price.
+        cdef object instrument = self._cache.instrument(instrument_id)
+        cdef IndexPriceUpdate index_price
+        cdef Price price
+        if instrument is not None and instrument.asset_class is AssetClass.INDEX:
+            if instrument.instrument_class is InstrumentClass.FUTURE:
+                price = self._cache.price(instrument_id, PriceType.MID)
+                if price is not None:
+                    return price
+
+                price = self._cache.price(instrument_id, PriceType.LAST)
+                if price is not None:
+                    return price
+
+            index_price = self._cache.index_price(instrument_id)
+            if index_price is not None:
+                return index_price.value
+
+        price = self._cache.price(instrument_id, PriceType.MID)
+        if price is not None:
+            return price
+
+        price = self._cache.price(instrument_id, PriceType.LAST)
+        if price is not None:
+            return price
+
+        self._log.warning(f"No price available for {instrument_id}")
+
+        return None
 
     def portfolio_greeks(
         self,
@@ -533,6 +576,8 @@ cdef class GreeksCalculator:
         beta_weights: dict[InstrumentId, float] | None = None,
         greeks_filter: callable | None = None,
         vega_time_weight_base: int | None = None,
+        vol_index_instrument_id: InstrumentId | None = None,
+        vol_beta_weights: dict[InstrumentId, float] | None = None,
     ) -> PortfolioGreeks | None:
         """
         Calculate the portfolio Greeks for a given set of positions.
@@ -542,7 +587,7 @@ cdef class GreeksCalculator:
         Additional features:
         - Apply shocks to the spot value of an instrument's underlying, implied volatility or time to expiry.
         - Compute percent greeks.
-        - Compute beta-weighted delta and gamma with respect to an index.
+        - Compute beta-weighted delta, gamma and vega with respect to an index.
         - Update volatility to a target price from a previously calculated volatility.
 
         Parameters
@@ -591,6 +636,10 @@ cdef class GreeksCalculator:
         vega_time_weight_base : int, optional
             Base value in days for time-weighting vega. When provided, vega is multiplied by sqrt(vega_time_weight_base / expiry_in_days).
             Also enables percent vega calculation where vega is multiplied by vol / 100.
+        vol_index_instrument_id : InstrumentId, optional
+            The reference volatility instrument id vega beta is computed with respect to, for example VIX.
+        vol_beta_weights : dict[InstrumentId, float], optional
+            Dictionary of volatility beta weights used to compute portfolio vega.
 
         Returns
         -------
@@ -633,6 +682,7 @@ cdef class GreeksCalculator:
                 position_instrument_id, flat_interest_rate, flat_dividend_yield, spot_shock, vol_shock,
                 time_to_expiry_shock, use_cached_greeks, update_vol, cache_greeks, ts_event, position,
                 percent_greeks, index_instrument_id, beta_weights, vega_time_weight_base,
+                vol_index_instrument_id, vol_beta_weights,
             )
             if instrument_greeks is None:
                 self._log.warning(f"No greeks available for underlying {position_instrument_id}")

--- a/nautilus_trader/model/greeks.pyx
+++ b/nautilus_trader/model/greeks.pyx
@@ -146,7 +146,7 @@ cdef class GreeksCalculator:
             Dictionary of beta weights used to compute portfolio delta and gamma.
         vega_time_weight_base : int, optional
             Base value in days for time-weighting vega. When provided, vega is multiplied by sqrt(vega_time_weight_base / expiry_in_days).
-            Also enables percent vega calculation where vega is multiplied by vol / 100.
+            Also enables percent vega calculation where vega is multiplied by vol * 0.01
         vol_index_instrument_id : InstrumentId, optional
             The reference volatility instrument id vega beta is computed with respect to, for example VIX.
         vol_beta_weights : dict[InstrumentId, float], optional
@@ -285,6 +285,9 @@ cdef class GreeksCalculator:
         if underlying_price_obj is None:
             return None
 
+        if vol_index_instrument_id is not None and self._get_price(vol_index_instrument_id) is None:
+            return None
+
         cdef double option_price = float(option_price_obj)
         cdef double underlying_price = float(underlying_price_obj)
 
@@ -405,6 +408,8 @@ cdef class GreeksCalculator:
         unshocked_vol: float = 0.0,
         vol_index_instrument_id: InstrumentId | None = None,
         vol_beta_weights: dict[InstrumentId, float] | None = None,
+        index_price: float | None = None,
+        vol_index_price: float | None = None,
     ) -> tuple[float, float, float]:
         """
         Modify delta, gamma and vega based on beta weighting and percentage calculations.
@@ -441,6 +446,10 @@ cdef class GreeksCalculator:
             The reference volatility instrument id vega beta is computed with respect to, for example VIX.
         vol_beta_weights : dict[InstrumentId, float], optional
             Dictionary of volatility beta weights used to compute portfolio vega.
+        index_price : float, optional
+            Explicit beta index price to use instead of looking up index_instrument_id in the cache.
+        vol_index_price : float, optional
+            Explicit volatility index price to use instead of looking up vol_index_instrument_id in the cache.
 
         Returns
         -------
@@ -471,50 +480,63 @@ cdef class GreeksCalculator:
         cdef double delta = delta_input
         cdef double gamma = gamma_input
         cdef double vega = vega_input
-        cdef object index_price = None
-        cdef object vol_index_price = None
+        cdef object used_index_price = index_price
+        cdef object used_index_vol = vol_index_price
         cdef double delta_multiplier = 1.0
         cdef double beta = 1.
         cdef double vega_beta = 1.
+        cdef double used_vol = vol
 
-        if index_instrument_id is not None:
-            index_price = float(self._get_price(index_instrument_id))
+        if unshocked_vol != 0.0:
+            used_vol = unshocked_vol
+
+        if used_index_price is None and index_instrument_id is not None:
+            used_index_price = self._get_price(index_instrument_id)
+
+        if used_index_price is not None:
+            used_index_price = float(used_index_price)
 
             if beta_weights is not None:
                 beta = beta_weights.get(underlying_instrument_id, 1.0)
 
             if underlying_price != unshocked_underlying_price:
-                index_price += 1. / beta * (index_price / unshocked_underlying_price) * (underlying_price - unshocked_underlying_price)
+                used_index_price += 1. / beta * (used_index_price / unshocked_underlying_price) * (underlying_price - unshocked_underlying_price)
 
-            delta_multiplier = beta * underlying_price / index_price
+            delta_multiplier = beta * underlying_price / used_index_price
             delta *= delta_multiplier
             gamma *= delta_multiplier ** 2
 
-        if vol_index_instrument_id is not None:
-            vol_index_price = float(self._get_price(vol_index_instrument_id))
+        if used_index_vol is None and vol_index_instrument_id is not None:
+            used_index_vol = self._get_price(vol_index_instrument_id)
+
+        if used_index_vol is not None:
+            used_index_vol = float(used_index_vol) * 0.01
 
             if vol_beta_weights is not None:
                 vega_beta = vol_beta_weights.get(underlying_instrument_id, 1.0)
 
-            if vol != unshocked_vol:
-                vol_index_price += (
-                    1. / vega_beta * (vol_index_price / unshocked_vol) * (vol - unshocked_vol)
+            if vol != used_vol and used_vol != 0.0:
+                used_index_vol += (
+                    1. / vega_beta
+                    * (used_index_vol / used_vol)
+                    * (vol - used_vol)
                 )
 
-            vega *= vega_beta * vol / vol_index_price
+            if used_index_vol != 0.0:
+                vega *= vega_beta * vol / used_index_vol
 
         if percent_greeks:
-            if index_price is None:
-                delta *= underlying_price / 100.
-                gamma *= (underlying_price / 100.) ** 2
+            if used_index_price is None:
+                delta *= underlying_price * 0.01
+                gamma *= (underlying_price * 0.01) ** 2
             else:
-                delta *= index_price / 100.
-                gamma *= (index_price / 100.) ** 2
+                delta *= used_index_price * 0.01
+                gamma *= (used_index_price * 0.01) ** 2
 
-            if vol_index_price is None:
-                vega *= vol / 100.0
+            if used_index_vol is None:
+                vega *= vol * 0.01
             else:
-                vega *= vol_index_price / 100.0
+                vega *= used_index_vol * 0.01
 
         cdef double time_weight
         if vega_time_weight_base is not None and expiry_in_days > 0:
@@ -529,14 +551,12 @@ cdef class GreeksCalculator:
         # For true index instruments (non-futures), prefer the published index price.
         cdef object instrument = self._cache.instrument(instrument_id)
         cdef IndexPriceUpdate index_price
-        cdef Price price
+        cdef Price price = self._cache.price(instrument_id, PriceType.MID)
+        if price is None:
+            price = self._cache.price(instrument_id, PriceType.LAST)
+
         if instrument is not None and instrument.asset_class is AssetClass.INDEX:
             if instrument.instrument_class is InstrumentClass.FUTURE:
-                price = self._cache.price(instrument_id, PriceType.MID)
-                if price is not None:
-                    return price
-
-                price = self._cache.price(instrument_id, PriceType.LAST)
                 if price is not None:
                     return price
 
@@ -544,11 +564,6 @@ cdef class GreeksCalculator:
             if index_price is not None:
                 return index_price.value
 
-        price = self._cache.price(instrument_id, PriceType.MID)
-        if price is not None:
-            return price
-
-        price = self._cache.price(instrument_id, PriceType.LAST)
         if price is not None:
             return price
 
@@ -635,7 +650,7 @@ cdef class GreeksCalculator:
             Filter function to select which greeks to add to the portfolio_greeks.
         vega_time_weight_base : int, optional
             Base value in days for time-weighting vega. When provided, vega is multiplied by sqrt(vega_time_weight_base / expiry_in_days).
-            Also enables percent vega calculation where vega is multiplied by vol / 100.
+            Also enables percent vega calculation where vega is multiplied by vol * 0.01
         vol_index_instrument_id : InstrumentId, optional
             The reference volatility instrument id vega beta is computed with respect to, for example VIX.
         vol_beta_weights : dict[InstrumentId, float], optional

--- a/tests/unit_tests/risk/test_greeks_calculator.py
+++ b/tests/unit_tests/risk/test_greeks_calculator.py
@@ -213,10 +213,88 @@ class TestGreeksCalculator:
             vol_beta_weights={self.underlying_id: 0.75},
         )
 
-        expected_vega = greeks.vega * 0.75 * greeks.vol / 25.00
+        expected_vega = greeks.vega * 0.75 * (greeks.vol * 100.0) / 25.00
         assert round(vol_weighted_greeks.delta, 12) == round(greeks.delta, 12)
         assert round(vol_weighted_greeks.gamma, 12) == round(greeks.gamma, 12)
         assert round(vol_weighted_greeks.vega, 12) == round(expected_vega, 12)
+
+    def test_instrument_greeks_missing_vol_index_price_returns_none(self):
+        underlying_price = Price.from_str("155.00")
+        option_price = Price.from_str("8.50")
+        vol_index_id = InstrumentId(Symbol("VIX"), Venue("XCBF"))
+
+        self.cache.add_quote_tick(
+            QuoteTick(
+                instrument_id=self.underlying_id,
+                bid_price=underlying_price,
+                ask_price=underlying_price,
+                bid_size=Quantity.from_int(100),
+                ask_size=Quantity.from_int(100),
+                ts_event=self.clock.timestamp_ns(),
+                ts_init=self.clock.timestamp_ns(),
+            ),
+        )
+        self.cache.add_quote_tick(
+            QuoteTick(
+                instrument_id=self.option_id,
+                bid_price=option_price,
+                ask_price=option_price,
+                bid_size=Quantity.from_int(100),
+                ask_size=Quantity.from_int(100),
+                ts_event=self.clock.timestamp_ns(),
+                ts_init=self.clock.timestamp_ns(),
+            ),
+        )
+
+        greeks = self.greeks_calculator.instrument_greeks(
+            instrument_id=self.option_id,
+            cache_greeks=False,
+            ts_event=self.clock.timestamp_ns(),
+            vol_index_instrument_id=vol_index_id,
+        )
+
+        assert greeks is None
+
+    def test_modify_greeks_accepts_explicit_index_prices(self):
+        delta, gamma, vega = self.greeks_calculator.modify_greeks(
+            delta_input=1.0,
+            gamma_input=2.0,
+            underlying_instrument_id=self.underlying_id,
+            underlying_price=150.0,
+            unshocked_underlying_price=150.0,
+            percent_greeks=False,
+            index_instrument_id=None,
+            beta_weights={self.underlying_id: 0.5},
+            vega_input=2.0,
+            vol=0.30,
+            vol_beta_weights={self.underlying_id: 0.75},
+            index_price=200.0,
+            vol_index_price=25.0,
+        )
+
+        assert round(delta, 12) == 0.375
+        assert round(gamma, 12) == 0.28125
+        assert round(vega, 12) == 1.8
+
+        delta, gamma, vega = self.greeks_calculator.modify_greeks(
+            delta_input=1.0,
+            gamma_input=2.0,
+            underlying_instrument_id=self.underlying_id,
+            underlying_price=150.0,
+            unshocked_underlying_price=150.0,
+            percent_greeks=True,
+            index_instrument_id=None,
+            beta_weights={self.underlying_id: 0.5},
+            vega_input=2.0,
+            vol=0.30,
+            vol_beta_weights={self.underlying_id: 0.75},
+            index_price=200.0,
+            vol_index_price=25.0,
+        )
+
+        assert round(delta, 12) == 0.75
+        assert round(gamma, 12) == 1.125
+        assert round(vega, 12) == 0.0045
 
     def test_instrument_greeks_with_caching(self):
         # Test greeks calculation with caching

--- a/tests/unit_tests/risk/test_greeks_calculator.py
+++ b/tests/unit_tests/risk/test_greeks_calculator.py
@@ -17,6 +17,8 @@ from datetime import UTC
 from datetime import datetime
 from math import exp
 
+import pytest
+
 from nautilus_trader.common.component import TestClock
 from nautilus_trader.common.factories import OrderFactory
 from nautilus_trader.model.data import IndexPriceUpdate
@@ -295,6 +297,25 @@ class TestGreeksCalculator:
         assert round(delta, 12) == 0.75
         assert round(gamma, 12) == 1.125
         assert round(vega, 12) == 0.0045
+
+    def test_modify_greeks_missing_vol_index_price_raises(self):
+        vol_index_id = InstrumentId(Symbol("VIX"), Venue("XCBF"))
+
+        with pytest.raises(ValueError, match=r"No price available for VIX\.XCBF"):
+            self.greeks_calculator.modify_greeks(
+                delta_input=1.0,
+                gamma_input=2.0,
+                underlying_instrument_id=self.underlying_id,
+                underlying_price=150.0,
+                unshocked_underlying_price=150.0,
+                percent_greeks=False,
+                index_instrument_id=None,
+                beta_weights=None,
+                vega_input=2.0,
+                vol=0.30,
+                vol_index_instrument_id=vol_index_id,
+                vol_beta_weights=None,
+            )
 
     def test_instrument_greeks_with_caching(self):
         # Test greeks calculation with caching

--- a/tests/unit_tests/risk/test_greeks_calculator.py
+++ b/tests/unit_tests/risk/test_greeks_calculator.py
@@ -21,6 +21,8 @@ from nautilus_trader.common.component import TestClock
 from nautilus_trader.common.factories import OrderFactory
 from nautilus_trader.model.data import IndexPriceUpdate
 from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import AggressorSide
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OmsType
 from nautilus_trader.model.enums import OptionKind
@@ -30,6 +32,7 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import PositionId
 from nautilus_trader.model.identifiers import StrategyId
 from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.instruments import Equity
 from nautilus_trader.model.instruments import FuturesContract
@@ -157,6 +160,63 @@ class TestGreeksCalculator:
         assert abs(greeks.theta - (-0.087698151199)) < 1e-3, (
             f"Theta mismatch: {greeks.theta} vs -0.087698151199"
         )
+
+    def test_instrument_greeks_beta_weights_vega_to_vol_index(self):
+        underlying_price = Price.from_str("155.00")
+        option_price = Price.from_str("8.50")
+        vol_index_id = InstrumentId(Symbol("VIX"), Venue("XCBF"))
+
+        self.cache.add_quote_tick(
+            QuoteTick(
+                instrument_id=self.underlying_id,
+                bid_price=underlying_price,
+                ask_price=underlying_price,
+                bid_size=Quantity.from_int(100),
+                ask_size=Quantity.from_int(100),
+                ts_event=self.clock.timestamp_ns(),
+                ts_init=self.clock.timestamp_ns(),
+            ),
+        )
+        self.cache.add_quote_tick(
+            QuoteTick(
+                instrument_id=self.option_id,
+                bid_price=option_price,
+                ask_price=option_price,
+                bid_size=Quantity.from_int(100),
+                ask_size=Quantity.from_int(100),
+                ts_event=self.clock.timestamp_ns(),
+                ts_init=self.clock.timestamp_ns(),
+            ),
+        )
+        self.cache.add_trade_tick(
+            TradeTick(
+                instrument_id=vol_index_id,
+                price=Price.from_str("25.00"),
+                size=Quantity.from_int(1),
+                aggressor_side=AggressorSide.NO_AGGRESSOR,
+                trade_id=TradeId("1"),
+                ts_event=self.clock.timestamp_ns(),
+                ts_init=self.clock.timestamp_ns(),
+            ),
+        )
+
+        greeks = self.greeks_calculator.instrument_greeks(
+            instrument_id=self.option_id,
+            cache_greeks=False,
+            ts_event=self.clock.timestamp_ns(),
+        )
+        vol_weighted_greeks = self.greeks_calculator.instrument_greeks(
+            instrument_id=self.option_id,
+            cache_greeks=False,
+            ts_event=self.clock.timestamp_ns(),
+            vol_index_instrument_id=vol_index_id,
+            vol_beta_weights={self.underlying_id: 0.75},
+        )
+
+        expected_vega = greeks.vega * 0.75 * greeks.vol / 25.00
+        assert round(vol_weighted_greeks.delta, 12) == round(greeks.delta, 12)
+        assert round(vol_weighted_greeks.gamma, 12) == round(greeks.gamma, 12)
+        assert round(vol_weighted_greeks.vega, 12) == round(expected_vega, 12)
 
     def test_instrument_greeks_with_caching(self):
         # Test greeks calculation with caching


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

### PR title

Beta weight vega greeks against volatility index instruments

### Summary

- Added vega beta weighting support to Cython and Rust greeks calculations with `vol_index_instrument_id` and `vol_beta_weights`.
- Extended `instrument_greeks`, `portfolio_greeks`, option shock handling, and `modify_greeks` so vega can be transformed through a volatility index such as VIX.
- Updated delta and gamma beta weighting in `modify_greeks` to use the shared price lookup path alongside the new vega weighting path.
- Added explicit `index_price` and `vol_index_price` overrides to the public Cython and PyO3 `modify_greeks` bindings so callers can rebase delta, gamma, and vega without requiring cached index instruments.
- Hardened missing volatility-index price handling so Rust returns a clean error and Cython returns `None` through the existing missing-price path.
- Converted Rust greeks parameter structs to `bon::Builder` and updated builder tests, PyO3 bindings, and greeks examples.
- Updated the greeks actor example and markdown guide to use the builder API and the modern `DataActor::on_data(&CustomData)` callback shape.

### Design notes

- Vega beta weighting follows the same change-of-variable approach used for beta-weighted delta and gamma, using implied volatility and a volatility index price as the reference variable.
- Volatility index quotes such as VIX are accepted in vol points, converted once to decimal form for rebasing, and percent greeks still apply the 1% move scaling.
- Percent-greek vega applies the same 1% scaling whether vega is referenced to the option implied volatility or to a volatility index. With a volatility index present, Cython uses `used_index_vol * 0.01` and Rust uses the equivalent `idx_vol / 100.0`.
- The new volatility index arguments are optional and preserve existing behavior when omitted.
- The implementation defaults `unshocked_vol` to the current volatility inside `modify_greeks` when callers omit it, avoiding non-finite vega rebasing in direct calls.
- Rust and Cython now share the same price lookup ordering: MID/LAST tradable prices first, with published index prices preferred for non-future index instruments.
- Cython and Rust comments document that `vol_index_instrument_id` can correspond to a volatility index such as VIX.
- Greeks publishing remains on the typed `GreeksData` message bus route via `publish_greeks` and `subscribe_greeks`; `on_data` is documented as the custom-data wrapper callback, not the greeks delivery path.

### Review follow-ups

- Corrected VIX-style vega beta weighting so `greeks.vega`, which is already per 1% volatility move, is rebased against volatility-index quotes in matching units.
- Reworked direct `modify_greeks` calls so explicit `index_price` and `vol_index_price` values can be supplied without cache state, while preserving cache lookup behavior for instrument-driven calls.
- Kept Rust and Cython behavior aligned for `used_index_price`, `used_index_vol`, and `used_vol` handling, including missing-price behavior and percent-greek scaling.
- Simplified Cython and Rust price lookup control flow without extracting a helper, removing repeated MID/LAST lookup code while preserving the existing index future behavior.

### Tests

- `cargo test -p nautilus-common greeks::tests`.
- `make build-debug`.
- `uv run --no-sync pytest tests/unit_tests/risk/test_greeks_calculator.py`.
- `make format`.
- `make pre-commit`.

### Notes

- Rust and Cython coverage now includes explicit index overrides, VIX-style vol-point conversion, missing volatility-index prices, and percent-greek vega scaling with a volatility index.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
