### PR TITLE
Allow IB Rust orders to route MIC venue instruments

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -415,6 +415,8 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         self.core.venue
     }
 
+    // IB uses a broker venue for the client while routing exchange-MIC instruments;
+    // contract transformation remains the authority for actual venue support.
     fn handles_order_venue(&self, _venue: Venue) -> bool {
         true
     }

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -415,6 +415,10 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         self.core.venue
     }
 
+    fn handles_order_venue(&self, _venue: Venue) -> bool {
+        true
+    }
+
     fn oms_type(&self) -> OmsType {
         self.core.oms_type
     }

--- a/crates/common/src/clients/execution.rs
+++ b/crates/common/src/clients/execution.rs
@@ -50,6 +50,15 @@ pub trait ExecutionClient {
     fn oms_type(&self) -> OmsType;
     fn get_account(&self) -> Option<AccountAny>;
 
+    /// Returns whether this client can execute orders for the given instrument venue.
+    ///
+    /// Single-venue clients should use the default behavior. Routing brokers can
+    /// override this when their client venue identifies the broker rather than
+    /// the instrument's exchange venue.
+    fn handles_order_venue(&self, venue: Venue) -> bool {
+        self.venue() == venue
+    }
+
     /// Generates and publishes the account state event.
     ///
     /// # Errors

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -1848,9 +1848,12 @@ impl ExecutionEngine {
         let order_venue = order.instrument_id().venue;
         let client_venue = client.venue();
         if !client.handles_order_venue(order_venue) {
+            let client_id = client.client_id();
             self.deny_order(
                 &order,
-                &format!("Order venue {order_venue} does not match client venue {client_venue}"),
+                &format!(
+                    "Client {client_id} does not handle order venue {order_venue} (client venue {client_venue})"
+                ),
             );
             return;
         }
@@ -1910,10 +1913,14 @@ impl ExecutionEngine {
         let order_list_venue = cmd.instrument_id.venue;
         let client_venue = client.venue();
         if !client.handles_order_venue(order_list_venue) {
+            let client_id = client.client_id();
+
             for order in &orders {
                 self.deny_order(
                     order,
-                    &format!("Order list venue {order_list_venue} does not match client venue {client_venue}"),
+                    &format!(
+                        "Client {client_id} does not handle order list venue {order_list_venue} (client venue {client_venue})"
+                    ),
                 );
             }
             return;

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -1847,7 +1847,7 @@ impl ExecutionEngine {
 
         let order_venue = order.instrument_id().venue;
         let client_venue = client.venue();
-        if order_venue != client_venue {
+        if !client.handles_order_venue(order_venue) {
             self.deny_order(
                 &order,
                 &format!("Order venue {order_venue} does not match client venue {client_venue}"),
@@ -1909,7 +1909,7 @@ impl ExecutionEngine {
 
         let order_list_venue = cmd.instrument_id.venue;
         let client_venue = client.venue();
-        if order_list_venue != client_venue {
+        if !client.handles_order_venue(order_list_venue) {
             for order in &orders {
                 self.deny_order(
                     order,

--- a/crates/execution/src/engine/stubs.rs
+++ b/crates/execution/src/engine/stubs.rs
@@ -32,7 +32,7 @@ use nautilus_core::UnixNanos;
 use nautilus_model::{
     accounts::AccountAny,
     enums::OmsType,
-    identifiers::{AccountId, ClientId, Venue},
+    identifiers::{AccountId, ClientId, ClientOrderId, Venue},
     instruments::InstrumentAny,
     types::{AccountBalance, MarginBalance},
 };
@@ -56,6 +56,7 @@ pub struct StubExecutionClient {
     stop_count: Rc<Cell<usize>>,
     reset_count: Rc<Cell<usize>>,
     dispose_count: Rc<Cell<usize>>,
+    submitted_order_ids: Rc<RefCell<Vec<ClientOrderId>>>,
     handles_all_order_venues: bool,
 }
 
@@ -82,6 +83,7 @@ impl StubExecutionClient {
             stop_count: Rc::new(Cell::new(0)),
             reset_count: Rc::new(Cell::new(0)),
             dispose_count: Rc::new(Cell::new(0)),
+            submitted_order_ids: Rc::new(RefCell::new(Vec::new())),
             handles_all_order_venues: false,
         }
     }
@@ -97,6 +99,12 @@ impl StubExecutionClient {
     #[must_use]
     pub fn received_instruments(&self) -> Rc<RefCell<Vec<InstrumentAny>>> {
         self.received_instruments.clone()
+    }
+
+    /// Returns a shared handle to the submitted order IDs.
+    #[must_use]
+    pub fn submitted_order_ids(&self) -> Rc<RefCell<Vec<ClientOrderId>>> {
+        self.submitted_order_ids.clone()
     }
 
     /// Returns the number of times [`ExecutionClient::start`] was invoked.
@@ -186,7 +194,11 @@ impl ExecutionClient for StubExecutionClient {
         Ok(())
     }
 
-    fn submit_order(&self, _cmd: SubmitOrder) -> anyhow::Result<()> {
+    fn submit_order(&self, cmd: SubmitOrder) -> anyhow::Result<()> {
+        self.submitted_order_ids
+            .borrow_mut()
+            .push(cmd.client_order_id);
+
         Ok(()) // Stub implementation always succeeds
     }
 

--- a/crates/execution/src/engine/stubs.rs
+++ b/crates/execution/src/engine/stubs.rs
@@ -56,6 +56,7 @@ pub struct StubExecutionClient {
     stop_count: Rc<Cell<usize>>,
     reset_count: Rc<Cell<usize>>,
     dispose_count: Rc<Cell<usize>>,
+    handles_all_order_venues: bool,
 }
 
 impl StubExecutionClient {
@@ -81,7 +82,15 @@ impl StubExecutionClient {
             stop_count: Rc::new(Cell::new(0)),
             reset_count: Rc::new(Cell::new(0)),
             dispose_count: Rc::new(Cell::new(0)),
+            handles_all_order_venues: false,
         }
+    }
+
+    /// Configures this stub to accept orders for any instrument venue.
+    #[must_use]
+    pub fn with_handles_all_order_venues(mut self) -> Self {
+        self.handles_all_order_venues = true;
+        self
     }
 
     /// Returns a shared handle to the instruments delivered via [`ExecutionClient::on_instrument`].
@@ -131,6 +140,10 @@ impl ExecutionClient for StubExecutionClient {
 
     fn venue(&self) -> Venue {
         self.venue
+    }
+
+    fn handles_order_venue(&self, venue: Venue) -> bool {
+        self.handles_all_order_venues || self.venue == venue
     }
 
     fn oms_type(&self) -> OmsType {

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -114,7 +114,9 @@ fn futures_contract_xcme() -> FuturesContract {
         AssetClass::Index,
         Some(Ustr::from("XCME")),
         Ustr::from("ES"),
+        // Activation: 2026-04-06 00:00:00 UTC
         UnixNanos::from(1_775_433_600_000_000_000),
+        // Expiration: 2026-06-17 16:00:00 UTC
         UnixNanos::from(1_781_712_000_000_000_000),
         Currency::USD(),
         2,
@@ -1554,6 +1556,8 @@ fn test_submit_order_denies_when_client_does_not_handle_instrument_venue(
         OmsType::Netting,
         None,
     );
+    let submitted_order_ids = stub_client.submitted_order_ids();
+
     execution_engine
         .register_client(Box::new(stub_client))
         .unwrap();
@@ -1602,15 +1606,16 @@ fn test_submit_order_denies_when_client_does_not_handle_instrument_venue(
     if let OrderEventAny::Denied(denied) = cached_order.last_event() {
         assert_eq!(
             denied.reason.as_str(),
-            "Order venue XCME does not match client venue IB",
+            "Client IB does not handle order venue XCME (client venue IB)",
         );
     } else {
         panic!("Expected OrderDenied event");
     }
+    assert!(submitted_order_ids.borrow().is_empty());
 }
 
 #[rstest]
-fn test_submit_order_allows_routing_broker_for_databento_venue(
+fn test_submit_order_allows_routing_broker_for_exchange_mic_venue(
     mut execution_engine: ExecutionEngine,
 ) {
     let trader_id = TraderId::test_default();
@@ -1626,6 +1631,8 @@ fn test_submit_order_allows_routing_broker_for_databento_venue(
         None,
     )
     .with_handles_all_order_venues();
+    let submitted_order_ids = stub_client.submitted_order_ids();
+
     execution_engine
         .register_client(Box::new(stub_client))
         .unwrap();
@@ -1674,6 +1681,10 @@ fn test_submit_order_allows_routing_broker_for_databento_venue(
     assert_eq!(
         cached_order.instrument_id(),
         InstrumentId::from("ESM6.XCME")
+    );
+    assert_eq!(
+        submitted_order_ids.borrow().as_slice(),
+        &[order.client_order_id()],
     );
 }
 

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -49,18 +49,18 @@ use nautilus_execution::engine::{
 use nautilus_model::{
     accounts::CashAccount,
     enums::{
-        AccountType, ContingencyType, LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType,
-        PositionSide, PositionSideSpecified, TimeInForce, TriggerType,
+        AccountType, AssetClass, ContingencyType, LiquiditySide, OmsType, OrderSide, OrderStatus,
+        OrderType, PositionSide, PositionSideSpecified, TimeInForce, TriggerType,
     },
     events::{
         AccountState, OrderCanceled, OrderEventAny, OrderFilled, OrderPendingUpdate, OrderUpdated,
     },
     identifiers::{
         AccountId, ClientId, ClientOrderId, ExecAlgorithmId, InstrumentId, OrderListId, PositionId,
-        StrategyId, TradeId, TraderId, Venue, VenueOrderId,
+        StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
     instruments::{
-        CurrencyPair, Instrument, InstrumentAny,
+        CurrencyPair, FuturesContract, Instrument, InstrumentAny,
         stubs::{audusd_sim, gbpusd_sim},
     },
     orders::{Order, OrderAny, OrderList, builder::OrderTestBuilder, stubs::TestOrderEventStubs},
@@ -72,6 +72,7 @@ use nautilus_model::{
 use rstest::*;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
+use ustr::Ustr;
 
 #[fixture]
 fn test_clock() -> Rc<RefCell<dyn clock::Clock>> {
@@ -104,6 +105,34 @@ fn execution_engine_with_config() -> ExecutionEngine {
     };
 
     ExecutionEngine::new(clock, cache, Some(config))
+}
+
+fn futures_contract_xcme() -> FuturesContract {
+    FuturesContract::new(
+        InstrumentId::from("ESM6.XCME"),
+        Symbol::from("ESM6"),
+        AssetClass::Index,
+        Some(Ustr::from("XCME")),
+        Ustr::from("ES"),
+        UnixNanos::from(1_775_433_600_000_000_000),
+        UnixNanos::from(1_781_712_000_000_000_000),
+        Currency::USD(),
+        2,
+        Price::from("0.25"),
+        Quantity::from(50),
+        Quantity::from(1),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
 }
 
 #[fixture]
@@ -1506,6 +1535,145 @@ fn test_submit_order_successfully_processes_and_caches_order(
         cached_order.status(),
         OrderStatus::Initialized,
         "Order should be in Initialized status after submission"
+    );
+}
+
+#[rstest]
+fn test_submit_order_denies_when_client_does_not_handle_instrument_venue(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = futures_contract_xcme();
+    let client_id = ClientId::from("IB");
+
+    let stub_client = StubExecutionClient::new(
+        client_id,
+        AccountId::from("IB-001"),
+        Venue::from("IB"),
+        OmsType::Netting,
+        None,
+    );
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .quantity(Quantity::from(1))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id), true)
+        .unwrap();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        position_id: None,
+        params: None,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        client_id: Some(client_id),
+        instrument_id: instrument.id,
+        exec_algorithm_id: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache
+        .order(&order.client_order_id())
+        .expect("Order should be retrievable from cache");
+    assert_eq!(cached_order.status(), OrderStatus::Denied);
+    if let OrderEventAny::Denied(denied) = cached_order.last_event() {
+        assert_eq!(
+            denied.reason.as_str(),
+            "Order venue XCME does not match client venue IB",
+        );
+    } else {
+        panic!("Expected OrderDenied event");
+    }
+}
+
+#[rstest]
+fn test_submit_order_allows_routing_broker_for_databento_venue(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = futures_contract_xcme();
+    let client_id = ClientId::from("IB");
+
+    let stub_client = StubExecutionClient::new(
+        client_id,
+        AccountId::from("IB-001"),
+        Venue::from("IB"),
+        OmsType::Netting,
+        None,
+    )
+    .with_handles_all_order_venues();
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .quantity(Quantity::from(1))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id), true)
+        .unwrap();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        position_id: None,
+        params: None,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        client_id: Some(client_id),
+        instrument_id: instrument.id,
+        exec_algorithm_id: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache
+        .order(&order.client_order_id())
+        .expect("Order should be retrievable from cache");
+    assert_eq!(cached_order.status(), OrderStatus::Initialized);
+    assert_eq!(
+        cached_order.instrument_id(),
+        InstrumentId::from("ESM6.XCME")
     );
 }
 

--- a/examples/live/interactive_brokers_v2/_common.py
+++ b/examples/live/interactive_brokers_v2/_common.py
@@ -178,6 +178,7 @@ def default_es_put_spread_instrument_id(
     long_strike: float = 6800.0,
     short_strike: float = 6750.0,
 ) -> str:
+    # IB generic spread IDs encode signed leg ratios in the instrument ID
     leg_ratios = [
         (default_es_put_option_local_symbol(long_strike), 1),
         (default_es_put_option_local_symbol(short_strike), -1),

--- a/examples/live/interactive_brokers_v2/_common.py
+++ b/examples/live/interactive_brokers_v2/_common.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import signal
@@ -24,6 +25,21 @@ from nautilus_trader.core import nautilus_pyo3 as pyo3
 IB = "IB"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_TWS_PORT = 7497
+FUTURES_MONTH_CODES = {
+    1: "F",
+    2: "G",
+    3: "H",
+    4: "J",
+    5: "K",
+    6: "M",
+    7: "N",
+    8: "Q",
+    9: "U",
+    10: "V",
+    11: "X",
+    12: "Z",
+}
+QUARTERLY_CONTRACT_MONTHS = (3, 6, 9, 12)
 
 
 def env_bool(name: str, default: bool = False) -> bool:
@@ -68,6 +84,117 @@ def ib_account_id(raw_account_id: str) -> pyo3.AccountId:
     return pyo3.AccountId.from_str(f"{IB}-{raw_account_id}")
 
 
+def contract_month_code(year: int, month: int) -> str:
+    return f"{FUTURES_MONTH_CODES[month]}{year % 10}"
+
+
+def third_friday(year: int, month: int) -> dt.date:
+    first_day = dt.date(year, month, 1)
+    first_friday_offset = (4 - first_day.weekday()) % 7
+    return first_day + dt.timedelta(days=first_friday_offset + 14)
+
+
+def active_quarterly_contract(
+    *,
+    symbol: str,
+    venue: str,
+    today: dt.date | None = None,
+    min_days_to_expiry: int = 45,
+) -> tuple[str, str, str]:
+    today = today or dt.date.today()
+    target_expiry = today + dt.timedelta(days=min_days_to_expiry)
+    year = today.year
+
+    while True:
+        for month in QUARTERLY_CONTRACT_MONTHS:
+            expiry = third_friday(year, month)
+            if expiry >= target_expiry:
+                local_symbol = f"{symbol}{contract_month_code(year, month)}"
+                return local_symbol, f"{local_symbol}.{venue}", expiry.strftime("%Y%m%d")
+        year += 1
+
+
+def active_monthly_contract(
+    *,
+    symbol: str,
+    venue: str,
+    today: dt.date | None = None,
+    min_days_to_contract_month: int = 45,
+) -> tuple[str, str, str]:
+    today = today or dt.date.today()
+    target_month = today + dt.timedelta(days=min_days_to_contract_month)
+    year = today.year
+    month = today.month
+
+    while dt.date(year, month, 1) < target_month:
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+
+    local_symbol = f"{symbol}{contract_month_code(year, month)}"
+    return local_symbol, f"{local_symbol}.{venue}", f"{year}{month:02d}"
+
+
+def default_es_future() -> tuple[str, str, str]:
+    return active_quarterly_contract(symbol="ES", venue="XCME")
+
+
+def default_ym_future() -> tuple[str, str, str]:
+    return active_quarterly_contract(symbol="YM", venue="XCBT")
+
+
+def default_cl_future() -> tuple[str, str, str]:
+    return active_monthly_contract(symbol="CL", venue="XNYM")
+
+
+def default_es_future_instrument_id() -> str:
+    return default_es_future()[1]
+
+
+def default_ym_future_instrument_id() -> str:
+    return default_ym_future()[1]
+
+
+def default_cl_future_instrument_id() -> str:
+    return default_cl_future()[1]
+
+
+def format_option_strike(strike: float) -> str:
+    strike_value = float(strike)
+    return str(int(strike_value)) if strike_value.is_integer() else str(strike_value)
+
+
+def default_es_put_option_local_symbol(strike: float = 6800.0) -> str:
+    local_symbol, _, _ = default_es_future()
+    return f"{local_symbol} P{format_option_strike(strike)}"
+
+
+def default_es_put_option_instrument_id(strike: float = 6800.0) -> str:
+    return f"{default_es_put_option_local_symbol(strike)}.XCME"
+
+
+def default_es_put_spread_instrument_id(
+    long_strike: float = 6800.0,
+    short_strike: float = 6750.0,
+) -> str:
+    leg_ratios = [
+        (default_es_put_option_local_symbol(long_strike), 1),
+        (default_es_put_option_local_symbol(short_strike), -1),
+    ]
+    leg_ratios.sort(key=lambda value: value[0])
+
+    symbol_parts = []
+
+    for symbol, ratio in leg_ratios:
+        if ratio > 0:
+            symbol_parts.append(f"({ratio}){symbol}")
+        else:
+            symbol_parts.append(f"(({abs(ratio)})){symbol}")
+
+    return f"{'_'.join(symbol_parts)}.XCME"
+
+
 def default_stock_contracts() -> list[dict[str, str]]:
     ib = pyo3.interactive_brokers
     return [
@@ -99,16 +226,17 @@ def futures_contract(
     *,
     symbol: str = "ES",
     exchange: str = "CME",
-    local_symbol: str = "ESM6",
-    expiry: str = "20260618",
+    local_symbol: str | None = None,
+    expiry: str | None = None,
 ) -> dict[str, object]:
     ib = pyo3.interactive_brokers
+    default_local_symbol, _, default_expiry = default_es_future()
     return {
         "secType": ib.IbSecurityType.FUTURE.as_str(),
         "symbol": symbol,
         "exchange": exchange,
-        "localSymbol": local_symbol,
-        "lastTradeDateOrContractMonth": expiry,
+        "localSymbol": local_symbol or default_local_symbol,
+        "lastTradeDateOrContractMonth": expiry or default_expiry,
         "currency": "USD",
     }
 
@@ -117,20 +245,22 @@ def option_contract(
     *,
     symbol: str = "ES",
     exchange: str = "CME",
-    local_symbol: str,
-    expiry: str = "20260618",
+    local_symbol: str | None = None,
+    expiry: str | None = None,
     right: Any | None = None,
     strike: float | None = None,
 ) -> dict[str, object]:
     ib = pyo3.interactive_brokers
     right = right or ib.IbOptionRight.PUT
     right_value = right.as_str() if hasattr(right, "as_str") else str(right)
+    default_local_symbol = default_es_put_option_local_symbol(strike or 6800.0)
+    _, _, default_expiry = default_es_future()
     contract: dict[str, object] = {
         "secType": ib.IbSecurityType.FUTURES_OPTION.as_str(),
         "symbol": symbol,
         "exchange": exchange,
-        "localSymbol": local_symbol,
-        "lastTradeDateOrContractMonth": expiry,
+        "localSymbol": local_symbol or default_local_symbol,
+        "lastTradeDateOrContractMonth": expiry or default_expiry,
         "right": right_value,
         "currency": "USD",
     }

--- a/examples/live/interactive_brokers_v2/connect_with_dockerized_gateway.py
+++ b/examples/live/interactive_brokers_v2/connect_with_dockerized_gateway.py
@@ -14,6 +14,9 @@ import os
 
 from _common import add_strategy_from_config
 from _common import build_ib_live_node
+from _common import default_cl_future
+from _common import default_es_future_instrument_id
+from _common import default_ym_future_instrument_id
 from _common import env_bool
 from _common import env_int
 from _common import instrument_provider_config
@@ -49,6 +52,7 @@ def main() -> None:
         port = gateway.port
 
     account_id = os.getenv("TWS_ACCOUNT") if env_bool("IB_V2_ENABLE_EXECUTION") else None
+    cl_local_symbol, cl_instrument_id, _ = default_cl_future()
     os.environ.setdefault("IB_V2_SUBSCRIPTION_INSTRUMENT_ID", "EUR/USD.IDEALPRO")
     os.environ.setdefault("IB_V2_SUBSCRIBE_QUOTES", "1")
     provider_config = instrument_provider_config(
@@ -57,9 +61,9 @@ def main() -> None:
             "BTC/USD.PAXOS",
             "SPY.ARCA",
             "V.NYSE",
-            "YMM6.CBOT",
-            "CLM6.NYMEX",
-            "ESM6.CME",
+            os.getenv("IB_V2_DOCKER_YM_INSTRUMENT_ID", default_ym_future_instrument_id()),
+            os.getenv("IB_V2_DOCKER_CL_INSTRUMENT_ID", cl_instrument_id),
+            os.getenv("IB_V2_DOCKER_ES_INSTRUMENT_ID", default_es_future_instrument_id()),
         ],
         load_contracts=[
             {
@@ -80,7 +84,7 @@ def main() -> None:
             {
                 "secType": ib.IbSecurityType.FUTURE.as_str(),
                 "exchange": "NYMEX",
-                "localSymbol": "CLM6",
+                "localSymbol": os.getenv("IB_V2_DOCKER_CL_LOCAL_SYMBOL", cl_local_symbol),
                 "build_futures_chain": False,
             },
         ],

--- a/examples/live/interactive_brokers_v2/ib_v2_order_strategies.py
+++ b/examples/live/interactive_brokers_v2/ib_v2_order_strategies.py
@@ -12,6 +12,11 @@ import os
 from typing import Any
 from uuid import uuid4
 
+from _common import default_es_future_instrument_id
+from _common import default_es_put_option_instrument_id
+from _common import default_es_put_spread_instrument_id
+from _common import default_ym_future_instrument_id
+
 from nautilus_trader.core import nautilus_pyo3 as pyo3
 
 
@@ -214,7 +219,7 @@ class OptionGreeksStrategy(pyo3.Strategy):  # type: ignore[name-defined]
         )
         self.instrument_id = env_instrument_id(
             "IB_V2_OPTION_INSTRUMENT_ID",
-            "ESM6 P6800.IB",
+            default_es_put_option_instrument_id(),
         )
         self._subscribed = False
         self._count = 0
@@ -244,7 +249,7 @@ class OptionGreeksStrategy(pyo3.Strategy):  # type: ignore[name-defined]
 
 class IbV2OrderStrategy(pyo3.Strategy):  # type: ignore[name-defined]
     strategy_id_value = "IB-V2-ORDER-001"
-    instrument_id_value = "ESM6.IB"
+    instrument_id_value = default_es_future_instrument_id()
 
     def __init__(self) -> None:
         super().__init__(
@@ -603,34 +608,21 @@ class SimpleConditionsStrategy(IbV2OrderStrategy):
 
 class SpreadOrderStrategy(IbV2OrderStrategy):
     strategy_id_value = "IB-V2-SPREAD-STRATEGY"
-    instrument_id_value = "ESM6P6800.IB"
+    instrument_id_value = default_es_put_spread_instrument_id()
 
     def __init__(self) -> None:
         super().__init__()
+        self.instrument_id = env_instrument_id(
+            "IB_V2_SPREAD_INSTRUMENT_ID",
+            self.instrument_id_value,
+        )
         self._flatten_submitted = False
 
     def submit_example_orders(self) -> None:
-        ib = pyo3.interactive_brokers
         order = self.market_order(
             self.client_order_id("SPREAD"),
             pyo3.OrderSide.BUY,
             env_quantity("IB_V2_SPREAD_QUANTITY"),
-            tags=[
-                ib_order_tags(
-                    spreadLegs=[
-                        {
-                            "localSymbol": "ESM6 P6800",
-                            "action": ib.IbLegAction.BUY.as_str(),
-                            "ratio": 1,
-                        },
-                        {
-                            "localSymbol": "ESM6 P6775",
-                            "action": ib.IbLegAction.SELL.as_str(),
-                            "ratio": 1,
-                        },
-                    ],
-                ),
-            ],
         )
         self.submit_ib_order(order)
 
@@ -659,7 +651,7 @@ class SpreadOrderStrategy(IbV2OrderStrategy):
 
 class DatabentoInstrumentIdStrategy(IbV2OrderStrategy):
     strategy_id_value = "IB-V2-DB-ID-STRATEGY"
-    instrument_id_value = "YMM6.XCBT"
+    instrument_id_value = default_ym_future_instrument_id()
 
     def __init__(self) -> None:
         super().__init__()

--- a/examples/live/interactive_brokers_v2/notebooks/order_example_driver.py
+++ b/examples/live/interactive_brokers_v2/notebooks/order_example_driver.py
@@ -20,12 +20,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from _common import add_strategy_from_config
 from _common import build_ib_live_node
+from _common import default_es_future_instrument_id
+from _common import default_es_put_spread_instrument_id
+from _common import default_ym_future_instrument_id
 from _common import env_bool
 from _common import env_int
-from _common import futures_contract
 from _common import ib_order_tags
 from _common import instrument_provider_config
-from _common import option_contract
 from _common import resolve_ib_endpoint
 from _common import schedule_node_stop
 
@@ -62,27 +63,24 @@ class OrderExample:
 
 def futures_provider_config() -> object:
     return instrument_provider_config(
-        load_contracts=[futures_contract()],
-        symbol_to_mic_venue={"ES": "IB"},
+        load_ids=[
+            os.getenv("IB_V2_ORDER_INSTRUMENT_ID", default_es_future_instrument_id()),
+        ],
     )
 
 
 def spread_provider_config() -> object:
-    ib = pyo3.interactive_brokers
-    leg_contracts = [
-        option_contract(local_symbol="ESM6 P6800", right=ib.IbOptionRight.PUT, strike=6800.0),
-        option_contract(local_symbol="ESM6 P6775", right=ib.IbOptionRight.PUT, strike=6775.0),
-    ]
     return instrument_provider_config(
-        load_contracts=leg_contracts,
-        symbol_to_mic_venue={"ES": "IB"},
+        load_ids=[
+            os.getenv("IB_V2_SPREAD_INSTRUMENT_ID", default_es_put_spread_instrument_id()),
+        ],
     )
 
 
 def databento_provider_config() -> object:
     return instrument_provider_config(
         load_ids=[
-            os.getenv("IB_V2_DATABENTO_INSTRUMENT_ID", "YMM6.XCBT"),
+            os.getenv("IB_V2_DATABENTO_INSTRUMENT_ID", default_ym_future_instrument_id()),
         ],
     )
 
@@ -109,8 +107,9 @@ def set_databento_request_contracts_default() -> None:
 
 
 def print_bracket_details(_node: object) -> None:
+    instrument_id = os.getenv("IB_V2_ORDER_INSTRUMENT_ID", default_es_future_instrument_id())
     print(
-        "Built v2 bracket-order node and registered BracketOrderStrategy for ESM6.IB.",
+        f"Built v2 bracket-order node and registered BracketOrderStrategy for {instrument_id}.",
         flush=True,
     )
     print(
@@ -120,8 +119,9 @@ def print_bracket_details(_node: object) -> None:
 
 
 def print_market_details(_node: object) -> None:
+    instrument_id = os.getenv("IB_V2_ORDER_INSTRUMENT_ID", default_es_future_instrument_id())
     print(
-        "Built v2 market-order node and registered MarketOrderStrategy for ESM6.IB.",
+        f"Built v2 market-order node and registered MarketOrderStrategy for {instrument_id}.",
         flush=True,
     )
     print(

--- a/examples/live/interactive_brokers_v2/option_greeks.py
+++ b/examples/live/interactive_brokers_v2/option_greeks.py
@@ -15,12 +15,12 @@ import os
 
 from _common import add_strategy_from_config
 from _common import build_ib_live_node
+from _common import default_es_future_instrument_id
+from _common import default_es_put_option_instrument_id
 from _common import env_bool
 from _common import env_int
-from _common import futures_contract
 from _common import instrument_provider_config
 from _common import is_ib_endpoint_reachable
-from _common import option_contract
 from _common import resolve_ib_endpoint
 from _common import schedule_node_stop
 
@@ -34,15 +34,11 @@ async def main() -> None:
         print(f"IB Gateway/TWS is not reachable at {host}:{port}", flush=True)
         return
 
-    option_contracts = [
-        option_contract(
-            local_symbol=os.getenv("IB_V2_OPTION_LOCAL_SYMBOL", "ESM6 P6800"),
-            right=ib.IbOptionRight.PUT,
-            strike=float(os.getenv("IB_V2_OPTION_STRIKE", "6800")),
-        ),
-    ]
     provider_config = instrument_provider_config(
-        load_contracts=[futures_contract(), *option_contracts],
+        load_ids=[
+            os.getenv("IB_V2_OPTION_UNDERLYING_INSTRUMENT_ID", default_es_future_instrument_id()),
+            os.getenv("IB_V2_OPTION_INSTRUMENT_ID", default_es_put_option_instrument_id()),
+        ],
     )
     provider = ib.InteractiveBrokersInstrumentProvider(provider_config)
     client_config = ib.InteractiveBrokersDataClientConfig(
@@ -60,8 +56,14 @@ async def main() -> None:
         print(f"Failed to connect to IB Gateway/TWS at {host}:{port}: {exc}", flush=True)
         return
 
-    print("Requesting bounded option contracts...", flush=True)
-    instruments = await client.request_instruments(contracts=option_contracts)
+    print("Requesting option instruments...", flush=True)
+    instruments = await client.request_instruments(
+        instrument_ids=[
+            pyo3.InstrumentId.from_str(
+                os.getenv("IB_V2_OPTION_INSTRUMENT_ID", default_es_put_option_instrument_id()),
+            ),
+        ],
+    )
     print(f"Loaded {len(instruments)} option instrument(s)", flush=True)
     for instrument in instruments:
         print(instrument.id, flush=True)

--- a/examples/live/interactive_brokers_v2/with_databento_client.py
+++ b/examples/live/interactive_brokers_v2/with_databento_client.py
@@ -14,6 +14,8 @@ import os
 from pathlib import Path
 
 from _common import add_strategy_from_config
+from _common import default_cl_future_instrument_id
+from _common import default_es_future_instrument_id
 from _common import env_bool
 from _common import env_int
 from _common import ib_account_id
@@ -43,8 +45,8 @@ def main() -> None:
             "SPY.XNAS",
             "AAPL.XNAS",
             "V.XNYS",
-            "CLM6.XNYM",
-            "ESM6.XCME",
+            os.getenv("IB_V2_DATABENTO_CL_INSTRUMENT_ID", default_cl_future_instrument_id()),
+            os.getenv("IB_V2_DATABENTO_ES_INSTRUMENT_ID", default_es_future_instrument_id()),
         ],
     )
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Added `ExecutionClient::handles_order_venue` so execution venue validation can distinguish single-venue clients from routing brokers.
- Updated the execution engine to use the new venue handling hook for single orders and order lists while preserving the existing denial path for clients that do not handle the instrument venue.
- Overrode `handles_order_venue` for the Interactive Brokers execution client, allowing orders for exchange MIC venues such as `XCME`, `XCBT`, and `XNYM` to route through the `IB` client.
- Added execution engine regression coverage for both the denied single-venue case and the allowed IB-style routing broker case.
- Updated the Interactive Brokers v2 PyO3 examples to use dynamic, run-date-based futures, options, and spread instrument IDs instead of fixed expiring symbols.
- Updated the spread order example so the generic spread instrument definition carries the leg structure instead of passing `spreadLegs` order tags.

### Design notes

- The strict venue check was introduced by `d35bc26e79` on 2026-02-02 in `crates/execution/src/engine/mod.rs` as part of centralized Rust execution venue validation.
- The new default `handles_order_venue` implementation keeps the original behavior for normal clients by comparing `self.venue()` with the order instrument venue.
- IB uses a broker venue for the client but can route orders to exchange venues, so its implementation accepts instrument venues without requiring examples to use `.IB` instrument IDs or symbol-to-MIC venue remapping.
- IB's venue predicate is intentionally broad because exact venue support is validated later by the IB contract transformation and API response path.
- Example defaults now select active contracts from the run date, currently resolving on 2026-05-24 to `ESU6.XCME`, `YMU6.XCBT`, and `CLQ6.XNYM`.
- Cython/Python execution did not have the same strict venue-equality gate, so the routing fix is specific to the Rust execution path used by the PyO3 examples.

### Review follow-ups

- Reworded the venue denial reason to say the client does not handle the order or order-list venue, instead of implying the only possible failure is strict venue equality.
- Added a short comment on the IB execution client override explaining that IB routes exchange-MIC instruments through broker venue `IB`, while contract transformation and IB API responses remain the venue-support authority.
- Renamed the routing regression test from Databento-specific wording to `test_submit_order_allows_routing_broker_for_exchange_mic_venue`.
- Extended the stub execution client to record submitted order IDs so the routing test directly asserts the client was called.
- Added a denial-path assertion that the stub execution client was not called when the venue predicate rejects the order.
- Added ISO timestamp comments for the raw nanosecond futures-contract test values.
- Added a comment documenting the IB generic spread instrument-ID convention.

### Verification

- Ran `make build-debug`.
- Ran `cargo test -p nautilus-execution --test exec_engine test_submit_order_ -- --nocapture`.
- Ran `uv run --no-sync python -m py_compile $(find examples/live/interactive_brokers_v2 -maxdepth 3 -name '*.py' -print)`.
- Ran `make format`.
- Ran `make pre-commit`.
- Ran the Interactive Brokers v2 PyO3 examples as bounded real paper-account runs against TWS. Databento live connectivity reached authentication but was blocked by missing `XNAS.ITCH` live entitlement.

### Operational notes

- Some Sunday paper runs on 2026-05-24 produced IB closed-session warnings and short-lived `PENDING_CANCEL` states at auto-stop, but the order routing and submission paths were exercised.
- The examples still allow environment variable overrides for specific instruments when a different contract or strike is needed.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4122

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
