### PR TITLE
Fix downsample_to_daily_bins to compound intraday returns

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -69,6 +69,7 @@ Released on TBD (UTC).
 - Fixed `StackStr::from_c_ptr_checked` to return `None` for null C string pointers
 
 ### Fixes
+- Fixed `PortfolioStatistic.downsample_to_daily_bins` arithmetic-sum aggregation producing incorrect `SharpeRatio`/`SortinoRatio`/`ReturnsVolatility`/`RiskReturnRatio`/`CAGR` for sub-daily returns; now compounds geometrically (Rust + Python)
 - Fixed unbounded Cache `VecDeque` memory leak (Rust) (#4107), thanks @filipmacek
 - Fixed `BacktestEngine` option positions remaining open when data stops before expiry
 - Fixed `BacktestEngine` losing latency-deferred commands at shutdown (Rust) (#4062), thanks for reporting @zhanghaoda

--- a/crates/analysis/src/statistic.rs
+++ b/crates/analysis/src/statistic.rs
@@ -78,7 +78,13 @@ pub trait PortfolioStatistic: Debug {
         !returns.is_empty()
     }
 
-    /// Downsamples high-frequency returns to daily bins for daily statistics calculation.
+    /// Downsamples high-frequency returns to daily bins by geometric compounding.
+    ///
+    /// Within each UTC day, returns are combined via `(1 + r1)(1 + r2) - 1` to produce
+    /// the day's effective return, which is the standard convention for chaining
+    /// arithmetic period returns. For daily-frequency inputs (one return per day) the
+    /// bin value is identical to the input value, so callers that already operate on
+    /// daily returns observe no behavior change.
     fn downsample_to_daily_bins(&self, returns: &Returns) -> Returns {
         let nanos_per_day = 86_400_000_000_000; // Number of nanoseconds in a day
         let mut daily_bins = BTreeMap::new();
@@ -87,8 +93,9 @@ pub trait PortfolioStatistic: Debug {
             // Calculate the start of the day in nanoseconds for the given timestamp
             let day_start = timestamp - (timestamp.as_u64() % nanos_per_day);
 
-            // Sum returns for each day
-            *daily_bins.entry(day_start).or_insert(0.0) += value;
+            // Geometrically compound returns within each day
+            let entry = daily_bins.entry(day_start).or_insert(0.0_f64);
+            *entry = (1.0_f64 + *entry).mul_add(1.0_f64 + value, -1.0_f64);
         }
 
         daily_bins
@@ -106,5 +113,81 @@ pub trait PortfolioStatistic: Debug {
         let variance = returns.values().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
 
         variance.sqrt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct DummyStat;
+
+    impl PortfolioStatistic for DummyStat {
+        type Item = f64;
+
+        fn name(&self) -> String {
+            "DummyStat".to_string()
+        }
+    }
+
+    const NANOS_PER_DAY: u64 = 86_400_000_000_000;
+    const BASE_NS: u64 = 1_600_000_000_000_000_000;
+
+    #[rstest]
+    fn test_downsample_compounds_intraday_returns() {
+        // Two intraday returns in the same UTC day: +5% then -5%.
+        //   arithmetic sum:  0.05 + (-0.05) = 0.00      (incorrect)
+        //   geometric chain: (1.05)(0.95) - 1 = -0.0025 (correct)
+        let stat = DummyStat;
+        let mut returns: Returns = BTreeMap::new();
+        returns.insert(UnixNanos::from(BASE_NS), 0.05);
+        returns.insert(UnixNanos::from(BASE_NS + 3_600_000_000_000), -0.05);
+
+        let daily = stat.downsample_to_daily_bins(&returns);
+
+        assert_eq!(daily.len(), 1);
+        let value = *daily.values().next().unwrap();
+        assert!(approx_eq!(f64, value, -0.0025, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_downsample_daily_inputs_unchanged() {
+        // For one-return-per-day inputs the bin value equals the input return,
+        // so existing callers that already pass daily returns see no change.
+        let stat = DummyStat;
+        let mut returns: Returns = BTreeMap::new();
+        returns.insert(UnixNanos::from(BASE_NS), 0.01);
+        returns.insert(UnixNanos::from(BASE_NS + NANOS_PER_DAY), -0.02);
+        returns.insert(UnixNanos::from(BASE_NS + 2 * NANOS_PER_DAY), 0.015);
+
+        let daily = stat.downsample_to_daily_bins(&returns);
+
+        let values: Vec<f64> = daily.values().copied().collect();
+        assert_eq!(values.len(), 3);
+        assert!(approx_eq!(f64, values[0], 0.01, epsilon = 1e-15));
+        assert!(approx_eq!(f64, values[1], -0.02, epsilon = 1e-15));
+        assert!(approx_eq!(f64, values[2], 0.015, epsilon = 1e-15));
+    }
+
+    #[rstest]
+    fn test_downsample_chains_three_intraday_returns() {
+        // Three returns in the same day: +1%, +2%, -1%.
+        //   geometric chain: (1.01)(1.02)(0.99) - 1 = 0.019998
+        let stat = DummyStat;
+        let mut returns: Returns = BTreeMap::new();
+        returns.insert(UnixNanos::from(BASE_NS), 0.01);
+        returns.insert(UnixNanos::from(BASE_NS + 3_600_000_000_000), 0.02);
+        returns.insert(UnixNanos::from(BASE_NS + 7_200_000_000_000), -0.01);
+
+        let daily = stat.downsample_to_daily_bins(&returns);
+
+        assert_eq!(daily.len(), 1);
+        let value = *daily.values().next().unwrap();
+        let expected = 1.01_f64 * 1.02 * 0.99 - 1.0;
+        assert!(approx_eq!(f64, value, expected, epsilon = 1e-12));
     }
 }

--- a/nautilus_trader/analysis/statistic.py
+++ b/nautilus_trader/analysis/statistic.py
@@ -134,4 +134,11 @@ class PortfolioStatistic:
         return not (returns is None or returns.empty or returns.isna().all())
 
     def _downsample_to_daily_bins(self, returns: pd.Series) -> pd.Series:
-        return returns.dropna().resample("1D").sum()
+        # Geometrically compound returns within each day: (1 + r1)(1 + r2) - 1
+        # is the standard convention for chaining arithmetic period returns. For
+        # daily-frequency inputs (one return per day) the bin value equals the
+        # input value, so callers already operating on daily returns observe no
+        # behavior change. `pd.Series(...)` narrows the pandas-stub Series|DataFrame
+        # union back to Series for mypy; the runtime is always Series.
+        compounded = returns.dropna().resample("1D").agg(lambda x: (1.0 + x).prod() - 1.0)
+        return pd.Series(compounded)

--- a/tests/unit_tests/analysis/test_statistic.py
+++ b/tests/unit_tests/analysis/test_statistic.py
@@ -13,6 +13,9 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import pandas as pd
+import pytest
+
 from nautilus_trader.analysis.statistic import PortfolioStatistic
 
 
@@ -33,3 +36,33 @@ class TestPortfolioStatistic:
 
         # Assert
         assert result == "Portfolio Statistic"
+
+    def test_downsample_to_daily_bins_compounds_intraday_returns(self):
+        # Two intraday returns in the same UTC day: +5% then -5%.
+        #   arithmetic sum:  0.05 + (-0.05) = 0.00      (incorrect)
+        #   geometric chain: (1.05)(0.95) - 1 = -0.0025 (correct)
+        stat = PortfolioStatistic()
+        day = pd.Timestamp("2024-01-02", tz="UTC")
+        returns = pd.Series(
+            [0.05, -0.05],
+            index=[day, day + pd.Timedelta(hours=1)],
+        )
+
+        daily = stat._downsample_to_daily_bins(returns)
+
+        assert len(daily) == 1
+        assert daily.iloc[0] == pytest.approx(-0.0025)
+
+    def test_downsample_to_daily_bins_daily_inputs_unchanged(self):
+        # For one-return-per-day inputs the bin value equals the input return,
+        # so existing callers already operating on daily returns see no change.
+        stat = PortfolioStatistic()
+        index = pd.date_range("2024-01-02", periods=3, freq="D", tz="UTC")
+        returns = pd.Series([0.01, -0.02, 0.015], index=index)
+
+        daily = stat._downsample_to_daily_bins(returns)
+
+        assert len(daily) == 3
+        assert daily.iloc[0] == pytest.approx(0.01)
+        assert daily.iloc[1] == pytest.approx(-0.02)
+        assert daily.iloc[2] == pytest.approx(0.015)

--- a/tests/unit_tests/analysis/test_statistics_returns_volatility.py
+++ b/tests/unit_tests/analysis/test_statistics_returns_volatility.py
@@ -81,4 +81,7 @@ class TestReturnsAnnualVolatilityPortfolioStatistic:
         result = stat.calculate_from_returns(convert_series_to_dict(data))
 
         # Assert
-        assert result == 57.23635208501674
+        # Intraday returns are geometrically compounded into daily bins before
+        # the std/annualization step; value reflects the corrected downsampling
+        # rather than the previous arithmetic-sum behavior.
+        assert result == 114.83901775964475

--- a/tests/unit_tests/analysis/test_statistics_sharpe_ratio.py
+++ b/tests/unit_tests/analysis/test_statistics_sharpe_ratio.py
@@ -86,5 +86,8 @@ class TestSharpeRatioPortfolioStatistic:
         result = stat.calculate_from_returns(convert_series_to_dict(data))
 
         # Assert
+        # Intraday returns are geometrically compounded into daily bins before
+        # the Sharpe calculation; value reflects the corrected downsampling
+        # rather than the previous arithmetic-sum behavior.
         assert result
-        assert math.isclose(result, 27.6097808756245, rel_tol=1e-9)
+        assert math.isclose(result, 23.89673625674424, rel_tol=1e-9)

--- a/tests/unit_tests/analysis/test_statistics_sortino_ratio.py
+++ b/tests/unit_tests/analysis/test_statistics_sortino_ratio.py
@@ -81,4 +81,7 @@ class TestSortinoRatioPortfolioStatistic:
         result = stat.calculate_from_returns(convert_series_to_dict(data))
 
         # Assert
-        assert result == 9.16515138991168
+        # Intraday returns are geometrically compounded into daily bins before
+        # the Sortino calculation; value reflects the corrected downsampling
+        # rather than the previous arithmetic-sum behavior.
+        assert result == 20.4939015319192


### PR DESCRIPTION
## Summary

`PortfolioStatistic.downsample_to_daily_bins` on both the Rust trait and the Python base aggregated intraday returns by arithmetic sum, so `SharpeRatio`, `SortinoRatio`, `ReturnsVolatility`, `RiskReturnRatio`, and `CAGR` reported incorrect numbers for any backtest fed sub-daily data.

Two intraday returns of +5% and -5% should fold to `(1.05)(0.95) - 1 = -0.25%`. The current implementation returns `0.05 + (-0.05) = 0%`.

Switch both paths to geometric compounding via `(1 + r1)(1 + r2) - 1`. For daily-frequency inputs (one return per day) the bin value still equals the input value, so existing daily-data callers see no behavior change.

The Python path edit keeps `nautilus_trader.analysis.statistic.PortfolioStatistic` in sync with the Rust trait so user-defined Python statistics that subclass it inherit the corrected helper; the built-in `SharpeRatio`/`SortinoRatio`/etc. exposed under `nautilus_trader.analysis` are PyO3-bound and pick up the fix through the Rust path.

## Migration

| Input shape | Behavior |
|---|---|
| Daily-frequency returns (one per day) | **Unchanged** — 131 existing Rust tests still pass with their original expected values |
| Intraday-frequency returns (multiple per day) | **Corrected** — geometric chain instead of arithmetic sum. Users running intraday backtests will observe corrected Sharpe/Sortino/ReturnsVolatility/RiskReturnRatio/CAGR values after upgrading. |

Three existing Python tests on the Rust-backed PyO3 stats encoded the arithmetic-sum outputs of synthetic 12h-frequency fixtures; their expected values are updated to the compounded results with an inline comment in each test documenting the change.

## Test plan

- **Rust:** `cargo test -p nautilus-analysis --lib` → 134 passed, 0 failed (3 new tests covering compounding correctness, daily-input invariance, and a three-leg chain).
- **Python (new):** `pytest tests/unit_tests/analysis/test_statistic.py` → 4 passed (2 new compounding tests).
- **Python (downstream PyO3 stats):** `pytest tests/unit_tests/analysis/test_statistics_*.py` → 70 passed (3 fixture-value updates; the 2 failures in `test_statistics_long_ratio.py` are pre-existing on `develop` and unrelated to this change).
- **Lint/format:** `cargo clippy -p nautilus-analysis --all-targets --no-deps -- -D warnings` clean, `cargo fmt -p nautilus-analysis -- --check` clean, `ruff format --check` + `ruff check` + `mypy` on the Python changes all clean.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] Updated `RELEASES.md` under `### Fixes` for 1.228.0 Beta.

## Files changed

- `crates/analysis/src/statistic.rs` — fix `downsample_to_daily_bins`; add 3 unit tests
- `nautilus_trader/analysis/statistic.py` — port the same fix to keep `PortfolioStatistic` parity
- `tests/unit_tests/analysis/test_statistic.py` — add 2 compounding tests
- `tests/unit_tests/analysis/test_statistics_returns_volatility.py` — update one fixture's expected value
- `tests/unit_tests/analysis/test_statistics_sharpe_ratio.py` — update one fixture's expected value
- `tests/unit_tests/analysis/test_statistics_sortino_ratio.py` — update one fixture's expected value
- `RELEASES.md` — `### Fixes` entry