### PR TITLE
Fix sandbox IOC cancel after local accept

### DIFF
--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -4908,7 +4908,15 @@ impl OrderMatchingEngine {
 
         if order.status() != OrderStatus::Accepted {
             let venue_order_id = self.ids_generator.get_venue_order_id(order).unwrap();
-            self.generate_order_accepted(order, venue_order_id);
+            let event = self.create_order_accepted(order, venue_order_id);
+            if let Err(e) = order.apply(event.clone()) {
+                log::error!(
+                    "Failed to apply accepted event for {}: {e}",
+                    order.client_order_id(),
+                );
+                return;
+            }
+            self.dispatch_order_event(event);
 
             // Activate before emitting `OrderUpdated` so `match_info` below
             // carries the activation flag.
@@ -5275,12 +5283,16 @@ impl OrderMatchingEngine {
         );
     }
 
-    fn generate_order_accepted(&self, order: &OrderAny, venue_order_id: VenueOrderId) {
+    fn create_order_accepted(
+        &self,
+        order: &OrderAny,
+        venue_order_id: VenueOrderId,
+    ) -> OrderEventAny {
         let ts_now = self.clock.borrow().timestamp_ns();
         let account_id = order
             .account_id()
             .unwrap_or(self.account_ids.get(&order.trader_id()).unwrap().to_owned());
-        let event = OrderEventAny::Accepted(OrderAccepted::new(
+        OrderEventAny::Accepted(OrderAccepted::new(
             order.trader_id(),
             order.strategy_id(),
             order.instrument_id(),
@@ -5291,8 +5303,11 @@ impl OrderMatchingEngine {
             ts_now,
             ts_now,
             false,
-        ));
+        ))
+    }
 
+    fn generate_order_accepted(&self, order: &OrderAny, venue_order_id: VenueOrderId) {
+        let event = self.create_order_accepted(order, venue_order_id);
         self.dispatch_order_event(event);
     }
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -1317,6 +1317,54 @@ fn test_process_limit_order_matched_immediate_fill(
 }
 
 #[rstest]
+fn test_process_ioc_limit_order_without_immediate_match_emits_cancel(
+    instrument_eth_usdt: InstrumentAny,
+    order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    account_id: AccountId,
+) {
+    let mut engine_l2 =
+        get_order_matching_engine_l2(instrument_eth_usdt.clone(), None, None, None, None);
+
+    let orderbook_delta_sell = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .build();
+    let client_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut limit_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1495.00"))
+        .quantity(Quantity::from("1.000"))
+        .time_in_force(TimeInForce::Ioc)
+        .client_order_id(client_order_id)
+        .build();
+
+    engine_l2
+        .process_order_book_delta(&orderbook_delta_sell)
+        .unwrap();
+    engine_l2.process_order(&mut limit_order, account_id);
+
+    let saved_messages = get_order_event_handler_messages(&order_event_handler);
+    let accepted = match saved_messages.first().unwrap() {
+        OrderEventAny::Accepted(accepted) => accepted,
+        _ => panic!("Expected OrderAccepted event in first message"),
+    };
+    let canceled = match saved_messages.get(1).unwrap() {
+        OrderEventAny::Canceled(canceled) => canceled,
+        _ => panic!("Expected OrderCanceled event in second message"),
+    };
+
+    assert_eq!(saved_messages.len(), 2);
+    assert_eq!(accepted.client_order_id, client_order_id);
+    assert_eq!(canceled.client_order_id, client_order_id);
+}
+
+#[rstest]
 fn test_process_stop_market_order_triggered_rejected(
     instrument_eth_usdt: InstrumentAny,
     order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,


### PR DESCRIPTION
## Summary

- Apply `OrderAccepted` to the local sandbox order before continuing same-call-stack matching-engine handling.
- Add a regression test for a freshly initialized IOC limit order that is accepted but not immediately marketable, expecting `OrderAccepted` followed by `OrderCanceled`.

Fixes #4112.

## Why

`accept_order` previously dispatched the accepted event without updating the mutable local `OrderAny`. In the IOC/FOK no-immediate-match branch, `process_limit_order` could then call `cancel_order` with an order still in `INITIALIZED`, which logs `Cannot cancel an order with INITIALIZED from the matching engine` and drops the cancel event.

## Tests

```text
cargo test -p nautilus-execution --test matching_engine test_process_ioc_limit_order_without_immediate_match_emits_cancel
cargo test -p nautilus-execution --test matching_engine test_process_limit_order_matched_immediate_fill
cargo test -p nautilus-execution --test matching_engine test_ioc_order_canceled_when_liquidity_consumption_exhausts_fills
cargo fmt --check --package nautilus-execution
git diff --check
```
