### PR TITLE
Add OptionGreeks persistence and replay support

### DIFF
--- a/crates/adapters/deribit/src/python/websocket.rs
+++ b/crates/adapters/deribit/src/python/websocket.rs
@@ -76,6 +76,7 @@ where
 fn ws_data_to_pyobject(py: Python<'_>, data: Data) -> PyResult<Py<PyAny>> {
     match data {
         Data::Custom(custom) => Py::new(py, custom).map(|obj| obj.into_any()),
+        Data::OptionGreeks(greeks) => Py::new(py, greeks).map(|obj| obj.into_any()),
         other => Ok(data_to_pycapsule(py, other)),
     }
 }

--- a/crates/adapters/hyperliquid/src/python/websocket.rs
+++ b/crates/adapters/hyperliquid/src/python/websocket.rs
@@ -45,6 +45,7 @@ use crate::{
 fn ws_data_to_pyobject(py: Python<'_>, data: Data) -> PyResult<Py<PyAny>> {
     match data {
         Data::Custom(custom) => Py::new(py, custom).map(|obj| obj.into_any()),
+        Data::OptionGreeks(greeks) => Py::new(py, greeks).map(|obj| obj.into_any()),
         other => Ok(data_to_pycapsule(py, other)),
     }
 }

--- a/crates/adapters/tardis/src/replay.rs
+++ b/crates/adapters/tardis/src/replay.rs
@@ -211,6 +211,7 @@ pub async fn run_tardis_machine_replay_from_config(config_filepath: &Path) -> an
                     Data::MarkPriceUpdate(_)
                     | Data::IndexPriceUpdate(_)
                     | Data::InstrumentStatus(_)
+                    | Data::OptionGreeks(_)
                     | Data::InstrumentClose(_)
                     | Data::Custom(_) => {
                         log::debug!(

--- a/crates/backtest/src/config.rs
+++ b/crates/backtest/src/config.rs
@@ -58,6 +58,7 @@ pub enum NautilusDataType {
     MarkPriceUpdate,
     IndexPriceUpdate,
     InstrumentStatus,
+    OptionGreeks,
     InstrumentClose,
 }
 
@@ -80,6 +81,7 @@ impl FromStr for NautilusDataType {
             stringify!(MarkPriceUpdate) => Ok(Self::MarkPriceUpdate),
             stringify!(IndexPriceUpdate) => Ok(Self::IndexPriceUpdate),
             stringify!(InstrumentStatus) => Ok(Self::InstrumentStatus),
+            stringify!(OptionGreeks) => Ok(Self::OptionGreeks),
             stringify!(InstrumentClose) => Ok(Self::InstrumentClose),
             _ => anyhow::bail!("Invalid `NautilusDataType`: '{s}'"),
         }

--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -1051,7 +1051,10 @@ impl BacktestEngine {
     fn route_data_to_exchange(&self, data: &Data) {
         if matches!(
             data,
-            Data::MarkPriceUpdate(_) | Data::IndexPriceUpdate(_) | Data::Custom(_)
+            Data::MarkPriceUpdate(_)
+                | Data::IndexPriceUpdate(_)
+                | Data::OptionGreeks(_)
+                | Data::Custom(_)
         ) {
             return;
         }
@@ -1069,7 +1072,10 @@ impl BacktestEngine {
                 Data::InstrumentStatus(status) => exchange.process_instrument_status(*status),
                 Data::InstrumentClose(close) => exchange.process_instrument_close(*close),
                 Data::Depth10(depth) => exchange.process_order_book_depth10(depth),
-                Data::MarkPriceUpdate(_) | Data::IndexPriceUpdate(_) | Data::Custom(_) => {
+                Data::MarkPriceUpdate(_)
+                | Data::IndexPriceUpdate(_)
+                | Data::OptionGreeks(_)
+                | Data::Custom(_) => {
                     unreachable!("filtered by early return above")
                 }
             }

--- a/crates/backtest/src/node.rs
+++ b/crates/backtest/src/node.rs
@@ -22,7 +22,7 @@ use nautilus_core::UnixNanos;
 use nautilus_model::{
     data::{
         Bar, Data, HasTsInit, IndexPriceUpdate, InstrumentClose, InstrumentStatus, MarkPriceUpdate,
-        OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
+        OptionGreeks, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
     },
     enums::{BookType, OtoTriggerMode},
     identifiers::{InstrumentId, Venue},
@@ -560,6 +560,9 @@ fn dispatch_query(
         }
         NautilusDataType::InstrumentStatus => {
             catalog.query::<InstrumentStatus>(identifiers, start, end, filter, None, optimize)
+        }
+        NautilusDataType::OptionGreeks => {
+            catalog.query::<OptionGreeks>(identifiers, start, end, filter, None, optimize)
         }
         NautilusDataType::InstrumentClose => {
             catalog.query::<InstrumentClose>(identifiers, start, end, filter, None, optimize)

--- a/crates/backtest/src/python/engine.rs
+++ b/crates/backtest/src/python/engine.rs
@@ -40,8 +40,8 @@ use nautilus_model::{
     accounts::margin_model::{LeveragedMarginModel, MarginModelAny, StandardMarginModel},
     data::{
         Bar, Data, IndexPriceUpdate, InstrumentClose, InstrumentStatus, MarkPriceUpdate,
-        OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API, OrderBookDepth10, QuoteTick,
-        TradeTick,
+        OptionGreeks, OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API, OrderBookDepth10,
+        QuoteTick, TradeTick,
     },
     enums::{AccountType, BookType, OmsType, OtoTriggerMode},
     identifiers::{ActorId, ClientId, ComponentId, InstrumentId, StrategyId, TraderId, Venue},
@@ -999,6 +999,10 @@ fn pyobject_to_data(_py: Python, obj: &Bound<'_, PyAny>) -> PyResult<Data> {
         return Ok(Data::InstrumentStatus(status));
     }
 
+    if let Ok(greeks) = obj.extract::<OptionGreeks>() {
+        return Ok(Data::OptionGreeks(greeks));
+    }
+
     if let Ok(close) = obj.extract::<InstrumentClose>() {
         return Ok(Data::InstrumentClose(close));
     }
@@ -1030,6 +1034,10 @@ fn pyobject_to_data(_py: Python, obj: &Bound<'_, PyAny>) -> PyResult<Data> {
 
     if let Ok(status) = InstrumentStatus::from_pyobject(obj) {
         return Ok(Data::InstrumentStatus(status));
+    }
+
+    if let Ok(greeks) = OptionGreeks::from_pyobject(obj) {
+        return Ok(Data::OptionGreeks(greeks));
     }
 
     if let Ok(close) = InstrumentClose::from_pyobject(obj) {

--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -492,6 +492,12 @@ impl MessagingSwitchboard {
     }
 
     #[must_use]
+    pub fn get_pipeline_option_greeks_topic(&mut self, instrument_id: InstrumentId) -> MStr<Topic> {
+        let live = self.get_option_greeks_topic(instrument_id);
+        self.pipeline_topic(live)
+    }
+
+    #[must_use]
     pub fn get_pipeline_instrument_close_topic(
         &mut self,
         instrument_id: InstrumentId,
@@ -595,6 +601,7 @@ define_wrappers! {
     get_pipeline_index_price_topic(instrument_id: InstrumentId) -> MStr<Topic>,
     get_pipeline_funding_rate_topic(instrument_id: InstrumentId) -> MStr<Topic>,
     get_pipeline_instrument_status_topic(instrument_id: InstrumentId) -> MStr<Topic>,
+    get_pipeline_option_greeks_topic(instrument_id: InstrumentId) -> MStr<Topic>,
     get_pipeline_instrument_close_topic(instrument_id: InstrumentId) -> MStr<Topic>,
     get_order_fills_topic(instrument_id: InstrumentId) -> MStr<Topic>,
     get_order_cancels_topic(instrument_id: InstrumentId) -> MStr<Topic>,

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -1672,6 +1672,12 @@ impl DataEngine {
                 self.handle_instrument_status(status);
                 self.drain_deferred_commands();
             }
+            Data::OptionGreeks(greeks) => {
+                self.cache.borrow_mut().add_option_greeks(greeks);
+                let topic = switchboard::get_option_greeks_topic(greeks.instrument_id);
+                msgbus::publish_option_greeks(topic, &greeks);
+                self.drain_deferred_commands();
+            }
             Data::InstrumentClose(close) => self.handle_instrument_close(close),
             Data::Custom(custom) => self.handle_custom_data(&custom),
         }
@@ -1696,6 +1702,7 @@ impl DataEngine {
             Data::MarkPriceUpdate(mark_price) => self.handle_mark_price_pipeline(mark_price),
             Data::IndexPriceUpdate(index_price) => self.handle_index_price_pipeline(index_price),
             Data::InstrumentStatus(status) => self.handle_instrument_status_pipeline(status),
+            Data::OptionGreeks(greeks) => self.handle_option_greeks_pipeline(greeks),
             Data::InstrumentClose(close) => self.handle_instrument_close_pipeline(close),
             Data::Custom(custom) => self.handle_custom_data_pipeline(&custom),
         }
@@ -2740,6 +2747,15 @@ impl DataEngine {
 
         let topic = switchboard::get_pipeline_instrument_status_topic(status.instrument_id);
         msgbus::publish_any(topic, &status);
+    }
+
+    fn handle_option_greeks_pipeline(&self, greeks: OptionGreeks) {
+        if self.pipeline_cache_writes_allowed() {
+            self.cache.borrow_mut().add_option_greeks(greeks);
+        }
+
+        let topic = switchboard::get_pipeline_option_greeks_topic(greeks.instrument_id);
+        msgbus::publish_option_greeks(topic, &greeks);
     }
 
     fn handle_instrument_close_pipeline(&self, close: InstrumentClose) {

--- a/crates/model/src/data/greeks.rs
+++ b/crates/model/src/data/greeks.rs
@@ -22,6 +22,7 @@ use std::{
 
 use implied_vol::{DefaultSpecialFn, ImpliedBlackVolatility, SpecialFn};
 use nautilus_core::{UnixNanos, datetime::unix_nanos_to_iso8601, math::quadratic_interpolation};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     data::{
@@ -40,7 +41,7 @@ const VEGA_PERCENT_FACTOR: f64 = 0.01;
 /// Core option Greek sensitivity values (the 5 standard sensitivities).
 /// Designed as a composable building block embedded in all Greeks-carrying types.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.model", from_py_object)

--- a/crates/model/src/data/mod.rs
+++ b/crates/model/src/data/mod.rs
@@ -107,6 +107,7 @@ pub enum Data {
     MarkPriceUpdate(MarkPriceUpdate), // TODO: Rename to MarkPrice once Cython gone
     IndexPriceUpdate(IndexPriceUpdate), // TODO: Rename to IndexPrice once Cython gone
     InstrumentStatus(InstrumentStatus),
+    OptionGreeks(OptionGreeks),
     InstrumentClose(InstrumentClose),
     Custom(CustomData),
 }
@@ -147,6 +148,9 @@ impl TryFrom<Data> for DataFFI {
             Data::IndexPriceUpdate(x) => Ok(Self::IndexPriceUpdate(x)),
             Data::InstrumentStatus(_) => {
                 anyhow::bail!("Cannot convert Data::InstrumentStatus to DataFFI")
+            }
+            Data::OptionGreeks(_) => {
+                anyhow::bail!("Cannot convert Data::OptionGreeks to DataFFI")
             }
             Data::InstrumentClose(x) => Ok(Self::InstrumentClose(x)),
             Data::Custom(_) => anyhow::bail!("Cannot convert Data::Custom to DataFFI"),
@@ -212,6 +216,9 @@ impl<'de> Deserialize<'de> for Data {
             "InstrumentStatus" => Ok(Self::InstrumentStatus(
                 serde_json::from_value(value).map_err(D::Error::custom)?,
             )),
+            "OptionGreeks" => Ok(Self::OptionGreeks(
+                serde_json::from_value(value).map_err(D::Error::custom)?,
+            )),
             "InstrumentClose" => Ok(Self::InstrumentClose(
                 serde_json::from_value(value).map_err(D::Error::custom)?,
             )),
@@ -240,6 +247,7 @@ impl Clone for Data {
             Self::MarkPriceUpdate(x) => Self::MarkPriceUpdate(*x),
             Self::IndexPriceUpdate(x) => Self::IndexPriceUpdate(*x),
             Self::InstrumentStatus(x) => Self::InstrumentStatus(*x),
+            Self::OptionGreeks(x) => Self::OptionGreeks(*x),
             Self::InstrumentClose(x) => Self::InstrumentClose(*x),
             Self::Custom(x) => Self::Custom(x.clone()),
         }
@@ -258,6 +266,7 @@ impl PartialEq for Data {
             (Self::MarkPriceUpdate(a), Self::MarkPriceUpdate(b)) => a == b,
             (Self::IndexPriceUpdate(a), Self::IndexPriceUpdate(b)) => a == b,
             (Self::InstrumentStatus(a), Self::InstrumentStatus(b)) => a == b,
+            (Self::OptionGreeks(a), Self::OptionGreeks(b)) => a == b,
             (Self::InstrumentClose(a), Self::InstrumentClose(b)) => a == b,
             (Self::Custom(a), Self::Custom(b)) => a == b,
             _ => false,
@@ -280,6 +289,7 @@ impl Serialize for Data {
             Self::MarkPriceUpdate(x) => x.serialize(serializer),
             Self::IndexPriceUpdate(x) => x.serialize(serializer),
             Self::InstrumentStatus(x) => x.serialize(serializer),
+            Self::OptionGreeks(x) => x.serialize(serializer),
             Self::InstrumentClose(x) => x.serialize(serializer),
             Self::Custom(x) => x.serialize(serializer),
         }
@@ -320,6 +330,7 @@ impl_try_from_data!(Bar, Bar);
 impl_try_from_data!(MarkPriceUpdate, MarkPriceUpdate);
 impl_try_from_data!(IndexPriceUpdate, IndexPriceUpdate);
 impl_try_from_data!(InstrumentStatus, InstrumentStatus);
+impl_try_from_data!(OptionGreeks, OptionGreeks);
 impl_try_from_data!(InstrumentClose, InstrumentClose);
 
 /// Converts a vector of `Data` items to a specific variant type.
@@ -347,6 +358,7 @@ impl Data {
             Self::MarkPriceUpdate(mark_price) => mark_price.instrument_id,
             Self::IndexPriceUpdate(index_price) => index_price.instrument_id,
             Self::InstrumentStatus(status) => status.instrument_id,
+            Self::OptionGreeks(greeks) => greeks.instrument_id,
             Self::InstrumentClose(close) => close.instrument_id,
             Self::Custom(custom) => custom
                 .data_type
@@ -416,6 +428,7 @@ impl_catalog_path_prefix!(IndexPriceUpdate, "index_prices");
 impl_catalog_path_prefix!(MarkPriceUpdate, "mark_prices");
 impl_catalog_path_prefix!(FundingRateUpdate, "funding_rate_update");
 impl_catalog_path_prefix!(InstrumentStatus, "instrument_status");
+impl_catalog_path_prefix!(OptionGreeks, "option_greeks");
 impl_catalog_path_prefix!(InstrumentClose, "instrument_closes");
 
 use crate::instruments::InstrumentAny;
@@ -433,6 +446,7 @@ impl HasTsInit for Data {
             Self::MarkPriceUpdate(p) => p.ts_init,
             Self::IndexPriceUpdate(p) => p.ts_init,
             Self::InstrumentStatus(s) => s.ts_init,
+            Self::OptionGreeks(g) => g.ts_init,
             Self::InstrumentClose(c) => c.ts_init,
             Self::Custom(c) => c.data.ts_init(),
         }
@@ -498,6 +512,12 @@ impl From<IndexPriceUpdate> for Data {
 impl From<InstrumentStatus> for Data {
     fn from(value: InstrumentStatus) -> Self {
         Self::InstrumentStatus(value)
+    }
+}
+
+impl From<OptionGreeks> for Data {
+    fn from(value: OptionGreeks) -> Self {
+        Self::OptionGreeks(value)
     }
 }
 

--- a/crates/model/src/data/option_chain.rs
+++ b/crates/model/src/data/option_chain.rs
@@ -21,7 +21,7 @@ use std::{
     ops::Deref,
 };
 
-use nautilus_core::UnixNanos;
+use nautilus_core::{UnixNanos, serialization::Serializable};
 use serde::{Deserialize, Serialize};
 
 use super::HasTsInit;
@@ -133,7 +133,8 @@ impl StrikeRange {
 
 /// Exchange-provided option Greeks and implied volatility for a single instrument.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.model", from_py_object)
@@ -216,6 +217,8 @@ impl Display for OptionGreeks {
         )
     }
 }
+
+impl Serializable for OptionGreeks {}
 
 /// Combined quote and Greeks data for a single strike in an option chain.
 #[derive(Clone, Debug)]
@@ -480,6 +483,34 @@ mod tests {
         assert!(display.contains("OptionGreeks"));
         assert!(display.contains("PRICE_ADJUSTED"));
         assert!(display.contains("0.55"));
+    }
+
+    #[rstest]
+    fn test_option_greeks_data_serde_round_trip() {
+        let greeks = OptionGreeks {
+            instrument_id: InstrumentId::from("BTC-20240101-50000-C.DERIBIT"),
+            convention: GreeksConvention::PriceAdjusted,
+            greeks: OptionGreekValues {
+                delta: 0.55,
+                gamma: 0.001,
+                vega: 10.0,
+                theta: -5.0,
+                rho: 0.2,
+            },
+            mark_iv: Some(0.65),
+            bid_iv: None,
+            ask_iv: Some(0.66),
+            underlying_price: Some(50_000.0),
+            open_interest: None,
+            ts_event: UnixNanos::from(1u64),
+            ts_init: UnixNanos::from(2u64),
+        };
+        let data = crate::data::Data::OptionGreeks(greeks);
+
+        let json = serde_json::to_string(&data).unwrap();
+        let roundtripped: crate::data::Data = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(roundtripped, data);
     }
 
     #[rstest]

--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -51,7 +51,7 @@ use pyo3::{prelude::*, types::PyCapsule};
 use crate::data::DataFFI;
 use crate::data::{
     Bar, CustomData, Data, DataType, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus,
-    MarkPriceUpdate, OrderBookDelta, QuoteTick, TradeTick, close::InstrumentClose,
+    MarkPriceUpdate, OptionGreeks, OrderBookDelta, QuoteTick, TradeTick, close::InstrumentClose,
     is_monotonically_increasing_by_init, register_python_data_class,
 };
 
@@ -409,6 +409,24 @@ pub fn pyobjects_to_instrument_statuses(
     }
 
     Ok(statuses)
+}
+
+/// Transforms the given Python objects into a vector of [`OptionGreeks`] objects.
+///
+/// # Errors
+///
+/// Returns a `PyErr` if element conversion fails or the data is not monotonically increasing.
+pub fn pyobjects_to_option_greeks(data: Vec<Bound<'_, PyAny>>) -> PyResult<Vec<OptionGreeks>> {
+    let greeks: Vec<OptionGreeks> = data
+        .into_iter()
+        .map(|obj| OptionGreeks::from_pyobject(&obj))
+        .collect::<PyResult<Vec<OptionGreeks>>>()?;
+
+    if !is_monotonically_increasing_by_init(&greeks) {
+        return Err(to_pyvalue_err(ERROR_MONOTONICITY));
+    }
+
+    Ok(greeks)
 }
 
 /// Transforms the given Python objects into a vector of [`InstrumentClose`] objects.

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -89,7 +89,7 @@ use nautilus_core::{
 use nautilus_model::{
     data::{
         Bar, CustomData, Data, FundingRateUpdate, HasTsInit, IndexPriceUpdate, InstrumentStatus,
-        MarkPriceUpdate, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
+        MarkPriceUpdate, OptionGreeks, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
         close::InstrumentClose, is_monotonically_increasing_by_init, to_variant,
     },
     events::{
@@ -385,6 +385,7 @@ impl ParquetDataCatalog {
         let mut mark_prices: Vec<MarkPriceUpdate> = Vec::new();
         let mut index_prices: Vec<IndexPriceUpdate> = Vec::new();
         let mut statuses: Vec<InstrumentStatus> = Vec::new();
+        let mut option_greeks: Vec<OptionGreeks> = Vec::new();
         let mut closes: Vec<InstrumentClose> = Vec::new();
         // Group custom data by full DataType identity (type_name + identifier + metadata)
         // so each batch is written to the correct path with consistent schema/metadata.
@@ -425,6 +426,9 @@ impl ParquetDataCatalog {
                 Data::InstrumentStatus(s) => {
                     statuses.push(s);
                 }
+                Data::OptionGreeks(g) => {
+                    option_greeks.push(g);
+                }
                 Data::InstrumentClose(c) => {
                     closes.push(c);
                 }
@@ -444,6 +448,7 @@ impl ParquetDataCatalog {
         self.write_to_parquet(mark_prices, start, end, skip_disjoint_check)?;
         self.write_to_parquet(index_prices, start, end, skip_disjoint_check)?;
         self.write_to_parquet(statuses, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(option_greeks, start, end, skip_disjoint_check)?;
         self.write_to_parquet(closes, start, end, skip_disjoint_check)?;
 
         for (_, items) in custom_data {
@@ -2141,6 +2146,16 @@ impl ParquetDataCatalog {
         self.query_typed_data::<InstrumentClose>(instrument_ids, start, end, None, None, true)
     }
 
+    /// Queries option greeks data for the specified instrument(s) and time range.
+    pub fn option_greeks(
+        &mut self,
+        instrument_ids: Option<Vec<String>>,
+        start: Option<UnixNanos>,
+        end: Option<UnixNanos>,
+    ) -> anyhow::Result<Vec<OptionGreeks>> {
+        self.query_typed_data::<OptionGreeks>(instrument_ids, start, end, None, None, true)
+    }
+
     /// Queries any instrument data for the specified instrument(s) and time range.
     pub fn instruments(
         &self,
@@ -3399,6 +3414,11 @@ impl ParquetDataCatalog {
                             self.convert_record_batches_to_data(batches, false)?;
                         prices.into_iter().map(Data::from).collect()
                     }
+                    "option_greeks" => {
+                        let greeks: Vec<OptionGreeks> =
+                            self.convert_record_batches_to_data(batches, false)?;
+                        greeks.into_iter().map(Data::from).collect()
+                    }
                     "instrument_status" => {
                         let statuses: Vec<InstrumentStatus> =
                             self.convert_record_batches_to_data(batches, false)?;
@@ -4034,6 +4054,7 @@ impl ParquetDataCatalog {
                     | "bars"
                     | "index_prices"
                     | "mark_prices"
+                    | "option_greeks"
                     | "instrument_status"
                     | "instrument_closes"
                     | "funding_rate_update"
@@ -4125,6 +4146,7 @@ impl_catalog_path_prefix!(IndexPriceUpdate, "index_prices");
 impl_catalog_path_prefix!(MarkPriceUpdate, "mark_prices");
 impl_catalog_path_prefix!(FundingRateUpdate, "funding_rate_update");
 impl_catalog_path_prefix!(InstrumentStatus, "instrument_status");
+impl_catalog_path_prefix!(OptionGreeks, "option_greeks");
 impl_catalog_path_prefix!(InstrumentClose, "instrument_closes");
 impl_catalog_path_prefix!(InstrumentAny, "instruments");
 impl_catalog_path_prefix!(AccountState, "account_state");

--- a/crates/persistence/src/backend/custom.rs
+++ b/crates/persistence/src/backend/custom.rs
@@ -28,8 +28,9 @@ use datafusion::arrow::{
 };
 use nautilus_core::UnixNanos;
 use nautilus_model::data::{
-    Bar, CustomData, CustomDataTrait, Data, IndexPriceUpdate, MarkPriceUpdate, OrderBookDelta,
-    OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose, encode_custom_to_arrow,
+    Bar, CustomData, CustomDataTrait, Data, IndexPriceUpdate, MarkPriceUpdate, OptionGreeks,
+    OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
+    encode_custom_to_arrow,
 };
 use nautilus_serialization::arrow::DecodeDataFromRecordBatch;
 #[cfg(feature = "python")]
@@ -197,6 +198,7 @@ pub fn decode_batch_to_data(
         "IndexPriceUpdate" | "index_price_updates" => {
             Ok(IndexPriceUpdate::decode_data_batch(metadata, batch)?)
         }
+        "OptionGreeks" | "option_greeks" => Ok(OptionGreeks::decode_data_batch(metadata, batch)?),
         "InstrumentClose" | "instrument_closes" => {
             Ok(InstrumentClose::decode_data_batch(metadata, batch)?)
         }

--- a/crates/persistence/src/backend/feather.rs
+++ b/crates/persistence/src/backend/feather.rs
@@ -35,9 +35,9 @@ use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
     data::{
         Bar, CatalogPathPrefix, CustomData, CustomDataTrait, Data, FundingRateUpdate,
-        IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OrderBookDelta, OrderBookDeltas,
-        OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose, encode_custom_to_arrow,
-        get_arrow_schema,
+        IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OptionGreeks, OrderBookDelta,
+        OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
+        encode_custom_to_arrow, get_arrow_schema,
     },
     events::{
         AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderDenied,
@@ -741,6 +741,7 @@ impl FeatherWriter {
             Data::IndexPriceUpdate(price) => self.write(price).await,
             Data::MarkPriceUpdate(price) => self.write(price).await,
             Data::InstrumentStatus(status) => self.write(status).await,
+            Data::OptionGreeks(greeks) => self.write(greeks).await,
             Data::InstrumentClose(close) => self.write(close).await,
             Data::Custom(custom) => self.write_custom_data(&custom).await,
             Data::Deltas(deltas_api) => {
@@ -841,6 +842,7 @@ impl FeatherWriter {
             try_write!(message, IndexPriceUpdate, "IndexPriceUpdate");
             try_write!(message, MarkPriceUpdate, "MarkPriceUpdate");
             try_write!(message, InstrumentStatus, "InstrumentStatus");
+            try_write!(message, OptionGreeks, "OptionGreeks");
             try_write!(message, InstrumentClose, "InstrumentClose");
             try_write!(message, FundingRateUpdate, "FundingRateUpdate");
             try_write!(message, AccountState, "AccountState");

--- a/crates/persistence/src/python/backend/session.rs
+++ b/crates/persistence/src/python/backend/session.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use nautilus_core::python::{IntoPyObjectNautilusExt, to_pyruntime_err};
 use nautilus_model::{
     data::{
-        Bar, Data, DataFFI, InstrumentStatus, MarkPriceUpdate, OrderBookDelta, OrderBookDepth10,
-        QuoteTick, TradeTick,
+        Bar, Data, DataFFI, InstrumentStatus, MarkPriceUpdate, OptionGreeks, OrderBookDelta,
+        OrderBookDepth10, QuoteTick, TradeTick,
     },
     python::data::DataFfiCVec,
 };
@@ -46,6 +46,7 @@ fn data_to_pyobject(py: Python<'_>, item: Data) -> PyResult<Py<PyAny>> {
         Data::IndexPriceUpdate(price) => Py::new(py, price).map(|x| x.into_any()),
         Data::MarkPriceUpdate(price) => Py::new(py, price).map(|x| x.into_any()),
         Data::InstrumentStatus(status) => Py::new(py, status).map(|x| x.into_any()),
+        Data::OptionGreeks(greeks) => Py::new(py, greeks).map(|x| x.into_any()),
         Data::InstrumentClose(close) => Py::new(py, close).map(|x| x.into_any()),
         Data::Custom(custom) => Py::new(py, custom).map(|x| x.into_any()),
     }
@@ -64,6 +65,7 @@ pub enum NautilusDataType {
     Bar = 5,
     MarkPriceUpdate = 6,
     InstrumentStatus = 7,
+    OptionGreeks = 8,
 }
 
 #[pymethods]
@@ -127,6 +129,9 @@ impl DataBackendSession {
                 .map_err(to_pyruntime_err),
             NautilusDataType::InstrumentStatus => slf
                 .add_file::<InstrumentStatus>(table_name, file_path, sql_query, None)
+                .map_err(to_pyruntime_err),
+            NautilusDataType::OptionGreeks => slf
+                .add_file::<OptionGreeks>(table_name, file_path, sql_query, None)
                 .map_err(to_pyruntime_err),
         }
     }
@@ -229,12 +234,15 @@ impl DataQueryResult {
 
         match acc {
             Some(acc) if !acc.is_empty() => {
-                let has_non_ffi = acc
-                    .iter()
-                    .any(|d| matches!(d, Data::Custom(_) | Data::InstrumentStatus(_)));
+                let has_non_ffi = acc.iter().any(|d| {
+                    matches!(
+                        d,
+                        Data::Custom(_) | Data::InstrumentStatus(_) | Data::OptionGreeks(_)
+                    )
+                });
 
                 if has_non_ffi {
-                    // Custom and instrument-status data: convert directly to Python objects (bypasses FFI)
+                    // Non-FFI data: convert directly to Python objects.
                     let objects: Vec<Py<PyAny>> = acc
                         .into_iter()
                         .map(|item| data_to_pyobject(py, item))

--- a/crates/persistence/src/python/catalog.rs
+++ b/crates/persistence/src/python/catalog.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use nautilus_core::{UnixNanos, python::to_pytype_err};
 use nautilus_model::{
     data::{
-        Bar, Data, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OrderBookDelta,
-        OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
+        Bar, Data, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OptionGreeks,
+        OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
     },
     python::instruments::{instrument_any_to_pyobject, pyobject_to_instrument_any},
 };
@@ -39,6 +39,7 @@ fn data_to_pyobject(py: Python<'_>, item: Data) -> PyResult<Py<PyAny>> {
         Data::IndexPriceUpdate(price) => Py::new(py, price).map(|x| x.into_any()),
         Data::MarkPriceUpdate(price) => Py::new(py, price).map(|x| x.into_any()),
         Data::InstrumentStatus(status) => Py::new(py, status).map(|x| x.into_any()),
+        Data::OptionGreeks(greeks) => Py::new(py, greeks).map(|x| x.into_any()),
         Data::InstrumentClose(close) => Py::new(py, close).map(|x| x.into_any()),
         Data::Custom(custom) => Py::new(py, custom).map(|x| x.into_any()),
     }
@@ -963,6 +964,20 @@ impl PyParquetDataCatalog {
                     .map_err(|e| PyIOError::new_err(format!("Query failed: {e}")))?;
                 statuses.into_iter().map(Data::from).collect()
             }
+            "option_greeks" => {
+                let greeks = self
+                    .inner
+                    .query_typed_data::<OptionGreeks>(
+                        identifiers,
+                        start_nanos,
+                        end_nanos,
+                        where_clause,
+                        files,
+                        optimize_file_loading,
+                    )
+                    .map_err(|e| PyIOError::new_err(format!("Query failed: {e}")))?;
+                greeks.into_iter().map(Data::from).collect()
+            }
             "instrument_closes" => {
                 let closes = self
                     .inner
@@ -1248,6 +1263,30 @@ impl PyParquetDataCatalog {
                 where_clause,
                 None,
                 true, // optimize_file_loading=true for directory-based registration (default)
+            )
+            .map_err(|e| PyIOError::new_err(format!("Failed to query data: {e}")))
+    }
+
+    /// Query option greeks data from Parquet files.
+    #[pyo3(signature = (instrument_ids=None, start=None, end=None, where_clause=None))]
+    pub fn query_option_greeks(
+        &mut self,
+        instrument_ids: Option<Vec<String>>,
+        start: Option<u64>,
+        end: Option<u64>,
+        where_clause: Option<&str>,
+    ) -> PyResult<Vec<OptionGreeks>> {
+        let start_nanos = start.map(UnixNanos::from);
+        let end_nanos = end.map(UnixNanos::from);
+
+        self.inner
+            .query_typed_data::<OptionGreeks>(
+                instrument_ids,
+                start_nanos,
+                end_nanos,
+                where_clause,
+                None,
+                true,
             )
             .map_err(|e| PyIOError::new_err(format!("Failed to query data: {e}")))
     }

--- a/crates/persistence/src/python/feather.rs
+++ b/crates/persistence/src/python/feather.rs
@@ -30,7 +30,8 @@ use nautilus_core::UnixNanos;
 use nautilus_model::{
     data::{
         Bar, Data, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate,
-        OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
+        OptionGreeks, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
+        close::InstrumentClose,
     },
     events::{
         AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderDenied,
@@ -199,6 +200,7 @@ impl PyStreamingFeatherWriter {
         per_instrument_types.insert("bars".to_string());
         per_instrument_types.insert("order_book_deltas".to_string());
         per_instrument_types.insert("order_book_depths".to_string());
+        per_instrument_types.insert("option_greeks".to_string());
         per_instrument_types.insert("quotes".to_string());
         per_instrument_types.insert("trades".to_string());
 
@@ -328,6 +330,14 @@ impl PyStreamingFeatherWriter {
             return runtime
                 .block_on(async { writer.write_data(Data::MarkPriceUpdate(price)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write MarkPriceUpdate: {e}")));
+        }
+
+        if let Ok(greeks) = data.extract::<OptionGreeks>(py) {
+            let mut writer = self.writer.borrow_mut();
+            let runtime = get_runtime();
+            return runtime
+                .block_on(async { writer.write_data(Data::OptionGreeks(greeks)).await })
+                .map_err(|e| PyIOError::new_err(format!("Failed to write OptionGreeks: {e}")));
         }
 
         if let Ok(close) = data.extract::<InstrumentClose>(py) {

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -19,12 +19,13 @@ use nautilus_core::{Params, UnixNanos};
 use nautilus_model::{
     data::{
         Bar, BarSpecification, BarType, BookOrder, CustomData, Data, DataType, HasTsInit,
-        IndexPriceUpdate, MarkPriceUpdate, OrderBookDelta, OrderBookDepth10, QuoteTick, TradeTick,
-        depth::DEPTH10_LEN, is_monotonically_increasing_by_init, to_variant,
+        IndexPriceUpdate, MarkPriceUpdate, OptionGreekValues, OptionGreeks, OrderBookDelta,
+        OrderBookDepth10, QuoteTick, TradeTick, depth::DEPTH10_LEN,
+        is_monotonically_increasing_by_init, to_variant,
     },
     enums::{
-        AggregationSource, AggressorSide, BarAggregation, BookAction, CurrencyType, OrderSide,
-        PriceType,
+        AggregationSource, AggressorSide, BarAggregation, BookAction, CurrencyType,
+        GreeksConvention, OrderSide, PriceType,
     },
     identifiers::{InstrumentId, Symbol, TradeId},
     instruments::{
@@ -221,6 +222,27 @@ fn create_index_price_update(ts_init: u64) -> IndexPriceUpdate {
         UnixNanos::from(0),
         UnixNanos::from(ts_init),
     )
+}
+
+fn create_option_greeks(ts_init: u64) -> OptionGreeks {
+    OptionGreeks {
+        instrument_id: ethusdt_binance_id(),
+        convention: GreeksConvention::PriceAdjusted,
+        greeks: OptionGreekValues {
+            delta: 0.55,
+            gamma: 0.012,
+            vega: 3.4,
+            theta: -1.2,
+            rho: 0.01,
+        },
+        mark_iv: Some(0.64),
+        bid_iv: None,
+        ask_iv: Some(0.66),
+        underlying_price: Some(100_000.0),
+        open_interest: None,
+        ts_event: UnixNanos::from(ts_init - 1),
+        ts_init: UnixNanos::from(ts_init),
+    }
 }
 
 fn create_bar(ts_init: u64) -> Bar {
@@ -1419,6 +1441,30 @@ fn test_generic_query_typed_data_bars() {
     let b = &result[0];
     assert_eq!(b.bar_type.instrument_id().to_string(), "AUD/USD.SIM");
     assert_eq!(b.ts_init, UnixNanos::from(1000));
+}
+
+#[rstest]
+fn test_write_data_enum_option_greeks_round_trip() {
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+    let greeks = vec![create_option_greeks(1000), create_option_greeks(2000)];
+    let data: Vec<Data> = greeks.iter().copied().map(Data::OptionGreeks).collect();
+
+    catalog
+        .write_data_enum(&data, None, None, Some(false))
+        .unwrap();
+
+    let result = catalog
+        .query_typed_data::<OptionGreeks>(
+            Some(vec!["ETH/USDT.BINANCE".to_string()]),
+            Some(UnixNanos::from(500)),
+            Some(UnixNanos::from(2500)),
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(result, greeks);
 }
 
 #[rstest]

--- a/crates/serialization/src/arrow/mod.rs
+++ b/crates/serialization/src/arrow/mod.rs
@@ -29,6 +29,7 @@ pub mod instrument;
 pub mod instrument_status;
 pub mod json;
 pub mod mark_price;
+pub mod option_greeks;
 pub mod order_event;
 pub mod position_event;
 pub mod quote;
@@ -51,8 +52,8 @@ use arrow::{
 use nautilus_model::{
     data::{
         Data, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, bar::Bar,
-        close::InstrumentClose, delta::OrderBookDelta, depth::OrderBookDepth10, quote::QuoteTick,
-        trade::TradeTick,
+        close::InstrumentClose, delta::OrderBookDelta, depth::OrderBookDepth10,
+        option_chain::OptionGreeks, quote::QuoteTick, trade::TradeTick,
     },
     types::{
         PRICE_ERROR, PRICE_UNDEF, Price, QUANTITY_UNDEF, Quantity,
@@ -642,6 +643,26 @@ pub fn instrument_status_to_arrow_record_batch_bytes(
     let first = data.first().unwrap();
     let metadata = first.metadata();
     InstrumentStatus::encode_batch(&metadata, data).map_err(EncodingError::ArrowError)
+}
+
+/// Converts a vector of `OptionGreeks` into an Arrow `RecordBatch`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - `data` is empty: `EncodingError::EmptyData`.
+/// - Encoding fails: `EncodingError::ArrowError`.
+#[expect(clippy::missing_panics_doc)] // Guarded by empty check
+pub fn option_greeks_to_arrow_record_batch_bytes(
+    data: &[OptionGreeks],
+) -> Result<RecordBatch, EncodingError> {
+    if data.is_empty() {
+        return Err(EncodingError::EmptyData);
+    }
+
+    let first = data.first().unwrap();
+    let metadata = first.metadata();
+    OptionGreeks::encode_batch(&metadata, data).map_err(EncodingError::ArrowError)
 }
 
 /// Converts a vector of `InstrumentClose` into an Arrow `RecordBatch`.

--- a/crates/serialization/src/arrow/option_greeks.rs
+++ b/crates/serialization/src/arrow/option_greeks.rs
@@ -1,0 +1,268 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use arrow::{
+    array::{Array, Float64Array, Float64Builder, StringBuilder, UInt64Array},
+    datatypes::{DataType, Field, Schema},
+    error::ArrowError,
+    record_batch::RecordBatch,
+};
+use nautilus_model::{
+    data::{Data, greeks::OptionGreekValues, option_chain::OptionGreeks},
+    enums::GreeksConvention,
+    identifiers::InstrumentId,
+};
+
+use super::{
+    ArrowSchemaProvider, DecodeDataFromRecordBatch, DecodeFromRecordBatch, EncodeToRecordBatch,
+    EncodingError, KEY_INSTRUMENT_ID, extract_column, extract_column_string,
+};
+
+const TYPE_NAME: &str = "OptionGreeks";
+
+impl ArrowSchemaProvider for OptionGreeks {
+    fn get_schema(metadata: Option<HashMap<String, String>>) -> Schema {
+        let fields = vec![
+            Field::new("instrument_id", DataType::Utf8, false),
+            Field::new("delta", DataType::Float64, false),
+            Field::new("gamma", DataType::Float64, false),
+            Field::new("vega", DataType::Float64, false),
+            Field::new("theta", DataType::Float64, false),
+            Field::new("rho", DataType::Float64, false),
+            Field::new("mark_iv", DataType::Float64, true),
+            Field::new("bid_iv", DataType::Float64, true),
+            Field::new("ask_iv", DataType::Float64, true),
+            Field::new("underlying_price", DataType::Float64, true),
+            Field::new("open_interest", DataType::Float64, true),
+            Field::new("ts_event", DataType::UInt64, false),
+            Field::new("ts_init", DataType::UInt64, false),
+            Field::new("convention", DataType::Utf8, false),
+        ];
+
+        let mut metadata = metadata.unwrap_or_default();
+        metadata.insert("type".to_string(), TYPE_NAME.to_string());
+        Schema::new_with_metadata(fields, metadata)
+    }
+}
+
+fn append_optional_f64(builder: &mut Float64Builder, value: Option<f64>) {
+    match value {
+        Some(value) => builder.append_value(value),
+        None => builder.append_null(),
+    }
+}
+
+fn optional_f64(values: &Float64Array, row: usize) -> Option<f64> {
+    if values.is_null(row) {
+        None
+    } else {
+        Some(values.value(row))
+    }
+}
+
+impl EncodeToRecordBatch for OptionGreeks {
+    fn encode_batch(
+        metadata: &HashMap<String, String>,
+        data: &[Self],
+    ) -> Result<RecordBatch, ArrowError> {
+        let mut instrument_id_builder = StringBuilder::new();
+        let mut delta_builder = Float64Builder::new();
+        let mut gamma_builder = Float64Builder::new();
+        let mut vega_builder = Float64Builder::new();
+        let mut theta_builder = Float64Builder::new();
+        let mut rho_builder = Float64Builder::new();
+        let mut mark_iv_builder = Float64Builder::new();
+        let mut bid_iv_builder = Float64Builder::new();
+        let mut ask_iv_builder = Float64Builder::new();
+        let mut underlying_price_builder = Float64Builder::new();
+        let mut open_interest_builder = Float64Builder::new();
+        let mut ts_event_builder = UInt64Array::builder(data.len());
+        let mut ts_init_builder = UInt64Array::builder(data.len());
+        let mut convention_builder = StringBuilder::new();
+
+        for greeks in data {
+            instrument_id_builder.append_value(greeks.instrument_id.to_string());
+            delta_builder.append_value(greeks.delta);
+            gamma_builder.append_value(greeks.gamma);
+            vega_builder.append_value(greeks.vega);
+            theta_builder.append_value(greeks.theta);
+            rho_builder.append_value(greeks.rho);
+            append_optional_f64(&mut mark_iv_builder, greeks.mark_iv);
+            append_optional_f64(&mut bid_iv_builder, greeks.bid_iv);
+            append_optional_f64(&mut ask_iv_builder, greeks.ask_iv);
+            append_optional_f64(&mut underlying_price_builder, greeks.underlying_price);
+            append_optional_f64(&mut open_interest_builder, greeks.open_interest);
+            ts_event_builder.append_value(greeks.ts_event.as_u64());
+            ts_init_builder.append_value(greeks.ts_init.as_u64());
+            convention_builder.append_value(greeks.convention);
+        }
+
+        RecordBatch::try_new(
+            Arc::new(Self::get_schema(Some(metadata.clone()))),
+            vec![
+                Arc::new(instrument_id_builder.finish()),
+                Arc::new(delta_builder.finish()),
+                Arc::new(gamma_builder.finish()),
+                Arc::new(vega_builder.finish()),
+                Arc::new(theta_builder.finish()),
+                Arc::new(rho_builder.finish()),
+                Arc::new(mark_iv_builder.finish()),
+                Arc::new(bid_iv_builder.finish()),
+                Arc::new(ask_iv_builder.finish()),
+                Arc::new(underlying_price_builder.finish()),
+                Arc::new(open_interest_builder.finish()),
+                Arc::new(ts_event_builder.finish()),
+                Arc::new(ts_init_builder.finish()),
+                Arc::new(convention_builder.finish()),
+            ],
+        )
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        HashMap::from([
+            ("type".to_string(), TYPE_NAME.to_string()),
+            (
+                KEY_INSTRUMENT_ID.to_string(),
+                self.instrument_id.to_string(),
+            ),
+        ])
+    }
+}
+
+impl DecodeFromRecordBatch for OptionGreeks {
+    fn decode_batch(
+        _metadata: &HashMap<String, String>,
+        record_batch: RecordBatch,
+    ) -> Result<Vec<Self>, EncodingError> {
+        let cols = record_batch.columns();
+
+        let instrument_id_values = extract_column_string(cols, "instrument_id", 0)?;
+        let delta_values = extract_column::<Float64Array>(cols, "delta", 1, DataType::Float64)?;
+        let gamma_values = extract_column::<Float64Array>(cols, "gamma", 2, DataType::Float64)?;
+        let vega_values = extract_column::<Float64Array>(cols, "vega", 3, DataType::Float64)?;
+        let theta_values = extract_column::<Float64Array>(cols, "theta", 4, DataType::Float64)?;
+        let rho_values = extract_column::<Float64Array>(cols, "rho", 5, DataType::Float64)?;
+        let mark_iv_values = extract_column::<Float64Array>(cols, "mark_iv", 6, DataType::Float64)?;
+        let bid_iv_values = extract_column::<Float64Array>(cols, "bid_iv", 7, DataType::Float64)?;
+        let ask_iv_values = extract_column::<Float64Array>(cols, "ask_iv", 8, DataType::Float64)?;
+        let underlying_price_values =
+            extract_column::<Float64Array>(cols, "underlying_price", 9, DataType::Float64)?;
+        let open_interest_values =
+            extract_column::<Float64Array>(cols, "open_interest", 10, DataType::Float64)?;
+        let ts_event_values =
+            extract_column::<UInt64Array>(cols, "ts_event", 11, DataType::UInt64)?;
+        let ts_init_values = extract_column::<UInt64Array>(cols, "ts_init", 12, DataType::UInt64)?;
+        let convention_values = extract_column_string(cols, "convention", 13)?;
+
+        let result: Result<Vec<Self>, EncodingError> = (0..record_batch.num_rows())
+            .map(|row| {
+                let instrument_id = InstrumentId::from_str(instrument_id_values.value(row))
+                    .map_err(|e| EncodingError::ParseError("instrument_id", e.to_string()))?;
+                let convention = GreeksConvention::from_str(convention_values.value(row))
+                    .map_err(|e| EncodingError::ParseError("convention", e.to_string()))?;
+
+                Ok(Self {
+                    instrument_id,
+                    convention,
+                    greeks: OptionGreekValues {
+                        delta: delta_values.value(row),
+                        gamma: gamma_values.value(row),
+                        vega: vega_values.value(row),
+                        theta: theta_values.value(row),
+                        rho: rho_values.value(row),
+                    },
+                    mark_iv: optional_f64(mark_iv_values, row),
+                    bid_iv: optional_f64(bid_iv_values, row),
+                    ask_iv: optional_f64(ask_iv_values, row),
+                    underlying_price: optional_f64(underlying_price_values, row),
+                    open_interest: optional_f64(open_interest_values, row),
+                    ts_event: ts_event_values.value(row).into(),
+                    ts_init: ts_init_values.value(row).into(),
+                })
+            })
+            .collect();
+
+        result
+    }
+}
+
+impl DecodeDataFromRecordBatch for OptionGreeks {
+    fn decode_data_batch(
+        metadata: &HashMap<String, String>,
+        record_batch: RecordBatch,
+    ) -> Result<Vec<Data>, EncodingError> {
+        let greeks = Self::decode_batch(metadata, record_batch)?;
+        Ok(greeks.into_iter().map(Data::from).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_model::{enums::GreeksConvention, identifiers::InstrumentId};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_encode_decode_round_trip() {
+        let instrument_id = InstrumentId::from("BTC-20260529-100000-C.OKX");
+        let original = vec![
+            OptionGreeks {
+                instrument_id,
+                convention: GreeksConvention::BlackScholes,
+                greeks: OptionGreekValues {
+                    delta: 0.55,
+                    gamma: 0.012,
+                    vega: 3.4,
+                    theta: -1.2,
+                    rho: 0.01,
+                },
+                mark_iv: Some(0.64),
+                bid_iv: Some(0.62),
+                ask_iv: Some(0.66),
+                underlying_price: Some(100_000.0),
+                open_interest: Some(42.0),
+                ts_event: 1.into(),
+                ts_init: 2.into(),
+            },
+            OptionGreeks {
+                instrument_id,
+                convention: GreeksConvention::PriceAdjusted,
+                greeks: OptionGreekValues {
+                    delta: 0.42,
+                    gamma: 0.009,
+                    vega: 2.9,
+                    theta: -0.9,
+                    rho: 0.02,
+                },
+                mark_iv: None,
+                bid_iv: None,
+                ask_iv: None,
+                underlying_price: None,
+                open_interest: None,
+                ts_event: 3.into(),
+                ts_init: 4.into(),
+            },
+        ];
+
+        let metadata = original[0].metadata();
+        let record_batch = OptionGreeks::encode_batch(&metadata, &original).unwrap();
+        let decoded = OptionGreeks::decode_batch(&metadata, record_batch).unwrap();
+
+        assert_eq!(decoded, original);
+    }
+}

--- a/crates/serialization/src/python/arrow.rs
+++ b/crates/serialization/src/python/arrow.rs
@@ -22,13 +22,13 @@ use arrow::{
 use nautilus_core::python::{to_pyruntime_err, to_pytype_err, to_pyvalue_err};
 use nautilus_model::{
     data::{
-        Bar, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OrderBookDelta, OrderBookDepth10,
-        QuoteTick, TradeTick, close::InstrumentClose,
+        Bar, IndexPriceUpdate, InstrumentStatus, MarkPriceUpdate, OptionGreeks, OrderBookDelta,
+        OrderBookDepth10, QuoteTick, TradeTick, close::InstrumentClose,
     },
     python::data::{
         pyobjects_to_bars, pyobjects_to_book_deltas, pyobjects_to_index_prices,
         pyobjects_to_instrument_closes, pyobjects_to_instrument_statuses, pyobjects_to_mark_prices,
-        pyobjects_to_quotes, pyobjects_to_trades,
+        pyobjects_to_option_greeks, pyobjects_to_quotes, pyobjects_to_trades,
     },
 };
 use pyo3::{
@@ -38,10 +38,11 @@ use pyo3::{
 };
 
 use crate::arrow::{
-    ArrowSchemaProvider, DecodeTypedFromRecordBatch, bars_to_arrow_record_batch_bytes,
-    book_deltas_to_arrow_record_batch_bytes, book_depth10_to_arrow_record_batch_bytes,
-    index_prices_to_arrow_record_batch_bytes, instrument_closes_to_arrow_record_batch_bytes,
-    instrument_status_to_arrow_record_batch_bytes, mark_prices_to_arrow_record_batch_bytes,
+    ArrowSchemaProvider, DecodeFromRecordBatch, DecodeTypedFromRecordBatch,
+    bars_to_arrow_record_batch_bytes, book_deltas_to_arrow_record_batch_bytes,
+    book_depth10_to_arrow_record_batch_bytes, index_prices_to_arrow_record_batch_bytes,
+    instrument_closes_to_arrow_record_batch_bytes, instrument_status_to_arrow_record_batch_bytes,
+    mark_prices_to_arrow_record_batch_bytes, option_greeks_to_arrow_record_batch_bytes,
     quotes_to_arrow_record_batch_bytes, trades_to_arrow_record_batch_bytes,
 };
 
@@ -86,6 +87,7 @@ pub fn get_arrow_schema_map(py: Python<'_>, cls: &Bound<'_, PyType>) -> PyResult
         stringify!(MarkPriceUpdate) => MarkPriceUpdate::get_schema_map(),
         stringify!(IndexPriceUpdate) => IndexPriceUpdate::get_schema_map(),
         stringify!(InstrumentStatus) => InstrumentStatus::get_schema_map(),
+        stringify!(OptionGreeks) => OptionGreeks::get_schema_map(),
         stringify!(InstrumentClose) => InstrumentClose::get_schema_map(),
         _ => {
             return Err(to_pytype_err(format!(
@@ -151,6 +153,10 @@ pub fn pyobjects_to_arrow_record_batch_bytes(
         stringify!(InstrumentStatus) => {
             let statuses = pyobjects_to_instrument_statuses(data)?;
             py_instrument_status_to_arrow_record_batch_bytes(py, statuses)
+        }
+        stringify!(OptionGreeks) => {
+            let greeks = pyobjects_to_option_greeks(data)?;
+            py_option_greeks_to_arrow_record_batch_bytes(py, greeks)
         }
         stringify!(InstrumentClose) => {
             let closes = pyobjects_to_instrument_closes(data)?;
@@ -301,6 +307,50 @@ pub fn py_instrument_status_to_arrow_record_batch_bytes(
         Ok(batch) => arrow_record_batch_to_pybytes(py, &batch),
         Err(e) => Err(to_pyvalue_err(e)),
     }
+}
+
+/// Converts a list of `OptionGreeks` into Arrow IPC bytes for Python.
+///
+/// # Errors
+///
+/// Returns a `PyErr` if encoding fails.
+#[pyfunction(name = "option_greeks_to_arrow_record_batch_bytes")]
+#[pyo3_stub_gen::derive::gen_stub_pyfunction(module = "nautilus_trader.serialization")]
+#[expect(clippy::needless_pass_by_value)]
+pub fn py_option_greeks_to_arrow_record_batch_bytes(
+    py: Python,
+    data: Vec<OptionGreeks>,
+) -> PyResult<Py<PyBytes>> {
+    match option_greeks_to_arrow_record_batch_bytes(&data) {
+        Ok(batch) => arrow_record_batch_to_pybytes(py, &batch),
+        Err(e) => Err(to_pyvalue_err(e)),
+    }
+}
+
+/// Decodes Arrow IPC bytes into a list of `OptionGreeks`.
+///
+/// # Errors
+///
+/// Returns a `PyErr` if decoding fails.
+#[pyfunction(name = "option_greeks_from_arrow_record_batch_bytes")]
+#[pyo3_stub_gen::derive::gen_stub_pyfunction(module = "nautilus_trader.serialization")]
+pub fn py_option_greeks_from_arrow_record_batch_bytes(
+    _py: Python,
+    data: Vec<u8>,
+) -> PyResult<Vec<OptionGreeks>> {
+    let cursor = Cursor::new(data);
+    let reader = StreamReader::try_new(cursor, None).map_err(to_pyruntime_err)?;
+
+    let mut results = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result.map_err(to_pyruntime_err)?;
+        let metadata = batch.schema().metadata().clone();
+        let decoded = OptionGreeks::decode_batch(&metadata, batch).map_err(to_pyvalue_err)?;
+        results.extend(decoded);
+    }
+
+    Ok(results)
 }
 
 /// Decodes Arrow IPC bytes into a list of `InstrumentStatus`.

--- a/crates/serialization/src/python/mod.rs
+++ b/crates/serialization/src/python/mod.rs
@@ -77,6 +77,14 @@ pub fn serialization(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
             m
         )?)?;
         m.add_function(wrap_pyfunction!(
+            crate::python::arrow::py_option_greeks_to_arrow_record_batch_bytes,
+            m
+        )?)?;
+        m.add_function(wrap_pyfunction!(
+            crate::python::arrow::py_option_greeks_from_arrow_record_batch_bytes,
+            m
+        )?)?;
+        m.add_function(wrap_pyfunction!(
             crate::python::arrow::py_instrument_status_from_arrow_record_batch_bytes,
             m
         )?)?;

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -5556,6 +5556,7 @@ class NautilusDataType(Enum):
     Bar = 5
     MarkPriceUpdate = 6
     InstrumentStatus = 7
+    OptionGreeks = 8
 
 class DataBackendSession:
     def __init__(self, chunk_size: int = 10_000) -> None: ...
@@ -5678,6 +5679,8 @@ def instrument_status_to_arrow_record_batch_bytes(data: list[InstrumentStatus]) 
 def instrument_status_from_arrow_record_batch_bytes(
     data: bytes,
 ) -> list[InstrumentStatus]: ...
+def option_greeks_to_arrow_record_batch_bytes(data: list[OptionGreeks]) -> bytes: ...
+def option_greeks_from_arrow_record_batch_bytes(data: bytes) -> list[OptionGreeks]: ...
 def instrument_closes_to_arrow_record_batch_bytes(data: list[InstrumentClose]) -> bytes: ...
 
 ###################################################################################################

--- a/nautilus_trader/model/data.pyx
+++ b/nautilus_trader/model/data.pyx
@@ -352,6 +352,8 @@ cpdef list pyo3_list_to_data_list(list pyo3_items):
             result.append(MarkPriceUpdate.from_pyo3(item))
         elif type_name == "IndexPriceUpdate":
             result.append(IndexPriceUpdate.from_pyo3(item))
+        elif type_name == "OptionGreeks":
+            result.append(OptionGreeks.from_pyo3(item))
         elif type_name == "InstrumentStatus":
             result.append(InstrumentStatus.from_pyo3(item))
         elif type_name == "InstrumentClose":

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -55,6 +55,7 @@ from nautilus_trader.model.data import CustomData
 from nautilus_trader.model.data import DataType
 from nautilus_trader.model.data import InstrumentStatus
 from nautilus_trader.model.data import MarkPriceUpdate
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import OrderBookDepth10
@@ -78,6 +79,7 @@ NautilusRustDataType = Union[  # noqa: UP007 (mypy does not like pipe operators)
     nautilus_pyo3.QuoteTick,
     nautilus_pyo3.TradeTick,
     nautilus_pyo3.Bar,
+    nautilus_pyo3.OptionGreeks,
 ]
 
 
@@ -1633,6 +1635,7 @@ class ParquetDataCatalog(BaseDataCatalog):
                 TradeTick,
                 Bar,
                 MarkPriceUpdate,
+                OptionGreeks,
             )
             or self._is_rust_custom_data(data_cls)
         ) and files is None:
@@ -1701,6 +1704,10 @@ class ParquetDataCatalog(BaseDataCatalog):
         for chunk in result:
             if isinstance(chunk, list):
                 for item in chunk:
+                    if data_cls == OptionGreeks:
+                        data.append(OptionGreeks.from_pyo3(item))
+                        continue
+
                     inner = item.data if hasattr(item, "data") else item
                     data.append(data_cls.from_dict(inner.to_dict()))  # type: ignore[attr-defined]
             else:
@@ -2000,6 +2007,8 @@ class ParquetDataCatalog(BaseDataCatalog):
             return NautilusDataType.MarkPriceUpdate
         elif data_cls == InstrumentStatus:
             return NautilusDataType.InstrumentStatus
+        elif data_cls == OptionGreeks:
+            return NautilusDataType.OptionGreeks
         else:
             return None
 

--- a/nautilus_trader/persistence/funcs.py
+++ b/nautilus_trader/persistence/funcs.py
@@ -23,6 +23,7 @@ from nautilus_trader.core.nautilus_pyo3 import convert_to_snake_case
 from nautilus_trader.model.data import Bar
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.data import MarkPriceUpdate
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDepth10
 from nautilus_trader.model.data import QuoteTick
@@ -63,6 +64,7 @@ def filename_to_class(filename: str) -> type | None:
         "order_book_deltas": OrderBookDelta,
         "order_book_depths": OrderBookDepth10,
         "mark_price_update": MarkPriceUpdate,
+        "option_greeks": OptionGreeks,
     }
 
     if filename in builtin_filename_to_class:

--- a/nautilus_trader/persistence/writer.py
+++ b/nautilus_trader/persistence/writer.py
@@ -139,6 +139,7 @@ class StreamingFeatherWriter:
             "quote_tick",
             "trade_tick",
             "funding_rate_update",
+            "option_greeks",
         }
         self.rotation_mode = rotation_mode
         self.max_file_size = max_file_size

--- a/nautilus_trader/serialization/arrow/schema.py
+++ b/nautilus_trader/serialization/arrow/schema.py
@@ -26,6 +26,7 @@ from nautilus_trader.model.data import IndexPriceUpdate
 from nautilus_trader.model.data import InstrumentClose
 from nautilus_trader.model.data import InstrumentStatus
 from nautilus_trader.model.data import MarkPriceUpdate
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDepth10
 from nautilus_trader.model.data import QuoteTick
@@ -117,6 +118,25 @@ NAUTILUS_ARROW_SCHEMA = {
             "ts_init": pa.uint64(),
         },
         metadata={"type": "InstrumentStatus"},
+    ),
+    OptionGreeks: pa.schema(
+        [
+            pa.field("instrument_id", pa.string(), False),
+            pa.field("delta", pa.float64(), False),
+            pa.field("gamma", pa.float64(), False),
+            pa.field("vega", pa.float64(), False),
+            pa.field("theta", pa.float64(), False),
+            pa.field("rho", pa.float64(), False),
+            pa.field("mark_iv", pa.float64(), True),
+            pa.field("bid_iv", pa.float64(), True),
+            pa.field("ask_iv", pa.float64(), True),
+            pa.field("underlying_price", pa.float64(), True),
+            pa.field("open_interest", pa.float64(), True),
+            pa.field("ts_event", pa.uint64(), False),
+            pa.field("ts_init", pa.uint64(), False),
+            pa.field("convention", pa.string(), False),
+        ],
+        metadata={"type": "OptionGreeks"},
     ),
     InstrumentClose: pa.schema(
         {

--- a/nautilus_trader/serialization/arrow/serializer.py
+++ b/nautilus_trader/serialization/arrow/serializer.py
@@ -34,6 +34,7 @@ from nautilus_trader.model.data import FundingRateUpdate
 from nautilus_trader.model.data import IndexPriceUpdate
 from nautilus_trader.model.data import InstrumentClose
 from nautilus_trader.model.data import MarkPriceUpdate
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import OrderBookDepth10
@@ -67,6 +68,7 @@ NautilusRustDataType = Union[  # noqa: UP007 (mypy does not like pipe operators)
     nautilus_pyo3.Bar,
     nautilus_pyo3.MarkPriceUpdate,
     nautilus_pyo3.IndexPriceUpdate,
+    nautilus_pyo3.OptionGreeks,
     nautilus_pyo3.InstrumentClose,
 ]
 
@@ -161,6 +163,8 @@ class ArrowSerializer:
                 batch_bytes = nautilus_pyo3.trades_to_arrow_record_batch_bytes(data)
             case nautilus_pyo3.Bar:
                 batch_bytes = nautilus_pyo3.bars_to_arrow_record_batch_bytes(data)
+            case nautilus_pyo3.OptionGreeks:
+                batch_bytes = nautilus_pyo3.option_greeks_to_arrow_record_batch_bytes(data)
             case _:
                 if data_cls in (OrderBookDelta, OrderBookDeltas):
                     pyo3_deltas = OrderBookDelta.to_pyo3_list(data)
@@ -194,6 +198,11 @@ class ArrowSerializer:
                     pyo3_instrument_closes = InstrumentClose.to_pyo3_list(data)
                     batch_bytes = nautilus_pyo3.instrument_closes_to_arrow_record_batch_bytes(
                         pyo3_instrument_closes,
+                    )
+                elif data_cls == OptionGreeks:
+                    pyo3_option_greeks = [item.to_pyo3() for item in data]
+                    batch_bytes = nautilus_pyo3.option_greeks_to_arrow_record_batch_bytes(
+                        pyo3_option_greeks,
                     )
                 elif data_cls == OrderBookDepth10:
                     data = [
@@ -326,8 +335,13 @@ class ArrowSerializer:
             Bar: BarDataWranglerV2,
             MarkPriceUpdate: None,
             IndexPriceUpdate: None,
+            OptionGreeks: None,
             InstrumentClose: None,
         }[data_cls]
+
+        if data_cls == OptionGreeks:
+            pyo3_greeks = _option_greeks_decoder(table)
+            return [OptionGreeks.from_pyo3(item) for item in pyo3_greeks]
 
         if Wrangler is None:
             raise NotImplementedError
@@ -381,6 +395,7 @@ RUST_SERIALIZERS = {
     Bar,
     MarkPriceUpdate,
     IndexPriceUpdate,
+    OptionGreeks,
     # InstrumentClose,  # TODO: Not implemented yet
 }
 RUST_STR_SERIALIZERS = {s.__name__ for s in RUST_SERIALIZERS}
@@ -553,4 +568,37 @@ register_arrow(
     encoder=_instrument_status_encoder,
     decoder=_instrument_status_decoder,
     batch_encoder=_instrument_status_encoder,
+)
+
+
+_OPTION_GREEKS_PYO3_SCHEMA = NAUTILUS_ARROW_SCHEMA[OptionGreeks]
+
+
+def _option_greeks_encoder(data: list) -> pa.RecordBatch:
+    if not isinstance(data, list):
+        data = [data]
+    batch_bytes = nautilus_pyo3.option_greeks_to_arrow_record_batch_bytes(data)
+    reader = pa.ipc.open_stream(BytesIO(batch_bytes))
+    table = reader.read_all()
+    return table.to_batches()[0]
+
+
+def _option_greeks_decoder(table) -> list:
+    if isinstance(table, pa.RecordBatch):
+        table = pa.Table.from_batches([table])
+    sink = pa.BufferOutputStream()
+    writer = pa.ipc.new_stream(sink, table.schema)
+    for batch in table.to_batches():
+        writer.write_batch(batch)
+    writer.close()
+    ipc_bytes = sink.getvalue().to_pybytes()
+    return nautilus_pyo3.option_greeks_from_arrow_record_batch_bytes(ipc_bytes)
+
+
+register_arrow(
+    nautilus_pyo3.OptionGreeks,
+    schema=_OPTION_GREEKS_PYO3_SCHEMA,
+    encoder=_option_greeks_encoder,
+    decoder=_option_greeks_decoder,
+    batch_encoder=_option_greeks_encoder,
 )

--- a/tests/unit_tests/persistence/test_backend.py
+++ b/tests/unit_tests/persistence/test_backend.py
@@ -17,8 +17,10 @@ import pandas as pd
 import pytest
 
 from nautilus_trader import TEST_DATA_DIR
+from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.core.nautilus_pyo3 import DataBackendSession
 from nautilus_trader.core.nautilus_pyo3 import NautilusDataType
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import capsule_to_list
 from nautilus_trader.model.objects import HIGH_PRECISION
 
@@ -266,6 +268,39 @@ def test_pyo3_list_to_data_list_unknown_type_raises() -> None:
 
     with pytest.raises(RuntimeError, match="Cannot convert PyO3 data type"):
         pyo3_list_to_data_list(["not a data object"])
+
+
+def test_pyo3_list_to_data_list_option_greeks() -> None:
+    from nautilus_trader.model.data import pyo3_list_to_data_list
+
+    instrument_id = nautilus_pyo3.InstrumentId.from_str("BTC-20260529-100000-C.OKX")
+    pyo3_greeks = nautilus_pyo3.OptionGreeks(
+        instrument_id,
+        0.55,
+        0.012,
+        3.4,
+        -1.2,
+        0.01,
+        0.64,
+        None,
+        0.66,
+        100_000.0,
+        None,
+        1_000_000_000,
+        1_000_000_001,
+        nautilus_pyo3.GreeksConvention.PRICE_ADJUSTED,
+    )
+
+    result = pyo3_list_to_data_list([pyo3_greeks])
+
+    assert len(result) == 1
+    greeks = result[0]
+    assert isinstance(greeks, OptionGreeks)
+    assert greeks.instrument_id == OptionGreeks.from_pyo3(pyo3_greeks).instrument_id
+    assert greeks.delta == 0.55
+    assert greeks.bid_iv is None
+    assert greeks.open_interest is None
+    assert greeks.convention == nautilus_pyo3.GreeksConvention.PRICE_ADJUSTED
 
 
 def test_backend_session_register_object_store_from_uri_invalid_uri() -> None:

--- a/tests/unit_tests/persistence/test_funcs.py
+++ b/tests/unit_tests/persistence/test_funcs.py
@@ -16,6 +16,7 @@
 import pandas as pd
 import pytest
 
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
@@ -28,6 +29,7 @@ from nautilus_trader.persistence.funcs import filename_to_class
     [
         (TradeTick, "trade_tick"),
         (OrderBookDelta, "order_book_deltas"),
+        (OptionGreeks, "option_greeks"),
         (pd.DataFrame, "custom_data_frame"),
     ],
 )
@@ -40,6 +42,7 @@ def test_class_to_filename(s, expected):
     [
         ("trade_tick", TradeTick),
         ("order_book_deltas", OrderBookDelta),
+        ("option_greeks", OptionGreeks),
         ("quote_tick", QuoteTick),
         ("nonexistent_filename", None),
     ],

--- a/tests/unit_tests/serialization/test_arrow.py
+++ b/tests/unit_tests/serialization/test_arrow.py
@@ -30,6 +30,7 @@ from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.currencies import USDT
 from nautilus_trader.model.custom import customdataclass
+from nautilus_trader.model.data import OptionGreeks
 from nautilus_trader.model.data import OrderBookDelta
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.enums import AccountType
@@ -1280,6 +1281,63 @@ class TestArrowSerializer:
         assert roundtripped.is_trading is True
         assert roundtripped.is_quoting is True
         assert roundtripped.is_short_sell_restricted is False
+
+    def test_serialize_and_deserialize_pyo3_option_greeks(self):
+        from nautilus_trader.core import nautilus_pyo3
+
+        instrument_id = nautilus_pyo3.InstrumentId.from_str("BTC-20260529-100000-C.OKX")
+        greeks = nautilus_pyo3.OptionGreeks(
+            instrument_id,
+            0.55,
+            0.012,
+            3.4,
+            -1.2,
+            0.01,
+            0.64,
+            None,
+            0.66,
+            100_000.0,
+            None,
+            1_000_000_000,
+            1_000_000_001,
+            nautilus_pyo3.GreeksConvention.PRICE_ADJUSTED,
+        )
+
+        batch = ArrowSerializer.serialize_batch(
+            [greeks],
+            data_cls=nautilus_pyo3.OptionGreeks,
+        )
+        assert isinstance(batch, pa.Table)
+        assert batch.num_rows == 1
+
+        deserialized = ArrowSerializer.deserialize(
+            data_cls=nautilus_pyo3.OptionGreeks,
+            batch=batch,
+        )
+        assert len(deserialized) == 1
+        roundtripped = deserialized[0]
+        assert roundtripped.instrument_id == instrument_id
+        assert roundtripped.delta == 0.55
+        assert roundtripped.gamma == 0.012
+        assert roundtripped.vega == 3.4
+        assert roundtripped.theta == -1.2
+        assert roundtripped.rho == 0.01
+        assert roundtripped.mark_iv == 0.64
+        assert roundtripped.bid_iv is None
+        assert roundtripped.ask_iv == 0.66
+        assert roundtripped.underlying_price == 100_000.0
+        assert roundtripped.open_interest is None
+        assert roundtripped.ts_event == 1_000_000_000
+        assert roundtripped.ts_init == 1_000_000_001
+        assert roundtripped.convention == nautilus_pyo3.GreeksConvention.PRICE_ADJUSTED
+
+        self.catalog.write_data([OptionGreeks.from_pyo3(greeks)])
+        queried = self.catalog.query(data_cls=OptionGreeks, as_dataframe=False)
+        assert len(queried) == 1
+        assert str(queried[0].instrument_id) == str(instrument_id)
+        assert queried[0].bid_iv is None
+        assert queried[0].open_interest is None
+        assert queried[0].convention == nautilus_pyo3.GreeksConvention.PRICE_ADJUSTED
 
     @pytest.mark.parametrize("obj", nautilus_objects())
     def test_serialize_and_deserialize_all(self, obj):


### PR DESCRIPTION
## Summary

Fixes #4130.

Adds first-class Arrow/catalog persistence and backtest replay support for native `OptionGreeks` data.

This wires `OptionGreeks` through the Rust model/serialization/catalog path, Python Arrow serializer/catalog bridge, streaming writer mapping, and Python replay conversion path so persisted greeks can round-trip through catalog storage and replay as built-in market data.

## Changes

- Add Arrow schema, encoder, and decoder support for `OptionGreeks`.
- Add persistence/catalog support for writing and querying `Data::OptionGreeks`.
- Add Python Arrow serialization and catalog bridge coverage for `OptionGreeks`.
- Add streaming writer, filename mapping, and Parquet catalog data type mapping for `OptionGreeks`.
- Add Python replay conversion for PyO3-native `OptionGreeks` objects.
- Extend adapter/backtest dispatch paths where native greeks data needs to cross Rust/Python boundaries.
- Add focused Rust and Python regression tests for round-trip and replay conversion behavior.

## Verification

- `make build-debug VERBOSE=true`
- `make check-capnp-schemas`
- `cargo test -p nautilus-persistence test_write_data_enum_option_greeks_round_trip --test test_catalog`
- `cargo test --lib -p nautilus-serialization --features "$(./scripts/crate-test-features.sh nautilus-serialization)"`
- `cargo test -p nautilus-model test_option_greeks_data_serde_round_trip --lib`
- `uv run --active --no-sync pytest tests/unit_tests/persistence/test_backend.py::test_pyo3_list_to_data_list_option_greeks tests/unit_tests/persistence/test_backend.py::test_pyo3_list_to_data_list_unknown_type_raises -q`
- `uv run --active --no-sync pytest tests/unit_tests/serialization/test_arrow.py tests/unit_tests/persistence/test_funcs.py -q`
- `cargo fmt --check`
- `ruff format --check`
- `git diff --check`

## Notes

Full Python test suite, full workspace cargo test, and live adapter smoke were not run locally. Focused persistence, serialization, schema, formatting, and replay conversion checks passed.
