### PR TITLE
Close Rust IB data, historical, and parsing parity gaps

### DIFF
--- a/crates/adapters/interactive_brokers/src/common/parse.rs
+++ b/crates/adapters/interactive_brokers/src/common/parse.rs
@@ -154,7 +154,7 @@ pub fn ib_contract_to_instrument_id_simplified(
             }
         }
         SecurityType::FuturesOption => {
-            // FOP: Format like "ESM23 C4500" -> "ESM23C4500"
+            // FOP: Preserve IB local symbol spacing, matching Python simplified symbology.
             if contract.local_symbol.is_empty() {
                 // Fallback construction
                 let expiry = contract.last_trade_date_or_contract_month.as_str();
@@ -169,8 +169,7 @@ pub fn ib_contract_to_instrument_id_simplified(
                 );
                 NautilusSymbol::from(symbol_str.as_str())
             } else {
-                let cleaned = contract.local_symbol.as_str().replace(' ', "");
-                NautilusSymbol::from(cleaned.as_str())
+                NautilusSymbol::from(contract.local_symbol.as_str())
             }
         }
         SecurityType::CFD => {
@@ -368,15 +367,30 @@ const VENUES_CASH: &[&str] = &["IDEALPRO"];
 const VENUES_CRYPTO: &[&str] = &["PAXOS"];
 const VENUES_OPT: &[&str] = &["SMART", "EUREX"];
 const VENUES_FUT: &[&str] = &[
+    "BELFOX",
     "GLOBEX",
-    "NYMEX",
-    "NYBOT",
     "CBOT",
-    "CME",
     "CFE",
-    "ICE",
-    "ECBOT",
+    "CME",
+    "COMEX",
     "CBOE",
+    "DTB",
+    "EUREX",
+    "HKFE",
+    "ICE",
+    "ICEEU",
+    "ICEEUSOFT",
+    "IDEM",
+    "IPE",
+    "KCBT",
+    "MEXDER",
+    "MGE",
+    "NYBOT",
+    "NYMEX",
+    "OSE.JPN",
+    "SNFE",
+    "SOFFEX",
+    "VRTX",
     "CMECRYPTO",
     "NYMEXMETALS",
     "NYMEXNG",
@@ -395,8 +409,9 @@ const VENUES_FUT: &[&str] = &[
     "CBOTOPTIONS",
     "NYMEXOPTIONS",
     "NYBOTOPTIONS",
+    "ECBOT",
 ];
-const VENUES_CFD: &[&str] = &["SMART"];
+const VENUES_CFD: &[&str] = &["IBCFD", "SMART"];
 const VENUES_CMDTY: &[&str] = &["IBCMDTY"];
 
 fn venue_matches(venue_str: &str, venues: &[&str]) -> bool {
@@ -565,7 +580,7 @@ pub fn instrument_id_to_ib_contract(
 
     // Handle Crypto
     if venue_matches(venue_str.as_str(), VENUES_CRYPTO)
-        && let Some(captures) = parse_cash_symbol(symbol_str)
+        && let Some(captures) = parse_crypto_symbol(symbol_str)
     {
         return Ok(Contract {
             contract_id: 0,
@@ -581,17 +596,13 @@ pub fn instrument_id_to_ib_contract(
     // Handle Options (OPT)
     if venue_matches(venue_str.as_str(), VENUES_OPT) {
         if let Some(opt) = parse_option_symbol(symbol_str) {
-            let local_symbol = format!(
-                "{:6}{}{}{}{:08}",
-                opt.symbol, opt.expiry, opt.right, opt.strike_integer, opt.strike_decimal
-            );
             return Ok(Contract {
                 contract_id: 0,
                 symbol: Symbol::from(&opt.symbol),
                 security_type: SecurityType::Option,
                 exchange: Exchange::from(exchange_str),
                 currency: Currency::from("USD"), // Will be resolved from contract details
-                local_symbol,
+                local_symbol: opt.local_symbol,
                 last_trade_date_or_contract_month: opt.expiry,
                 strike: opt.strike_value,
                 right: opt.right,
@@ -617,6 +628,19 @@ pub fn instrument_id_to_ib_contract(
 
     // Handle Futures and Futures Options
     if venue_matches(venue_str.as_str(), VENUES_FUT) {
+        if let Some(fut) = parse_named_futures_symbol(symbol_str) {
+            return Ok(Contract {
+                contract_id: 0,
+                symbol: Symbol::from(&fut.underlying),
+                security_type: SecurityType::Future,
+                exchange: Exchange::from(exchange_str),
+                currency: Currency::from("USD"),
+                trading_class: fut.trading_class,
+                last_trade_date_or_contract_month: fut.expiry,
+                ..Default::default()
+            });
+        }
+
         // Check for continuous futures (underlying only, no expiry)
         // IB uses FUT with no expiry date to represent continuous futures
         if let Some(underlying) = parse_futures_underlying(symbol_str) {
@@ -656,8 +680,10 @@ pub fn instrument_id_to_ib_contract(
     }
 
     // Handle CFDs
-    if VENUES_CFD.contains(&venue_str.as_str()) {
-        if let Some(captures) = parse_cfd_cash_symbol(symbol_str) {
+    if venue_matches(venue_str.as_str(), VENUES_CFD) {
+        if let Some(captures) =
+            parse_cash_symbol(symbol_str).or_else(|| parse_cfd_cash_symbol(symbol_str))
+        {
             return Ok(Contract {
                 contract_id: 0,
                 symbol: Symbol::from(&captures.base),
@@ -788,6 +814,22 @@ fn parse_cash_symbol(symbol: &str) -> Option<CurrencyPair> {
     None
 }
 
+/// Parse crypto symbol like "BTC/USD".
+fn parse_crypto_symbol(symbol: &str) -> Option<CurrencyPair> {
+    if let Some((base, quote)) = symbol.split_once('/')
+        && !base.is_empty()
+        && base.chars().all(|ch| ch.is_ascii_uppercase())
+        && quote.len() == 3
+        && quote.chars().all(|ch| ch.is_ascii_uppercase())
+    {
+        return Some(CurrencyPair {
+            base: base.to_string(),
+            quote: quote.to_string(),
+        });
+    }
+    None
+}
+
 /// Parse CFD cash symbol like "EUR.USD"
 fn parse_cfd_cash_symbol(symbol: &str) -> Option<CurrencyPair> {
     if let Some((base, quote)) = symbol.split_once('.')
@@ -807,8 +849,7 @@ struct OptionSymbol {
     symbol: String,
     expiry: String,
     right: String,
-    strike_integer: String,
-    strike_decimal: String,
+    local_symbol: String,
     strike_value: f64,
 }
 
@@ -821,7 +862,7 @@ fn parse_option_symbol(symbol: &str) -> Option<OptionSymbol> {
     }
 
     // Try to match: 6-char symbol, 6-char date, 1-char right (C/P), remainder is strike
-    let symbol_part = &symbol[..6.min(symbol.len())].trim();
+    let symbol_part = symbol[..6.min(symbol.len())].trim();
     let remaining = &symbol[6.min(symbol.len())..];
 
     if remaining.len() < 15 {
@@ -846,23 +887,11 @@ fn parse_option_symbol(symbol: &str) -> Option<OptionSymbol> {
         strike_int as f64 / 1000.0
     };
 
-    let strike_integer = if strike_str.len() >= 8 {
-        &strike_str[..strike_str.len().min(8)]
-    } else {
-        strike_str
-    };
-    let strike_decimal = if strike_str.len() > 8 {
-        &strike_str[8..]
-    } else {
-        ""
-    };
-
     Some(OptionSymbol {
-        symbol: (*symbol_part).to_string(),
+        symbol: symbol_part.to_string(),
         expiry: expiry.to_string(),
         right: right.to_string(),
-        strike_integer: strike_integer.to_string(),
-        strike_decimal: strike_decimal.to_string(),
+        local_symbol: symbol.to_string(),
         strike_value,
     })
 }
@@ -873,6 +902,31 @@ struct NamedOptionSymbol {
     expiry: String,
     right: String,
     strike_value: f64,
+}
+
+/// Named futures symbol captures for formats like "ESTX50 FESX 20240315".
+struct NamedFuturesSymbol {
+    underlying: String,
+    trading_class: String,
+    expiry: String,
+}
+
+fn parse_named_futures_symbol(symbol: &str) -> Option<NamedFuturesSymbol> {
+    let parts: Vec<&str> = symbol.split_whitespace().collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let expiry = parts[2];
+    if expiry.len() != 8 || !expiry.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(NamedFuturesSymbol {
+        underlying: parts[0].to_string(),
+        trading_class: parts[1].to_string(),
+        expiry: expiry.to_string(),
+    })
 }
 
 fn parse_named_option_symbol(symbol: &str) -> Option<NamedOptionSymbol> {
@@ -1177,6 +1231,22 @@ mod tests {
     }
 
     #[rstest]
+    fn test_ib_contract_to_instrument_id_simplified_preserves_fop_spacing() {
+        let contract = Contract {
+            symbol: Symbol::from("EX2"),
+            security_type: SecurityType::FuturesOption,
+            exchange: Exchange::from("NYBOT"),
+            currency: Currency::from("USD"),
+            local_symbol: "EX2G3 P4080".to_string(),
+            ..Default::default()
+        };
+
+        let instrument_id = ib_contract_to_instrument_id_simplified(&contract, None).unwrap();
+
+        assert_eq!(instrument_id, InstrumentId::from("EX2G3 P4080.NYBOT"));
+    }
+
+    #[rstest]
     fn test_instrument_id_to_ib_contract_parses_named_option_symbol() {
         let instrument_id = InstrumentId::from("C OESX 20260213 4775.EUREX");
 
@@ -1195,6 +1265,40 @@ mod tests {
     }
 
     #[rstest]
+    fn test_instrument_id_to_ib_contract_preserves_occ_local_symbol() {
+        let instrument_id = InstrumentId::from("AAPL  230217P00155000.SMART");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Option);
+        assert_eq!(contract.exchange.as_str(), "SMART");
+        assert_eq!(contract.symbol.as_str(), "AAPL");
+        assert_eq!(contract.local_symbol.as_str(), "AAPL  230217P00155000");
+        assert_eq!(
+            contract.last_trade_date_or_contract_month.as_str(),
+            "230217"
+        );
+        assert_eq!(contract.right.as_str(), "P");
+        assert_eq!(contract.strike, 155.0);
+    }
+
+    #[rstest]
+    fn test_instrument_id_to_ib_contract_parses_named_futures_symbol() {
+        let instrument_id = InstrumentId::from("ESTX50 FESX 20240315.EUREX");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Future);
+        assert_eq!(contract.exchange.as_str(), "EUREX");
+        assert_eq!(contract.symbol.as_str(), "ESTX50");
+        assert_eq!(contract.trading_class.as_str(), "FESX");
+        assert_eq!(
+            contract.last_trade_date_or_contract_month.as_str(),
+            "20240315"
+        );
+    }
+
+    #[rstest]
     fn test_instrument_id_to_ib_contract_maps_xcbt_to_cbot_exchange() {
         let instrument_id = InstrumentId::from("YMM6.XCBT");
 
@@ -1208,6 +1312,17 @@ mod tests {
     }
 
     #[rstest]
+    fn test_instrument_id_to_ib_contract_maps_mic_future_to_member_exchange() {
+        let instrument_id = InstrumentId::from("OESXH6.XEUR");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Future);
+        assert_eq!(contract.exchange.as_str(), "DTB");
+        assert_eq!(contract.local_symbol.as_str(), "OESXH6");
+    }
+
+    #[rstest]
     fn test_instrument_id_to_ib_contract_parses_futures_option_with_month_code_in_symbol() {
         let instrument_id = InstrumentId::from("YMM6 C45000.XCBT");
 
@@ -1216,6 +1331,32 @@ mod tests {
         assert_eq!(contract.security_type, SecurityType::FuturesOption);
         assert_eq!(contract.exchange.as_str(), "CBOT");
         assert_eq!(contract.local_symbol.as_str(), "YMM6 C45000");
+    }
+
+    #[rstest]
+    fn test_instrument_id_to_ib_contract_parses_ibcfd_cash_symbol() {
+        let instrument_id = InstrumentId::from("EUR/USD.IBCFD");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::CFD);
+        assert_eq!(contract.exchange.as_str(), "SMART");
+        assert_eq!(contract.symbol.as_str(), "EUR");
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "EUR.USD");
+    }
+
+    #[rstest]
+    fn test_instrument_id_to_ib_contract_parses_long_crypto_symbol() {
+        let instrument_id = InstrumentId::from("DOGE/USD.PAXOS");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Crypto);
+        assert_eq!(contract.exchange.as_str(), "PAXOS");
+        assert_eq!(contract.symbol.as_str(), "DOGE");
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "DOGE.USD");
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/config.rs
+++ b/crates/adapters/interactive_brokers/src/config.rs
@@ -216,6 +216,10 @@ pub struct InteractiveBrokersInstrumentProviderConfig {
     /// Security types to filter out.
     #[builder(default)]
     pub filter_sec_types: HashSet<String>,
+    /// Fully-qualified Python callable path for custom instrument filtering.
+    ///
+    /// Configuring this without the Python feature enabled is an error.
+    pub filter_callable: Option<String>,
     /// Path to cache file for persistent instrument caching (equivalent to pickle_path in Python).
     /// If provided, instruments will be cached to disk and loaded from cache if still valid.
     pub cache_path: Option<String>,

--- a/crates/adapters/interactive_brokers/src/data/convert.rs
+++ b/crates/adapters/interactive_brokers/src/data/convert.rs
@@ -49,7 +49,7 @@ pub fn bar_type_to_ib_bar_size(bar_type: &BarType) -> anyhow::Result<HistoricalB
         (BarAggregation::Minute, 2) => HistoricalBarSize::Min2,
         (BarAggregation::Minute, 3) => HistoricalBarSize::Min3,
         (BarAggregation::Minute, 5) => HistoricalBarSize::Min5,
-        (BarAggregation::Minute, 10) => HistoricalBarSize::Min15, // IB doesn't have 10-min, closest is 15
+        (BarAggregation::Minute, 10) => HistoricalBarSize::Min10,
         (BarAggregation::Minute, 15) => HistoricalBarSize::Min15,
         (BarAggregation::Minute, 20) => HistoricalBarSize::Min20,
         (BarAggregation::Minute, 30) => HistoricalBarSize::Min30,
@@ -82,6 +82,32 @@ pub fn price_type_to_ib_what_to_show(price_type: PriceType) -> HistoricalWhatToS
         PriceType::Ask => HistoricalWhatToShow::Ask,
         PriceType::Mid => HistoricalWhatToShow::MidPoint,
         _ => HistoricalWhatToShow::Trades, // Default to trades
+    }
+}
+
+#[must_use]
+pub fn apply_price_magnifier(price: f64, price_magnifier: i32) -> f64 {
+    if price_magnifier > 0 {
+        price / f64::from(price_magnifier)
+    } else {
+        price
+    }
+}
+
+#[must_use]
+pub fn apply_bar_price_magnifier(
+    ib_bar: &ibapi::market_data::historical::Bar,
+    price_magnifier: i32,
+) -> ibapi::market_data::historical::Bar {
+    ibapi::market_data::historical::Bar {
+        date: ib_bar.date,
+        open: apply_price_magnifier(ib_bar.open, price_magnifier),
+        high: apply_price_magnifier(ib_bar.high, price_magnifier),
+        low: apply_price_magnifier(ib_bar.low, price_magnifier),
+        close: apply_price_magnifier(ib_bar.close, price_magnifier),
+        volume: ib_bar.volume,
+        wap: apply_price_magnifier(ib_bar.wap, price_magnifier),
+        count: ib_bar.count,
     }
 }
 

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -19,6 +19,7 @@
 mod streams;
 
 use std::{
+    collections::HashMap,
     fmt::Debug,
     sync::{
         Arc,
@@ -48,6 +49,7 @@ use nautilus_common::{
 };
 use nautilus_core::{
     UnixNanos,
+    params::Params,
     time::{AtomicTime, get_atomic_clock_realtime},
 };
 use nautilus_model::{
@@ -67,8 +69,9 @@ use self::streams::{
 use super::{
     cache::{OptionGreeksCache, QuoteCache},
     convert::{
-        bar_type_to_ib_bar_size, calculate_duration, calculate_duration_segments,
-        chrono_to_ib_datetime, ib_bar_to_nautilus_bar, price_type_to_ib_what_to_show,
+        apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
+        calculate_duration, calculate_duration_segments, chrono_to_ib_datetime,
+        ib_bar_to_nautilus_bar, price_type_to_ib_what_to_show,
     },
 };
 use crate::{
@@ -161,6 +164,14 @@ fn parse_bool_param_value(value: &str) -> bool {
     matches!(value, "true" | "True" | "1")
 }
 
+fn params_to_string_filters(params: Option<&Params>) -> Option<HashMap<String, String>> {
+    let filters: HashMap<String, String> = params?
+        .iter()
+        .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+        .collect();
+    (!filters.is_empty()).then_some(filters)
+}
+
 fn datetime_to_unix_nanos(dt: chrono::DateTime<chrono::Utc>) -> UnixNanos {
     UnixNanos::from(
         dt.timestamp_nanos_opt()
@@ -179,7 +190,7 @@ fn request_trading_hours(use_regular_trading_hours: bool) -> ibapi::market_data:
 fn retreat_historical_tick_end_datetime(
     min_ts_nanos: u64,
 ) -> Option<chrono::DateTime<chrono::Utc>> {
-    let new_end_nanos = min_ts_nanos.saturating_sub(1);
+    let new_end_nanos = min_ts_nanos.saturating_sub(1_000_000);
     let seconds = (new_end_nanos / 1_000_000_000) as i64;
     let nanos = (new_end_nanos % 1_000_000_000) as u32;
     chrono::DateTime::from_timestamp(seconds, nanos)
@@ -189,9 +200,9 @@ fn should_continue_historical_tick_pagination(
     current_start_date: Option<chrono::DateTime<chrono::Utc>>,
     current_end_date: Option<chrono::DateTime<chrono::Utc>>,
     current_len: usize,
-    limit: usize,
+    limit: Option<usize>,
 ) -> bool {
-    current_len < limit
+    limit.is_none_or(|limit| current_len < limit)
         && current_start_date
             .zip(current_end_date)
             .is_none_or(|(start, end)| end > start)
@@ -227,7 +238,7 @@ fn extend_historical_tick_batch<T>(
     current_end_date: &mut Option<chrono::DateTime<chrono::Utc>>,
     start_nanos: Option<UnixNanos>,
     end_nanos: Option<UnixNanos>,
-    limit: usize,
+    limit: Option<usize>,
     ts_event: impl Fn(&T) -> UnixNanos,
 ) -> bool {
     if batch_ticks.is_empty() {
@@ -251,7 +262,7 @@ fn extend_historical_tick_batch<T>(
         return false;
     }
 
-    all_ticks.len() < limit
+    limit.is_none_or(|limit| all_ticks.len() < limit)
 }
 
 impl InteractiveBrokersDataClient {
@@ -1264,6 +1275,7 @@ impl DataClient for InteractiveBrokersDataClient {
                     last_bars,
                     bar_timeout_tasks,
                     handle_revised_bars,
+                    use_rth,
                     subscription_token_clone,
                 )
                 .await
@@ -1452,6 +1464,19 @@ impl DataClient for InteractiveBrokersDataClient {
     // Request handlers
     fn request_instrument(&self, cmd: RequestInstrument) -> anyhow::Result<()> {
         tracing::debug!("Requesting instrument: {}", cmd.instrument_id);
+        if cmd.start.is_some() {
+            tracing::warn!(
+                "Requesting instrument {} with specified `start` which has no effect",
+                cmd.instrument_id
+            );
+        }
+
+        if cmd.end.is_some() {
+            tracing::warn!(
+                "Requesting instrument {} with specified `end` which has no effect",
+                cmd.instrument_id
+            );
+        }
 
         // Check if force_instrument_update is requested
         let force_update = cmd
@@ -1481,8 +1506,9 @@ impl DataClient for InteractiveBrokersDataClient {
                 let client_clone = client.as_arc().clone();
 
                 get_runtime().spawn(async move {
+                    let filters = params_to_string_filters(params.as_ref());
                     if let Err(e) = instrument_provider
-                        .fetch_contract_details(&client_clone, instrument_id, false, None)
+                        .fetch_contract_details(&client_clone, instrument_id, force_update, filters)
                         .await
                     {
                         tracing::error!(
@@ -1563,28 +1589,44 @@ impl DataClient for InteractiveBrokersDataClient {
         let mut contract_specs_to_load: Vec<serde_json::Value> = Vec::new();
 
         if let Some(params) = &cmd.params
-            && let Some(ib_contracts_json_str) = params.get_str("ib_contracts")
+            && let Some(ib_contracts_value) = params.get("ib_contracts")
         {
-            // Parse JSON string containing array of contracts.
-            match serde_json::from_str::<serde_json::Value>(ib_contracts_json_str) {
-                Ok(serde_json::Value::Array(contract_specs)) => {
+            match ib_contracts_value {
+                serde_json::Value::Array(contract_specs) => {
                     tracing::info!(
-                        "Parsed {} contract specs from ib_contracts JSON",
+                        "Parsed {} structured contract specs from ib_contracts",
                         contract_specs.len()
                     );
-                    log::debug!("Parsed ib_contracts payload: {}", ib_contracts_json_str);
-                    contract_specs_to_load = contract_specs;
+                    contract_specs_to_load = contract_specs.clone();
                 }
-                Ok(value) => {
+                serde_json::Value::String(ib_contracts_json_str) => {
+                    match serde_json::from_str::<serde_json::Value>(ib_contracts_json_str) {
+                        Ok(serde_json::Value::Array(contract_specs)) => {
+                            tracing::info!(
+                                "Parsed {} contract specs from ib_contracts JSON",
+                                contract_specs.len()
+                            );
+                            log::debug!("Parsed ib_contracts payload: {}", ib_contracts_json_str);
+                            contract_specs_to_load = contract_specs;
+                        }
+                        Ok(value) => {
+                            tracing::warn!(
+                                "Expected ib_contracts JSON array, received {}. Continuing without contracts",
+                                value
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to parse ib_contracts JSON: {}. Continuing without contracts",
+                                e
+                            );
+                        }
+                    }
+                }
+                value => {
                     tracing::warn!(
-                        "Expected ib_contracts JSON array, received {}. Continuing without contracts",
+                        "Expected ib_contracts array or JSON string, received {}. Continuing without contracts",
                         value
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to parse ib_contracts JSON: {}. Continuing without contracts",
-                        e
                     );
                 }
             }
@@ -1674,7 +1716,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 let instruments = if return_loaded_only {
                     instrument_provider.find_all(&loaded_instrument_ids)
                 } else {
-                    instrument_provider.get_all()
+                    Vec::new()
                 };
                 let instruments_count = instruments.len();
 
@@ -1700,14 +1742,11 @@ impl DataClient for InteractiveBrokersDataClient {
                 }
             });
         } else {
-            // Get all instruments from provider (no loading needed)
-            let instruments = self.instrument_provider.get_all();
-
             let response = DataResponse::Instruments(InstrumentsResponse::new(
                 cmd.request_id,
                 cmd.client_id.unwrap_or(self.client_id),
                 venue,
-                instruments,
+                Vec::new(),
                 start_nanos,
                 end_nanos,
                 self.clock.get_time_ns(),
@@ -1717,10 +1756,7 @@ impl DataClient for InteractiveBrokersDataClient {
             if let Err(e) = self.data_sender.send(DataEvent::Response(response)) {
                 tracing::error!("Failed to send instruments response: {e}");
             } else {
-                tracing::info!(
-                    "Successfully sent {} instruments response",
-                    self.instrument_provider.count()
-                );
+                tracing::info!("Successfully sent empty instruments response");
             }
         }
 
@@ -1753,7 +1789,6 @@ impl DataClient for InteractiveBrokersDataClient {
             .resolve_contract_for_instrument(cmd.instrument_id)
             .context("Failed to convert instrument_id to IB contract")?;
 
-        // Determine number of ticks from limit or default to 1000
         let number_of_ticks = cmd.limit.map_or(1000, |l| l.get() as i32).min(1000);
 
         let instrument_id = cmd.instrument_id;
@@ -1767,12 +1802,13 @@ impl DataClient for InteractiveBrokersDataClient {
 
         // Spawn async task to handle the request with pagination
         let client_clone = client.as_arc().clone();
-        let limit = cmd.limit.map_or(1000, |l| l.get());
+        let limit = cmd.limit.map(|l| l.get());
         let start_nanos_clone = start_nanos;
         let end_nanos_clone = end_nanos;
         let cmd_start = cmd.start;
         let cmd_end = cmd.end;
         let trading_hours = request_trading_hours(self.config.use_regular_trading_hours);
+        let price_magnifier = self.instrument_provider.get_price_magnifier(&instrument_id);
 
         get_runtime().spawn(async move {
             let mut all_quotes = Vec::new();
@@ -1817,8 +1853,8 @@ impl DataClient for InteractiveBrokersDataClient {
 
                             match super::parse::parse_quote_tick(
                                 instrument_id,
-                                Some(tick.price_bid),
-                                Some(tick.price_ask),
+                                Some(apply_price_magnifier(tick.price_bid, price_magnifier)),
+                                Some(apply_price_magnifier(tick.price_ask, price_magnifier)),
                                 Some(tick.size_bid as f64),
                                 Some(tick.size_ask as f64),
                                 price_precision,
@@ -1865,6 +1901,11 @@ impl DataClient for InteractiveBrokersDataClient {
             );
 
             all_quotes.sort_by_key(|q| q.ts_event);
+            if let Some(limit) = limit
+                && all_quotes.len() > limit
+            {
+                all_quotes = all_quotes.split_off(all_quotes.len() - limit);
+            }
 
             let quotes_count = all_quotes.len();
             let response = DataResponse::Quotes(QuotesResponse::new(
@@ -1927,7 +1968,6 @@ impl DataClient for InteractiveBrokersDataClient {
             .resolve_contract_for_instrument(cmd.instrument_id)
             .context("Failed to convert instrument_id to IB contract")?;
 
-        // Determine number of ticks from limit or default to 1000
         let number_of_ticks = cmd.limit.map_or(1000, |l| l.get() as i32).min(1000);
 
         let instrument_id = cmd.instrument_id;
@@ -1941,12 +1981,13 @@ impl DataClient for InteractiveBrokersDataClient {
 
         // Spawn async task to handle the request with pagination
         let client_clone = client.as_arc().clone();
-        let limit = cmd.limit.map_or(1000, |l| l.get());
+        let limit = cmd.limit.map(|l| l.get());
         let start_nanos_clone = start_nanos;
         let end_nanos_clone = end_nanos;
         let cmd_start = cmd.start;
         let cmd_end = cmd.end;
         let trading_hours = request_trading_hours(self.config.use_regular_trading_hours);
+        let price_magnifier = self.instrument_provider.get_price_magnifier(&instrument_id);
 
         get_runtime().spawn(async move {
             let mut all_trades = Vec::new();
@@ -1993,7 +2034,7 @@ impl DataClient for InteractiveBrokersDataClient {
 
                             match super::parse::parse_trade_tick(
                                 instrument_id,
-                                tick.price,
+                                apply_price_magnifier(tick.price, price_magnifier),
                                 tick.size as f64,
                                 price_precision,
                                 size_precision,
@@ -2040,6 +2081,11 @@ impl DataClient for InteractiveBrokersDataClient {
             );
 
             all_trades.sort_by_key(|t| t.ts_event);
+            if let Some(limit) = limit
+                && all_trades.len() > limit
+            {
+                all_trades = all_trades.split_off(all_trades.len() - limit);
+            }
 
             let trades_count = all_trades.len();
             let response = DataResponse::Trades(TradesResponse::new(
@@ -2122,6 +2168,8 @@ impl DataClient for InteractiveBrokersDataClient {
         let params = cmd.params.clone();
         let start_nanos = cmd.start.map(datetime_to_unix_nanos);
         let end_nanos = cmd.end.map(datetime_to_unix_nanos);
+        let limit = cmd.limit.map(|limit| limit.get());
+        let price_magnifier = self.instrument_provider.get_price_magnifier(&instrument_id);
 
         // Spawn async task to handle the request with segmentation
         let client_clone = client.as_arc().clone();
@@ -2147,8 +2195,9 @@ impl DataClient for InteractiveBrokersDataClient {
                     Ok(historical_data) => {
                         // Convert IB bars to Nautilus bars
                         for ib_bar in &historical_data.bars {
+                            let ib_bar = apply_bar_price_magnifier(ib_bar, price_magnifier);
                             match ib_bar_to_nautilus_bar(
-                                ib_bar,
+                                &ib_bar,
                                 bar_type,
                                 price_precision,
                                 size_precision,
@@ -2176,13 +2225,20 @@ impl DataClient for InteractiveBrokersDataClient {
             }
 
             // Return aggregated results
-            let bars_count = all_bars.len();
-            if bars_count == 0 {
+            if all_bars.is_empty() {
                 tracing::warn!("No bar data received for {}", bar_type);
             }
 
-            // Sort bars by timestamp as segments might overlap or be out of order from IB
+            // Sort and deduplicate bars as segments might overlap or be out of order from IB.
             all_bars.sort_by_key(|b| b.ts_event);
+            all_bars.dedup();
+
+            if let Some(limit) = limit
+                && all_bars.len() > limit
+            {
+                all_bars = all_bars.split_off(all_bars.len() - limit);
+            }
+            let bars_count = all_bars.len();
 
             let response = DataResponse::Bars(BarsResponse::new(
                 request_id,
@@ -2234,10 +2290,10 @@ mod tests {
     }
 
     #[rstest]
-    fn test_retreat_historical_tick_end_datetime_subtracts_one_nanosecond() {
+    fn test_retreat_historical_tick_end_datetime_subtracts_one_millisecond() {
         let result = retreat_historical_tick_end_datetime(1_234_567_890).unwrap();
 
-        assert_eq!(result.timestamp_nanos_opt().unwrap() as u64, 1_234_567_889);
+        assert_eq!(result.timestamp_nanos_opt().unwrap() as u64, 1_233_567_890);
     }
 
     #[rstest]
@@ -2248,15 +2304,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 0, 10, true)]
-    #[case(Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 0, 10, true)]
-    #[case(Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), 0, 10, false)]
-    #[case(Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 10, 10, false)]
+    #[case(None, Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 0, Some(10), true)]
+    #[case(Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 0, Some(10), true)]
+    #[case(Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), 0, Some(10), false)]
+    #[case(Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 10, Some(10), false)]
+    #[case(Some(chrono::DateTime::from_timestamp(1, 0).unwrap()), Some(chrono::DateTime::from_timestamp(2, 0).unwrap()), 10, None, true)]
     fn test_should_continue_historical_tick_pagination(
         #[case] start: Option<chrono::DateTime<chrono::Utc>>,
         #[case] end: Option<chrono::DateTime<chrono::Utc>>,
         #[case] current_len: usize,
-        #[case] limit: usize,
+        #[case] limit: Option<usize>,
         #[case] expected: bool,
     ) {
         assert_eq!(

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -433,7 +433,7 @@ impl InteractiveBrokersDataClient {
 
         let count = self
             .instrument_provider
-            .fetch_option_chain_by_range(client, &underlying, expiry_min, expiry_max)
+            .fetch_option_chain_by_range(client, &underlying, expiry_min, expiry_max, None)
             .await?;
         log::debug!(
             "Fetched {} IB option instruments for {}",
@@ -647,22 +647,12 @@ impl DataClient for InteractiveBrokersDataClient {
         self.ib_client = Some(handle);
         self.is_connected.store(true, Ordering::Relaxed);
 
-        // Initialize provider and load instruments from cache if configured
+        // Initialize provider and load instruments from cache/config if configured
         tracing::debug!("Initializing IB data instrument provider");
-        if let Err(e) = self.instrument_provider.initialize().await {
-            tracing::warn!("Failed to initialize instrument provider: {}", e);
-        }
-
-        tracing::debug!("Loading configured IB data instruments");
 
         if let Err(e) = self
             .instrument_provider
-            .load_all_async(
-                self.ib_client.as_ref().unwrap().as_arc().as_ref(),
-                None,
-                None,
-                false,
-            )
+            .initialize_with_client(self.ib_client.as_ref().unwrap().as_arc().as_ref())
             .await
         {
             if !self.config.instrument_provider.load_ids.is_empty()

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -110,7 +110,7 @@ pub(super) async fn handle_historical_bars_subscription(
     use_rth: bool,
     start_ns: Option<UnixNanos>,
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
-    _handle_revised_bars: bool,
+    handle_revised_bars: bool,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
 ) -> anyhow::Result<()> {
@@ -194,6 +194,10 @@ pub(super) async fn handle_historical_bars_subscription(
                             }
                         }
                         Some(HistoricalBarUpdate::Update(ib_bar)) => {
+                            if !handle_revised_bars {
+                                continue;
+                            }
+
                             let bar = ib_bar_to_nautilus_bar(
                                 &ib_bar,
                                 bar_type,
@@ -530,16 +534,22 @@ pub(super) async fn handle_realtime_bars_subscription(
     last_bars: Arc<tokio::sync::Mutex<AHashMap<String, RealtimeBar>>>,
     bar_timeout_tasks: Arc<tokio::sync::Mutex<AHashMap<String, tokio::task::JoinHandle<()>>>>,
     handle_revised_bars: bool,
+    use_rth: bool,
     cancellation_token: CancellationToken,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting bars subscription for {}", bar_type);
+    let trading_hours = if use_rth {
+        TradingHours::Regular
+    } else {
+        TradingHours::Extended
+    };
 
     let mut subscription = client
         .realtime_bars(
             &contract,
             RealtimeBarSize::Sec5,
             RealtimeWhatToShow::Trades,
-            TradingHours::Regular,
+            trading_hours,
         )
         .await
         .context("Failed to create realtime bars subscription")?;

--- a/crates/adapters/interactive_brokers/src/execution/account.rs
+++ b/crates/adapters/interactive_brokers/src/execution/account.rs
@@ -39,9 +39,7 @@ use nautilus_model::{
 };
 use rust_decimal::{Decimal, prelude::ToPrimitive};
 
-use crate::common::parse::ib_contract_to_instrument_id_simple;
-
-fn raw_ib_account_code(account_id: &AccountId) -> String {
+pub(crate) fn raw_ib_account_code(account_id: &AccountId) -> String {
     account_id
         .to_string()
         .strip_prefix("IB-")
@@ -265,10 +263,8 @@ pub async fn check_external_position_change(
     let mut tracker = position_tracker.lock().await;
     let known_quantity = tracker.get(&contract_id).copied().unwrap_or(Decimal::ZERO);
 
-    // Skip zero positions
     if new_quantity.is_zero() {
-        tracker.remove(&contract_id);
-        return None;
+        return (!known_quantity.is_zero()).then_some((true, known_quantity));
     }
 
     // Check if this is an external position change
@@ -373,6 +369,7 @@ pub async fn subscribe_positions(
 
     let exec_sender = get_exec_event_sender();
     let clock = get_atomic_clock_realtime();
+    let client_for_instruments = Arc::clone(client);
 
     // Spawn background task to handle position updates
     nautilus_common::live::get_runtime().spawn(async move {
@@ -401,89 +398,83 @@ pub async fn subscribe_positions(
                             new_quantity
                         );
 
-                        // Convert IB contract to instrument ID
-                        match ib_contract_to_instrument_id_simple(&position.contract) {
-                            Ok(instrument_id) => {
-                                // Get instrument for precision
-                                if let Some(instrument) = instrument_provider.find(&instrument_id) {
-                                    // Determine position side
-                                    let position_side = if new_quantity.is_zero() {
-                                        PositionSideSpecified::Flat
-                                    } else if new_quantity > Decimal::ZERO {
-                                        PositionSideSpecified::Long
-                                    } else {
-                                        PositionSideSpecified::Short
-                                    };
-
-                                    let quantity = Quantity::new(
-                                        new_quantity.abs().to_f64().unwrap_or(0.0),
-                                        instrument.size_precision(),
-                                    );
-
-                                    // Convert IB avg_cost to Nautilus Price, accounting for price magnifier and multiplier
-                                    // Python: converted_avg_cost = avg_cost / (multiplier * price_magnifier)
-                                    let avg_px_open = if position.average_cost > 0.0 {
-                                        let price_magnifier = instrument_provider
-                                            .get_price_magnifier(&instrument_id)
-                                            as f64;
-                                        let multiplier = instrument.multiplier().as_f64();
-                                        let converted_avg_cost =
-                                            position.average_cost / (multiplier * price_magnifier);
-                                        let price_precision = instrument.price_precision();
-                                        Some(
-                                            Decimal::from_f64_retain(converted_avg_cost)
-                                                .and_then(|d| {
-                                                    // Round to price precision
-                                                    let rounded =
-                                                        d.round_dp(price_precision as u32);
-                                                    Some(rounded)
-                                                })
-                                                .unwrap_or_default(),
-                                        )
-                                    } else {
-                                        None
-                                    };
-
-                                    let ts_init = clock.get_time_ns();
-
-                                    let report = PositionStatusReport::new(
-                                        account_id,
-                                        instrument_id,
-                                        position_side,
-                                        quantity,
-                                        ts_init,
-                                        ts_init,
-                                        None, // report_id: auto-generated
-                                        None, // venue_position_id
-                                        avg_px_open,
-                                    );
-
-                                    // Send position status report
-                                    let event = ExecutionEvent::Report(
-                                        ExecutionReport::Position(
-                                            Box::new(report),
-                                        ),
-                                    );
-
-                                    if exec_sender.send(event).is_err() {
-                                        tracing::warn!(
-                                            "Failed to send position status report for external change"
-                                        );
-                                    } else {
-                                        tracing::info!(
-                                            "Generated position status report for external change (likely option exercise)"
-                                        );
-                                    }
+                        match instrument_provider
+                            .get_instrument(&client_for_instruments, &position.contract)
+                            .await
+                        {
+                            Ok(Some(instrument)) => {
+                                let instrument_id = instrument.id();
+                                let position_side = if new_quantity.is_zero() {
+                                    PositionSideSpecified::Flat
+                                } else if new_quantity > Decimal::ZERO {
+                                    PositionSideSpecified::Long
                                 } else {
+                                    PositionSideSpecified::Short
+                                };
+
+                                let quantity = Quantity::new(
+                                    new_quantity.abs().to_f64().unwrap_or(0.0),
+                                    instrument.size_precision(),
+                                );
+
+                                let avg_px_open = if position.average_cost > 0.0 {
+                                    let price_magnifier =
+                                        instrument_provider.get_price_magnifier(&instrument_id)
+                                            as f64;
+                                    let multiplier = instrument.multiplier().as_f64();
+                                    let converted_avg_cost =
+                                        position.average_cost / (multiplier * price_magnifier);
+                                    let price_precision = instrument.price_precision();
+                                    Some(
+                                        Decimal::from_f64_retain(converted_avg_cost)
+                                            .map(|d| d.round_dp(price_precision as u32))
+                                            .unwrap_or_default(),
+                                    )
+                                } else {
+                                    None
+                                };
+
+                                let ts_init = clock.get_time_ns();
+
+                                let report = PositionStatusReport::new(
+                                    account_id,
+                                    instrument_id,
+                                    position_side,
+                                    quantity,
+                                    ts_init,
+                                    ts_init,
+                                    None,
+                                    None,
+                                    avg_px_open,
+                                );
+                                let event = ExecutionEvent::Report(ExecutionReport::Position(
+                                    Box::new(report),
+                                ));
+
+                                if exec_sender.send(event).is_err() {
                                     tracing::warn!(
-                                        "Instrument not found for contract ID: {}",
-                                        contract_id
+                                        "Failed to send position status report for external change"
+                                    );
+                                } else {
+                                    if new_quantity.is_zero() {
+                                        position_tracker.lock().await.remove(&contract_id);
+                                    }
+
+                                    tracing::info!(
+                                        "Generated position status report for external change (likely option exercise)"
                                     );
                                 }
                             }
+                            Ok(None) => {
+                                tracing::warn!(
+                                    "Instrument not found for external position contract ID: {}",
+                                    contract_id
+                                );
+                            }
                             Err(e) => {
                                 tracing::warn!(
-                                    "Failed to convert contract to instrument ID: {}",
+                                    "Failed to resolve external position contract ID {}: {}",
+                                    contract_id,
                                     e
                                 );
                             }
@@ -548,10 +539,11 @@ mod tests {
     use ibapi::accounts::AccountSummary;
     use nautilus_model::types::{AccountBalance, Currency, MarginBalance, Money};
     use rstest::rstest;
+    use rust_decimal::Decimal;
 
     use super::{
-        AccountSummaryTags, merge_account_summary_balance, merge_account_summary_margin,
-        parse_currency,
+        AccountSummaryTags, check_external_position_change, create_position_tracker,
+        merge_account_summary_balance, merge_account_summary_margin, parse_currency,
     };
 
     fn margin_summary(tag: &str, value: &str, currency: &str) -> AccountSummary {
@@ -587,6 +579,21 @@ mod tests {
         assert_eq!(
             result.unwrap_err().to_string(),
             "Account summary currency was empty",
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_external_position_change_reports_tracked_zero_close() {
+        let tracker = create_position_tracker();
+        tracker.lock().await.insert(42, Decimal::new(5, 0));
+
+        let change = check_external_position_change(&tracker, 42, Decimal::ZERO).await;
+
+        assert_eq!(change, Some((true, Decimal::new(5, 0))));
+        assert_eq!(
+            tracker.lock().await.get(&42).copied(),
+            Some(Decimal::new(5, 0))
         );
     }
 

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -41,6 +41,7 @@ use anyhow::Context;
 use ibapi::{
     accounts::PositionUpdate,
     client::Client,
+    contracts::{Contract, SecurityType},
     orders::{
         ExecutionData, ExecutionFilter, Executions, OrderStatus as IBOrderStatus, OrderUpdate,
         Orders,
@@ -72,28 +73,33 @@ use nautilus_live::ExecutionClientCore;
 use nautilus_model::{
     accounts::AccountAny,
     enums::{
-        LiquiditySide, OmsType, OrderSide, OrderType, PositionSideSpecified, TrailingOffsetType,
+        LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType, PositionSideSpecified,
+        TimeInForce, TrailingOffsetType,
     },
     events::{
         AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderEventAny,
         OrderInitialized, OrderModifyRejected, OrderPendingCancel, OrderRejected, OrderSubmitted,
+        OrderUpdated,
     },
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TradeId, TraderId, Venue,
         VenueOrderId,
     },
-    instruments::Instrument,
+    instruments::{Instrument, InstrumentAny},
     orders::{Order, any::OrderAny},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, Currency, MarginBalance, Money, Price, Quantity},
 };
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, prelude::ToPrimitive};
 use tokio::{sync::Mutex as AsyncMutex, task::JoinHandle};
 use ustr::Ustr;
 
 use super::{
-    account::{PositionTracker, create_position_tracker},
-    parse::{parse_execution_time, parse_execution_to_fill_report, parse_order_status_to_report},
+    account::{PositionTracker, create_position_tracker, raw_ib_account_code},
+    parse::{
+        ib_venue_order_id, parse_execution_time, parse_execution_to_fill_report,
+        parse_order_status_to_report,
+    },
     transform::nautilus_order_to_ib_order,
 };
 use crate::{
@@ -181,6 +187,45 @@ struct PendingComboFill {
     client_order_id: ClientOrderId,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IbOrderSelector {
+    OrderId(i32),
+    PermId(i32),
+}
+
+impl IbOrderSelector {
+    fn from_venue_order_id(venue_order_id: &VenueOrderId) -> anyhow::Result<Self> {
+        let raw = venue_order_id.as_str();
+        if let Some(perm_id) = raw.strip_prefix("PERM-") {
+            return Ok(Self::PermId(perm_id.parse::<i32>().with_context(|| {
+                format!("Failed to parse venue_order_id {raw:?} as IB perm_id")
+            })?));
+        }
+
+        Ok(Self::OrderId(raw.parse::<i32>().with_context(|| {
+            format!("Failed to parse venue_order_id {raw:?} as IB order_id")
+        })?))
+    }
+
+    fn matches(self, order_id: i32, perm_id: i32) -> bool {
+        match self {
+            Self::OrderId(target_order_id) => order_id == target_order_id,
+            Self::PermId(target_perm_id) => perm_id == target_perm_id,
+        }
+    }
+
+    fn venue_order_id(self) -> VenueOrderId {
+        match self {
+            Self::OrderId(order_id) => VenueOrderId::from(order_id.to_string()),
+            Self::PermId(perm_id) => VenueOrderId::from(format!("PERM-{perm_id}")),
+        }
+    }
+
+    fn label(self) -> String {
+        self.venue_order_id().to_string()
+    }
 }
 
 impl Debug for InteractiveBrokersExecutionClient {
@@ -772,14 +817,33 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             .await
             .context("Timeout requesting open orders")??;
         let mut reports = Vec::new();
+        let mut open_order_fills: AHashMap<InstrumentId, Decimal> = AHashMap::new();
         let ts_init = get_atomic_clock_realtime().get_time_ns();
+        let raw_account_id = raw_ib_account_code(&self.core.account_id);
 
         while let Some(order_result) = subscription.next().await {
             match order_result {
                 Ok(Orders::OrderData(data)) => {
+                    if !data.order.account.is_empty() && data.order.account != raw_account_id {
+                        continue;
+                    }
+
                     // Convert IB contract to instrument ID
-                    let instrument_id = ib_contract_to_instrument_id_simple(&data.contract)
-                        .context("Failed to convert contract to instrument ID")?;
+                    let instrument_id =
+                        match self.resolve_report_contract_instrument_id(&data.contract) {
+                            Ok(instrument_id) => instrument_id,
+                            Err(e) => {
+                                tracing::warn!(
+                                    order_id = data.order_id,
+                                    sec_type = ?data.contract.security_type,
+                                    symbol = data.contract.symbol.as_str(),
+                                    con_id = data.contract.contract_id,
+                                    error = %e,
+                                    "Failed to resolve IBKR order status report instrument ID",
+                                );
+                                continue;
+                            }
+                        };
 
                     // Filter by instrument_id if specified
                     if let Some(filter_id) = cmd.instrument_id {
@@ -794,8 +858,9 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                         &IBOrderStatus {
                             order_id: data.order_id,
                             status: data.order_state.status.clone(),
-                            filled: 0.0,             // Not available in OrderState
-                            remaining: 0.0,          // Not available in OrderState
+                            filled: data.order.filled_quantity,
+                            remaining: (data.order.total_quantity - data.order.filled_quantity)
+                                .max(0.0),
                             average_fill_price: 0.0, // Not available in OrderState
                             perm_id: data.order.perm_id,
                             parent_id: 0,         // Not available in OrderState
@@ -810,7 +875,20 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                         &self.instrument_provider,
                         ts_init,
                     ) {
-                        Ok(report) => reports.push(report),
+                        Ok(report) => {
+                            if !cmd.open_only && report.filled_qty.as_decimal() > Decimal::ZERO {
+                                let signed_filled = if report.order_side == OrderSide::Buy {
+                                    report.filled_qty.as_decimal()
+                                } else {
+                                    -report.filled_qty.as_decimal()
+                                };
+                                open_order_fills
+                                    .entry(report.instrument_id)
+                                    .and_modify(|qty| *qty += signed_filled)
+                                    .or_insert(signed_filled);
+                            }
+                            reports.push(report);
+                        }
                         Err(e) => {
                             tracing::warn!("Failed to parse order status report: {e}");
                         }
@@ -821,6 +899,102 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 }
                 Err(e) => {
                     tracing::warn!("Error receiving order data: {e}");
+                }
+            }
+        }
+
+        if !cmd.open_only {
+            let mut positions = tokio::time::timeout(timeout_dur, client.positions())
+                .await
+                .context("Timeout requesting positions for synthetic order reports")??;
+
+            while let Some(position_result) = positions.next().await {
+                match position_result {
+                    Ok(PositionUpdate::Position(position)) => {
+                        if position.account != raw_account_id {
+                            continue;
+                        }
+
+                        let instrument = match self
+                            .instrument_provider
+                            .get_instrument(client.as_arc().as_ref(), &position.contract)
+                            .await
+                        {
+                            Ok(Some(instrument)) => instrument,
+                            Ok(None) => {
+                                tracing::warn!(
+                                    con_id = position.contract.contract_id,
+                                    sec_type = ?position.contract.security_type,
+                                    "Cannot generate synthetic order report: instrument not found",
+                                );
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    con_id = position.contract.contract_id,
+                                    sec_type = ?position.contract.security_type,
+                                    error = %e,
+                                    "Failed to resolve instrument for synthetic order report",
+                                );
+                                continue;
+                            }
+                        };
+
+                        let instrument_id = instrument.id();
+                        if let Some(filter_id) = cmd.instrument_id
+                            && instrument_id != filter_id
+                        {
+                            continue;
+                        }
+
+                        let position_qty =
+                            Decimal::from_f64_retain(position.position).unwrap_or_default();
+                        let open_fills = open_order_fills
+                            .get(&instrument_id)
+                            .copied()
+                            .unwrap_or_default();
+                        let adjusted_qty = position_qty - open_fills;
+                        if adjusted_qty.is_zero() {
+                            continue;
+                        }
+
+                        let quantity = Quantity::new(
+                            adjusted_qty.abs().to_f64().unwrap_or_default(),
+                            instrument.size_precision(),
+                        );
+                        let order_side = if adjusted_qty > Decimal::ZERO {
+                            OrderSide::Buy
+                        } else {
+                            OrderSide::Sell
+                        };
+                        let id = instrument_id.to_string();
+                        let mut report = OrderStatusReport::new(
+                            self.core.account_id,
+                            instrument_id,
+                            Some(ClientOrderId::new(id.clone())),
+                            VenueOrderId::new(id),
+                            order_side,
+                            OrderType::Market,
+                            TimeInForce::Fok,
+                            OrderStatus::Filled,
+                            quantity,
+                            quantity,
+                            ts_init,
+                            ts_init,
+                            ts_init,
+                            Some(UUID4::new()),
+                        );
+                        report.avg_px = self.position_avg_px_open(
+                            &instrument_id,
+                            &instrument,
+                            position.average_cost,
+                        );
+                        reports.push(report);
+                    }
+                    Ok(PositionUpdate::PositionEnd) => break,
+                    Err(e) => tracing::warn!(
+                        "Error receiving position data for synthetic order report: {e}"
+                    ),
                 }
             }
         }
@@ -837,13 +1011,10 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         // Get account code from account ID
         let account_code = self.core.account_id.to_string();
 
-        // Build time filter from start/end if provided
-        let time_filter = if let (Some(start), Some(end)) = (cmd.start, cmd.end) {
-            // Format: YYYYMMDD
-            // Convert UnixNanos to DateTime<Utc> then format
+        // Build time filter from start if provided.
+        let time_filter = if let Some(start) = cmd.start {
             let start_dt = start.to_datetime_utc();
-            let end_dt = end.to_datetime_utc();
-            format!("{} {}", start_dt.format("%Y%m%d"), end_dt.format("%Y%m%d"))
+            start_dt.format("%Y%m%d-%H:%M:%S").to_string()
         } else {
             String::new()
         };
@@ -882,7 +1053,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                             commission,
                             &commission_currency,
                             ts_init,
-                        )? {
+                        ) {
                             reports.push(report);
                         }
                     } else {
@@ -897,7 +1068,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                             commission.commission,
                             &commission.currency,
                             ts_init,
-                        )? {
+                        ) {
                             reports.push(report);
                         }
                     } else {
@@ -938,6 +1109,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             .context("Timeout requesting positions")??;
         let mut reports = Vec::new();
         let ts_init = get_atomic_clock_realtime().get_time_ns();
+        let raw_account_id = raw_ib_account_code(&self.core.account_id);
 
         // Process positions until PositionEnd; return empty list when none (reconciliation parity:
         // never return None/missing for "no positions").
@@ -945,13 +1117,35 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             match position_result {
                 Ok(PositionUpdate::Position(position)) => {
                     // Filter for the specific account
-                    if position.account != self.core.account_id.to_string() {
+                    if position.account != raw_account_id {
                         continue;
                     }
 
-                    // Convert IB contract to instrument ID
-                    let instrument_id = ib_contract_to_instrument_id_simple(&position.contract)
-                        .context("Failed to convert contract to instrument ID")?;
+                    let instrument = match self
+                        .instrument_provider
+                        .get_instrument(client.as_arc().as_ref(), &position.contract)
+                        .await
+                    {
+                        Ok(Some(instrument)) => instrument,
+                        Ok(None) => {
+                            tracing::warn!(
+                                con_id = position.contract.contract_id,
+                                sec_type = ?position.contract.security_type,
+                                "Cannot generate position status report: instrument not found",
+                            );
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                con_id = position.contract.contract_id,
+                                sec_type = ?position.contract.security_type,
+                                error = %e,
+                                "Failed to resolve position instrument",
+                            );
+                            continue;
+                        }
+                    };
+                    let instrument_id = instrument.id();
 
                     // Filter by instrument_id if specified
                     if let Some(filter_id) = cmd.instrument_id
@@ -959,12 +1153,6 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                     {
                         continue;
                     }
-
-                    // Get instrument for precision
-                    let instrument = self
-                        .instrument_provider
-                        .find(&instrument_id)
-                        .context("Instrument not found")?;
 
                     // Determine position side
                     let position_side = if position.position == 0.0 {
@@ -980,18 +1168,11 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
                     // Convert IB avg_cost to Nautilus Price, accounting for price magnifier and multiplier
                     // Python: converted_avg_cost = avg_cost / (multiplier * price_magnifier)
-                    let avg_px_open = if position.average_cost > 0.0 {
-                        let price_magnifier =
-                            self.instrument_provider.get_price_magnifier(&instrument_id) as f64;
-                        let multiplier = instrument.multiplier().as_f64();
-                        let converted_avg_cost =
-                            position.average_cost / (multiplier * price_magnifier);
-                        let price_precision = instrument.price_precision();
-                        rust_decimal::Decimal::from_f64_retain(converted_avg_cost)
-                            .map(|d| d.round_dp(price_precision as u32))
-                    } else {
-                        None
-                    };
+                    let avg_px_open = self.position_avg_px_open(
+                        &instrument_id,
+                        &instrument,
+                        position.average_cost,
+                    );
 
                     let report = PositionStatusReport::new(
                         self.core.account_id,
@@ -1015,6 +1196,26 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                     tracing::warn!("Error receiving position data: {e}");
                 }
             }
+        }
+
+        if reports.is_empty()
+            && let Some(instrument_id) = cmd.instrument_id
+        {
+            let precision = self
+                .instrument_provider
+                .find(&instrument_id)
+                .map_or(0, |instrument| instrument.size_precision());
+            reports.push(PositionStatusReport::new(
+                self.core.account_id,
+                instrument_id,
+                PositionSideSpecified::Flat,
+                Quantity::zero(precision),
+                ts_init,
+                ts_init,
+                None,
+                None,
+                None,
+            ));
         }
 
         Ok(reports)
@@ -1139,18 +1340,17 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let strategy_id = cmd.strategy_id;
         let instrument_id = cmd.instrument_id;
 
-        let target_ib_order_id: i32 = if let Some(venue_order_id) = &cmd.venue_order_id {
-            venue_order_id
-                .as_str()
-                .parse()
-                .context("Failed to parse venue_order_id as IB order id")?
+        let target_order = if let Some(venue_order_id) = &cmd.venue_order_id {
+            IbOrderSelector::from_venue_order_id(venue_order_id)?
         } else {
             let map = self
                 .order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock order_id_map"))?;
-            *map.get(&cmd.client_order_id)
-                .context("No venue order id for client_order_id")?
+            IbOrderSelector::OrderId(
+                *map.get(&cmd.client_order_id)
+                    .context("No venue order id for client_order_id")?,
+            )
         };
 
         let client_clone = client.as_arc().clone();
@@ -1161,6 +1361,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let ts_init = get_atomic_clock_realtime().get_time_ns();
         let request_timeout_secs = self.config.request_timeout;
         let pending_cancel_orders = Arc::clone(&self.pending_cancel_orders);
+        let raw_account_id = raw_ib_account_code(&self.core.account_id);
 
         let handle = get_runtime().spawn(async move {
             let timeout_dur = Duration::from_secs(request_timeout_secs);
@@ -1179,7 +1380,11 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
             while let Some(order_result) = subscription.next().await {
                 if let Ok(Orders::OrderData(data)) = order_result {
-                    if data.order_id != target_ib_order_id {
+                    if !data.order.account.is_empty() && data.order.account != raw_account_id {
+                        continue;
+                    }
+
+                    if !target_order.matches(data.order_id, data.order.perm_id) {
                         continue;
                     }
 
@@ -1189,7 +1394,9 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                     };
                     let instrument_id = match instrument_id {
                         Some(id) => id,
-                        None => match ib_contract_to_instrument_id_simple(&data.contract) {
+                        None => match instrument_provider
+                            .resolve_instrument_id_for_contract(&data.contract)
+                        {
                             Ok(id) => id,
                             Err(e) => {
                                 tracing::warn!("query_order: failed to convert contract: {e}");
@@ -1202,8 +1409,9 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                         &IBOrderStatus {
                             order_id: data.order_id,
                             status: data.order_state.status.clone(),
-                            filled: 0.0,
-                            remaining: 0.0,
+                            filled: data.order.filled_quantity,
+                            remaining: (data.order.total_quantity - data.order.filled_quantity)
+                                .max(0.0),
                             average_fill_price: 0.0,
                             perm_id: data.order.perm_id,
                             parent_id: 0,
@@ -1252,7 +1460,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                     ts_init,
                     ts_init,
                     false,
-                    Some(VenueOrderId::from(target_ib_order_id.to_string())),
+                    Some(target_order.venue_order_id()),
                     Some(account_id),
                 );
 
@@ -1265,7 +1473,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                     tracing::info!(
                         "query_order: inferred cancel for {} from missing open order {}",
                         client_order_id,
-                        target_ib_order_id
+                        target_order.label()
                     );
                 }
                 return;
@@ -1273,7 +1481,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
             tracing::debug!(
                 "query_order: order {} not found in open orders (may be filled or canceled)",
-                target_ib_order_id
+                target_order.label()
             );
         });
 
@@ -1368,6 +1576,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let clock = get_atomic_clock_realtime();
         let account_id = self.core.account_id;
         let client_clone = client.as_arc().clone();
+        let request_timeout_secs = self.config.request_timeout;
 
         let handle = get_runtime().spawn(async move {
             if let Err(e) = Self::handle_cancel_order_async(
@@ -1381,6 +1590,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 &exec_sender,
                 clock.get_time_ns(),
                 account_id,
+                request_timeout_secs,
             )
             .await
             {
@@ -1714,14 +1924,37 @@ impl InteractiveBrokersExecutionClient {
         commission: f64,
         commission_currency: &str,
         ts_init: UnixNanos,
-    ) -> anyhow::Result<Option<FillReport>> {
-        let instrument_id = ib_contract_to_instrument_id_simple(&exec_data.contract)
-            .context("Failed to convert contract to instrument ID")?;
+    ) -> Option<FillReport> {
+        let instrument_id = match self.resolve_historical_execution_instrument_id(exec_data) {
+            Ok(instrument_id) => instrument_id,
+            Err(e) => {
+                Self::warn_historical_fill_report_parse_error(exec_data, &e);
+                return None;
+            }
+        };
 
         if let Some(filter_id) = cmd.instrument_id
             && instrument_id != filter_id
         {
-            return Ok(None);
+            return None;
+        }
+
+        if let Some(filter_venue_order_id) = cmd.venue_order_id
+            && ib_venue_order_id(exec_data.execution.order_id, exec_data.execution.perm_id)
+                != filter_venue_order_id
+        {
+            return None;
+        }
+
+        if let Some(end) = cmd.end {
+            match parse_execution_time(&exec_data.execution.time) {
+                Ok(ts_event) if ts_event > end => return None,
+                Ok(_) => {}
+                Err(e) => {
+                    Self::warn_historical_fill_report_parse_error(exec_data, &e);
+                    return None;
+                }
+            }
         }
 
         match parse_execution_to_fill_report(
@@ -1735,12 +1968,73 @@ impl InteractiveBrokersExecutionClient {
             ts_init,
             None, // avg_px (not available in historical fills)
         ) {
-            Ok(report) => Ok(Some(report)),
+            Ok(report) => Some(report),
             Err(e) => {
-                tracing::warn!("Failed to parse fill report: {e}");
-                Ok(None)
+                Self::warn_historical_fill_report_parse_error(exec_data, &e);
+                None
             }
         }
+    }
+
+    fn resolve_historical_execution_instrument_id(
+        &self,
+        exec_data: &ExecutionData,
+    ) -> anyhow::Result<InstrumentId> {
+        self.resolve_report_contract_instrument_id(&exec_data.contract)
+    }
+
+    fn resolve_report_contract_instrument_id(
+        &self,
+        contract: &Contract,
+    ) -> anyhow::Result<InstrumentId> {
+        match self
+            .instrument_provider
+            .resolve_instrument_id_for_contract(contract)
+        {
+            Ok(instrument_id) => Ok(instrument_id),
+            Err(provider_error) if contract.security_type != SecurityType::Spread => {
+                ib_contract_to_instrument_id_simple(contract).with_context(|| {
+                    format!(
+                        "Failed to resolve IBKR contract to instrument ID using provider ({provider_error}) or simple conversion",
+                    )
+                })
+            }
+            Err(provider_error) => Err(provider_error)
+                .context("Failed to resolve BAG contract to spread instrument ID"),
+        }
+    }
+
+    fn position_avg_px_open(
+        &self,
+        instrument_id: &InstrumentId,
+        instrument: &InstrumentAny,
+        average_cost: f64,
+    ) -> Option<Decimal> {
+        if average_cost <= 0.0 {
+            return None;
+        }
+
+        let price_magnifier = self.instrument_provider.get_price_magnifier(instrument_id) as f64;
+        let multiplier = instrument.multiplier().as_f64();
+        let converted_avg_cost = average_cost / (multiplier * price_magnifier);
+        Decimal::from_f64_retain(converted_avg_cost)
+            .map(|price| price.round_dp(instrument.price_precision() as u32))
+    }
+
+    fn warn_historical_fill_report_parse_error(exec_data: &ExecutionData, error: &anyhow::Error) {
+        tracing::warn!(
+            symbol = exec_data.contract.symbol.as_str(),
+            sec_type = ?exec_data.contract.security_type,
+            exchange = exec_data.contract.exchange.as_str(),
+            primary_exchange = exec_data.contract.primary_exchange.as_str(),
+            local_symbol = exec_data.contract.local_symbol.as_str(),
+            con_id = exec_data.contract.contract_id,
+            order_id = exec_data.execution.order_id,
+            order_ref = exec_data.execution.order_reference.as_str(),
+            execution_id = exec_data.execution.execution_id.as_str(),
+            error = %error,
+            "Failed to parse IBKR historical fill report",
+        );
     }
 
     /// Handles cancel all orders asynchronously.
@@ -1759,21 +2053,26 @@ impl InteractiveBrokersExecutionClient {
         exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
         ts_init: UnixNanos,
         account_id: AccountId,
+        request_timeout_secs: u64,
     ) -> anyhow::Result<()> {
-        let ib_order_id = if let Some(venue_order_id) = &cmd.venue_order_id {
-            // Use venue order ID directly if available
-            venue_order_id
-                .as_str()
-                .parse::<i32>()
-                .map_err(|e| anyhow::anyhow!("Failed to parse venue order ID: {e}"))?
+        let order_selector = if let Some(venue_order_id) = &cmd.venue_order_id {
+            IbOrderSelector::from_venue_order_id(venue_order_id)?
         } else {
-            // Otherwise look it up from mapping
             let map = order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?;
-            *map.get(&cmd.client_order_id)
-                .context("No IB order ID mapping found for client order ID")?
+            IbOrderSelector::OrderId(
+                *map.get(&cmd.client_order_id)
+                    .context("No IB order ID mapping found for client order ID")?,
+            )
         };
+        let ib_order_id = Self::resolve_ib_order_id_for_cancel(
+            client,
+            order_selector,
+            account_id,
+            request_timeout_secs,
+        )
+        .await?;
 
         client
             .cancel_order(ib_order_id, "")
@@ -1793,6 +2092,52 @@ impl InteractiveBrokersExecutionClient {
         )?;
 
         Ok(())
+    }
+
+    async fn resolve_ib_order_id_for_cancel(
+        client: &Arc<Client>,
+        order_selector: IbOrderSelector,
+        account_id: AccountId,
+        request_timeout_secs: u64,
+    ) -> anyhow::Result<i32> {
+        let target_perm_id = match order_selector {
+            IbOrderSelector::OrderId(order_id) => return Ok(order_id),
+            IbOrderSelector::PermId(perm_id) => perm_id,
+        };
+
+        let timeout_dur = Duration::from_secs(request_timeout_secs);
+        let raw_account_id = raw_ib_account_code(&account_id);
+        let mut subscription = match tokio::time::timeout(timeout_dur, client.all_open_orders())
+            .await
+        {
+            Ok(Ok(subscription)) => subscription,
+            Ok(Err(e)) => anyhow::bail!("Failed to request open orders for perm_id lookup: {e}"),
+            Err(_) => anyhow::bail!("Timed out requesting open orders for perm_id lookup"),
+        };
+
+        while let Some(order_result) = subscription.next().await {
+            let Orders::OrderData(data) = order_result? else {
+                continue;
+            };
+
+            if !data.order.account.is_empty() && data.order.account != raw_account_id {
+                continue;
+            }
+
+            if data.order.perm_id != target_perm_id {
+                continue;
+            }
+
+            if data.order_id == 0 {
+                anyhow::bail!(
+                    "Cannot cancel PERM-{target_perm_id}: matching open order has no IB order_id"
+                );
+            }
+
+            return Ok(data.order_id);
+        }
+
+        anyhow::bail!("No open order found for PERM-{target_perm_id}")
     }
 
     async fn handle_cancel_all_orders_async(

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -556,23 +556,12 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
         self.ib_client = Some(handle);
 
-        // Initialize provider and load instruments from cache if configured
+        // Initialize provider and load instruments from cache/config if configured
         log::debug!("Initializing IB execution instrument provider");
-        if let Err(e) = self.instrument_provider.initialize().await {
-            tracing::warn!("Failed to initialize instrument provider: {}", e);
-        }
-
-        // Load instruments from config
-        log::debug!("Loading configured IB execution instruments");
 
         if let Err(e) = self
             .instrument_provider
-            .load_all_async(
-                self.ib_client.as_ref().unwrap().as_arc().as_ref(),
-                None,
-                None,
-                false,
-            )
+            .initialize_with_client(self.ib_client.as_ref().unwrap().as_arc().as_ref())
             .await
         {
             if !self.config.instrument_provider.load_ids.is_empty()

--- a/crates/adapters/interactive_brokers/src/execution/core_orders.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_orders.rs
@@ -397,113 +397,81 @@ impl InteractiveBrokersExecutionClient {
         order_submit_lock: &Arc<AsyncMutex<()>>,
     ) -> anyhow::Result<()> {
         let num_orders = orders.len();
-        let is_bracket_order = num_orders == 3;
-
-        let first_order = &orders[0];
-        let contract = Self::resolve_contract_for_instrument(
-            first_order.instrument_id(),
-            instrument_provider,
-        )?;
-        let contract = Self::contract_with_order_exchange_param(contract, cmd.params.as_ref())?;
+        anyhow::ensure!(!orders.is_empty(), "Cannot submit an empty order list");
 
         let _submit_guard = order_submit_lock.lock().await;
+        let ib_account = account_id
+            .to_string()
+            .split_once('-')
+            .map_or_else(|| account_id.to_string(), |(_, value)| value.to_string());
+        let mut ib_order_ids = AHashMap::with_capacity(num_orders);
 
-        if is_bracket_order {
-            let parent_order = &orders[0];
-            let tp_order = &orders[1];
-            let sl_order = &orders[2];
+        for order in orders {
+            let ib_order_id = Self::reserve_next_local_order_id(next_order_id)?;
+            ib_order_ids.insert(order.client_order_id(), ib_order_id);
+        }
 
-            let parent_id = Self::reserve_next_local_order_id(next_order_id)?;
-            let tp_id = Self::reserve_next_local_order_id(next_order_id)?;
-            let sl_id = Self::reserve_next_local_order_id(next_order_id)?;
+        for order in orders {
+            if let Some(parent_order_id) = order.parent_order_id()
+                && !ib_order_ids.contains_key(&parent_order_id)
+            {
+                let map = order_id_map
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?;
+                anyhow::ensure!(
+                    map.contains_key(&parent_order_id),
+                    "Parent order ID {parent_order_id} not found for order {}",
+                    order.client_order_id(),
+                );
+            }
+        }
 
-            let parent_ref = parent_order.client_order_id().to_string();
-            let mut parent_ib_order = nautilus_order_to_ib_order(
-                parent_order,
-                &contract,
+        for (index, order) in orders.iter().enumerate() {
+            let is_last = index == num_orders - 1;
+            let ib_order_id = ib_order_ids[&order.client_order_id()];
+
+            let order_contract =
+                Self::resolve_contract_for_instrument(order.instrument_id(), instrument_provider)?;
+            let order_contract =
+                Self::contract_with_order_exchange_param(order_contract, cmd.params.as_ref())?;
+
+            let order_ref = order.client_order_id().to_string();
+            let mut ib_order = nautilus_order_to_ib_order(
+                order,
+                &order_contract,
                 instrument_provider,
-                parent_id,
-                &parent_ref,
+                ib_order_id,
+                &order_ref,
             )
-            .context("Failed to transform parent order")?;
-            let ib_account = account_id
-                .to_string()
-                .split_once('-')
-                .map_or_else(|| account_id.to_string(), |(_, value)| value.to_string());
-            parent_ib_order.account = ib_account.clone();
-            parent_ib_order.clearing_account = ib_account.clone();
-            parent_ib_order.transmit = false;
+            .context("Failed to transform order")?;
+            ib_order.account = ib_account.clone();
+            ib_order.clearing_account = ib_account.clone();
+            ib_order.transmit = is_last;
 
-            let tp_ref = tp_order.client_order_id().to_string();
-            let mut tp_ib_order = nautilus_order_to_ib_order(
-                tp_order,
-                &contract,
-                instrument_provider,
-                tp_id,
-                &tp_ref,
-            )
-            .context("Failed to transform TP order")?;
-            tp_ib_order.account = ib_account.clone();
-            tp_ib_order.clearing_account = ib_account.clone();
-            tp_ib_order.parent_id = parent_id;
-            tp_ib_order.transmit = false;
+            if let Some(parent_order_id) = order.parent_order_id() {
+                let parent_ib_order_id =
+                    ib_order_ids.get(&parent_order_id).copied().or_else(|| {
+                        order_id_map
+                            .lock()
+                            .ok()
+                            .and_then(|map| map.get(&parent_order_id).copied())
+                    });
 
-            let sl_ref = sl_order.client_order_id().to_string();
-            let mut sl_ib_order = nautilus_order_to_ib_order(
-                sl_order,
-                &contract,
-                instrument_provider,
-                sl_id,
-                &sl_ref,
-            )
-            .context("Failed to transform SL order")?;
-            sl_ib_order.account = ib_account.clone();
-            sl_ib_order.clearing_account = ib_account;
-            sl_ib_order.parent_id = parent_id;
-            sl_ib_order.transmit = true;
+                if let Some(parent_ib_order_id) = parent_ib_order_id {
+                    ib_order.parent_id = parent_ib_order_id;
+                }
+            }
 
             client
-                .submit_order(parent_id, &contract, &parent_ib_order)
+                .submit_order(ib_order_id, &order_contract, &ib_order)
                 .await
-                .context("Failed to submit parent order")?;
-            client
-                .submit_order(tp_id, &contract, &tp_ib_order)
-                .await
-                .context("Failed to submit TP order")?;
-            client
-                .submit_order(sl_id, &contract, &sl_ib_order)
-                .await
-                .context("Failed to submit SL order")?;
+                .context("Failed to submit order from list")?;
 
             Self::cache_order_tracking(
-                parent_id,
-                parent_order.client_order_id(),
-                parent_order.instrument_id(),
-                parent_order.trader_id(),
-                strategy_id,
-                order_id_map,
-                venue_order_id_map,
-                instrument_id_map,
-                trader_id_map,
-                strategy_id_map,
-            )?;
-            Self::cache_order_tracking(
-                tp_id,
-                tp_order.client_order_id(),
-                tp_order.instrument_id(),
-                tp_order.trader_id(),
-                strategy_id,
-                order_id_map,
-                venue_order_id_map,
-                instrument_id_map,
-                trader_id_map,
-                strategy_id_map,
-            )?;
-            Self::cache_order_tracking(
-                sl_id,
-                sl_order.client_order_id(),
-                sl_order.instrument_id(),
-                sl_order.trader_id(),
+                ib_order_id,
+                order.client_order_id(),
+                order.instrument_id(),
+                order.trader_id(),
                 strategy_id,
                 order_id_map,
                 venue_order_id_map,
@@ -513,162 +481,49 @@ impl InteractiveBrokersExecutionClient {
             )?;
 
             let ts_event = clock.get_time_ns();
+            let event = OrderSubmitted::new(
+                order.trader_id(),
+                strategy_id,
+                order.instrument_id(),
+                order.client_order_id(),
+                account_id,
+                UUID4::new(),
+                ts_event,
+                ts_event,
+            );
 
-            for order in orders {
-                accepted_orders
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("Failed to lock accepted orders map"))?
-                    .insert(order.client_order_id());
+            exec_sender
+                .send(ExecutionEvent::Order(OrderEventAny::Submitted(event)))
+                .map_err(|e| anyhow::anyhow!("Failed to send order submitted event: {e}"))?;
 
-                let event = OrderSubmitted::new(
-                    order.trader_id(),
-                    strategy_id,
-                    order.instrument_id(),
-                    order.client_order_id(),
-                    account_id,
-                    UUID4::new(),
-                    ts_event,
-                    ts_event,
-                );
-                exec_sender
-                    .send(ExecutionEvent::Order(OrderEventAny::Submitted(event)))
-                    .map_err(|e| anyhow::anyhow!("Failed to send order submitted event: {e}"))?;
+            accepted_orders
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Failed to lock accepted orders map"))?
+                .insert(order.client_order_id());
 
-                let accepted_event = OrderAccepted::new(
-                    order.trader_id(),
-                    strategy_id,
-                    order.instrument_id(),
-                    order.client_order_id(),
-                    VenueOrderId::from(
-                        if order.client_order_id() == parent_order.client_order_id() {
-                            parent_id
-                        } else if order.client_order_id() == tp_order.client_order_id() {
-                            tp_id
-                        } else {
-                            sl_id
-                        }
-                        .to_string(),
-                    ),
-                    account_id,
-                    UUID4::new(),
-                    ts_event,
-                    ts_event,
-                    false,
-                );
-                exec_sender
-                    .send(ExecutionEvent::Order(OrderEventAny::Accepted(
-                        accepted_event,
-                    )))
-                    .map_err(|e| anyhow::anyhow!("Failed to send order accepted event: {e}"))?;
-            }
+            let accepted_event = OrderAccepted::new(
+                order.trader_id(),
+                strategy_id,
+                order.instrument_id(),
+                order.client_order_id(),
+                VenueOrderId::from(ib_order_id.to_string()),
+                account_id,
+                UUID4::new(),
+                ts_event,
+                ts_event,
+                false,
+            );
+            exec_sender
+                .send(ExecutionEvent::Order(OrderEventAny::Accepted(
+                    accepted_event,
+                )))
+                .map_err(|e| anyhow::anyhow!("Failed to send order accepted event: {e}"))?;
 
             tracing::info!(
-                "Submitted bracket order: parent={} (IB: {}), TP={} (IB: {}), SL={} (IB: {})",
-                parent_order.client_order_id(),
-                parent_id,
-                tp_order.client_order_id(),
-                tp_id,
-                sl_order.client_order_id(),
-                sl_id
+                "Submitted order {} from list as IB order ID {}",
+                order.client_order_id(),
+                ib_order_id,
             );
-        } else {
-            let oca_group_name = format!("OCA_{}", cmd.order_list.id);
-
-            for (index, order) in orders.iter().enumerate() {
-                let is_last = index == num_orders - 1;
-                let ib_order_id = Self::reserve_next_local_order_id(next_order_id)?;
-
-                let order_contract = Self::resolve_contract_for_instrument(
-                    order.instrument_id(),
-                    instrument_provider,
-                )?;
-                let order_contract =
-                    Self::contract_with_order_exchange_param(order_contract, cmd.params.as_ref())?;
-
-                let order_ref = order.client_order_id().to_string();
-                let mut ib_order = nautilus_order_to_ib_order(
-                    order,
-                    &order_contract,
-                    instrument_provider,
-                    ib_order_id,
-                    &order_ref,
-                )
-                .context("Failed to transform order")?;
-                let ib_account = account_id
-                    .to_string()
-                    .split_once('-')
-                    .map_or_else(|| account_id.to_string(), |(_, value)| value.to_string());
-                ib_order.account = ib_account.clone();
-                ib_order.clearing_account = ib_account;
-                ib_order.oca_group = oca_group_name.clone();
-                ib_order.oca_type =
-                    crate::common::enums::IbOcaType::CancelWithBlock.ibapi_oca_type();
-                ib_order.transmit = is_last;
-
-                client
-                    .submit_order(ib_order_id, &order_contract, &ib_order)
-                    .await
-                    .context("Failed to submit order from list")?;
-
-                Self::cache_order_tracking(
-                    ib_order_id,
-                    order.client_order_id(),
-                    order.instrument_id(),
-                    order.trader_id(),
-                    strategy_id,
-                    order_id_map,
-                    venue_order_id_map,
-                    instrument_id_map,
-                    trader_id_map,
-                    strategy_id_map,
-                )?;
-
-                let ts_event = clock.get_time_ns();
-                let event = OrderSubmitted::new(
-                    order.trader_id(),
-                    strategy_id,
-                    order.instrument_id(),
-                    order.client_order_id(),
-                    account_id,
-                    UUID4::new(),
-                    ts_event,
-                    ts_event,
-                );
-
-                exec_sender
-                    .send(ExecutionEvent::Order(OrderEventAny::Submitted(event)))
-                    .map_err(|e| anyhow::anyhow!("Failed to send order submitted event: {e}"))?;
-
-                accepted_orders
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("Failed to lock accepted orders map"))?
-                    .insert(order.client_order_id());
-
-                let accepted_event = OrderAccepted::new(
-                    order.trader_id(),
-                    strategy_id,
-                    order.instrument_id(),
-                    order.client_order_id(),
-                    VenueOrderId::from(ib_order_id.to_string()),
-                    account_id,
-                    UUID4::new(),
-                    ts_event,
-                    ts_event,
-                    false,
-                );
-                exec_sender
-                    .send(ExecutionEvent::Order(OrderEventAny::Accepted(
-                        accepted_event,
-                    )))
-                    .map_err(|e| anyhow::anyhow!("Failed to send order accepted event: {e}"))?;
-
-                tracing::info!(
-                    "Submitted order {} from list as IB order ID {} (OCA group: {})",
-                    order.client_order_id(),
-                    ib_order_id,
-                    oca_group_name
-                );
-            }
         }
 
         Ok(())

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -125,6 +125,27 @@ fn apply_client_order_id_floor(
 }
 
 #[rstest]
+fn ib_order_selector_parses_numeric_venue_order_id() {
+    let selector = IbOrderSelector::from_venue_order_id(&VenueOrderId::from("123")).unwrap();
+
+    assert_eq!(selector, IbOrderSelector::OrderId(123));
+    assert!(selector.matches(123, 456));
+    assert!(!selector.matches(124, 456));
+    assert_eq!(selector.venue_order_id(), VenueOrderId::from("123"));
+}
+
+#[rstest]
+fn ib_order_selector_parses_perm_venue_order_id() {
+    let selector = IbOrderSelector::from_venue_order_id(&VenueOrderId::from("PERM-456")).unwrap();
+
+    assert_eq!(selector, IbOrderSelector::PermId(456));
+    assert!(selector.matches(0, 456));
+    assert!(selector.matches(123, 456));
+    assert!(!selector.matches(123, 457));
+    assert_eq!(selector.venue_order_id(), VenueOrderId::from("PERM-456"));
+}
+
+#[rstest]
 fn submit_order_rejects_when_client_not_ready() {
     let (client, mut rx, _) = create_test_execution_client();
     let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
@@ -350,6 +371,112 @@ fn create_test_execution_data(
         cumulative_quantity: shares,
         average_price: price,
         order_reference: String::new(),
+        ev_rule: String::new(),
+        ev_multiplier: None,
+        model_code: String::new(),
+        last_liquidity: Liquidity::None,
+        pending_price_revision: false,
+        submitter: String::new(),
+    };
+
+    ExecutionData {
+        request_id: 0,
+        contract,
+        execution,
+    }
+}
+
+fn create_test_stock_execution_data(
+    contract_id: i32,
+    order_id: i32,
+    execution_id: &str,
+) -> ExecutionData {
+    let contract = Contract {
+        contract_id,
+        symbol: IBSymbol::from("AAPL"),
+        security_type: SecurityType::Stock,
+        exchange: Exchange::from("SMART"),
+        currency: IBCurrency::from("USD"),
+        ..Default::default()
+    };
+
+    let execution = Execution {
+        execution_id: execution_id.to_string(),
+        order_id,
+        time: String::from("20250101 08:00:00"),
+        side: String::from("BOT"),
+        shares: 10.0,
+        price: 150.25,
+        perm_id: 0,
+        client_id: 0,
+        liquidation: 0,
+        account_number: String::new(),
+        exchange: String::new(),
+        cumulative_quantity: 10.0,
+        average_price: 150.25,
+        order_reference: String::from("O-IB-001"),
+        ev_rule: String::new(),
+        ev_multiplier: None,
+        model_code: String::new(),
+        last_liquidity: Liquidity::None,
+        pending_price_revision: false,
+        submitter: String::new(),
+    };
+
+    ExecutionData {
+        request_id: 0,
+        contract,
+        execution,
+    }
+}
+
+fn create_test_bag_execution_data(order_id: i32, execution_id: &str) -> ExecutionData {
+    let contract = Contract {
+        contract_id: 0,
+        symbol: IBSymbol::from("SPY"),
+        security_type: SecurityType::Spread,
+        exchange: Exchange::from("SMART"),
+        currency: IBCurrency::from("USD"),
+        combo_legs: vec![
+            ibapi::contracts::ComboLeg {
+                contract_id: 12345,
+                ratio: 1,
+                action: String::from("BUY"),
+                exchange: String::from("SMART"),
+                open_close: ibapi::contracts::ComboLegOpenClose::Same,
+                short_sale_slot: 0,
+                designated_location: String::new(),
+                exempt_code: 0,
+            },
+            ibapi::contracts::ComboLeg {
+                contract_id: 67890,
+                ratio: 1,
+                action: String::from("SELL"),
+                exchange: String::from("SMART"),
+                open_close: ibapi::contracts::ComboLegOpenClose::Same,
+                short_sale_slot: 0,
+                designated_location: String::new(),
+                exempt_code: 0,
+            },
+        ],
+        ..Default::default()
+    };
+
+    let execution = Execution {
+        execution_id: execution_id.to_string(),
+        order_id,
+        time: String::from("20250101 08:00:00"),
+        side: String::from("BOT"),
+        shares: 1.0,
+        price: 1.25,
+        perm_id: 0,
+        client_id: 0,
+        liquidation: 0,
+        account_number: String::new(),
+        exchange: String::new(),
+        cumulative_quantity: 1.0,
+        average_price: 1.25,
+        order_reference: String::from("O-IB-SPREAD"),
         ev_rule: String::new(),
         ev_multiplier: None,
         model_code: String::new(),
@@ -637,6 +764,71 @@ fn test_cached_spread_instrument_ids_for_preload_ignores_non_spread_orders() {
     );
 
     assert!(spread_ids.is_empty());
+}
+
+#[rstest]
+fn test_parse_historical_fill_report_uses_provider_resolved_stock_venue() {
+    let (client, _, _) = create_test_execution_client();
+    let equity = equity_aapl();
+    let instrument_id = equity.id();
+    client
+        .instrument_provider
+        .insert_test_instrument(InstrumentAny::from(equity), 265598, 1);
+    let exec_data = create_test_stock_execution_data(0, 123, "exec-aapl-001");
+    let cmd = GenerateFillReportsBuilder::default()
+        .ts_init(UnixNanos::default())
+        .build()
+        .unwrap();
+
+    let report = client
+        .parse_historical_fill_report(&cmd, &exec_data, 1.25, "USD", UnixNanos::default())
+        .unwrap();
+
+    assert_eq!(report.instrument_id, instrument_id);
+    assert_eq!(
+        report.client_order_id,
+        Some(ClientOrderId::from("O-IB-001"))
+    );
+    assert_eq!(report.trade_id, TradeId::from("exec-aapl-001"));
+    assert_eq!(report.venue_order_id, VenueOrderId::from("123"));
+    assert_eq!(report.last_qty, Quantity::from(10));
+    assert_eq!(report.last_px, Price::from("150.25"));
+}
+
+#[rstest]
+fn test_parse_historical_fill_report_uses_cached_bag_spread_id() {
+    let (client, _, _) = create_test_execution_client();
+    let spread = create_test_option_spread();
+    let instrument_id = spread.id;
+    client
+        .instrument_provider
+        .insert_test_instrument(InstrumentAny::from(spread), 54321, 1);
+    client
+        .instrument_provider
+        .insert_test_contract_id_mapping(12345, create_test_leg_instrument());
+    client.instrument_provider.insert_test_contract_id_mapping(
+        67890,
+        InstrumentId::new(Symbol::from("SPY C410"), Venue::from("SMART")),
+    );
+    let exec_data = create_test_bag_execution_data(7001, "exec-spread-001");
+    let cmd = GenerateFillReportsBuilder::default()
+        .ts_init(UnixNanos::default())
+        .build()
+        .unwrap();
+
+    let report = client
+        .parse_historical_fill_report(&cmd, &exec_data, 2.00, "USD", UnixNanos::default())
+        .unwrap();
+
+    assert_eq!(report.instrument_id, instrument_id);
+    assert_eq!(
+        report.client_order_id,
+        Some(ClientOrderId::from("O-IB-SPREAD"))
+    );
+    assert_eq!(report.trade_id, TradeId::from("exec-spread-001"));
+    assert_eq!(report.venue_order_id, VenueOrderId::from("7001"));
+    assert_eq!(report.last_qty, Quantity::from(1));
+    assert_eq!(report.last_px, Price::from("1.25"));
 }
 
 #[tokio::test]

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -325,12 +325,9 @@ impl InteractiveBrokersExecutionClient {
                         order_data.order.order_ref
                     );
 
-                    let client_order_id = if !order_data.order.order_ref.is_empty() {
-                        let order_ref = if let Some(pos) = order_data.order.order_ref.rfind(':') {
-                            &order_data.order.order_ref[..pos]
-                        } else {
-                            &order_data.order.order_ref
-                        };
+                    let client_order_id = if let Some(order_ref) =
+                        parse::normalized_order_ref(&order_data.order.order_ref)
+                    {
                         Some(ClientOrderId::from(order_ref))
                     } else {
                         let map = venue_order_id_map
@@ -342,6 +339,21 @@ impl InteractiveBrokersExecutionClient {
                     if let Some(client_order_id) = client_order_id
                         && IbOrderStatus::from_str(status_str).is_ok_and(IbOrderStatus::is_accepted)
                     {
+                        let instrument_id = {
+                            Self::get_mapped_instrument_id(order_data.order_id, instrument_id_map)?
+                                .map(Ok)
+                                .unwrap_or_else(|| {
+                                    Self::resolve_contract_instrument_id(
+                                        instrument_provider,
+                                        &order_data.contract,
+                                    )
+                                })?
+                        };
+                        let (trader_id, strategy_id) = Self::get_required_order_actor_ids(
+                            order_data.order_id,
+                            trader_id_map,
+                            strategy_id_map,
+                        )?;
                         let mut accepted = accepted_orders
                             .lock()
                             .map_err(|_| anyhow::anyhow!("Failed to lock accepted orders map"))?;
@@ -349,31 +361,16 @@ impl InteractiveBrokersExecutionClient {
                         if !accepted.contains(&client_order_id) {
                             accepted.insert(client_order_id);
 
-                            let instrument_id = {
-                                Self::get_mapped_instrument_id(
-                                    order_data.order_id,
-                                    instrument_id_map,
-                                )?
-                                .map(Ok)
-                                .unwrap_or_else(|| {
-                                    crate::common::parse::ib_contract_to_instrument_id_simple(
-                                        &order_data.contract,
-                                    )
-                                })?
-                            };
-
-                            let (trader_id, strategy_id) = Self::get_required_order_actor_ids(
+                            let venue_order_id = parse::ib_venue_order_id(
                                 order_data.order_id,
-                                trader_id_map,
-                                strategy_id_map,
-                            )?;
-
+                                order_data.order.perm_id,
+                            );
                             let event = OrderAccepted::new(
                                 trader_id,
                                 strategy_id,
                                 instrument_id,
                                 client_order_id,
-                                VenueOrderId::from(order_data.order_id.to_string()),
+                                venue_order_id,
                                 account_id,
                                 UUID4::new(),
                                 ts_init,
@@ -392,6 +389,18 @@ impl InteractiveBrokersExecutionClient {
                                 status_str
                             );
                         }
+
+                        Self::emit_order_updated_from_open_order(
+                            order_data,
+                            client_order_id,
+                            instrument_id,
+                            trader_id_map,
+                            strategy_id_map,
+                            instrument_provider,
+                            exec_sender,
+                            ts_init,
+                            account_id,
+                        )?;
                     }
                 }
             }
@@ -401,6 +410,66 @@ impl InteractiveBrokersExecutionClient {
         }
 
         Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_order_updated_from_open_order(
+        order_data: &ibapi::orders::OrderData,
+        client_order_id: ClientOrderId,
+        instrument_id: InstrumentId,
+        trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
+        strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
+        instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
+        exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
+        ts_init: UnixNanos,
+        account_id: AccountId,
+    ) -> anyhow::Result<()> {
+        let Some(instrument) = instrument_provider.find(&instrument_id) else {
+            return Ok(());
+        };
+
+        if order_data.order.total_quantity <= 0.0 {
+            return Ok(());
+        }
+
+        let (trader_id, strategy_id) = Self::get_required_order_actor_ids(
+            order_data.order_id,
+            trader_id_map,
+            strategy_id_map,
+        )?;
+        let price_magnifier = instrument_provider.get_price_magnifier(&instrument_id) as f64;
+        let price = order_data
+            .order
+            .limit_price
+            .map(|price| Price::new(price * price_magnifier, instrument.price_precision()));
+        let trigger_price = order_data
+            .order
+            .aux_price
+            .map(|price| Price::new(price * price_magnifier, instrument.price_precision()));
+        let quantity = Quantity::new(order_data.order.total_quantity, instrument.size_precision());
+        let venue_order_id =
+            parse::ib_venue_order_id(order_data.order_id, order_data.order.perm_id);
+        let event = OrderUpdated::new(
+            trader_id,
+            strategy_id,
+            instrument_id,
+            client_order_id,
+            quantity,
+            UUID4::new(),
+            ts_init,
+            ts_init,
+            false,
+            Some(venue_order_id),
+            Some(account_id),
+            price,
+            trigger_price,
+            None,
+            false,
+        );
+
+        exec_sender
+            .send(ExecutionEvent::Order(OrderEventAny::Updated(event)))
+            .map_err(|e| anyhow::anyhow!("Failed to send order updated event: {e}"))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -457,6 +526,14 @@ impl InteractiveBrokersExecutionClient {
 
         let ib_order_status = IbOrderStatus::from_str(&status.status).ok();
 
+        if ib_order_status == Some(IbOrderStatus::Inactive) && status.why_held == "locate" {
+            tracing::warn!(
+                "Order {} held for short-sell locate, order remains active",
+                client_order_id
+            );
+            return Ok(());
+        }
+
         let is_terminal = ib_order_status.is_some_and(IbOrderStatus::is_terminal);
 
         if is_terminal {
@@ -481,7 +558,7 @@ impl InteractiveBrokersExecutionClient {
                 .remove(&client_order_id);
         }
 
-        let venue_order_id = VenueOrderId::from(format!("{}", status.order_id));
+        let venue_order_id = parse::ib_venue_order_id(status.order_id, status.perm_id);
         let status_str = status.status.as_str();
 
         match ib_order_status {
@@ -726,8 +803,10 @@ impl InteractiveBrokersExecutionClient {
 
         let client_order_id = if let Some(client_order_id) = mapped_client_order_id {
             client_order_id
-        } else if !exec_data.execution.order_reference.is_empty() {
-            let client_order_id = ClientOrderId::from(exec_data.execution.order_reference.as_str());
+        } else if let Some(order_ref) =
+            parse::normalized_order_ref(&exec_data.execution.order_reference)
+        {
+            let client_order_id = ClientOrderId::from(order_ref);
             order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?
@@ -754,8 +833,7 @@ impl InteractiveBrokersExecutionClient {
         {
             cached_id
         } else {
-            crate::common::parse::ib_contract_to_instrument_id_simple(&exec_data.contract)
-                .context("Failed to convert IB contract to instrument ID")?
+            Self::resolve_contract_instrument_id(instrument_provider, &exec_data.contract)?
         };
 
         let (commission, commission_currency) = {
@@ -1017,7 +1095,7 @@ impl InteractiveBrokersExecutionClient {
         instrument_id_map: &Arc<Mutex<AHashMap<i32, InstrumentId>>>,
         trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
         strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
-        _instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
+        instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
         exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
         ts_init: UnixNanos,
         account_id: AccountId,
@@ -1041,7 +1119,7 @@ impl InteractiveBrokersExecutionClient {
         let instrument_id = Self::get_mapped_instrument_id(order_data.order_id, instrument_id_map)?
             .map(Ok)
             .unwrap_or_else(|| {
-                crate::common::parse::ib_contract_to_instrument_id_simple(&order_data.contract)
+                Self::resolve_contract_instrument_id(instrument_provider, &order_data.contract)
             })?;
 
         let (trader_id, strategy_id) = Self::get_required_order_actor_ids(
@@ -1282,7 +1360,10 @@ impl InteractiveBrokersExecutionClient {
         Ok(PendingComboFill {
             account_id,
             instrument_id: spread_instrument_id,
-            venue_order_id: VenueOrderId::new(exec_data.execution.order_id.to_string()),
+            venue_order_id: parse::ib_venue_order_id(
+                exec_data.execution.order_id,
+                exec_data.execution.perm_id,
+            ),
             trade_id: TradeId::new(&exec_data.execution.execution_id),
             order_side: combo_order_side,
             last_qty: combo_quantity,
@@ -1336,10 +1417,10 @@ impl InteractiveBrokersExecutionClient {
             "{}-{}",
             exec_data.execution.execution_id, leg_position
         ));
-        let leg_venue_order_id = VenueOrderId::new(format!(
-            "{}-LEG-{}",
-            exec_data.execution.order_id, leg_position
-        ));
+        let venue_order_id =
+            parse::ib_venue_order_id(exec_data.execution.order_id, exec_data.execution.perm_id);
+        let leg_venue_order_id =
+            VenueOrderId::new(format!("{}-LEG-{}", venue_order_id.as_str(), leg_position));
 
         let ts_event = parse_execution_time(&exec_data.execution.time)?;
 
@@ -1407,5 +1488,23 @@ impl InteractiveBrokersExecutionClient {
             spread_instrument_id
         );
         0
+    }
+
+    fn resolve_contract_instrument_id(
+        instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
+        contract: &Contract,
+    ) -> anyhow::Result<InstrumentId> {
+        match instrument_provider.resolve_instrument_id_for_contract(contract) {
+            Ok(instrument_id) => Ok(instrument_id),
+            Err(provider_error) if contract.security_type != SecurityType::Spread => {
+                ib_contract_to_instrument_id_simple(contract).with_context(|| {
+                    format!(
+                        "Failed to resolve IBKR contract to instrument ID using provider ({provider_error}) or simple conversion",
+                    )
+                })
+            }
+            Err(provider_error) => Err(provider_error)
+                .context("Failed to resolve BAG contract to spread instrument ID"),
+        }
     }
 }

--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -48,6 +48,26 @@ pub(crate) fn should_use_avg_fill_price(avg_fill_price: f64, instrument_id: &Ins
         && (avg_fill_price > 0.0 || is_spread_instrument_id(instrument_id))
 }
 
+pub(crate) fn ib_venue_order_id(order_id: i32, perm_id: i32) -> VenueOrderId {
+    if order_id != 0 {
+        VenueOrderId::new(order_id.to_string())
+    } else {
+        VenueOrderId::new(format!("PERM-{perm_id}"))
+    }
+}
+
+pub(crate) fn normalized_order_ref(order_ref: &str) -> Option<&str> {
+    if order_ref.is_empty() {
+        return None;
+    }
+
+    Some(
+        order_ref
+            .rsplit_once(':')
+            .map_or(order_ref, |(base, _)| base),
+    )
+}
+
 /// Parse an IB execution to a Nautilus FillReport.
 ///
 /// # Errors
@@ -97,15 +117,9 @@ pub fn parse_execution_to_fill_report(
     // Create trade ID
     let trade_id = TradeId::new(&execution.execution_id);
 
-    // Create venue order ID
-    let venue_order_id = VenueOrderId::new(execution.order_id.to_string());
+    let venue_order_id = ib_venue_order_id(execution.order_id, execution.perm_id);
 
-    // Parse client order ID from order reference
-    let client_order_id = if !execution.order_reference.is_empty() {
-        Some(ClientOrderId::new(&execution.order_reference))
-    } else {
-        None
-    };
+    let client_order_id = normalized_order_ref(&execution.order_reference).map(ClientOrderId::new);
 
     let mut report = FillReport::new(
         account_id,
@@ -144,8 +158,7 @@ pub fn parse_order_status_to_report(
     // Get price magnifier from instrument provider
     let price_magnifier = instrument_provider.get_price_magnifier(&instrument_id) as f64;
 
-    // Convert Nautilus order status
-    let nautilus_status = match IbOrderStatus::from_str(&order_status.status) {
+    let mut nautilus_status = match IbOrderStatus::from_str(&order_status.status) {
         Ok(status) => status.nautilus_status(),
         _ => {
             tracing::warn!(
@@ -192,19 +205,18 @@ pub fn parse_order_status_to_report(
         0.0
     };
 
-    // Extract venue order ID from order_status
-    let venue_order_id = VenueOrderId::new(order_status.order_id.to_string());
+    if order_status.filled > 0.0
+        && (order_status.remaining > 0.0
+            || order.is_some_and(|order| order.total_quantity > order_status.filled))
+    {
+        nautilus_status = NautilusOrderStatus::PartiallyFilled;
+    }
 
-    // Extract client order ID from order reference if available
-    let client_order_id = if let Some(order) = order {
-        if order.order_ref.is_empty() {
-            None
-        } else {
-            Some(ClientOrderId::new(&order.order_ref))
-        }
-    } else {
-        None
-    };
+    let venue_order_id = ib_venue_order_id(order_status.order_id, order_status.perm_id);
+
+    let client_order_id = order
+        .and_then(|order| normalized_order_ref(&order.order_ref))
+        .map(ClientOrderId::new);
 
     // Map order type from IB order if available
     let order_type = order
@@ -629,6 +641,65 @@ mod tests {
         .unwrap();
 
         assert_eq!(report.order_status, NautilusOrderStatus::Rejected);
+    }
+
+    #[rstest]
+    fn test_parse_order_status_to_report_partial_fill_and_perm_fallback() {
+        let instrument_provider = create_test_instrument_provider();
+        let instrument_id = create_test_instrument_id();
+        let account_id = AccountId::from("IB-001");
+
+        let order_status = OrderStatus {
+            order_id: 0,
+            status: String::from("Submitted"),
+            filled: 3.0,
+            remaining: 7.0,
+            average_fill_price: 150.25,
+            perm_id: 123_456,
+            parent_id: 0,
+            last_fill_price: 150.25,
+            client_id: 0,
+            why_held: String::new(),
+            market_cap_price: 0.0,
+        };
+        let order = Order {
+            action: Action::Buy,
+            total_quantity: 10.0,
+            order_type: "LMT".to_string(),
+            limit_price: Some(150.25),
+            order_ref: "O-20260527-001:123".to_string(),
+            ..Default::default()
+        };
+
+        let report = parse_order_status_to_report(
+            &order_status,
+            Some(&order),
+            instrument_id,
+            account_id,
+            &instrument_provider,
+            UnixNanos::new(0),
+        )
+        .unwrap();
+
+        assert_eq!(report.order_status, NautilusOrderStatus::PartiallyFilled);
+        assert_eq!(report.venue_order_id.to_string(), "PERM-123456");
+        assert_eq!(
+            report.client_order_id,
+            Some(ClientOrderId::from("O-20260527-001"))
+        );
+    }
+
+    #[rstest]
+    fn test_ib_venue_order_id_prefers_order_id_and_falls_back_to_perm_id() {
+        assert_eq!(ib_venue_order_id(123, 456).to_string(), "123");
+        assert_eq!(ib_venue_order_id(0, 456).to_string(), "PERM-456");
+    }
+
+    #[rstest]
+    fn test_normalized_order_ref_strips_ib_suffix() {
+        assert_eq!(normalized_order_ref("O-001:123"), Some("O-001"));
+        assert_eq!(normalized_order_ref("O-001"), Some("O-001"));
+        assert_eq!(normalized_order_ref(""), None);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/execution/transform.rs
+++ b/crates/adapters/interactive_brokers/src/execution/transform.rs
@@ -764,7 +764,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_order_list_id_sets_oca_group_when_missing() {
+    fn test_order_list_id_does_not_set_oca_group() {
         let order = OrderTestBuilder::new(OrderType::Limit)
             .instrument_id(InstrumentId::new(
                 NautilusSymbol::from("AAPL"),
@@ -790,7 +790,7 @@ mod tests {
         let ib_order = nautilus_order_to_ib_order(&order, &contract, &provider, 1, "TEST-001")
             .expect("order transform should succeed");
 
-        assert_eq!(ib_order.oca_group, "OL-001");
+        assert!(ib_order.oca_group.is_empty());
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/execution/transform/policy.rs
+++ b/crates/adapters/interactive_brokers/src/execution/transform/policy.rs
@@ -96,10 +96,7 @@ pub(super) fn apply_display_quantity_policy(ib_order: &mut IBOrder, order: &Orde
     }
 }
 
-pub(super) fn apply_order_list_policy(ib_order: &mut IBOrder, order: &OrderAny) {
-    if let Some(order_list_id) = order.order_list_id()
-        && ib_order.oca_group.is_empty()
-    {
-        ib_order.oca_group = order_list_id.to_string();
-    }
+pub(super) fn apply_order_list_policy(_ib_order: &mut IBOrder, _order: &OrderAny) {
+    // Order lists only control parent/transmit behavior at the execution client layer.
+    // IB OCA groups must be requested explicitly through IB order tags.
 }

--- a/crates/adapters/interactive_brokers/src/factories.rs
+++ b/crates/adapters/interactive_brokers/src/factories.rs
@@ -79,7 +79,7 @@ impl DataClientFactory for InteractiveBrokersDataClientFactory {
         &self,
         name: &str,
         config: &dyn ClientConfig,
-        _cache: CacheView,
+        cache: CacheView,
         _clock: Rc<RefCell<dyn Clock>>,
     ) -> anyhow::Result<Box<dyn DataClient>> {
         let ib_config = config
@@ -95,6 +95,7 @@ impl DataClientFactory for InteractiveBrokersDataClientFactory {
         let instrument_provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
             ib_config.instrument_provider.clone(),
         ));
+        seed_provider_from_cache(&instrument_provider, &cache);
         let client = InteractiveBrokersDataClient::new(
             ClientId::from(name),
             ib_config,
@@ -161,6 +162,11 @@ impl ExecutionClientFactory for InteractiveBrokersExecutionClientFactory {
         };
         ib_config.account_id = Some(account_id.to_string());
 
+        let instrument_provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
+            ib_config.instrument_provider.clone(),
+        ));
+        seed_provider_from_cache(&instrument_provider, &cache);
+
         let core = ExecutionClientCore::new(
             self.trader_id,
             ClientId::from(name),
@@ -172,9 +178,6 @@ impl ExecutionClientFactory for InteractiveBrokersExecutionClientFactory {
             cache,
         );
 
-        let instrument_provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
-            ib_config.instrument_provider.clone(),
-        ));
         let client = InteractiveBrokersExecutionClient::new(core, ib_config, instrument_provider)?;
         Ok(Box::new(client))
     }
@@ -197,6 +200,28 @@ fn resolve_account_id(name: &str, account_id: &str) -> anyhow::Result<AccountId>
     let issuer = if name.is_empty() { IB } else { name };
     AccountId::new_checked(format!("{issuer}-{account_id}"))
         .map_err(|e| anyhow::anyhow!("Invalid Interactive Brokers account_id: {e}"))
+}
+
+fn seed_provider_from_cache(
+    instrument_provider: &InteractiveBrokersInstrumentProvider,
+    cache: &CacheView,
+) {
+    let instruments = {
+        let cache = cache.borrow();
+        cache
+            .instrument_ids(None)
+            .into_iter()
+            .filter_map(|instrument_id| cache.instrument(instrument_id).cloned())
+            .collect::<Vec<_>>()
+    };
+
+    let count = instrument_provider.add_cached_instruments(instruments);
+    if count > 0 {
+        tracing::debug!(
+            "Seeded Interactive Brokers instrument provider with {} cached instruments",
+            count
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/adapters/interactive_brokers/src/historical/client.rs
+++ b/crates/adapters/interactive_brokers/src/historical/client.rs
@@ -34,7 +34,11 @@ use nautilus_model::{
 };
 
 use crate::{
-    common::enums::IbHistoricalTickType,
+    common::{
+        enums::IbHistoricalTickType,
+        shared_client::{self, SharedClientHandle},
+    },
+    config::InteractiveBrokersDataClientConfig,
     data::convert::{
         bar_type_to_ib_bar_size, chrono_to_ib_datetime, ib_bar_to_nautilus_bar,
         ib_timestamp_to_unix_nanos, price_type_to_ib_what_to_show,
@@ -59,6 +63,8 @@ pub struct HistoricalInteractiveBrokersClient {
     ib_client: Arc<Client>,
     /// Instrument provider.
     instrument_provider: Arc<InteractiveBrokersInstrumentProvider>,
+    /// Shared client handle, when this client owns the connection lifecycle.
+    _shared_client: Option<Arc<SharedClientHandle>>,
 }
 
 impl Clone for HistoricalInteractiveBrokersClient {
@@ -66,6 +72,7 @@ impl Clone for HistoricalInteractiveBrokersClient {
         Self {
             ib_client: Arc::clone(&self.ib_client),
             instrument_provider: Arc::clone(&self.instrument_provider),
+            _shared_client: self._shared_client.clone(),
         }
     }
 }
@@ -93,7 +100,74 @@ impl HistoricalInteractiveBrokersClient {
         Self {
             ib_client,
             instrument_provider,
+            _shared_client: None,
         }
+    }
+
+    /// Connect to Interactive Brokers and create a historical data client.
+    ///
+    /// This initializes an instrument provider from `config.instrument_provider` and acquires the
+    /// shared IB client for the configured host, port, and client ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if provider initialization or the IB connection fails.
+    pub async fn connect(config: InteractiveBrokersDataClientConfig) -> anyhow::Result<Self> {
+        let instrument_provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
+            config.instrument_provider.clone(),
+        ));
+        instrument_provider.initialize().await?;
+
+        let shared_client = shared_client::get_or_connect(
+            &config.host,
+            config.port,
+            config.client_id,
+            config.connection_timeout,
+        )
+        .await?;
+
+        Ok(Self::from_shared_client(shared_client, instrument_provider))
+    }
+
+    pub(crate) fn from_shared_client(
+        shared_client: SharedClientHandle,
+        instrument_provider: Arc<InteractiveBrokersInstrumentProvider>,
+    ) -> Self {
+        let ib_client = Arc::clone(shared_client.as_arc());
+
+        Self {
+            ib_client,
+            instrument_provider,
+            _shared_client: Some(Arc::new(shared_client)),
+        }
+    }
+
+    /// Connect a historical data client with a supplied provider using the shared IB client registry.
+    ///
+    /// This keeps standalone Rust callers from needing to acquire `common::shared_client`
+    /// directly before requesting instruments or historical data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the shared client cannot connect or the instrument provider cannot
+    /// initialize.
+    pub async fn connect_with_provider(
+        instrument_provider: InteractiveBrokersInstrumentProvider,
+        config: InteractiveBrokersDataClientConfig,
+    ) -> anyhow::Result<Self> {
+        instrument_provider.initialize().await?;
+        let shared_client = shared_client::get_or_connect(
+            &config.host,
+            config.port,
+            config.client_id,
+            config.connection_timeout,
+        )
+        .await?;
+
+        Ok(Self::from_shared_client(
+            shared_client,
+            Arc::new(instrument_provider),
+        ))
     }
 
     /// Request historical bars.
@@ -165,7 +239,8 @@ impl HistoricalInteractiveBrokersClient {
             // Try to convert instrument ID to contract
             if let Ok(contract) = self
                 .instrument_provider
-                .resolve_contract_for_instrument(instrument_id)
+                .resolve_contract_for_instrument_async(&self.ib_client, instrument_id)
+                .await
             {
                 all_contracts.push(contract);
             } else {
@@ -377,7 +452,8 @@ impl HistoricalInteractiveBrokersClient {
 
             if let Ok(contract) = self
                 .instrument_provider
-                .resolve_contract_for_instrument(instrument_id)
+                .resolve_contract_for_instrument_async(&self.ib_client, instrument_id)
+                .await
             {
                 all_contracts.push(contract);
             } else {

--- a/crates/adapters/interactive_brokers/src/historical/client.rs
+++ b/crates/adapters/interactive_brokers/src/historical/client.rs
@@ -40,8 +40,9 @@ use crate::{
     },
     config::InteractiveBrokersDataClientConfig,
     data::convert::{
-        bar_type_to_ib_bar_size, chrono_to_ib_datetime, ib_bar_to_nautilus_bar,
-        ib_timestamp_to_unix_nanos, price_type_to_ib_what_to_show,
+        apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
+        chrono_to_ib_datetime, ib_bar_to_nautilus_bar, ib_timestamp_to_unix_nanos,
+        price_type_to_ib_what_to_show,
     },
     providers::instruments::InteractiveBrokersInstrumentProvider,
 };
@@ -116,8 +117,6 @@ impl HistoricalInteractiveBrokersClient {
         let instrument_provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
             config.instrument_provider.clone(),
         ));
-        instrument_provider.initialize().await?;
-
         let shared_client = shared_client::get_or_connect(
             &config.host,
             config.port,
@@ -125,6 +124,16 @@ impl HistoricalInteractiveBrokersClient {
             config.connection_timeout,
         )
         .await?;
+        let client = shared_client.as_arc();
+
+        if config.market_data_type != crate::config::MarketDataType::Realtime {
+            let market_data_type: ibapi::market_data::MarketDataType =
+                config.market_data_type.into();
+            client.switch_market_data_type(market_data_type).await?;
+        }
+        instrument_provider
+            .initialize_with_client(client.as_ref())
+            .await?;
 
         Ok(Self::from_shared_client(shared_client, instrument_provider))
     }
@@ -155,7 +164,6 @@ impl HistoricalInteractiveBrokersClient {
         instrument_provider: InteractiveBrokersInstrumentProvider,
         config: InteractiveBrokersDataClientConfig,
     ) -> anyhow::Result<Self> {
-        instrument_provider.initialize().await?;
         let shared_client = shared_client::get_or_connect(
             &config.host,
             config.port,
@@ -163,6 +171,16 @@ impl HistoricalInteractiveBrokersClient {
             config.connection_timeout,
         )
         .await?;
+        let client = shared_client.as_arc();
+
+        if config.market_data_type != crate::config::MarketDataType::Realtime {
+            let market_data_type: ibapi::market_data::MarketDataType =
+                config.market_data_type.into();
+            client.switch_market_data_type(market_data_type).await?;
+        }
+        instrument_provider
+            .initialize_with_client(client.as_ref())
+            .await?;
 
         Ok(Self::from_shared_client(
             shared_client,
@@ -207,6 +225,12 @@ impl HistoricalInteractiveBrokersClient {
             && start >= end_date_time
         {
             anyhow::bail!("Start date must be before end date");
+        }
+
+        if let Some(duration) = duration {
+            duration.parse::<historical::Duration>().with_context(|| {
+                format!("duration must be in format: 'int S|D|W|M|Y', was '{duration}'")
+            })?;
         }
 
         let contracts = contracts.unwrap_or_default();
@@ -366,11 +390,14 @@ impl HistoricalInteractiveBrokersClient {
                         } else {
                             (5, 0) // Default fallback
                         };
+                    let price_magnifier =
+                        self.instrument_provider.get_price_magnifier(&instrument_id);
 
                     // Create new bar_type with correct instrument_id
                     for ib_bar in &historical_data.bars {
+                        let ib_bar = apply_bar_price_magnifier(ib_bar, price_magnifier);
                         let nautilus_bar = ib_bar_to_nautilus_bar(
-                            ib_bar,
+                            &ib_bar,
                             bar_type_with_id,
                             price_precision,
                             size_precision,
@@ -400,6 +427,7 @@ impl HistoricalInteractiveBrokersClient {
     /// * `instrument_ids` - List of instrument IDs
     /// * `use_rth` - Use regular trading hours only
     /// * `timeout` - Request timeout in seconds
+    /// * `limit` - Maximum number of ticks to return, or 0 for no explicit limit
     ///
     /// # Errors
     ///
@@ -413,10 +441,19 @@ impl HistoricalInteractiveBrokersClient {
         contracts: Option<Vec<Contract>>,
         instrument_ids: Option<Vec<InstrumentId>>,
         use_rth: bool,
-        _timeout: u64,
+        timeout: u64,
+        limit: usize,
     ) -> anyhow::Result<Vec<Data>> {
         if start_date_time >= end_date_time {
             anyhow::bail!("Start date must be before end date");
+        }
+
+        let limit = (limit > 0).then_some(limit);
+
+        if end_date_time.signed_duration_since(start_date_time) > chrono::Duration::days(1) {
+            tracing::warn!(
+                "Requesting tick data for more than 1 day may take a long time, particularly for liquid instruments"
+            );
         }
 
         let contracts = contracts.unwrap_or_default();
@@ -499,10 +536,18 @@ impl HistoricalInteractiveBrokersClient {
                 } else {
                     (5, 0) // Default fallback
                 };
+            let price_magnifier = self.instrument_provider.get_price_magnifier(&instrument_id);
+            let contract_start_len = all_ticks.len();
 
             // Pagination loop for ticks (similar to Python _handle_timestamp_iteration)
             let mut current_end_date = end_date_time;
             let current_start_date = start_date_time;
+            let start_date_time_ns = UnixNanos::from(
+                start_date_time
+                    .timestamp_nanos_opt()
+                    .unwrap_or_else(|| start_date_time.timestamp() * 1_000_000_000)
+                    as u64,
+            );
             let end_date_time_ns = UnixNanos::from(
                 end_date_time
                     .timestamp_nanos_opt()
@@ -514,30 +559,36 @@ impl HistoricalInteractiveBrokersClient {
                 IbHistoricalTickType::Trades => {
                     loop {
                         // Make request for this batch
-                        let mut subscription = self
-                            .ib_client
-                            .historical_ticks_trade(
+                        let mut subscription = tokio::time::timeout(
+                            std::time::Duration::from_secs(timeout),
+                            self.ib_client.historical_ticks_trade(
                                 &contract,
                                 Some(chrono_to_ib_datetime(&current_start_date)),
                                 Some(chrono_to_ib_datetime(&current_end_date)),
-                                1000, // Number of ticks per request
+                                1000,
                                 trading_hours,
-                            )
-                            .await?;
+                            ),
+                        )
+                        .await
+                        .context(format!(
+                            "Historical trades request timed out after {} seconds",
+                            timeout
+                        ))??;
 
                         let mut batch_ticks = Vec::new();
 
                         while let Some(tick) = subscription.next().await {
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
-                            // Filter out ticks after end_date_time
-                            if ts_event > end_date_time_ns {
+                            if ts_event < start_date_time_ns || ts_event > end_date_time_ns {
                                 continue;
                             }
 
                             let ts_init = ts_event;
 
-                            let price = Price::new(tick.price, price_precision);
+                            let converted_price =
+                                apply_price_magnifier(tick.price, price_magnifier);
+                            let price = Price::new(converted_price, price_precision);
                             let size = Quantity::new(tick.size as f64, size_precision);
 
                             let trade_tick = TradeTick::new(
@@ -547,7 +598,7 @@ impl HistoricalInteractiveBrokersClient {
                                 AggressorSide::NoAggressor,
                                 crate::common::parse::generate_ib_trade_id(
                                     ts_event,
-                                    tick.price,
+                                    converted_price,
                                     tick.size as f64,
                                 ),
                                 ts_event,
@@ -581,6 +632,12 @@ impl HistoricalInteractiveBrokersClient {
 
                         all_ticks.extend(batch_ticks);
 
+                        if let Some(limit) = limit
+                            && all_ticks.len() - contract_start_len >= limit
+                        {
+                            break;
+                        }
+
                         // Check if we should continue - need current_end > current_start
                         if !should_continue_backward_pagination(
                             current_end_date,
@@ -589,10 +646,14 @@ impl HistoricalInteractiveBrokersClient {
                             break;
                         }
 
-                        // Filter out ticks after end_date_time if needed
+                        // Filter out ticks outside the requested range if needed
                         all_ticks.retain(|t| match t {
-                            Data::Trade(t) => t.ts_event <= end_date_time_ns,
-                            Data::Quote(q) => q.ts_event <= end_date_time_ns,
+                            Data::Trade(t) => {
+                                t.ts_event >= start_date_time_ns && t.ts_event <= end_date_time_ns
+                            }
+                            Data::Quote(q) => {
+                                q.ts_event >= start_date_time_ns && q.ts_event <= end_date_time_ns
+                            }
                             _ => true,
                         });
                     }
@@ -600,33 +661,43 @@ impl HistoricalInteractiveBrokersClient {
                 IbHistoricalTickType::BidAsk => {
                     loop {
                         // Make request for this batch
-                        let mut subscription = self
-                            .ib_client
-                            .historical_ticks_bid_ask(
+                        let mut subscription = tokio::time::timeout(
+                            std::time::Duration::from_secs(timeout),
+                            self.ib_client.historical_ticks_bid_ask(
                                 &contract,
                                 Some(chrono_to_ib_datetime(&current_start_date)),
                                 Some(chrono_to_ib_datetime(&current_end_date)),
                                 1000,
                                 trading_hours,
                                 false, // ignore_size
-                            )
-                            .await?;
+                            ),
+                        )
+                        .await
+                        .context(format!(
+                            "Historical bid/ask ticks request timed out after {} seconds",
+                            timeout
+                        ))??;
 
                         let mut batch_ticks = Vec::new();
 
                         while let Some(tick) = subscription.next().await {
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
-                            // Filter out ticks after end_date_time
-                            if ts_event > end_date_time_ns {
+                            if ts_event < start_date_time_ns || ts_event > end_date_time_ns {
                                 continue;
                             }
 
                             let ts_init = ts_event;
 
-                            let bid_price = Price::new(tick.price_bid, price_precision);
+                            let bid_price = Price::new(
+                                apply_price_magnifier(tick.price_bid, price_magnifier),
+                                price_precision,
+                            );
                             let bid_size = Quantity::new(tick.size_bid as f64, size_precision);
-                            let ask_price = Price::new(tick.price_ask, price_precision);
+                            let ask_price = Price::new(
+                                apply_price_magnifier(tick.price_ask, price_magnifier),
+                                price_precision,
+                            );
                             let ask_size = Quantity::new(tick.size_ask as f64, size_precision);
 
                             let quote_tick = QuoteTick::new(
@@ -665,6 +736,12 @@ impl HistoricalInteractiveBrokersClient {
 
                         all_ticks.extend(batch_ticks);
 
+                        if let Some(limit) = limit
+                            && all_ticks.len() - contract_start_len >= limit
+                        {
+                            break;
+                        }
+
                         // Check if we should continue
                         if !should_continue_backward_pagination(
                             current_end_date,
@@ -673,14 +750,32 @@ impl HistoricalInteractiveBrokersClient {
                             break;
                         }
 
-                        // Filter out ticks after end_date_time if needed
+                        // Filter out ticks outside the requested range if needed
                         all_ticks.retain(|t| match t {
-                            Data::Trade(t) => t.ts_event <= end_date_time_ns,
-                            Data::Quote(q) => q.ts_event <= end_date_time_ns,
+                            Data::Trade(t) => {
+                                t.ts_event >= start_date_time_ns && t.ts_event <= end_date_time_ns
+                            }
+                            Data::Quote(q) => {
+                                q.ts_event >= start_date_time_ns && q.ts_event <= end_date_time_ns
+                            }
                             _ => true,
                         });
                     }
                 }
+            }
+
+            if let Some(limit) = limit {
+                let mut contract_ticks = all_ticks.split_off(contract_start_len);
+                contract_ticks.sort_by_key(|tick| match tick {
+                    Data::Trade(t) => t.ts_event,
+                    Data::Quote(q) => q.ts_event,
+                    _ => UnixNanos::default(),
+                });
+
+                if contract_ticks.len() > limit {
+                    contract_ticks = contract_ticks.split_off(contract_ticks.len() - limit);
+                }
+                all_ticks.extend(contract_ticks);
             }
         }
 

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -127,6 +127,16 @@ impl InteractiveBrokersInstrumentProvider {
         self.price_magnifiers.insert(instrument_id, price_magnifier);
     }
 
+    #[cfg(test)]
+    pub(crate) fn insert_test_contract_id_mapping(
+        &self,
+        contract_id: i32,
+        instrument_id: InstrumentId,
+    ) {
+        self.contract_id_to_instrument_id
+            .insert(contract_id, instrument_id);
+    }
+
     /// Initialize the provider by loading cache if configured.
     ///
     /// This is equivalent to Python's `provider.initialize()` method.
@@ -181,8 +191,16 @@ impl InteractiveBrokersInstrumentProvider {
             let Some(contract) = contract_from_instrument_info(&instrument) else {
                 continue;
             };
+            let price_magnifier = price_magnifier_from_instrument_info(&instrument);
 
-            if self.cache_instrument(instrument_id, instrument, None, Some(contract), None, false) {
+            if self.cache_instrument(
+                instrument_id,
+                instrument,
+                None,
+                Some(contract),
+                price_magnifier,
+                false,
+            ) {
                 added += 1;
             }
         }
@@ -330,6 +348,38 @@ impl InteractiveBrokersInstrumentProvider {
         self.contract_id_to_instrument_id
             .get(&contract_id)
             .map(|entry| *entry.value())
+    }
+
+    /// Resolve an instrument ID from an IB contract using provider symbology and venue rules.
+    ///
+    /// This first checks the provider's contract ID cache, then derives the instrument ID using the
+    /// configured symbology method and `determine_venue`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the contract cannot be converted to an instrument ID.
+    pub fn resolve_instrument_id_for_contract(
+        &self,
+        contract: &Contract,
+    ) -> anyhow::Result<InstrumentId> {
+        if contract.contract_id != 0
+            && let Some(instrument_id) = self.get_instrument_id_by_contract_id(contract.contract_id)
+        {
+            return Ok(instrument_id);
+        }
+
+        if contract.security_type == SecurityType::Spread {
+            return self.resolve_spread_instrument_id_for_contract(contract);
+        }
+
+        let venue = self.determine_venue(contract, None);
+
+        match self.config.symbology_method {
+            SymbologyMethod::Simplified => {
+                ib_contract_to_instrument_id_simplified(contract, Some(venue))
+            }
+            SymbologyMethod::Raw => ib_contract_to_instrument_id_raw(contract, Some(venue)),
+        }
     }
 
     fn resolve_spread_instrument_id_for_contract(
@@ -1309,12 +1359,45 @@ fn contract_from_instrument_info(instrument: &InstrumentAny) -> Option<Contract>
     parse_contract_from_json(contract_json).ok()
 }
 
+fn price_magnifier_from_instrument_info(instrument: &InstrumentAny) -> Option<i32> {
+    let value = serde_json::to_value(instrument).ok()?;
+    let price_magnifier = find_price_magnifier_json(&value)?;
+    parse_i32_json(price_magnifier)
+}
+
 fn find_contract_json(value: &serde_json::Value) -> Option<&serde_json::Value> {
     if let Some(contract_json) = value.get("info").and_then(|info| info.get("contract")) {
         return Some(contract_json);
     }
 
     value.as_object()?.values().find_map(find_contract_json)
+}
+
+fn find_price_magnifier_json(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    if let Some(info) = value.get("info")
+        && let Some(price_magnifier) = info
+            .get("priceMagnifier")
+            .or_else(|| info.get("price_magnifier"))
+    {
+        return Some(price_magnifier);
+    }
+
+    value
+        .as_object()?
+        .values()
+        .find_map(find_price_magnifier_json)
+}
+
+fn parse_i32_json(value: &serde_json::Value) -> Option<i32> {
+    if let Some(value) = value.as_i64() {
+        return i32::try_from(value).ok();
+    }
+
+    if let Some(value) = value.as_u64() {
+        return i32::try_from(value).ok();
+    }
+
+    value.as_str()?.parse::<i32>().ok()
 }
 
 fn expiry_bound_from_days(days: Option<u32>) -> Option<String> {
@@ -2558,9 +2641,15 @@ mod tests {
         .into()
     }
 
-    fn create_contract_info(contract: &Contract) -> Params {
+    fn create_contract_info(contract: &Contract, price_magnifier: Option<i32>) -> Params {
         let mut info = Params::new();
         info.insert(String::from("contract"), contract_to_json_value(contract));
+        if let Some(price_magnifier) = price_magnifier {
+            info.insert(
+                String::from("priceMagnifier"),
+                serde_json::Value::from(price_magnifier),
+            );
+        }
         info
     }
 
@@ -2728,7 +2817,7 @@ mod tests {
         };
         let ib_instrument = create_test_instrument_with_info(
             ib_instrument_id,
-            Some(create_contract_info(&contract)),
+            Some(create_contract_info(&contract, Some(100))),
         );
         let non_ib_instrument = create_test_instrument(non_ib_instrument_id);
 
@@ -2745,6 +2834,7 @@ mod tests {
                 .contract_id,
             265598
         );
+        assert_eq!(provider.get_price_magnifier(&ib_instrument_id), 100);
     }
 
     #[tokio::test]

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -29,14 +29,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     common::{
+        contracts::parse_contract_from_json,
         enums::IbAction,
         parse::{
             create_spread_instrument_id, determine_venue_from_contract, exchange_to_mic_venue,
+            ib_contract_to_instrument_id_raw, ib_contract_to_instrument_id_simplified,
             instrument_id_to_ib_contract, is_spread_instrument_id,
             parse_spread_instrument_id_to_legs, possible_exchanges_for_venue,
         },
     },
-    config::InteractiveBrokersInstrumentProviderConfig,
+    config::{InteractiveBrokersInstrumentProviderConfig, SymbologyMethod},
     providers::parse::{parse_ib_contract_to_instrument, parse_spread_instrument_any},
 };
 
@@ -49,6 +51,12 @@ struct InstrumentCache {
     contract_id_to_instrument_id: Vec<(i32, String)>,
     /// Instrument ID to Price Magnifier mappings.
     price_magnifiers: Vec<(String, i32)>,
+    /// Instrument ID to IB contracts.
+    #[serde(default)]
+    contracts: Vec<(String, Contract)>,
+    /// Instrument ID to IB contract details.
+    #[serde(default)]
+    contract_details: Vec<(String, ibapi::contracts::ContractDetails)>,
     /// Instruments serialized as JSON strings (since InstrumentAny is serializable).
     instruments: Vec<(String, String)>, // (instrument_id, json)
 }
@@ -148,6 +156,37 @@ impl InteractiveBrokersInstrumentProvider {
             }
         }
         Ok(())
+    }
+
+    pub async fn initialize_with_client(
+        &self,
+        client: &ibapi::Client,
+    ) -> anyhow::Result<Vec<InstrumentId>> {
+        self.initialize().await?;
+        self.load_all_async(client, None, None, false).await
+    }
+
+    /// Adds instruments already held by the Nautilus cache into the provider cache.
+    ///
+    /// This mirrors the Python provider's use of `client._cache` for venue resolution and for
+    /// recovering stored IB contract metadata from `instrument.info["contract"]`.
+    pub fn add_cached_instruments<I>(&self, instruments: I) -> usize
+    where
+        I: IntoIterator<Item = InstrumentAny>,
+    {
+        let mut added = 0;
+
+        for instrument in instruments {
+            let instrument_id = instrument.id();
+            let Some(contract) = contract_from_instrument_info(&instrument) else {
+                continue;
+            };
+
+            if self.cache_instrument(instrument_id, instrument, None, Some(contract), None, false) {
+                added += 1;
+            }
+        }
+        added
     }
 
     /// Determine venue from contract using provider configuration.
@@ -293,6 +332,43 @@ impl InteractiveBrokersInstrumentProvider {
             .map(|entry| *entry.value())
     }
 
+    fn resolve_spread_instrument_id_for_contract(
+        &self,
+        contract: &Contract,
+    ) -> anyhow::Result<InstrumentId> {
+        if contract.combo_legs.is_empty() {
+            anyhow::bail!("Cannot resolve BAG contract without combo legs or cached contract ID");
+        }
+
+        let mut leg_tuples = Vec::with_capacity(contract.combo_legs.len());
+
+        for combo_leg in &contract.combo_legs {
+            let leg_instrument_id = self
+                .get_instrument_id_by_contract_id(combo_leg.contract_id)
+                .with_context(|| {
+                    format!(
+                        "Cannot resolve BAG leg con_id {} to cached instrument ID",
+                        combo_leg.contract_id
+                    )
+                })?;
+            let ratio = IbAction::from_str(&combo_leg.action)
+                .context("Invalid BAG combo leg action")?
+                .signed_multiplier()
+                * combo_leg.ratio;
+
+            leg_tuples.push((leg_instrument_id, ratio));
+        }
+
+        let spread_instrument_id = create_spread_instrument_id(&leg_tuples)
+            .context("Failed to create spread instrument ID from BAG combo legs")?;
+
+        if self.find(&spread_instrument_id).is_none() {
+            anyhow::bail!("Resolved BAG spread {spread_instrument_id} is not cached");
+        }
+
+        Ok(spread_instrument_id)
+    }
+
     /// Check if a security type should be filtered.
     ///
     /// # Arguments
@@ -304,7 +380,10 @@ impl InteractiveBrokersInstrumentProvider {
     /// Returns `true` if the security type should be filtered.
     #[must_use]
     pub fn is_filtered_sec_type(&self, sec_type: &str) -> bool {
-        self.config.filter_sec_types.contains(sec_type)
+        self.config
+            .filter_sec_types
+            .iter()
+            .any(|filtered| filtered.eq_ignore_ascii_case(sec_type))
     }
 
     /// Get all cached instruments.
@@ -410,7 +489,7 @@ impl InteractiveBrokersInstrumentProvider {
             contract.last_trade_date_or_contract_month.as_str()
         );
         // Check if security type is filtered
-        let sec_type_str = format!("{:?}", contract.security_type);
+        let sec_type_str = security_type_code(&contract.security_type);
         if self.is_filtered_sec_type(&sec_type_str) {
             tracing::warn!(
                 "Skipping filtered security type {} for contract",
@@ -444,6 +523,12 @@ impl InteractiveBrokersInstrumentProvider {
             {
                 return Ok(self.find(spread_instrument_id.value()));
             }
+
+            if let Ok(spread_instrument_id) =
+                self.resolve_spread_instrument_id_for_contract(contract)
+            {
+                return Ok(self.find(&spread_instrument_id));
+            }
         }
 
         // For non-BAG contracts, fetch contract details and load
@@ -465,51 +550,17 @@ impl InteractiveBrokersInstrumentProvider {
             return Ok(None);
         }
 
-        let details = &details_vec[0];
-        log::debug!(
-            "IB get_instrument using first detail sec_type={:?} con_id={} local_symbol={} exchange={} under_con_id={}",
-            details.contract.security_type,
-            details.contract.contract_id,
-            details.contract.local_symbol.as_str(),
-            details.contract.exchange.as_str(),
-            details.under_contract_id
-        );
-        let venue = self.determine_venue(&details.contract, Some(details));
-        let instrument_id = match self.config.symbology_method {
-            crate::config::SymbologyMethod::Simplified => {
-                crate::common::parse::ib_contract_to_instrument_id_simplified(
-                    &details.contract,
-                    Some(venue),
-                )
-            }
-            crate::config::SymbologyMethod::Raw => {
-                crate::common::parse::ib_contract_to_instrument_id_raw(
-                    &details.contract,
-                    Some(venue),
-                )
-            }
+        let loaded_ids = self.process_contract_details(details_vec, None, false);
+
+        if contract_id != 0
+            && let Some(instrument) = self.find_by_contract_id(contract_id)
+        {
+            return Ok(Some(instrument));
         }
-        .context("Failed to convert contract to instrument ID")?;
 
-        log::debug!(
-            "IB get_instrument mapped to instrument_id={}",
-            instrument_id
-        );
-
-        // Parse and cache the instrument
-        let instrument = parse_ib_contract_to_instrument(details, instrument_id)
-            .context("Failed to parse instrument")?;
-
-        self.instruments.insert(instrument_id, instrument.clone());
-        self.contract_details.insert(instrument_id, details.clone());
-        self.contracts
-            .insert(instrument_id, details.contract.clone());
-        self.contract_id_to_instrument_id
-            .insert(details.contract.contract_id, instrument_id);
-        self.price_magnifiers
-            .insert(instrument_id, details.price_magnifier);
-
-        Ok(Some(instrument))
+        Ok(loaded_ids
+            .first()
+            .and_then(|instrument_id| self.find(instrument_id)))
     }
 
     pub(crate) async fn load_contract_spec(
@@ -525,6 +576,8 @@ impl InteractiveBrokersInstrumentProvider {
             || self.config.build_options_chain.unwrap_or(false);
         let min_expiry_days = json_u32(spec, "min_expiry_days").or(self.config.min_expiry_days);
         let max_expiry_days = json_u32(spec, "max_expiry_days").or(self.config.max_expiry_days);
+        let options_chain_exchange = json_string(spec, "options_chain_exchange")
+            .or_else(|| json_string(spec, "optionsChainExchange"));
         let chain_contract = if contract.security_type == SecurityType::ContinuousFuture
             && (build_futures_chain || build_options_chain)
         {
@@ -629,6 +682,7 @@ impl InteractiveBrokersInstrumentProvider {
                         &underlying,
                         expiry_min.as_deref(),
                         expiry_max.as_deref(),
+                        options_chain_exchange.as_deref(),
                     )
                     .await?;
                 tracing::info!(
@@ -639,11 +693,15 @@ impl InteractiveBrokersInstrumentProvider {
                 );
             }
 
-            loaded_ids.extend(self.cached_contract_ids_for(
-                contract.symbol.as_str(),
-                contract.exchange.as_str(),
-                &[SecurityType::Option, SecurityType::FuturesOption],
-            ));
+            loaded_ids.extend(
+                self.cached_contract_ids_for(
+                    contract.symbol.as_str(),
+                    options_chain_exchange
+                        .as_deref()
+                        .unwrap_or_else(|| contract.exchange.as_str()),
+                    &[SecurityType::Option, SecurityType::FuturesOption],
+                ),
+            );
         }
 
         if !build_futures_chain
@@ -727,15 +785,44 @@ impl InteractiveBrokersInstrumentProvider {
         &self,
         instrument_id: InstrumentId,
     ) -> anyhow::Result<Contract> {
-        if let Some(contract) = self.instrument_id_to_ib_contract(&instrument_id) {
-            return Ok(contract);
+        let cached_contract = self.instrument_id_to_ib_contract(&instrument_id);
+        if let Some(contract) = cached_contract.as_ref()
+            && (contract.contract_id != 0 || is_spread_instrument_id(&instrument_id))
+        {
+            return Ok(contract.clone());
         }
 
         if let Some(details) = self.instrument_id_to_ib_contract_details(&instrument_id) {
             return Ok(details.contract);
         }
 
+        if let Some(contract) = cached_contract {
+            return Ok(contract);
+        }
+
         instrument_id_to_ib_contract(instrument_id, None)
+    }
+
+    pub async fn resolve_contract_for_instrument_async(
+        &self,
+        client: &ibapi::Client,
+        instrument_id: InstrumentId,
+    ) -> anyhow::Result<Contract> {
+        if let Ok(contract) = self.resolve_contract_for_instrument(instrument_id)
+            && (contract.contract_id != 0 || self.contract_details.contains_key(&instrument_id))
+        {
+            return Ok(contract);
+        }
+
+        if is_spread_instrument_id(&instrument_id) {
+            self.fetch_spread_instrument(client, instrument_id, false, None)
+                .await?;
+        } else {
+            self.fetch_contract_details(client, instrument_id, false, None)
+                .await?;
+        }
+
+        self.resolve_contract_for_instrument(instrument_id)
     }
 
     /// Load a single instrument (does not return loaded IDs).
@@ -811,6 +898,15 @@ impl InteractiveBrokersInstrumentProvider {
         } else {
             Ok(None)
         }
+    }
+
+    pub async fn load_contract_with_return_async(
+        &self,
+        client: &ibapi::Client,
+        contract: &Contract,
+        spec: Option<&serde_json::Value>,
+    ) -> anyhow::Result<Vec<InstrumentId>> {
+        self.load_contract_spec(client, contract, spec).await
     }
 
     /// Load multiple instruments (does not return loaded IDs).
@@ -1184,6 +1280,10 @@ fn normalize_price_magnifier(price_magnifier: i32) -> i32 {
     }
 }
 
+fn security_type_code(security_type: &SecurityType) -> String {
+    security_type.to_string()
+}
+
 fn json_bool(spec: Option<&serde_json::Value>, key: &str) -> bool {
     spec.and_then(|value| value.get(key))
         .and_then(serde_json::Value::as_bool)
@@ -1194,6 +1294,27 @@ fn json_u32(spec: Option<&serde_json::Value>, key: &str) -> Option<u32> {
     spec.and_then(|value| value.get(key))
         .and_then(serde_json::Value::as_u64)
         .and_then(|value| u32::try_from(value).ok())
+}
+
+fn json_string(spec: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    spec.and_then(|value| value.get(key))
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn contract_from_instrument_info(instrument: &InstrumentAny) -> Option<Contract> {
+    let value = serde_json::to_value(instrument).ok()?;
+    let contract_json = find_contract_json(&value)?;
+    parse_contract_from_json(contract_json).ok()
+}
+
+fn find_contract_json(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    if let Some(contract_json) = value.get("info").and_then(|info| info.get("contract")) {
+        return Some(contract_json);
+    }
+
+    value.as_object()?.values().find_map(find_contract_json)
 }
 
 fn expiry_bound_from_days(days: Option<u32>) -> Option<String> {
@@ -1223,7 +1344,10 @@ impl InteractiveBrokersInstrumentProvider {
         filters: Option<HashMap<String, String>>,
     ) -> anyhow::Result<()> {
         if !force_instrument_update {
-            if self.instruments.contains_key(&instrument_id) {
+            if self.instruments.contains_key(&instrument_id)
+                && (self.contract_details.contains_key(&instrument_id)
+                    || self.contracts.contains_key(&instrument_id))
+            {
                 tracing::debug!(
                     "Instrument {} already cached, skipping fetch",
                     instrument_id
@@ -1279,45 +1403,195 @@ impl InteractiveBrokersInstrumentProvider {
             return Ok(());
         }
 
-        // Process the first contract detail (usually there's only one)
-        let details = &details_vec[0];
+        let loaded_ids = self.process_contract_details(
+            details_vec,
+            Some(instrument_id.venue),
+            force_instrument_update,
+        );
 
-        // Check if security type is filtered
-        let sec_type_str = format!("{:?}", details.contract.security_type);
-        if self.is_filtered_sec_type(&sec_type_str) {
-            tracing::warn!("Skipping filtered security type: {}", sec_type_str);
-            return Ok(());
+        if loaded_ids.is_empty() {
+            tracing::warn!("No contract details were processed for {}", instrument_id);
+        } else {
+            tracing::info!(
+                "Successfully loaded {} instrument(s) for {}",
+                loaded_ids.len(),
+                instrument_id
+            );
+        }
+        Ok(())
+    }
+
+    fn process_contract_details(
+        &self,
+        details_vec: Vec<ibapi::contracts::ContractDetails>,
+        venue: Option<Venue>,
+        force_instrument_update: bool,
+    ) -> Vec<InstrumentId> {
+        let mut processed_ids = Vec::new();
+
+        for details in details_vec {
+            match self.process_contract_detail(&details, venue, force_instrument_update) {
+                Ok(Some(instrument_id)) => processed_ids.push(instrument_id),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to process IB contract details con_id={} sec_type={}: {}",
+                        details.contract.contract_id,
+                        security_type_code(&details.contract.security_type),
+                        e
+                    );
+                }
+            }
         }
 
-        // Parse to Nautilus instrument
-        let parsed_instrument = parse_ib_contract_to_instrument(details, instrument_id)
-            .context("Failed to parse IB contract to Nautilus instrument")?;
+        processed_ids
+    }
 
-        // TODO: Filter callable support (Python feature)
-        // Python's filter_callable allows custom filtering of instruments via a Python callable.
-        // This requires calling Python functions from Rust, which needs GIL handling and Python interop.
-        // For now, users can filter instruments in Python after loading if needed.
-        // To implement: Accept PyObject callable in config, call it here with parsed_instrument,
-        // skip instrument if callable returns False.
+    fn process_contract_detail(
+        &self,
+        details: &ibapi::contracts::ContractDetails,
+        venue: Option<Venue>,
+        force_instrument_update: bool,
+    ) -> anyhow::Result<Option<InstrumentId>> {
+        let sec_type = security_type_code(&details.contract.security_type);
+        if self.is_filtered_sec_type(&sec_type) {
+            tracing::warn!(
+                "Skipping filtered security type {} for contract {:?}",
+                sec_type,
+                details.contract
+            );
+            return Ok(None);
+        }
 
-        // Cache the instrument and mappings (force update if requested)
-        if force_instrument_update || !self.instruments.contains_key(&instrument_id) {
-            self.instruments.insert(instrument_id, parsed_instrument);
-            self.contract_details.insert(instrument_id, details.clone());
+        let resolved_venue =
+            venue.unwrap_or_else(|| self.determine_venue(&details.contract, Some(details)));
+        let instrument_id = self
+            .instrument_id_from_contract(&details.contract, resolved_venue)
+            .context("Failed to convert IB contract to instrument ID")?;
+        let instrument = match parse_ib_contract_to_instrument(details, instrument_id) {
+            Ok(instrument) => instrument,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse IB contract details for {}: {}",
+                    instrument_id,
+                    e
+                );
+                return Ok(None);
+            }
+        };
+
+        if !self.passes_filter_callable(&instrument)? {
+            return Ok(None);
+        }
+
+        self.cache_instrument(
+            instrument_id,
+            instrument,
+            Some(details.clone()),
+            None,
+            None,
+            force_instrument_update,
+        );
+
+        Ok(Some(instrument_id))
+    }
+
+    fn instrument_id_from_contract(
+        &self,
+        contract: &Contract,
+        venue: Venue,
+    ) -> anyhow::Result<InstrumentId> {
+        match self.config.symbology_method {
+            SymbologyMethod::Simplified => {
+                ib_contract_to_instrument_id_simplified(contract, Some(venue))
+            }
+            SymbologyMethod::Raw => ib_contract_to_instrument_id_raw(contract, Some(venue)),
+        }
+    }
+
+    fn cache_instrument(
+        &self,
+        instrument_id: InstrumentId,
+        instrument: InstrumentAny,
+        details: Option<ibapi::contracts::ContractDetails>,
+        contract: Option<Contract>,
+        price_magnifier: Option<i32>,
+        force_instrument_update: bool,
+    ) -> bool {
+        let should_update =
+            force_instrument_update || !self.instruments.contains_key(&instrument_id);
+
+        if should_update {
+            self.instruments.insert(instrument_id, instrument);
+        }
+
+        if let Some(details) = details {
+            let contract_id = details.contract.contract_id;
             self.contracts
                 .insert(instrument_id, details.contract.clone());
-            self.contract_id_to_instrument_id
-                .insert(details.contract.contract_id, instrument_id);
-            self.price_magnifiers
-                .insert(instrument_id, details.price_magnifier);
+            self.contract_details.insert(instrument_id, details.clone());
+
+            if contract_id != 0 {
+                self.contract_id_to_instrument_id
+                    .insert(contract_id, instrument_id);
+            }
+            self.price_magnifiers.insert(
+                instrument_id,
+                normalize_price_magnifier(details.price_magnifier),
+            );
+        } else if let Some(contract) = contract {
+            if contract.contract_id != 0 {
+                self.contract_id_to_instrument_id
+                    .insert(contract.contract_id, instrument_id);
+            }
+            self.contracts.insert(instrument_id, contract);
         }
 
-        tracing::info!(
-            "Successfully loaded instrument: {} (price_magnifier: {})",
-            instrument_id,
-            details.price_magnifier
-        );
-        Ok(())
+        if let Some(price_magnifier) = price_magnifier {
+            self.price_magnifiers
+                .insert(instrument_id, normalize_price_magnifier(price_magnifier));
+        }
+
+        should_update
+    }
+
+    fn passes_filter_callable(&self, instrument: &InstrumentAny) -> anyhow::Result<bool> {
+        let Some(filter_callable) = self.config.filter_callable.as_deref() else {
+            return Ok(true);
+        };
+
+        #[cfg(feature = "python")]
+        {
+            use nautilus_model::python::instruments::instrument_any_to_pyobject;
+            use pyo3::{prelude::*, types::PyModule};
+
+            Python::attach(|py| {
+                let (module_name, callable_name) =
+                    filter_callable.rsplit_once('.').ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Invalid filter_callable path {filter_callable:?}; expected module.callable"
+                        )
+                    })?;
+                let callable = PyModule::import(py, module_name)
+                    .map_err(|e| anyhow::anyhow!("Failed to import {module_name}: {e}"))?
+                    .getattr(callable_name)
+                    .map_err(|e| anyhow::anyhow!("Failed to resolve {filter_callable}: {e}"))?;
+                let py_instrument = instrument_any_to_pyobject(py, instrument.clone())
+                    .map_err(|e| anyhow::anyhow!("Failed to convert instrument to Python: {e}"))?;
+                callable
+                    .call1((py_instrument,))
+                    .and_then(|result| result.extract::<bool>())
+                    .map_err(|e| anyhow::anyhow!("filter_callable {filter_callable} failed: {e}"))
+            })
+        }
+
+        #[cfg(not(feature = "python"))]
+        {
+            let _ = instrument;
+            anyhow::bail!(
+                "filter_callable {filter_callable:?} requires the Interactive Brokers adapter to be built with the python feature"
+            );
+        }
     }
 
     /// Batch load multiple instrument IDs.
@@ -1375,7 +1649,7 @@ impl InteractiveBrokersInstrumentProvider {
                         // Check security type (try to infer from instrument)
                         if let Some(contract_details) = self.contract_details.get(instrument_id) {
                             let sec_type_str =
-                                format!("{:?}", contract_details.contract.security_type);
+                                security_type_code(&contract_details.contract.security_type);
 
                             if sec_type_str.to_uppercase().contains(&filter.to_uppercase()) {
                                 return true;
@@ -1446,11 +1720,13 @@ impl InteractiveBrokersInstrumentProvider {
         underlying: &Contract,
         expiry_min: Option<&str>,
         expiry_max: Option<&str>,
+        option_chain_exchange: Option<&str>,
     ) -> anyhow::Result<usize> {
+        let exchange = option_chain_exchange.unwrap_or_else(|| underlying.exchange.as_str());
         tracing::info!(
             "Building option chain for {}.{} (sec_type={:?}, contract_id={}, expiry_min={:?}, expiry_max={:?}, config_min_days={:?}, config_max_days={:?})",
             underlying.symbol.as_str(),
-            underlying.exchange.as_str(),
+            exchange,
             underlying.security_type,
             underlying.contract_id,
             expiry_min,
@@ -1461,8 +1737,6 @@ impl InteractiveBrokersInstrumentProvider {
 
         // First, get option chain metadata to determine expirations
         let symbol = underlying.symbol.as_str();
-        let exchange = underlying.exchange.as_str();
-
         let mut option_chain_stream = client
             .option_chain(
                 symbol,
@@ -1538,7 +1812,7 @@ impl InteractiveBrokersInstrumentProvider {
             "Filtered {} option expirations for {}.{}",
             all_expirations.len(),
             underlying.symbol.as_str(),
-            underlying.exchange.as_str(),
+            exchange,
         );
 
         // Now fetch contract details for each expiry using contract_details
@@ -1546,7 +1820,7 @@ impl InteractiveBrokersInstrumentProvider {
             tracing::info!(
                 "Requesting option contract details for {}.{} expiry {}",
                 underlying.symbol.as_str(),
-                underlying.exchange.as_str(),
+                exchange,
                 expiration,
             );
 
@@ -1562,7 +1836,7 @@ impl InteractiveBrokersInstrumentProvider {
                 strike: f64::MAX,
                 right: String::new(),
                 multiplier: String::new(),
-                exchange: underlying.exchange.clone(),
+                exchange: Exchange::from(exchange),
                 currency: underlying.currency.clone(),
                 local_symbol: String::new(),
                 primary_exchange: Exchange::from(""),
@@ -1584,7 +1858,7 @@ impl InteractiveBrokersInstrumentProvider {
                         "Received {} raw option contract details for {}.{} expiry {}",
                         details_vec.len(),
                         underlying.symbol.as_str(),
-                        underlying.exchange.as_str(),
+                        exchange,
                         expiration,
                     );
 
@@ -1600,40 +1874,11 @@ impl InteractiveBrokersInstrumentProvider {
                             continue;
                         }
 
-                        let venue = self.determine_venue(&details.contract, Some(&details));
-                        let instrument_id = match self.config.symbology_method {
-                            crate::config::SymbologyMethod::Simplified => {
-                                crate::common::parse::ib_contract_to_instrument_id_simplified(
-                                    &details.contract,
-                                    Some(venue),
-                                )
-                            }
-                            crate::config::SymbologyMethod::Raw => {
-                                crate::common::parse::ib_contract_to_instrument_id_raw(
-                                    &details.contract,
-                                    Some(venue),
-                                )
-                            }
-                        }
-                        .context("Failed to convert IB contract to instrument ID")?;
-
-                        let sec_type_str = format!("{:?}", details.contract.security_type);
-                        if self.is_filtered_sec_type(&sec_type_str) {
-                            continue;
-                        }
-
-                        match parse_ib_contract_to_instrument(&details, instrument_id) {
-                            Ok(parsed_instrument) => {
-                                self.instruments.insert(instrument_id, parsed_instrument);
-                                self.contract_details.insert(instrument_id, details.clone());
-                                self.contracts
-                                    .insert(instrument_id, details.contract.clone());
-                                self.contract_id_to_instrument_id
-                                    .insert(contract_id, instrument_id);
-                                self.price_magnifiers
-                                    .insert(instrument_id, details.price_magnifier);
+                        match self.process_contract_detail(&details, None, false) {
+                            Ok(Some(_instrument_id)) => {
                                 total_loaded += 1;
                             }
+                            Ok(None) => {}
                             Err(e) => {
                                 tracing::warn!("Failed to parse option instrument: {}", e);
                             }
@@ -1654,7 +1899,7 @@ impl InteractiveBrokersInstrumentProvider {
             "Successfully loaded {} option instruments from chain for {}.{}",
             total_loaded,
             underlying.symbol.as_str(),
-            underlying.exchange.as_str(),
+            exchange,
         );
 
         // Save cache if cache_path is configured
@@ -1760,26 +2005,8 @@ impl InteractiveBrokersInstrumentProvider {
                 continue;
             }
 
-            // Generate instrument ID using configured symbology method
-            let venue = self.determine_venue(&details.contract, Some(&details));
-            let instrument_id = match self.config.symbology_method {
-                crate::config::SymbologyMethod::Simplified => {
-                    crate::common::parse::ib_contract_to_instrument_id_simplified(
-                        &details.contract,
-                        Some(venue),
-                    )
-                }
-                crate::config::SymbologyMethod::Raw => {
-                    crate::common::parse::ib_contract_to_instrument_id_raw(
-                        &details.contract,
-                        Some(venue),
-                    )
-                }
-            }
-            .context("Failed to convert IB contract to instrument ID")?;
-
             // Check if security type is filtered
-            let sec_type_str = format!("{:?}", details.contract.security_type);
+            let sec_type_str = security_type_code(&details.contract.security_type);
             if self.is_filtered_sec_type(&sec_type_str) {
                 continue;
             }
@@ -1809,20 +2036,11 @@ impl InteractiveBrokersInstrumentProvider {
                 }
             }
 
-            // Parse to Nautilus instrument
-            match parse_ib_contract_to_instrument(&details, instrument_id) {
-                Ok(parsed_instrument) => {
-                    // Cache the instrument and mappings
-                    self.instruments.insert(instrument_id, parsed_instrument);
-                    self.contract_details.insert(instrument_id, details.clone());
-                    self.contracts
-                        .insert(instrument_id, details.contract.clone());
-                    self.contract_id_to_instrument_id
-                        .insert(contract_id, instrument_id);
-                    self.price_magnifiers
-                        .insert(instrument_id, details.price_magnifier);
+            match self.process_contract_detail(&details, None, false) {
+                Ok(Some(_instrument_id)) => {
                     total_loaded += 1;
                 }
+                Ok(None) => {}
                 Err(e) => {
                     tracing::warn!("Failed to parse futures instrument: {}", e);
                 }
@@ -2010,12 +2228,6 @@ impl InteractiveBrokersInstrumentProvider {
         let spread_instrument_id = create_spread_instrument_id(&leg_tuples)
             .context("Failed to create spread instrument ID from leg tuples")?;
 
-        // Check if spread is already cached
-        if self.instruments.contains_key(&spread_instrument_id) {
-            tracing::info!("Spread instrument {} already cached", spread_instrument_id);
-            return Ok(0);
-        }
-
         // Fetch BAG contract details (for storing the mapping)
         let bag_details_vec = client
             .contract_details(bag_contract)
@@ -2024,11 +2236,34 @@ impl InteractiveBrokersInstrumentProvider {
 
         if bag_details_vec.is_empty() {
             tracing::warn!("No contract details returned for BAG contract");
+
+            if bag_contract.contract_id != 0 && self.instruments.contains_key(&spread_instrument_id)
+            {
+                self.contract_id_to_instrument_id
+                    .insert(bag_contract.contract_id, spread_instrument_id);
+            }
             return Ok(0);
         }
 
         let bag_details = &bag_details_vec[0];
         let bag_contract_id = bag_details.contract.contract_id;
+
+        if bag_contract_id != 0 {
+            self.contract_id_to_instrument_id
+                .insert(bag_contract_id, spread_instrument_id);
+        }
+
+        // Check if spread is already cached after ensuring the BAG contract ID is mapped.
+        if self.instruments.contains_key(&spread_instrument_id) {
+            tracing::info!("Spread instrument {} already cached", spread_instrument_id);
+            self.contract_details
+                .insert(spread_instrument_id, bag_details.clone());
+            self.contracts
+                .insert(spread_instrument_id, bag_details.contract.clone());
+            self.price_magnifiers
+                .insert(spread_instrument_id, bag_details.price_magnifier);
+            return Ok(0);
+        }
 
         // Create the spread instrument
         let timestamp = nautilus_core::time::get_atomic_clock_realtime().get_time_ns();
@@ -2052,8 +2287,6 @@ impl InteractiveBrokersInstrumentProvider {
             .insert(spread_instrument_id, bag_details.clone());
         self.contracts
             .insert(spread_instrument_id, bag_details.contract.clone());
-        self.contract_id_to_instrument_id
-            .insert(bag_contract_id, spread_instrument_id);
         self.price_magnifiers
             .insert(spread_instrument_id, bag_details.price_magnifier);
 
@@ -2094,6 +2327,16 @@ impl InteractiveBrokersInstrumentProvider {
                 .price_magnifiers
                 .iter()
                 .map(|entry| (entry.key().to_string(), *entry.value()))
+                .collect(),
+            contracts: self
+                .contracts
+                .iter()
+                .map(|entry| (entry.key().to_string(), entry.value().clone()))
+                .collect(),
+            contract_details: self
+                .contract_details
+                .iter()
+                .map(|entry| (entry.key().to_string(), entry.value().clone()))
                 .collect(),
             instruments: self
                 .instruments
@@ -2172,11 +2415,13 @@ impl InteractiveBrokersInstrumentProvider {
 
                         if let Ok(value) =
                             serde_json::from_str::<serde_json::Value>(instrument_json)
-                            && let Some(contract_json) =
-                                value.get("info").and_then(|info| info.get("contract"))
-                            && let Ok(contract) =
-                                crate::common::contracts::parse_contract_from_json(contract_json)
+                            && let Some(contract_json) = find_contract_json(&value)
+                            && let Ok(contract) = parse_contract_from_json(contract_json)
                         {
+                            if contract.contract_id != 0 {
+                                self.contract_id_to_instrument_id
+                                    .insert(contract.contract_id, instrument_id);
+                            }
                             self.contracts.insert(instrument_id, contract);
                         }
                         loaded_count += 1;
@@ -2192,6 +2437,29 @@ impl InteractiveBrokersInstrumentProvider {
                 Err(e) => {
                     tracing::warn!("Failed to parse instrument ID {}: {}", instrument_id_str, e);
                 }
+            }
+        }
+
+        // Restore contracts and contract details
+        for (instrument_id_str, contract) in &cache.contracts {
+            if let Ok(instrument_id) = InstrumentId::from_str(instrument_id_str) {
+                if contract.contract_id != 0 {
+                    self.contract_id_to_instrument_id
+                        .insert(contract.contract_id, instrument_id);
+                }
+                self.contracts.insert(instrument_id, contract.clone());
+            }
+        }
+
+        for (instrument_id_str, details) in &cache.contract_details {
+            if let Ok(instrument_id) = InstrumentId::from_str(instrument_id_str) {
+                if details.contract.contract_id != 0 {
+                    self.contract_id_to_instrument_id
+                        .insert(details.contract.contract_id, instrument_id);
+                }
+                self.contracts
+                    .insert(instrument_id, details.contract.clone());
+                self.contract_details.insert(instrument_id, details.clone());
             }
         }
 
@@ -2224,15 +2492,17 @@ impl InteractiveBrokersInstrumentProvider {
 mod tests {
     use std::fs;
 
-    use nautilus_core::UnixNanos;
+    use nautilus_core::{Params, UnixNanos};
     use nautilus_model::{
         identifiers::{Symbol, Venue},
         instruments::CurrencyPair,
         types::{Price, Quantity, currency::Currency},
     };
+    use rstest::rstest;
     use tempfile::TempDir;
 
     use super::*;
+    use crate::common::contract_to_json_value;
 
     fn create_test_provider_with_cache() -> (InteractiveBrokersInstrumentProvider, TempDir) {
         let temp_dir = TempDir::new().unwrap();
@@ -2253,6 +2523,13 @@ mod tests {
     }
 
     fn create_test_instrument(instrument_id: InstrumentId) -> InstrumentAny {
+        create_test_instrument_with_info(instrument_id, None)
+    }
+
+    fn create_test_instrument_with_info(
+        instrument_id: InstrumentId,
+        info: Option<Params>,
+    ) -> InstrumentAny {
         CurrencyPair::new(
             instrument_id,
             Symbol::from("EUR/USD"),
@@ -2274,11 +2551,17 @@ mod tests {
             None,
             None,
             None,
-            None,
+            info,
             UnixNanos::default(),
             UnixNanos::default(),
         )
         .into()
+    }
+
+    fn create_contract_info(contract: &Contract) -> Params {
+        let mut info = Params::new();
+        info.insert(String::from("contract"), contract_to_json_value(contract));
+        info
     }
 
     #[tokio::test]
@@ -2366,6 +2649,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_load_cache_restores_contract_details() {
+        let (provider, _temp_dir) = create_test_provider_with_cache();
+        let cache_path = provider.config.cache_path.as_ref().unwrap().clone();
+        let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("XNAS"));
+        let instrument = create_test_instrument(instrument_id);
+        let contract = Contract {
+            contract_id: 265598,
+            symbol: ibapi::contracts::Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            primary_exchange: Exchange::from("NASDAQ"),
+            currency: ibapi::contracts::Currency::from("USD"),
+            ..Default::default()
+        };
+        let details = ibapi::contracts::ContractDetails {
+            contract: contract.clone(),
+            price_magnifier: 1,
+            ..Default::default()
+        };
+
+        provider.cache_instrument(
+            instrument_id,
+            instrument,
+            Some(details),
+            Some(contract),
+            Some(1),
+            false,
+        );
+        provider.save_cache(&cache_path).await.unwrap();
+
+        let new_provider = InteractiveBrokersInstrumentProvider::new(provider.config.clone());
+
+        assert!(new_provider.load_cache(&cache_path).await.unwrap());
+        assert_eq!(
+            new_provider
+                .resolve_contract_for_instrument(instrument_id)
+                .unwrap()
+                .contract_id,
+            265598
+        );
+        assert_eq!(
+            new_provider
+                .instrument_id_to_ib_contract_details(&instrument_id)
+                .unwrap()
+                .contract
+                .contract_id,
+            265598
+        );
+    }
+
+    #[rstest]
+    fn test_filter_sec_types_uses_ib_codes_case_insensitive() {
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            filter_sec_types: [String::from("opt")].into_iter().collect(),
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+
+        assert!(provider.is_filtered_sec_type(&security_type_code(&SecurityType::Option)));
+        assert!(!provider.is_filtered_sec_type(&security_type_code(&SecurityType::Stock)));
+    }
+
+    #[rstest]
+    fn test_add_cached_instruments_only_seeds_ib_contracts() {
+        let provider = InteractiveBrokersInstrumentProvider::new(Default::default());
+        let ib_instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("XNAS"));
+        let non_ib_instrument_id =
+            InstrumentId::new(Symbol::from("BTCUSDT"), Venue::from("BINANCE"));
+        let contract = Contract {
+            contract_id: 265598,
+            symbol: ibapi::contracts::Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            primary_exchange: Exchange::from("NASDAQ"),
+            currency: ibapi::contracts::Currency::from("USD"),
+            ..Default::default()
+        };
+        let ib_instrument = create_test_instrument_with_info(
+            ib_instrument_id,
+            Some(create_contract_info(&contract)),
+        );
+        let non_ib_instrument = create_test_instrument(non_ib_instrument_id);
+
+        let count = provider.add_cached_instruments([ib_instrument, non_ib_instrument]);
+
+        assert_eq!(count, 1);
+        assert_eq!(provider.count(), 1);
+        assert!(provider.find(&ib_instrument_id).is_some());
+        assert!(provider.find(&non_ib_instrument_id).is_none());
+        assert_eq!(
+            provider
+                .resolve_contract_for_instrument(ib_instrument_id)
+                .unwrap()
+                .contract_id,
+            265598
+        );
+    }
+
+    #[tokio::test]
     async fn test_load_cache_missing_file() {
         let (provider, _temp_dir) = create_test_provider_with_cache();
         let cache_path = "/nonexistent/path/cache.json";
@@ -2392,6 +2774,8 @@ mod tests {
             cache_timestamp: old_timestamp,
             contract_id_to_instrument_id: vec![],
             price_magnifiers: vec![],
+            contracts: vec![],
+            contract_details: vec![],
             instruments: vec![],
         };
 

--- a/crates/adapters/interactive_brokers/src/providers/parse.rs
+++ b/crates/adapters/interactive_brokers/src/providers/parse.rs
@@ -168,7 +168,9 @@ pub fn parse_ib_contract_to_instrument(
         SecurityType::Stock => Ok(parse_equity_contract(details, instrument_id)),
         SecurityType::ForexPair => Ok(parse_forex_contract(details, instrument_id)),
         SecurityType::Crypto => Ok(parse_crypto_contract(details, instrument_id)),
-        SecurityType::Future => Ok(parse_futures_contract(details, instrument_id)),
+        SecurityType::Future | SecurityType::ContinuousFuture => {
+            Ok(parse_futures_contract(details, instrument_id))
+        }
         SecurityType::Option => parse_option_contract(details, instrument_id),
         SecurityType::FuturesOption => parse_option_contract(details, instrument_id), // FOP uses same parsing as OPT
         SecurityType::Index => Ok(parse_index_contract(details, instrument_id)),
@@ -378,9 +380,19 @@ fn parse_futures_contract(
 
     let multiplier = parse_contract_multiplier(&details.contract.multiplier, 1.0);
 
+    let raw_symbol = if matches!(
+        details.contract.security_type,
+        SecurityType::ContinuousFuture
+    ) && !details.contract.symbol.as_str().is_empty()
+    {
+        details.contract.symbol.as_str()
+    } else {
+        details.contract.local_symbol.as_str()
+    };
+
     let instrument = FuturesContract::new(
         instrument_id,
-        Symbol::from(details.contract.local_symbol.as_str()),
+        Symbol::from(raw_symbol),
         sec_type_to_asset_class(details.under_security_type.as_str()),
         None, // exchange
         Ustr::from(details.under_symbol.as_str()),
@@ -487,12 +499,15 @@ mod tests {
         enums::AssetClass,
         identifiers::{InstrumentId, Symbol as NautilusSymbol, Venue},
         instruments::{Instrument, InstrumentAny},
-        types::Quantity,
+        types::{Price, Quantity},
     };
     use rstest::rstest;
     use ustr::Ustr;
 
-    use super::{parse_contract_multiplier, parse_ib_contract_to_instrument};
+    use super::{
+        parse_contract_multiplier, parse_ib_contract_to_instrument,
+        parse_option_spread_instrument_id,
+    };
 
     #[rstest]
     fn test_parse_option_contract_prefixes_index_underlying() {
@@ -571,6 +586,79 @@ mod tests {
             Quantity::new(expected, 0)
         );
     }
+
+    #[rstest]
+    fn test_parse_continuous_future_contract_uses_symbol_as_raw_symbol() {
+        let details = ContractDetails {
+            contract: Contract {
+                symbol: Symbol::from("ES"),
+                security_type: SecurityType::ContinuousFuture,
+                exchange: Exchange::from("CME"),
+                currency: Currency::from("USD"),
+                local_symbol: String::new(),
+                multiplier: "50".to_string(),
+                ..Default::default()
+            },
+            min_tick: 0.25,
+            under_symbol: "ES".to_string(),
+            under_security_type: "IND".to_string(),
+            ..Default::default()
+        };
+        let instrument_id = InstrumentId::new(NautilusSymbol::from("ES"), Venue::from("CME"));
+
+        let instrument = parse_ib_contract_to_instrument(&details, instrument_id).unwrap();
+
+        let InstrumentAny::FuturesContract(future) = instrument else {
+            panic!("expected futures contract");
+        };
+
+        assert_eq!(future.raw_symbol().as_str(), "ES");
+    }
+
+    #[rstest]
+    fn test_parse_option_spread_uses_minimum_leg_tick() {
+        let leg1 = ContractDetails {
+            contract: Contract {
+                symbol: Symbol::from("SPY"),
+                security_type: SecurityType::Option,
+                exchange: Exchange::from("SMART"),
+                currency: Currency::from("USD"),
+                local_symbol: "SPY   260120C00400000".to_string(),
+                multiplier: "100".to_string(),
+                ..Default::default()
+            },
+            min_tick: 0.05,
+            under_symbol: "SPY".to_string(),
+            ..Default::default()
+        };
+        let leg2 = ContractDetails {
+            contract: Contract {
+                symbol: Symbol::from("SPY"),
+                security_type: SecurityType::Option,
+                exchange: Exchange::from("SMART"),
+                currency: Currency::from("USD"),
+                local_symbol: "SPY   260120C00410000".to_string(),
+                multiplier: "100".to_string(),
+                ..Default::default()
+            },
+            min_tick: 0.01,
+            under_symbol: "SPY".to_string(),
+            ..Default::default()
+        };
+        let instrument_id =
+            InstrumentId::from("(1)SPY   260120C00400000_((-1))SPY   260120C00410000.SMART");
+
+        let spread = parse_option_spread_instrument_id(
+            instrument_id,
+            &[(&leg1, 1), (&leg2, -1)],
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(spread.price_precision(), 2);
+        assert_eq!(spread.price_increment(), Price::from("0.01"));
+    }
 }
 
 /// Parse index contract (IND).
@@ -641,9 +729,13 @@ pub fn parse_spread_instrument_id(
         _ => AssetClass::Equity,                                            // Equity options
     };
 
-    // Calculate price precision and increment
-    let price_precision = tick_size_to_precision(first_details.min_tick);
-    let price_increment = Price::new(first_details.min_tick, price_precision);
+    // Calculate price precision and increment from the finest leg tick.
+    let min_tick = leg_contract_details
+        .iter()
+        .map(|(details, _)| details.min_tick)
+        .fold(first_details.min_tick, f64::min);
+    let price_precision = tick_size_to_precision(min_tick);
+    let price_increment = Price::new(min_tick, price_precision);
 
     // Use provided timestamp or current time
     let timestamp = timestamp_ns.unwrap_or_else(|| get_atomic_clock_realtime().get_time_ns());
@@ -713,8 +805,12 @@ pub fn parse_futures_spread_instrument_id(
     };
     let multiplier = Quantity::from_str(&first_contract.multiplier.to_string())
         .unwrap_or_else(|_| Quantity::new(1.0, 0));
-    let price_precision = tick_size_to_precision(first_details.min_tick);
-    let price_increment = Price::new(first_details.min_tick, price_precision);
+    let min_tick = leg_contract_details
+        .iter()
+        .map(|(details, _)| details.min_tick)
+        .fold(first_details.min_tick, f64::min);
+    let price_precision = tick_size_to_precision(min_tick);
+    let price_increment = Price::new(min_tick, price_precision);
     let timestamp = timestamp_ns.unwrap_or_else(|| get_atomic_clock_realtime().get_time_ns());
 
     Ok(FuturesSpread::new_checked(

--- a/crates/adapters/interactive_brokers/src/providers/parse.rs
+++ b/crates/adapters/interactive_brokers/src/providers/parse.rs
@@ -189,6 +189,10 @@ fn ib_contract_info(details: &ibapi::contracts::ContractDetails) -> nautilus_cor
     }
 
     info.insert("contract".to_string(), serde_json::Value::Object(contract));
+    info.insert(
+        "priceMagnifier".to_string(),
+        serde_json::Value::from(details.price_magnifier),
+    );
     info
 }
 
@@ -523,6 +527,35 @@ mod tests {
 
         assert_eq!(option.asset_class(), AssetClass::Index);
         assert_eq!(option.underlying(), Some(Ustr::from("^SPX")));
+    }
+
+    #[rstest]
+    fn test_parse_contract_preserves_price_magnifier_in_info() {
+        let details = ContractDetails {
+            contract: Contract {
+                symbol: Symbol::from("AAPL"),
+                security_type: SecurityType::Stock,
+                exchange: Exchange::from("SMART"),
+                primary_exchange: Exchange::from("NASDAQ"),
+                currency: Currency::from("USD"),
+                local_symbol: String::from("AAPL"),
+                ..Default::default()
+            },
+            min_tick: 0.01,
+            price_magnifier: 100,
+            ..Default::default()
+        };
+        let instrument_id = InstrumentId::new(NautilusSymbol::from("AAPL"), Venue::from("XNAS"));
+
+        let instrument = parse_ib_contract_to_instrument(&details, instrument_id).unwrap();
+        let InstrumentAny::Equity(equity) = instrument else {
+            panic!("expected equity");
+        };
+
+        assert_eq!(
+            equity.info.unwrap().get("priceMagnifier"),
+            Some(&serde_json::Value::from(100))
+        );
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/providers/tests.rs
+++ b/crates/adapters/interactive_brokers/src/providers/tests.rs
@@ -17,17 +17,24 @@
 
 #[cfg(test)]
 mod tests {
-    use ibapi::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
+    use ibapi::contracts::{
+        ComboLeg, ComboLegOpenClose, Contract, Currency, Exchange, SecurityType, Symbol,
+    };
+    use nautilus_core::UnixNanos;
     use nautilus_model::{
+        enums::AssetClass,
         identifiers::{InstrumentId, Symbol as NautilusSymbol, Venue},
         instruments::{
-            Instrument, InstrumentAny,
+            Instrument, InstrumentAny, OptionSpread,
             stubs::{audusd_sim, equity_aapl, gbpusd_sim},
         },
+        types::{Currency as ModelCurrency, Price, Quantity},
     };
     use rstest::rstest;
+    use ustr::Ustr;
 
     use crate::{
+        common::parse::create_spread_instrument_id,
         config::InteractiveBrokersInstrumentProviderConfig,
         providers::instruments::InteractiveBrokersInstrumentProvider,
     };
@@ -35,6 +42,35 @@ mod tests {
     fn create_test_provider() -> InteractiveBrokersInstrumentProvider {
         let config = InteractiveBrokersInstrumentProviderConfig::default();
         InteractiveBrokersInstrumentProvider::new(config)
+    }
+
+    fn create_test_option_spread(instrument_id: InstrumentId) -> OptionSpread {
+        OptionSpread::new(
+            instrument_id,
+            NautilusSymbol::from(instrument_id.symbol.as_str()),
+            AssetClass::Equity,
+            Some(Ustr::from("XNAS")),
+            Ustr::from("SPY"),
+            Ustr::from("SPY"),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            ModelCurrency::USD(),
+            2,
+            Price::from("0.01"),
+            Quantity::from(1),
+            Quantity::from(1),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        )
     }
 
     // Note: Tests for load_async, load_with_return_async, load_ids_async, and load_ids_with_return_async
@@ -53,6 +89,98 @@ mod tests {
                 .get_instrument_id_by_contract_id(contract_id)
                 .is_none()
         );
+    }
+
+    #[rstest]
+    fn test_resolve_instrument_id_for_contract_uses_cached_contract_id() {
+        let provider = create_test_provider();
+        let instrument = equity_aapl();
+        let expected_id = instrument.id();
+        provider.insert_test_instrument(InstrumentAny::from(instrument), 265598, 1);
+        let contract = Contract {
+            contract_id: 265598,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let instrument_id = provider
+            .resolve_instrument_id_for_contract(&contract)
+            .unwrap();
+
+        assert_eq!(instrument_id, expected_id);
+    }
+
+    #[rstest]
+    fn test_resolve_instrument_id_for_contract_reuses_cached_stock_venue() {
+        let provider = create_test_provider();
+        let instrument = equity_aapl();
+        let expected_id = instrument.id();
+        provider.insert_test_instrument(InstrumentAny::from(instrument), 265598, 1);
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let instrument_id = provider
+            .resolve_instrument_id_for_contract(&contract)
+            .unwrap();
+
+        assert_eq!(instrument_id, expected_id);
+    }
+
+    #[rstest]
+    fn test_resolve_instrument_id_for_bag_contract_uses_cached_combo_legs() {
+        let provider = create_test_provider();
+        let long_leg = InstrumentId::from("SPY C400.SMART");
+        let short_leg = InstrumentId::from("SPY C410.SMART");
+        let expected_id = create_spread_instrument_id(&[(long_leg, 1), (short_leg, -1)]).unwrap();
+        let spread = create_test_option_spread(expected_id);
+        provider.insert_test_instrument(InstrumentAny::from(spread), 9000, 1);
+        provider.insert_test_contract_id_mapping(1001, long_leg);
+        provider.insert_test_contract_id_mapping(1002, short_leg);
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("SPY"),
+            security_type: SecurityType::Spread,
+            exchange: Exchange::from("SMART"),
+            currency: Currency::from("USD"),
+            combo_legs: vec![
+                ComboLeg {
+                    contract_id: 1001,
+                    ratio: 1,
+                    action: String::from("BUY"),
+                    exchange: String::from("SMART"),
+                    open_close: ComboLegOpenClose::Same,
+                    short_sale_slot: 0,
+                    designated_location: String::new(),
+                    exempt_code: 0,
+                },
+                ComboLeg {
+                    contract_id: 1002,
+                    ratio: 1,
+                    action: String::from("SELL"),
+                    exchange: String::from("SMART"),
+                    open_close: ComboLegOpenClose::Same,
+                    short_sale_slot: 0,
+                    designated_location: String::new(),
+                    exempt_code: 0,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let instrument_id = provider
+            .resolve_instrument_id_for_contract(&contract)
+            .unwrap();
+
+        assert_eq!(instrument_id, expected_id);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/python/config.rs
+++ b/crates/adapters/interactive_brokers/src/python/config.rs
@@ -302,7 +302,7 @@ impl InteractiveBrokersExecClientConfig {
 impl InteractiveBrokersInstrumentProviderConfig {
     /// Creates a new `InteractiveBrokersInstrumentProviderConfig` instance.
     #[new]
-    #[pyo3(signature = (symbology_method=None, load_ids=None, load_contracts=None, min_expiry_days=None, max_expiry_days=None, build_options_chain=None, build_futures_chain=None, cache_validity_days=None, convert_exchange_to_mic_venue=None, symbol_to_mic_venue=None, filter_sec_types=None, cache_path=None))]
+    #[pyo3(signature = (symbology_method=None, load_ids=None, load_contracts=None, min_expiry_days=None, max_expiry_days=None, build_options_chain=None, build_futures_chain=None, cache_validity_days=None, convert_exchange_to_mic_venue=None, symbol_to_mic_venue=None, filter_sec_types=None, filter_callable=None, cache_path=None))]
     #[allow(clippy::too_many_arguments)]
     fn py_new(
         py: Python<'_>,
@@ -317,6 +317,7 @@ impl InteractiveBrokersInstrumentProviderConfig {
         convert_exchange_to_mic_venue: Option<bool>,
         symbol_to_mic_venue: Option<std::collections::HashMap<String, String>>,
         filter_sec_types: Option<std::collections::HashSet<String>>,
+        filter_callable: Option<String>,
         cache_path: Option<String>,
     ) -> PyResult<Self> {
         Ok(Self {
@@ -335,6 +336,7 @@ impl InteractiveBrokersInstrumentProviderConfig {
             convert_exchange_to_mic_venue: convert_exchange_to_mic_venue.unwrap_or(false),
             symbol_to_mic_venue: symbol_to_mic_venue.unwrap_or_default(),
             filter_sec_types: filter_sec_types.unwrap_or_default(),
+            filter_callable,
             cache_path,
         })
     }
@@ -411,6 +413,12 @@ impl InteractiveBrokersInstrumentProviderConfig {
     #[getter]
     fn filter_sec_types(&self) -> Vec<String> {
         self.filter_sec_types.iter().cloned().collect()
+    }
+
+    /// Returns the custom instrument filter callable path.
+    #[getter]
+    fn filter_callable(&self) -> Option<String> {
+        self.filter_callable.clone()
     }
 
     /// Returns the cache path for persistent instrument caching.

--- a/crates/adapters/interactive_brokers/src/python/historical.rs
+++ b/crates/adapters/interactive_brokers/src/python/historical.rs
@@ -126,7 +126,8 @@ impl HistoricalInteractiveBrokersClient {
     /// * `instrument_ids` - Optional list of instrument IDs
     /// * `use_rth` - Use regular trading hours only
     /// * `timeout` - Request timeout in seconds
-    #[pyo3(signature = (tick_type, start_date_time, end_date_time, contracts=None, instrument_ids=None, use_rth=true, timeout=60))]
+    /// * `limit` - Maximum number of ticks to return, or 0 for no explicit limit
+    #[pyo3(signature = (tick_type, start_date_time, end_date_time, contracts=None, instrument_ids=None, use_rth=true, timeout=60, limit=0))]
     #[pyo3(name = "request_ticks")]
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::needless_pass_by_value)]
@@ -140,6 +141,7 @@ impl HistoricalInteractiveBrokersClient {
         instrument_ids: Option<Vec<InstrumentId>>,
         use_rth: bool,
         timeout: u64,
+        limit: usize,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.clone();
 
@@ -166,6 +168,7 @@ impl HistoricalInteractiveBrokersClient {
                     instrument_ids,
                     use_rth,
                     timeout,
+                    limit,
                 )
                 .await
                 .map_err(to_pyruntime_err)?;

--- a/crates/adapters/interactive_brokers/src/python/historical.rs
+++ b/crates/adapters/interactive_brokers/src/python/historical.rs
@@ -15,8 +15,6 @@
 
 //! Python bindings for the Interactive Brokers historical data client.
 
-use std::sync::Arc;
-
 use chrono::{DateTime, Utc};
 use ibapi::contracts::Contract;
 use nautilus_common::live::get_runtime;
@@ -42,19 +40,9 @@ impl HistoricalInteractiveBrokersClient {
         instrument_provider: crate::providers::instruments::InteractiveBrokersInstrumentProvider,
         config: crate::config::InteractiveBrokersDataClientConfig,
     ) -> PyResult<Self> {
-        let shared_client = get_runtime()
-            .block_on(crate::common::shared_client::get_or_connect(
-                &config.host,
-                config.port,
-                config.client_id,
-                config.connection_timeout,
-            ))
-            .map_err(to_pyruntime_err)?;
-
-        Ok(Self::new(
-            Arc::clone(shared_client.as_arc()),
-            Arc::new(instrument_provider),
-        ))
+        get_runtime()
+            .block_on(Self::connect_with_provider(instrument_provider, config))
+            .map_err(to_pyruntime_err)
     }
 
     fn __repr__(&self) -> String {

--- a/examples/live/interactive_brokers_v2/notebooks/reconciliation_example.py
+++ b/examples/live/interactive_brokers_v2/notebooks/reconciliation_example.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _common import add_strategy_from_config
+from _common import build_ib_live_node
+from _common import default_stock_contracts
+from _common import env_int
+from _common import instrument_provider_config
+from _common import resolve_ib_endpoint
+from _common import schedule_node_stop
+
+
+def main() -> None:
+    account_id = os.getenv("TWS_ACCOUNT")
+    if account_id is None:
+        raise RuntimeError("Set TWS_ACCOUNT to run the IB v2 reconciliation example")
+
+    os.environ.setdefault("IB_V2_RECONCILIATION", "1")
+    host, port = resolve_ib_endpoint()
+    provider_config = instrument_provider_config(load_contracts=default_stock_contracts())
+    node = build_ib_live_node(
+        name="IB-V2-RECONCILIATION-001",
+        trader_id="IB-V2-RECONCILIATION-001",
+        host=host,
+        port=port,
+        data_client_id=env_int("IB_V2_DATA_CLIENT_ID", 1501),
+        exec_client_id=env_int("IB_V2_EXEC_CLIENT_ID", 1502),
+        account_id=account_id,
+        provider_config=provider_config,
+    )
+    add_strategy_from_config(
+        node,
+        "ib_v2_order_strategies:IbV2SubscriptionStrategy",
+    )
+
+    print(
+        f"Running v2 IB reconciliation example against {host}:{port}; press Ctrl+C to stop.",
+        flush=True,
+    )
+    schedule_node_stop(node, env_int("IB_V2_AUTO_STOP_SECONDS", 20))
+    node.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/nautilus_trader/adapters/interactive_brokers_pyo3/historical.py
+++ b/nautilus_trader/adapters/interactive_brokers_pyo3/historical.py
@@ -22,7 +22,6 @@ Brokers adapter, providing the same API as the Python adapter but with Rust perf
 
 from __future__ import annotations
 
-from datetime import UTC
 from datetime import datetime
 
 from nautilus_trader.adapters.interactive_brokers_pyo3._contracts import IBContractSpec
@@ -108,19 +107,6 @@ class HistoricalInteractiveBrokersClient:
 
         return data
 
-    @staticmethod
-    def _normalize_request_datetime(value: datetime, field_name: str) -> datetime:
-        if value.tzinfo is None:
-            return value.replace(tzinfo=UTC)
-
-        offset = value.utcoffset()
-        if offset is None or offset.total_seconds() != 0:
-            raise ValueError(
-                f"{field_name} must be UTC. Configure TWS / IB Gateway to use UTC timestamps.",
-            )
-
-        return value.astimezone(UTC)
-
     async def request_instruments(
         self,
         instrument_ids: list[str] | None = None,
@@ -199,21 +185,11 @@ class HistoricalInteractiveBrokersClient:
         # Convert instrument ID strings to InstrumentId objects
         instrument_id_objs = self._normalize_instrument_ids(instrument_ids)
 
-        end_date_time = self._normalize_request_datetime(end_date_time, "end_date_time")
-
-        start_dt_utc = None
-
-        if start_date_time:
-            start_dt_utc = self._normalize_request_datetime(
-                start_date_time,
-                "start_date_time",
-            )
-
         # Call Rust client method
         result = await self._rust_client.request_bars(
             bar_specifications=bar_specifications,
             end_date_time=end_date_time,
-            start_date_time=start_dt_utc,
+            start_date_time=start_date_time,
             duration=duration,
             contracts=contracts_dicts,
             instrument_ids=instrument_id_objs,
@@ -232,6 +208,7 @@ class HistoricalInteractiveBrokersClient:
         instrument_ids: list[str] | None = None,
         use_rth: bool = True,
         timeout: int = 120,
+        limit: int = 0,
     ) -> list[Data]:
         """
         Request historical ticks from Interactive Brokers.
@@ -252,6 +229,8 @@ class HistoricalInteractiveBrokersClient:
             Use regular trading hours only.
         timeout : int, default 120
             Request timeout in seconds.
+        limit : int, default 0
+            Maximum number of ticks to return. Zero means no explicit limit.
 
         Returns
         -------
@@ -264,9 +243,6 @@ class HistoricalInteractiveBrokersClient:
         # Convert instrument ID strings to InstrumentId objects
         instrument_id_objs = self._normalize_instrument_ids(instrument_ids)
 
-        start_date_time = self._normalize_request_datetime(start_date_time, "start_date_time")
-        end_date_time = self._normalize_request_datetime(end_date_time, "end_date_time")
-
         # Call Rust client method
         result = await self._rust_client.request_ticks(
             tick_type=tick_type,
@@ -276,6 +252,7 @@ class HistoricalInteractiveBrokersClient:
             instrument_ids=instrument_id_objs,
             use_rth=use_rth,
             timeout=timeout,
+            limit=limit,
         )
 
         return self._normalize_data(result)

--- a/tests/integration_tests/adapters/interactive_brokers/test_ib_pyo3_provider.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_ib_pyo3_provider.py
@@ -298,18 +298,22 @@ async def test_pyo3_historical_client_normalizes_results_for_v1(monkeypatch):
         instrument_provider=provider,
         config=config,
     )
+    bars_start = pd.Timestamp("2025-11-06 09:30:00").to_pydatetime()
+    bars_end = pd.Timestamp("2025-11-06 10:30:00").to_pydatetime()
+    ticks_start = pd.Timestamp("2025-11-06 10:00:00").to_pydatetime()
+    ticks_end = pd.Timestamp("2025-11-06 10:01:00").to_pydatetime()
 
     instruments = await client.request_instruments(instrument_ids=["AAPL.NASDAQ"])
     bars = await client.request_bars(
         bar_specifications=["1-HOUR-LAST"],
-        start_date_time=pd.Timestamp("2025-11-06 09:30:00").to_pydatetime(),
-        end_date_time=pd.Timestamp("2025-11-06 10:30:00").to_pydatetime(),
+        start_date_time=bars_start,
+        end_date_time=bars_end,
         instrument_ids=["AAPL.NASDAQ"],
     )
     ticks = await client.request_ticks(
         tick_type="TRADES",
-        start_date_time=pd.Timestamp("2025-11-06 10:00:00").to_pydatetime(),
-        end_date_time=pd.Timestamp("2025-11-06 10:01:00").to_pydatetime(),
+        start_date_time=ticks_start,
+        end_date_time=ticks_end,
         instrument_ids=["AAPL.NASDAQ"],
     )
 
@@ -321,11 +325,15 @@ async def test_pyo3_historical_client_normalizes_results_for_v1(monkeypatch):
         "contracts": None,
     }
     assert client._rust_client.request_bars_kwargs["instrument_ids"] == ["pyo3:AAPL.NASDAQ"]
+    assert client._rust_client.request_bars_kwargs["start_date_time"] == bars_start
+    assert client._rust_client.request_bars_kwargs["end_date_time"] == bars_end
     assert client._rust_client.request_ticks_kwargs["instrument_ids"] == ["pyo3:AAPL.NASDAQ"]
+    assert client._rust_client.request_ticks_kwargs["start_date_time"] == ticks_start
+    assert client._rust_client.request_ticks_kwargs["end_date_time"] == ticks_end
 
 
 @pytest.mark.asyncio
-async def test_pyo3_historical_client_rejects_non_utc_aware_datetimes(monkeypatch):
+async def test_pyo3_historical_client_leaves_datetime_validation_to_rust(monkeypatch):
     from nautilus_trader.adapters.interactive_brokers_pyo3 import historical as historical_module
 
     monkeypatch.setattr(
@@ -334,35 +342,48 @@ async def test_pyo3_historical_client_rejects_non_utc_aware_datetimes(monkeypatc
         _FakeHistoricalRustClient,
     )
     monkeypatch.setattr(historical_module, "PyO3InstrumentId", _FakePyO3InstrumentId)
+    monkeypatch.setattr(
+        historical_module,
+        "Bar",
+        type("_FakeBar", (), {"from_pyo3_list": staticmethod(lambda values: values)}),
+    )
+    monkeypatch.setattr(historical_module, "capsule_to_data", lambda value: value)
 
     client = historical_module.HistoricalInteractiveBrokersClient(
         instrument_provider=SimpleNamespace(_rust_provider=object()),
         config=SimpleNamespace(),
     )
 
-    with pytest.raises(ValueError, match="must be UTC"):
-        await client.request_bars(
-            bar_specifications=["1-HOUR-LAST"],
-            start_date_time=pd.Timestamp("2025-11-06 09:30:00").to_pydatetime(),
-            end_date_time=pd.Timestamp("2025-11-06 10:30:00")
-            .to_pydatetime()
-            .replace(
-                tzinfo=timezone(timedelta(hours=-5)),
-            ),
-            instrument_ids=["AAPL.NASDAQ"],
+    bars_end = (
+        pd.Timestamp("2025-11-06 10:30:00")
+        .to_pydatetime()
+        .replace(
+            tzinfo=timezone(timedelta(hours=-5)),
         )
+    )
+    ticks_start = (
+        pd.Timestamp("2025-11-06 10:00:00")
+        .to_pydatetime()
+        .replace(
+            tzinfo=timezone(timedelta(hours=1)),
+        )
+    )
 
-    with pytest.raises(ValueError, match="must be UTC"):
-        await client.request_ticks(
-            tick_type="TRADES",
-            start_date_time=pd.Timestamp("2025-11-06 10:00:00")
-            .to_pydatetime()
-            .replace(
-                tzinfo=timezone(timedelta(hours=1)),
-            ),
-            end_date_time=pd.Timestamp("2025-11-06 10:01:00").to_pydatetime(),
-            instrument_ids=["AAPL.NASDAQ"],
-        )
+    await client.request_bars(
+        bar_specifications=["1-HOUR-LAST"],
+        start_date_time=pd.Timestamp("2025-11-06 09:30:00").to_pydatetime(),
+        end_date_time=bars_end,
+        instrument_ids=["AAPL.NASDAQ"],
+    )
+    await client.request_ticks(
+        tick_type="TRADES",
+        start_date_time=ticks_start,
+        end_date_time=pd.Timestamp("2025-11-06 10:01:00").to_pydatetime(),
+        instrument_ids=["AAPL.NASDAQ"],
+    )
+
+    assert client._rust_client.request_bars_kwargs["end_date_time"] == bars_end
+    assert client._rust_client.request_ticks_kwargs["start_date_time"] == ticks_start
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/adapters/interactive_brokers/test_pyo3_config.py
+++ b/tests/unit_tests/adapters/interactive_brokers/test_pyo3_config.py
@@ -86,9 +86,11 @@ def test_adapter_config_and_status_enums_are_python_accessible() -> None:
 
     provider_config = ib.InteractiveBrokersInstrumentProviderConfig(
         symbology_method=ib.SymbologyMethod.RAW,
+        filter_callable="package.module.filter_instrument",
     )
 
     assert provider_config.symbology_method == ib.SymbologyMethod.RAW
+    assert provider_config.filter_callable == "package.module.filter_instrument"
     assert ib.ContainerStatus.READY == ib.ContainerStatus.READY
     assert ib.ErrorCategory.CONNECTIVITY_ERROR.as_str() == "ConnectivityError"
     assert ib.InteractiveBrokersErrorKind.IB_API.as_str() == "IbApi"


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Applied configured historical `market_data_type` during Rust historical connection and initialized the provider with the connected IB client.
- Added historical tick `limit` and timeout support through the Rust historical API and exposed them through PyO3.
- Kept historical request datetime policy in Rust/PyO3 types by passing datetimes through the Python wrapper without wrapper-side normalization.
- Applied IB price magnifiers to Rust historical bars, historical ticks, and data-client historical quote/trade responses.
- Removed the implicit 1000-tick cap when historical quote/trade requests do not specify `limit`.
- Matched Python historical tick pagination by retreating end timestamps by one millisecond.
- Sorted, de-duplicated, and limit-trimmed historical bar responses across segmented requests.
- Propagated realtime bar `use_regular_trading_hours` and historical streaming `handle_revised_bars`.
- Passed `force` and string filter params through Rust `request_instrument` resolution.
- Accepted structured `ib_contracts` request params in addition to JSON strings and returned an empty response for request-instruments calls without explicit contracts.
- Aligned Rust parsing with Python parsing for FOP spacing, OCC option local symbols, named futures, MIC futures exchanges, `IBCFD`, longer crypto base symbols, continuous futures contract details, and spread min-tick precision.
- Added regression coverage for historical pagination helpers, data request options, and parsing parity cases.

### Design notes

- Historical requests now use provider metadata before converting prices, which keeps index and option values consistent with the Python adapter when IB returns magnified prices.
- Tick request limits are optional. The Rust historical client owns the `0` means unlimited sentinel, and when no limit is provided Rust continues pagination instead of silently stopping at 1000 ticks.
- Historical bar segmentation keeps the most recent requested bars after sorting and de-duplication, matching the user-facing `RequestBars.limit` contract.
- Parsing changes keep Rust behavior aligned with the existing Python adapter instead of introducing new symbology rules.

### Verification

- `cargo check -p nautilus-interactive-brokers --features python`.
- `cargo test -p nautilus-interactive-brokers --features python common::parse`.
- `cargo test -p nautilus-interactive-brokers --features python providers::parse`.
- `cargo test -p nautilus-interactive-brokers --features python data::convert`.
- `cargo test -p nautilus-interactive-brokers --features python data::core`.
- `cargo test -p nautilus-interactive-brokers --features python historical::client`.
- `make build-debug`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_ib_pyo3_provider.py tests/integration_tests/adapters/interactive_brokers/test_parsing.py`.
- `make format`.
- `make pre-commit`.

### References

- Fixes https://github.com/nautechsystems/nautilus_trader/issues/4142.
- Supports https://github.com/nautechsystems/nautilus_trader/issues/4148.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
