### PR TITLE
Guard Rust IBKR order requests on client readiness

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -75,8 +75,8 @@ use nautilus_model::{
         LiquiditySide, OmsType, OrderSide, OrderType, PositionSideSpecified, TrailingOffsetType,
     },
     events::{
-        AccountState, OrderAccepted, OrderCanceled, OrderEventAny, OrderPendingCancel,
-        OrderRejected, OrderSubmitted,
+        AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderEventAny,
+        OrderInitialized, OrderModifyRejected, OrderPendingCancel, OrderRejected, OrderSubmitted,
     },
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TradeId, TraderId, Venue,
@@ -459,6 +459,11 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
     }
 
     fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
+        if let Err(reason) = self.ensure_client_ready_for_order_request("submit order") {
+            self.reject_submit_order_not_ready(&cmd, &reason)?;
+            return Ok(());
+        }
+
         let client = self.ib_client.as_ref().context("IB client not connected")?;
 
         let order_id_map = Arc::clone(&self.order_id_map);
@@ -1286,12 +1291,21 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
     }
 
     fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
-        self.ib_client.as_ref().context("IB client not connected")?;
+        if let Err(reason) = self.ensure_client_ready_for_order_request("submit order list") {
+            self.reject_submit_order_list_not_ready(&cmd, &reason)?;
+            return Ok(());
+        }
+
         let orders = self.core.get_orders_for_list(&cmd.order_list)?;
         self.submit_order_list_with_orders(cmd, orders)
     }
 
     fn modify_order(&self, cmd: ModifyOrder) -> anyhow::Result<()> {
+        if let Err(reason) = self.ensure_client_ready_for_order_request("modify order") {
+            self.reject_modify_order_not_ready(&cmd, &reason)?;
+            return Ok(());
+        }
+
         let client = self.ib_client.as_ref().context("IB client not connected")?;
 
         let order_id_map = Arc::clone(&self.order_id_map);
@@ -1343,6 +1357,11 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
     }
 
     fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        if let Err(reason) = self.ensure_client_ready_for_order_request("cancel order") {
+            self.reject_cancel_order_not_ready(&cmd, &reason)?;
+            return Ok(());
+        }
+
         let client = self.ib_client.as_ref().context("IB client not connected")?;
 
         let order_id_map = Arc::clone(&self.order_id_map);
@@ -1383,8 +1402,6 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
     }
 
     fn cancel_all_orders(&self, cmd: CancelAllOrders) -> anyhow::Result<()> {
-        let client = self.ib_client.as_ref().context("IB client not connected")?;
-
         // Warn if order_side is specified (IB doesn't support side filtering)
         if cmd.order_side != OrderSide::NoOrderSide {
             tracing::warn!(
@@ -1393,6 +1410,13 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 cmd.order_side
             );
         }
+
+        if let Err(reason) = self.ensure_client_ready_for_order_request("cancel orders") {
+            self.reject_open_order_cancels_not_ready(&cmd, &reason)?;
+            return Ok(());
+        }
+
+        let client = self.ib_client.as_ref().context("IB client not connected")?;
 
         // Get open orders from cache before spawning async task (Rc doesn't work across async boundaries)
         // Note: In Rust, instrument_id is always required, so we always filter by it
@@ -1496,6 +1520,193 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             self.cancel_order(cancel_cmd)?;
         }
         Ok(())
+    }
+}
+
+impl InteractiveBrokersExecutionClient {
+    fn is_ready_for_order_request(&self) -> bool {
+        if !self.is_connected.load(Ordering::Relaxed) {
+            return false;
+        }
+
+        if !self
+            .ib_client
+            .as_ref()
+            .is_some_and(|client| client.is_connected())
+        {
+            return false;
+        }
+
+        self.next_order_id
+            .lock()
+            .is_ok_and(|next_order_id| *next_order_id > 0)
+    }
+
+    fn ensure_client_ready_for_order_request(&self, request: &str) -> Result<(), String> {
+        if self.is_ready_for_order_request() {
+            return Ok(());
+        }
+
+        let reason = format!("Interactive Brokers client is not ready; refusing to {request}");
+        tracing::warn!("{reason}");
+        Err(reason)
+    }
+
+    fn reject_submit_order_not_ready(&self, cmd: &SubmitOrder, reason: &str) -> anyhow::Result<()> {
+        Self::send_order_rejected(
+            cmd.order_init.trader_id,
+            cmd.strategy_id,
+            cmd.instrument_id,
+            cmd.order_init.client_order_id,
+            self.core.account_id,
+            reason,
+        )
+    }
+
+    fn reject_submit_order_list_not_ready(
+        &self,
+        cmd: &SubmitOrderList,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        for order_init in &cmd.order_inits {
+            Self::send_order_rejected_from_init(
+                order_init,
+                cmd.strategy_id,
+                cmd.instrument_id,
+                self.core.account_id,
+                reason,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn reject_modify_order_not_ready(&self, cmd: &ModifyOrder, reason: &str) -> anyhow::Result<()> {
+        let ts_event = get_atomic_clock_realtime().get_time_ns();
+        let event = OrderModifyRejected::new(
+            cmd.trader_id,
+            cmd.strategy_id,
+            cmd.instrument_id,
+            cmd.client_order_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event,
+            ts_event,
+            false,
+            cmd.venue_order_id,
+            Some(self.core.account_id),
+        );
+
+        get_exec_event_sender()
+            .send(ExecutionEvent::Order(OrderEventAny::ModifyRejected(event)))
+            .map_err(|e| anyhow::anyhow!("Failed to send order modify rejected event: {e}"))
+    }
+
+    fn reject_cancel_order_not_ready(&self, cmd: &CancelOrder, reason: &str) -> anyhow::Result<()> {
+        Self::send_order_cancel_rejected(
+            cmd.trader_id,
+            cmd.strategy_id,
+            cmd.instrument_id,
+            cmd.client_order_id,
+            cmd.venue_order_id,
+            self.core.account_id,
+            reason,
+        )
+    }
+
+    fn reject_open_order_cancels_not_ready(
+        &self,
+        cmd: &CancelAllOrders,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let cache = self.core.cache();
+        for order in cache.orders_open(None, Some(&cmd.instrument_id), None, None, None) {
+            Self::send_order_cancel_rejected(
+                order.trader_id(),
+                order.strategy_id(),
+                order.instrument_id(),
+                order.client_order_id(),
+                order.venue_order_id(),
+                self.core.account_id,
+                reason,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn send_order_rejected_from_init(
+        order_init: &OrderInitialized,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        account_id: AccountId,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        Self::send_order_rejected(
+            order_init.trader_id,
+            strategy_id,
+            instrument_id,
+            order_init.client_order_id,
+            account_id,
+            reason,
+        )
+    }
+
+    fn send_order_rejected(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        account_id: AccountId,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let ts_event = get_atomic_clock_realtime().get_time_ns();
+        let event = OrderRejected::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            account_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event,
+            ts_event,
+            false,
+            false,
+        );
+
+        get_exec_event_sender()
+            .send(ExecutionEvent::Order(OrderEventAny::Rejected(event)))
+            .map_err(|e| anyhow::anyhow!("Failed to send order rejected event: {e}"))
+    }
+
+    fn send_order_cancel_rejected(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        venue_order_id: Option<VenueOrderId>,
+        account_id: AccountId,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let ts_event = get_atomic_clock_realtime().get_time_ns();
+        let event = OrderCancelRejected::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            Ustr::from(reason),
+            UUID4::new(),
+            ts_event,
+            ts_event,
+            false,
+            venue_order_id,
+            Some(account_id),
+        );
+
+        get_exec_event_sender()
+            .send(ExecutionEvent::Order(OrderEventAny::CancelRejected(event)))
+            .map_err(|e| anyhow::anyhow!("Failed to send order cancel rejected event: {e}"))
     }
 }
 

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -7,6 +7,8 @@
 //  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
 // -------------------------------------------------------------------------------------------------
 
+use std::{cell::RefCell, rc::Rc};
+
 use ibapi::{
     contracts::{Contract, Currency as IBCurrency, Exchange, SecurityType, Symbol as IBSymbol},
     orders::{
@@ -15,15 +17,16 @@ use ibapi::{
     },
     subscriptions::Subscription,
 };
-use nautilus_common::cache::Cache;
+use nautilus_common::{cache::Cache, live::runner::replace_exec_event_sender};
+use nautilus_live::ExecutionClientCore;
 use nautilus_model::{
-    enums::{AssetClass, LiquiditySide, OrderSide, OrderType},
+    enums::{AccountType, AssetClass, LiquiditySide, OmsType, OrderSide, OrderType},
     identifiers::{
-        AccountId, ClientOrderId, InstrumentId, StrategyId, Symbol, TradeId, TraderId, Venue,
-        VenueOrderId,
+        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
+        Venue, VenueOrderId,
     },
     instruments::{InstrumentAny, OptionSpread, stubs::equity_aapl},
-    orders::builder::OrderTestBuilder,
+    orders::{OrderList, builder::OrderTestBuilder},
     types::{Currency, Money, Price, Quantity},
 };
 use rstest::rstest;
@@ -31,10 +34,42 @@ use rust_decimal::Decimal;
 use ustr::Ustr;
 
 use super::*;
+use crate::common::consts::{IB_CLIENT_ID, IB_VENUE};
 
 fn create_test_instrument_provider() -> Arc<InteractiveBrokersInstrumentProvider> {
     let config = crate::config::InteractiveBrokersInstrumentProviderConfig::default();
     Arc::new(InteractiveBrokersInstrumentProvider::new(config))
+}
+
+fn create_test_execution_client() -> (
+    InteractiveBrokersExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
+    let trader_id = TraderId::from("TESTER-001");
+    let account_id = AccountId::from("IB-001");
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let core = ExecutionClientCore::new(
+        trader_id,
+        *IB_CLIENT_ID,
+        *IB_VENUE,
+        OmsType::Netting,
+        account_id,
+        AccountType::Margin,
+        None,
+        cache.clone(),
+    );
+    let instrument_provider = create_test_instrument_provider();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    replace_exec_event_sender(tx);
+    let client = InteractiveBrokersExecutionClient::new(
+        core,
+        InteractiveBrokersExecClientConfig::default(),
+        instrument_provider,
+    )
+    .unwrap();
+
+    (client, rx, cache)
 }
 
 fn create_test_spread_instrument() -> InstrumentId {
@@ -46,6 +81,30 @@ fn create_test_spread_instrument() -> InstrumentId {
 
 fn create_test_leg_instrument() -> InstrumentId {
     InstrumentId::new(Symbol::from("SPY C400"), Venue::from("SMART"))
+}
+
+fn create_test_stock_instrument() -> InstrumentId {
+    InstrumentId::new(Symbol::from("AAPL"), Venue::from("SMART"))
+}
+
+fn create_test_limit_order(client_order_id: ClientOrderId) -> OrderAny {
+    OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(create_test_stock_instrument())
+        .client_order_id(client_order_id)
+        .side(OrderSide::Buy)
+        .price(Price::from("100.00"))
+        .quantity(Quantity::from(1))
+        .submit(true)
+        .build()
+}
+
+fn next_order_event(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+) -> OrderEventAny {
+    match rx.try_recv().unwrap() {
+        ExecutionEvent::Order(event) => event,
+        event => panic!("Expected order event, was {event:?}"),
+    }
 }
 
 #[rstest]
@@ -63,6 +122,194 @@ fn apply_client_order_id_floor(
         InteractiveBrokersExecutionClient::apply_client_order_id_floor(next_id, client_id),
         expected
     );
+}
+
+#[rstest]
+fn submit_order_rejects_when_client_not_ready() {
+    let (client, mut rx, _) = create_test_execution_client();
+    let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let cmd = SubmitOrder::from_order(
+        &order,
+        client.core.trader_id,
+        Some(client.core.client_id),
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+    );
+
+    client.submit_order(cmd).unwrap();
+
+    match next_order_event(&mut rx) {
+        OrderEventAny::Rejected(event) => {
+            assert_eq!(event.client_order_id, order.client_order_id());
+            assert_eq!(
+                event.reason.to_string(),
+                "Interactive Brokers client is not ready; refusing to submit order"
+            );
+        }
+        event => panic!("Expected OrderRejected, was {event:?}"),
+    }
+}
+
+#[rstest]
+fn submit_order_list_rejects_all_orders_when_client_not_ready() {
+    let (client, mut rx, _) = create_test_execution_client();
+    let order1 = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let order2 = create_test_limit_order(ClientOrderId::from("O-IB-002"));
+    let order_list = OrderList::new(
+        OrderListId::from("OL-IB-001"),
+        order1.instrument_id(),
+        order1.strategy_id(),
+        vec![order1.client_order_id(), order2.client_order_id()],
+        UnixNanos::default(),
+    );
+    let cmd = SubmitOrderList::new(
+        client.core.trader_id,
+        Some(client.core.client_id),
+        order1.strategy_id(),
+        order_list,
+        vec![
+            OrderInitialized::from(&order1),
+            OrderInitialized::from(&order2),
+        ],
+        None,
+        None,
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    );
+
+    client.submit_order_list(cmd).unwrap();
+
+    for expected_client_order_id in [order1.client_order_id(), order2.client_order_id()] {
+        match next_order_event(&mut rx) {
+            OrderEventAny::Rejected(event) => {
+                assert_eq!(event.client_order_id, expected_client_order_id);
+                assert_eq!(
+                    event.reason.to_string(),
+                    "Interactive Brokers client is not ready; refusing to submit order list"
+                );
+            }
+            event => panic!("Expected OrderRejected, was {event:?}"),
+        }
+    }
+}
+
+#[rstest]
+fn modify_order_rejects_when_client_not_ready() {
+    let (client, mut rx, _) = create_test_execution_client();
+    let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let cmd = ModifyOrder::new(
+        client.core.trader_id,
+        Some(client.core.client_id),
+        order.strategy_id(),
+        order.instrument_id(),
+        order.client_order_id(),
+        Some(VenueOrderId::from("1001")),
+        Some(Quantity::from(2)),
+        Some(Price::from("101.00")),
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.modify_order(cmd).unwrap();
+
+    match next_order_event(&mut rx) {
+        OrderEventAny::ModifyRejected(event) => {
+            assert_eq!(event.client_order_id, order.client_order_id());
+            assert_eq!(event.venue_order_id, Some(VenueOrderId::from("1001")));
+            assert_eq!(
+                event.reason.to_string(),
+                "Interactive Brokers client is not ready; refusing to modify order"
+            );
+        }
+        event => panic!("Expected OrderModifyRejected, was {event:?}"),
+    }
+}
+
+#[rstest]
+fn cancel_order_rejects_when_client_not_ready() {
+    let (client, mut rx, _) = create_test_execution_client();
+    let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let cmd = CancelOrder::new(
+        client.core.trader_id,
+        Some(client.core.client_id),
+        order.strategy_id(),
+        order.instrument_id(),
+        order.client_order_id(),
+        Some(VenueOrderId::from("1001")),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.cancel_order(cmd).unwrap();
+
+    match next_order_event(&mut rx) {
+        OrderEventAny::CancelRejected(event) => {
+            assert_eq!(event.client_order_id, order.client_order_id());
+            assert_eq!(event.venue_order_id, Some(VenueOrderId::from("1001")));
+            assert_eq!(
+                event.reason.to_string(),
+                "Interactive Brokers client is not ready; refusing to cancel order"
+            );
+        }
+        event => panic!("Expected OrderCancelRejected, was {event:?}"),
+    }
+}
+
+#[rstest]
+fn cancel_all_orders_rejects_open_orders_when_client_not_ready() {
+    let (client, mut rx, cache) = create_test_execution_client();
+    let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let accepted = OrderEventAny::Accepted(OrderAccepted::new(
+        order.trader_id(),
+        order.strategy_id(),
+        order.instrument_id(),
+        order.client_order_id(),
+        VenueOrderId::from("1001"),
+        client.core.account_id,
+        UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        false,
+    ));
+    {
+        let mut cache = cache.borrow_mut();
+        cache
+            .add_order(order.clone(), None, Some(client.core.client_id), false)
+            .unwrap();
+        cache.update_order(&accepted).unwrap();
+    }
+    let cmd = CancelAllOrders::new(
+        client.core.trader_id,
+        Some(client.core.client_id),
+        order.strategy_id(),
+        order.instrument_id(),
+        OrderSide::NoOrderSide,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.cancel_all_orders(cmd).unwrap();
+
+    match next_order_event(&mut rx) {
+        OrderEventAny::CancelRejected(event) => {
+            assert_eq!(event.client_order_id, order.client_order_id());
+            assert_eq!(
+                event.reason.to_string(),
+                "Interactive Brokers client is not ready; refusing to cancel orders"
+            );
+        }
+        event => panic!("Expected OrderCancelRejected, was {event:?}"),
+    }
 }
 
 fn create_test_execution_data(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Migrates the IBKR client-readiness guard from commit `17cc1916` into the Rust Interactive Brokers execution adapter.
- Rejects submit, submit-list, modify, cancel, and cancel-all order requests before scheduling IB API calls when the Rust client is not ready.
- Emits the matching Nautilus order events for each rejected request: `OrderRejected`, `OrderModifyRejected`, and `OrderCancelRejected`.
- Adds Rust unit coverage for each not-ready order request path.

### Design notes

- Readiness is checked at the execution-client boundary before any async IB task is spawned.
- The guard requires the execution client to be marked connected, the shared IB client to report connected, and a valid local next order ID to be initialized.
- Cancel-all rejection mirrors the Python behavior by rejecting each open cached order for the requested instrument.

### Verification

- `cargo test -p nautilus-interactive-brokers --lib`
- `make build-debug`
- `make format`
- `make pre-commit`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/pull/4100

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
