### PR TITLE
Allow custom client order ID generators

### DIFF
--- a/nautilus_trader/common/factories.pxd
+++ b/nautilus_trader/common/factories.pxd
@@ -19,7 +19,6 @@ from cpython.datetime cimport datetime
 
 from nautilus_trader.cache.base cimport CacheFacade
 from nautilus_trader.common.component cimport Clock
-from nautilus_trader.common.generators cimport ClientOrderIdGenerator
 from nautilus_trader.common.generators cimport OrderListIdGenerator
 from nautilus_trader.core.rust.model cimport ContingencyType
 from nautilus_trader.core.rust.model cimport OrderSide
@@ -50,7 +49,7 @@ from nautilus_trader.model.orders.trailing_stop_market cimport TrailingStopMarke
 cdef class OrderFactory:
     cdef Clock _clock
     cdef CacheFacade _cache
-    cdef ClientOrderIdGenerator _order_id_generator
+    cdef object _order_id_generator
     cdef OrderListIdGenerator _order_list_id_generator
 
     cdef readonly TraderId trader_id
@@ -66,6 +65,7 @@ cdef class OrderFactory:
     cpdef get_order_list_id_count(self)
     cpdef void set_client_order_id_count(self, int count)
     cpdef void set_order_list_id_count(self, int count)
+    cpdef void set_client_order_id_generator(self, object generator)
     cpdef ClientOrderId generate_client_order_id(self)
     cpdef OrderListId generate_order_list_id(self)
     cpdef void reset(self)

--- a/nautilus_trader/common/factories.pyx
+++ b/nautilus_trader/common/factories.pyx
@@ -153,6 +153,20 @@ cdef class OrderFactory:
         """
         self._order_list_id_generator.set_count(count)
 
+    cpdef void set_client_order_id_generator(self, object generator):
+        """
+        Set the client order ID generator used by the factory.
+
+        Parameters
+        ----------
+        generator : object
+            The generator, which must provide a ``generate`` method returning a `ClientOrderId`.
+
+        """
+        Condition.not_none(generator, "generator")
+        Condition.is_true(hasattr(generator, "generate"), "generator must provide a generate method")
+        self._order_id_generator = generator
+
     cpdef ClientOrderId generate_client_order_id(self):
         """
         Generate and return a new client order ID.
@@ -166,7 +180,7 @@ cdef class OrderFactory:
         """
         cdef ClientOrderId client_order_id = self._order_id_generator.generate()
 
-        if self._order_id_generator.use_uuids:
+        if getattr(self._order_id_generator, "use_uuids", False):
             return client_order_id
 
         if self._cache is not None:

--- a/tests/unit_tests/common/test_factories.py
+++ b/tests/unit_tests/common/test_factories.py
@@ -26,6 +26,22 @@ from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 ETHUSDT_PERP_BINANCE = TestInstrumentProvider.ethusdt_perp_binance()
 
 
+class PrefixedClientOrderIdGenerator:
+    def __init__(self):
+        self.count = 0
+        self.use_uuids = False
+
+    def generate(self):
+        self.count += 1
+        return ClientOrderId(f"t-{self.count}")
+
+    def set_count(self, count):
+        self.count = count
+
+    def reset(self):
+        self.count = 0
+
+
 class TestOrderFactory:
     def setup(self):
         # Fixture Setup
@@ -127,6 +143,18 @@ class TestOrderFactory:
 
         # Assert
         assert result == OrderListId("OL-19700101-000000-000-001-2")
+
+    def test_set_client_order_id_generator(self):
+        # Arrange
+        generator = PrefixedClientOrderIdGenerator()
+        self.order_factory.set_client_order_id_generator(generator)
+
+        # Act
+        result = self.order_factory.generate_client_order_id()
+
+        # Assert
+        assert result == ClientOrderId("t-1")
+        assert self.order_factory.get_client_order_id_count() == 1
 
     def test_create_list(self):
         # Arrange


### PR DESCRIPTION
## Summary
- Adds `OrderFactory.set_client_order_id_generator(...)` so adapters and strategies can supply venue-specific `ClientOrderId` generation logic.
- Keeps the existing cache-based uniqueness loop in `OrderFactory.generate_client_order_id()` for non-UUID generators.
- Adds unit coverage for a custom prefixed generator, covering the use case described in #3505.

## Issue
Addresses #3505.

## Test plan
- `uvx ruff@0.15.13 check tests/unit_tests/common/test_factories.py`
- `uvx cython==3.2.4 -3 nautilus_trader/common/factories.pyx --working /tmp/nautilus-cython`

Full pytest was not run locally because this machine does not have `rustc`, which is required to build Nautilus Trader from source.