### PR TITLE
Fix LiveNode signal handling during startup connection wait

### DIFF
--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -373,6 +373,12 @@ impl LiveNode {
 
         self.kernel.connect_exec_clients().await;
 
+        if self.handle.should_stop() {
+            log::info!("Stop signal received during startup, aborting start");
+            self.handle.set_state(NodeState::Stopped);
+            return Ok(());
+        }
+
         if !self.await_engines_connected().await {
             log::error!("Cannot start trader: engine client(s) not connected");
             self.handle.set_state(NodeState::Running);
@@ -425,6 +431,11 @@ impl LiveNode {
         let interval = Duration::from_millis(100);
 
         while start.elapsed() < timeout {
+            if self.handle.should_stop() {
+                log::warn!("Stop signal received, aborting connection wait");
+                return false;
+            }
+
             if self.kernel.check_engines_connected() {
                 log::info!("All engine clients connected");
                 return true;
@@ -680,9 +691,6 @@ impl LiveNode {
 
         // Startup phase 1: Connect data clients and drain instrument events into cache.
         // This ensures the cache is populated before execution clients connect.
-        // TODO: Add ctrl_c and stop_handle monitoring here to allow aborting a
-        // hanging startup. Currently signals during startup are ignored, and
-        // any pending stop_flag is cleared when transitioning to Running.
         drive_with_event_buffering(
             self.kernel.connect_data_clients(),
             &mut pending,
@@ -728,6 +736,12 @@ impl LiveNode {
             pending.is_empty(),
             "all startup events must be processed before reconciliation",
         );
+
+        if self.handle.should_stop() {
+            log::info!("Stop signal received during startup, aborting run");
+            self.handle.set_state(NodeState::Stopped);
+            return Ok(());
+        }
 
         if engines_connected {
             // Run reconciliation now that instruments are in cache and start trader


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

### Problem

When engine clients are slow to connect or fail entirely, the LiveNode enters `await_engines_connected()` which polls for the duration configured by `timeout_connection` (default 120s). During this window:

1. **Stop signals are ignored** — the polling loop only checks `check_engines_connected()`, never `should_stop()`
2. **Stop signals are erased** — after the timeout, `set_state(NodeState::Running)` clears the stop flag (by design)
3. **The node becomes uncontrollable** — any stop/restart command sent during startup is silently lost, and the operator must wait the full `timeout_connection` duration before the node begins to respond

This was documented as a known limitation via a TODO comment in `run()`.

### Fix

Four targeted changes in `nautilus_trader/crates/live/src/node.rs`:

- **`await_engines_connected()`** — check `should_stop()` each iteration of the 100ms polling loop; return `false` immediately if set
- **`run()`** — after `connect_exec_phase()` completes, check `should_stop()` and return early with `NodeState::Stopped` *before* `set_state(Running)` clears the flag
- **`start()`** — same early-exit guard after `connect_exec_clients()` for the non-event-loop startup path
- Remove the stale TODO comment that described this limitation

### Result

Stop/restart commands sent during the engine connection wait are now detected within 100ms. The node exits startup cleanly and the restart loop can rebuild immediately.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore