### PR TITLE
Fix unbounded Cache VecDeque memory leak

### DIFF
--- a/crates/common/src/cache/bounded.rs
+++ b/crates/common/src/cache/bounded.rs
@@ -1,0 +1,247 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! A bounded FIFO deque that automatically evicts the oldest entry when at capacity.
+
+use std::{collections::VecDeque, ops::Deref};
+
+/// A bounded deque that maintains at most `capacity` elements.
+///
+/// Uses a `VecDeque` internally with runtime-configured capacity.
+/// When capacity is exceeded on `push_front`, the oldest entry (back) is automatically evicted.
+#[derive(Debug, Clone)]
+pub struct BoundedVecDeque<T> {
+    inner: VecDeque<T>,
+    capacity: usize,
+}
+
+impl<T> BoundedVecDeque<T> {
+    /// Creates a new [`BoundedVecDeque`] with the given maximum capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Pushes an item to the front. If at capacity, the oldest item (back) is evicted.
+    pub fn push_front(&mut self, item: T) {
+        if self.inner.len() >= self.capacity {
+            self.inner.pop_back();
+        }
+        self.inner.push_front(item);
+    }
+
+    /// Returns the maximum capacity.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the number of elements.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether the deque is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns a reference to the front (newest) element.
+    #[must_use]
+    pub fn front(&self) -> Option<&T> {
+        self.inner.front()
+    }
+
+    /// Returns a reference to the element at the given index.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.inner.get(index)
+    }
+
+    /// Returns an iterator over the elements.
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
+        self.inner.iter()
+    }
+
+    /// Clears all elements from the deque.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<T> Deref for BoundedVecDeque<T> {
+    type Target = VecDeque<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, T> IntoIterator for &'a BoundedVecDeque<T> {
+    type Item = &'a T;
+    type IntoIter = std::collections::vec_deque::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_new_deque_is_empty_with_correct_capacity() {
+        let deque: BoundedVecDeque<i32> = BoundedVecDeque::new(100);
+
+        assert!(deque.is_empty());
+        assert_eq!(deque.len(), 0);
+        assert_eq!(deque.capacity(), 100);
+        assert_eq!(deque.front(), None);
+        assert_eq!(deque.get(0), None);
+    }
+
+    #[rstest]
+    fn test_push_front_maintains_newest_first_ordering() {
+        let mut deque = BoundedVecDeque::new(5);
+        for i in 1..=5 {
+            deque.push_front(i * 10);
+        }
+
+        assert_eq!(deque.len(), 5);
+        assert_eq!(deque.front(), Some(&50)); // newest
+        assert_eq!(deque.get(0), Some(&50));
+        assert_eq!(deque.get(1), Some(&40));
+        assert_eq!(deque.get(2), Some(&30));
+        assert_eq!(deque.get(3), Some(&20));
+        assert_eq!(deque.get(4), Some(&10)); // oldest
+        assert_eq!(deque.get(5), None); // out of bounds
+
+        let items: Vec<_> = deque.iter().copied().collect();
+        assert_eq!(items, vec![50, 40, 30, 20, 10]);
+    }
+
+    #[rstest]
+    fn test_eviction_drops_oldest_and_preserves_order() {
+        let mut deque = BoundedVecDeque::new(3);
+
+        // Fill to capacity: front=[30, 20, 10]=back
+        deque.push_front(10);
+        deque.push_front(20);
+        deque.push_front(30);
+        assert_eq!(deque.len(), 3);
+
+        // Push 40: evicts 10 (oldest) -> front=[40, 30, 20]=back
+        deque.push_front(40);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.front(), Some(&40));
+        let items: Vec<_> = deque.iter().copied().collect();
+        assert_eq!(items, vec![40, 30, 20]);
+
+        // Push 50: evicts 20 -> front=[50, 40, 30]=back
+        deque.push_front(50);
+        assert_eq!(deque.len(), 3);
+        let items: Vec<_> = deque.iter().copied().collect();
+        assert_eq!(items, vec![50, 40, 30]);
+
+        // Push 60: evicts 30 -> front=[60, 50, 40]=back
+        deque.push_front(60);
+        assert_eq!(deque.len(), 3);
+        let items: Vec<_> = deque.iter().copied().collect();
+        assert_eq!(items, vec![60, 50, 40]);
+    }
+
+    #[rstest]
+    fn test_capacity_one_always_holds_latest() {
+        let mut deque = BoundedVecDeque::new(1);
+
+        for i in 1..=100 {
+            deque.push_front(i);
+            assert_eq!(deque.len(), 1);
+            assert_eq!(deque.front(), Some(&i));
+        }
+    }
+
+    #[rstest]
+    fn test_len_never_exceeds_capacity_under_sustained_load() {
+        let capacity = 50;
+        let mut deque = BoundedVecDeque::new(capacity);
+
+        for i in 0..10_000 {
+            deque.push_front(i);
+            assert!(
+                deque.len() <= capacity,
+                "len {} exceeded capacity {} after {} pushes",
+                deque.len(),
+                capacity,
+                i + 1,
+            );
+        }
+
+        assert_eq!(deque.len(), capacity);
+        // Most recent item is at front
+        assert_eq!(deque.front(), Some(&9_999));
+        // Oldest surviving item is at back (via Deref)
+        assert_eq!(deque.back(), Some(&(10_000 - capacity as i32)));
+    }
+
+    #[rstest]
+    fn test_clear_resets_to_empty_but_preserves_capacity() {
+        let mut deque = BoundedVecDeque::new(5);
+        for i in 0..5 {
+            deque.push_front(i);
+        }
+        assert_eq!(deque.len(), 5);
+
+        deque.clear();
+        assert!(deque.is_empty());
+        assert_eq!(deque.len(), 0);
+        assert_eq!(deque.capacity(), 5);
+        assert_eq!(deque.front(), None);
+
+        // Verify usable after clear — capacity still enforced
+        for i in 0..10 {
+            deque.push_front(i);
+        }
+        assert_eq!(deque.len(), 5);
+        assert_eq!(deque.front(), Some(&9));
+    }
+
+    #[rstest]
+    fn test_deref_exposes_immutable_vecdeque_methods() {
+        let mut deque = BoundedVecDeque::new(4);
+        deque.push_front(10);
+        deque.push_front(20);
+        deque.push_front(30);
+
+        // back() — oldest element, available via Deref<Target=VecDeque>
+        assert_eq!(deque.back(), Some(&10));
+
+        // contains() — membership check via Deref
+        assert!(deque.contains(&20));
+        assert!(!deque.contains(&99));
+
+        // iter().copied().collect() — the pattern used by Cache getters
+        let snapshot: Vec<i32> = deque.iter().copied().collect();
+        assert_eq!(snapshot, vec![30, 20, 10]);
+    }
+}

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -1938,7 +1938,7 @@ impl Cache {
         let bars_deque = self
             .bars
             .entry(bar_type)
-            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.bar_capacity));
 
         for bar in bars {
             bars_deque.push_front(*bar);

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -17,6 +17,7 @@
 //!
 //! Provides methods to load, query, and update cached data such as instruments, orders, and prices.
 
+pub mod bounded;
 pub mod config;
 pub mod database;
 pub mod fifo;
@@ -31,7 +32,6 @@ mod tests;
 use std::{
     borrow::Cow,
     cell::{Ref, RefCell},
-    collections::VecDeque,
     fmt::{Debug, Display},
     rc::Rc,
     str::FromStr,
@@ -39,6 +39,7 @@ use std::{
 };
 
 use ahash::{AHashMap, AHashSet};
+use bounded::BoundedVecDeque;
 use bytes::Bytes;
 pub use config::CacheConfig; // Re-export
 use database::{CacheDatabaseAdapter, CacheMap};
@@ -216,14 +217,14 @@ pub struct Cache {
     synthetics: AHashMap<InstrumentId, SyntheticInstrument>,
     books: AHashMap<InstrumentId, OrderBook>,
     own_books: AHashMap<InstrumentId, OwnOrderBook>,
-    quotes: AHashMap<InstrumentId, VecDeque<QuoteTick>>,
-    trades: AHashMap<InstrumentId, VecDeque<TradeTick>>,
+    quotes: AHashMap<InstrumentId, BoundedVecDeque<QuoteTick>>,
+    trades: AHashMap<InstrumentId, BoundedVecDeque<TradeTick>>,
     mark_xrates: AHashMap<(Currency, Currency), f64>,
-    mark_prices: AHashMap<InstrumentId, VecDeque<MarkPriceUpdate>>,
-    index_prices: AHashMap<InstrumentId, VecDeque<IndexPriceUpdate>>,
-    funding_rates: AHashMap<InstrumentId, VecDeque<FundingRateUpdate>>,
-    instrument_statuses: AHashMap<InstrumentId, VecDeque<InstrumentStatus>>,
-    bars: AHashMap<BarType, VecDeque<Bar>>,
+    mark_prices: AHashMap<InstrumentId, BoundedVecDeque<MarkPriceUpdate>>,
+    index_prices: AHashMap<InstrumentId, BoundedVecDeque<IndexPriceUpdate>>,
+    funding_rates: AHashMap<InstrumentId, BoundedVecDeque<FundingRateUpdate>>,
+    instrument_statuses: AHashMap<InstrumentId, BoundedVecDeque<InstrumentStatus>>,
+    bars: AHashMap<BarType, BoundedVecDeque<Bar>>,
     greeks: AHashMap<InstrumentId, GreeksData>,
     option_greeks: AHashMap<InstrumentId, OptionGreeks>,
     yield_curves: AHashMap<String, YieldCurveData>,
@@ -1685,7 +1686,7 @@ impl Cache {
         let mark_prices_deque = self
             .mark_prices
             .entry(mark_price.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         mark_prices_deque.push_front(mark_price);
         Ok(())
     }
@@ -1708,7 +1709,7 @@ impl Cache {
         let index_prices_deque = self
             .index_prices
             .entry(index_price.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         index_prices_deque.push_front(index_price);
         Ok(())
     }
@@ -1731,7 +1732,7 @@ impl Cache {
         let funding_rates_deque = self
             .funding_rates
             .entry(funding_rate.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         funding_rates_deque.push_front(funding_rate);
         Ok(())
     }
@@ -1761,7 +1762,7 @@ impl Cache {
         let funding_rate_deque = self
             .funding_rates
             .entry(instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
 
         for funding_rate in funding_rates {
             funding_rate_deque.push_front(*funding_rate);
@@ -1784,7 +1785,7 @@ impl Cache {
         let statuses_deque = self
             .instrument_statuses
             .entry(status.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         statuses_deque.push_front(status);
         Ok(())
     }
@@ -1806,7 +1807,7 @@ impl Cache {
         let quotes_deque = self
             .quotes
             .entry(quote.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         quotes_deque.push_front(quote);
         Ok(())
     }
@@ -1833,7 +1834,7 @@ impl Cache {
         let quotes_deque = self
             .quotes
             .entry(instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
 
         for quote in quotes {
             quotes_deque.push_front(*quote);
@@ -1858,7 +1859,7 @@ impl Cache {
         let trades_deque = self
             .trades
             .entry(trade.instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
         trades_deque.push_front(trade);
         Ok(())
     }
@@ -1885,7 +1886,7 @@ impl Cache {
         let trades_deque = self
             .trades
             .entry(instrument_id)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
 
         for trade in trades {
             trades_deque.push_front(*trade);
@@ -1910,7 +1911,7 @@ impl Cache {
         let bars = self
             .bars
             .entry(bar.bar_type)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.bar_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.bar_capacity));
         bars.push_front(bar);
         Ok(())
     }
@@ -1937,7 +1938,7 @@ impl Cache {
         let bars_deque = self
             .bars
             .entry(bar_type)
-            .or_insert_with(|| VecDeque::with_capacity(self.config.tick_capacity));
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity));
 
         for bar in bars {
             bars_deque.push_front(*bar);
@@ -5100,7 +5101,7 @@ impl Cache {
     pub fn quote_count(&self, instrument_id: &InstrumentId) -> usize {
         self.quotes
             .get(instrument_id)
-            .map_or(0, std::collections::VecDeque::len)
+            .map_or(0, BoundedVecDeque::len)
     }
 
     /// Gets the trade tick count for the `instrument_id`.
@@ -5108,15 +5109,13 @@ impl Cache {
     pub fn trade_count(&self, instrument_id: &InstrumentId) -> usize {
         self.trades
             .get(instrument_id)
-            .map_or(0, std::collections::VecDeque::len)
+            .map_or(0, BoundedVecDeque::len)
     }
 
     /// Gets the bar count for the `instrument_id`.
     #[must_use]
     pub fn bar_count(&self, bar_type: &BarType) -> usize {
-        self.bars
-            .get(bar_type)
-            .map_or(0, std::collections::VecDeque::len)
+        self.bars.get(bar_type).map_or(0, BoundedVecDeque::len)
     }
 
     /// Returns whether the cache contains an order book for the `instrument_id`.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Add `BoundedVecDeque<T>` — a runtime-capacity newtype wrapper around `VecDeque<T>` that auto-evicts the oldest entry on `push_front()` when at capacity
- Replace all 7 unbounded `VecDeque` fields in `Cache` (quotes, trades, bars, mark_prices, index_prices, funding_rates, instrument_statuses) with `BoundedVecDeque`
- Fix `add_bars()` batch method incorrectly using `tick_capacity` instead of `bar_capacity` for pre-allocation

## Problem

`CacheConfig` defines `tick_capacity` (default 10,000) and `bar_capacity` (default 10,000), but these were only passed to `VecDeque::with_capacity()` — a pre-allocation hint, **not a size limit**. Every `add_*` method calls `push_front()` without eviction, so VecDeques grow unboundedly in long-running nodes.

Discovered in production: one trading node subscribing to hundreds of instruments grew from ~98 MB to nearly 2 GB over two days before being OOM-killed. Other trading nodes showed the same linear growth pattern at ~20 MB/hr. Both confirmed unbounded cache accumulation as the root cause.

## Approach

The codebase already has `ArrayDeque`/`FifoCache` in `cache/fifo.rs`, but these require compile-time `const N` — unusable here since capacity comes from runtime `CacheConfig`.

`BoundedVecDeque<T>` uses the **newtype pattern** to encode the capacity invariant in the type system rather than relying on manual `pop_back()` calls across 14 insertion sites. The eviction logic lives in one place (`push_front`), making it impossible to introduce new `add_*` methods that forget to enforce the bound. `Deref<Target = VecDeque<T>>` provides transparent read-only access, while mutable operations go through the bounded API.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore