### PR TITLE
Add support for trigger children statuses in Hyperliquid order responses

### DIFF
--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -3089,95 +3089,202 @@ impl HyperliquidHttpClient {
         let mut reports = Vec::with_capacity(order_response.statuses.len());
 
         for (order, order_status) in orders.iter().zip(order_response.statuses.iter()) {
-            let instrument_id = order.instrument_id();
-            let symbol = instrument_id.symbol.as_str();
-            let product_type = HyperliquidProductType::from_symbol(symbol).ok();
+            reports.push(self.build_status_report(
+                order.instrument_id(),
+                order.client_order_id(),
+                order.order_side(),
+                order.order_type(),
+                order.quantity(),
+                order.time_in_force(),
+                order.price(),
+                order.trigger_price(),
+                order_status,
+                account_id,
+                ts_init,
+            )?);
+        }
 
-            // Mirror the alias `cache_instrument` stored (token form for
-            // outcomes, leading segment for perps / spots).
-            let asset = cache_alias_for_symbol(symbol).unwrap_or_else(|| symbol.to_string());
-            let instrument = self
-                .get_or_create_instrument(&Ustr::from(asset.as_str()), product_type)
-                .ok_or_else(|| Error::bad_request(format!("Instrument not found for {asset}")))?;
+        Ok(reports)
+    }
 
-            let report = match order_status {
-                HyperliquidExecOrderStatus::Resting { resting } => self.create_order_status_report(
-                    order.instrument_id(),
-                    Some(order.client_order_id()),
-                    VenueOrderId::new(resting.oid.to_string()),
-                    order.order_side(),
-                    order.order_type(),
-                    order.quantity(),
-                    order.time_in_force(),
-                    order.price(),
-                    order.trigger_price(),
+    /// Parse a Hyperliquid exchange `Order` response for a single-order submit
+    /// into an `OrderStatusReport`. Returns `Ok(None)` only if the venue
+    /// returned an empty `statuses` array.
+    ///
+    /// Shared by both the HTTP and WebSocket single-submit paths. Reuses the
+    /// same per-status mapping as the batch helper, so a `filled` immediate
+    /// fill, a `resting` accept, and a `Tag` (`waitingForFill`) all surface as
+    /// the corresponding `OrderStatusReport` instead of being dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if account credentials are missing, the response is
+    /// malformed, or the order returned an `error` status.
+    #[expect(clippy::too_many_arguments)]
+    pub fn build_submit_order_report(
+        &self,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        order_type: OrderType,
+        quantity: Quantity,
+        time_in_force: TimeInForce,
+        price: Option<Price>,
+        trigger_price: Option<Price>,
+        response: HyperliquidExchangeResponse,
+    ) -> Result<Option<OrderStatusReport>> {
+        let response_data = match response {
+            HyperliquidExchangeResponse::Status {
+                status,
+                response: response_data,
+            } if status == RESPONSE_STATUS_OK => response_data,
+            HyperliquidExchangeResponse::Error { error } => {
+                return Err(Error::bad_request(format!(
+                    "Order submission failed: {error}"
+                )));
+            }
+            _ => return Err(Error::bad_request("Unexpected response format")),
+        };
+
+        let data_value = if let Some(data) = response_data.get("data") {
+            data.clone()
+        } else {
+            response_data
+        };
+
+        let order_response: HyperliquidExecOrderResponseData = serde_json::from_value(data_value)
+            .map_err(|e| Error::bad_request(format!("Failed to parse order response: {e}")))?;
+
+        let Some(order_status) = order_response.statuses.first() else {
+            return Ok(None);
+        };
+
+        let account_id = self
+            .account_id
+            .ok_or_else(|| Error::bad_request("Account ID not set"))?;
+        let ts_init = self.clock.get_time_ns();
+
+        Ok(Some(self.build_status_report(
+            instrument_id,
+            client_order_id,
+            order_side,
+            order_type,
+            quantity,
+            time_in_force,
+            price,
+            trigger_price,
+            order_status,
+            account_id,
+            ts_init,
+        )?))
+    }
+
+    /// Build a single `OrderStatusReport` from one venue status entry.
+    ///
+    /// Looks up the instrument (creating it if needed for outcome aliases),
+    /// then maps the venue status to NT's `OrderStatus` + venue oid:
+    ///   * `resting` -> `Accepted` with real oid
+    ///   * `filled`  -> `Filled` with real oid and totalSz
+    ///   * `Tag`     -> `Accepted` with `pending-cloid:<client_order_id>`
+    ///                  placeholder (real oid arrives via user-events WS)
+    ///   * `error`   -> `Err`
+    #[expect(clippy::too_many_arguments)]
+    fn build_status_report(
+        &self,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        order_side: OrderSide,
+        order_type: OrderType,
+        quantity: Quantity,
+        time_in_force: TimeInForce,
+        price: Option<Price>,
+        trigger_price: Option<Price>,
+        order_status: &HyperliquidExecOrderStatus,
+        account_id: AccountId,
+        ts_init: UnixNanos,
+    ) -> Result<OrderStatusReport> {
+        let symbol = instrument_id.symbol.as_str();
+        let product_type = HyperliquidProductType::from_symbol(symbol).ok();
+
+        // Mirror the alias `cache_instrument` stored (token form for
+        // outcomes, leading segment for perps / spots).
+        let asset = cache_alias_for_symbol(symbol).unwrap_or_else(|| symbol.to_string());
+        let instrument = self
+            .get_or_create_instrument(&Ustr::from(asset.as_str()), product_type)
+            .ok_or_else(|| Error::bad_request(format!("Instrument not found for {asset}")))?;
+
+        let report = match order_status {
+            HyperliquidExecOrderStatus::Resting { resting } => self.create_order_status_report(
+                instrument_id,
+                Some(client_order_id),
+                VenueOrderId::new(resting.oid.to_string()),
+                order_side,
+                order_type,
+                quantity,
+                time_in_force,
+                price,
+                trigger_price,
+                OrderStatus::Accepted,
+                Quantity::new(0.0, instrument.size_precision()),
+                &instrument,
+                account_id,
+                ts_init,
+            ),
+            HyperliquidExecOrderStatus::Filled { filled } => {
+                let filled_qty = Quantity::new(
+                    filled.total_sz.to_string().parse::<f64>().unwrap_or(0.0),
+                    instrument.size_precision(),
+                );
+                self.create_order_status_report(
+                    instrument_id,
+                    Some(client_order_id),
+                    VenueOrderId::new(filled.oid.to_string()),
+                    order_side,
+                    order_type,
+                    quantity,
+                    time_in_force,
+                    price,
+                    trigger_price,
+                    OrderStatus::Filled,
+                    filled_qty,
+                    &instrument,
+                    account_id,
+                    ts_init,
+                )
+            }
+            HyperliquidExecOrderStatus::Error { error } => {
+                return Err(Error::bad_request(format!(
+                    "Order {client_order_id} rejected: {error}"
+                )));
+            }
+            HyperliquidExecOrderStatus::Tag(_) => {
+                // Deferred status (e.g. `waitingForFill` trigger child of a
+                // `normalTpsl` bracket): venue accepted the order but has not
+                // assigned an oid yet. Use a `pending-cloid:` placeholder —
+                // the real oid arrives via the user-events WS stream and is
+                // reconciled via the cloid mapping.
+                let placeholder =
+                    VenueOrderId::new(format!("pending-cloid:{}", client_order_id.as_str()));
+                self.create_order_status_report(
+                    instrument_id,
+                    Some(client_order_id),
+                    placeholder,
+                    order_side,
+                    order_type,
+                    quantity,
+                    time_in_force,
+                    price,
+                    trigger_price,
                     OrderStatus::Accepted,
                     Quantity::new(0.0, instrument.size_precision()),
                     &instrument,
                     account_id,
                     ts_init,
-                ),
-                HyperliquidExecOrderStatus::Filled { filled } => {
-                    let filled_qty = Quantity::new(
-                        filled.total_sz.to_string().parse::<f64>().unwrap_or(0.0),
-                        instrument.size_precision(),
-                    );
-                    self.create_order_status_report(
-                        order.instrument_id(),
-                        Some(order.client_order_id()),
-                        VenueOrderId::new(filled.oid.to_string()),
-                        order.order_side(),
-                        order.order_type(),
-                        order.quantity(),
-                        order.time_in_force(),
-                        order.price(),
-                        order.trigger_price(),
-                        OrderStatus::Filled,
-                        filled_qty,
-                        &instrument,
-                        account_id,
-                        ts_init,
-                    )
-                }
-                HyperliquidExecOrderStatus::Error { error } => {
-                    return Err(Error::bad_request(format!(
-                        "Order {} rejected: {error}",
-                        order.client_order_id()
-                    )));
-                }
-                HyperliquidExecOrderStatus::Tag(_) => {
-                    // Trigger child of a `normalTpsl` bracket (SL/TP): venue
-                    // accepted it atomically but has not assigned an oid yet.
-                    // Use a `pending-cloid:` placeholder — the real oid arrives
-                    // via the user-events WS stream and is reconciled via the
-                    // cloid mapping.
-                    let placeholder = VenueOrderId::new(format!(
-                        "pending-cloid:{}",
-                        order.client_order_id().as_str(),
-                    ));
-                    self.create_order_status_report(
-                        order.instrument_id(),
-                        Some(order.client_order_id()),
-                        placeholder,
-                        order.order_side(),
-                        order.order_type(),
-                        order.quantity(),
-                        order.time_in_force(),
-                        order.price(),
-                        order.trigger_price(),
-                        OrderStatus::Accepted,
-                        Quantity::new(0.0, instrument.size_precision()),
-                        &instrument,
-                        account_id,
-                        ts_init,
-                    )
-                }
-            };
+                )
+            }
+        };
 
-            reports.push(report);
-        }
-
-        Ok(reports)
+        Ok(report)
     }
 }
 

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -3086,10 +3086,13 @@ impl HyperliquidHttpClient {
             )));
         }
 
+        // `Tag` rows (deferred trigger children) return `None` and are elided
+        // here — those orders stay SUBMITTED until the user-events WS stream
+        // delivers an `OrderAccepted` with the real oid.
         let mut reports = Vec::with_capacity(order_response.statuses.len());
 
         for (order, order_status) in orders.iter().zip(order_response.statuses.iter()) {
-            reports.push(self.build_status_report(
+            if let Some(report) = self.build_status_report(
                 order.instrument_id(),
                 order.client_order_id(),
                 order.order_side(),
@@ -3101,20 +3104,25 @@ impl HyperliquidHttpClient {
                 order_status,
                 account_id,
                 ts_init,
-            )?);
+            )? {
+                reports.push(report);
+            }
         }
 
         Ok(reports)
     }
 
     /// Parse a Hyperliquid exchange `Order` response for a single-order submit
-    /// into an `OrderStatusReport`. Returns `Ok(None)` only if the venue
-    /// returned an empty `statuses` array.
+    /// into an `OrderStatusReport`.
+    ///
+    /// Returns `Ok(None)` when the venue returned an empty `statuses` array
+    /// OR when the only status is a deferred `Tag` (e.g. `waitingForFill`):
+    /// the venue accepted the order but hasn't assigned an oid yet, so we
+    /// leave the order in `SUBMITTED` and let the user-events WS stream
+    /// drive the first `OrderAccepted` with the real oid.
     ///
     /// Shared by both the HTTP and WebSocket single-submit paths. Reuses the
-    /// same per-status mapping as the batch helper, so a `filled` immediate
-    /// fill, a `resting` accept, and a `Tag` (`waitingForFill`) all surface as
-    /// the corresponding `OrderStatusReport` instead of being dropped.
+    /// same per-status mapping as the batch helper.
     ///
     /// # Errors
     ///
@@ -3164,7 +3172,10 @@ impl HyperliquidHttpClient {
             .ok_or_else(|| Error::bad_request("Account ID not set"))?;
         let ts_init = self.clock.get_time_ns();
 
-        Ok(Some(self.build_status_report(
+        // `Tag` statuses return `Ok(None)` from `build_status_report` so the
+        // caller leaves the order in SUBMITTED until the user-events WS stream
+        // confirms a real oid.
+        self.build_status_report(
             instrument_id,
             client_order_id,
             order_side,
@@ -3176,18 +3187,28 @@ impl HyperliquidHttpClient {
             order_status,
             account_id,
             ts_init,
-        )?))
+        )
     }
 
     /// Build a single `OrderStatusReport` from one venue status entry.
     ///
     /// Looks up the instrument (creating it if needed for outcome aliases),
     /// then maps the venue status to NT's `OrderStatus` + venue oid:
-    ///   * `resting` -> `Accepted` with real oid
-    ///   * `filled`  -> `Filled` with real oid and totalSz
-    ///   * `Tag`     -> `Accepted` with `pending-cloid:<client_order_id>`
-    ///                  placeholder (real oid arrives via user-events WS)
+    ///   * `resting` -> `Some(Accepted)` with real oid
+    ///   * `filled`  -> `Some(Filled)` with real oid and totalSz
+    ///   * `Tag`     -> `None` — the venue hasn't assigned an oid yet (e.g.
+    ///                  a `waitingForFill` trigger child of a `normalTpsl`
+    ///                  bracket). The caller should leave the order in
+    ///                  `SUBMITTED` and let the user-events WS stream drive
+    ///                  the first `OrderAccepted` with the real oid.
     ///   * `error`   -> `Err`
+    ///
+    /// Earlier revisions emitted a synthetic `pending-cloid:<client_order_id>`
+    /// venue id for `Tag` rows, but the subsequent user-events `OrderAccepted`
+    /// was deduped against the placeholder accept and the cache never picked
+    /// up the real oid — leaving cancel/modify by venue id broken on bracket
+    /// children. Eliding the row keeps the order honest until the venue
+    /// confirms an oid.
     #[expect(clippy::too_many_arguments)]
     fn build_status_report(
         &self,
@@ -3202,7 +3223,13 @@ impl HyperliquidHttpClient {
         order_status: &HyperliquidExecOrderStatus,
         account_id: AccountId,
         ts_init: UnixNanos,
-    ) -> Result<OrderStatusReport> {
+    ) -> Result<Option<OrderStatusReport>> {
+        // Tag rows carry no oid — return None so the caller can leave the
+        // order in SUBMITTED and defer to the user-events WS stream.
+        if matches!(order_status, HyperliquidExecOrderStatus::Tag(_)) {
+            return Ok(None);
+        }
+
         let symbol = instrument_id.symbol.as_str();
         let product_type = HyperliquidProductType::from_symbol(symbol).ok();
 
@@ -3257,34 +3284,10 @@ impl HyperliquidHttpClient {
                     "Order {client_order_id} rejected: {error}"
                 )));
             }
-            HyperliquidExecOrderStatus::Tag(_) => {
-                // Deferred status (e.g. `waitingForFill` trigger child of a
-                // `normalTpsl` bracket): venue accepted the order but has not
-                // assigned an oid yet. Use a `pending-cloid:` placeholder —
-                // the real oid arrives via the user-events WS stream and is
-                // reconciled via the cloid mapping.
-                let placeholder =
-                    VenueOrderId::new(format!("pending-cloid:{}", client_order_id.as_str()));
-                self.create_order_status_report(
-                    instrument_id,
-                    Some(client_order_id),
-                    placeholder,
-                    order_side,
-                    order_type,
-                    quantity,
-                    time_in_force,
-                    price,
-                    trigger_price,
-                    OrderStatus::Accepted,
-                    Quantity::new(0.0, instrument.size_precision()),
-                    &instrument,
-                    account_id,
-                    ts_init,
-                )
-            }
+            HyperliquidExecOrderStatus::Tag(_) => unreachable!("handled above"),
         };
 
-        Ok(report)
+        Ok(Some(report))
     }
 }
 
@@ -3329,7 +3332,10 @@ mod tests {
             consts::HYPERLIQUID_VENUE,
             enums::{HyperliquidEnvironment, HyperliquidProductType},
         },
-        http::{models::Cloid, query::InfoRequest},
+        http::{
+            models::{Cloid, HyperliquidExchangeResponse},
+            query::InfoRequest,
+        },
     };
 
     const TEST_PRIVATE_KEY: &str =
@@ -3410,6 +3416,51 @@ mod tests {
         let pretty = serde_json::to_string_pretty(&val).unwrap();
         assert!(pretty.contains("\"type\": \"l2Book\""));
         assert!(pretty.contains("\"coin\": \"BTC\""));
+    }
+
+    #[rstest]
+    fn test_build_submit_order_report_elides_waiting_for_fill_tag() {
+        // A `Tag` status (e.g. `waitingForFill` trigger child of a normalTpsl
+        // bracket) must surface as `Ok(None)` so the caller leaves the order
+        // in SUBMITTED until the user-events WS stream confirms a real oid.
+        // Earlier revisions returned a synthetic `pending-cloid:<cid>` venue
+        // id that the WS path then failed to overwrite due to the
+        // `_accepted_orders` dedup short-circuit.
+        let mut client =
+            HyperliquidHttpClient::new(HyperliquidEnvironment::Mainnet, 60, None).unwrap();
+        client.set_account_id(nautilus_model::identifiers::AccountId::from(
+            "HYPERLIQUID-001",
+        ));
+
+        let response: HyperliquidExchangeResponse = serde_json::from_value(json!({
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": ["waitingForFill"]
+                }
+            }
+        }))
+        .unwrap();
+
+        let result = client
+            .build_submit_order_report(
+                InstrumentId::from("ARB-USD-PERP.HYPERLIQUID"),
+                ClientOrderId::from("O-WAITING-CHILD"),
+                nautilus_model::enums::OrderSide::Buy,
+                nautilus_model::enums::OrderType::StopMarket,
+                Quantity::new(100.0, 0),
+                nautilus_model::enums::TimeInForce::Gtc,
+                None,
+                Some(Price::new(0.16136, 5)),
+                response,
+            )
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "Tag status must elide so the order stays SUBMITTED; got {result:?}",
+        );
     }
 
     #[rstest]

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -3025,153 +3025,159 @@ impl HyperliquidHttpClient {
         // Submit to exchange using the typed exec endpoint
         let response = self.inner.post_action_exec(&action).await?;
 
-        // Parse the response to extract order statuses
-        match response {
+        self.build_submit_orders_reports(orders, grouping, response)
+    }
+
+    /// Parse a Hyperliquid exchange `Order` response into per-order
+    /// `OrderStatusReport`s, paired with the originating `orders` slice.
+    ///
+    /// Shared by both the HTTP and WebSocket batch-submit paths since the
+    /// response envelope is identical regardless of transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if account credentials are missing, the response is
+    /// malformed, an order returns an `error` status, or — for ungrouped
+    /// submissions — the response status count diverges from the order count.
+    pub fn build_submit_orders_reports(
+        &self,
+        orders: &[&OrderAny],
+        grouping: HyperliquidExecGrouping,
+        response: HyperliquidExchangeResponse,
+    ) -> Result<Vec<OrderStatusReport>> {
+        let response_data = match response {
             HyperliquidExchangeResponse::Status {
                 status,
                 response: response_data,
-            } if status == RESPONSE_STATUS_OK => {
-                // Extract the 'data' field from the response if it exists (new format)
-                // Otherwise use response_data directly (old format)
-                let data_value = if let Some(data) = response_data.get("data") {
-                    data.clone()
-                } else {
-                    response_data
-                };
+            } if status == RESPONSE_STATUS_OK => response_data,
+            HyperliquidExchangeResponse::Error { error } => {
+                return Err(Error::bad_request(format!(
+                    "Order submission failed: {error}"
+                )));
+            }
+            _ => return Err(Error::bad_request("Unexpected response format")),
+        };
 
-                // Parse the response data to extract order statuses
-                let order_response: HyperliquidExecOrderResponseData =
-                    serde_json::from_value(data_value).map_err(|e| {
-                        Error::bad_request(format!("Failed to parse order response: {e}"))
-                    })?;
+        // New format wraps statuses under `data`; old format uses the body directly.
+        let data_value = if let Some(data) = response_data.get("data") {
+            data.clone()
+        } else {
+            response_data
+        };
 
-                let account_id = self
-                    .account_id
-                    .ok_or_else(|| Error::bad_request("Account ID not set"))?;
-                let ts_init = self.clock.get_time_ns();
+        let order_response: HyperliquidExecOrderResponseData = serde_json::from_value(data_value)
+            .map_err(|e| Error::bad_request(format!("Failed to parse order response: {e}")))?;
 
-                // For grouped orders (NormalTpsl/PositionTpsl), the exchange
-                // returns a single status for the whole group. Only enforce
-                // 1:1 matching for ungrouped (Na) submissions.
-                if grouping == HyperliquidExecGrouping::Na
-                    && order_response.statuses.len() != orders.len()
-                {
+        let account_id = self
+            .account_id
+            .ok_or_else(|| Error::bad_request("Account ID not set"))?;
+        let ts_init = self.clock.get_time_ns();
+
+        // For grouped orders (NormalTpsl/PositionTpsl), the exchange returns
+        // a single status for the whole group. Only enforce 1:1 matching for
+        // ungrouped (Na) submissions.
+        if grouping == HyperliquidExecGrouping::Na
+            && order_response.statuses.len() != orders.len()
+        {
+            return Err(Error::bad_request(format!(
+                "Mismatch between submitted orders ({}) and response statuses ({})",
+                orders.len(),
+                order_response.statuses.len()
+            )));
+        }
+
+        let mut reports = Vec::with_capacity(order_response.statuses.len());
+
+        for (order, order_status) in orders.iter().zip(order_response.statuses.iter()) {
+            let instrument_id = order.instrument_id();
+            let symbol = instrument_id.symbol.as_str();
+            let product_type = HyperliquidProductType::from_symbol(symbol).ok();
+
+            // Mirror the alias `cache_instrument` stored (token form for
+            // outcomes, leading segment for perps / spots).
+            let asset = cache_alias_for_symbol(symbol).unwrap_or_else(|| symbol.to_string());
+            let instrument = self
+                .get_or_create_instrument(&Ustr::from(asset.as_str()), product_type)
+                .ok_or_else(|| Error::bad_request(format!("Instrument not found for {asset}")))?;
+
+            let report = match order_status {
+                HyperliquidExecOrderStatus::Resting { resting } => self.create_order_status_report(
+                    order.instrument_id(),
+                    Some(order.client_order_id()),
+                    VenueOrderId::new(resting.oid.to_string()),
+                    order.order_side(),
+                    order.order_type(),
+                    order.quantity(),
+                    order.time_in_force(),
+                    order.price(),
+                    order.trigger_price(),
+                    OrderStatus::Accepted,
+                    Quantity::new(0.0, instrument.size_precision()),
+                    &instrument,
+                    account_id,
+                    ts_init,
+                ),
+                HyperliquidExecOrderStatus::Filled { filled } => {
+                    let filled_qty = Quantity::new(
+                        filled.total_sz.to_string().parse::<f64>().unwrap_or(0.0),
+                        instrument.size_precision(),
+                    );
+                    self.create_order_status_report(
+                        order.instrument_id(),
+                        Some(order.client_order_id()),
+                        VenueOrderId::new(filled.oid.to_string()),
+                        order.order_side(),
+                        order.order_type(),
+                        order.quantity(),
+                        order.time_in_force(),
+                        order.price(),
+                        order.trigger_price(),
+                        OrderStatus::Filled,
+                        filled_qty,
+                        &instrument,
+                        account_id,
+                        ts_init,
+                    )
+                }
+                HyperliquidExecOrderStatus::Error { error } => {
                     return Err(Error::bad_request(format!(
-                        "Mismatch between submitted orders ({}) and response statuses ({})",
-                        orders.len(),
-                        order_response.statuses.len()
+                        "Order {} rejected: {error}",
+                        order.client_order_id()
                     )));
                 }
-
-                let mut reports = Vec::new();
-
-                // Create OrderStatusReport for each order with a matching
-                // status. For grouped submissions the exchange may return
-                // fewer statuses; remaining orders are confirmed via WS.
-                for (order, order_status) in orders.iter().zip(order_response.statuses.iter()) {
-                    let instrument_id = order.instrument_id();
-                    let symbol = instrument_id.symbol.as_str();
-                    let product_type = HyperliquidProductType::from_symbol(symbol).ok();
-
-                    // Mirror the alias `cache_instrument` stored (token form
-                    // for outcomes, leading segment for perps / spots).
-                    let asset =
-                        cache_alias_for_symbol(symbol).unwrap_or_else(|| symbol.to_string());
-                    let instrument = self
-                        .get_or_create_instrument(&Ustr::from(asset.as_str()), product_type)
-                        .ok_or_else(|| {
-                            Error::bad_request(format!("Instrument not found for {asset}"))
-                        })?;
-
-                    // Create OrderStatusReport based on the order status
-                    let report = match order_status {
-                        HyperliquidExecOrderStatus::Resting { resting } => {
-                            // Order is resting on the order book
-                            self.create_order_status_report(
-                                order.instrument_id(),
-                                Some(order.client_order_id()),
-                                VenueOrderId::new(resting.oid.to_string()),
-                                order.order_side(),
-                                order.order_type(),
-                                order.quantity(),
-                                order.time_in_force(),
-                                order.price(),
-                                order.trigger_price(),
-                                OrderStatus::Accepted,
-                                Quantity::new(0.0, instrument.size_precision()),
-                                &instrument,
-                                account_id,
-                                ts_init,
-                            )
-                        }
-                        HyperliquidExecOrderStatus::Filled { filled } => {
-                            // Order was filled immediately
-                            let filled_qty = Quantity::new(
-                                filled.total_sz.to_string().parse::<f64>().unwrap_or(0.0),
-                                instrument.size_precision(),
-                            );
-                            self.create_order_status_report(
-                                order.instrument_id(),
-                                Some(order.client_order_id()),
-                                VenueOrderId::new(filled.oid.to_string()),
-                                order.order_side(),
-                                order.order_type(),
-                                order.quantity(),
-                                order.time_in_force(),
-                                order.price(),
-                                order.trigger_price(),
-                                OrderStatus::Filled,
-                                filled_qty,
-                                &instrument,
-                                account_id,
-                                ts_init,
-                            )
-                        }
-                        HyperliquidExecOrderStatus::Error { error } => {
-                            return Err(Error::bad_request(format!(
-                                "Order {} rejected: {error}",
-                                order.client_order_id()
-                            )));
-                        }
-                        HyperliquidExecOrderStatus::Tag(_) => {
-                            // Trigger child of a `normalTpsl` bracket (SL/TP):
-                            // venue accepted it atomically but has not assigned
-                            // an oid yet. Use a `pending-cloid:` placeholder —
-                            // the real oid arrives via the user-events WS
-                            // stream and is reconciled via the cloid mapping.
-                            let placeholder = VenueOrderId::new(format!(
-                                "pending-cloid:{}",
-                                order.client_order_id().as_str(),
-                            ));
-                            self.create_order_status_report(
-                                order.instrument_id(),
-                                Some(order.client_order_id()),
-                                placeholder,
-                                order.order_side(),
-                                order.order_type(),
-                                order.quantity(),
-                                order.time_in_force(),
-                                order.price(),
-                                order.trigger_price(),
-                                OrderStatus::Accepted,
-                                Quantity::new(0.0, instrument.size_precision()),
-                                &instrument,
-                                account_id,
-                                ts_init,
-                            )
-                        }
-                    };
-
-                    reports.push(report);
+                HyperliquidExecOrderStatus::Tag(_) => {
+                    // Trigger child of a `normalTpsl` bracket (SL/TP): venue
+                    // accepted it atomically but has not assigned an oid yet.
+                    // Use a `pending-cloid:` placeholder — the real oid arrives
+                    // via the user-events WS stream and is reconciled via the
+                    // cloid mapping.
+                    let placeholder = VenueOrderId::new(format!(
+                        "pending-cloid:{}",
+                        order.client_order_id().as_str(),
+                    ));
+                    self.create_order_status_report(
+                        order.instrument_id(),
+                        Some(order.client_order_id()),
+                        placeholder,
+                        order.order_side(),
+                        order.order_type(),
+                        order.quantity(),
+                        order.time_in_force(),
+                        order.price(),
+                        order.trigger_price(),
+                        OrderStatus::Accepted,
+                        Quantity::new(0.0, instrument.size_precision()),
+                        &instrument,
+                        account_id,
+                        ts_init,
+                    )
                 }
+            };
 
-                Ok(reports)
-            }
-            HyperliquidExchangeResponse::Error { error } => Err(Error::bad_request(format!(
-                "Order submission failed: {error}"
-            ))),
-            _ => Err(Error::bad_request("Unexpected response format")),
+            reports.push(report);
         }
+
+        Ok(reports)
     }
 }
 

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -2891,6 +2891,9 @@ impl HyperliquidHttpClient {
                     HyperliquidExecOrderStatus::Error { error } => {
                         Err(Error::bad_request(format!("Order rejected: {error}")))
                     }
+                    HyperliquidExecOrderStatus::Tag(tag) => Err(Error::bad_request(format!(
+                        "Unexpected bare status {tag:?} for single-order submission"
+                    ))),
                 }
             }
             HyperliquidExchangeResponse::Error { error } => Err(Error::bad_request(format!(
@@ -3129,6 +3132,29 @@ impl HyperliquidHttpClient {
                                 "Order {} rejected: {error}",
                                 order.client_order_id()
                             )));
+                        }
+                        HyperliquidExecOrderStatus::Tag(_) => {
+                            // Trigger child of a `normalTpsl` bracket (SL/TP):
+                            // venue accepted it atomically but has not assigned
+                            // an oid yet. Mark Accepted with the client order id
+                            // as a placeholder venue id — the real oid arrives
+                            // via the user-events WS stream.
+                            self.create_order_status_report(
+                                order.instrument_id(),
+                                Some(order.client_order_id()),
+                                VenueOrderId::new(order.client_order_id().to_string()),
+                                order.order_side(),
+                                order.order_type(),
+                                order.quantity(),
+                                order.time_in_force(),
+                                order.price(),
+                                order.trigger_price(),
+                                OrderStatus::Accepted,
+                                Quantity::new(0.0, instrument.size_precision()),
+                                &instrument,
+                                account_id,
+                                ts_init,
+                            )
                         }
                     };
 

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -3136,13 +3136,17 @@ impl HyperliquidHttpClient {
                         HyperliquidExecOrderStatus::Tag(_) => {
                             // Trigger child of a `normalTpsl` bracket (SL/TP):
                             // venue accepted it atomically but has not assigned
-                            // an oid yet. Mark Accepted with the client order id
-                            // as a placeholder venue id — the real oid arrives
-                            // via the user-events WS stream.
+                            // an oid yet. Use a `pending-cloid:` placeholder —
+                            // the real oid arrives via the user-events WS
+                            // stream and is reconciled via the cloid mapping.
+                            let placeholder = VenueOrderId::new(format!(
+                                "pending-cloid:{}",
+                                order.client_order_id().as_str(),
+                            ));
                             self.create_order_status_report(
                                 order.instrument_id(),
                                 Some(order.client_order_id()),
-                                VenueOrderId::new(order.client_order_id().to_string()),
+                                placeholder,
                                 order.order_side(),
                                 order.order_type(),
                                 order.quantity(),

--- a/crates/adapters/hyperliquid/src/http/models.rs
+++ b/crates/adapters/hyperliquid/src/http/models.rs
@@ -1601,14 +1601,16 @@ pub enum HyperliquidExecOrderStatus {
     Tag(HyperliquidExecOrderStatusTag),
 }
 
-/// Bare-string order status returned for trigger children of a `normalTpsl`
-/// group, parked until the entry leg fills (or the trigger fires).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// Status tags HL serializes as a bare JSON string. Trigger children of a
+/// `normalTpsl` group plus standalone trigger orders that haven't armed yet
+/// fall in this bucket — the venue defers oid assignment until activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HyperliquidExecOrderStatusTag {
     /// Trigger child parked until the parent (entry) order fills.
+    #[serde(rename = "waitingForFill")]
     WaitingForFill,
     /// Trigger child parked until its trigger price condition is met.
+    #[serde(rename = "waitingForTrigger")]
     WaitingForTrigger,
 }
 

--- a/crates/adapters/hyperliquid/src/http/models.rs
+++ b/crates/adapters/hyperliquid/src/http/models.rs
@@ -1041,6 +1041,35 @@ mod tests {
             })
         );
     }
+
+    #[rstest]
+    fn test_order_response_normal_tpsl_with_waiting_children() {
+        // `normalTpsl` bracket: entry rests with an oid, SL/TP children come
+        // back as bare strings until the parent fills / trigger fires.
+        let json = r#"{
+            "statuses": [
+                {"resting": {"oid": 446050656712}},
+                "waitingForFill",
+                "waitingForTrigger"
+            ]
+        }"#;
+
+        let data: HyperliquidExecOrderResponseData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.statuses.len(), 3);
+
+        assert!(matches!(
+            data.statuses[0],
+            HyperliquidExecOrderStatus::Resting { ref resting } if resting.oid == 446050656712
+        ));
+        assert!(matches!(
+            data.statuses[1],
+            HyperliquidExecOrderStatus::Tag(HyperliquidExecOrderStatusTag::WaitingForFill)
+        ));
+        assert!(matches!(
+            data.statuses[2],
+            HyperliquidExecOrderStatus::Tag(HyperliquidExecOrderStatusTag::WaitingForTrigger)
+        ));
+    }
 }
 
 /// Time-in-force for limit orders in exchange endpoint.
@@ -1566,6 +1595,21 @@ pub enum HyperliquidExecOrderStatus {
         /// Error message.
         error: String,
     },
+    /// Bare status string. Used for trigger children of a `normalTpsl` group
+    /// (SL/TP), which Hyperliquid serializes as a JSON string rather than an
+    /// object — e.g. `"waitingForFill"` or `"waitingForTrigger"`.
+    Tag(HyperliquidExecOrderStatusTag),
+}
+
+/// Bare-string order status returned for trigger children of a `normalTpsl`
+/// group, parked until the entry leg fills (or the trigger fires).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum HyperliquidExecOrderStatusTag {
+    /// Trigger child parked until the parent (entry) order fills.
+    WaitingForFill,
+    /// Trigger child parked until its trigger price condition is met.
+    WaitingForTrigger,
 }
 
 /// Information about a resting order via exchange endpoint.

--- a/crates/adapters/hyperliquid/src/python/websocket.rs
+++ b/crates/adapters/hyperliquid/src/python/websocket.rs
@@ -31,7 +31,7 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 use nautilus_network::websocket::TransportBackend;
-use pyo3::{conversion::IntoPyObjectExt, prelude::*};
+use pyo3::{conversion::IntoPyObjectExt, prelude::*, types::PyList};
 
 use crate::{
     common::enums::HyperliquidEnvironment,
@@ -157,6 +157,11 @@ impl HyperliquidWebSocketClient {
     }
 
     /// Submit multiple orders through the Hyperliquid WebSocket post API.
+    ///
+    /// Returns a list of `OrderStatusReport`s, one per accepted order in the
+    /// same order as `orders`. Trigger children of a `normalTpsl` group carry
+    /// a `pending-cloid:` placeholder venue id until the real oid arrives via
+    /// the user-events stream.
     #[pyo3(name = "submit_orders")]
     fn py_submit_orders<'py>(
         &self,
@@ -177,11 +182,16 @@ impl HyperliquidWebSocketClient {
             })?;
             let order_refs: Vec<&OrderAny> = order_anys.iter().collect();
 
-            client
+            let reports = client
                 .submit_orders(&signer, &order_refs)
                 .await
                 .map_err(to_pyvalue_err)?;
-            Ok(())
+
+            Python::attach(|py| {
+                let pylist =
+                    PyList::new(py, reports.into_iter().map(|r| r.into_py_any_unwrap(py)))?;
+                Ok(pylist.into_py_any_unwrap(py))
+            })
         })
     }
 

--- a/crates/adapters/hyperliquid/src/python/websocket.rs
+++ b/crates/adapters/hyperliquid/src/python/websocket.rs
@@ -103,6 +103,11 @@ impl HyperliquidWebSocketClient {
     ///
     /// The HTTP client supplies signing credentials, builder attribution, and
     /// cached instrument metadata. The action itself is sent over WebSocket.
+    ///
+    /// Returns an `OrderStatusReport` describing the venue's response (a
+    /// `filled` for an immediate IOC fill, `resting` for a resting LIMIT, or
+    /// `Accepted` with a `pending-cloid:` placeholder for a `waitingForFill`
+    /// trigger child), or `None` if the venue returned no statuses.
     #[pyo3(name = "submit_order", signature = (
         signer,
         instrument_id,
@@ -136,7 +141,7 @@ impl HyperliquidWebSocketClient {
         let signer = signer.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            client
+            let report = client
                 .submit_order(
                     &signer,
                     instrument_id,
@@ -152,7 +157,11 @@ impl HyperliquidWebSocketClient {
                 )
                 .await
                 .map_err(to_pyvalue_err)?;
-            Ok(())
+
+            Python::attach(|py| match report {
+                Some(r) => Ok(r.into_py_any_unwrap(py)),
+                None => Ok(py.None()),
+            })
         })
     }
 

--- a/crates/adapters/hyperliquid/src/websocket/client.rs
+++ b/crates/adapters/hyperliquid/src/websocket/client.rs
@@ -482,7 +482,7 @@ impl HyperliquidWebSocketClient {
         trigger_price: Option<Price>,
         post_only: bool,
         reduce_only: bool,
-    ) -> HyperliquidResult<()> {
+    ) -> HyperliquidResult<Option<OrderStatusReport>> {
         let symbol = instrument_id.symbol.as_str();
         let asset = signer.get_asset_index(symbol).ok_or_else(|| {
             HyperliquidError::bad_request(format!(
@@ -553,7 +553,20 @@ impl HyperliquidWebSocketClient {
         };
         let response = self.post_action_exec(signer, &action).await?;
 
-        ensure_ws_action_accepted(&response, "Order submission")
+        // `build_submit_order_report` parses the same envelope as
+        // `ensure_ws_action_accepted` did previously, and turns per-order
+        // `error` statuses into Err — so the rejection cascade is preserved.
+        signer.build_submit_order_report(
+            instrument_id,
+            client_order_id,
+            order_side,
+            order_type,
+            quantity,
+            time_in_force,
+            price,
+            trigger_price,
+            response,
+        )
     }
 
     /// Submit multiple orders through the Hyperliquid WebSocket post API.

--- a/crates/adapters/hyperliquid/src/websocket/client.rs
+++ b/crates/adapters/hyperliquid/src/websocket/client.rs
@@ -34,6 +34,7 @@ use nautilus_model::{
     identifiers::{AccountId, ClientOrderId, InstrumentId, VenueOrderId},
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
+    reports::OrderStatusReport,
     types::{Price, Quantity},
 };
 use nautilus_network::{
@@ -556,11 +557,16 @@ impl HyperliquidWebSocketClient {
     }
 
     /// Submit multiple orders through the Hyperliquid WebSocket post API.
+    ///
+    /// Returns one `OrderStatusReport` per accepted order in the same order
+    /// as `orders`. Trigger children of a `normalTpsl` bracket carry a
+    /// `pending-cloid:<client_order_id>` placeholder venue id that is
+    /// overwritten when the real oid arrives via the user-events stream.
     pub async fn submit_orders(
         &self,
         signer: &HyperliquidHttpClient,
         orders: &[&OrderAny],
-    ) -> HyperliquidResult<()> {
+    ) -> HyperliquidResult<Vec<OrderStatusReport>> {
         let mut hyperliquid_orders = Vec::with_capacity(orders.len());
         let mut client_order_ids = Vec::with_capacity(orders.len());
 
@@ -601,7 +607,7 @@ impl HyperliquidWebSocketClient {
         };
         let response = self.post_action_exec(signer, &action).await?;
 
-        ensure_ws_action_accepted(&response, "Order list submission")
+        signer.build_submit_orders_reports(orders, grouping, response)
     }
 
     /// Cancel an order through the Hyperliquid WebSocket post API.

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -782,8 +782,10 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         # Drive each order through the same handler the WS uses so the state
         # machine transitions SUBMITTED -> ACCEPTED|FILLED|REJECTED at submit
-        # time. Trigger children carry a `pending-cloid:` placeholder venue id
-        # that is overwritten when the userEvents stream delivers the real oid.
+        # time. Deferred trigger children (waitingForFill / waitingForTrigger)
+        # are intentionally absent from `pyo3_reports` — they stay SUBMITTED
+        # until the user-events WS stream delivers an OrderAccepted with the
+        # real venue oid.
         for pyo3_report in pyo3_reports or ():
             try:
                 self._handle_order_status_report_pyo3(pyo3_report)

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -745,7 +745,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         try:
             pyo3_orders = [transform_order_to_pyo3(order) for order in orders]
-            await self._ws_client.submit_orders(self._client, pyo3_orders)
+            pyo3_reports = await self._client.submit_orders(pyo3_orders)
         except Exception as e:
             if _is_transport_error(e):
                 self._log.warning(
@@ -767,6 +767,20 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                     reason=error_str,
                     ts_event=self._clock.timestamp_ns(),
                     due_post_only=due_post_only,
+                )
+            return
+
+        # Drive each order through the same handler the WS uses so the state
+        # machine transitions SUBMITTED -> ACCEPTED|FILLED|REJECTED at submit
+        # time. Trigger children carry a `pending-cloid:` placeholder venue id
+        # that is overwritten when the userEvents stream delivers the real oid.
+        for pyo3_report in pyo3_reports or ():
+            try:
+                self._handle_order_status_report_pyo3(pyo3_report)
+            except Exception as e:
+                self._log.warning(
+                    f"Failed to process submit response report "
+                    f"({type(e).__name__}: {e}); awaiting WS reconciliation",
                 )
 
     async def _modify_order(self, command: ModifyOrder) -> None:  # noqa: C901 (sequence of guard clauses)

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -672,7 +672,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
             cloid = nautilus_pyo3.hyperliquid_cloid_from_client_order_id(pyo3_client_order_id)
             self._ws_client.cache_cloid_mapping(cloid, pyo3_client_order_id)
 
-            await self._ws_client.submit_order(
+            pyo3_report = await self._ws_client.submit_order(
                 self._client,
                 instrument_id=pyo3_instrument_id,
                 client_order_id=pyo3_client_order_id,
@@ -706,6 +706,16 @@ class HyperliquidExecutionClient(LiveExecutionClient):
                 ts_event=self._clock.timestamp_ns(),
                 due_post_only=due_post_only,
             )
+            return
+
+        if pyo3_report is not None:
+            try:
+                self._handle_order_status_report_pyo3(pyo3_report)
+            except Exception as e:
+                self._log.warning(
+                    f"Failed to process submit response report "
+                    f"({type(e).__name__}: {e}); awaiting WS reconciliation",
+                )
 
     async def _submit_order_list(self, command: SubmitOrderList) -> None:
         order_list = command.order_list

--- a/nautilus_trader/adapters/hyperliquid/execution.py
+++ b/nautilus_trader/adapters/hyperliquid/execution.py
@@ -745,7 +745,7 @@ class HyperliquidExecutionClient(LiveExecutionClient):
 
         try:
             pyo3_orders = [transform_order_to_pyo3(order) for order in orders]
-            pyo3_reports = await self._client.submit_orders(pyo3_orders)
+            pyo3_reports = await self._ws_client.submit_orders(self._client, pyo3_orders)
         except Exception as e:
             if _is_transport_error(e):
                 self._log.warning(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes two HL order-submission bugs that silently orphaned positions on the venue:

- `normalTpsl` brackets were rejected wholesale because HL returns the SL/TP children as bare strings (`"waitingForFill"` / `"waitingForTrigger"`) that the response enum couldn't deserialize.
- MARKET orders that filled atomically never surfaced as `OrderFilled` — the WS submit path threw the parsed response away, the inflight check eventually timed out, and the order resolved as `OrderRejected(reason='UNKNOWN')` while the position sat open on HL.

Both transports (HTTP and WS, singleton and batch) now parse the response through a shared helper and feed each `OrderStatusReport` into the same handler the WS userEvents stream uses, so orders transition `SUBMITTED → ACCEPTED|FILLED|REJECTED` at submit time. Trigger children of a bracket carry a `pending-cloid:` placeholder venue id until the real oid arrives via WS.

## Related Issues/PRs

<!-- Closes #<issue> -->

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

`HyperliquidWebSocketClient::submit_order` / `submit_orders` (and their PyO3 wrappers) now return the parsed report(s) instead of `()`. Callers that ignored the return are unaffected.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added a deserialization test covering the exact `normalTpsl` payload from the bug report. Existing single/batch submit tests still pass. `cargo check -p nautilus-hyperliquid` is clean. Manually reproduced on HL mainnet — MARKET fills and bracket submits now propagate end-to-end.
