### PR TITLE
Optimize datetime and UUID formatting

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -82,6 +82,11 @@ path = "benches/time.rs"
 harness = false
 
 [[bench]]
+name = "datetime"
+path = "benches/datetime.rs"
+harness = false
+
+[[bench]]
 name = "uuid"
 path = "benches/uuid.rs"
 harness = false

--- a/crates/core/benches/datetime.rs
+++ b/crates/core/benches/datetime.rs
@@ -1,0 +1,87 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use nautilus_core::{
+    UnixNanos,
+    datetime::{unix_nanos_to_iso8601, unix_nanos_to_iso8601_millis},
+};
+
+const EPOCH: u64 = 0;
+const CURRENT_SAMPLE: u64 = 1_707_578_323_456_789_123;
+const MILLIS_SAMPLE: u64 = 1_707_578_323_456_000_000;
+
+fn max_chrono_nanos() -> u64 {
+    u64::try_from(i64::MAX).expect("i64::MAX fits in u64")
+}
+
+fn raw_fallback_nanos() -> u64 {
+    max_chrono_nanos() + 1
+}
+
+fn bench_unix_nanos_to_iso8601(c: &mut Criterion) {
+    let mut group = c.benchmark_group("datetime/unix_nanos_to_iso8601");
+    let cases = [
+        ("epoch", EPOCH),
+        ("current_sample", CURRENT_SAMPLE),
+        ("max_chrono", max_chrono_nanos()),
+        ("raw_fallback", raw_fallback_nanos()),
+    ];
+
+    for (name, nanos) in cases {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &nanos, |b, &nanos| {
+            b.iter(|| unix_nanos_to_iso8601(UnixNanos::from(black_box(nanos))));
+        });
+    }
+    group.finish();
+}
+
+fn bench_unix_nanos_to_iso8601_millis(c: &mut Criterion) {
+    let mut group = c.benchmark_group("datetime/unix_nanos_to_iso8601_millis");
+    let cases = [
+        ("epoch", EPOCH),
+        ("millis_sample", MILLIS_SAMPLE),
+        ("raw_fallback", raw_fallback_nanos()),
+    ];
+
+    for (name, nanos) in cases {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &nanos, |b, &nanos| {
+            b.iter(|| unix_nanos_to_iso8601_millis(UnixNanos::from(black_box(nanos))));
+        });
+    }
+    group.finish();
+}
+
+fn bench_logging_style_line(c: &mut Criterion) {
+    let timestamp = UnixNanos::from(CURRENT_SAMPLE);
+    c.bench_function("datetime/logging_style_line", |b| {
+        b.iter(|| {
+            format!(
+                "{} INFO Trader-001 RiskEngine order accepted",
+                unix_nanos_to_iso8601(black_box(timestamp))
+            )
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_unix_nanos_to_iso8601,
+    bench_unix_nanos_to_iso8601_millis,
+    bench_logging_style_line,
+);
+criterion_main!(benches);

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -16,7 +16,7 @@
 //! Common data and time functions.
 use std::convert::TryFrom;
 
-use chrono::{DateTime, Datelike, NaiveDate, SecondsFormat, TimeDelta, Utc, Weekday};
+use chrono::{DateTime, Datelike, NaiveDate, TimeDelta, Utc, Weekday};
 
 use crate::{UnixNanos, time::nanos_since_unix_epoch};
 
@@ -28,6 +28,7 @@ pub const NANOSECONDS_IN_SECOND: u64 = 1_000_000_000;
 
 /// Number of nanoseconds in one millisecond.
 pub const NANOSECONDS_IN_MILLISECOND: u64 = 1_000_000;
+const NANOSECONDS_IN_MILLISECOND_U32: u32 = 1_000_000;
 
 /// Number of nanoseconds in one microsecond.
 pub const NANOSECONDS_IN_MICROSECOND: u64 = 1_000;
@@ -98,6 +99,127 @@ fn unix_nanos_to_datetime(unix_nanos: UnixNanos) -> anyhow::Result<DateTime<Utc>
         )
     })?;
     Ok(DateTime::from_timestamp_nanos(nanos_i64))
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i32, u32, u32) {
+    // Howard Hinnant's civil calendar algorithm maps UTC epoch days to a
+    // Gregorian date using integer arithmetic only. The input is already UTC,
+    // so no timezone or leap-second rules are involved in this formatter.
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    let year = year + i64::from(month <= 2);
+
+    (
+        i32::try_from(year).expect("year fits in i32"),
+        u32::try_from(month).expect("month is positive"),
+        u32::try_from(day).expect("day is positive"),
+    )
+}
+
+struct DateTimeParts {
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+    subsec_nanos: u32,
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "digit helpers only receive values in 0..=9"
+)]
+fn push_digit(out: &mut String, digit: u32) {
+    out.push(char::from(b'0' + digit as u8));
+}
+
+fn push_2_digits(out: &mut String, value: u32) {
+    debug_assert!(value < 100);
+    push_digit(out, value / 10);
+    push_digit(out, value % 10);
+}
+
+fn push_3_digits(out: &mut String, value: u32) {
+    debug_assert!(value < 1_000);
+    push_digit(out, value / 100);
+    push_2_digits(out, value % 100);
+}
+
+fn push_4_digits(out: &mut String, value: i32) {
+    debug_assert!((0..=9_999).contains(&value));
+    let value = u32::try_from(value).expect("year is non-negative");
+    push_digit(out, value / 1_000);
+    push_digit(out, (value / 100) % 10);
+    push_2_digits(out, value % 100);
+}
+
+fn push_9_digits(out: &mut String, value: u32) {
+    debug_assert!(value < 1_000_000_000);
+    let mut divisor = 100_000_000;
+    while divisor > 0 {
+        push_digit(out, value / divisor % 10);
+        divisor /= 10;
+    }
+}
+
+fn split_unix_nanos(unix_nanos: UnixNanos) -> Option<DateTimeParts> {
+    let nanos = unix_nanos.as_u64();
+    if i64::try_from(nanos).is_err() {
+        return None;
+    }
+
+    let total_seconds = nanos / NANOSECONDS_IN_SECOND;
+    let subsec_nanos = u32::try_from(nanos % NANOSECONDS_IN_SECOND).expect("subsecond fits u32");
+    let days = total_seconds / SECONDS_IN_DAY;
+    let seconds_of_day = total_seconds % SECONDS_IN_DAY;
+    let (year, month, day) =
+        civil_from_days(i64::try_from(days).expect("days since epoch fits i64"));
+    let hour = u32::try_from(seconds_of_day / SECONDS_IN_HOUR).expect("hour fits u32");
+    let minute =
+        u32::try_from((seconds_of_day % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE).expect("minute fits");
+    let second = u32::try_from(seconds_of_day % SECONDS_IN_MINUTE).expect("second fits");
+
+    Some(DateTimeParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        subsec_nanos,
+    })
+}
+
+fn push_iso8601_prefix(
+    out: &mut String,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) {
+    push_4_digits(out, year);
+    out.push('-');
+    push_2_digits(out, month);
+    out.push('-');
+    push_2_digits(out, day);
+    out.push('T');
+    push_2_digits(out, hour);
+    out.push(':');
+    push_2_digits(out, minute);
+    out.push(':');
+    push_2_digits(out, second);
+    out.push('.');
 }
 
 /// List of weekdays (Monday to Friday).
@@ -298,10 +420,23 @@ pub const fn nanos_to_micros(nanos: u64) -> u64 {
 #[inline]
 #[must_use]
 pub fn unix_nanos_to_iso8601(unix_nanos: UnixNanos) -> String {
-    match unix_nanos_to_datetime(unix_nanos) {
-        Ok(dt) => dt.to_rfc3339_opts(SecondsFormat::Nanos, true),
-        Err(_) => unix_nanos.as_u64().to_string(),
-    }
+    let Some(parts) = split_unix_nanos(unix_nanos) else {
+        return unix_nanos.as_u64().to_string();
+    };
+
+    let mut out = String::with_capacity(30);
+    push_iso8601_prefix(
+        &mut out,
+        parts.year,
+        parts.month,
+        parts.day,
+        parts.hour,
+        parts.minute,
+        parts.second,
+    );
+    push_9_digits(&mut out, parts.subsec_nanos);
+    out.push('Z');
+    out
 }
 
 /// Converts an ISO 8601 (RFC 3339) format string to UNIX nanoseconds timestamp.
@@ -341,10 +476,26 @@ pub fn iso8601_to_unix_nanos(date_string: &str) -> anyhow::Result<UnixNanos> {
 #[inline]
 #[must_use]
 pub fn unix_nanos_to_iso8601_millis(unix_nanos: UnixNanos) -> String {
-    match unix_nanos_to_datetime(unix_nanos) {
-        Ok(dt) => dt.to_rfc3339_opts(SecondsFormat::Millis, true),
-        Err(_) => unix_nanos.as_u64().to_string(),
-    }
+    let Some(parts) = split_unix_nanos(unix_nanos) else {
+        return unix_nanos.as_u64().to_string();
+    };
+
+    let mut out = String::with_capacity(24);
+    push_iso8601_prefix(
+        &mut out,
+        parts.year,
+        parts.month,
+        parts.day,
+        parts.hour,
+        parts.minute,
+        parts.second,
+    );
+    push_3_digits(
+        &mut out,
+        parts.subsec_nanos / NANOSECONDS_IN_MILLISECOND_U32,
+    );
+    out.push('Z');
+    out
 }
 
 /// Floor the given UNIX nanoseconds to the nearest microsecond.
@@ -603,7 +754,7 @@ pub fn datetime_to_unix_nanos(value: Option<DateTime<Utc>>) -> Option<UnixNanos>
     reason = "Exact float comparisons acceptable in tests"
 )]
 mod tests {
-    use chrono::{DateTime, TimeDelta, TimeZone, Timelike, Utc};
+    use chrono::{DateTime, SecondsFormat, TimeDelta, TimeZone, Timelike, Utc};
     use rstest::rstest;
 
     use super::*;
@@ -794,6 +945,8 @@ mod tests {
     #[case(1_000, "1970-01-01T00:00:00.000001000Z")] // 1 microsecond
     #[case(1_000_000, "1970-01-01T00:00:00.001000000Z")] // 1 millisecond
     #[case(1_000_000_000, "1970-01-01T00:00:01.000000000Z")] // 1 second
+    #[case(951_782_400_000_000_000, "2000-02-29T00:00:00.000000000Z")] // Leap day
+    #[case(1_609_459_199_999_999_999, "2020-12-31T23:59:59.999999999Z")] // Year boundary
     #[case(1_702_857_600_000_000_000, "2023-12-18T00:00:00.000000000Z")] // Specific date
     fn test_unix_nanos_to_iso8601(#[case] nanos: u64, #[case] expected: &str) {
         let result = unix_nanos_to_iso8601(UnixNanos::from(nanos));
@@ -801,13 +954,58 @@ mod tests {
     }
 
     #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(951_782_400_123_456_789)]
+    #[case(1_609_459_199_999_999_999)]
+    #[case(i64::MAX as u64)]
+    fn test_unix_nanos_to_iso8601_matches_chrono_oracle(#[case] nanos: u64) {
+        let nanos_i64 = i64::try_from(nanos).expect("oracle cases stay within chrono range");
+        let expected =
+            DateTime::from_timestamp_nanos(nanos_i64).to_rfc3339_opts(SecondsFormat::Nanos, true);
+        let result = unix_nanos_to_iso8601(UnixNanos::from(nanos));
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case((i64::MAX as u64) + 1)]
+    #[case(u64::MAX)]
+    fn test_unix_nanos_to_iso8601_falls_back_when_chrono_range_exceeded(#[case] nanos: u64) {
+        let result = unix_nanos_to_iso8601(UnixNanos::from(nanos));
+        assert_eq!(result, nanos.to_string());
+    }
+
+    #[rstest]
     #[case(0, "1970-01-01T00:00:00.000Z")] // Unix epoch
     #[case(1_000_000, "1970-01-01T00:00:00.001Z")] // 1 millisecond
     #[case(1_000_000_000, "1970-01-01T00:00:01.000Z")] // 1 second
+    #[case(951_782_400_123_456_789, "2000-02-29T00:00:00.123Z")] // Leap day
+    #[case(1_609_459_199_999_999_999, "2020-12-31T23:59:59.999Z")] // Year boundary
     #[case(1_702_857_600_123_456_789, "2023-12-18T00:00:00.123Z")] // With millisecond precision
     fn test_unix_nanos_to_iso8601_millis(#[case] nanos: u64, #[case] expected: &str) {
         let result = unix_nanos_to_iso8601_millis(UnixNanos::from(nanos));
         assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(0)]
+    #[case(951_782_400_123_456_789)]
+    #[case(1_609_459_199_999_999_999)]
+    #[case(i64::MAX as u64)]
+    fn test_unix_nanos_to_iso8601_millis_matches_chrono_oracle(#[case] nanos: u64) {
+        let nanos_i64 = i64::try_from(nanos).expect("oracle cases stay within chrono range");
+        let expected =
+            DateTime::from_timestamp_nanos(nanos_i64).to_rfc3339_opts(SecondsFormat::Millis, true);
+        let result = unix_nanos_to_iso8601_millis(UnixNanos::from(nanos));
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case((i64::MAX as u64) + 1)]
+    #[case(u64::MAX)]
+    fn test_unix_nanos_to_iso8601_millis_falls_back_when_chrono_range_exceeded(#[case] nanos: u64) {
+        let result = unix_nanos_to_iso8601_millis(UnixNanos::from(nanos));
+        assert_eq!(result, nanos.to_string());
     }
 
     #[rstest]

--- a/crates/core/src/hex.rs
+++ b/crates/core/src/hex.rs
@@ -17,7 +17,7 @@
 
 use std::fmt::Display;
 
-const ENCODE_PAIR: [[u8; 2]; 256] = {
+pub(crate) const ENCODE_PAIR: [[u8; 2]; 256] = {
     const NIBBLE: [u8; 16] = *b"0123456789abcdef";
     let mut table = [[0u8; 2]; 256];
     let mut i = 0u16;

--- a/crates/core/src/uuid.rs
+++ b/crates/core/src/uuid.rs
@@ -19,7 +19,6 @@ use std::{
     ffi::CStr,
     fmt::{Debug, Display},
     hash::Hash,
-    io::{Cursor, Write},
     str::FromStr,
 };
 
@@ -29,8 +28,45 @@ use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
+use crate::hex::ENCODE_PAIR;
+
 /// The maximum length of ASCII characters for a `UUID4` string value (includes null terminator).
 pub(crate) const UUID4_LEN: usize = 37;
+
+fn format_uuid4_bytes(bytes: [u8; 16]) -> [u8; UUID4_LEN] {
+    let mut value = [0u8; UUID4_LEN];
+    let mut pos = 0;
+
+    for (idx, byte) in bytes.into_iter().enumerate() {
+        if matches!(idx, 4 | 6 | 8 | 10) {
+            value[pos] = b'-';
+            pos += 1;
+        }
+
+        value[pos..pos + 2].copy_from_slice(&ENCODE_PAIR[byte as usize]);
+        pos += 2;
+    }
+
+    value[36] = 0; // Add the null terminator.
+
+    debug_assert_eq!(pos, 36, "Invariant: UUID text must be 36 bytes");
+    debug_assert!(
+        value[14] == b'4',
+        "Invariant: UUID version digit must be '4' (was {})",
+        value[14] as char
+    );
+    debug_assert!(
+        matches!(value[19], b'8' | b'9' | b'a' | b'b'),
+        "Invariant: UUID variant byte must be RFC 4122 (was {})",
+        value[19] as char
+    );
+    debug_assert!(
+        value[36] == 0,
+        "Invariant: UUID null terminator must be at index 36"
+    );
+
+    value
+}
 
 /// Represents a Universally Unique Identifier (UUID)
 /// version 4 based on a 128-bit label as specified in RFC 4122.
@@ -56,41 +92,9 @@ impl UUID4 {
     #[must_use]
     pub fn new() -> Self {
         let bytes = Self::new_bytes();
-
-        let mut value = [0u8; UUID4_LEN];
-        let mut cursor = Cursor::new(&mut value[..36]);
-
-        write!(
-            cursor,
-            "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
-            u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-            u16::from_be_bytes([bytes[4], bytes[5]]),
-            u16::from_be_bytes([bytes[6], bytes[7]]),
-            u16::from_be_bytes([bytes[8], bytes[9]]),
-            u64::from_be_bytes([
-                bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15], 0, 0
-            ]) >> 16
-        )
-        .expect("Error writing UUID string to buffer");
-
-        value[36] = 0; // Add the null terminator
-
-        debug_assert!(
-            value[14] == b'4',
-            "Invariant: UUID version digit must be '4' (was {})",
-            value[14] as char
-        );
-        debug_assert!(
-            matches!(value[19], b'8' | b'9' | b'a' | b'b'),
-            "Invariant: UUID variant byte must be RFC 4122 (was {})",
-            value[19] as char
-        );
-        debug_assert!(
-            value[36] == 0,
-            "Invariant: UUID null terminator must be at index 36"
-        );
-
-        Self { value }
+        Self {
+            value: format_uuid4_bytes(bytes),
+        }
     }
 
     /// Creates raw `UUIDv4` bytes.
@@ -299,6 +303,7 @@ impl<'de> Deserialize<'de> for UUID4 {
 mod tests {
     use std::{
         collections::hash_map::DefaultHasher,
+        ffi::CStr,
         hash::{Hash, Hasher},
     };
 
@@ -349,6 +354,23 @@ mod tests {
 
         let s = uuid.to_string();
         assert_eq!(s.chars().nth(14).unwrap(), '4');
+    }
+
+    #[rstest]
+    fn test_format_uuid4_bytes_golden() {
+        let bytes = [
+            0x2d, 0x89, 0x66, 0x6b, 0x1a, 0x1e, 0x4a, 0x75, 0xb1, 0x93, 0x4e, 0xb3, 0xb4, 0x54,
+            0xc7, 0x57,
+        ];
+
+        let formatted = format_uuid4_bytes(bytes);
+        let text = CStr::from_bytes_with_nul(&formatted)
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        assert_eq!(text, "2d89666b-1a1e-4a75-b193-4eb3b454c757");
+        assert_eq!(formatted[36], 0);
     }
 
     #[rstest]

--- a/crates/core/tests/layout.rs
+++ b/crates/core/tests/layout.rs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::mem::{align_of, size_of};
+
+use nautilus_core::UUID4;
+use rstest::rstest;
+
+#[rstest]
+fn uuid4_layout_stays_c_string_compatible() {
+    assert_eq!(size_of::<UUID4>(), 37);
+    assert_eq!(align_of::<UUID4>(), 1);
+
+    let uuid = UUID4::from("2d89666b-1a1e-4a75-b193-4eb3b454c757");
+    let text = uuid.as_str();
+
+    assert_eq!(text.len(), 36);
+    assert_eq!(&text[8..9], "-");
+    assert_eq!(&text[13..14], "-");
+    assert_eq!(&text[18..19], "-");
+    assert_eq!(&text[23..24], "-");
+    assert_eq!(&text[14..15], "4");
+    assert!(matches!(text.as_bytes()[19], b'8' | b'9' | b'a' | b'b'));
+}


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR optimizes two fixed-format core formatting paths without changing public APIs or wire/FFI layout. It replaces chrono RFC3339 formatting in `unix_nanos_to_iso8601[_millis]` with fixed-width UTC integer formatting, and replaces `UUID4::new` runtime `write!` formatting with fixed-position lowercase hex table writes.

The retained changes are behavior-equivalent: the datetime functions still return `String`, out-of-range timestamps still fall back to the raw nanosecond string, and `UUID4` remains `#[repr(C)]` with the same `[u8; 37]` NUL-terminated layout.

## Performance summary

Benchmarks compare the baseline on `develop` (`63966996dc`) against this branch. Values are Criterion mean ranges from a local macOS/aarch64 workstation; latency reduction and speedup are approximate midpoint calculations unless noted.

| Area | Benchmark | Before | After | Latency reduction | Speedup |
| --- | --- | ---: | ---: | ---: | ---: |
| Datetime nanos | `datetime/unix_nanos_to_iso8601/epoch` | 66.079-66.317 ns | 47.189-47.289 ns | ~28.6% | ~1.40x |
| Datetime nanos | `datetime/unix_nanos_to_iso8601/current_sample` | 53.335-53.440 ns | 46.990-47.210 ns | ~11.8% | ~1.13x |
| Datetime nanos | `datetime/unix_nanos_to_iso8601/max_chrono` | 54.516-60.261 ns | 47.470-47.721 ns | ~17.1% midpoint, noisy | ~1.14-1.21x |
| Datetime fallback | `datetime/unix_nanos_to_iso8601/raw_fallback` | 94.683-94.911 ns | 30.190-30.355 ns | ~68.1% | ~3.13x |
| Datetime millis | `datetime/unix_nanos_to_iso8601_millis/epoch` | 54.429-54.536 ns | 43.995-44.185 ns | ~19.1% | ~1.24x |
| Datetime millis | `datetime/unix_nanos_to_iso8601_millis/millis_sample` | 51.505-51.604 ns | 43.668-43.784 ns | ~15.2% | ~1.18x |
| Datetime fallback | `datetime/unix_nanos_to_iso8601_millis/raw_fallback` | 94.667-94.946 ns | 29.667-29.819 ns | ~68.6% | ~3.18x |
| Integration style | `datetime/logging_style_line` | 89.532-89.720 ns | 82.718-83.091 ns | ~7.5% | ~1.08x |
| UUID | `UUID4::new` | 113.96-114.54 ns | 25.304-25.724 ns | ~77.7% | ~4.5x |

## Detailed benchmark results

### Datetime fixed formatter

The old path constructed a chrono `DateTime` and used `to_rfc3339_opts`. The new path splits a UTC nanosecond timestamp into date/time parts with integer arithmetic, writes fixed-width fields into a pre-sized `String`, and keeps the same raw-string fallback when the timestamp exceeds chrono's `i64` nanosecond range.

| Benchmark | Before | After | Result |
| --- | ---: | ---: | --- |
| `datetime/unix_nanos_to_iso8601/epoch` | 66.079-66.317 ns | 47.189-47.289 ns | ~1.40x faster |
| `datetime/unix_nanos_to_iso8601/current_sample` | 53.335-53.440 ns | 46.990-47.210 ns | ~1.13x faster |
| `datetime/unix_nanos_to_iso8601/max_chrono` | 54.516-60.261 ns | 47.470-47.721 ns | faster; baseline was noisy |
| `datetime/unix_nanos_to_iso8601/raw_fallback` | 94.683-94.911 ns | 30.190-30.355 ns | ~3.13x faster |
| `datetime/unix_nanos_to_iso8601_millis/epoch` | 54.429-54.536 ns | 43.995-44.185 ns | ~1.24x faster |
| `datetime/unix_nanos_to_iso8601_millis/millis_sample` | 51.505-51.604 ns | 43.668-43.784 ns | ~1.18x faster |
| `datetime/unix_nanos_to_iso8601_millis/raw_fallback` | 94.667-94.946 ns | 29.667-29.819 ns | ~3.18x faster |
| `datetime/logging_style_line` | 89.532-89.720 ns | 82.718-83.091 ns | ~1.08x faster |

ASM evidence:

- Baseline inspection showed the chrono RFC3339 path going through repeated `RawVecInner::reserve::do_reserve_and_handle` blocks and chrono date formatting machinery.
- The retained implementation no longer calls chrono RFC3339 formatting on the successful path; it uses fixed-width integer formatting helpers with exact `String::with_capacity(30)` for nanos and `String::with_capacity(24)` for millis.
- The public formatter symbols are inlined in the release artifact. Helper symbols such as `push_iso8601_prefix`, `push_9_digits`, and `split_unix_nanos` remain visible. Their reserve fallback blocks still exist because they write to `String`, but the public functions pre-size the buffer so the normal path does not need to grow it.

Correctness coverage:

- Added chrono-oracle tests for representative in-range timestamps.
- Added out-of-range fallback tests for values greater than `i64::MAX` nanoseconds.
- Added leap-day and year-boundary cases for nanos and millis formatting.

### UUID fixed formatter

The old `UUID4::new` path generated UUID bytes, then formatted the fixed UUID text through `write!` and generic lower-hex formatting. The new path writes each byte through a lowercase hex lookup table and inserts hyphens at fixed positions.

| Benchmark | Before | After | Result |
| --- | ---: | ---: | --- |
| `UUID4::new` | 113.96-114.54 ns | 25.304-25.724 ns | ~4.5x faster |
| `UUID4::as_bytes` | 22.387-22.592 ns | 22.168-22.236 ns | neutral/slightly faster; behavior unchanged |
| `UUID4::as_bytes_then_hash` | 22.997-23.052 ns | 22.968-23.017 ns | neutral; behavior unchanged |
| `UUID4::to_string` | 52.609-53.206 ns | 53.080-53.416 ns | neutral; behavior unchanged |

Baseline ASM evidence for `UUID4::new` showed the generic formatting path:

```asm
sub sp, sp, #272
bl  nautilus_core::uuid::UUID4::new_bytes
bl  core::fmt::write
bl  __rustc::__rust_dealloc
```

After the change, `cargo asm -p nautilus-core --lib --asm 'nautilus_core::uuid::UUID4::new' 0` shows fixed byte writes and no `core::fmt::write` in `UUID4::new`:

```asm
bl      nautilus_core::uuid::UUID4::new_bytes
ldrh    w8, [x6, x8, lsl #1]
strh    w8, [x19]
strb    w8, [x19, #8]
strb    wzr, [x19, #36]
```

Correctness and compatibility coverage:

- Added a deterministic golden test for the private fixed-position UUID formatter.
- Added a layout test to keep `UUID4` at 37 bytes with 1-byte alignment.
- The test also pins key byte positions: hyphens, version digit, RFC4122 variant digit, and NUL terminator.

## Type of change

- [x] Improvement (non-breaking)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validation run on this branch:

```bash
cargo test -p nautilus-core --lib
# 975 passed

cargo test -p nautilus-core --test layout
# 1 passed
```

Benchmark commands used for the retained changes:

```bash
cargo bench -p nautilus-core --bench datetime -- --quiet
cargo bench -p nautilus-core --bench uuid -- --quiet
cargo asm -p nautilus-core --lib --asm 'nautilus_core::uuid::UUID4::new' 0
```


<details>
<summary>Core experiment data and rejected options</summary>

## Experiment scope

This section records the broader `crates/core` performance experiments that were measured during this work. Only the behavior-compatible datetime and UUID formatting changes are retained in this PR. Other measured wins are recorded here so the data is available for follow-up discussion without expanding the current PR scope.

Benchmarks were run on a local macOS/aarch64 workstation using Criterion. The baseline commit used for the retained changes was `develop` at `63966996dc`. Local workstation noise is possible, so small differences should be treated as directional unless the speedup is large and consistent.

## Retained in this PR

| Area | Change | Main result | Compatibility |
| --- | --- | ---: | --- |
| Datetime | Fixed-width ISO-8601 nanos/millis formatter | `unix_nanos_to_iso8601/epoch`: ~66.2 ns -> ~47.2 ns, ~1.40x | Existing `String` API preserved |
| UUID | Fixed-position UUID text formatter | `UUID4::new`: ~114 ns -> ~25.5 ns, ~4.5x | `#[repr(C)]` and `[u8; 37]` preserved |
| Layout | UUID4 FFI layout assertion | `[u8; 37]`, 1-byte alignment, hyphen/version/variant/NUL positions pinned | Test-only compatibility guard |

## Datetime baseline and retained result

| Benchmark | Before | After | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| `datetime/unix_nanos_to_iso8601/epoch` | 66.079-66.317 ns | 47.189-47.289 ns | ~1.40x | Kept |
| `datetime/unix_nanos_to_iso8601/current_sample` | 53.335-53.440 ns | 46.990-47.210 ns | ~1.13x | Kept |
| `datetime/unix_nanos_to_iso8601/max_chrono` | 54.516-60.261 ns | 47.470-47.721 ns | faster; baseline noisy | Kept |
| `datetime/unix_nanos_to_iso8601/raw_fallback` | 94.683-94.911 ns | 30.190-30.355 ns | ~3.13x | Kept |
| `datetime/unix_nanos_to_iso8601_millis/epoch` | 54.429-54.536 ns | 43.995-44.185 ns | ~1.24x | Kept |
| `datetime/unix_nanos_to_iso8601_millis/millis_sample` | 51.505-51.604 ns | 43.668-43.784 ns | ~1.18x | Kept |
| `datetime/unix_nanos_to_iso8601_millis/raw_fallback` | 94.667-94.946 ns | 29.667-29.819 ns | ~3.18x | Kept |
| `datetime/logging_style_line` | 89.532-89.720 ns | 82.718-83.091 ns | ~1.08x | Kept |

ASM evidence:

- The previous implementation used chrono RFC3339 formatting and showed repeated `RawVecInner::reserve::do_reserve_and_handle` blocks in the formatting path.
- The retained implementation uses integer date splitting and fixed-width writers with `String::with_capacity(30)` for nanos and `String::with_capacity(24)` for millis.
- The public formatter functions are inlined in the release artifact; helper symbols such as `push_iso8601_prefix`, `push_9_digits`, and `split_unix_nanos` remain visible. Reserve fallback blocks still exist in helper code because the output type is `String`, but the retained public functions pre-size the buffer for the normal path.

## UUID baseline and retained result

| Benchmark | Before | After | Speedup / result | Decision |
| --- | ---: | ---: | ---: | --- |
| `UUID4::new` | 113.96-114.54 ns | 25.304-25.724 ns | ~4.5x | Kept |
| `Uuid::new` | 914.85-917.69 ns | 908.32-911.43 ns | unrelated/noisy | External baseline |
| `UUID4::to_string` | 52.609-53.206 ns | 53.080-53.416 ns | neutral | Unchanged |
| `UUID4::from_str` | 62.929-63.216 ns | 63.520-64.517 ns | noisy neutral/slightly slower | Unchanged |
| `UUID4::as_bytes` | 22.387-22.592 ns | 22.168-22.236 ns | neutral/slightly faster | Unchanged |
| `UUID4::as_bytes_then_hash` | 22.997-23.052 ns | 22.968-23.017 ns | neutral | Unchanged |
| `UUID4::serialize` | 88.204-88.618 ns | 89.145-89.410 ns | noisy neutral/slightly slower | Unchanged |
| `UUID4::deserialize` | 99.236-99.927 ns | 100.20-100.89 ns | noisy neutral/slightly slower | Unchanged |
| `UUID4::round_trip` | 188.84-189.66 ns | 189.49-190.18 ns | noisy neutral | Unchanged |

Baseline ASM evidence for `UUID4::new` showed generic formatting work:

```asm
sub sp, sp, #272
bl  nautilus_core::uuid::UUID4::new_bytes
bl  core::fmt::write
bl  __rustc::__rust_dealloc
```

After the retained change, `UUID4::new` no longer shows `core::fmt::write`; the hot body uses fixed byte writes from the lowercase hex lookup table:

```asm
bl      nautilus_core::uuid::UUID4::new_bytes
ldrh    w8, [x6, x8, lsl #1]
strh    w8, [x19]
strb    w8, [x19, #8]
strb    wzr, [x19, #36]
```

## AtomicTime experiments not retained

Current realtime semantics are strict: each call returns a globally unique, strictly increasing timestamp. That is enforced with wall-clock retrieval plus a CAS loop against `timestamp_ns`.

Single-thread results:

| Variant | Result | Speedup vs current | Decision |
| --- | ---: | ---: | --- |
| Current `AcqRel` CAS | 29.754-29.886 ns | 1.00x | Baseline |
| Padded `AcqRel` CAS prototype | 29.928-30.070 ns | neutral/slower | Not retained |
| Relaxed strict CAS prototype | 28.695-28.741 ns | ~1.04x | Not retained |
| Relaxed `fetch_max` non-unique prototype | 28.260-28.631 ns | ~1.05x | Not retained as default |
| `Instant` offset non-unique prototype | 26.951-27.033 ns | ~1.10x | Not retained as default |

Mode-specific helper results:

| Benchmark | Current public path | Direct mode-specific path | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| static | `get_time_ns/static`: 1.473-1.478 ns | `timestamp_ns.load`: 960.7-969.7 ps | ~1.5x | Candidate additive helper |
| realtime | `get_time_ns/realtime`: 29.923-30.090 ns | `time_since_epoch`: 29.664-29.722 ns | ~1.01x | Not worth changing |

Contention results:

| Threads | Current `AcqRel` CAS | Padded CAS | Relaxed strict CAS | `fetch_max` non-unique | Decision |
| ---: | ---: | ---: | ---: | ---: | --- |
| 2 | 1.302-1.317 ms | 1.303-1.319 ms | 1.289-1.306 ms | 816.5-827.4 us | `fetch_max` faster but semantic change |
| 4 | 5.656-5.844 ms | 4.993-5.163 ms | 5.182-5.339 ms | 2.123-2.167 ms | `fetch_max` faster but semantic change |
| 8 | 26.072-27.017 ms | 24.732-25.364 ms | 24.865-25.261 ms | 4.623-4.696 ms | `fetch_max` faster but semantic change |
| 16 | 57.902-58.606 ms | 58.895-59.954 ms | 58.608-59.532 ms | 11.046-11.181 ms | `fetch_max` ~5.2x faster but semantic change |

Decision:

- Keep current strict realtime behavior by default.
- Record `fetch_max` as a strong future opt-in candidate only if maintainers accept non-unique/non-strict realtime timestamps for a specific workload.
- Do not retain padding or relaxed strict CAS from this data.

## Hex caller-buffer experiments not retained

The caller-buffer APIs were measured because existing `hex::encode` and `hex::decode` allocate. They were removed from the current PR because no production hot call site currently uses them, and keeping new public APIs without a migrated hot caller would add API surface and unsafe/internal complexity for no demonstrated product-path benefit.

| Benchmark | Existing allocating API | Caller-buffer API | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| `hex::encode (32 bytes)` vs `hex::encode_to_slice` | 37.401-37.579 ns | 10.084-10.121 ns | ~3.70x | Measured, not retained |
| `hex::decode (64 chars)` vs `hex::decode_to_slice` | 46.055-46.445 ns | 18.226-18.388 ns | ~2.51x | Measured, not retained |
| `hex::decode_array::<32>` | 28.821-28.992 ns | 26.588-29.159 ns | noisy neutral | Reverted to original implementation |
| `hex roundtrip (32 bytes)` | 82.350-82.729 ns | 81.605-81.804 ns | neutral/slightly faster | Existing API not changed |

ASM evidence:

- Standalone generic caller-buffer symbols were often inlined/monomorphized away in the library artifact, so the bench data is stronger than library-symbol asm here.
- The measured successful caller-buffer path removes heap allocation from the operation.

## URL encoding experiments not retained

URL encoding improvements were measured, but the audited production call sites were connection setup, login form construction, or REST request setup. They are not tight market-data or order hot loops, so the code churn was removed from this PR.

Existing API before/after prototype:

| Benchmark | Before | After prototype | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| `encode (unreserved, short)` | 11.748-12.390 ns | 11.179-11.306 ns | ~1.06x | Not retained |
| `encode (unreserved, long)` | 23.920-24.024 ns | 23.763-23.808 ns | ~1.01x | Not retained |
| `encode (ISO timestamp)` | 49.656-50.026 ns | 42.818-44.116 ns | ~1.15x | Not retained |
| `encode (JSON payload)` | 236.65-237.70 ns | 153.08-153.51 ns | ~1.55x | Not retained |
| `encode (UTF-8 mixed)` | 94.245-94.554 ns | 54.785-54.964 ns | ~1.72x | Not retained |
| `encode (all reserved)` | 368.06-369.52 ns | 249.81-251.59 ns | ~1.47x | Not retained |
| `decode (encoded JSON)` | 240.01-240.75 ns | 237.36-237.91 ns | neutral | Unchanged |
| `decode (encoded UTF-8)` | 68.093-68.346 ns | 67.575-67.976 ns | neutral | Unchanged |

Caller-buffer API prototypes:

| Benchmark | Existing API after encode prototype | Caller-buffer API | Speedup vs existing after | Decision |
| --- | ---: | ---: | ---: | --- |
| `encode (ISO timestamp)` vs `encode_to_slice` | 42.818-44.116 ns | 13.934-14.151 ns | ~3.1x | Measured, not retained |
| `encode (JSON payload)` vs `encode_to_slice` | 153.08-153.51 ns | 112.68-113.33 ns | ~1.35x | Measured, not retained |
| `encode (UTF-8 mixed)` vs `encode_to_slice` | 54.785-54.964 ns | 20.927-21.478 ns | ~2.6x | Measured, not retained |
| `encode (all reserved)` vs `encode_to_slice` | 249.81-251.59 ns | 139.44-140.01 ns | ~1.8x | Measured, not retained |
| `decode (encoded JSON)` vs `decode_to_slice` | 237.36-237.91 ns | 170.13-171.24 ns | ~1.4x | Measured, not retained |
| `decode (encoded UTF-8)` vs `decode_to_slice` | 67.575-67.976 ns | 30.652-30.827 ns | ~2.2x | Measured, not retained |

Prototype note:

- A bench-local `decode_to_slice_prototype` measured faster than the safe production API shape (`encoded JSON`: ~121 ns prototype vs ~171 ns capacity-checked API).
- A future internal hot path could consider an unchecked helper only when buffer capacity is proven by construction.

## Math interpolation experiment not retained

A prevalidated quadratic interpolator was measured by validating `xs`/`ys` once at construction and keeping repeated interpolation calls smaller. The win is real, but this PR did not prove that the attempted production migration is exercised in a trading/valuation hot loop.

| Benchmark | Existing checked API | Prevalidated interpolator | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| lower boundary | 3.553-3.806 ns | 1.587-1.593 ns | ~2.3x | Measured, not retained |
| exact point | 21.032-21.092 ns | 9.849-9.889 ns | ~2.1x | Measured, not retained |
| midpoint | 21.058-21.210 ns | 9.912-9.950 ns | ~2.1x | Measured, not retained |
| upper boundary | 3.484-3.492 ns | 1.903-1.911 ns | ~1.8x | Measured, not retained |
| 16-point batch | 212.58-213.07 ns | 108.86-109.33 ns | ~1.95x | Measured, not retained |

ASM evidence:

- The successful interpolator body is straight-line floating-point arithmetic plus a `partition_point`-style binary search.
- Per-call denominator and finite validation from the existing checked API is not in the successful interpolation path.
- Bounds/panic blocks remain for public safety and impossible invariant violations.

## Serialization experiment not retained

Changing `serialize_vec_decimal_as_str` from `&Vec<Decimal>` to `&[Decimal]` is a reasonable cleanup and should remain source-compatible through deref coercion, but the measured result is neutral and the helper is not a proven hot path.

| Benchmark | Before | After prototype | Decision |
| --- | ---: | ---: | --- |
| 0 decimals | 24.604-24.728 ns | 24.398-24.465 ns | Not retained |
| 4 decimals | 264.80-266.11 ns | 264.16-265.94 ns | Not retained |
| 64 decimals | 4.1416-4.1605 us | 4.1330-4.1466 us | Not retained |
| 1024 decimals | 63.803-64.058 us | 63.548-63.746 us | Not retained |

## UUID experiments not retained

### Direct fixed-layout text decode

A direct parser for the existing `[u8; 37]` string storage was measured and rejected because it was slower than the current parser path on this machine.

| Benchmark | Current | Prototype | Decision |
| --- | ---: | ---: | --- |
| `UUID4::as_bytes` | 22.312-22.366 ns | 29.200-29.311 ns before UUID formatter; 29.237-29.323 ns after UUID formatter | Not retained |

### Binary UUID storage

Binary UUID storage is a strong performance candidate, but replacing the current storage would be ABI/FFI breaking because `UUID4` is currently a C-compatible 37-byte NUL-terminated string.

| Benchmark | Current compatible storage | Binary prototype | Speedup | Decision |
| --- | ---: | ---: | ---: | --- |
| `new` | 25.304-25.724 ns | 16.009-16.059 ns | ~1.6x | ABI-breaking candidate |
| `as_bytes` | 22.168-22.236 ns | ~380 ps | ~58x | ABI-breaking candidate |
| `hash` | 2.455-2.461 ns | 1.474-1.477 ns | ~1.7x | ABI-breaking candidate |
| `to_string` | 53.080-53.416 ns | 37.839-37.931 ns | ~1.4x | ABI-breaking candidate |

Decision:

- Do not silently replace `UUID4` storage in this PR.
- The data is strong enough to justify a future dedicated compatibility/design discussion.

## StackStr experiment not retained

An unchecked copy constructor gives a clear lower bound when the caller can prove all invariants upfront, but no audited call site currently proves non-empty ASCII, no NUL, max length, and non-whitespace invariants strongly enough to justify exposing or retaining it.

| Benchmark | Result |
| --- | ---: |
| `StackStr::new (medium)` | 13.061-13.180 ns |
| `StackStr::unchecked_copy_prototype (medium)` | 3.1845-3.1967 ns |
| `StackStr::new_then_hash (medium)` | 26.270-26.854 ns |
| `Ustr::from_then_hash (medium)` | 14.360-14.466 ns |

Decision:

- Do not add a public unsafe constructor.
- Consider only an internal constructor in the future, and only for audited call sites with proven invariants.

## AtomicMap data moved to the adapter PR

AtomicMap read-pattern data was measured during the same research pass, but the production migration is adapter-specific and was split into the adapter PR. The core result is still useful for context:

| Pattern | Result | Throughput | Decision |
| --- | ---: | ---: | --- |
| `get_cloned_each_lookup` over 256 reads | 2.946-2.962 us | ~86.7 Melem/s | Baseline |
| `load_each_lookup` over 256 reads | 2.952-2.958 us | ~86.6 Melem/s | Baseline |
| `load_once_guard` over 256 reads | 2.180-2.189 us | ~117.2 Melem/s | Use this pattern in repeated-read paths |
| 16 repeated `insert` clone-and-swap writes | 490.02-492.76 us | ~32.6 Kelem/s | Measured, no hot-path migration |
| single `rcu` batch for 16 writes | 47.729-48.312 us | ~333 Kelem/s | Measured, no hot-path migration |

Decision:

- No new `AtomicMap` API is required; existing `load()` and `rcu()` already express the faster patterns.
- Guard-hoisted reads belong in adapter hot paths and are handled in the separate adapter PR.
- Batch `rcu` writes remain documented for future hot batch-writer candidates, but this core PR does not migrate bootstrap/control paths.

## Final retained/rejected summary

Retained in this PR:

- Fixed-width datetime formatter.
- Fixed-position UUID formatter.
- UUID4 layout assertion.
- Bench coverage for retained core formatting changes.

Measured but not retained in this PR:

- AtomicTime `fetch_max` or `Instant` offset as default behavior.
- AtomicTime padding or relaxed strict CAS.
- UUID binary storage replacement.
- UUID direct text decode for current storage.
- Hex caller-buffer APIs and neutral existing-API internal rewrites.
- URL encode owned-path simplification and caller-buffer APIs.
- Decimal serialization slice signature.
- Prevalidated quadratic interpolator and attempted yield-curve migration.
- Public unsafe StackStr unchecked constructor.
- AtomicMap adapter hot-path migrations, which were split into a separate adapter PR.

</details>
