### PR TITLE
Refine live cancel/update reconciliation

### DIFF
--- a/crates/live/src/manager.rs
+++ b/crates/live/src/manager.rs
@@ -55,7 +55,7 @@ use nautilus_execution::{
 };
 use nautilus_model::{
     enums::{OrderSide, OrderStatus, OrderType, TimeInForce},
-    events::{OrderCanceled, OrderEventAny, OrderFilled, OrderInitialized},
+    events::{OrderEventAny, OrderFilled, OrderInitialized},
     identifiers::{
         AccountId, ClientOrderId, InstrumentId, PositionId, StrategyId, TradeId, TraderId,
         VenueOrderId,
@@ -882,20 +882,12 @@ impl ExecutionManager {
                                 }
                             }
                             OrderStatus::PendingUpdate | OrderStatus::PendingCancel => {
-                                // Generate cancellation for orders stuck in pending modify/cancel
-                                let event = OrderEventAny::Canceled(OrderCanceled::new(
-                                    order.trader_id(),
-                                    order.strategy_id(),
-                                    order.instrument_id(),
+                                log::warn!(
+                                    "Order {} exceeded max inflight retries while {}, leaving unresolved for venue reconciliation",
                                     order.client_order_id(),
-                                    UUID4::new(),
-                                    ts_now,
-                                    ts_now,
-                                    true, // reconciliation
-                                    order.venue_order_id(),
-                                    order.account_id(),
-                                ));
-                                result.events.push(event);
+                                    order.status()
+                                );
+                                continue;
                             }
                             _ => {
                                 // Order already resolved, just clear tracking

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -1767,7 +1767,7 @@ fn test_inflight_increments_retry_count_before_max() {
 }
 
 #[rstest]
-fn test_inflight_pending_update_generates_canceled() {
+fn test_inflight_pending_update_stays_unresolved_at_max_retries() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -1795,20 +1795,22 @@ fn test_inflight_pending_update_generates_canceled() {
 
     let result = ctx.manager.check_inflight_orders();
 
-    assert_eq!(result.events.len(), 1);
     assert!(
-        matches!(result.events[0], OrderEventAny::Canceled(_)),
-        "Expected Canceled for PendingUpdate, was {:?}",
-        result.events[0]
+        result.events.is_empty(),
+        "PendingUpdate timeout must not synthesize terminal events"
     );
-
-    if let OrderEventAny::Canceled(canceled) = &result.events[0] {
-        assert_eq!(canceled.client_order_id, client_order_id);
-    }
+    assert!(
+        result.queries.is_empty(),
+        "No query should be generated when retry budget is exhausted"
+    );
+    assert!(
+        format!("{:?}", ctx.manager).contains(client_order_id.as_str()),
+        "Unresolved PendingUpdate should remain tracked for later reconciliation"
+    );
 }
 
 #[rstest]
-fn test_inflight_pending_cancel_generates_canceled() {
+fn test_inflight_pending_cancel_stays_unresolved_at_max_retries() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -1836,16 +1838,18 @@ fn test_inflight_pending_cancel_generates_canceled() {
 
     let result = ctx.manager.check_inflight_orders();
 
-    assert_eq!(result.events.len(), 1);
     assert!(
-        matches!(result.events[0], OrderEventAny::Canceled(_)),
-        "Expected Canceled for PendingCancel, was {:?}",
-        result.events[0]
+        result.events.is_empty(),
+        "PendingCancel timeout must not synthesize terminal events"
     );
-
-    if let OrderEventAny::Canceled(canceled) = &result.events[0] {
-        assert_eq!(canceled.client_order_id, client_order_id);
-    }
+    assert!(
+        result.queries.is_empty(),
+        "No query should be generated when retry budget is exhausted"
+    );
+    assert!(
+        format!("{:?}", ctx.manager).contains(client_order_id.as_str()),
+        "Unresolved PendingCancel should remain tracked for later reconciliation"
+    );
 }
 
 #[rstest]

--- a/docs/concepts/live.md
+++ b/docs/concepts/live.md
@@ -71,8 +71,9 @@ When the outcome is unknown:
   the state.
 
 For never-acknowledged submits, the `LiveExecutionEngine` in-flight check queries the venue. If the
-order stays unconfirmed beyond `inflight_check_retries`, the engine resolves it to `REJECTED`. See
-the Runtime checks table below.
+order stays unconfirmed beyond `inflight_check_retries`, the engine resolves it to `REJECTED`. Pending
+cancel and update outcomes remain unresolved until venue reconciliation resolves them. See the Runtime
+checks table below.
 
 ## Execution reconciliation
 
@@ -212,7 +213,8 @@ The tables below cover startup reconciliation (mass status) and runtime checks (
 | Scenario                          | Description                                             | System behavior                                                            |
 |-----------------------------------|---------------------------------------------------------|----------------------------------------------------------------------------|
 | **Ambiguous submit failure**      | Submit call fails without confirmed venue rejection.    | Logs failure, keeps order in flight, and waits for reconciliation.         |
-| **In‑flight order timeout**       | Order remains unconfirmed beyond threshold.             | After `inflight_check_retries`, resolves to `REJECTED`.                    |
+| **In‑flight submit timeout**      | `SUBMITTED` order remains unconfirmed beyond threshold. | After `inflight_check_retries`, resolves to `REJECTED`.                    |
+| **In‑flight cancel/update timeout** | `PENDING_CANCEL` or `PENDING_UPDATE` remains unconfirmed beyond threshold. | Logs warning and remains unresolved for venue reconciliation. |
 | **Open orders check discrepancy** | Periodic poll detects a venue state change.             | Confirms status at `open_check_interval_secs` and applies transitions.     |
 | **Own books audit mismatch**      | Own order books diverge from venue public books.        | Audits at `own_books_audit_interval_secs`, logs inconsistencies.           |
 

--- a/docs/how_to/configure_live_trading.md
+++ b/docs/how_to/configure_live_trading.md
@@ -211,11 +211,11 @@ When retries are exhausted, the engine resolves the order as follows:
 
 **In-flight order timeout resolution** (venue does not respond after max retries):
 
-| Current status   | Resolved to | Rationale                                  |
-|------------------|-------------|--------------------------------------------|
-| `SUBMITTED`      | `REJECTED`  | No confirmation received from venue.       |
-| `PENDING_UPDATE` | `CANCELED`  | Modification remains unacknowledged.       |
-| `PENDING_CANCEL` | `CANCELED`  | Venue never confirmed the cancellation.    |
+| Current status   | Resolved to | Rationale                                      |
+|------------------|-------------|------------------------------------------------|
+| `SUBMITTED`      | `REJECTED`  | No confirmation received from venue.           |
+| `PENDING_UPDATE` | Unresolved  | Modification outcome remains unknown.          |
+| `PENDING_CANCEL` | Unresolved  | Cancellation outcome remains unknown.          |
 
 **Order consistency checks** (when cache state differs from venue state):
 

--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -784,12 +784,12 @@ class LiveExecutionEngine(ExecutionEngine):
             self._log.debug(f"Generated {rejected}")
             self._handle_event_with_tracking(rejected)
         elif order.status in (OrderStatus.PENDING_UPDATE, OrderStatus.PENDING_CANCEL):
-            canceled = create_order_canceled_event(
-                order=order,
-                ts_now=ts_now,
+            self._log.warning(
+                f"Order {order.client_order_id!r} exceeded max inflight retries while "
+                f"{order.status_string()}, leaving unresolved for venue reconciliation",
+                LogColor.YELLOW,
             )
-            self._log.debug(f"Generated {canceled}")
-            self._handle_event_with_tracking(canceled)
+            return
         else:
             raise RuntimeError(f"Invalid status for in-flight order, was '{order.status_string()}'")
 

--- a/tests/unit_tests/live/test_execution_engine.py
+++ b/tests/unit_tests/live/test_execution_engine.py
@@ -547,7 +547,7 @@ class TestLiveExecutionEngine:
         assert order.status == OrderStatus.REJECTED
 
     @pytest.mark.asyncio
-    async def test_resolve_inflight_order_when_pending_update(self):
+    async def test_resolve_inflight_order_when_pending_update_stays_unresolved(self):
         # Arrange
         order = self.strategy.order_factory.limit(
             instrument_id=AUDUSD_SIM.id,
@@ -567,10 +567,10 @@ class TestLiveExecutionEngine:
         self.exec_engine._resolve_inflight_order(order)
 
         # Assert
-        assert order.status == OrderStatus.CANCELED
+        assert order.status == OrderStatus.PENDING_UPDATE
 
     @pytest.mark.asyncio
-    async def test_resolve_inflight_order_when_pending_cancel(self):
+    async def test_resolve_inflight_order_when_pending_cancel_stays_unresolved(self):
         # Arrange
         order = self.strategy.order_factory.limit(
             instrument_id=AUDUSD_SIM.id,
@@ -590,7 +590,7 @@ class TestLiveExecutionEngine:
         self.exec_engine._resolve_inflight_order(order)
 
         # Assert
-        assert order.status == OrderStatus.CANCELED
+        assert order.status == OrderStatus.PENDING_CANCEL
 
     @pytest.mark.asyncio
     async def test_graceful_shutdown_cmd_queue_exception_enabled_calls_shutdown_system(self):

--- a/tests/unit_tests/live/test_execution_order_checks.py
+++ b/tests/unit_tests/live/test_execution_order_checks.py
@@ -713,6 +713,100 @@ async def test_check_inflight_orders_respects_retry_limit(
 
 
 @pytest.mark.asyncio
+async def test_check_inflight_pending_update_stays_unresolved_at_retry_limit(
+    exec_engine_inflight_check,
+    cache,
+    account_id,
+    clock,
+):
+    """
+    Test _check_inflight_orders does not synthesize a terminal event for pending updates.
+    """
+    # Arrange
+    exec_engine = exec_engine_inflight_check
+    order = TestExecStubs.limit_order(instrument=AUDUSD_SIM)
+    cache.add_order(order)
+
+    old_ts = clock.timestamp_ns() - 1_000_000_000
+    submitted_event = TestEventStubs.order_submitted(
+        order,
+        account_id=account_id,
+        ts_event=old_ts,
+    )
+    order.apply(submitted_event)
+    exec_engine.process(submitted_event)
+
+    accepted_event = TestEventStubs.order_accepted(
+        order,
+        account_id=account_id,
+        ts_event=old_ts,
+    )
+    order.apply(accepted_event)
+    exec_engine.process(accepted_event)
+
+    pending_event = TestEventStubs.order_pending_update(order, ts_event=old_ts)
+    order.apply(pending_event)
+    exec_engine.process(pending_event)
+    cache.update_order(order)
+
+    exec_engine._recon_check_retries[order.client_order_id] = 2
+
+    # Act
+    await exec_engine._check_inflight_orders()
+
+    # Assert
+    assert order.status == OrderStatus.PENDING_UPDATE
+    assert exec_engine._recon_check_retries[order.client_order_id] == 2
+
+
+@pytest.mark.asyncio
+async def test_check_inflight_pending_cancel_stays_unresolved_at_retry_limit(
+    exec_engine_inflight_check,
+    cache,
+    account_id,
+    clock,
+):
+    """
+    Test _check_inflight_orders does not synthesize a terminal event for pending cancels.
+    """
+    # Arrange
+    exec_engine = exec_engine_inflight_check
+    order = TestExecStubs.limit_order(instrument=AUDUSD_SIM)
+    cache.add_order(order)
+
+    old_ts = clock.timestamp_ns() - 1_000_000_000
+    submitted_event = TestEventStubs.order_submitted(
+        order,
+        account_id=account_id,
+        ts_event=old_ts,
+    )
+    order.apply(submitted_event)
+    exec_engine.process(submitted_event)
+
+    accepted_event = TestEventStubs.order_accepted(
+        order,
+        account_id=account_id,
+        ts_event=old_ts,
+    )
+    order.apply(accepted_event)
+    exec_engine.process(accepted_event)
+
+    pending_event = TestEventStubs.order_pending_cancel(order, ts_event=old_ts)
+    order.apply(pending_event)
+    exec_engine.process(pending_event)
+    cache.update_order(order)
+
+    exec_engine._recon_check_retries[order.client_order_id] = 2
+
+    # Act
+    await exec_engine._check_inflight_orders()
+
+    # Assert
+    assert order.status == OrderStatus.PENDING_CANCEL
+    assert exec_engine._recon_check_retries[order.client_order_id] == 2
+
+
+@pytest.mark.asyncio
 async def test_check_inflight_orders_increments_retry_count(
     exec_engine_inflight_check,
     cache,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Refine live cancel/update reconciliation so ambiguous `PENDING_CANCEL` and `PENDING_UPDATE` outcomes are no longer converted into synthetic `OrderCanceled` events after the inflight retry budget is exhausted. The Rust live manager and Python live execution engine now leave those orders unresolved and warn for venue reconciliation instead, while preserving the existing `SUBMITTED` timeout rejection path.

## Related Issues/PRs

Closes #4152

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not expected to be breaking in the API or schema sense. The behavioral change is that unresolved pending cancel/update orders are no longer force-closed locally when retry exhaustion alone does not prove the venue outcome.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

Suggested release note:

```markdown
- Refined live cancel/update reconciliation so pending orders remain unresolved until venue reconciliation, instead of being synthesized as canceled on retry exhaustion.
```

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Planned validation / examples:

```bash
cargo test -p nautilus-live --test manager inflight_pending -- --nocapture
cargo test -p nautilus-live --test manager inflight -- --nocapture
cargo test -p nautilus-live --test manager -- --nocapture
uv run --group test pytest tests/unit_tests/live/test_execution_engine.py -q
uv run --group test pytest tests/unit_tests/live/test_execution_order_checks.py -q
cargo fmt --check -p nautilus-live
git diff --check
```