### PR TITLE
Guard IBKR order submit on client readiness

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -191,6 +191,13 @@ class InteractiveBrokersClient(
         # Start client
         self._request_id_seq: int = 10000
 
+    @property
+    def is_client_ready(self) -> bool:
+        """
+        Return whether the Interactive Brokers client is ready for requests.
+        """
+        return self._is_client_ready.is_set()
+
     def _start(self) -> None:
         """
         Start the client.

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -192,7 +192,7 @@ class InteractiveBrokersClient(
         self._request_id_seq: int = 10000
 
     @property
-    def is_client_ready(self) -> bool:
+    def is_ready(self) -> bool:
         """
         Return whether the Interactive Brokers client is ready for requests.
         """

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1131,7 +1131,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         self._client.place_order(ib_order)
 
     def _ensure_client_ready_for_order_request(self, request: str) -> None:
-        if not self._client.is_client_ready:
+        if not self._client.is_ready:
             raise ValueError(
                 f"Interactive Brokers client is not ready; refusing to {request}",
             )

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -981,6 +981,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         PyCondition.type(command, SubmitOrder, "command")
 
         try:
+            self._ensure_client_ready_for_order_submission()
             ib_order: IBOrder = self._transform_order_to_ib_order(
                 command.order,
                 command.params,
@@ -997,6 +998,17 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
     async def _submit_order_list(self, command: SubmitOrderList) -> None:
         PyCondition.type(command, SubmitOrderList, "command")
+
+        try:
+            self._ensure_client_ready_for_order_submission()
+        except ValueError as e:
+            for order in command.order_list.orders:
+                self._handle_order_event(
+                    status=OrderStatus.REJECTED,
+                    order=order,
+                    reason=str(e),
+                )
+            return
 
         order_id_map = {}
         client_id_to_orders = {}
@@ -1104,6 +1116,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         self._log.info(f"Placing {ib_order!r}")
         self._client.place_order(ib_order)
+
+    def _ensure_client_ready_for_order_submission(self) -> None:
+        if not self._client._is_client_ready.is_set():
+            raise ValueError(
+                "Interactive Brokers client is not ready; refusing to submit order",
+            )
 
     def _transform_order_to_ib_order(  # noqa: C901
         self,

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -981,7 +981,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         PyCondition.type(command, SubmitOrder, "command")
 
         try:
-            self._ensure_client_ready_for_order_submission()
+            self._ensure_client_ready_for_order_request("submit order")
             ib_order: IBOrder = self._transform_order_to_ib_order(
                 command.order,
                 command.params,
@@ -1000,7 +1000,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         PyCondition.type(command, SubmitOrderList, "command")
 
         try:
-            self._ensure_client_ready_for_order_submission()
+            self._ensure_client_ready_for_order_request("submit order list")
         except ValueError as e:
             for order in command.order_list.orders:
                 self._handle_order_event(
@@ -1064,6 +1064,19 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         if not (command.quantity or command.price or command.trigger_price):
             return
 
+        try:
+            self._ensure_client_ready_for_order_request("modify order")
+        except ValueError as e:
+            self.generate_order_modify_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=command.venue_order_id,
+                reason=str(e),
+                ts_event=self._clock.timestamp_ns(),
+            )
+            return
+
         nautilus_order: Order = self._cache.order(command.client_order_id)
         self._log.info(f"Nautilus order status is {nautilus_order.status_string()}")
 
@@ -1117,10 +1130,10 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         self._log.info(f"Placing {ib_order!r}")
         self._client.place_order(ib_order)
 
-    def _ensure_client_ready_for_order_submission(self) -> None:
-        if not self._client._is_client_ready.is_set():
+    def _ensure_client_ready_for_order_request(self, request: str) -> None:
+        if not self._client.is_client_ready:
             raise ValueError(
-                "Interactive Brokers client is not ready; refusing to submit order",
+                f"Interactive Brokers client is not ready; refusing to {request}",
             )
 
     def _transform_order_to_ib_order(  # noqa: C901
@@ -1433,6 +1446,19 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
     async def _cancel_order(self, command: CancelOrder) -> None:
         PyCondition.not_none(command, "command")
 
+        try:
+            self._ensure_client_ready_for_order_request("cancel order")
+        except ValueError as e:
+            self.generate_order_cancel_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=command.venue_order_id,
+                reason=str(e),
+                ts_event=self._clock.timestamp_ns(),
+            )
+            return
+
         venue_order_id = command.venue_order_id
 
         if venue_order_id:
@@ -1446,6 +1472,22 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 f"Interactive Brokers does not support order_side filtering for cancel all orders; "
                 f"ignoring order_side={order_side_to_str(command.order_side)} and canceling all orders",
             )
+
+        try:
+            self._ensure_client_ready_for_order_request("cancel orders")
+        except ValueError as e:
+            for order in self._cache.orders_open(
+                instrument_id=command.instrument_id,
+            ):
+                self.generate_order_cancel_rejected(
+                    strategy_id=order.strategy_id,
+                    instrument_id=order.instrument_id,
+                    client_order_id=order.client_order_id,
+                    venue_order_id=order.venue_order_id,
+                    reason=str(e),
+                    ts_event=self._clock.timestamp_ns(),
+                )
+            return
 
         for order in self._cache.orders_open(
             instrument_id=command.instrument_id,

--- a/tests/integration_tests/adapters/interactive_brokers/conftest.py
+++ b/tests/integration_tests/adapters/interactive_brokers/conftest.py
@@ -270,6 +270,8 @@ def mock_connection_setup(mocker, exec_client):
         # Mock _connect with event handlers
         async def mock_connect():
             # Register event handlers as the real _connect does
+            target_client._client._is_client_ready.set()
+            target_client._client._is_ib_connected.set()
             account = target_client.account_id.get_id()
             target_client._client.subscribe_event(
                 f"accountSummary-{account}",

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -341,6 +341,42 @@ async def test_submit_order(
 
 
 @pytest.mark.asyncio
+async def test_submit_order_rejects_when_ib_client_not_ready(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+    client_order_id,
+):
+    # Arrange
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+    exec_client._set_connected(True)
+    exec_client._client._is_client_ready.clear()
+    place_order = mocker.patch.object(exec_client._client, "place_order")
+
+    order = TestExecStubs.limit_order(
+        instrument=instrument,
+        client_order_id=client_order_id,
+    )
+    cache.add_order(order, None)
+    command = TestCommandStubs.submit_order_command(order=order)
+
+    # Act
+    exec_client.submit_order(command=command)
+    await asyncio.sleep(0)
+
+    # Assert
+    place_order.assert_not_called()
+    assert cache.order(client_order_id).status == OrderStatus.REJECTED
+
+
+@pytest.mark.asyncio
 async def test_submit_order_what_if(
     mocker,
     exec_client,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -27,6 +27,7 @@ from nautilus_trader.adapters.interactive_brokers.factories import (
 )
 from nautilus_trader.adapters.interactive_brokers.parsing.execution import timestring_to_timestamp
 from nautilus_trader.execution.messages import BatchCancelOrders
+from nautilus_trader.execution.messages import CancelAllOrders
 from nautilus_trader.execution.messages import GenerateOrderStatusReport
 from nautilus_trader.execution.messages import QueryAccount
 from nautilus_trader.model.enums import AssetClass
@@ -887,6 +888,59 @@ async def test_batch_cancel_orders_rejects_when_ib_client_not_ready(
     assert (
         generate_order_cancel_rejected.call_args.kwargs["reason"]
         == "Interactive Brokers client is not ready; refusing to cancel order"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_orders_rejects_when_ib_client_not_ready(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+    client_order_id,
+    venue_order_id,
+):
+    # Arrange
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+    exec_client._set_connected(True)
+    exec_client._client._is_client_ready.clear()
+    cancel_order = mocker.patch.object(exec_client._client, "cancel_order")
+    generate_order_cancel_rejected = mocker.patch.object(
+        exec_client,
+        "generate_order_cancel_rejected",
+    )
+
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    command = CancelAllOrders(
+        trader_id=order.trader_id,
+        strategy_id=order.strategy_id,
+        instrument_id=order.instrument_id,
+        order_side=OrderSide.NO_ORDER_SIDE,
+        command_id=TestIdStubs.uuid(),
+        ts_init=0,
+    )
+
+    # Act
+    await exec_client._cancel_all_orders(command)
+
+    # Assert
+    cancel_order.assert_not_called()
+    generate_order_cancel_rejected.assert_called_once()
+    assert (
+        generate_order_cancel_rejected.call_args.kwargs["reason"]
+        == "Interactive Brokers client is not ready; refusing to cancel orders"
     )
 
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -923,6 +923,7 @@ async def test_cancel_all_orders_rejects_when_ib_client_not_ready(
         venue_order_id=venue_order_id,
         status=OrderStatus.ACCEPTED,
     )
+    cache.update_order(order)
     command = CancelAllOrders(
         trader_id=order.trader_id,
         strategy_id=order.strategy_id,

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -26,6 +26,7 @@ from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveExecClientFactory,
 )
 from nautilus_trader.adapters.interactive_brokers.parsing.execution import timestring_to_timestamp
+from nautilus_trader.execution.messages import BatchCancelOrders
 from nautilus_trader.execution.messages import GenerateOrderStatusReport
 from nautilus_trader.execution.messages import QueryAccount
 from nautilus_trader.model.enums import AssetClass
@@ -670,6 +671,7 @@ async def test_modify_order_child_before_parent_acceptance_skips_parent_id(
     )
     cache.add_order(parent_order, None)
     cache.add_order(child_order, None)
+    exec_client._client._is_client_ready.set()
 
     place_order = mocker.patch.object(exec_client._client, "place_order")
 
@@ -684,6 +686,56 @@ async def test_modify_order_child_before_parent_acceptance_skips_parent_id(
     assert ib_order.orderId == 9102
     assert ib_order.parentId == 0
     assert ib_order.totalQuantity == 150.0
+
+
+@pytest.mark.asyncio
+async def test_modify_order_rejects_when_ib_client_not_ready(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+    client_order_id,
+    venue_order_id,
+):
+    # Arrange
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+    exec_client._set_connected(True)
+    exec_client._client._is_client_ready.clear()
+    place_order = mocker.patch.object(exec_client._client, "place_order")
+    generate_order_modify_rejected = mocker.patch.object(
+        exec_client,
+        "generate_order_modify_rejected",
+    )
+
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    command = TestCommandStubs.modify_order_command(
+        price=Price.from_int(95),
+        order=order,
+    )
+
+    # Act
+    exec_client.modify_order(command=command)
+    await asyncio.sleep(0)
+
+    # Assert
+    place_order.assert_not_called()
+    generate_order_modify_rejected.assert_called_once()
+    assert (
+        generate_order_modify_rejected.call_args.kwargs["reason"]
+        == "Interactive Brokers client is not ready; refusing to modify order"
+    )
 
 
 @pytest.mark.asyncio
@@ -735,6 +787,107 @@ async def test_cancel_order(
 
     # Assert
     assert cache.order(client_order_id).status == OrderStatus.CANCELED
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_rejects_when_ib_client_not_ready(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+    client_order_id,
+    venue_order_id,
+):
+    # Arrange
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+    exec_client._set_connected(True)
+    exec_client._client._is_client_ready.clear()
+    cancel_order = mocker.patch.object(exec_client._client, "cancel_order")
+    generate_order_cancel_rejected = mocker.patch.object(
+        exec_client,
+        "generate_order_cancel_rejected",
+    )
+
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    command = TestCommandStubs.cancel_order_command(order=order)
+
+    # Act
+    exec_client.cancel_order(command=command)
+    await asyncio.sleep(0)
+
+    # Assert
+    cancel_order.assert_not_called()
+    generate_order_cancel_rejected.assert_called_once()
+    assert (
+        generate_order_cancel_rejected.call_args.kwargs["reason"]
+        == "Interactive Brokers client is not ready; refusing to cancel order"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_cancel_orders_rejects_when_ib_client_not_ready(
+    mocker,
+    exec_client,
+    cache,
+    instrument,
+    contract_details,
+    client_order_id,
+    venue_order_id,
+):
+    # Arrange
+    instrument_setup(
+        exec_client=exec_client,
+        cache=cache,
+        instrument=instrument,
+        contract_details=contract_details,
+    )
+    exec_client._set_connected(True)
+    exec_client._client._is_client_ready.clear()
+    cancel_order = mocker.patch.object(exec_client._client, "cancel_order")
+    generate_order_cancel_rejected = mocker.patch.object(
+        exec_client,
+        "generate_order_cancel_rejected",
+    )
+
+    order = order_setup(
+        exec_client=exec_client,
+        instrument=instrument,
+        client_order_id=client_order_id,
+        venue_order_id=venue_order_id,
+        status=OrderStatus.ACCEPTED,
+    )
+    cancel = TestCommandStubs.cancel_order_command(order=order)
+    command = BatchCancelOrders(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        instrument_id=instrument.id,
+        cancels=[cancel],
+        command_id=TestIdStubs.uuid(),
+        ts_init=0,
+    )
+
+    # Act
+    await exec_client._batch_cancel_orders(command)
+
+    # Assert
+    cancel_order.assert_not_called()
+    generate_order_cancel_rejected.assert_called_once()
+    assert (
+        generate_order_cancel_rejected.call_args.kwargs["reason"]
+        == "Interactive Brokers client is not ready; refusing to cancel order"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replaces #4089 after recreating the fork path to remove cached sensitive-data exposure.\n\nThis PR contains only the IBKR client readiness guard changes from the original PR.