### PR TITLE
Fix DataFusion S3 object store registration root

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -119,8 +119,8 @@ use super::{
     session::{self, DataBackendSession, QueryResult, build_query},
 };
 use crate::parquet::{
-    is_remote_uri_scheme, read_parquet_from_object_store, remote_full_uri, remote_store_root_url,
-    write_batches_to_object_store,
+    datafusion_store_root_url, is_remote_uri_scheme, read_parquet_from_object_store,
+    remote_full_uri, remote_store_root_url, write_batches_to_object_store,
 };
 
 /// A high-performance data catalog for storing and retrieving financial market data using Apache Parquet format.
@@ -2828,7 +2828,7 @@ impl ParquetDataCatalog {
 
     fn register_remote_object_store(&mut self) -> anyhow::Result<()> {
         if self.is_remote_uri() {
-            let base_url = remote_store_root_url(&self.original_uri)?;
+            let base_url = datafusion_store_root_url(&self.original_uri)?;
             self.session
                 .register_object_store(&base_url, self.object_store.clone());
         }

--- a/crates/persistence/src/backend/session.rs
+++ b/crates/persistence/src/backend/session.rs
@@ -109,7 +109,8 @@ impl DataBackendSession {
         let location =
             crate::parquet::create_object_store_location_from_path(uri, storage_options)?;
 
-        if let Some(root_url) = location.store_root_url().cloned() {
+        if location.store_root_url().is_some() {
+            let root_url = crate::parquet::datafusion_store_root_url(uri)?;
             self.register_object_store(&root_url, location.object_store);
         }
 

--- a/crates/persistence/src/parquet.rs
+++ b/crates/persistence/src/parquet.rs
@@ -44,6 +44,18 @@ pub(crate) fn remote_store_root_url(uri: &str) -> anyhow::Result<Url> {
     Ok(url)
 }
 
+pub(crate) fn datafusion_store_root_url(uri: &str) -> anyhow::Result<Url> {
+    let url = Url::parse(uri)?;
+
+    match url.scheme() {
+        // DataFusion's object store registry resolves S3 paths through the
+        // scheme-level store URL. The concrete bucket remains configured on
+        // the AmazonS3 object store itself.
+        "s3" => Ok(Url::parse("s3://")?),
+        _ => remote_store_root_url(uri),
+    }
+}
+
 pub(crate) fn remote_full_uri(uri: &str, object_path: &str) -> anyhow::Result<String> {
     let root = remote_store_root_url(uri)?;
     let root = root.as_str().trim_end_matches('/');
@@ -1089,6 +1101,19 @@ mod tests {
                 .expect("S3 should be remote")
                 .as_str()
                 .trim_end_matches('/'),
+            "s3://test-bucket"
+        );
+    }
+
+    #[rstest]
+    #[cfg(feature = "cloud")]
+    fn test_datafusion_store_root_url_uses_generic_s3_scheme() {
+        let root = datafusion_store_root_url("s3://test-bucket/path/to/catalog").unwrap();
+        assert_eq!(root.as_str(), "s3://");
+
+        let catalog_root = remote_store_root_url("s3://test-bucket/path/to/catalog").unwrap();
+        assert_eq!(
+            catalog_root.as_str().trim_end_matches('/'),
             "s3://test-bucket"
         );
     }


### PR DESCRIPTION
Closes #3120.

## Summary

This patch fixes S3 object-store registration for DataFusion-backed catalog queries without changing the catalog URI helpers that still need bucket-aware roots.

DataFusion resolves S3 object stores from the scheme-level registry URL (`s3://`), while Nautilus catalog path reconstruction and cross-store validation still need the bucket-aware root (`s3://bucket`). To keep those responsibilities separate, this patch adds `datafusion_store_root_url(...)` and uses it only where an object store is registered with DataFusion.

## Changes

- Add `datafusion_store_root_url(...)`.
- Use the DataFusion-specific root in `ParquetDataCatalog::register_remote_object_store(...)`.
- Use the same helper in `DataBackendSession::register_object_store_from_uri(...)`.
- Add a regression test verifying:
  - DataFusion S3 registration uses `s3://`.
  - Catalog root helpers still preserve `s3://test-bucket`.

## Validation

- `cargo fmt -- crates/persistence/src/parquet.rs crates/persistence/src/backend/catalog.rs crates/persistence/src/backend/session.rs`
- Verified `url::Url::parse("s3://")` with the `url` crate locally.

I could not run the focused Nautilus cargo test on my machine because current `develop` requires `rustc 1.95.0`; my environment has `rustc 1.94.1` and does not have `rustup` installed.

