### PR TITLE
Rename custom data field serialization marker to serde

### DIFF
--- a/crates/adapters/betfair/src/data_types.rs
+++ b/crates/adapters/betfair/src/data_types.rs
@@ -57,16 +57,16 @@ pub struct BetfairTicker {
     /// The instrument ID for this ticker.
     pub instrument_id: InstrumentId,
     /// Last traded price.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub last_traded_price: Option<Decimal>,
     /// Total traded volume.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub traded_volume: Option<Decimal>,
     /// Starting price near (projected BSP from matched portion).
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub starting_price_near: Option<Decimal>,
     /// Starting price far (projected BSP from unmatched portion).
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub starting_price_far: Option<Decimal>,
     /// UNIX timestamp (nanoseconds) when the data event occurred.
     pub ts_event: UnixNanos,
@@ -82,7 +82,7 @@ pub struct BetfairStartingPrice {
     /// The instrument ID for this starting price.
     pub instrument_id: InstrumentId,
     /// The realized best starting price value.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub bsp: Decimal,
     /// UNIX timestamp (nanoseconds) when the data event occurred.
     pub ts_event: UnixNanos,
@@ -104,10 +104,10 @@ pub struct BetfairBspBookDelta {
     /// The order side as `OrderSide` u8.
     pub side: u32,
     /// The price level.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub price: Decimal,
     /// The size at this price level.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub size: Decimal,
     /// UNIX timestamp (nanoseconds) when the data event occurred.
     pub ts_event: UnixNanos,
@@ -140,21 +140,21 @@ pub struct BetfairOrderVoided {
     /// The venue (Betfair) order ID (bet ID).
     pub venue_order_id: String,
     /// The size that was voided.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub size_voided: Decimal,
     /// The order price.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub price: Decimal,
     /// The original order size.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub size: Decimal,
     /// The order side ("BACK" or "LAY").
     pub side: String,
     /// The average price matched.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub avg_price_matched: Option<Decimal>,
     /// The total size matched.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub size_matched: Option<Decimal>,
     /// The void reason. Empty string if absent.
     pub reason: String,

--- a/crates/adapters/hyperliquid/src/data_types.rs
+++ b/crates/adapters/hyperliquid/src/data_types.rs
@@ -36,7 +36,7 @@ use rust_decimal::Decimal;
 )]
 pub struct HyperliquidAllMids {
     /// Mapping of instrument ID to mid price for all tradable coins.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub mids: HashMap<InstrumentId, Price>,
     /// UNIX timestamp (nanoseconds) when the data event occurred.
     pub ts_event: UnixNanos,
@@ -60,7 +60,7 @@ pub struct HyperliquidOpenInterest {
     /// The instrument ID for this open interest update.
     pub instrument_id: InstrumentId,
     /// The current open interest for the perpetual instrument.
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub open_interest: Decimal,
     /// UNIX timestamp (nanoseconds) when the data event occurred.
     pub ts_event: UnixNanos,

--- a/crates/persistence/macros/src/custom.rs
+++ b/crates/persistence/macros/src/custom.rs
@@ -45,12 +45,14 @@
 //! - `no_display`: Do not generate `repr()` or `Display`; the user may implement them manually.
 //! - `no_arrow`: Do not generate Arrow schema or record batch encode/decode methods. Use this for
 //!   live-only custom data that does not need catalog persistence.
+//! - `no_new`: Do not generate the all-fields Rust `new` constructor; use this when the type
+//!   already has a domain-specific constructor.
 //! - `stub_module = "nautilus_trader.<module>"`: Generate pyo3-stub-gen metadata for the
 //!   given module. Requires `pyo3`.
-//! - `#[custom_data_field(json)]` on a field: Stores the field as a JSON-backed Arrow
-//!   `Utf8` column. The field type must implement Serde `Serialize` and `Deserialize`.
+//! - `#[custom_data_field(serde)]` on a field: Stores the field as a Serde JSON-backed
+//!   Arrow `Utf8` column. The field type must implement Serde `Serialize` and `Deserialize`.
 //!   Python access uses typed dict conversion for supported `HashMap<K, V>` and
-//!   `IndexMap<K, V>` field types, and a full JSON conversion for other JSON-backed fields.
+//!   `IndexMap<K, V>` field types, and a full Serde JSON conversion for other fields.
 //!   Use this for convenience and persistence rather than hot path fields.
 //!
 //! # Example
@@ -60,7 +62,7 @@
 //! pub struct MyCustomData {
 //!     pub instrument_id: InstrumentId,
 //!     pub value: f64,
-//!     #[custom_data_field(json)]
+//!     #[custom_data_field(serde)]
 //!     pub prices: IndexMap<InstrumentId, Price>,
 //!     pub ts_event: UnixNanos,
 //!     pub ts_init: UnixNanos,
@@ -69,11 +71,12 @@
 //! (The macro adds `#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]`.)
 
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{
     Field, Fields, Ident, ItemStruct, LitStr, Token, Type,
     parse::{Parse, ParseStream},
-    parse2,
+    parse_quote, parse2,
+    punctuated::Punctuated,
 };
 
 /// Returns the path for a type, if it is a path type.
@@ -585,12 +588,13 @@ struct CustomDataOptions {
     pyo3: bool,
     no_display: bool,
     no_arrow: bool,
+    no_new: bool,
     stub_module: Option<LitStr>,
 }
 
 #[derive(Clone, Copy, Default)]
 struct FieldOptions {
-    json: bool,
+    serde: bool,
 }
 
 struct FieldSpec {
@@ -614,8 +618,9 @@ fn parse_custom_data_option(
         ("pyo3" | "python", None) => options.pyo3 = true,
         ("no_display", None) => options.no_display = true,
         ("no_arrow", None) => options.no_arrow = true,
+        ("no_new", None) => options.no_new = true,
         ("stub_module", Some(module)) => options.stub_module = Some(module.clone()),
-        ("pyo3" | "python" | "no_display" | "no_arrow", Some(_)) => {
+        ("pyo3" | "python" | "no_display" | "no_arrow" | "no_new", Some(_)) => {
             return Err(syn::Error::new_spanned(
                 ident,
                 "option does not accept a value",
@@ -630,7 +635,7 @@ fn parse_custom_data_option(
         _ => {
             return Err(syn::Error::new_spanned(
                 ident,
-                "expected `pyo3`, `python`, `no_display`, `no_arrow`, or `stub_module`; unknown option",
+                "expected `pyo3`, `python`, `no_display`, `no_arrow`, `no_new`, or `stub_module`; unknown option",
             ));
         }
     }
@@ -684,6 +689,7 @@ fn parse_options(attr: &TokenStream) -> Result<CustomDataOptions, syn::Error> {
         pyo3: false,
         no_display: false,
         no_arrow: false,
+        no_new: false,
         stub_module: None,
     };
     let attr_str = attr.to_string();
@@ -711,11 +717,11 @@ fn parse_field_option_ident(
 ) -> Result<(), syn::Error> {
     let s = ident.to_string();
     match s.as_str() {
-        "json" => options.json = true,
+        "serde" => options.serde = true,
         _ => {
             return Err(syn::Error::new_spanned(
                 ident,
-                "expected `json`; unknown field option",
+                "expected `serde`; unknown field option",
             ));
         }
     }
@@ -738,6 +744,60 @@ fn parse_field_options(field: &Field) -> Result<FieldOptions, syn::Error> {
     Ok(options)
 }
 
+fn attr_has_ident(attr: &syn::Attribute, ident: &str) -> bool {
+    attr.path().get_ident().is_some_and(|i| *i == ident)
+}
+
+fn push_derive_path(paths: &mut Vec<syn::Path>, path: syn::Path) {
+    let key = path.to_token_stream().to_string();
+    if !paths.iter().any(|p| p.to_token_stream().to_string() == key) {
+        paths.push(path);
+    }
+}
+
+fn derive_path_name(path: &syn::Path) -> Option<String> {
+    path.segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+}
+
+fn push_required_derive_path(paths: &mut Vec<syn::Path>, path: syn::Path) {
+    let Some(name) = derive_path_name(&path) else {
+        push_derive_path(paths, path);
+        return;
+    };
+
+    if !paths
+        .iter()
+        .any(|p| derive_path_name(p).as_deref() == Some(name.as_str()))
+    {
+        paths.push(path);
+    }
+}
+
+fn derived_attr(attrs: &[syn::Attribute]) -> Result<TokenStream, syn::Error> {
+    let mut paths: Vec<syn::Path> = Vec::new();
+
+    for attr in attrs.iter().filter(|attr| attr_has_ident(attr, "derive")) {
+        let parsed: Punctuated<syn::Path, Token![,]> =
+            attr.parse_args_with(Punctuated::parse_terminated)?;
+
+        for path in parsed {
+            push_derive_path(&mut paths, path);
+        }
+    }
+
+    push_required_derive_path(&mut paths, parse_quote!(Debug));
+    push_required_derive_path(&mut paths, parse_quote!(Clone));
+    push_required_derive_path(&mut paths, parse_quote!(serde::Serialize));
+    push_required_derive_path(&mut paths, parse_quote!(serde::Deserialize));
+    push_required_derive_path(&mut paths, parse_quote!(PartialEq));
+
+    Ok(quote! {
+        #[derive(#(#paths),*)]
+    })
+}
+
 /// Context passed to each expansion generator for readability and testability.
 struct ExpansionContext<'a> {
     name: &'a Ident,
@@ -749,6 +809,10 @@ struct ExpansionContext<'a> {
 }
 
 fn gen_new_fn(ctx: &ExpansionContext<'_>) -> TokenStream {
+    if ctx.options.no_new {
+        return quote! {};
+    }
+
     let name = ctx.name;
     let generics = ctx.generics;
     let vis = ctx.vis;
@@ -932,7 +996,7 @@ fn gen_arrow_schema_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
-            let (arrow_dt, _, _) = arrow_type_for_rust_type(ty, f.options.json).unwrap();
+            let (arrow_dt, _, _) = arrow_type_for_rust_type(ty, f.options.serde).unwrap();
             let fn_str = ident.to_string();
             quote! {
                 arrow::datatypes::Field::new(#fn_str, #arrow_dt, false)
@@ -964,9 +1028,9 @@ fn gen_encode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
     for f in field_list {
         let ident = &f.ident;
         let ty = &f.ty;
-        let builder = encode_builder_for_field(ty, f.options.json, &len_var).unwrap();
-        let append = encode_field_expr(ident, ty, f.options.json).unwrap();
-        let finish = encode_finish_builder(ty, f.options.json).unwrap();
+        let builder = encode_builder_for_field(ty, f.options.serde, &len_var).unwrap();
+        let append = encode_field_expr(ident, ty, f.options.serde).unwrap();
+        let finish = encode_finish_builder(ty, f.options.serde).unwrap();
         let col_name = format_ident!("col_{}", col_builds.len());
         col_names.push(col_name.clone());
         col_builds.push(quote! {
@@ -1014,7 +1078,7 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
             let ident = &f.ident;
             let ty = &f.ty;
             let col_name = format_ident!("col_{}", idx);
-            let rhs = decode_field_rhs(ident, ty, f.options.json, &col_name).unwrap();
+            let rhs = decode_field_rhs(ident, ty, f.options.serde, &col_name).unwrap();
             quote! { #ident: #rhs }
         })
         .collect();
@@ -1027,7 +1091,7 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
             let col_name = format_ident!("col_{}", idx);
             let fn_str = ident.to_string();
 
-            if use_string_extract(ty, f.options.json) {
+            if use_string_extract(ty, f.options.serde) {
                 quote! {
                     let #col_name = nautilus_serialization::arrow::extract_column_string(
                         record_batch.columns(),
@@ -1036,7 +1100,8 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
                     )?;
                 }
             } else {
-                let (arrow_dt, _, array_ty) = arrow_type_for_rust_type(ty, f.options.json).unwrap();
+                let (arrow_dt, _, array_ty) =
+                    arrow_type_for_rust_type(ty, f.options.serde).unwrap();
                 quote! {
                     let #col_name = nautilus_serialization::arrow::extract_column::<#array_ty>(
                         record_batch.columns(),
@@ -1122,7 +1187,7 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
-            let py_ty = py_param_ty(ty, f.options.json).unwrap();
+            let py_ty = py_param_ty(ty, f.options.serde).unwrap();
             quote! { #ident: #py_ty }
         })
         .collect();
@@ -1131,7 +1196,7 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
-            let init = py_field_init(ident, ty, f.options.json).unwrap();
+            let init = py_field_init(ident, ty, f.options.serde).unwrap();
             quote! { let #ident = #init; }
         })
         .collect();
@@ -1147,8 +1212,8 @@ fn gen_pymethods_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
-            let ret_ty = py_getter_ret_ty(ty, f.options.json).unwrap();
-            let body = py_getter_body(ident, ty, f.options.json).unwrap();
+            let ret_ty = py_getter_ret_ty(ty, f.options.serde).unwrap();
+            let body = py_getter_body(ident, ty, f.options.serde).unwrap();
             quote! {
                 #[getter]
                 fn #ident(&self) -> #ret_ty {
@@ -1358,12 +1423,12 @@ pub(crate) fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenS
     };
 
     for field in &field_list {
-        if arrow_type_for_rust_type(&field.ty, field.options.json).is_none() {
+        if arrow_type_for_rust_type(&field.ty, field.options.serde).is_none() {
             let ident = &field.ident;
             return syn::Error::new_spanned(
                 &field.ty,
                 format!(
-                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>, or fields marked #[custom_data_field(json)]"
+                    "#[custom_data] does not support field type for '{ident}'; supported: InstrumentId, AccountId, Currency, BarType, Params, UnixNanos, f64, f32, bool, String, u64, i64, u32, i32, Vec<f64>, Vec<u8>, or fields marked #[custom_data_field(serde)]"
                 ),
             )
             .to_compile_error();
@@ -1427,9 +1492,13 @@ pub(crate) fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenS
     let struct_attrs: Vec<syn::Attribute> = input
         .attrs
         .iter()
-        .filter(|a| a.path().get_ident().is_none_or(|i| *i != "custom_data"))
+        .filter(|a| !attr_has_ident(a, "custom_data") && !attr_has_ident(a, "derive"))
         .cloned()
         .collect();
+    let derived_attr = match derived_attr(&input.attrs) {
+        Ok(attr) => attr,
+        Err(e) => return e.to_compile_error(),
+    };
     let pyclass_attr_ts: TokenStream = if options.pyo3 {
         quote! {
             #[cfg_attr(feature = "python", pyo3::pyclass(from_py_object))]
@@ -1457,9 +1526,6 @@ pub(crate) fn expand_custom_data(attr: TokenStream, item: TokenStream) -> TokenS
         })
         .collect();
 
-    let derived_attr = quote! {
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-    };
     quote! {
         #derived_attr
         #(#struct_attrs)*
@@ -1525,8 +1591,33 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "expected `pyo3`, `python`, `no_display`, `no_arrow`, or `stub_module`; unknown option",
+            "expected `pyo3`, `python`, `no_display`, `no_arrow`, `no_new`, or `stub_module`; unknown option",
         );
+    }
+
+    #[rstest]
+    fn expand_preserves_existing_imported_serde_derives_without_duplicates() {
+        let attr = quote! {};
+        let item = quote! {
+            #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+            pub struct TestData {
+                pub value: f64,
+                pub ts_event: nautilus_core::UnixNanos,
+                pub ts_init: nautilus_core::UnixNanos,
+            }
+        };
+
+        let expanded = expand_custom_data(attr, item).to_string();
+        let derive_tokens = expanded
+            .split("pub struct")
+            .next()
+            .expect("expanded struct must contain derives before struct");
+
+        assert_eq!(derive_tokens.matches("Serialize ,").count(), 1);
+        assert_eq!(derive_tokens.matches("Deserialize ,").count(), 1);
+        assert!(derive_tokens.contains("Copy"));
+        assert!(!derive_tokens.contains("serde :: Serialize"));
+        assert!(!derive_tokens.contains("serde :: Deserialize"));
     }
 
     #[rstest]

--- a/crates/persistence/macros/src/lib.rs
+++ b/crates/persistence/macros/src/lib.rs
@@ -30,12 +30,12 @@ use proc_macro::TokenStream;
 /// Requires fields to include `ts_event` and `ts_init` (e.g. `nautilus_core::UnixNanos`).
 /// Supported field types include InstrumentId, AccountId, Currency, BarType, Params, UnixNanos,
 /// f64, f32, bool, String, u64, i64, u32, i32, `Vec<f64>`, and `Vec<u8>`.
-/// Use `#[custom_data_field(json)]` on a field to store any Serde serializable field as a
-/// JSON-backed Arrow `Utf8` column. Python access uses typed dict conversion when both
+/// Use `#[custom_data_field(serde)]` on a field to store any Serde serializable field as a
+/// Serde JSON-backed Arrow `Utf8` column. Python access uses typed dict conversion when both
 /// `K` and `V` of `HashMap<K, V>` or `IndexMap<K, V>` are in the typed-element whitelist:
 /// `InstrumentId`, `AccountId`, `Currency`, `BarType`, `Price`, `Quantity`, `Money`, `String`,
 /// `f64`, `f32`, `bool`, `u64`, `i64`, `u32`, `i32` (see `is_typed_json_map_segment` in
-/// `custom.rs`). All other JSON-backed fields use the generic JSON bridge and accept/return
+/// `custom.rs`). All other Serde-backed fields use the generic JSON bridge and accept/return
 /// JSON-compatible Python values.
 ///
 /// Use `#[custom_data(pyo3)]` or `#[custom_data(python)]` to also generate Python bindings:
@@ -44,6 +44,7 @@ use proc_macro::TokenStream;
 /// named `new`; Python `__init__` forwards to it.
 /// Use `#[custom_data(pyo3, no_display)]` to skip generating `repr()` and `Display` so you can implement them manually.
 /// Use `#[custom_data(pyo3, no_arrow)]` for live-only custom data that does not need Arrow or catalog persistence.
+/// Use `#[custom_data(no_new)]` to skip generating the all-fields Rust `new` constructor.
 /// Use `stub_module = "nautilus_trader.<module>"` with `pyo3` to emit pyo3-stub-gen metadata.
 #[proc_macro_attribute]
 pub fn custom_data(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/persistence/src/test_data.rs
+++ b/crates/persistence/src/test_data.rs
@@ -67,7 +67,7 @@ pub struct RustTestParamsCustomData {
 #[custom_data(pyo3)]
 pub struct RustTestPriceMapCustomData {
     pub name: String,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub prices: IndexMap<InstrumentId, Price>,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
@@ -77,45 +77,45 @@ pub struct RustTestPriceMapCustomData {
 #[custom_data(pyo3)]
 pub struct RustTestTypedMapCustomData {
     pub name: String,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub instrument_ids: IndexMap<String, InstrumentId>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub account_ids: IndexMap<String, AccountId>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub currencies: IndexMap<String, Currency>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub bar_types: IndexMap<String, BarType>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub prices: IndexMap<String, Price>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub quantities: IndexMap<String, Quantity>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub monies: IndexMap<String, Money>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub prices_by_instrument: IndexMap<InstrumentId, Price>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub quantities_by_account: IndexMap<AccountId, Quantity>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub monies_by_currency: IndexMap<Currency, Money>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub prices_by_bar_type: IndexMap<BarType, Price>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub hash_prices_by_instrument: HashMap<InstrumentId, Price>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub strings: HashMap<String, String>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub floats_64: HashMap<String, f64>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub floats_32: HashMap<String, f32>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub booleans: HashMap<String, bool>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub integers_u64: HashMap<String, u64>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub integers_i64: HashMap<String, i64>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub integers_u32: HashMap<String, u32>,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub integers_i32: HashMap<String, i32>,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
@@ -125,8 +125,33 @@ pub struct RustTestTypedMapCustomData {
 #[custom_data]
 pub struct RustTestHashMapCustomData {
     pub name: String,
-    #[custom_data_field(json)]
+    #[custom_data_field(serde)]
     pub prices: HashMap<String, Price>,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
+/// Plain Serde enum stored inside custom data as a field.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum RustTestSerdeFieldKind {
+    Alpha,
+    Beta { count: u64 },
+}
+
+/// Plain Serde payload stored inside custom data without its own timestamps.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RustTestSerdeFieldPayload {
+    pub kind: RustTestSerdeFieldKind,
+    pub label: String,
+    pub values: Vec<f64>,
+}
+
+/// Rust custom data type that exercises arbitrary Serde field support.
+#[custom_data]
+pub struct RustTestSerdeFieldCustomData {
+    pub name: String,
+    #[custom_data_field(serde)]
+    pub payload: RustTestSerdeFieldPayload,
     pub ts_event: UnixNanos,
     pub ts_init: UnixNanos,
 }
@@ -134,7 +159,9 @@ pub struct RustTestHashMapCustomData {
 #[cfg(test)]
 mod tests {
     use arrow::datatypes::DataType;
-    use nautilus_serialization::arrow::ArrowSchemaProvider;
+    use nautilus_serialization::arrow::{
+        ArrowSchemaProvider, DecodeDataFromRecordBatch, EncodeToRecordBatch,
+    };
     use rstest::rstest;
 
     use super::*;
@@ -175,6 +202,38 @@ mod tests {
         let prices_field = schema.field_with_name("prices").unwrap();
 
         assert_eq!(prices_field.data_type(), &DataType::Utf8);
+    }
+
+    #[rstest]
+    fn test_rust_test_serde_field_custom_data_schema_uses_utf8_for_payload() {
+        let schema = RustTestSerdeFieldCustomData::get_schema(None);
+        let payload_field = schema.field_with_name("payload").unwrap();
+
+        assert_eq!(payload_field.data_type(), &DataType::Utf8);
+    }
+
+    #[rstest]
+    fn test_rust_test_serde_field_custom_data_roundtrip_decodes_exact_payload() {
+        let original = RustTestSerdeFieldCustomData {
+            name: "serde-field".to_string(),
+            payload: RustTestSerdeFieldPayload {
+                kind: RustTestSerdeFieldKind::Beta { count: 7 },
+                label: "payload".to_string(),
+                values: vec![1.0, 2.0, 3.0],
+            },
+            ts_event: UnixNanos::from(10),
+            ts_init: UnixNanos::from(11),
+        };
+        let metadata = original.metadata();
+        let batch =
+            RustTestSerdeFieldCustomData::encode_batch(&metadata, std::slice::from_ref(&original))
+                .unwrap();
+        let decoded = RustTestSerdeFieldCustomData::decode_data_batch(&metadata, batch).unwrap();
+
+        assert_eq!(decoded.len(), 1);
+        let decoded =
+            RustTestSerdeFieldCustomData::try_from(decoded.into_iter().next().unwrap()).unwrap();
+        assert_eq!(decoded, original);
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Renames the custom data field marker from `#[custom_data_field(json)]` to `#[custom_data_field(serde)]` to reflect that arbitrary Serde-compatible fields are serialized through JSON-backed Arrow `Utf8` columns.
- Updates custom data macro parsing, documentation, error messages, and generated code paths to use the new `serde` field option.
- Preserves user-specified derives when expanding `#[custom_data]` while still ensuring required derives are present.
- Adds a `no_new` macro option so future custom data structs with domain-specific constructors can opt out of generated all-fields constructors.
- Updates existing Betfair, Hyperliquid, and persistence test custom data types to use the new field marker.

### Testing

- `cargo test -p nautilus-persistence-macros`
- `cargo test -p nautilus-persistence test_rust_test_serde_field_custom_data --lib`
- `cargo fmt -p nautilus-model -p nautilus-persistence-macros -p nautilus-persistence`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4130

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
