### PR TITLE
Optimize logging hot paths

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -154,6 +154,11 @@ name = "mstr"
 path = "benches/mstr.rs"
 harness = false
 
+[[bench]]
+name = "logging"
+path = "benches/logging.rs"
+harness = false
+
 # Run with `cargo run -p nautilus-common --features live --example greeks_actor_example`
 [[example]]
 name = "greeks_actor_example"

--- a/crates/common/benches/logging.rs
+++ b/crates/common/benches/logging.rs
@@ -1,0 +1,748 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Logging benchmarks for the producer-adjacent and writer-adjacent hot paths.
+//!
+//! These benches intentionally focus on reusable units instead of the global
+//! logger singleton, so optimization experiments can be compared without
+//! cross-benchmark state leaking through `log::set_logger`.
+
+use std::{
+    hint::black_box,
+    io::{self, BufWriter, Write},
+    sync::OnceLock,
+    thread,
+};
+
+use ahash::AHashMap;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use log::{Level, LevelFilter, Log, kv::Value};
+use nautilus_common::{
+    enums::{LogColor, LogLevel},
+    logging::{
+        logger::{
+            LogEvent, LogFields, LogLine, LogLineWrapper, Logger, LoggerConfig, should_filter_log,
+        },
+        writer::{FileWriter, FileWriterConfig, LogWriter},
+    },
+};
+use nautilus_core::{UUID4, UnixNanos};
+use nautilus_model::identifiers::TraderId;
+use tempfile::{TempDir, tempdir};
+use ustr::Ustr;
+
+const TIMESTAMP_NS: u64 = 1_725_000_000_123_456_789;
+const TRADER_ID: &str = "TRADER-001";
+const INSTANCE_ID: &str = "INSTANCE-001";
+const COMPONENT: &str = "nautilus_trader::adapters::binance::execution";
+const MESSAGE: &str = "Order accepted: client_order_id=O-20260527-000001 venue_order_id=123456789";
+const CLEAN_FILE_LINE: &str =
+    "2026-05-27T10:00:00.123456789Z [INFO] TRADER-001.Component: clean log line\n";
+const ANSI_FILE_LINE: &str =
+    "\x1b[1m2026-05-27T10:00:00.123456789Z\x1b[0m [INFO] Component: colored\x1b[0m\n";
+const FILTERED_COMPONENT: &str = "BenchFiltered";
+const FILTERED_TARGET: &str = "BenchFiltered";
+const COMPONENT_TARGETS_12: [&str; 12] = [
+    "nautilus_trader::adapters::binance::execution",
+    "nautilus_trader::adapters::bybit::execution",
+    "nautilus_trader::adapters::okx::execution",
+    "nautilus_trader::adapters::coinbase::execution",
+    "nautilus_trader::adapters::kraken::execution",
+    "nautilus_trader::adapters::bitmex::execution",
+    "nautilus_trader::adapters::deribit::execution",
+    "nautilus_trader::adapters::dydx::execution",
+    "nautilus_trader::adapters::hyperliquid::execution",
+    "nautilus_trader::adapters::databento::execution",
+    "nautilus_trader::adapters::betfair::execution",
+    "nautilus_trader::adapters::sandbox::execution",
+];
+
+static FILTERED_LOGGER_INIT: OnceLock<()> = OnceLock::new();
+
+fn make_log_line(fields: LogFields, color: LogColor) -> LogLine {
+    LogLine {
+        timestamp: UnixNanos::from(TIMESTAMP_NS),
+        level: Level::Info,
+        color,
+        component: Ustr::from(COMPONENT),
+        message: MESSAGE.to_string(),
+        fields,
+    }
+}
+
+fn make_log_line_without_fields() -> LogLine {
+    make_log_line(LogFields::new(), LogColor::Normal)
+}
+
+fn make_log_line_with_fields() -> LogLine {
+    let mut fields = LogFields::new();
+    fields.push((Ustr::from("venue"), "BINANCE".to_string()));
+    fields.push((Ustr::from("symbol"), "ETHUSDT-PERP".to_string()));
+    fields.push((Ustr::from("strategy_id"), "S-001".to_string()));
+    fields.push((Ustr::from("latency_ns"), "7421".to_string()));
+
+    make_log_line(fields, LogColor::Green)
+}
+
+fn make_log_line_with_two_fields() -> LogLine {
+    let mut fields = LogFields::new();
+    fields.push((Ustr::from("venue"), "BINANCE".to_string()));
+    fields.push((Ustr::from("symbol"), "ETHUSDT-PERP".to_string()));
+
+    make_log_line(fields, LogColor::Green)
+}
+
+fn make_file_writer(name: &str) -> (TempDir, FileWriter) {
+    let dir = tempdir().expect("failed to create temporary benchmark directory");
+    let config = FileWriterConfig::new(
+        Some(dir.path().to_string_lossy().into_owned()),
+        Some(name.to_string()),
+        None,
+        None,
+    );
+
+    let writer = FileWriter::new(
+        TRADER_ID.to_string(),
+        INSTANCE_ID.to_string(),
+        config,
+        LevelFilter::Debug,
+        true,
+    )
+    .expect("failed to create benchmark file writer");
+
+    (dir, writer)
+}
+
+fn init_filtered_global_logger() {
+    FILTERED_LOGGER_INIT.get_or_init(|| {
+        // Criterion runs these producer benches in one process, while `log` allows only one
+        // global logger. Leak the guard intentionally so all producer cases share one stable
+        // filtered logger config for the benchmark binary lifetime.
+        let config = LoggerConfig::from_spec("stdout=Info;fileout=Off;BenchFiltered=Error")
+            .expect("valid benchmark logger config");
+        let guard = Logger::init_with_config(
+            TraderId::from("BENCHER-001"),
+            UUID4::new(),
+            config,
+            FileWriterConfig::default(),
+        )
+        .expect("failed to initialize benchmark logger");
+
+        std::mem::forget(guard);
+    });
+}
+
+fn make_direct_logger(config: LoggerConfig) -> (Logger, thread::JoinHandle<()>) {
+    let (tx, rx) = std::sync::mpsc::channel::<LogEvent>();
+    let logger = Logger::new_for_benchmark(config, tx);
+
+    let drain = thread::spawn(move || {
+        while let Ok(event) = rx.recv() {
+            black_box(event);
+        }
+    });
+
+    (logger, drain)
+}
+
+fn log_direct_no_fields(logger: &Logger, target: &'static str, value: u64) {
+    let args = format_args!("direct benchmark message {value}");
+    let record = log::Record::builder()
+        .args(args)
+        .level(Level::Info)
+        .target(target)
+        .build();
+
+    logger.log(&record);
+}
+
+fn log_direct_with_fields(
+    logger: &Logger,
+    target: &'static str,
+    component: &'static str,
+    value: u64,
+) {
+    let key_values = [
+        ("component", Value::from(component)),
+        ("venue", Value::from("BINANCE")),
+        ("latency_ns", Value::from(value)),
+    ];
+    let args = format_args!("direct benchmark message {value}");
+    let record = log::Record::builder()
+        .args(args)
+        .level(Level::Info)
+        .target(target)
+        .key_values(&key_values)
+        .build();
+
+    logger.log(&record);
+}
+
+fn bench_log_line_formatting(c: &mut Criterion) {
+    let trader_id = Ustr::from(TRADER_ID);
+    let no_fields = make_log_line_without_fields();
+    let with_two_fields = make_log_line_with_two_fields();
+    let with_fields = make_log_line_with_fields();
+
+    let mut group = c.benchmark_group("logging/line_format");
+
+    // Measures the cold plain-text formatting path with a fresh wrapper each iteration.
+    // This covers timestamp conversion, capacity sizing, and String writes for stdout/file logs.
+    group.bench_function("plain_cold_no_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(no_fields.clone(), trader_id),
+            |mut wrapper| black_box(wrapper.get_string().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures cold plain-text formatting with 4 extra structured fields.
+    // This shows how fields affect capacity sizing, SmallVec storage, and field appends.
+    group.bench_function("plain_cold_4_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(with_fields.clone(), trader_id),
+            |mut wrapper| black_box(wrapper.get_string().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures the middle case with 2 extra fields.
+    // This avoids drawing conclusions from only the 0-field and 4-field endpoints.
+    group.bench_function("plain_cold_2_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(with_two_fields.clone(), trader_id),
+            |mut wrapper| black_box(wrapper.get_string().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures cold colored formatting, including ANSI prefixes/suffixes and color selection.
+    // This represents the formatter cost for colored stdout/stderr output.
+    group.bench_function("colored_cold_4_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(with_fields.clone(), trader_id),
+            |mut wrapper| black_box(wrapper.get_colored().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures wrapper cache-hit cost.
+    // Re-reading the plain string should be near-free when one line is written to multiple sinks.
+    group.bench_function("plain_cached", |b| {
+        let mut wrapper = LogLineWrapper::new(with_fields.clone(), trader_id);
+        black_box(wrapper.get_string().len());
+
+        b.iter(|| black_box(wrapper.get_string().len()));
+    });
+
+    // Measures cold JSON formatting without extra fields.
+    // This isolates serde streaming, fixed-field serialization, and the trailing newline append.
+    group.bench_function("json_cold_no_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(no_fields.clone(), trader_id),
+            |wrapper| black_box(wrapper.get_json().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures cold JSON formatting with 4 extra fields.
+    // This captures extra-field serialization, reserved-key filtering, and duplicate fallback checks.
+    group.bench_function("json_cold_4_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(with_fields.clone(), trader_id),
+            |wrapper| black_box(wrapper.get_json().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures the middle JSON case with 2 extra fields.
+    // This checks that field-storage changes do not only optimize extreme inputs.
+    group.bench_function("json_cold_2_fields", |b| {
+        b.iter_batched(
+            || LogLineWrapper::new(with_two_fields.clone(), trader_id),
+            |wrapper| black_box(wrapper.get_json().len()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_filtering(c: &mut Criterion) {
+    let component = Ustr::from(COMPONENT);
+    let mut component_levels = AHashMap::new();
+    component_levels.insert(component, LevelFilter::Warn);
+
+    let mut module_filters = vec![
+        (Ustr::from("nautilus_trader::adapters"), LevelFilter::Info),
+        (
+            Ustr::from("nautilus_trader::adapters::binance"),
+            LevelFilter::Warn,
+        ),
+        (Ustr::from("nautilus_trader::common"), LevelFilter::Debug),
+        (Ustr::from("nautilus_trader::core"), LevelFilter::Info),
+        (Ustr::from("nautilus_trader::data"), LevelFilter::Info),
+        (Ustr::from("nautilus_trader::execution"), LevelFilter::Debug),
+        (Ustr::from("nautilus_trader::model"), LevelFilter::Info),
+        (Ustr::from("nautilus_trader::portfolio"), LevelFilter::Debug),
+    ];
+    module_filters.sort_by_key(|(path, _)| std::cmp::Reverse(path.len()));
+
+    let mut group = c.benchmark_group("logging/filter");
+
+    // Measures the empty filter path with no module/component filters configured.
+    // This should stay close to a simple branch cost for default logging configs.
+    group.bench_function("no_filters", |b| {
+        let modules = Vec::new();
+        let components = AHashMap::new();
+
+        b.iter(|| {
+            black_box(should_filter_log(
+                black_box(&component),
+                black_box(Level::Info),
+                black_box(&modules),
+                black_box(&components),
+                black_box(false),
+            ))
+        });
+    });
+
+    // Measures longest-prefix scanning across 8 module filters.
+    // This tells us whether O(n) prefix matching deserves a more complex data structure.
+    group.bench_function("module_prefix_8_filters", |b| {
+        let components = AHashMap::new();
+
+        b.iter(|| {
+            black_box(should_filter_log(
+                black_box(&component),
+                black_box(Level::Info),
+                black_box(&module_filters),
+                black_box(&components),
+                black_box(false),
+            ))
+        });
+    });
+
+    // Measures an exact component-filter hit through AHashMap.
+    // This represents producer-side filtering when log levels are tuned by component name.
+    group.bench_function("component_filter_hit", |b| {
+        let modules = Vec::new();
+
+        b.iter(|| {
+            black_box(should_filter_log(
+                black_box(&component),
+                black_box(Level::Info),
+                black_box(&modules),
+                black_box(&component_levels),
+                black_box(false),
+            ))
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_file_writer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("logging/file_writer");
+
+    // Measures file-writer cost for a clean plain line.
+    // The key question is whether the sanitizer fast path avoids regex work and String allocation.
+    group.bench_function("plain_clean_line", |b| {
+        let (_dir, mut writer) = make_file_writer("plain-clean-line");
+
+        b.iter(|| writer.write(black_box(CLEAN_FILE_LINE)));
+    });
+
+    // Measures file-writer cost for a line containing ANSI escapes.
+    // This verifies the sanitizer slow path still cleans colored output without major regressions.
+    group.bench_function("plain_ansi_line", |b| {
+        let (_dir, mut writer) = make_file_writer("plain-ansi-line");
+
+        b.iter(|| writer.write(black_box(ANSI_FILE_LINE)));
+    });
+
+    group.finish();
+}
+
+fn bench_file_flush(c: &mut Criterion) {
+    let mut group = c.benchmark_group("logging/file_flush");
+
+    // Measures buffered file flush when durability is left to the OS page cache.
+    // This is the candidate replacement cost if `FileWriter::flush` ever drops `sync_all`.
+    group.bench_function("bufwriter_flush_after_write", |b| {
+        let file = tempfile::tempfile().expect("failed to create benchmark temp file");
+        let mut writer = BufWriter::new(file);
+
+        b.iter(|| {
+            writer
+                .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                .expect("buffered file write should not fail");
+            black_box(writer.flush().expect("buffered file flush should not fail"));
+        });
+    });
+
+    // Measures the current durability semantics: flush userspace buffering, then fsync.
+    // This isolates the cost that regular `Flush` events currently pay through `sync_all`.
+    group.bench_function("bufwriter_flush_sync_all_after_write", |b| {
+        let file = tempfile::tempfile().expect("failed to create benchmark temp file");
+        let mut writer = BufWriter::new(file);
+
+        b.iter(|| {
+            writer
+                .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                .expect("buffered file write should not fail");
+            writer.flush().expect("buffered file flush should not fail");
+            black_box(
+                writer
+                    .get_ref()
+                    .sync_all()
+                    .expect("file sync should not fail"),
+            );
+        });
+    });
+
+    // Measures the production `FileWriter::flush` path after a normal log write.
+    // Current production semantics include `sync_all`, so this should stay in the ms range.
+    group.bench_function("file_writer_flush_after_write", |b| {
+        let (_dir, mut writer) = make_file_writer("flush-after-write");
+
+        b.iter(|| {
+            writer.write(black_box(CLEAN_FILE_LINE));
+            writer.flush();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_std_stream_proxy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("logging/std_stream");
+
+    // Measures the direct Write lower bound without syscalls.
+    // `io::sink()` estimates the minimum overhead of the benchmark loop and write_all call.
+    group.bench_function("direct_sink_line", |b| {
+        let mut writer = io::sink();
+
+        b.iter(|| {
+            black_box(
+                writer
+                    .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                    .expect("sink write should not fail"),
+            );
+        });
+    });
+
+    // Measures BufWriter's fixed overhead without syscalls.
+    // If this is slower than direct sink, BufWriter can only win by reducing lower-level writes.
+    group.bench_function("bufwriter_sink_line", |b| {
+        let mut writer = BufWriter::new(io::sink());
+
+        b.iter(|| {
+            black_box(
+                writer
+                    .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                    .expect("sink write should not fail"),
+            );
+        });
+    });
+
+    // Uses a tempfile as a syscall-like proxy for direct stdout/stderr writes.
+    // This is not an exact terminal benchmark, but it shows the order of magnitude for kernel writes.
+    group.bench_function("direct_temp_file_line", |b| {
+        let mut file = tempfile::tempfile().expect("failed to create benchmark temp file");
+
+        b.iter(|| {
+            black_box(
+                file.write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                    .expect("file write should not fail"),
+            );
+        });
+    });
+
+    // Measures direct writer cost when every line is flushed.
+    // This models conservative stderr/error semantics where each line should be visible immediately.
+    group.bench_function("direct_temp_file_flush_each_line", |b| {
+        let mut file = tempfile::tempfile().expect("failed to create benchmark temp file");
+
+        b.iter(|| {
+            file.write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                .expect("file write should not fail");
+            black_box(file.flush().expect("file flush should not fail"));
+        });
+    });
+
+    // Measures the benefit of BufWriter when flush can be delayed.
+    // This informs the "can stdout be buffered?" tradeoff, but does not directly represent stderr.
+    group.bench_function("bufwriter_temp_file_line", |b| {
+        let file = tempfile::tempfile().expect("failed to create benchmark temp file");
+        let mut writer = BufWriter::new(file);
+
+        b.iter(|| {
+            black_box(
+                writer
+                    .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                    .expect("buffered file write should not fail"),
+            );
+        });
+    });
+
+    // Measures whether BufWriter still helps when every line is flushed.
+    // If this matches direct flush, stderr/error should not be buffered only for performance.
+    group.bench_function("bufwriter_temp_file_flush_each_line", |b| {
+        let file = tempfile::tempfile().expect("failed to create benchmark temp file");
+        let mut writer = BufWriter::new(file);
+
+        b.iter(|| {
+            writer
+                .write_all(black_box(CLEAN_FILE_LINE).as_bytes())
+                .expect("buffered file write should not fail");
+            black_box(writer.flush().expect("buffered file flush should not fail"));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_channel_send(c: &mut Criterion) {
+    let no_fields = make_log_line_without_fields();
+    let with_two_fields = make_log_line_with_two_fields();
+    let with_fields = make_log_line_with_fields();
+    let (tx, rx) = std::sync::mpsc::channel::<LogEvent>();
+    let drain = thread::spawn(move || {
+        while let Ok(event) = rx.recv() {
+            black_box(event);
+        }
+    });
+
+    let mut group = c.benchmark_group("logging/channel");
+
+    // Measures by-value channel send cost for LogEvent without extra fields.
+    // This is the most common producer-side payload and validates LogLine size reductions.
+    group.bench_function("send_log_event_no_fields", |b| {
+        b.iter_batched(
+            || no_fields.clone(),
+            |line| black_box(tx.send(LogEvent::Log(line)).expect("receiver should drain")),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures by-value channel send cost with 4 extra fields.
+    // This exposes how structured-field storage affects channel copy/drop paths.
+    group.bench_function("send_log_event_4_fields", |b| {
+        b.iter_batched(
+            || with_fields.clone(),
+            |line| black_box(tx.send(LogEvent::Log(line)).expect("receiver should drain")),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Measures a middle channel payload with 2 extra fields.
+    // This keeps LogFields decisions from being based only on extreme payloads.
+    group.bench_function("send_log_event_2_fields", |b| {
+        b.iter_batched(
+            || with_two_fields.clone(),
+            |line| black_box(tx.send(LogEvent::Log(line)).expect("receiver should drain")),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+    drop(tx);
+    drain.join().expect("drain thread should exit");
+}
+
+fn bench_producer_filter(c: &mut Criterion) {
+    init_filtered_global_logger();
+
+    let mut group = c.benchmark_group("logging/producer");
+
+    // Measures the filtered producer path with a KV component.
+    // This covers FieldCollector, component parsing, producer-side filtering, and skipped format/send.
+    group.bench_function("filtered_info_component", |b| {
+        b.iter(|| {
+            log::info!(
+                component = FILTERED_COMPONENT;
+                "filtered benchmark message {}", black_box(42)
+            );
+        });
+    });
+
+    // Measures filtered producer cost when non-reserved KV fields are present.
+    // This catches regressions where filtered logs still stringify structured fields before skip.
+    group.bench_function("filtered_info_component_with_fields", |b| {
+        b.iter(|| {
+            log::info!(
+                component = FILTERED_COMPONENT,
+                venue = "BINANCE",
+                latency_ns = black_box(42_u64);
+                "filtered benchmark message {}", black_box(42)
+            );
+        });
+    });
+
+    // Measures the filtered producer path that relies on metadata target fallback.
+    // This isolates `record.metadata().target()` and repeated-Ustr cache behavior.
+    group.bench_function("filtered_info_target", |b| {
+        b.iter(|| {
+            log::info!(
+                target: FILTERED_TARGET,
+                "filtered benchmark message {}", black_box(42)
+            );
+        });
+    });
+
+    // Measures metadata-target filtering with extra KV fields.
+    // This verifies target-filtered structured logs skip field String allocation before drop.
+    group.bench_function("filtered_info_target_with_fields", |b| {
+        b.iter(|| {
+            log::info!(
+                target: FILTERED_TARGET,
+                venue = "BINANCE",
+                latency_ns = black_box(42_u64);
+                "filtered benchmark message {}", black_box(42)
+            );
+        });
+    });
+
+    // Measures the project-level `logger::log(...)` wrapper.
+    // This API passes a Ustr component and color KV, matching common Nautilus internal calls.
+    group.bench_function("filtered_info_logger_api", |b| {
+        let component = Ustr::from(FILTERED_COMPONENT);
+
+        b.iter(|| {
+            nautilus_common::logging::logger::log(
+                LogLevel::Info,
+                LogColor::Normal,
+                black_box(component),
+                black_box("filtered benchmark message"),
+            );
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_producer_direct(c: &mut Criterion) {
+    let no_filter_config =
+        LoggerConfig::from_spec("stdout=Info;fileout=Off").expect("valid benchmark logger config");
+    let filter_active_config =
+        LoggerConfig::from_spec("stdout=Info;fileout=Off;BenchFiltered=Error")
+            .expect("valid benchmark logger config");
+    let (no_filter_logger, no_filter_drain) = make_direct_logger(no_filter_config);
+    let (filter_active_logger, filter_active_drain) = make_direct_logger(filter_active_config);
+
+    let mut group = c.benchmark_group("logging/producer_direct");
+
+    // Measures the real no-filter `Logger::log` path without the global logger singleton.
+    // The local channel is drained, so this captures producer construction and send cost only.
+    group.bench_function("no_filter_info_target_no_fields", |b| {
+        b.iter(|| {
+            log_direct_no_fields(
+                black_box(&no_filter_logger),
+                black_box(COMPONENT),
+                black_box(42),
+            );
+        });
+    });
+
+    // Measures repeated-Ustr cache pressure when one thread rotates over more targets than the
+    // 8-slot TLS cache can hold. This bounds the miss-heavy producer fallback path.
+    group.bench_function("no_filter_info_12_targets_no_fields", |b| {
+        let mut target_index = 0_usize;
+
+        b.iter(|| {
+            let target = COMPONENT_TARGETS_12[target_index];
+            target_index += 1;
+            if target_index == COMPONENT_TARGETS_12.len() {
+                target_index = 0;
+            }
+
+            log_direct_no_fields(
+                black_box(&no_filter_logger),
+                black_box(target),
+                black_box(42),
+            );
+        });
+    });
+
+    // Measures no-filter structured logs through the one-visit FieldCollector path.
+    // This is the production path when module/component filters are not configured.
+    group.bench_function("no_filter_info_component_with_fields", |b| {
+        b.iter(|| {
+            log_direct_with_fields(
+                black_box(&no_filter_logger),
+                black_box(COMPONENT),
+                black_box(COMPONENT),
+                black_box(42),
+            );
+        });
+    });
+
+    // Measures filter-active logs that pass the filter and therefore pay the two-visitor path.
+    // Compare against the no-filter structured case to bound E010's pass-through overhead.
+    group.bench_function("filter_active_pass_info_component_with_fields", |b| {
+        b.iter(|| {
+            log_direct_with_fields(
+                black_box(&filter_active_logger),
+                black_box(COMPONENT),
+                black_box(COMPONENT),
+                black_box(42),
+            );
+        });
+    });
+
+    group.finish();
+
+    drop(no_filter_logger);
+    drop(filter_active_logger);
+    no_filter_drain
+        .join()
+        .expect("no-filter drain thread should exit");
+    filter_active_drain
+        .join()
+        .expect("filter-active drain thread should exit");
+}
+
+fn bench_ustr(c: &mut Criterion) {
+    let mut group = c.benchmark_group("logging/ustr");
+
+    // Measures repeated `Ustr::from(&'static str)` in isolation.
+    // This helps decide whether the repeated-Ustr TLS cache belongs on the producer hot path.
+    group.bench_function("from_static_target_repeat", |b| {
+        b.iter(|| black_box(Ustr::from(black_box(COMPONENT))));
+    });
+
+    // Measures component-value stringification as an allocation-cost proxy.
+    // Compare this with producer component benches to separate KV `to_string()` from Ustr interning.
+    group.bench_function("component_value_to_string", |b| {
+        b.iter(|| black_box(black_box(FILTERED_COMPONENT).to_string()));
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_log_line_formatting,
+    bench_filtering,
+    bench_file_writer,
+    bench_file_flush,
+    bench_std_stream_proxy,
+    bench_channel_send,
+    bench_producer_filter,
+    bench_producer_direct,
+    bench_ustr
+);
+criterion_main!(benches);

--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -14,7 +14,8 @@
 // -------------------------------------------------------------------------------------------------
 
 use std::{
-    fmt::Display,
+    cell::RefCell,
+    fmt::{Display, Write as _},
     sync::{Mutex, OnceLock, atomic::Ordering, mpsc::SendError},
 };
 
@@ -31,7 +32,7 @@ use nautilus_core::{
     time::{get_atomic_clock_realtime, get_atomic_clock_static},
 };
 use nautilus_model::identifiers::TraderId;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeMap};
 use smallvec::SmallVec;
 use ustr::Ustr;
 
@@ -48,10 +49,51 @@ use crate::{
 const LOGGING: &str = "logging";
 const KV_COLOR: &str = "color";
 const KV_COMPONENT: &str = "component";
-const LOG_FIELDS_INLINE_CAP: usize = 4;
+const LOG_FIELDS_INLINE_CAP: usize = 0;
+const MAX_LEVEL_DISPLAY_LEN: usize = "ERROR".len();
+const ANSI_BOLD_LEN: usize = "\x1b[1m".len();
+const ANSI_RESET_LEN: usize = "\x1b[0m".len();
+const PLAIN_FORMAT_OVERHEAD: usize = " [".len() + "] ".len() + ".".len() + ": ".len() + "\n".len();
+const COLORED_FORMAT_OVERHEAD: usize = ANSI_BOLD_LEN
+    + ANSI_RESET_LEN
+    + " ".len()
+    + "[".len()
+    + "] ".len()
+    + ".".len()
+    + ": ".len()
+    + ANSI_RESET_LEN
+    + "\n".len();
+const REPEATED_USTR_CACHE_CAP: usize = 8;
 
-/// Inline-optimized storage for structured log fields.
-/// Up to 4 key-value pairs are stored on the stack; beyond that, spills to heap.
+thread_local! {
+    static REPEATED_USTR_CACHE: RefCell<RepeatedUstrCache> =
+        const { RefCell::new(RepeatedUstrCache::new()) };
+}
+
+#[derive(Clone, Copy)]
+struct RepeatedUstrCacheEntry {
+    ptr: usize,
+    len: usize,
+    value: Ustr,
+}
+
+#[derive(Clone, Copy)]
+struct RepeatedUstrCache {
+    entries: [Option<RepeatedUstrCacheEntry>; REPEATED_USTR_CACHE_CAP],
+    next: usize,
+}
+
+impl RepeatedUstrCache {
+    const fn new() -> Self {
+        Self {
+            entries: [None; REPEATED_USTR_CACHE_CAP],
+            next: 0,
+        }
+    }
+}
+
+/// Storage for structured log fields.
+/// Inline capacity is intentionally zero to keep the producer-side `LogLine` payload small.
 pub type LogFields = SmallVec<[(Ustr, String); LOG_FIELDS_INLINE_CAP]>;
 
 /// Global log sender which allows multiple log guards per process.
@@ -60,6 +102,45 @@ static LOGGER_TX: OnceLock<std::sync::mpsc::Sender<LogEvent>> = OnceLock::new();
 /// Global handle to the logging thread - only one thread exists per process.
 static LOGGER_HANDLE: Mutex<Option<std::thread::JoinHandle<()>>> = Mutex::new(None);
 
+/// Producer-side filtering policy derived from [`LoggerConfig`].
+#[derive(Debug, Clone)]
+struct FilterPolicy {
+    /// Module filters pre-sorted by descending path length for longest-prefix lookup.
+    modules_by_longest_prefix: Vec<(Ustr, LevelFilter)>,
+    /// Per-component log level overrides.
+    components: AHashMap<Ustr, LevelFilter>,
+    /// Whether logs without an explicit component/module filter should be skipped.
+    components_only: bool,
+}
+
+impl FilterPolicy {
+    fn from_config(config: &LoggerConfig) -> Option<Self> {
+        let modules_by_longest_prefix = sorted_module_filters_from_map(&config.module_level);
+        if !config.log_components_only
+            && modules_by_longest_prefix.is_empty()
+            && config.component_level.is_empty()
+        {
+            return None;
+        }
+
+        Some(Self {
+            modules_by_longest_prefix,
+            components: config.component_level.clone(),
+            components_only: config.log_components_only,
+        })
+    }
+
+    fn should_skip(&self, component: &Ustr, level: Level) -> bool {
+        should_filter_log_inner(
+            component,
+            level,
+            &self.modules_by_longest_prefix,
+            &self.components,
+            self.components_only,
+        )
+    }
+}
+
 /// A high-performance logger utilizing a MPSC channel under the hood.
 ///
 /// A logger is initialized with a [`LoggerConfig`] to set up different logging levels for
@@ -67,8 +148,13 @@ static LOGGER_HANDLE: Mutex<Option<std::thread::JoinHandle<()>>> = Mutex::new(No
 /// sent via an MPSC channel.
 #[derive(Debug)]
 pub struct Logger {
-    /// Configuration for logging levels and behavior.
+    /// Initialization snapshot for logging levels and behavior.
+    ///
+    /// Producer filters are derived into `filter_policy` at initialization; mutating this field
+    /// after registration does not reload component/module filters.
     pub config: LoggerConfig,
+    /// Producer-side component/module filtering policy.
+    filter_policy: Option<FilterPolicy>,
     /// Transmitter for sending log events to the 'logging' thread.
     tx: std::sync::mpsc::Sender<LogEvent>,
 }
@@ -148,14 +234,23 @@ impl LogLineWrapper {
     /// same log message needs to be printed multiple times.
     pub fn get_string(&mut self) -> &str {
         self.cache.get_or_insert_with(|| {
-            let mut s = format!(
+            let timestamp = unix_nanos_to_iso8601(self.line.timestamp);
+            let mut s = String::with_capacity(plain_log_line_capacity(
+                &timestamp,
+                self.trader_id,
+                &self.line,
+            ));
+
+            write!(
+                s,
                 "{} [{}] {}.{}: {}",
-                unix_nanos_to_iso8601(self.line.timestamp),
+                timestamp,
                 self.line.level,
                 self.trader_id,
                 &self.line.component,
                 &self.line.message,
-            );
+            )
+            .expect("writing to String should not fail");
 
             for (k, v) in &self.line.fields {
                 s.push(' ');
@@ -175,15 +270,26 @@ impl LogLineWrapper {
     /// logger is configured to use colors.
     pub fn get_colored(&mut self) -> &str {
         self.colored.get_or_insert_with(|| {
-            let mut s = format!(
+            let timestamp = unix_nanos_to_iso8601(self.line.timestamp);
+            let color_ansi = self.line.color.as_ansi();
+            let mut s = String::with_capacity(colored_log_line_capacity(
+                &timestamp,
+                color_ansi,
+                self.trader_id,
+                &self.line,
+            ));
+
+            write!(
+                s,
                 "\x1b[1m{}\x1b[0m {}[{}] {}.{}: {}",
-                unix_nanos_to_iso8601(self.line.timestamp),
-                &self.line.color.as_ansi(),
+                timestamp,
+                color_ansi,
                 self.line.level,
                 self.trader_id,
                 &self.line.component,
                 &self.line.message,
-            );
+            )
+            .expect("writing to String should not fail");
 
             for (k, v) in &self.line.fields {
                 s.push(' ');
@@ -206,10 +312,51 @@ impl LogLineWrapper {
     /// Panics if serialization of the log event to JSON fails.
     #[must_use]
     pub fn get_json(&self) -> String {
-        let json_string =
+        let mut json_string =
             serde_json::to_string(&self).expect("Error serializing log event to string");
-        format!("{json_string}\n")
+        json_string.push('\n');
+        json_string
     }
+}
+
+fn formatted_fields_len(fields: &LogFields) -> usize {
+    fields.iter().map(|(k, v)| 2 + k.len() + v.len()).sum()
+}
+
+fn log_line_capacity(
+    timestamp: &str,
+    trader_id: Ustr,
+    line: &LogLine,
+    overhead: usize,
+    ansi_extra_len: usize,
+) -> usize {
+    timestamp.len()
+        + overhead
+        + ansi_extra_len
+        + MAX_LEVEL_DISPLAY_LEN
+        + trader_id.len()
+        + line.component.len()
+        + line.message.len()
+        + formatted_fields_len(&line.fields)
+}
+
+fn plain_log_line_capacity(timestamp: &str, trader_id: Ustr, line: &LogLine) -> usize {
+    log_line_capacity(timestamp, trader_id, line, PLAIN_FORMAT_OVERHEAD, 0)
+}
+
+fn colored_log_line_capacity(
+    timestamp: &str,
+    color_ansi: &str,
+    trader_id: Ustr,
+    line: &LogLine,
+) -> usize {
+    log_line_capacity(
+        timestamp,
+        trader_id,
+        line,
+        COLORED_FORMAT_OVERHEAD,
+        color_ansi.len(),
+    )
 }
 
 impl Serialize for LogLineWrapper {
@@ -217,25 +364,206 @@ impl Serialize for LogLineWrapper {
     where
         S: Serializer,
     {
-        let mut json_obj = IndexMap::new();
+        if has_duplicate_json_field(&self.line.fields) {
+            return serialize_log_line_with_indexmap(self, serializer);
+        }
+
         let timestamp = unix_nanos_to_iso8601(self.line.timestamp);
-        json_obj.insert("timestamp".to_string(), timestamp);
-        json_obj.insert("trader_id".to_string(), self.trader_id.to_string());
-        json_obj.insert("level".to_string(), self.line.level.to_string());
-        json_obj.insert("color".to_string(), self.line.color.to_string());
-        json_obj.insert("component".to_string(), self.line.component.to_string());
-        json_obj.insert("message".to_string(), self.line.message.clone());
+        let mut map = serializer.serialize_map(None)?;
+
+        map.serialize_entry("timestamp", &timestamp)?;
+        map.serialize_entry("trader_id", self.trader_id.as_str())?;
+        map.serialize_entry("level", &DisplayAsString(&self.line.level))?;
+        map.serialize_entry("color", &DisplayAsString(&self.line.color))?;
+        map.serialize_entry("component", self.line.component.as_str())?;
+        map.serialize_entry("message", &self.line.message)?;
+
         for (k, v) in &self.line.fields {
             let key = k.as_str();
-            if !matches!(
-                key,
-                "timestamp" | "trader_id" | "level" | "color" | "component" | "message"
-            ) {
-                json_obj.insert(k.to_string(), v.clone());
+            if !is_reserved_json_key(key) {
+                map.serialize_entry(key, v)?;
             }
         }
 
-        json_obj.serialize(serializer)
+        map.end()
+    }
+}
+
+struct DisplayAsString<'a, T: ?Sized>(&'a T);
+
+impl<T> Serialize for DisplayAsString<'_, T>
+where
+    T: Display + ?Sized,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self.0)
+    }
+}
+
+fn is_reserved_json_key(key: &str) -> bool {
+    matches!(
+        key,
+        "timestamp" | "trader_id" | "level" | "color" | "component" | "message"
+    )
+}
+
+fn has_duplicate_json_field(fields: &LogFields) -> bool {
+    if fields.is_empty() {
+        return false;
+    }
+
+    for (idx, (key, _)) in fields.iter().enumerate() {
+        let key = key.as_str();
+        if is_reserved_json_key(key) {
+            continue;
+        }
+
+        if fields
+            .iter()
+            .take(idx)
+            .any(|(prev, _)| !is_reserved_json_key(prev.as_str()) && prev.as_str() == key)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn serialize_log_line_with_indexmap<S>(
+    wrapper: &LogLineWrapper,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut json_obj = IndexMap::new();
+    let timestamp = unix_nanos_to_iso8601(wrapper.line.timestamp);
+    json_obj.insert("timestamp".to_string(), timestamp);
+    json_obj.insert("trader_id".to_string(), wrapper.trader_id.to_string());
+    json_obj.insert("level".to_string(), wrapper.line.level.to_string());
+    json_obj.insert("color".to_string(), wrapper.line.color.to_string());
+    json_obj.insert("component".to_string(), wrapper.line.component.to_string());
+    json_obj.insert("message".to_string(), wrapper.line.message.clone());
+    for (k, v) in &wrapper.line.fields {
+        let key = k.as_str();
+        if !is_reserved_json_key(key) {
+            json_obj.insert(k.to_string(), v.clone());
+        }
+    }
+
+    json_obj.serialize(serializer)
+}
+
+fn sorted_module_filters_from_map(
+    module_level: &AHashMap<Ustr, LevelFilter>,
+) -> Vec<(Ustr, LevelFilter)> {
+    let mut filters: Vec<_> = module_level
+        .iter()
+        .map(|(path, level)| (*path, *level))
+        .collect();
+    filters.sort_by_key(|(path, _)| std::cmp::Reverse(path.len()));
+    filters
+}
+
+fn current_log_timestamp() -> UnixNanos {
+    if LOGGING_REALTIME.load(Ordering::Relaxed) {
+        get_atomic_clock_realtime().get_time_ns()
+    } else {
+        get_atomic_clock_static().get_time_ns()
+    }
+}
+
+fn intern_repeated(value: &str) -> Ustr {
+    REPEATED_USTR_CACHE.with(|cache| {
+        let mut cache_state = cache.borrow_mut();
+        let ptr = value.as_ptr() as usize;
+        let len = value.len();
+
+        // Targets and components are usually repeated static strings; the content check keeps
+        // dynamic RecordBuilder targets correct if an allocator reuses the same pointer.
+        for entry in cache_state.entries.iter().flatten() {
+            if entry.ptr == ptr && entry.len == len && entry.value.as_str() == value {
+                return entry.value;
+            }
+        }
+
+        let interned = Ustr::from(value);
+        let insert_idx = cache_state.next;
+        cache_state.entries[insert_idx] = Some(RepeatedUstrCacheEntry {
+            ptr,
+            len,
+            value: interned,
+        });
+        cache_state.next = (insert_idx + 1) % REPEATED_USTR_CACHE_CAP;
+        interned
+    })
+}
+
+fn intern_component_value(value: &log::kv::Value<'_>) -> Ustr {
+    match value.to_borrowed_str() {
+        Some(component) => intern_repeated(component),
+        None => Ustr::from(&value.to_string()),
+    }
+}
+
+struct ComponentProbe {
+    component: Option<Ustr>,
+}
+
+impl ComponentProbe {
+    const fn new() -> Self {
+        Self { component: None }
+    }
+}
+
+impl<'kvs> log::kv::VisitSource<'kvs> for ComponentProbe {
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'kvs>,
+        value: log::kv::Value<'kvs>,
+    ) -> Result<(), log::kv::Error> {
+        if key.as_str() == KV_COMPONENT {
+            self.component = Some(intern_component_value(&value));
+        }
+        Ok(())
+    }
+}
+
+struct PayloadCollector {
+    color: Option<LogColor>,
+    fields: LogFields,
+}
+
+impl PayloadCollector {
+    fn new() -> Self {
+        Self {
+            color: None,
+            fields: SmallVec::new(),
+        }
+    }
+}
+
+impl<'kvs> log::kv::VisitSource<'kvs> for PayloadCollector {
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'kvs>,
+        value: log::kv::Value<'kvs>,
+    ) -> Result<(), log::kv::Error> {
+        match key.as_str() {
+            KV_COLOR => {
+                self.color = value.to_u64().map(|v| (v as u8).into());
+            }
+            KV_COMPONENT => {}
+            _ => {
+                self.fields
+                    .push((Ustr::from(key.as_str()), value.to_string()));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -266,7 +594,7 @@ impl<'kvs> log::kv::VisitSource<'kvs> for FieldCollector {
                 self.color = value.to_u64().map(|v| (v as u8).into());
             }
             KV_COMPONENT => {
-                self.component = Some(Ustr::from(&value.to_string()));
+                self.component = Some(intern_component_value(&value));
             }
             _ => {
                 self.fields
@@ -287,20 +615,45 @@ impl Log for Logger {
 
     fn log(&self, record: &log::Record) {
         if self.enabled(record.metadata()) {
-            let timestamp = if LOGGING_REALTIME.load(Ordering::Relaxed) {
-                get_atomic_clock_realtime().get_time_ns()
-            } else {
-                get_atomic_clock_static().get_time_ns()
-            };
             let level = record.level();
 
+            if let Some(filter_policy) = &self.filter_policy {
+                // Probe only the component before filtering. Skipped logs should not pay for
+                // timestamps, message formatting, or non-reserved structured-field strings.
+                let mut probe = ComponentProbe::new();
+                let _ = record.key_values().visit(&mut probe);
+                let component = probe
+                    .component
+                    .unwrap_or_else(|| intern_repeated(record.metadata().target()));
+
+                if filter_policy.should_skip(&component, level) {
+                    return;
+                }
+
+                let timestamp = current_log_timestamp();
+                let mut collector = PayloadCollector::new();
+                let _ = record.key_values().visit(&mut collector);
+                let color = collector.color.unwrap_or_else(|| level.into());
+
+                self.send_log_line(LogLine {
+                    timestamp,
+                    level,
+                    color,
+                    component,
+                    message: format!("{}", record.args()),
+                    fields: collector.fields,
+                });
+                return;
+            }
+
+            // With no component/module filters configured, keep the producer path to one KV visit.
+            let timestamp = current_log_timestamp();
             let mut collector = FieldCollector::new();
             let _ = record.key_values().visit(&mut collector);
-
             let color = collector.color.unwrap_or_else(|| level.into());
             let component = collector
                 .component
-                .unwrap_or_else(|| Ustr::from(record.metadata().target()));
+                .unwrap_or_else(|| intern_repeated(record.metadata().target()));
 
             let line = LogLine {
                 timestamp,
@@ -311,9 +664,7 @@ impl Log for Logger {
                 fields: collector.fields,
             };
 
-            if let Err(SendError(LogEvent::Log(line))) = self.tx.send(LogEvent::Log(line)) {
-                eprintln!("Error sending log event (receiver closed): {line}");
-            }
+            self.send_log_line(line);
         }
     }
 
@@ -330,6 +681,28 @@ impl Log for Logger {
 }
 
 impl Logger {
+    /// Creates a logger instance for direct benchmark harnesses.
+    ///
+    /// This bypasses the global `log::set_logger` singleton so benchmark code can compare
+    /// multiple logger configurations in one process. It does not spawn a writer thread.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn new_for_benchmark(config: LoggerConfig, tx: std::sync::mpsc::Sender<LogEvent>) -> Self {
+        let filter_policy = FilterPolicy::from_config(&config);
+
+        Self {
+            config,
+            filter_policy,
+            tx,
+        }
+    }
+
+    fn send_log_line(&self, line: LogLine) {
+        if let Err(SendError(LogEvent::Log(line))) = self.tx.send(LogEvent::Log(line)) {
+            eprintln!("Error sending log event (receiver closed): {line}");
+        }
+    }
+
     /// Initializes the logger based on the `NAUTILUS_LOG` environment variable.
     ///
     /// # Errors
@@ -363,11 +736,13 @@ impl Logger {
         }
 
         let (tx, rx) = std::sync::mpsc::channel::<LogEvent>();
+        let filter_policy = FilterPolicy::from_config(&config);
 
         let logger_tx = tx.clone();
         let logger = Self {
-            tx: logger_tx,
             config: config.clone(),
+            filter_policy,
+            tx: logger_tx,
         };
 
         set_boxed_logger(Box::new(logger))?;
@@ -452,9 +827,9 @@ impl Logger {
         let LoggerConfig {
             stdout_level,
             fileout_level,
-            component_level,
-            module_level,
-            log_components_only,
+            component_level: _,
+            module_level: _,
+            log_components_only: _,
             is_colored,
             print_config: _,
             use_tracing: _,
@@ -462,11 +837,6 @@ impl Logger {
             file_config: _,
             clear_log_file,
         } = config;
-
-        // Pre-sort module filters by descending path length for O(n) longest-prefix lookup
-        let mut module_filters_sorted: Vec<(Ustr, LevelFilter)> =
-            module_level.into_iter().collect();
-        module_filters_sorted.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
         let trader_id_cache = Ustr::from(&trader_id);
 
@@ -493,16 +863,6 @@ impl Logger {
                              file_writer_opt: &mut Option<FileWriter>| {
             match event {
                 LogEvent::Log(line) => {
-                    if should_filter_log(
-                        &line.component,
-                        line.level,
-                        &module_filters_sorted,
-                        &component_level,
-                        log_components_only,
-                    ) {
-                        return;
-                    }
-
                     let mut wrapper = LogLineWrapper::new(line, trader_id_cache);
 
                     if stderr_writer.enabled(&wrapper.line) {
@@ -600,6 +960,22 @@ impl Logger {
 /// first `starts_with` match is the longest prefix.
 #[must_use]
 pub fn should_filter_log(
+    component: &Ustr,
+    line_level: log::Level,
+    module_filters_sorted: &[(Ustr, LevelFilter)],
+    component_level: &AHashMap<Ustr, LevelFilter>,
+    log_components_only: bool,
+) -> bool {
+    should_filter_log_inner(
+        component,
+        line_level,
+        module_filters_sorted,
+        component_level,
+        log_components_only,
+    )
+}
+
+fn should_filter_log_inner(
     component: &Ustr,
     line_level: log::Level,
     module_filters_sorted: &[(Ustr, LevelFilter)],
@@ -1100,6 +1476,28 @@ mod tests {
         assert_eq!(parsed["message"], "Real message");
         assert_ne!(parsed["timestamp"], "bogus");
         assert_eq!(parsed["venue"], "BINANCE");
+    }
+
+    #[rstest]
+    fn test_log_line_wrapper_json_duplicate_extra_fields_last_value_wins() {
+        let line = LogLine {
+            timestamp: 1_650_000_000_000_000_000.into(),
+            level: log::Level::Info,
+            color: LogColor::Normal,
+            component: Ustr::from("Test"),
+            message: "Duplicate field".to_string(),
+            fields: smallvec::smallvec![
+                (Ustr::from("venue"), "BINANCE".to_string()),
+                (Ustr::from("venue"), "OKX".to_string()),
+            ],
+        };
+
+        let wrapper = LogLineWrapper::new(line, Ustr::from("TRADER-001"));
+        let json = wrapper.get_json();
+        let parsed: Value = serde_json::from_str(json.trim()).unwrap();
+
+        assert_eq!(json.matches("\"venue\"").count(), 1);
+        assert_eq!(parsed["venue"], "OKX");
     }
 
     /// Helper to convert module level map to sorted vec (descending by path length)

--- a/crates/common/src/logging/writer.rs
+++ b/crates/common/src/logging/writer.rs
@@ -14,22 +14,19 @@
 // -------------------------------------------------------------------------------------------------
 
 use std::{
+    borrow::Cow,
     collections::VecDeque,
     fs::{File, create_dir_all},
     io::{self, BufWriter, Stderr, Stdout, Write},
     path::PathBuf,
-    sync::OnceLock,
 };
 
 use chrono::{NaiveDate, Utc};
 use log::LevelFilter;
 use nautilus_core::consts::NAUTILUS_PREFIX;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::logging::logger::LogLine;
-
-static ANSI_RE: OnceLock<Regex> = OnceLock::new();
 
 pub trait LogWriter {
     /// Writes a log line.
@@ -413,7 +410,7 @@ fn cleanup_backups(rotate_config: &mut FileRotateConfig) {
 
 impl LogWriter for FileWriter {
     fn write(&mut self, line: &str) {
-        let line = strip_ansi_codes(line);
+        let line = sanitize_file_line(line);
         let line_size = line.len() as u64;
 
         // Rotate file if needed (size-based or date-based depending on configuration)
@@ -449,17 +446,110 @@ impl LogWriter for FileWriter {
     }
 }
 
-fn strip_nonprinting_except_newline(s: &str) -> String {
+fn contains_ansi_escape(s: &str) -> bool {
+    s.as_bytes().contains(&b'\x1b')
+}
+
+fn contains_nonprinting_except_newline(s: &str) -> bool {
+    if s.is_ascii() {
+        return s.bytes().any(|b| b != b'\n' && (b < b' ' || b == b'\x7f'));
+    }
+
+    s.chars()
+        .any(|c| c != '\n' && (c.is_control() || c == '\u{7F}'))
+}
+
+fn strip_nonprinting_except_newline(s: &str) -> Cow<'_, str> {
+    if !contains_nonprinting_except_newline(s) {
+        return Cow::Borrowed(s);
+    }
+
+    Cow::Owned(strip_nonprinting_to_string(s))
+}
+
+fn strip_nonprinting_to_string(s: &str) -> String {
     s.chars()
         .filter(|&c| c == '\n' || (!c.is_control() && c != '\u{7F}'))
         .collect()
 }
 
-fn strip_ansi_codes(s: &str) -> String {
-    let re = ANSI_RE.get_or_init(|| Regex::new(r"\x1B\[[0-9;?=]*[A-Za-z]|\x1B\].*?\x07").unwrap());
-    // Strip ANSI codes first (while \x1B is still present), then remove other control chars
-    let no_ansi = re.replace_all(s, "");
-    strip_nonprinting_except_newline(&no_ansi)
+fn sanitize_file_line(s: &str) -> Cow<'_, str> {
+    if !contains_ansi_escape(s) {
+        return strip_nonprinting_except_newline(s);
+    }
+
+    Cow::Owned(strip_ansi_and_nonprinting_to_string(s))
+}
+
+fn strip_ansi_and_nonprinting_to_string(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\x1b' {
+            if let Some(end) = ansi_escape_end(bytes, i) {
+                i = end;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        if bytes[i].is_ascii() {
+            if bytes[i] == b'\n' || (bytes[i] >= b' ' && bytes[i] != b'\x7f') {
+                out.push(bytes[i] as char);
+            }
+            i += 1;
+            continue;
+        }
+
+        let ch = s[i..]
+            .chars()
+            .next()
+            .expect("valid UTF-8 char boundary expected");
+
+        if ch == '\n' || (!ch.is_control() && ch != '\u{7F}') {
+            out.push(ch);
+        }
+        i += ch.len_utf8();
+    }
+
+    out
+}
+
+fn ansi_escape_end(bytes: &[u8], start: usize) -> Option<usize> {
+    match bytes.get(start + 1).copied() {
+        Some(b'[') => csi_escape_end(bytes, start + 2),
+        Some(b']') => osc_escape_end(bytes, start + 2),
+        _ => None,
+    }
+}
+
+fn csi_escape_end(bytes: &[u8], mut i: usize) -> Option<usize> {
+    while let Some(byte) = bytes.get(i).copied() {
+        if byte.is_ascii_alphabetic() {
+            return Some(i + 1);
+        }
+
+        if !matches!(byte, b'0'..=b'9' | b';' | b'?' | b'=') {
+            return None;
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn osc_escape_end(bytes: &[u8], mut i: usize) -> Option<usize> {
+    while let Some(byte) = bytes.get(i).copied() {
+        if byte == b'\x07' {
+            return Some(i + 1);
+        }
+        i += 1;
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -523,9 +613,18 @@ mod tests {
     #[case("Before\x1B[0mAfter", "BeforeAfter")]
     #[case("\x1B]0;Title\x07Content", "Content")]
     #[case("Text\t\x1B[31mRed\x1B[0m", "TextRed")]
-    fn test_strip_ansi_codes(#[case] input: &str, #[case] expected: &str) {
-        let result = strip_ansi_codes(input);
+    #[case("Broken\x1B[31", "Broken[31")]
+    #[case("Broken\x1B]Title", "Broken]Title")]
+    fn test_sanitize_file_line(#[case] input: &str, #[case] expected: &str) {
+        let result = sanitize_file_line(input);
         assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn test_sanitize_file_line_borrows_clean_input() {
+        let result = sanitize_file_line("Plain text\n");
+
+        assert!(matches!(result, Cow::Borrowed(_)));
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR optimizes the `nautilus-common` logging hot paths with benchmark-backed changes. It moves filter decisions into the producer path, reduces `LogLine` payload size, removes unnecessary formatting allocations, replaces file-log regex sanitizing with a single-pass scanner, and adds Criterion coverage for formatting, filtering, writers, flushes, channels, producer paths, and `Ustr` intern behavior.

The largest improvements are in filtered producer logs, JSON/text formatting, file writer sanitizing, and channel send payload size. Behavior-changing optimizations such as removing per-flush `sync_all()` and delayed stdout/stderr buffering were benchmarked but intentionally not shipped in this PR.

## Headline Results: Common Logging Scenarios

The logging pipeline is split across producer, formatting, and writer stages, so these are isolated microbenchmarks rather than one mixed end-to-end benchmark. This table gives the closest reviewer-facing view of what happens when a log line is formatted, filtered, sent, or written.

| Scenario | Benchmark case | Before | After | Improvement | Speedup |
| --- | --- | ---: | ---: | ---: | ---: |
| Format one plain text log line, no structured fields | `logging/line_format/plain_cold_no_fields` | 269.38 ns | 157.58 ns | -41.50% | 1.71x |
| Format one plain text log line with 4 structured fields | `logging/line_format/plain_cold_4_fields` | 345.59 ns | 248.27 ns | -28.16% | 1.39x |
| Format one colored log line with 4 structured fields | `logging/line_format/colored_cold_4_fields` | 427.58 ns | 286.81 ns | -32.92% | 1.49x |
| Format one JSON log line, no structured fields | `logging/line_format/json_cold_no_fields` | 888.84 ns | 290.44 ns | -67.32% | 3.06x |
| Format one JSON log line with 4 structured fields | `logging/line_format/json_cold_4_fields` | 1.5010 us | 501.95 ns | -66.56% | 2.99x |
| Write one clean plain line to a file writer | `logging/file_writer/plain_clean_line` | 403.28 ns | 134.36 ns | -66.68% | 3.00x |
| Write one ANSI/colored line to a file writer after sanitizing | `logging/file_writer/plain_ansi_line` | 416.37 ns | 151.50 ns | -63.61% | 2.75x |
| Drop one filtered component log on the producer side | `logging/producer/filtered_info_component` | 182.92 ns | 16.229 ns | -91.13% | 11.27x |
| Send one 4-field `LogEvent` through the channel | `logging/channel/send_log_event_4_fields` | 28.39 ns | 16.25 ns | -42.76% | 1.75x |

Assembly-level headline:

| Hot path | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| `<Logger as log::Log>::log` stack frame | 592 B | 304 B | -48.65% |
| `<FileWriter as LogWriter>::write` stack frame | 800 B | 400 B | -50.00% |

## Type of change

- [x] Improvement (non-breaking)
- [x] Maintenance / chore

The following behavior-changing optimizations were measured but deferred:

- `FileWriter::flush()` still calls `sync_all()`.
- stdout/stderr writers are not switched to delayed buffering.
- JSON duplicate extra-field behavior is preserved.
- Reserved JSON fields still cannot overwrite fixed fields.
- File-log ANSI/control sanitizing behavior is preserved.

Future PRs may choose to split `flush()` from `sync_all()` or add configurable stdout/stderr buffering, but those changes should include explicit compatibility controls and breaking-change notes.

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validation run locally:

```bash
cargo fmt -p nautilus-common
cargo check -p nautilus-common
cargo bench -p nautilus-common --bench logging --no-run
cargo test -p nautilus-common logging::writer
cargo test -p nautilus-common logging::logger::tests::test_filter
cargo test -p nautilus-common logging::logger::tests::test_log_line_wrapper
cargo test -p nautilus-common test_log_component_level_filtering -- --test-threads=1
cargo test -p nautilus-common test_module_level_filtering -- --test-threads=1
cargo test -p nautilus-common test_logging_to_file_with_kv_fields -- --test-threads=1
cargo test -p nautilus-common test_logging_to_file_json_with_kv_fields -- --test-threads=1
cargo test -p nautilus-common test_logging_to_file_in_json_format -- --test-threads=1
```

Assembly checks run locally:

```bash
cargo asm -p nautilus-common --lib \
  "<nautilus_common::logging::logger::Logger as log::Log>::log"

cargo asm -p nautilus-common --lib \
  "<nautilus_common::logging::writer::FileWriter as nautilus_common::logging::writer::LogWriter>::write"

cargo asm -p nautilus-common --lib \
  "<nautilus_common::logging::writer::FileWriter as nautilus_common::logging::writer::LogWriter>::flush"

cargo asm -p nautilus-common --lib "LogLineWrapper::get_json"
```

## Benchmark Environment

- Host: `aarch64-apple-darwin`
- Profile: `bench`
- Baseline data is Criterion quick data unless a full run is explicitly listed.
- Full Criterion runs were used for the producer, file writer, file flush, stdout/stderr proxy, and direct producer guard benchmarks where noted.

## Optimization Details

### Producer-side filtering

Filtered logs now return before timestamp lookup, message formatting, payload collection, and channel send.

| Case | Previous full | Current full | Improvement | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `logging/producer/filtered_info_component` | 37.612 ns | 16.229 ns | -56.85% | 2.32x |
| `logging/producer/filtered_info_target` | 36.377 ns | 11.962 ns | -67.12% | 3.04x |
| `logging/producer/filtered_info_logger_api` | 39.135 ns | 18.134 ns | -53.66% | 2.16x |

Extra-KV filtered guard cases:

| Case | Current full | Note |
| --- | ---: | --- |
| `logging/producer/filtered_info_component_with_fields` | 19.090 ns | Only ~2.86 ns above the no-fields component path |
| `logging/producer/filtered_info_target_with_fields` | 15.416 ns | Only ~3.45 ns above the no-fields target path |

Assembly evidence:

- `<Logger as log::Log>::log` remains at `sub sp, sp, #304`.
- `AtomicTime::get_time_ns`, `alloc::fmt::format::format_inner`, payload collection, and `Logger::send_log_line` are after the filter check.
- The no-filter path still uses one KV visitor; only filter-active pass-through logs pay the second KV visit.

### `Ustr` and KV component parsing

The benchmark split repeated `Ustr::from(target)` cost from KV component stringification.

| Case | Mean | Note |
| --- | ---: | --- |
| `logging/ustr/from_static_target_repeat` | 8.0463 ns | Repeated static target intern is measurable but not the largest item |
| `logging/ustr/component_value_to_string` | 18.094 ns | KV component string allocation is the larger cost |

This PR keeps the `Value::to_borrowed_str()` fast path for KV component parsing and the 8-slot thread-local repeated `Ustr` cache. The cache cap is not increased because the 12-target pressure benchmark shows only about +8% overhead and there is no production hit-rate evidence yet.

### Text formatting allocations

Plain/colored formatting now pre-computes capacity and writes into a pre-sized `String`.

| Case | Baseline | Optimized | Improvement | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `logging/line_format/plain_cold_no_fields` | 269.38 ns | 156.72 ns | -41.82% | 1.72x |
| `logging/line_format/plain_cold_4_fields` | 345.59 ns | 234.83 ns | -32.05% | 1.47x |
| `logging/line_format/colored_cold_4_fields` | 427.58 ns | 264.18 ns | -38.22% | 1.62x |
| `logging/line_format/plain_cached` | 1.5135 ns | 1.5000 ns | -0.89% | 1.01x |

Assembly evidence:

- `get_string` and `get_colored` no longer build the main body through `alloc::fmt::format::format_inner`.
- Formatting uses one pre-sized allocation plus `core::fmt::write`.
- Field append reserve branches remain, but the capacity estimate avoids them in normal cases.

### JSON serialization

JSON formatting now streams through serde `SerializeMap` on the common path instead of building an intermediate `IndexMap<String, String>`.

| Case | Baseline | Current | Improvement | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `logging/line_format/json_cold_no_fields` | 888.84 ns | 290.44 ns | -67.32% | 3.06x |
| `logging/line_format/json_cold_4_fields` | 1.5010 us | 501.95 ns | -66.56% | 2.99x |

Assembly evidence:

- The common JSON path no longer constructs fixed-field `String` keys/values or clones the message through an `IndexMap`.
- `IndexMap::insert_full` remains only in the duplicate-extra-key fallback path to preserve existing “last value wins” semantics.
- `get_json()` appends `\n` directly instead of formatting `{json_string}\n`.

### `LOG_FIELDS_INLINE_CAP = 0`

This reduces hot producer/channel payload size by removing the fixed 4-field inline `SmallVec` storage from every `LogLine`.

| Case | cap=4 | cap=0 | Improvement | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `logging/channel/send_log_event_no_fields` | 30.72 ns | 22.19 ns | -27.77% | 1.38x |
| `logging/channel/send_log_event_2_fields` | 28.15 ns | 16.60 ns | -41.03% | 1.70x |
| `logging/channel/send_log_event_4_fields` | 28.39 ns | 16.25 ns | -42.76% | 1.75x |

Recorded tradeoff on writer-side formatting:

| Case | cap=4 | cap=0 | Change |
| --- | ---: | ---: | ---: |
| `logging/line_format/plain_cold_2_fields` | 202.66 ns | 211.11 ns | +4.17% |
| `logging/line_format/plain_cold_4_fields` | 239.79 ns | 248.27 ns | +3.54% |
| `logging/line_format/colored_cold_4_fields` | 269.92 ns | 286.81 ns | +6.26% |
| `logging/line_format/json_cold_4_fields` | 494.06 ns | 506.71 ns | +2.56% |

The tradeoff is accepted because producer/channel cost is the critical path, while the smaller formatting regression happens on the writer side.

Assembly evidence:

- `Logger::log` stack frame moves from `sub sp, sp, #592` to `sub sp, sp, #304`.
- The 128-byte inline `SmallVec` zero-initialization is removed from the hot path.

### File writer sanitizer

The file writer now uses a single-pass ANSI/control scanner instead of regex replacement.

| Case | Original baseline | Scanner full | Improvement | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `logging/file_writer/plain_clean_line` | 403.28 ns | 134.36 ns | -66.68% | 3.00x |
| `logging/file_writer/plain_ansi_line` | 416.37 ns | 151.50 ns | -63.61% | 2.75x |

Assembly evidence:

- `<FileWriter as LogWriter>::write` stack frame moves from `sub sp, sp, #800` to `sub sp, sp, #400`.
- The hot path no longer contains `regex`, `Regex::create_captures`, or `ANSI_RE`.
- Clean lines go directly to the write path after ESC/control checks.

## Additional Guard Benchmarks

Direct producer benchmarks quantify the no-filter path and the pass-through cost of two-phase filtering.

| Case | Full mean | Note |
| --- | ---: | --- |
| `logging/producer_direct/no_filter_info_target_no_fields` | 146.25 ns | No filter, no KV |
| `logging/producer_direct/no_filter_info_component_with_fields` | 297.67 ns | No filter, one KV visit |
| `logging/producer_direct/filter_active_pass_info_component_with_fields` | 315.59 ns | Filter active, passes filter, two KV visits |

The filter-active pass-through structured case is about +6.0% over the no-filter structured case. This is the accepted cost for making skipped logs much cheaper.

Repeated-`Ustr` cache pressure:

| Case | Full mean | Note |
| --- | ---: | --- |
| `logging/producer_direct/no_filter_info_target_no_fields` | 146.25 ns | Single target |
| `logging/producer_direct/no_filter_info_12_targets_no_fields` | 157.93 ns | 12-target rotation |

12-target rotation is about +8.0%. This proves cache pressure exists, but not enough to increase the cache cap without production hit-rate evidence.

## Benchmark Coverage Added

This PR adds Criterion coverage for the following groups:

| Group | Purpose |
| --- | --- |
| `logging/line_format` | Plain, colored, cached, and JSON formatting costs |
| `logging/filter` | Empty filters, module-prefix filters, and component filter hits |
| `logging/file_writer` | Clean-line and ANSI/control sanitizer costs |
| `logging/file_flush` | Flush-only, flush + `sync_all()`, and production `FileWriter::flush()` |
| `logging/std_stream` | Direct vs buffered stdout/stderr-like write proxies |
| `logging/channel` | `LogEvent::Log(LogLine)` channel send payload cost |
| `logging/producer` | Global logger producer-side filtered log cost |
| `logging/producer_direct` | Direct `Logger::log` no-filter and pass-through producer cost |
| `logging/ustr` | Repeated `Ustr::from(&'static str)` and KV value stringification proxies |

<details>
<summary>Experiment details, rejected options, and deferred work</summary>

## Experiment Sequence

The optimization sequence was deliberately evidence-driven:

1. Add sanitizer fast path and prove clean file lines can avoid regex allocation.
2. Add plain/colored capacity estimates and replace main-body `format!` with `write!`.
3. Replace JSON `IndexMap<String, String>` construction with serde streaming on the common path.
4. Move component/module filtering to the producer side.
5. Reduce `LogFields` inline capacity to shrink `LogLine` and channel payloads.
6. Test `Box<LogLine>` and roll it back after fields cases regressed.
7. Benchmark `flush()` vs `sync_all()` and keep current durability semantics unchanged.
8. Benchmark stdout/stderr buffering and keep current visibility semantics unchanged.
9. Split KV component `to_string()` cost from repeated `Ustr::from(target)` cost.
10. Complete producer filtering with a two-phase KV visitor and timestamp-after-filter ordering.
11. Replace regex sanitizer with a single-pass ANSI/control scanner.
12. Remove the JSON map size count pass and add the duplicate-check empty fast path.
13. Add direct `Logger::log` guard benchmarks for no-filter and pass-through cases.
14. Add 12-target repeated-`Ustr` cache pressure coverage.

## `Box<LogLine>` was tested and rolled back

| Case | cap=0 by-value | `Box<LogLine>` | Change |
| --- | ---: | ---: | ---: |
| `logging/channel/send_log_event_no_fields` | 20.61 ns | 19.11 ns | -7.28% |
| `logging/channel/send_log_event_4_fields` | 17.84 ns | 24.09 ns | +35.03% |

The stack reduction was real, but the producer-side heap allocation made the fields case worse. After reducing `LogLine` with `LOG_FIELDS_INLINE_CAP = 0`, keeping by-value channel sends is faster and simpler.

## `flush()` / `sync_all()` split is deferred

| Case | Full mean | Note |
| --- | ---: | --- |
| `logging/file_flush/bufwriter_flush_after_write` | 1.5544 us | Flush userspace buffer only |
| `logging/file_flush/bufwriter_flush_sync_all_after_write` | 4.5962 ms | Flush + `sync_all()` |
| `logging/file_flush/file_writer_flush_after_write` | 4.5517 ms | Current production path |

`sync_all()` makes flush roughly 2957x slower than flush-only. This is a high-value future optimization, but it changes durability semantics, so this PR records the data and leaves production behavior unchanged.

A future breaking-change PR should provide:

- A normal flush path that only flushes userspace buffers to the OS page cache.
- An explicit sync-to-disk API for callers that require crash-durable file logs.
- A writer-thread sync event with acknowledgement, so callers can wait until all prior queued logs have been flushed and synced.
- Shutdown behavior that still performs final `sync_all()`.
- A compatibility option if maintainers want a transition period.

## stdout/stderr `BufWriter` is deferred

| Case | Full mean | Note |
| --- | ---: | --- |
| `logging/std_stream/direct_temp_file_line` | 1.5478 us | Direct syscall-like write |
| `logging/std_stream/bufwriter_temp_file_line` | 64.128 ns | Delayed flush allowed |
| `logging/std_stream/direct_temp_file_flush_each_line` | 1.5408 us | Direct write + flush each line |
| `logging/std_stream/bufwriter_temp_file_flush_each_line` | 1.5488 us | Buffered but flushed each line |

`BufWriter` only helps when delayed visibility is allowed. Changing stdout/stderr visibility should be a separate user-visible semantics decision, especially for stderr/error logs that users may expect to appear immediately.

## Cache cap was not increased

A 12-target rotation benchmark shows the current 8-slot repeated-`Ustr` cache has measurable miss-heavy cost:

| Case | Full mean | Change |
| --- | ---: | ---: |
| Single target | 146.25 ns | baseline |
| 12-target rotation | 157.93 ns | +8.0% |

This is not enough evidence to raise the cap in this PR. Raising the cap increases TLS footprint and worst-case scan length for the common hit path. A future change should use production target-cardinality or hit-rate data before changing the cache size.

</details>
