### PR TITLE
Optimize AtomicMap snapshot borrowing

### DIFF
--- a/crates/adapters/bybit/src/python/websocket.rs
+++ b/crates/adapters/bybit/src/python/websocket.rs
@@ -304,11 +304,6 @@ impl BybitWebSocketClient {
                 let mut funding_cache: AHashMap<Ustr, (Option<String>, Option<String>)> =
                     AHashMap::new();
                 let _client = client;
-                let _resolve = |raw_symbol: &Ustr| -> Option<InstrumentAny> {
-                    let key =
-                        product_type.map_or(*raw_symbol, |pt| make_bybit_symbol(raw_symbol, pt));
-                    instruments.get_cloned(&key)
-                };
 
                 tokio::pin!(stream);
 
@@ -1365,13 +1360,13 @@ fn register_batch_pending(
     }
 }
 
-fn resolve_instrument(
+fn resolve_instrument_from_snapshot<'a>(
     raw_symbol: &Ustr,
     product_type: Option<BybitProductType>,
-    instruments: &AtomicMap<Ustr, InstrumentAny>,
-) -> Option<InstrumentAny> {
+    instruments: &'a AHashMap<Ustr, InstrumentAny>,
+) -> Option<&'a InstrumentAny> {
     let key = product_type.map_or(*raw_symbol, |pt| make_bybit_symbol(raw_symbol, pt));
-    instruments.get_cloned(&key)
+    instruments.get(&key)
 }
 
 fn send_data_to_python(data: Data, call_soon: &Py<PyAny>, callback: &Py<PyAny>) {
@@ -1402,12 +1397,15 @@ fn handle_orderbook(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = resolve_instrument(&msg.data.s, product_type, instruments) else {
+    let instruments_snapshot = instruments.load();
+    let Some(instrument) =
+        resolve_instrument_from_snapshot(&msg.data.s, product_type, &instruments_snapshot)
+    else {
         return;
     };
     let ts_init = clock.get_time_ns();
 
-    match parse_orderbook_deltas(msg, &instrument, ts_init) {
+    match parse_orderbook_deltas(msg, instrument, ts_init) {
         Ok(deltas) => {
             send_data_to_python(
                 Data::Deltas(OrderBookDeltas_API::new(deltas)),
@@ -1421,7 +1419,7 @@ fn handle_orderbook(
     let instrument_id = instrument.id();
     let last_quote = quote_cache.get(&instrument_id);
 
-    match parse_orderbook_quote(msg, &instrument, last_quote, ts_init) {
+    match parse_orderbook_quote(msg, instrument, last_quote, ts_init) {
         Ok(quote) => {
             quote_cache.insert(instrument_id, quote);
             send_data_to_python(Data::Quote(quote), call_soon, callback);
@@ -1440,9 +1438,12 @@ fn handle_trade(
     callback: &Py<PyAny>,
 ) {
     let ts_init = clock.get_time_ns();
+    let instruments_snapshot = instruments.load();
 
     for trade in &msg.data {
-        let Some(instrument) = resolve_instrument(&trade.s, product_type, instruments) else {
+        let Some(instrument) =
+            resolve_instrument_from_snapshot(&trade.s, product_type, &instruments_snapshot)
+        else {
             continue;
         };
 
@@ -1453,7 +1454,7 @@ fn handle_trade(
             continue;
         }
 
-        match parse_ws_trade_tick(trade, &instrument, ts_init) {
+        match parse_ws_trade_tick(trade, instrument, ts_init) {
             Ok(tick) => send_data_to_python(Data::Trade(tick), call_soon, callback),
             Err(e) => log::error!("Failed to parse trade tick: {e}"),
         }
@@ -1475,7 +1476,10 @@ fn handle_kline(
         return;
     };
     let ustr_symbol = Ustr::from(raw_symbol);
-    let Some(instrument) = resolve_instrument(&ustr_symbol, product_type, instruments) else {
+    let instruments_snapshot = instruments.load();
+    let Some(instrument) =
+        resolve_instrument_from_snapshot(&ustr_symbol, product_type, &instruments_snapshot)
+    else {
         return;
     };
     let Some(bar_type) = bar_types_cache.load().get(msg.topic.as_str()).copied() else {
@@ -1491,7 +1495,7 @@ fn handle_kline(
 
         match parse_ws_kline_bar(
             kline,
-            &instrument,
+            instrument,
             bar_type,
             bars_timestamp_on_close,
             ts_init,
@@ -1513,14 +1517,17 @@ fn handle_ticker_linear(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = resolve_instrument(&msg.data.symbol, product_type, instruments) else {
+    let instruments_snapshot = instruments.load();
+    let Some(instrument) =
+        resolve_instrument_from_snapshot(&msg.data.symbol, product_type, &instruments_snapshot)
+    else {
         return;
     };
     let instrument_id = instrument.id();
     let ts_init = clock.get_time_ns();
 
     if msg.data.bid1_price.is_some() {
-        match parse_ticker_linear_quote(msg, &instrument, ts_init) {
+        match parse_ticker_linear_quote(msg, instrument, ts_init) {
             Ok(quote) => {
                 let last = quote_cache.get(&instrument_id);
 
@@ -1566,14 +1573,14 @@ fn handle_ticker_linear(
     }
 
     if msg.data.mark_price.is_some() {
-        match parse_ticker_linear_mark_price(&msg.data, &instrument, ts_event, ts_init) {
+        match parse_ticker_linear_mark_price(&msg.data, instrument, ts_event, ts_init) {
             Ok(update) => send_to_python(update, call_soon, callback),
             Err(e) => log::debug!("Skipping mark price update: {e}"),
         }
     }
 
     if msg.data.index_price.is_some() {
-        match parse_ticker_linear_index_price(&msg.data, &instrument, ts_event, ts_init) {
+        match parse_ticker_linear_index_price(&msg.data, instrument, ts_event, ts_init) {
             Ok(update) => send_to_python(update, call_soon, callback),
             Err(e) => log::debug!("Skipping index price update: {e}"),
         }
@@ -1591,13 +1598,16 @@ fn handle_ticker_option(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = resolve_instrument(&msg.data.symbol, product_type, instruments) else {
+    let instruments_snapshot = instruments.load();
+    let Some(instrument) =
+        resolve_instrument_from_snapshot(&msg.data.symbol, product_type, &instruments_snapshot)
+    else {
         return;
     };
     let instrument_id = instrument.id();
     let ts_init = clock.get_time_ns();
 
-    match parse_ticker_option_quote(msg, &instrument, ts_init) {
+    match parse_ticker_option_quote(msg, instrument, ts_init) {
         Ok(quote) => {
             let last = quote_cache.get(&instrument_id);
 
@@ -1609,18 +1619,18 @@ fn handle_ticker_option(
         Err(e) => log::error!("Failed to parse ticker option quote: {e}"),
     }
 
-    match parse_ticker_option_mark_price(msg, &instrument, ts_init) {
+    match parse_ticker_option_mark_price(msg, instrument, ts_init) {
         Ok(update) => send_to_python(update, call_soon, callback),
         Err(e) => log::error!("Failed to parse ticker option mark price: {e}"),
     }
 
-    match parse_ticker_option_index_price(msg, &instrument, ts_init) {
+    match parse_ticker_option_index_price(msg, instrument, ts_init) {
         Ok(update) => send_to_python(update, call_soon, callback),
         Err(e) => log::error!("Failed to parse ticker option index price: {e}"),
     }
 
     if option_greeks_subs.contains(&instrument_id) {
-        match parse_ticker_option_greeks(msg, &instrument, ts_init) {
+        match parse_ticker_option_greeks(msg, instrument, ts_init) {
             Ok(greeks) => send_to_python(greeks, call_soon, callback),
             Err(e) => log::error!("Failed to parse option greeks: {e}"),
         }
@@ -1636,10 +1646,11 @@ fn handle_account_order(
     callback: &Py<PyAny>,
 ) {
     let ts_init = clock.get_time_ns();
+    let instruments_snapshot = instruments.load();
 
     for order in &msg.data {
         let symbol = make_bybit_symbol(order.symbol, order.category);
-        let Some(instrument) = instruments.get_cloned(&symbol) else {
+        let Some(instrument) = instruments_snapshot.get(&symbol) else {
             log::warn!("No instrument for order update: {symbol}");
             continue;
         };
@@ -1647,7 +1658,7 @@ fn handle_account_order(
             continue;
         };
 
-        match parse_ws_order_status_report(order, &instrument, account_id, ts_init) {
+        match parse_ws_order_status_report(order, instrument, account_id, ts_init) {
             Ok(report) => send_to_python(report, call_soon, callback),
             Err(e) => log::error!("Failed to parse order status report: {e}"),
         }
@@ -1663,10 +1674,11 @@ fn handle_account_execution(
     callback: &Py<PyAny>,
 ) {
     let ts_init = clock.get_time_ns();
+    let instruments_snapshot = instruments.load();
 
     for exec in &msg.data {
         let symbol = make_bybit_symbol(exec.symbol, exec.category);
-        let Some(instrument) = instruments.get_cloned(&symbol) else {
+        let Some(instrument) = instruments_snapshot.get(&symbol) else {
             log::warn!("No instrument for execution update: {symbol}");
             continue;
         };
@@ -1674,7 +1686,7 @@ fn handle_account_execution(
             continue;
         };
 
-        match parse_ws_fill_report(exec, account_id, &instrument, ts_init) {
+        match parse_ws_fill_report(exec, account_id, instrument, ts_init) {
             Ok(report) => send_to_python(report, call_soon, callback),
             Err(e) => log::error!("Failed to parse fill report: {e}"),
         }
@@ -1690,10 +1702,11 @@ fn handle_account_execution_fast(
     callback: &Py<PyAny>,
 ) {
     let ts_init = clock.get_time_ns();
+    let instruments_snapshot = instruments.load();
 
     for exec in &msg.data {
         let symbol = make_bybit_symbol(exec.symbol, exec.category);
-        let Some(instrument) = instruments.get_cloned(&symbol) else {
+        let Some(instrument) = instruments_snapshot.get(&symbol) else {
             log::warn!("No instrument for fast-execution update: {symbol}");
             continue;
         };
@@ -1701,7 +1714,7 @@ fn handle_account_execution_fast(
             continue;
         };
 
-        match parse_ws_fill_report_fast(exec, account_id, &instrument, None, ts_init) {
+        match parse_ws_fill_report_fast(exec, account_id, instrument, None, ts_init) {
             Ok(report) => send_to_python(report, call_soon, callback),
             Err(e) => log::error!("Failed to parse fast fill report: {e}"),
         }
@@ -1738,10 +1751,11 @@ fn handle_account_position(
     callback: &Py<PyAny>,
 ) {
     let ts_init = clock.get_time_ns();
+    let instruments_snapshot = instruments.load();
 
     for position in &msg.data {
         let symbol = make_bybit_symbol(position.symbol, position.category);
-        let Some(instrument) = instruments.get_cloned(&symbol) else {
+        let Some(instrument) = instruments_snapshot.get(&symbol) else {
             log::warn!("No instrument for position update: {symbol}");
             continue;
         };
@@ -1749,7 +1763,7 @@ fn handle_account_position(
             continue;
         };
 
-        match parse_ws_position_status_report(position, account_id, &instrument, ts_init) {
+        match parse_ws_position_status_report(position, account_id, instrument, ts_init) {
             Ok(report) => send_to_python(report, call_soon, callback),
             Err(e) => log::error!("Failed to parse position status report: {e}"),
         }

--- a/crates/adapters/coinbase/src/websocket/handler.rs
+++ b/crates/adapters/coinbase/src/websocket/handler.rs
@@ -48,9 +48,17 @@ fn instrument_id_from_product(product_id: &Ustr) -> InstrumentId {
     InstrumentId::new(Symbol::new(*product_id), *COINBASE_VENUE)
 }
 
-fn resolve_instrument_id(aliases: &AtomicMap<Ustr, Ustr>, product_id: &Ustr) -> InstrumentId {
-    let resolved = aliases.get_cloned(product_id).unwrap_or(*product_id);
+fn resolve_instrument_id_from_aliases(
+    aliases: &AHashMap<Ustr, Ustr>,
+    product_id: &Ustr,
+) -> InstrumentId {
+    let resolved = aliases.get(product_id).copied().unwrap_or(*product_id);
     instrument_id_from_product(&resolved)
+}
+
+fn resolve_instrument_id(aliases: &AtomicMap<Ustr, Ustr>, product_id: &Ustr) -> InstrumentId {
+    let aliases = aliases.load();
+    resolve_instrument_id_from_aliases(&aliases, product_id)
 }
 
 /// Commands sent from [`super::client::CoinbaseWebSocketClient`] to the feed handler.
@@ -351,9 +359,10 @@ impl FeedHandler {
         };
 
         let mut first: Option<NautilusWsMessage> = None;
+        let aliases = self.subscription_aliases.load();
 
         for event in events {
-            let instrument_id = self.resolve_instrument_id(&event.product_id);
+            let instrument_id = resolve_instrument_id_from_aliases(&aliases, &event.product_id);
 
             let instrument = match self.instruments.get(&instrument_id) {
                 Some(inst) => inst,
@@ -393,9 +402,11 @@ impl FeedHandler {
         events: &[crate::websocket::messages::WsMarketTradesEvent],
         ts_init: UnixNanos,
     ) -> Option<NautilusWsMessage> {
+        let aliases = self.subscription_aliases.load();
+
         for event in events {
             for trade in &event.trades {
-                let instrument_id = self.resolve_instrument_id(&trade.product_id);
+                let instrument_id = resolve_instrument_id_from_aliases(&aliases, &trade.product_id);
 
                 let instrument = match self.instruments.get(&instrument_id) {
                     Some(inst) => inst,
@@ -427,6 +438,7 @@ impl FeedHandler {
         ts_init: UnixNanos,
     ) {
         let mut found_current = false;
+        let aliases = self.subscription_aliases.load();
 
         for event in events {
             let is_current_event = std::ptr::eq(event, current_event);
@@ -439,7 +451,7 @@ impl FeedHandler {
                     continue;
                 }
 
-                let instrument_id = self.resolve_instrument_id(&trade.product_id);
+                let instrument_id = resolve_instrument_id_from_aliases(&aliases, &trade.product_id);
 
                 if let Some(instrument) = self.instruments.get(&instrument_id)
                     && let Ok(tick) = parse_ws_trade(trade, instrument, ts_init)
@@ -459,10 +471,12 @@ impl FeedHandler {
         let ts_event = crate::http::parse::parse_rfc3339_timestamp(timestamp).unwrap_or(ts_init);
 
         let mut first: Option<NautilusWsMessage> = None;
+        let aliases = self.subscription_aliases.load();
 
         for event in events {
             for ticker in &event.tickers {
-                let instrument_id = self.resolve_instrument_id(&ticker.product_id);
+                let instrument_id =
+                    resolve_instrument_id_from_aliases(&aliases, &ticker.product_id);
 
                 let instrument = match self.instruments.get(&instrument_id) {
                     Some(inst) => inst,
@@ -515,12 +529,13 @@ impl FeedHandler {
         };
 
         let mut first: Option<NautilusWsMessage> = None;
+        let aliases = self.subscription_aliases.load();
 
         for event in events {
             let is_snapshot = matches!(event.event_type, WsEventType::Snapshot);
 
             for order in &event.orders {
-                let instrument_id = self.resolve_instrument_id(&order.product_id);
+                let instrument_id = resolve_instrument_id_from_aliases(&aliases, &order.product_id);
                 let instrument = match self.instruments.get(&instrument_id).cloned() {
                     Some(inst) => inst,
                     None => {
@@ -646,6 +661,7 @@ impl FeedHandler {
         ts_init: UnixNanos,
     ) -> Option<NautilusWsMessage> {
         let mut first: Option<NautilusWsMessage> = None;
+        let aliases = self.subscription_aliases.load();
 
         for event in events {
             for candle in &event.candles {
@@ -659,7 +675,8 @@ impl FeedHandler {
                     }
                 };
 
-                let instrument_id = self.resolve_instrument_id(&candle.product_id);
+                let instrument_id =
+                    resolve_instrument_id_from_aliases(&aliases, &candle.product_id);
 
                 let instrument = match self.instruments.get(&instrument_id) {
                     Some(inst) => inst,

--- a/crates/adapters/hyperliquid/src/execution.rs
+++ b/crates/adapters/hyperliquid/src/execution.rs
@@ -552,10 +552,10 @@ impl ExecutionClient for HyperliquidExecutionClient {
         }
 
         let http_client = self.http_client.clone();
-        let symbol = order.instrument_id().symbol.to_string();
+        let symbol = order.instrument_id().symbol.inner();
 
         // Validate asset index exists before marking as submitted
-        let asset = match http_client.get_asset_index(&symbol) {
+        let asset = match http_client.get_asset_index_for_symbol(symbol) {
             Some(a) => a,
             None => {
                 self.emitter
@@ -565,7 +565,9 @@ impl ExecutionClient for HyperliquidExecutionClient {
         };
 
         // Validate order conversion before marking as submitted
-        let price_decimals = http_client.get_price_precision(&symbol).unwrap_or(2);
+        let price_decimals = http_client
+            .get_price_precision_for_symbol(symbol)
+            .unwrap_or(2);
         let slippage_bps = self.resolve_slippage_bps(cmd.params.as_ref());
         let mut hyperliquid_order = match order_to_hyperliquid_request_with_asset_and_cloid(
             &order,
@@ -706,8 +708,8 @@ impl ExecutionClient for HyperliquidExecutionClient {
                 continue;
             }
 
-            let symbol = order.instrument_id().symbol.to_string();
-            let asset = match http_client.get_asset_index(&symbol) {
+            let symbol = order.instrument_id().symbol.inner();
+            let asset = match http_client.get_asset_index_for_symbol(symbol) {
                 Some(a) => a,
                 None => {
                     self.emitter
@@ -716,7 +718,9 @@ impl ExecutionClient for HyperliquidExecutionClient {
                 }
             };
 
-            let price_decimals = http_client.get_price_precision(&symbol).unwrap_or(2);
+            let price_decimals = http_client
+                .get_price_precision_for_symbol(symbol)
+                .unwrap_or(2);
 
             match order_to_hyperliquid_request_with_asset_and_cloid(
                 order,
@@ -921,7 +925,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         };
 
         let http_client = self.http_client.clone();
-        let symbol = cmd.instrument_id.symbol.to_string();
+        let symbol = cmd.instrument_id.symbol.inner();
         let should_normalize = self.config.normalize_prices;
         let slippage_bps = self.resolve_slippage_bps(cmd.params.as_ref());
 
@@ -945,8 +949,10 @@ impl ExecutionClient for HyperliquidExecutionClient {
         }
 
         let quantity = target_total_qty - filled_qty;
-        let price_decimals = http_client.get_price_precision(&symbol).unwrap_or(2);
-        let asset = match http_client.get_asset_index(&symbol) {
+        let price_decimals = http_client
+            .get_price_precision_for_symbol(symbol)
+            .unwrap_or(2);
+        let asset = match http_client.get_asset_index_for_symbol(symbol) {
             Some(a) => a,
             None => {
                 log::warn!(
@@ -1077,11 +1083,11 @@ impl ExecutionClient for HyperliquidExecutionClient {
         let strategy_id = cmd.strategy_id;
         let instrument_id = cmd.instrument_id;
         let venue_order_id = cmd.venue_order_id;
-        let symbol = cmd.instrument_id.symbol.to_string();
+        let symbol = cmd.instrument_id.symbol.inner();
         let ws_client = self.ws_client.clone();
 
         self.spawn_task("cancel_order", async move {
-            let asset = match http_client.get_asset_index(&symbol) {
+            let asset = match http_client.get_asset_index_for_symbol(symbol) {
                 Some(a) => a,
                 None => {
                     log::warn!(
@@ -1174,7 +1180,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
             return Ok(());
         }
 
-        let symbol = cmd.instrument_id.symbol.to_string();
+        let symbol = cmd.instrument_id.symbol.inner();
         let instrument_id = cmd.instrument_id;
         let strategy_id = cmd.strategy_id;
         let entries: Vec<CancelEntry> = open_orders
@@ -1184,7 +1190,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
                 instrument_id,
                 client_order_id: o.client_order_id(),
                 venue_order_id: o.venue_order_id(),
-                symbol: symbol.clone(),
+                symbol,
             })
             .collect();
 
@@ -1194,7 +1200,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
         let ws_client = self.ws_client.clone();
 
         self.spawn_task("cancel_all_orders", async move {
-            let asset = match http_client.get_asset_index(&symbol) {
+            let asset = match http_client.get_asset_index_for_symbol(symbol) {
                 Some(a) => a,
                 None => {
                     log::warn!(
@@ -1246,7 +1252,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
                 instrument_id: c.instrument_id,
                 client_order_id: c.client_order_id,
                 venue_order_id: c.venue_order_id,
-                symbol: c.instrument_id.symbol.to_string(),
+                symbol: c.instrument_id.symbol.inner(),
             })
             .collect();
 
@@ -1259,7 +1265,7 @@ impl ExecutionClient for HyperliquidExecutionClient {
             let mut cancel_dispatch = CancelDispatch::new();
 
             for entry in &entries {
-                let asset = match http_client.get_asset_index(&entry.symbol) {
+                let asset = match http_client.get_asset_index_for_symbol(entry.symbol) {
                     Some(a) => a,
                     None => {
                         log::warn!(
@@ -1797,7 +1803,7 @@ struct CancelEntry {
     instrument_id: InstrumentId,
     client_order_id: ClientOrderId,
     venue_order_id: Option<VenueOrderId>,
-    symbol: String,
+    symbol: Ustr,
 }
 
 struct CancelDispatch {

--- a/crates/adapters/hyperliquid/src/http/client.rs
+++ b/crates/adapters/hyperliquid/src/http/client.rs
@@ -1488,14 +1488,26 @@ impl HyperliquidHttpClient {
     ///
     /// Returns `None` if the symbol is not found in the map.
     pub fn get_asset_index(&self, symbol: &str) -> Option<u32> {
-        self.asset_indices.load().get(&Ustr::from(symbol)).copied()
+        self.get_asset_index_for_symbol(Ustr::from(symbol))
+    }
+
+    /// Get asset index for an already-interned symbol from the cached map.
+    ///
+    /// Returns `None` if the symbol is not found in the map.
+    pub(crate) fn get_asset_index_for_symbol(&self, symbol: Ustr) -> Option<u32> {
+        self.asset_indices.load().get(&symbol).copied()
     }
 
     /// Get the price precision for a cached instrument by symbol.
     pub fn get_price_precision(&self, symbol: &str) -> Option<u8> {
+        self.get_price_precision_for_symbol(Ustr::from(symbol))
+    }
+
+    /// Get the price precision for a cached instrument by interned symbol.
+    pub(crate) fn get_price_precision_for_symbol(&self, symbol: Ustr) -> Option<u8> {
         self.instruments
             .load()
-            .get(&Ustr::from(symbol))
+            .get(&symbol)
             .map(|inst| inst.price_precision())
     }
 
@@ -1664,8 +1676,8 @@ impl HyperliquidHttpClient {
         venue_order_id: Option<VenueOrderId>,
     ) -> Result<()> {
         // Get asset ID from cached indices map
-        let symbol = instrument_id.symbol.as_str();
-        let asset_id = self.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset_id = self.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             Error::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
@@ -1758,8 +1770,8 @@ impl HyperliquidHttpClient {
         time_in_force: TimeInForce,
         client_order_id: Option<ClientOrderId>,
     ) -> Result<()> {
-        let symbol = instrument_id.symbol.as_str();
-        let asset_id = self.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset_id = self.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             Error::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
@@ -1771,7 +1783,7 @@ impl HyperliquidHttpClient {
             .map_err(|_| Error::bad_request("Invalid venue order ID format"))?;
 
         let is_buy = matches!(order_side, OrderSide::Buy);
-        let decimals = self.get_price_precision(symbol).unwrap_or(2);
+        let decimals = self.get_price_precision_for_symbol(symbol).unwrap_or(2);
 
         let normalized_price = if self.normalize_prices {
             normalize_price(price.as_decimal(), decimals).normalize()
@@ -2675,15 +2687,15 @@ impl HyperliquidHttpClient {
         post_only: bool,
         reduce_only: bool,
     ) -> Result<OrderStatusReport> {
-        let symbol = instrument_id.symbol.as_str();
-        let asset = self.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset = self.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             Error::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
         })?;
 
         let is_buy = matches!(order_side, OrderSide::Buy);
-        let price_precision = self.get_price_precision(symbol).unwrap_or(2);
+        let price_precision = self.get_price_precision_for_symbol(symbol).unwrap_or(2);
 
         let price_decimal = match price {
             Some(px) if self.normalize_prices => {
@@ -2984,13 +2996,13 @@ impl HyperliquidHttpClient {
 
         for order in orders {
             let instrument_id = order.instrument_id();
-            let symbol = instrument_id.symbol.as_str();
-            let asset = self.get_asset_index(symbol).ok_or_else(|| {
+            let symbol = instrument_id.symbol.inner();
+            let asset = self.get_asset_index_for_symbol(symbol).ok_or_else(|| {
                 Error::bad_request(format!(
                     "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
                 ))
             })?;
-            let price_decimals = self.get_price_precision(symbol).unwrap_or(2);
+            let price_decimals = self.get_price_precision_for_symbol(symbol).unwrap_or(2);
             let request = order_to_hyperliquid_request_with_asset_and_cloid(
                 order,
                 asset,

--- a/crates/adapters/hyperliquid/src/websocket/client.rs
+++ b/crates/adapters/hyperliquid/src/websocket/client.rs
@@ -482,14 +482,14 @@ impl HyperliquidWebSocketClient {
         post_only: bool,
         reduce_only: bool,
     ) -> HyperliquidResult<()> {
-        let symbol = instrument_id.symbol.as_str();
-        let asset = signer.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset = signer.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             HyperliquidError::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
         })?;
         let is_buy = matches!(order_side, OrderSide::Buy);
-        let price_precision = signer.get_price_precision(symbol).unwrap_or(2);
+        let price_precision = signer.get_price_precision_for_symbol(symbol).unwrap_or(2);
 
         let price_decimal = match price {
             Some(px) if signer.normalize_prices() => {
@@ -566,13 +566,13 @@ impl HyperliquidWebSocketClient {
 
         for order in orders {
             let instrument_id = order.instrument_id();
-            let symbol = instrument_id.symbol.as_str();
-            let asset = signer.get_asset_index(symbol).ok_or_else(|| {
+            let symbol = instrument_id.symbol.inner();
+            let asset = signer.get_asset_index_for_symbol(symbol).ok_or_else(|| {
                 HyperliquidError::bad_request(format!(
                     "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
                 ))
             })?;
-            let price_decimals = signer.get_price_precision(symbol).unwrap_or(2);
+            let price_decimals = signer.get_price_precision_for_symbol(symbol).unwrap_or(2);
             let request = order_to_hyperliquid_request_with_asset_and_cloid(
                 order,
                 asset,
@@ -612,8 +612,8 @@ impl HyperliquidWebSocketClient {
         client_order_id: Option<ClientOrderId>,
         venue_order_id: Option<VenueOrderId>,
     ) -> HyperliquidResult<()> {
-        let symbol = instrument_id.symbol.as_str();
-        let asset = signer.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset = signer.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             HyperliquidError::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
@@ -669,8 +669,8 @@ impl HyperliquidWebSocketClient {
 
         for (index, (instrument_id, client_order_id, venue_order_id)) in cancels.iter().enumerate()
         {
-            let symbol = instrument_id.symbol.as_str();
-            let Some(asset) = signer.get_asset_index(symbol) else {
+            let symbol = instrument_id.symbol.inner();
+            let Some(asset) = signer.get_asset_index_for_symbol(symbol) else {
                 results[index] = Some(format!(
                     "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
                 ));
@@ -798,8 +798,8 @@ impl HyperliquidWebSocketClient {
         time_in_force: TimeInForce,
         client_order_id: Option<ClientOrderId>,
     ) -> HyperliquidResult<()> {
-        let symbol = instrument_id.symbol.as_str();
-        let asset = signer.get_asset_index(symbol).ok_or_else(|| {
+        let symbol = instrument_id.symbol.inner();
+        let asset = signer.get_asset_index_for_symbol(symbol).ok_or_else(|| {
             HyperliquidError::bad_request(format!(
                 "Asset index not found for symbol: {symbol}. Ensure instruments are loaded."
             ))
@@ -809,7 +809,7 @@ impl HyperliquidWebSocketClient {
             .parse::<u64>()
             .map_err(|_| HyperliquidError::bad_request("Invalid venue order ID format"))?;
         let is_buy = matches!(order_side, OrderSide::Buy);
-        let price_decimals = signer.get_price_precision(symbol).unwrap_or(2);
+        let price_decimals = signer.get_price_precision_for_symbol(symbol).unwrap_or(2);
         let price = if signer.normalize_prices() {
             normalize_price(price.as_decimal(), price_decimals).normalize()
         } else {

--- a/crates/adapters/kraken/src/common/mod.rs
+++ b/crates/adapters/kraken/src/common/mod.rs
@@ -15,6 +15,12 @@
 
 //! Shared primitives and utilities for the Kraken adapter.
 
+use ahash::AHashMap;
+use nautilus_model::{
+    identifiers::{InstrumentId, Symbol},
+    instruments::InstrumentAny,
+};
+
 pub mod consts;
 pub mod credential;
 pub mod enums;
@@ -22,3 +28,12 @@ pub mod models;
 pub mod order_params;
 pub mod parse;
 pub mod urls;
+
+/// Looks up a Kraken instrument from a preloaded map snapshot by raw exchange symbol.
+pub(crate) fn lookup_instrument_in_snapshot<'a>(
+    instruments: &'a AHashMap<InstrumentId, InstrumentAny>,
+    raw_symbol: &str,
+) -> Option<&'a InstrumentAny> {
+    let instrument_id = InstrumentId::new(Symbol::new(raw_symbol), *consts::KRAKEN_VENUE);
+    instruments.get(&instrument_id)
+}

--- a/crates/adapters/kraken/src/data/futures.rs
+++ b/crates/adapters/kraken/src/data/futures.rs
@@ -52,7 +52,7 @@ use nautilus_core::{
 use nautilus_model::{
     data::{Data, OrderBookDeltas, OrderBookDeltas_API, QuoteTick},
     enums::BookType,
-    identifiers::{ClientId, InstrumentId, Symbol, Venue},
+    identifiers::{ClientId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
     orderbook::OrderBook,
 };
@@ -60,7 +60,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    common::consts::KRAKEN_VENUE,
+    common::{consts::KRAKEN_VENUE, lookup_instrument_in_snapshot},
     config::KrakenDataClientConfig,
     http::{
         KrakenFuturesHttpClient, futures::client::KRAKEN_FUTURES_DEFAULT_RATE_LIMIT_PER_SECOND,
@@ -237,14 +237,6 @@ impl KrakenFuturesDataClient {
         Ok(())
     }
 
-    fn lookup_instrument(
-        instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
-        product_id: &str,
-    ) -> Option<InstrumentAny> {
-        let instrument_id = InstrumentId::new(Symbol::new(product_id), *KRAKEN_VENUE);
-        instruments.load().get(&instrument_id).cloned()
-    }
-
     #[expect(clippy::too_many_arguments)]
     fn handle_ws_message(
         msg: KrakenFuturesWsMessage,
@@ -261,40 +253,42 @@ impl KrakenFuturesDataClient {
 
         match msg {
             KrakenFuturesWsMessage::Ticker(ticker) => {
+                let instruments = instruments.load();
                 let Some(instrument) =
-                    Self::lookup_instrument(instruments, ticker.product_id.as_str())
+                    lookup_instrument_in_snapshot(&instruments, ticker.product_id.as_str())
                 else {
                     log::warn!("No instrument for product_id: {}", ticker.product_id);
                     return;
                 };
 
-                if let Some(mark) = parse_futures_ws_mark_price(&ticker, &instrument, ts_init)
+                if let Some(mark) = parse_futures_ws_mark_price(&ticker, instrument, ts_init)
                     && let Err(e) = sender.send(DataEvent::Data(Data::MarkPriceUpdate(mark)))
                 {
                     log::error!("Failed to send mark price: {e}");
                 }
 
-                if let Some(index) = parse_futures_ws_index_price(&ticker, &instrument, ts_init)
+                if let Some(index) = parse_futures_ws_index_price(&ticker, instrument, ts_init)
                     && let Err(e) = sender.send(DataEvent::Data(Data::IndexPriceUpdate(index)))
                 {
                     log::error!("Failed to send index price: {e}");
                 }
 
-                if let Some(funding) = parse_futures_ws_funding_rate(&ticker, &instrument, ts_init)
+                if let Some(funding) = parse_futures_ws_funding_rate(&ticker, instrument, ts_init)
                     && let Err(e) = sender.send(DataEvent::FundingRate(funding))
                 {
                     log::error!("Failed to send funding rate: {e}");
                 }
             }
             KrakenFuturesWsMessage::Trade(trade) => {
+                let instruments = instruments.load();
                 let Some(instrument) =
-                    Self::lookup_instrument(instruments, trade.product_id.as_str())
+                    lookup_instrument_in_snapshot(&instruments, trade.product_id.as_str())
                 else {
                     log::warn!("No instrument for product_id: {}", trade.product_id);
                     return;
                 };
 
-                match parse_futures_ws_trade_tick(&trade, &instrument, ts_init) {
+                match parse_futures_ws_trade_tick(&trade, instrument, ts_init) {
                     Ok(tick) => {
                         if let Err(e) = sender.send(DataEvent::Data(Data::Trade(tick))) {
                             log::error!("Failed to send trade: {e}");
@@ -304,8 +298,9 @@ impl KrakenFuturesDataClient {
                 }
             }
             KrakenFuturesWsMessage::BookSnapshot(snapshot) => {
+                let instruments = instruments.load();
                 let Some(instrument) =
-                    Self::lookup_instrument(instruments, snapshot.product_id.as_str())
+                    lookup_instrument_in_snapshot(&instruments, snapshot.product_id.as_str())
                 else {
                     log::warn!("No instrument for product_id: {}", snapshot.product_id);
                     return;
@@ -314,10 +309,7 @@ impl KrakenFuturesDataClient {
                 let sequence = book_sequence.load(Ordering::Relaxed);
 
                 match parse_futures_ws_book_snapshot_deltas(
-                    &snapshot,
-                    &instrument,
-                    sequence,
-                    ts_init,
+                    &snapshot, instrument, sequence, ts_init,
                 ) {
                     Ok(delta_vec) => {
                         if delta_vec.is_empty() {
@@ -359,15 +351,16 @@ impl KrakenFuturesDataClient {
                 }
             }
             KrakenFuturesWsMessage::BookDelta(delta) => {
+                let instruments = instruments.load();
                 let Some(instrument) =
-                    Self::lookup_instrument(instruments, delta.product_id.as_str())
+                    lookup_instrument_in_snapshot(&instruments, delta.product_id.as_str())
                 else {
                     log::warn!("No instrument for product_id: {}", delta.product_id);
                     return;
                 };
                 let instrument_id = instrument.id();
                 let sequence = book_sequence.fetch_add(1, Ordering::Relaxed);
-                match parse_futures_ws_book_delta(&delta, &instrument, sequence, ts_init) {
+                match parse_futures_ws_book_delta(&delta, instrument, sequence, ts_init) {
                     Ok(book_delta) => {
                         let deltas = OrderBookDeltas::new(instrument_id, vec![book_delta]);
 

--- a/crates/adapters/kraken/src/data/spot.rs
+++ b/crates/adapters/kraken/src/data/spot.rs
@@ -51,7 +51,7 @@ use nautilus_core::{
 use nautilus_model::{
     data::{Bar, Data, OrderBookDeltas, OrderBookDeltas_API},
     enums::{AggregationSource, BookType},
-    identifiers::{ClientId, InstrumentId, Symbol, Venue},
+    identifiers::{ClientId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
 };
 use tokio::task::JoinHandle;
@@ -62,7 +62,7 @@ type OhlcBufferKey = (Ustr, u32);
 type OhlcBuffer = Arc<Mutex<AHashMap<OhlcBufferKey, (Bar, UnixNanos)>>>;
 
 use crate::{
-    common::consts::KRAKEN_VENUE,
+    common::{consts::KRAKEN_VENUE, lookup_instrument_in_snapshot},
     config::KrakenDataClientConfig,
     http::{KrakenSpotHttpClient, spot::client::KRAKEN_SPOT_DEFAULT_RATE_LIMIT_PER_SECOND},
     websocket::spot_v2::{
@@ -420,14 +420,6 @@ impl KrakenSpotDataClient {
         Ok(())
     }
 
-    fn lookup_instrument(
-        instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
-        symbol: &str,
-    ) -> Option<InstrumentAny> {
-        let instrument_id = InstrumentId::new(Symbol::new(symbol), *KRAKEN_VENUE);
-        instruments.load().get(&instrument_id).cloned()
-    }
-
     fn flush_ohlc_buffer(
         ohlc_buffer: &OhlcBuffer,
         sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
@@ -455,15 +447,17 @@ impl KrakenSpotDataClient {
 
         match msg {
             KrakenSpotWsMessage::Ticker(tickers) => {
+                let instruments = instruments.load();
+
                 for ticker in &tickers {
                     let Some(instrument) =
-                        Self::lookup_instrument(instruments, ticker.symbol.as_str())
+                        lookup_instrument_in_snapshot(&instruments, ticker.symbol.as_str())
                     else {
                         log::warn!("No instrument for symbol: {}", ticker.symbol);
                         continue;
                     };
 
-                    match parse_quote_tick(ticker, &instrument, ts_init) {
+                    match parse_quote_tick(ticker, instrument, ts_init) {
                         Ok(quote) => {
                             if let Err(e) = sender.send(DataEvent::Data(Data::Quote(quote))) {
                                 log::error!("Failed to send quote: {e}");
@@ -474,15 +468,17 @@ impl KrakenSpotDataClient {
                 }
             }
             KrakenSpotWsMessage::Trade(trades) => {
+                let instruments = instruments.load();
+
                 for trade in &trades {
                     let Some(instrument) =
-                        Self::lookup_instrument(instruments, trade.symbol.as_str())
+                        lookup_instrument_in_snapshot(&instruments, trade.symbol.as_str())
                     else {
                         log::warn!("No instrument for symbol: {}", trade.symbol);
                         continue;
                     };
 
-                    match parse_trade_tick(trade, &instrument, ts_init) {
+                    match parse_trade_tick(trade, instrument, ts_init) {
                         Ok(tick) => {
                             if let Err(e) = sender.send(DataEvent::Data(Data::Trade(tick))) {
                                 log::error!("Failed to send trade: {e}");
@@ -496,15 +492,17 @@ impl KrakenSpotDataClient {
                 data,
                 is_snapshot: _,
             } => {
+                let instruments = instruments.load();
+
                 for book in &data {
                     let Some(instrument) =
-                        Self::lookup_instrument(instruments, book.symbol.as_str())
+                        lookup_instrument_in_snapshot(&instruments, book.symbol.as_str())
                     else {
                         log::warn!("No instrument for symbol: {}", book.symbol);
                         continue;
                     };
                     let sequence = book_sequence.load(Ordering::Relaxed);
-                    match parse_book_deltas(book, &instrument, sequence, ts_init) {
+                    match parse_book_deltas(book, instrument, sequence, ts_init) {
                         Ok(delta_vec) => {
                             if delta_vec.is_empty() {
                                 continue;
@@ -526,15 +524,17 @@ impl KrakenSpotDataClient {
                     return;
                 };
 
+                let instruments = instruments.load();
+
                 for ohlc in &ohlc_data {
                     let Some(instrument) =
-                        Self::lookup_instrument(instruments, ohlc.symbol.as_str())
+                        lookup_instrument_in_snapshot(&instruments, ohlc.symbol.as_str())
                     else {
                         log::warn!("No instrument for symbol: {}", ohlc.symbol);
                         continue;
                     };
 
-                    match parse_ws_bar(ohlc, &instrument, ts_init) {
+                    match parse_ws_bar(ohlc, instrument, ts_init) {
                         Ok(new_bar) => {
                             let key: (Ustr, u32) = (ohlc.symbol, ohlc.interval);
                             let new_interval_begin = UnixNanos::from(
@@ -1154,6 +1154,7 @@ mod tests {
     use nautilus_common::{live::runner::set_data_event_sender, messages::DataEvent};
     use nautilus_model::{
         enums::BookAction,
+        identifiers::Symbol,
         instruments::{InstrumentAny, currency_pair::CurrencyPair},
         types::{Currency, Price, Quantity},
     };

--- a/crates/adapters/kraken/src/python/websocket_futures.rs
+++ b/crates/adapters/kraken/src/python/websocket_futures.rs
@@ -30,9 +30,7 @@ use nautilus_core::{
 use nautilus_model::{
     data::{Data, OrderBookDeltas, OrderBookDeltas_API, QuoteTick},
     enums::{BookType, OrderSide, OrderStatus, OrderType, TimeInForce},
-    identifiers::{
-        AccountId, ClientOrderId, InstrumentId, StrategyId, Symbol, TraderId, VenueOrderId,
-    },
+    identifiers::{AccountId, ClientOrderId, InstrumentId, StrategyId, TraderId, VenueOrderId},
     instruments::{Instrument, InstrumentAny},
     orderbook::OrderBook,
     python::{data::data_to_pycapsule, instruments::pyobject_to_instrument_any},
@@ -44,9 +42,9 @@ use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::{
     common::{
-        consts::KRAKEN_VENUE,
         credential::KrakenCredential,
         enums::{KrakenEnvironment, KrakenProductType},
+        lookup_instrument_in_snapshot,
         urls::get_kraken_ws_public_url,
     },
     websocket::futures::{
@@ -696,14 +694,6 @@ impl KrakenFuturesWebSocketClient {
     }
 }
 
-fn lookup_instrument(
-    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
-    product_id: &str,
-) -> Option<InstrumentAny> {
-    let instrument_id = InstrumentId::new(Symbol::new(product_id), *KRAKEN_VENUE);
-    instruments.load().get(&instrument_id).cloned()
-}
-
 fn resolve_client_order_id(
     truncated: &str,
     truncated_id_map: &Arc<AtomicMap<String, ClientOrderId>>,
@@ -759,7 +749,8 @@ fn handle_open_orders_delta(
 
     let product_id = delta.order.instrument.as_str();
 
-    let Some(instrument) = lookup_instrument(instruments, product_id) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, product_id) else {
         log::warn!("No instrument for product_id: {product_id}");
         return;
     };
@@ -778,7 +769,7 @@ fn handle_open_orders_delta(
         &delta.order,
         delta.is_cancel,
         delta.reason.as_deref(),
-        &instrument,
+        instrument,
         acct_id,
         ts_init,
     ) {
@@ -891,6 +882,8 @@ fn handle_fills_delta(
         return;
     };
 
+    let instruments = instruments.load();
+
     for fill in &fills_delta.fills {
         let product_id = match &fill.instrument {
             Some(id) => id.as_str(),
@@ -900,12 +893,12 @@ fn handle_fills_delta(
             }
         };
 
-        let Some(instrument) = lookup_instrument(instruments, product_id) else {
+        let Some(instrument) = lookup_instrument_in_snapshot(&instruments, product_id) else {
             log::warn!("No instrument for product_id: {product_id}");
             continue;
         };
 
-        match parse_futures_ws_fill_report(fill, &instrument, acct_id, ts_init) {
+        match parse_futures_ws_fill_report(fill, instrument, acct_id, ts_init) {
             Ok(mut report) => {
                 if let Some(ref cl_ord_id) = fill.cli_ord_id {
                     let full_id = resolve_client_order_id(cl_ord_id, truncated_id_map);
@@ -925,25 +918,27 @@ fn handle_ticker(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = lookup_instrument(instruments, ticker.product_id.as_str()) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, ticker.product_id.as_str())
+    else {
         return;
     };
 
-    if let Some(mark_price) = parse_futures_ws_mark_price(ticker, &instrument, ts_init) {
+    if let Some(mark_price) = parse_futures_ws_mark_price(ticker, instrument, ts_init) {
         Python::attach(|py| {
             let py_obj = data_to_pycapsule(py, Data::MarkPriceUpdate(mark_price));
             call_python_threadsafe(py, call_soon, callback, py_obj);
         });
     }
 
-    if let Some(index_price) = parse_futures_ws_index_price(ticker, &instrument, ts_init) {
+    if let Some(index_price) = parse_futures_ws_index_price(ticker, instrument, ts_init) {
         Python::attach(|py| {
             let py_obj = data_to_pycapsule(py, Data::IndexPriceUpdate(index_price));
             call_python_threadsafe(py, call_soon, callback, py_obj);
         });
     }
 
-    if let Some(funding_rate) = parse_futures_ws_funding_rate(ticker, &instrument, ts_init) {
+    if let Some(funding_rate) = parse_futures_ws_funding_rate(ticker, instrument, ts_init) {
         Python::attach(|py| match funding_rate.into_py_any(py) {
             Ok(py_obj) => call_python_threadsafe(py, call_soon, callback, py_obj),
             Err(e) => log::error!("Failed to convert FundingRateUpdate to Python: {e}"),
@@ -958,11 +953,13 @@ fn handle_trade(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = lookup_instrument(instruments, trade.product_id.as_str()) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, trade.product_id.as_str())
+    else {
         return;
     };
 
-    match parse_futures_ws_trade_tick(trade, &instrument, ts_init) {
+    match parse_futures_ws_trade_tick(trade, instrument, ts_init) {
         Ok(tick) => {
             Python::attach(|py| {
                 let py_obj = data_to_pycapsule(py, Data::Trade(tick));
@@ -985,7 +982,10 @@ fn handle_book_snapshot(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = lookup_instrument(instruments, snapshot.product_id.as_str()) else {
+    let instruments = instruments.load();
+    let Some(instrument) =
+        lookup_instrument_in_snapshot(&instruments, snapshot.product_id.as_str())
+    else {
         return;
     };
     let instrument_id = instrument.id();
@@ -995,7 +995,7 @@ fn handle_book_snapshot(
         Ordering::Relaxed,
     );
 
-    match parse_futures_ws_book_snapshot_deltas(snapshot, &instrument, sequence, ts_init) {
+    match parse_futures_ws_book_snapshot_deltas(snapshot, instrument, sequence, ts_init) {
         Ok(delta_vec) => {
             if delta_vec.is_empty() {
                 return;
@@ -1047,14 +1047,16 @@ fn handle_book_delta(
     call_soon: &Py<PyAny>,
     callback: &Py<PyAny>,
 ) {
-    let Some(instrument) = lookup_instrument(instruments, delta.product_id.as_str()) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, delta.product_id.as_str())
+    else {
         return;
     };
     let instrument_id = instrument.id();
 
     let sequence = book_sequence.fetch_add(1, Ordering::Relaxed);
 
-    match parse_futures_ws_book_delta(delta, &instrument, sequence, ts_init) {
+    match parse_futures_ws_book_delta(delta, instrument, sequence, ts_init) {
         Ok(book_delta) => {
             let deltas = OrderBookDeltas::new(instrument_id, vec![book_delta]);
 

--- a/crates/adapters/kraken/src/python/websocket_spot.rs
+++ b/crates/adapters/kraken/src/python/websocket_spot.rs
@@ -260,15 +260,16 @@ impl KrakenSpotWebSocketClient {
 
                     match msg {
                         KrakenSpotWsMessage::Ticker(tickers) => {
+                            let instruments = instruments_map.load();
+
                             for ticker in &tickers {
                                 let instrument_id = InstrumentId::new(
                                     Symbol::new(ticker.symbol.as_str()),
                                     *KRAKEN_VENUE,
                                 );
-                                let instrument =
-                                    instruments_map.load().get(&instrument_id).cloned();
+                                let instrument = instruments.get(&instrument_id);
 
-                                if let Some(ref inst) = instrument {
+                                if let Some(inst) = instrument {
                                     match parse_quote_tick(ticker, inst, ts_init) {
                                         Ok(quote) => {
                                             Python::attach(|py| {
@@ -287,15 +288,16 @@ impl KrakenSpotWebSocketClient {
                             }
                         }
                         KrakenSpotWsMessage::Trade(trades) => {
+                            let instruments = instruments_map.load();
+
                             for trade in &trades {
                                 let instrument_id = InstrumentId::new(
                                     Symbol::new(trade.symbol.as_str()),
                                     *KRAKEN_VENUE,
                                 );
-                                let instrument =
-                                    instruments_map.load().get(&instrument_id).cloned();
+                                let instrument = instruments.get(&instrument_id);
 
-                                if let Some(ref inst) = instrument {
+                                if let Some(inst) = instrument {
                                     match parse_trade_tick(trade, inst, ts_init) {
                                         Ok(tick) => {
                                             Python::attach(|py| {
@@ -317,15 +319,16 @@ impl KrakenSpotWebSocketClient {
                             data,
                             is_snapshot: _,
                         } => {
+                            let instruments = instruments_map.load();
+
                             for book in &data {
                                 let instrument_id = InstrumentId::new(
                                     Symbol::new(book.symbol.as_str()),
                                     *KRAKEN_VENUE,
                                 );
-                                let instrument =
-                                    instruments_map.load().get(&instrument_id).cloned();
+                                let instrument = instruments.get(&instrument_id);
 
-                                if let Some(ref inst) = instrument {
+                                if let Some(inst) = instrument {
                                     let sequence = book_sequence.fetch_add(1, Ordering::Relaxed);
                                     match parse_book_deltas(book, inst, sequence, ts_init) {
                                         Ok(delta_vec) => {
@@ -351,15 +354,16 @@ impl KrakenSpotWebSocketClient {
                             }
                         }
                         KrakenSpotWsMessage::Ohlc(ohlc_data) => {
+                            let instruments = instruments_map.load();
+
                             for ohlc in &ohlc_data {
                                 let instrument_id = InstrumentId::new(
                                     Symbol::new(ohlc.symbol.as_str()),
                                     *KRAKEN_VENUE,
                                 );
-                                let instrument =
-                                    instruments_map.load().get(&instrument_id).cloned();
+                                let instrument = instruments.get(&instrument_id);
 
-                                if let Some(ref inst) = instrument {
+                                if let Some(inst) = instrument {
                                     match parse_ws_bar(ohlc, inst, ts_init) {
                                         Ok(bar) => {
                                             Python::attach(|py| {
@@ -385,14 +389,15 @@ impl KrakenSpotWebSocketClient {
                                 continue;
                             };
 
+                            let instruments = instruments_map.load();
+
                             for exec in &executions {
                                 let inst = if let Some(ref symbol) = exec.symbol {
                                     let instrument_id = InstrumentId::new(
                                         Symbol::new(symbol.as_str()),
                                         *KRAKEN_VENUE,
                                     );
-                                    let Some(inst) =
-                                        instruments_map.load().get(&instrument_id).cloned()
+                                    let Some(inst) = instruments.get(&instrument_id).cloned()
                                     else {
                                         log::warn!("No instrument for symbol: {symbol}");
                                         continue;

--- a/crates/adapters/kraken/src/websocket/dispatch/futures.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/futures.rs
@@ -21,6 +21,7 @@
 
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use nautilus_core::{AtomicMap, UUID4, UnixNanos};
 use nautilus_live::ExecutionEventEmitter;
 use nautilus_model::{
@@ -34,8 +35,9 @@ use nautilus_model::{
 
 use super::{
     DeltaSnapshot, OrderIdentity, WsDispatchState, ensure_accepted_emitted,
-    fill_report_to_order_filled, lookup_instrument, resolve_client_order_id,
+    fill_report_to_order_filled, resolve_client_order_id,
 };
+use crate::common::lookup_instrument_in_snapshot;
 use crate::websocket::futures::{
     messages::{
         KrakenFuturesFill, KrakenFuturesFillsDelta, KrakenFuturesOpenOrdersCancel,
@@ -73,7 +75,8 @@ pub fn open_orders_delta(
     }
 
     let product_id = delta.order.instrument.as_str();
-    let Some(instrument) = lookup_instrument(instruments, product_id) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, product_id) else {
         log::warn!("No instrument for product_id: {product_id}");
         return;
     };
@@ -113,7 +116,7 @@ pub fn open_orders_delta(
                 delta,
                 client_order_id,
                 &identity,
-                &instrument,
+                instrument,
                 state,
                 emitter,
                 account_id,
@@ -128,7 +131,7 @@ pub fn open_orders_delta(
         &delta.order,
         delta.is_cancel,
         delta.reason.as_deref(),
-        &instrument,
+        instrument,
         account_id,
         ts_init,
     ) {
@@ -372,14 +375,17 @@ pub fn fills_delta(
     account_id: AccountId,
     ts_init: UnixNanos,
 ) {
+    let instruments = instruments.load();
+    let venue_clients = venue_client_map.load();
+
     for fill in &fills_delta.fills {
         single_fill(
             fill,
             state,
             emitter,
-            instruments,
+            &instruments,
             truncated_id_map,
-            venue_client_map,
+            &venue_clients,
             account_id,
             ts_init,
         );
@@ -391,9 +397,9 @@ fn single_fill(
     fill: &KrakenFuturesFill,
     state: &WsDispatchState,
     emitter: &ExecutionEventEmitter,
-    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    instruments: &AHashMap<InstrumentId, InstrumentAny>,
     truncated_id_map: &Arc<AtomicMap<String, ClientOrderId>>,
-    venue_client_map: &Arc<AtomicMap<String, ClientOrderId>>,
+    venue_client_map: &AHashMap<String, ClientOrderId>,
     account_id: AccountId,
     ts_init: UnixNanos,
 ) {
@@ -405,12 +411,12 @@ fn single_fill(
         }
     };
 
-    let Some(instrument) = lookup_instrument(instruments, product_id) else {
+    let Some(instrument) = lookup_instrument_in_snapshot(instruments, product_id) else {
         log::warn!("No instrument for product_id: {product_id}");
         return;
     };
 
-    let mut report = match parse_futures_ws_fill_report(fill, &instrument, account_id, ts_init) {
+    let mut report = match parse_futures_ws_fill_report(fill, instrument, account_id, ts_init) {
         Ok(report) => report,
         Err(e) => {
             log::error!("Failed to parse futures fill report: {e}");
@@ -423,7 +429,7 @@ fn single_fill(
         .as_deref()
         .filter(|s| !s.is_empty())
         .map(|id| resolve_client_order_id(id, truncated_id_map))
-        .or_else(|| venue_client_map.load().get(&fill.order_id).copied());
+        .or_else(|| venue_client_map.get(&fill.order_id).copied());
 
     if let Some(cid) = resolved_id
         && state.filled_orders.contains(&cid)

--- a/crates/adapters/kraken/src/websocket/dispatch/mod.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/mod.rs
@@ -49,14 +49,11 @@ use nautilus_model::{
     enums::{OrderSide, OrderType},
     events::{OrderAccepted, OrderEventAny, OrderFilled},
     identifiers::{
-        AccountId, ClientOrderId, InstrumentId, StrategyId, Symbol, TradeId, TraderId, VenueOrderId,
+        AccountId, ClientOrderId, InstrumentId, StrategyId, TradeId, TraderId, VenueOrderId,
     },
-    instruments::InstrumentAny,
     reports::FillReport,
     types::{Currency, Quantity},
 };
-
-use crate::common::consts::KRAKEN_VENUE;
 
 const DEDUP_CAPACITY: usize = 10_000;
 
@@ -494,15 +491,6 @@ pub(crate) fn fill_report_to_order_filled(
         report.venue_position_id,
         Some(report.commission),
     )
-}
-
-/// Looks up an instrument from the shared instruments cache by raw symbol.
-pub(crate) fn lookup_instrument(
-    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
-    raw_symbol: &str,
-) -> Option<InstrumentAny> {
-    let instrument_id = InstrumentId::new(Symbol::new(raw_symbol), *KRAKEN_VENUE);
-    instruments.load().get(&instrument_id).cloned()
 }
 
 #[cfg(test)]

--- a/crates/adapters/kraken/src/websocket/dispatch/spot.rs
+++ b/crates/adapters/kraken/src/websocket/dispatch/spot.rs
@@ -37,8 +37,9 @@ use nautilus_model::{
 
 use super::{
     OrderIdentity, WsDispatchState, ensure_accepted_emitted, fill_report_to_order_filled,
-    lookup_instrument, resolve_client_order_id,
+    resolve_client_order_id,
 };
+use crate::common::lookup_instrument_in_snapshot;
 use crate::websocket::spot_v2::{
     enums::KrakenExecType,
     messages::KrakenWsExecutionData,
@@ -115,7 +116,8 @@ fn execution_inner(
             }
         },
     };
-    let Some(instrument) = lookup_instrument(instruments, symbol) else {
+    let instruments = instruments.load();
+    let Some(instrument) = lookup_instrument_in_snapshot(&instruments, symbol) else {
         log::warn!("No instrument for symbol: {symbol}");
         return;
     };
@@ -160,7 +162,7 @@ fn execution_inner(
     let identity = resolved_id.and_then(|cid| state.lookup_identity(&cid));
 
     // Status update.
-    match parse_ws_order_status_report(exec, &instrument, account_id, cached_qty, ts_init) {
+    match parse_ws_order_status_report(exec, instrument, account_id, cached_qty, ts_init) {
         Ok(mut report) => {
             if let Some(cid) = resolved_id {
                 report = report.with_client_order_id(cid);
@@ -187,7 +189,7 @@ fn execution_inner(
 
     // Fill (when present).
     if exec.exec_id.is_some() {
-        match parse_ws_fill_report(exec, &instrument, account_id, ts_init) {
+        match parse_ws_fill_report(exec, instrument, account_id, ts_init) {
             Ok(mut report) => {
                 if let Some(cid) = resolved_id {
                     report.client_order_id = Some(cid);
@@ -198,7 +200,7 @@ fn execution_inner(
                         &report,
                         client_order_id,
                         identity,
-                        &instrument,
+                        instrument,
                         state,
                         emitter,
                         account_id,

--- a/crates/adapters/kraken/src/websocket/spot_v2/level_3/runtime.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/level_3/runtime.rs
@@ -29,7 +29,7 @@ use nautilus_core::{AtomicMap, UnixNanos};
 use nautilus_model::{
     data::{OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API},
     enums::RecordFlag,
-    identifiers::{InstrumentId, Symbol},
+    identifiers::InstrumentId,
     instruments::{Instrument, InstrumentAny},
 };
 
@@ -38,7 +38,7 @@ use super::{
     checksum::{build_checksum_string, compute_checksum},
     parse::{CachedL3Order, parse_l3_snapshot, parse_l3_update},
 };
-use crate::common::consts::KRAKEN_VENUE;
+use crate::common::lookup_instrument_in_snapshot;
 
 /// Per-symbol L3 state tracked between WebSocket messages.
 #[derive(Debug)]
@@ -80,14 +80,6 @@ pub(crate) fn subscription_depth(depths: &Arc<Mutex<AHashMap<String, u32>>>, sym
         .map_or(1000, |depths| depths.get(symbol).copied().unwrap_or(1000))
 }
 
-fn lookup_instrument(
-    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
-    symbol: &str,
-) -> Option<InstrumentAny> {
-    let instrument_id = InstrumentId::new(Symbol::new(symbol), *KRAKEN_VENUE);
-    instruments.load().get(&instrument_id).cloned()
-}
-
 /// Emits a `Clear` delta (with `F_LAST`) after detecting a checksum mismatch.
 pub(crate) fn emit_l3_clear<S: L3Sink>(
     sink: &mut S,
@@ -124,7 +116,8 @@ pub(crate) fn process_l3_message<S: L3Sink>(
 ) -> Option<L3ResyncRequest> {
     match msg {
         KrakenL3WsMessage::Snapshot(snap) => {
-            let Some(instrument) = lookup_instrument(instruments, &snap.symbol) else {
+            let instruments = instruments.load();
+            let Some(instrument) = lookup_instrument_in_snapshot(&instruments, &snap.symbol) else {
                 log::warn!("L3 snapshot: no instrument for symbol={}", snap.symbol);
                 return None;
             };
@@ -142,7 +135,7 @@ pub(crate) fn process_l3_message<S: L3Sink>(
 
             match parse_l3_snapshot(
                 &snap,
-                &instrument,
+                instrument,
                 hasher,
                 &mut state.sequence,
                 ts_init,
@@ -212,7 +205,9 @@ pub(crate) fn process_l3_message<S: L3Sink>(
             }
         }
         KrakenL3WsMessage::Update(update) => {
-            let Some(instrument) = lookup_instrument(instruments, &update.symbol) else {
+            let instruments = instruments.load();
+            let Some(instrument) = lookup_instrument_in_snapshot(&instruments, &update.symbol)
+            else {
                 log::warn!("L3 update: no instrument for symbol={}", update.symbol);
                 return None;
             };
@@ -237,7 +232,7 @@ pub(crate) fn process_l3_message<S: L3Sink>(
 
             match parse_l3_update(
                 &update,
-                &instrument,
+                instrument,
                 hasher,
                 &mut state.sequence,
                 ts_init,
@@ -313,6 +308,7 @@ mod tests {
     use nautilus_core::time::get_atomic_clock_realtime;
     use nautilus_model::{
         enums::BookAction,
+        identifiers::Symbol,
         instruments::currency_pair::CurrencyPair,
         types::{Currency, Price, Quantity},
     };

--- a/crates/adapters/okx/src/websocket/client.rs
+++ b/crates/adapters/okx/src/websocket/client.rs
@@ -517,6 +517,20 @@ impl OKXWebSocketClient {
         self.inst_id_code_cache.load().get(inst_id).copied()
     }
 
+    fn inst_id_symbol_and_code_from_snapshot(
+        inst_id_codes: &AHashMap<Ustr, u64>,
+        inst_id: &InstrumentId,
+        action: &str,
+    ) -> Result<(Ustr, u64), OKXWsError> {
+        let inst_id_symbol = inst_id.symbol.inner();
+        let inst_id_code = inst_id_codes.get(&inst_id_symbol).copied().ok_or_else(|| {
+            OKXWsError::ClientError(format!(
+                "No instIdCode cached for {inst_id}, cannot {action} order"
+            ))
+        })?;
+        Ok((inst_id_symbol, inst_id_code))
+    }
+
     /// Sets the VIP level for this client.
     ///
     /// The VIP level determines which WebSocket channels are available.
@@ -2287,16 +2301,16 @@ impl OKXWebSocketClient {
         builder.td_mode(td_mode);
         builder.cl_ord_id(client_order_id.as_str());
 
-        let instrument = self
-            .instruments_cache
-            .get_cloned(&instrument_id.symbol.inner())
-            .ok_or_else(|| {
+        let (instrument_type, quote_currency) = {
+            let instruments = self.instruments_cache.load();
+            let symbol = instrument_id.symbol.inner();
+            let instrument = instruments.get(&symbol).ok_or_else(|| {
                 OKXWsError::ClientError(format!("Unknown instrument {instrument_id}"))
             })?;
-
-        let instrument_type =
-            okx_instrument_type(&instrument).map_err(|e| OKXWsError::ClientError(e.to_string()))?;
-        let quote_currency = instrument.quote_currency();
+            let instrument_type = okx_instrument_type(instrument)
+                .map_err(|e| OKXWsError::ClientError(e.to_string()))?;
+            (instrument_type, instrument.quote_currency())
+        };
 
         // OKX options only support limit-style orders
         if instrument_type == OKXInstrumentType::Option
@@ -2713,39 +2727,42 @@ impl OKXWebSocketClient {
     /// # References
     /// <https://www.okx.com/docs-v5/en/#order-book-trading-websocket-mass-cancel-order>
     pub async fn mass_cancel_orders(&self, instrument_id: InstrumentId) -> Result<(), OKXWsError> {
-        let instrument = self
-            .instruments_cache
-            .get_cloned(&instrument_id.symbol.inner())
-            .ok_or_else(|| {
-                OKXWsError::ClientError(format!("Unknown instrument {instrument_id}"))
-            })?;
+        let (inst_type, inst_family) = {
+            let instrument = self
+                .instruments_cache
+                .get_cloned(&instrument_id.symbol.inner())
+                .ok_or_else(|| {
+                    OKXWsError::ClientError(format!("Unknown instrument {instrument_id}"))
+                })?;
 
-        let inst_type =
-            okx_instrument_type(&instrument).map_err(|e| OKXWsError::ClientError(e.to_string()))?;
+            let inst_type = okx_instrument_type(&instrument)
+                .map_err(|e| OKXWsError::ClientError(e.to_string()))?;
 
-        let symbol = instrument.symbol().inner();
-        let inst_family = match &instrument {
-            InstrumentAny::CurrencyPair(_) => symbol.as_str().to_string(),
-            InstrumentAny::CryptoPerpetual(_) => symbol
-                .as_str()
-                .strip_suffix("-SWAP")
-                .unwrap_or(symbol.as_str())
-                .to_string(),
-            InstrumentAny::CryptoFuture(_) => {
-                let s = symbol.as_str();
-                if let Some(idx) = s.rfind('-') {
-                    s[..idx].to_string()
-                } else {
-                    s.to_string()
+            let symbol = instrument.symbol().inner();
+            let inst_family = match &instrument {
+                InstrumentAny::CurrencyPair(_) => symbol.as_str().to_string(),
+                InstrumentAny::CryptoPerpetual(_) => symbol
+                    .as_str()
+                    .strip_suffix("-SWAP")
+                    .unwrap_or(symbol.as_str())
+                    .to_string(),
+                InstrumentAny::CryptoFuture(_) => {
+                    let s = symbol.as_str();
+                    if let Some(idx) = s.rfind('-') {
+                        s[..idx].to_string()
+                    } else {
+                        s.to_string()
+                    }
                 }
-            }
-            _ => {
-                return Err(OKXWsError::ClientError(
-                    "Unsupported instrument type for mass cancel".to_string(),
-                ));
-            }
+                _ => {
+                    return Err(OKXWsError::ClientError(
+                        "Unsupported instrument type for mass cancel".to_string(),
+                    ));
+                }
+            };
+
+            (inst_type, inst_family)
         };
-        drop(instrument);
 
         let params = WsMassCancelParams {
             inst_type,
@@ -2802,116 +2819,121 @@ impl OKXWebSocketClient {
             Option<String>,
         )>,
     ) -> Result<(), OKXWsError> {
-        let mut args: Vec<Value> = Vec::with_capacity(orders.len());
+        let args: Vec<Value> = {
+            let mut args = Vec::with_capacity(orders.len());
+            let inst_id_codes = self.inst_id_code_cache.load();
+            let instruments = self.instruments_cache.load();
 
-        for (
-            inst_type,
-            inst_id,
-            td_mode,
-            cl_ord_id,
-            ord_side,
-            pos_side,
-            ord_type,
-            qty,
-            pr,
-            tp,
-            post_only,
-            reduce_only,
-            speed_bump,
-            outcome,
-        ) in orders
-        {
-            let mut builder = WsPostOrderParamsBuilder::default();
-
-            let inst_id_code = self
-                .get_inst_id_code(&inst_id.symbol.inner())
-                .ok_or_else(|| {
-                    OKXWsError::ClientError(format!(
-                        "No instIdCode cached for {inst_id}, cannot submit order"
-                    ))
-                })?;
-            builder.inst_id_code(inst_id_code);
-
-            builder.td_mode(td_mode);
-            builder.cl_ord_id(cl_ord_id.as_str());
-            builder.side(ord_side.as_specified());
-
-            if inst_type != OKXInstrumentType::Events
-                && let Some(instrument) = self.instruments_cache.get_cloned(&inst_id.symbol.inner())
-            {
-                builder.ccy(instrument.quote_currency().to_string());
-            }
-
-            if let Some(ps) = pos_side {
-                builder.pos_side(OKXPositionSide::from(ps));
-            } else if matches!(
+            for (
                 inst_type,
-                OKXInstrumentType::Swap | OKXInstrumentType::Futures | OKXInstrumentType::Option
-            ) {
-                builder.pos_side(OKXPositionSide::Net);
-            }
+                inst_id,
+                td_mode,
+                cl_ord_id,
+                ord_side,
+                pos_side,
+                ord_type,
+                qty,
+                pr,
+                tp,
+                post_only,
+                reduce_only,
+                speed_bump,
+                outcome,
+            ) in orders
+            {
+                let mut builder = WsPostOrderParamsBuilder::default();
 
-            let okx_ord_type = if post_only.unwrap_or(false) {
-                OKXOrderType::PostOnly
-            } else {
-                match ord_type {
-                    OrderType::Market => OKXOrderType::Market,
-                    OrderType::Limit => OKXOrderType::Limit,
-                    OrderType::MarketToLimit => OKXOrderType::Ioc,
-                    _ => {
-                        return Err(OKXWsError::ClientError(format!(
-                            "Unsupported order type for batch submit: {ord_type:?}"
-                        )));
-                    }
-                }
-            };
+                let (inst_id_symbol, inst_id_code) = Self::inst_id_symbol_and_code_from_snapshot(
+                    &inst_id_codes,
+                    &inst_id,
+                    "submit",
+                )?;
+                builder.inst_id_code(inst_id_code);
 
-            builder.ord_type(okx_ord_type);
-            builder.sz(qty.to_string());
+                builder.td_mode(td_mode);
+                builder.cl_ord_id(cl_ord_id.as_str());
+                builder.side(ord_side.as_specified());
 
-            if let Some(p) = pr {
-                builder.px(p.to_string());
-            } else if let Some(p) = tp {
-                builder.px(p.to_string());
-            }
-
-            if let Some(ro) = reduce_only {
-                builder.reduce_only(ro);
-            }
-
-            let speed_bump = if inst_type == OKXInstrumentType::Events {
-                if outcome.is_none() {
-                    return Err(OKXWsError::ClientError(
-                        "OKX event contract orders require `outcome`".to_string(),
-                    ));
+                if inst_type != OKXInstrumentType::Events
+                    && let Some(instrument) = instruments.get(&inst_id_symbol)
+                {
+                    builder.ccy(instrument.quote_currency().to_string());
                 }
 
-                if okx_ord_type == OKXOrderType::PostOnly {
-                    speed_bump
+                if let Some(ps) = pos_side {
+                    builder.pos_side(OKXPositionSide::from(ps));
+                } else if matches!(
+                    inst_type,
+                    OKXInstrumentType::Swap
+                        | OKXInstrumentType::Futures
+                        | OKXInstrumentType::Option
+                ) {
+                    builder.pos_side(OKXPositionSide::Net);
+                }
+
+                let okx_ord_type = if post_only.unwrap_or(false) {
+                    OKXOrderType::PostOnly
                 } else {
-                    Some(speed_bump.unwrap_or_else(|| "1".to_string()))
+                    match ord_type {
+                        OrderType::Market => OKXOrderType::Market,
+                        OrderType::Limit => OKXOrderType::Limit,
+                        OrderType::MarketToLimit => OKXOrderType::Ioc,
+                        _ => {
+                            return Err(OKXWsError::ClientError(format!(
+                                "Unsupported order type for batch submit: {ord_type:?}"
+                            )));
+                        }
+                    }
+                };
+
+                builder.ord_type(okx_ord_type);
+                builder.sz(qty.to_string());
+
+                if let Some(p) = pr {
+                    builder.px(p.to_string());
+                } else if let Some(p) = tp {
+                    builder.px(p.to_string());
                 }
-            } else {
-                speed_bump
-            };
 
-            if let Some(speed_bump) = speed_bump {
-                builder.speed_bump(speed_bump);
+                if let Some(ro) = reduce_only {
+                    builder.reduce_only(ro);
+                }
+
+                let speed_bump = if inst_type == OKXInstrumentType::Events {
+                    if outcome.is_none() {
+                        return Err(OKXWsError::ClientError(
+                            "OKX event contract orders require `outcome`".to_string(),
+                        ));
+                    }
+
+                    if okx_ord_type == OKXOrderType::PostOnly {
+                        speed_bump
+                    } else {
+                        Some(speed_bump.unwrap_or_else(|| "1".to_string()))
+                    }
+                } else {
+                    speed_bump
+                };
+
+                if let Some(speed_bump) = speed_bump {
+                    builder.speed_bump(speed_bump);
+                }
+
+                if let Some(outcome) = outcome {
+                    builder.outcome(outcome);
+                }
+
+                builder.tag(OKX_NAUTILUS_BROKER_ID);
+
+                let params = builder.build().map_err(|e| {
+                    OKXWsError::ClientError(format!("Build order params error: {e}"))
+                })?;
+                let val = serde_json::to_value(params)
+                    .map_err(|e| OKXWsError::JsonError(e.to_string()))?;
+                args.push(val);
             }
-
-            if let Some(outcome) = outcome {
-                builder.outcome(outcome);
-            }
-
-            builder.tag(OKX_NAUTILUS_BROKER_ID);
-
-            let params = builder
-                .build()
-                .map_err(|e| OKXWsError::ClientError(format!("Build order params error: {e}")))?;
-            let val =
-                serde_json::to_value(params).map_err(|e| OKXWsError::JsonError(e.to_string()))?;
-            args.push(val);
-        }
+            args
+        };
 
         self.ws_batch_place_orders(args).await
     }
@@ -2935,41 +2957,41 @@ impl OKXWebSocketClient {
             Option<String>,
         )>,
     ) -> Result<(), OKXWsError> {
-        let mut args: Vec<Value> = Vec::with_capacity(orders.len());
-        for (_inst_type, inst_id, cl_ord_id, new_cl_ord_id, pr, sz, speed_bump) in orders {
-            let mut builder = WsAmendOrderParamsBuilder::default();
+        let args: Vec<Value> = {
+            let mut args = Vec::with_capacity(orders.len());
+            let inst_id_codes = self.inst_id_code_cache.load();
 
-            let inst_id_code = self
-                .get_inst_id_code(&inst_id.symbol.inner())
-                .ok_or_else(|| {
-                    OKXWsError::ClientError(format!(
-                        "No instIdCode cached for {inst_id}, cannot amend order"
-                    ))
+            for (_inst_type, inst_id, cl_ord_id, new_cl_ord_id, pr, sz, speed_bump) in orders {
+                let mut builder = WsAmendOrderParamsBuilder::default();
+
+                let (_, inst_id_code) =
+                    Self::inst_id_symbol_and_code_from_snapshot(&inst_id_codes, &inst_id, "amend")?;
+                builder.inst_id_code(inst_id_code);
+
+                builder.cl_ord_id(cl_ord_id.as_str());
+                builder.new_cl_ord_id(new_cl_ord_id.as_str());
+
+                if let Some(p) = pr {
+                    builder.new_px(p.to_string());
+                }
+
+                if let Some(q) = sz {
+                    builder.new_sz(q.to_string());
+                }
+
+                if let Some(speed_bump) = speed_bump {
+                    builder.speed_bump(speed_bump);
+                }
+
+                let params = builder.build().map_err(|e| {
+                    OKXWsError::ClientError(format!("Build amend batch params error: {e}"))
                 })?;
-            builder.inst_id_code(inst_id_code);
-
-            builder.cl_ord_id(cl_ord_id.as_str());
-            builder.new_cl_ord_id(new_cl_ord_id.as_str());
-
-            if let Some(p) = pr {
-                builder.new_px(p.to_string());
+                let val = serde_json::to_value(params)
+                    .map_err(|e| OKXWsError::JsonError(e.to_string()))?;
+                args.push(val);
             }
-
-            if let Some(q) = sz {
-                builder.new_sz(q.to_string());
-            }
-
-            if let Some(speed_bump) = speed_bump {
-                builder.speed_bump(speed_bump);
-            }
-
-            let params = builder.build().map_err(|e| {
-                OKXWsError::ClientError(format!("Build amend batch params error: {e}"))
-            })?;
-            let val =
-                serde_json::to_value(params).map_err(|e| OKXWsError::JsonError(e.to_string()))?;
-            args.push(val);
-        }
+            args
+        };
 
         self.ws_batch_amend_orders(args).await
     }
@@ -2990,34 +3012,37 @@ impl OKXWebSocketClient {
         &self,
         orders: Vec<(InstrumentId, Option<ClientOrderId>, Option<VenueOrderId>)>,
     ) -> Result<(), OKXWsError> {
-        let mut args: Vec<Value> = Vec::with_capacity(orders.len());
-        for (inst_id, cl_ord_id, ord_id) in orders {
-            let mut builder = WsCancelOrderParamsBuilder::default();
+        let args: Vec<Value> = {
+            let mut args = Vec::with_capacity(orders.len());
+            let inst_id_codes = self.inst_id_code_cache.load();
 
-            let inst_id_code = self
-                .get_inst_id_code(&inst_id.symbol.inner())
-                .ok_or_else(|| {
-                    OKXWsError::ClientError(format!(
-                        "No instIdCode cached for {inst_id}, cannot cancel order"
-                    ))
+            for (inst_id, cl_ord_id, ord_id) in orders {
+                let mut builder = WsCancelOrderParamsBuilder::default();
+
+                let (_, inst_id_code) = Self::inst_id_symbol_and_code_from_snapshot(
+                    &inst_id_codes,
+                    &inst_id,
+                    "cancel",
+                )?;
+                builder.inst_id_code(inst_id_code);
+
+                if let Some(c) = cl_ord_id {
+                    builder.cl_ord_id(c.as_str());
+                }
+
+                if let Some(o) = ord_id {
+                    builder.ord_id(o.as_str());
+                }
+
+                let params = builder.build().map_err(|e| {
+                    OKXWsError::ClientError(format!("Build cancel batch params error: {e}"))
                 })?;
-            builder.inst_id_code(inst_id_code);
-
-            if let Some(c) = cl_ord_id {
-                builder.cl_ord_id(c.as_str());
+                let val = serde_json::to_value(params)
+                    .map_err(|e| OKXWsError::JsonError(e.to_string()))?;
+                args.push(val);
             }
-
-            if let Some(o) = ord_id {
-                builder.ord_id(o.as_str());
-            }
-
-            let params = builder.build().map_err(|e| {
-                OKXWsError::ClientError(format!("Build cancel batch params error: {e}"))
-            })?;
-            let val =
-                serde_json::to_value(params).map_err(|e| OKXWsError::JsonError(e.to_string()))?;
-            args.push(val);
-        }
+            args
+        };
 
         self.ws_batch_cancel_orders(args).await
     }

--- a/crates/adapters/polymarket/src/execution/mod.rs
+++ b/crates/adapters/polymarket/src/execution/mod.rs
@@ -30,7 +30,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use anyhow::Context;
 use async_trait::async_trait;
 use nautilus_common::{
@@ -414,6 +414,13 @@ impl PolymarketExecutionClient {
         self.neg_risk_index
             .get_cloned(instrument_id)
             .unwrap_or(false)
+    }
+
+    fn get_neg_risk_from_snapshot(
+        neg_risk_index: &AHashMap<InstrumentId, bool>,
+        instrument_id: &InstrumentId,
+    ) -> bool {
+        neg_risk_index.get(instrument_id).copied().unwrap_or(false)
     }
 
     fn load_instruments_from_cache(&self) {
@@ -1066,6 +1073,7 @@ impl ExecutionClient for PolymarketExecutionClient {
 
     fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let mut batch_orders = Vec::with_capacity(cmd.order_inits.len());
+        let neg_risk_index = self.neg_risk_index.load();
 
         for order_init in &cmd.order_inits {
             let Some(order) = self
@@ -1124,7 +1132,10 @@ impl ExecutionClient for PolymarketExecutionClient {
                     quantity: order.quantity(),
                     time_in_force: order.time_in_force(),
                     post_only: order.is_post_only(),
-                    neg_risk: self.get_neg_risk(&order.instrument_id()),
+                    neg_risk: Self::get_neg_risk_from_snapshot(
+                        &neg_risk_index,
+                        &order.instrument_id(),
+                    ),
                     expire_time: order.expire_time(),
                     tick_decimals: instrument.price_precision() as u32,
                 },

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -100,7 +100,8 @@ fn dispatch_order_update(
     ctx: &WsDispatchContext<'_>,
     state: &mut WsDispatchState,
 ) {
-    let instrument = match ctx.token_instruments.get_cloned(&order.asset_id) {
+    let instruments = ctx.token_instruments.load();
+    let instrument = match instruments.get(&order.asset_id) {
         Some(i) => i,
         None => {
             log::warn!("Unknown asset_id in order update: {}", order.asset_id);
@@ -113,7 +114,7 @@ fn dispatch_order_update(
 
     let ts_init = ctx.clock.get_time_ns();
     let mut report =
-        build_ws_order_status_report(order, &instrument, ctx.account_id, ts_event, ts_init);
+        build_ws_order_status_report(order, instrument, ctx.account_id, ts_event, ts_init);
     let local_client_order_id = local_client_order_id(&venue_order_id, ctx.pending_submits);
     let mut is_accepted = ctx.fill_tracker.contains(&venue_order_id);
     report.client_order_id = local_client_order_id;
@@ -278,9 +279,11 @@ fn dispatch_maker_fills(
         return;
     }
 
+    let instruments = ctx.token_instruments.load();
+
     for mo in user_orders {
         let asset_id = Ustr::from(mo.asset_id.as_str());
-        let instrument = match ctx.token_instruments.get_cloned(&asset_id) {
+        let instrument = match instruments.get(&asset_id) {
             Some(i) => i,
             None => {
                 log::warn!("Unknown asset_id in maker order: {asset_id}");
@@ -340,7 +343,8 @@ fn dispatch_taker_fill(
     ts_event: UnixNanos,
     ts_init: UnixNanos,
 ) {
-    let instrument = match ctx.token_instruments.get_cloned(&trade.asset_id) {
+    let instruments = ctx.token_instruments.load();
+    let instrument = match instruments.get(&trade.asset_id) {
         Some(i) => i,
         None => {
             log::warn!("Unknown asset_id in trade: {}", trade.asset_id);
@@ -352,7 +356,7 @@ fn dispatch_taker_fill(
 
     let mut report = build_ws_taker_fill_report(
         trade,
-        &instrument,
+        instrument,
         ctx.account_id,
         liquidity_side,
         ts_event,

--- a/crates/core/benches/concurrent_map.rs
+++ b/crates/core/benches/concurrent_map.rs
@@ -55,7 +55,7 @@ use std::{
 };
 
 use ahash::AHashMap;
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use dashmap::DashMap;
 use nautilus_core::AtomicMap;
 
@@ -63,6 +63,7 @@ const MAP_SIZES: [usize; 2] = [100, 1_000];
 const THREAD_COUNTS: [usize; 4] = [1, 4, 8, 16];
 const READS_PER_THREAD: usize = 10_000;
 const WRITES_PER_CYCLE: usize = 10;
+const ATOMIC_MAP_LOOKUPS_PER_ITER: usize = 256;
 const CONCURRENT_MEASUREMENT_TIME: Duration = Duration::from_secs(10);
 
 fn make_keys(n: usize) -> Vec<String> {
@@ -468,11 +469,66 @@ fn bench_write_once_read_many(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_atomic_map_read_patterns(c: &mut Criterion) {
+    let mut group = c.benchmark_group("atomic_map_read_patterns");
+    let keys = make_keys(1_000);
+    let atomic = populated_atomic_map(&keys);
+
+    group.throughput(Throughput::Elements(ATOMIC_MAP_LOOKUPS_PER_ITER as u64));
+
+    group.bench_function("get_cloned_each_lookup", |b| {
+        let mut idx = 0usize;
+        b.iter(|| {
+            let mut sum = 0u64;
+
+            for _ in 0..ATOMIC_MAP_LOOKUPS_PER_ITER {
+                let key = &keys[idx % keys.len()];
+                sum = sum.wrapping_add(atomic.get_cloned(key).unwrap_or_default());
+                idx = idx.wrapping_add(1);
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function("load_each_lookup", |b| {
+        let mut idx = 0usize;
+        b.iter(|| {
+            let mut sum = 0u64;
+
+            for _ in 0..ATOMIC_MAP_LOOKUPS_PER_ITER {
+                let key = &keys[idx % keys.len()];
+                let guard = atomic.load();
+                sum = sum.wrapping_add(guard.get(key).copied().unwrap_or_default());
+                idx = idx.wrapping_add(1);
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_function("load_once_guard", |b| {
+        let mut idx = 0usize;
+        b.iter(|| {
+            let guard = atomic.load();
+            let mut sum = 0u64;
+
+            for _ in 0..ATOMIC_MAP_LOOKUPS_PER_ITER {
+                let key = &keys[idx % keys.len()];
+                sum = sum.wrapping_add(guard.get(key).copied().unwrap_or_default());
+                idx = idx.wrapping_add(1);
+            }
+            black_box(sum)
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_single_thread_read,
     bench_concurrent_reads,
     bench_read_heavy_mixed,
     bench_write_once_read_many,
+    bench_atomic_map_read_patterns,
 );
 criterion_main!(benches);


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This PR updates hot adapter paths to reuse `AtomicMap::load()` snapshots inside message and batch handlers, and to borrow cached values from those snapshots instead of cloning them where possible. The main target is repeated `InstrumentAny` lookup in live WebSocket parsing and order-building paths, where the benchmarked `u64` fixture already shows a repeated-read win and likely understates the benefit for large enum payloads.

No new `AtomicMap` API is added. The change uses the existing `load()` snapshot API and keeps cold/control paths unchanged when the benchmarked win does not apply.

## Performance summary

Benchmarks compare three read patterns over 256 lookups using `AtomicMap<String, u64>`. The production migration applies the winning pattern to repeated reads and to hot instrument lookups that previously cloned larger `InstrumentAny` values.

| Optimization | Benchmark / pattern | Before | After | Latency reduction | Speedup / throughput |
| --- | --- | ---: | ---: | ---: | ---: |
| Reuse one snapshot for repeated reads | `get_cloned_each_lookup` -> `load_once_guard` over 256 reads | 2.946-2.962 us | 2.180-2.189 us | ~26.0% | ~1.35x |
| Avoid loading a guard per lookup | `load_each_lookup` -> `load_once_guard` over 256 reads | 2.952-2.958 us | 2.180-2.189 us | ~26.1% | ~1.35x |
| Improve read throughput | 256-read batch throughput | ~86.6-86.7 Melem/s | ~117.2 Melem/s | n/a | ~35% higher throughput |
| Batch writes, measured only | 16 repeated `insert` clone/swap -> one `rcu` batch | 490.02-492.76 us | 47.729-48.312 us | ~90.2% | ~10.2x |

The batch-write result is included as measured context but is not a production change in this PR. The audited candidate call sites were bootstrap/refresh/control paths rather than steady-state message or order hot paths.

## Detailed benchmark results

| Pattern | Result | Throughput | Decision |
| --- | ---: | ---: | --- |
| `get_cloned_each_lookup` over 256 reads | 2.946-2.962 us | ~86.7 Melem/s | Baseline |
| `load_each_lookup` over 256 reads | 2.952-2.958 us | ~86.6 Melem/s | Baseline |
| `load_once_guard` over 256 reads | 2.180-2.189 us | ~117.2 Melem/s | Use this pattern for repeated reads |
| 16 repeated `insert` clone-and-swap writes | 490.02-492.76 us | ~32.6 Kelem/s | Measured, not migrated here |
| Single `rcu` batch for 16 writes | 47.729-48.312 us | ~333 Kelem/s | Measured, no retained hot write-path migration |

### ASM evidence

There is no useful single-function `cargo asm` diff for this PR. The change is not an instruction-level rewrite of `AtomicMap`; it changes how adapter call sites use the existing `ArcSwap<AHashMap<_, _>>` API:

- before: repeatedly call `get_cloned()` or repeatedly create guards inside loops;
- after: call `load()` once per message/batch scope, then borrow from the snapshot with `get()`;
- after: avoid cloning large cached values such as `InstrumentAny` when parser/builders only need borrowed access.

The performance evidence is therefore the Criterion read-pattern benchmark plus the production call-site audit below.

## Production paths changed

| Adapter | Path | Why it is hot enough | Optimization applied |
| --- | --- | --- | --- |
| Bybit | Python WebSocket handlers for orderbook, trade, kline, ticker, order, execution, position | Runs inside live WebSocket message handling; several handlers process records per inbound message | Load one snapshot per handler and borrow instruments instead of cloning `InstrumentAny` |
| Coinbase | WebSocket L2, trade, ticker, user, candle handlers | Live WebSocket message loop; handlers can process multiple events per inbound message | Load one alias snapshot per message handler instead of loading the alias map for each product/trade |
| Hyperliquid | Order submit, modify, cancel, and batch order builders | Trading-path order APIs repeatedly resolve asset index and price precision before posting | Use already-interned `InstrumentId` symbols for cache lookups, avoiding `String` allocation and repeated `Ustr::from` on order paths |
| OKX | WebSocket submit and batch submit/modify/cancel order builders | Trading-path order APIs; batch APIs loop over user orders | Borrow instrument metadata from short-lived snapshots and load `inst_id_code_cache` once per batch |
| Polymarket | WebSocket order/trade dispatch and batch submit order builder | User-channel dispatch is a live execution path; batch submit loops over orders | Borrow token instruments in WS dispatch and load `neg_risk_index` once per batch submit |
| Kraken | Rust/Python Spot/Futures data and execution dispatch, including L3 runtime | Live ticker/trade/book/fill/order WebSocket paths; several messages carry repeated records | Borrow instrument snapshots instead of cloning `InstrumentAny`; fill-delta and batch arms load once per message |

## Scope deliberately not changed

| Candidate | Reason left unchanged |
| --- | --- |
| Cold helper methods, request-instrument paths, subscription-map insert/remove, ref-count lookups | The measured win is from repeated reads or avoiding large clones, not one-off control-plane operations |
| Bootstrap/reconnect owned snapshots such as `values().cloned().collect()` | Owned values are needed for setup/reconnect flows and are not steady-state message hot-path work |
| Single `Copy` lookups such as bar-type maps or boolean flags | Guard hoisting may add churn without evidence that a single guard dominates |
| OKX mass cancel owned lookup | Treated as control path, not tight trading-loop work |
| Polymarket reconciliation report builders | Background reconciliation path, not live WebSocket dispatch |
| Batch `rcu` write migrations | Strong microbench result, but audited candidates were bootstrap/refresh paths rather than hot batch writers |

## Related Issues/PRs

Related to #4161, which contains the separate core datetime/UUID formatter PR from the same performance investigation.

## Type of change

- [x] Improvement (non-breaking)

## Breaking change details (if applicable)

N/A. This PR does not add or remove public APIs and does not change `AtomicMap` semantics. It changes adapter call sites to use existing snapshot borrowing patterns.

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validation run on this branch:

```bash
cargo check -p nautilus-core --benches
cargo check -p nautilus-kraken --features python
cargo check -p nautilus-bybit --features python
cargo check -p nautilus-coinbase -p nautilus-hyperliquid -p nautilus-okx -p nautilus-polymarket
pre-commit run check-formatting-rs --files crates/core/benches/concurrent_map.rs crates/adapters/kraken/src/data/spot.rs crates/adapters/kraken/src/python/websocket_spot.rs crates/adapters/okx/src/websocket/client.rs
```

All commands above passed locally.
