### PR TITLE
Bybit demo trigger

### DIFF
--- a/crates/adapters/bybit/bin/flatten.rs
+++ b/crates/adapters/bybit/bin/flatten.rs
@@ -190,6 +190,7 @@ async fn close_position(
             position_idx,
             None,
             None,
+            None,
         )
         .await?;
 

--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -159,10 +159,13 @@ use crate::{
         },
         symbol::BybitSymbol,
     },
-    http::models::{
-        BybitExecution, BybitFeeRate, BybitFunding, BybitInstrumentInverse, BybitInstrumentLinear,
-        BybitInstrumentOption, BybitInstrumentSpot, BybitKline, BybitOrderbookResult,
-        BybitPosition, BybitTrade, BybitWalletBalance,
+    http::{
+        models::{
+            BybitExecution, BybitFeeRate, BybitFunding, BybitInstrumentInverse,
+            BybitInstrumentLinear, BybitInstrumentOption, BybitInstrumentSpot, BybitKline,
+            BybitOrderbookResult, BybitPosition, BybitTrade, BybitWalletBalance,
+        },
+        query::BybitNativeTpSlParams,
     },
     websocket::parse::parse_millis_i64,
 };
@@ -1547,6 +1550,26 @@ impl BybitTpSlParams {
 
     pub fn has_bbo(&self) -> bool {
         self.bbo_side_type.is_some()
+    }
+
+    /// Projects the native TP/SL + option fields onto the bundle the HTTP
+    /// submit_order entry expects. BBO + position_idx + leverage stay separate
+    /// because they're already first-class args on the submit signature.
+    pub fn to_native_tp_sl(&self) -> BybitNativeTpSlParams {
+        BybitNativeTpSlParams {
+            take_profit: self.take_profit.map(|p| p.to_string()),
+            stop_loss: self.stop_loss.map(|p| p.to_string()),
+            tp_trigger_by: self.tp_trigger_by,
+            sl_trigger_by: self.sl_trigger_by,
+            tp_order_type: self.tp_order_type,
+            sl_order_type: self.sl_order_type,
+            tp_limit_price: self.tp_limit_price.clone(),
+            sl_limit_price: self.sl_limit_price.clone(),
+            tpsl_mode: None,
+            close_on_trigger: self.close_on_trigger,
+            order_iv: self.order_iv.clone(),
+            mmp: self.mmp,
+        }
     }
 }
 

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -1135,16 +1135,6 @@ impl ExecutionClient for BybitExecutionClient {
             return Ok(());
         }
 
-        if self.config.environment == BybitEnvironment::Demo
-            && (tp_sl.has_tp_sl() || tp_sl.order_iv.is_some() || tp_sl.mmp.is_some())
-        {
-            self.emitter.emit_order_denied(
-                &order,
-                "Native TP/SL and option params are not supported in demo mode",
-            );
-            return Ok(());
-        }
-
         log::debug!("OrderSubmitted client_order_id={}", order.client_order_id());
         self.emitter.emit_order_submitted(&order);
 
@@ -1199,10 +1189,13 @@ impl ExecutionClient for BybitExecutionClient {
             let is_quote_quantity = order.is_quote_quantity();
             let is_leverage = tp_sl.is_leverage;
             let bbo_side_type = tp_sl.bbo_side_type;
-            let bbo_level = tp_sl.bbo_level;
+            let bbo_level = tp_sl.bbo_level.clone();
+            let native_tp_sl = tp_sl.to_native_tp_sl();
             let dispatch_state = Arc::clone(&self.dispatch_state);
 
             self.spawn_task("submit_order_http", async move {
+                let native_tp_sl_ref =
+                    (!native_tp_sl.is_empty()).then_some(&native_tp_sl);
                 let result = http_client
                     .submit_order(
                         account_id,
@@ -1222,6 +1215,7 @@ impl ExecutionClient for BybitExecutionClient {
                         position_idx,
                         bbo_side_type,
                         bbo_level,
+                        native_tp_sl_ref,
                     )
                     .await;
 
@@ -1477,6 +1471,7 @@ impl ExecutionClient for BybitExecutionClient {
                             position_idx,
                             bbo_side_type,
                             bbo_level.clone(),
+                            None,
                         )
                         .await
                     {

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -77,7 +77,7 @@ use super::{
         BybitCancelAllOrdersParamsBuilder, BybitCancelOrderParamsBuilder, BybitFeeRateParams,
         BybitFeeRateParamsBuilder, BybitFundingParams, BybitFundingParamsBuilder,
         BybitInstrumentsInfoParams, BybitKlinesParams, BybitKlinesParamsBuilder,
-        BybitNoConvertRepayParamsBuilder, BybitOpenOrdersParamsBuilder,
+        BybitNativeTpSlParams, BybitNoConvertRepayParamsBuilder, BybitOpenOrdersParamsBuilder,
         BybitOrderHistoryParamsBuilder, BybitOrderbookParams, BybitOrderbookParamsBuilder,
         BybitPlaceOrderParamsBuilder, BybitPositionListParams, BybitSetLeverageParamsBuilder,
         BybitSetMarginModeParamsBuilder, BybitSetTradingStopParams, BybitSubApiKeysParams,
@@ -92,7 +92,7 @@ use crate::common::{
     enums::{
         BybitAccountType, BybitBboSideType, BybitContractType, BybitEnvironment, BybitMarginMode,
         BybitOpenOnly, BybitOrderFilter, BybitOrderSide, BybitOrderType, BybitPositionIdx,
-        BybitPositionMode, BybitProductType,
+        BybitPositionMode, BybitProductType, BybitTpSlMode,
     },
     models::{BybitCursorListResponse, BybitErrorCheck, BybitResponseCheck},
     parse::{
@@ -2424,6 +2424,7 @@ impl BybitHttpClient {
         position_idx: Option<BybitPositionIdx>,
         bbo_side_type: Option<BybitBboSideType>,
         bbo_level: Option<String>,
+        native_tp_sl: Option<&BybitNativeTpSlParams>,
     ) -> anyhow::Result<OrderStatusReport> {
         let instrument = self.instrument_from_cache(&instrument_id.symbol)?;
         let bybit_symbol = BybitSymbol::new(instrument_id.symbol.as_str())?;
@@ -2480,6 +2481,51 @@ impl BybitHttpClient {
 
         order_entry.bbo_side_type(bbo_side_type);
         order_entry.bbo_level(bbo_level);
+
+        if let Some(tp_sl) = native_tp_sl {
+            if let Some(ref tp) = tp_sl.take_profit {
+                order_entry.take_profit(Some(tp.clone()));
+            }
+            if let Some(ref sl) = tp_sl.stop_loss {
+                order_entry.stop_loss(Some(sl.clone()));
+            }
+            if let Some(tp_trigger) = tp_sl.tp_trigger_by {
+                order_entry.tp_trigger_by(Some(tp_trigger));
+            }
+            if let Some(sl_trigger) = tp_sl.sl_trigger_by {
+                order_entry.sl_trigger_by(Some(sl_trigger));
+            }
+            if let Some(tp_ot) = tp_sl.tp_order_type {
+                order_entry.tp_order_type(Some(tp_ot));
+            }
+            if let Some(sl_ot) = tp_sl.sl_order_type {
+                order_entry.sl_order_type(Some(sl_ot));
+            }
+            if let Some(ref tp_lp) = tp_sl.tp_limit_price {
+                order_entry.tp_limit_price(Some(tp_lp.clone()));
+            }
+            if let Some(ref sl_lp) = tp_sl.sl_limit_price {
+                order_entry.sl_limit_price(Some(sl_lp.clone()));
+            }
+            // Mirror the WS path: default to `Full` when TP or SL is set
+            // without an explicit mode, so Bybit doesn't reject the field.
+            let mode = tp_sl.tpsl_mode.or_else(|| {
+                (tp_sl.take_profit.is_some() || tp_sl.stop_loss.is_some())
+                    .then_some(BybitTpSlMode::Full)
+            });
+            if let Some(m) = mode {
+                order_entry.tpsl_mode(Some(m));
+            }
+            if let Some(close) = tp_sl.close_on_trigger {
+                order_entry.close_on_trigger(Some(close));
+            }
+            if let Some(ref iv) = tp_sl.order_iv {
+                order_entry.order_iv(Some(iv.clone()));
+            }
+            if let Some(mmp) = tp_sl.mmp {
+                order_entry.mmp(Some(mmp));
+            }
+        }
 
         let order_entry = order_entry.build().build_anyhow()?;
 

--- a/crates/adapters/bybit/src/http/query.rs
+++ b/crates/adapters/bybit/src/http/query.rs
@@ -473,6 +473,49 @@ pub struct BybitBatchPlaceOrderParams {
     pub request: Vec<BybitBatchPlaceOrderEntry>,
 }
 
+/// Native TP/SL + option-specific fields that map onto the `POST /v5/order/create`
+/// (and batch) entry. Bundled to keep `submit_order` signatures manageable, and
+/// to give the demo HTTP path access to the same fields the mainnet WS path
+/// supports via [`crate::websocket::messages::BybitWsPlaceOrderParams`].
+///
+/// All fields are optional; populated fields are written onto the entry builder
+/// as-is. `tpsl_mode` defaults to `Full` upstream when only `take_profit` /
+/// `stop_loss` are set without an explicit mode.
+#[derive(Default, Clone, Debug)]
+pub struct BybitNativeTpSlParams {
+    pub take_profit: Option<String>,
+    pub stop_loss: Option<String>,
+    pub tp_trigger_by: Option<BybitTriggerType>,
+    pub sl_trigger_by: Option<BybitTriggerType>,
+    pub tp_order_type: Option<BybitOrderType>,
+    pub sl_order_type: Option<BybitOrderType>,
+    pub tp_limit_price: Option<String>,
+    pub sl_limit_price: Option<String>,
+    pub tpsl_mode: Option<BybitTpSlMode>,
+    pub close_on_trigger: Option<bool>,
+    pub order_iv: Option<String>,
+    pub mmp: Option<bool>,
+}
+
+impl BybitNativeTpSlParams {
+    /// Returns true if any TP/SL or option-specific field is set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.take_profit.is_none()
+            && self.stop_loss.is_none()
+            && self.tp_trigger_by.is_none()
+            && self.sl_trigger_by.is_none()
+            && self.tp_order_type.is_none()
+            && self.sl_order_type.is_none()
+            && self.tp_limit_price.is_none()
+            && self.sl_limit_price.is_none()
+            && self.tpsl_mode.is_none()
+            && self.close_on_trigger.is_none()
+            && self.order_iv.is_none()
+            && self.mmp.is_none()
+    }
+}
+
 /// Body parameters for `POST /v5/order/create`.
 ///
 /// # References

--- a/crates/adapters/bybit/src/python/http.rs
+++ b/crates/adapters/bybit/src/python/http.rs
@@ -48,7 +48,9 @@ use crate::{
         client::{BybitHttpClient, BybitRawHttpClient},
         error::BybitHttpError,
         models::BybitOrderCursorList,
+        query::BybitNativeTpSlParams as RustNativeTpSlParams,
     },
+    python::params::BybitNativeTpSlParams,
 };
 
 #[pymethods]
@@ -576,6 +578,7 @@ impl BybitHttpClient {
         position_idx = None,
         bbo_side_type = None,
         bbo_level = None,
+        native_tp_sl = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_submit_order<'py>(
@@ -598,6 +601,7 @@ impl BybitHttpClient {
         position_idx: Option<BybitPositionIdx>,
         bbo_side_type: Option<String>,
         bbo_level: Option<String>,
+        native_tp_sl: Option<BybitNativeTpSlParams>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.clone();
         let bbo_side_type = bbo_side_type
@@ -613,6 +617,9 @@ impl BybitHttpClient {
                 "'bbo_side_type' and 'bbo_level' must be provided together"
             )));
         }
+
+        let native_tp_sl: Option<RustNativeTpSlParams> =
+            native_tp_sl.map(RustNativeTpSlParams::try_from).transpose()?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let report = client
@@ -634,6 +641,7 @@ impl BybitHttpClient {
                     position_idx,
                     bbo_side_type,
                     bbo_level,
+                    native_tp_sl.as_ref(),
                 )
                 .await
                 .map_err(to_pyvalue_err)?;

--- a/crates/adapters/bybit/src/python/mod.rs
+++ b/crates/adapters/bybit/src/python/mod.rs
@@ -220,6 +220,7 @@ pub fn bybit(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<params::BybitWsAmendOrderParams>()?;
     m.add_class::<params::BybitWsCancelOrderParams>()?;
     m.add_class::<params::BybitTickersParams>()?;
+    m.add_class::<params::BybitNativeTpSlParams>()?;
     m.add_class::<BybitDataClientConfig>()?;
     m.add_class::<BybitExecClientConfig>()?;
     m.add_class::<BybitDataClientFactory>()?;

--- a/crates/adapters/bybit/src/python/params.rs
+++ b/crates/adapters/bybit/src/python/params.rs
@@ -25,6 +25,7 @@ use crate::{
         },
         parse::parse_bbo_level,
     },
+    http::query::BybitNativeTpSlParams as RustNativeTpSlParams,
     websocket::{error::BybitWsError, messages},
 };
 
@@ -769,5 +770,140 @@ impl From<BybitTickersParams> for crate::http::query::BybitTickersParams {
             base_coin: params.base_coin,
             exp_date: params.exp_date,
         }
+    }
+}
+
+/// Native TP/SL + option-specific fields for `POST /v5/order/create` (used by
+/// the demo HTTP path, since demo doesn't expose the mainnet WS Trade API).
+///
+/// Enum-typed fields are accepted as strings (matching the existing
+/// [`BybitWsPlaceOrderParams`] surface) and parsed at the binding boundary.
+#[pyclass(from_py_object)]
+#[pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.bybit")]
+#[derive(Clone, Debug, Default)]
+pub struct BybitNativeTpSlParams {
+    #[pyo3(get, set)]
+    pub take_profit: Option<String>,
+    #[pyo3(get, set)]
+    pub stop_loss: Option<String>,
+    #[pyo3(get, set)]
+    pub tp_trigger_by: Option<String>,
+    #[pyo3(get, set)]
+    pub sl_trigger_by: Option<String>,
+    #[pyo3(get, set)]
+    pub tp_order_type: Option<String>,
+    #[pyo3(get, set)]
+    pub sl_order_type: Option<String>,
+    #[pyo3(get, set)]
+    pub tp_limit_price: Option<String>,
+    #[pyo3(get, set)]
+    pub sl_limit_price: Option<String>,
+    #[pyo3(get, set)]
+    pub tpsl_mode: Option<String>,
+    #[pyo3(get, set)]
+    pub close_on_trigger: Option<bool>,
+    #[pyo3(get, set)]
+    pub order_iv: Option<String>,
+    #[pyo3(get, set)]
+    pub mmp: Option<bool>,
+}
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl BybitNativeTpSlParams {
+    #[new]
+    #[pyo3(signature = (
+        take_profit=None,
+        stop_loss=None,
+        tp_trigger_by=None,
+        sl_trigger_by=None,
+        tp_order_type=None,
+        sl_order_type=None,
+        tp_limit_price=None,
+        sl_limit_price=None,
+        tpsl_mode=None,
+        close_on_trigger=None,
+        order_iv=None,
+        mmp=None,
+    ))]
+    #[expect(clippy::too_many_arguments)]
+    fn py_new(
+        take_profit: Option<String>,
+        stop_loss: Option<String>,
+        tp_trigger_by: Option<String>,
+        sl_trigger_by: Option<String>,
+        tp_order_type: Option<String>,
+        sl_order_type: Option<String>,
+        tp_limit_price: Option<String>,
+        sl_limit_price: Option<String>,
+        tpsl_mode: Option<String>,
+        close_on_trigger: Option<bool>,
+        order_iv: Option<String>,
+        mmp: Option<bool>,
+    ) -> Self {
+        Self {
+            take_profit,
+            stop_loss,
+            tp_trigger_by,
+            sl_trigger_by,
+            tp_order_type,
+            sl_order_type,
+            tp_limit_price,
+            sl_limit_price,
+            tpsl_mode,
+            close_on_trigger,
+            order_iv,
+            mmp,
+        }
+    }
+}
+
+fn parse_enum<T>(field: &str, raw: &str) -> PyResult<T>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    serde_json::from_str::<T>(&format!("\"{raw}\"")).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid {field} '{raw}': {e}"))
+    })
+}
+
+impl TryFrom<BybitNativeTpSlParams> for RustNativeTpSlParams {
+    type Error = PyErr;
+
+    fn try_from(params: BybitNativeTpSlParams) -> Result<Self, Self::Error> {
+        Ok(Self {
+            take_profit: params.take_profit,
+            stop_loss: params.stop_loss,
+            tp_trigger_by: params
+                .tp_trigger_by
+                .as_deref()
+                .map(|v| parse_enum::<BybitTriggerType>("tp_trigger_by", v))
+                .transpose()?,
+            sl_trigger_by: params
+                .sl_trigger_by
+                .as_deref()
+                .map(|v| parse_enum::<BybitTriggerType>("sl_trigger_by", v))
+                .transpose()?,
+            tp_order_type: params
+                .tp_order_type
+                .as_deref()
+                .map(|v| parse_enum::<BybitOrderType>("tp_order_type", v))
+                .transpose()?,
+            sl_order_type: params
+                .sl_order_type
+                .as_deref()
+                .map(|v| parse_enum::<BybitOrderType>("sl_order_type", v))
+                .transpose()?,
+            tp_limit_price: params.tp_limit_price,
+            sl_limit_price: params.sl_limit_price,
+            tpsl_mode: params
+                .tpsl_mode
+                .as_deref()
+                .map(|v| parse_enum::<BybitTpSlMode>("tpsl_mode", v))
+                .transpose()?,
+            close_on_trigger: params.close_on_trigger,
+            order_iv: params.order_iv,
+            mmp: params.mmp,
+        })
     }
 }

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -2653,6 +2653,7 @@ async fn test_submit_order_stop_market_with_trigger_price() {
             None,  // position_idx
             None,  // bbo_side_type
             None,  // bbo_level
+            None,  // native_tp_sl
         )
         .await;
 
@@ -2740,6 +2741,7 @@ async fn test_submit_order_stop_limit_with_trigger_price_and_limit_price() {
             None,  // position_idx
             None,  // bbo_side_type
             None,  // bbo_level
+            None,  // native_tp_sl
         )
         .await;
 
@@ -2828,6 +2830,7 @@ async fn test_submit_order_market_if_touched_trigger_direction() {
             None,
             None,
             None,
+            None,
         )
         .await;
 
@@ -2899,6 +2902,7 @@ async fn test_submit_order_post_only() {
             None,
             None,
             None,
+            None,
         )
         .await;
 
@@ -2963,6 +2967,7 @@ async fn test_submit_order_with_bbo_sends_bbo_and_omits_price() {
             None,
             Some(BybitBboSideType::Queue),
             Some("3".to_string()),
+            None,
         )
         .await;
 
@@ -3030,6 +3035,7 @@ async fn test_submit_order_spot_market_base_quantity() {
             None,  // position_idx
             None,  // bbo_side_type
             None,  // bbo_level
+            None,  // native_tp_sl
         )
         .await;
 
@@ -3105,6 +3111,7 @@ async fn test_submit_order_spot_market_quote_quantity() {
             None,  // position_idx
             None,  // bbo_side_type
             None,  // bbo_level
+            None,  // native_tp_sl
         )
         .await;
 
@@ -3180,6 +3187,7 @@ async fn test_submit_order_linear_does_not_send_market_unit() {
             None,  // position_idx
             None,  // bbo_side_type
             None,  // bbo_level
+            None,  // native_tp_sl
         )
         .await;
 
@@ -3252,6 +3260,7 @@ async fn test_submit_order_limit_if_touched_trigger_direction() {
             false,
             false,
             false,
+            None,
             None,
             None,
             None,
@@ -3336,6 +3345,7 @@ async fn test_submit_order_serializes_position_idx(
             false,
             false,
             position_idx,
+            None,
             None,
             None,
         )

--- a/nautilus_trader/adapters/bybit/execution.py
+++ b/nautilus_trader/adapters/bybit/execution.py
@@ -938,21 +938,6 @@ class BybitExecutionClient(LiveExecutionClient):
             )
             return
 
-        if self._is_demo and (
-            tp_sl.get("take_profit")
-            or tp_sl.get("stop_loss")
-            or tp_sl.get("order_iv") is not None
-            or tp_sl.get("mmp") is not None
-        ):
-            self.generate_order_denied(
-                strategy_id=order.strategy_id,
-                instrument_id=order.instrument_id,
-                client_order_id=order.client_order_id,
-                reason="Native TP/SL and option params are not supported in demo mode",
-                ts_event=self._clock.timestamp_ns(),
-            )
-            return
-
         # Generate OrderSubmitted event
         self.generate_order_submitted(
             strategy_id=order.strategy_id,
@@ -1014,6 +999,7 @@ class BybitExecutionClient(LiveExecutionClient):
                     position_idx=position_idx,
                     bbo_side_type=tp_sl.get("bbo_side_type"),
                     bbo_level=tp_sl.get("bbo_level"),
+                    native_tp_sl=_build_native_tp_sl_params(tp_sl),
                 )
             elif (
                 tp_sl.get("take_profit")
@@ -1124,22 +1110,6 @@ class BybitExecutionClient(LiveExecutionClient):
             return
 
         if self._is_demo:
-            if (
-                tp_sl.get("take_profit")
-                or tp_sl.get("stop_loss")
-                or tp_sl.get("order_iv") is not None
-                or tp_sl.get("mmp") is not None
-            ):
-                now_ns = self._clock.timestamp_ns()
-                for order in command.order_list.orders:
-                    self.generate_order_denied(
-                        strategy_id=order.strategy_id,
-                        instrument_id=order.instrument_id,
-                        client_order_id=order.client_order_id,
-                        reason="Native TP/SL and option params are not supported in demo mode",
-                        ts_event=now_ns,
-                    )
-                return
             await self._submit_order_list_http(command, tp_sl)
             return
 
@@ -1222,6 +1192,7 @@ class BybitExecutionClient(LiveExecutionClient):
                     position_idx=position_idx,
                     bbo_side_type=tp_sl.get("bbo_side_type"),
                     bbo_level=tp_sl.get("bbo_level"),
+                    native_tp_sl=_build_native_tp_sl_params(tp_sl),
                 )
             except Exception as e:
                 error_msg = str(e)
@@ -2238,3 +2209,30 @@ def _apply_tp_sl_fields(order_params: object, tp_sl: dict) -> None:
         val = tp_sl.get(attr)
         if val is not None:
             setattr(order_params, attr, val)
+
+
+def _build_native_tp_sl_params(tp_sl: dict) -> object | None:
+    """Bundle native TP/SL + option fields for the HTTP `submit_order` path.
+
+    Returns ``None`` when no TP/SL or option field is set so the binding can
+    skip the conversion entirely. `tp/sl_trigger_price` are not threaded
+    through — the HTTP create-order entry doesn't carry them (mainnet's WS
+    Trade API does, via a separate field).
+    """
+    fields = (
+        "take_profit",
+        "stop_loss",
+        "tp_trigger_by",
+        "sl_trigger_by",
+        "tp_order_type",
+        "sl_order_type",
+        "tp_limit_price",
+        "sl_limit_price",
+        "close_on_trigger",
+        "order_iv",
+        "mmp",
+    )
+    kwargs = {f: tp_sl[f] for f in fields if tp_sl.get(f) is not None}
+    if not kwargs:
+        return None
+    return nautilus_pyo3.BybitNativeTpSlParams(**kwargs)

--- a/tests/integration_tests/adapters/bybit/test_execution.py
+++ b/tests/integration_tests/adapters/bybit/test_execution.py
@@ -1602,7 +1602,7 @@ def test_handle_fill_report_uses_cached_position_id_across_partial_fills(
 
 
 @pytest.mark.asyncio
-async def test_submit_order_with_tp_sl_in_demo_mode_emits_order_denied(
+async def test_submit_order_with_tp_sl_in_demo_mode_routes_to_http(
     exec_client_builder,
     monkeypatch,
     instrument,
@@ -1643,9 +1643,17 @@ async def test_submit_order_with_tp_sl_in_demo_mode_emits_order_denied(
     try:
         await client._submit_order(command)
 
+        # Native TP/SL on demo now goes through the HTTP create-order endpoint
+        # (Bybit demo accepts the same fields as mainnet) instead of being
+        # denied. The mainnet WS Trade API is still bypassed in demo.
         ws_trade_client.submit_order.assert_not_awaited()
         ws_trade_client.batch_place_orders.assert_not_awaited()
-        http_client.submit_order.assert_not_awaited()
+        http_client.submit_order.assert_awaited_once()
+        kwargs = http_client.submit_order.call_args.kwargs
+        native_tp_sl = kwargs["native_tp_sl"]
+        assert native_tp_sl is not None
+        assert native_tp_sl.take_profit == "55000.00"
+        assert native_tp_sl.stop_loss == "47000.00"
     finally:
         await client._disconnect()
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Bybit demo previously denied any order with `take_profit` / `stop_loss` / `order_iv` / `mmp` set, because the HTTP `submit_order` binding didn't accept those fields — even though the underlying `BybitBatchPlaceOrderEntry` already carries them and Bybit demo's `/v5/order/create` endpoint is identical to mainnet's. The deny gate was purely defensive against the pyo3 binding limitation. This plumbs the missing fields through so demo can use native TP/SL just like mainnet.

A new `BybitNativeTpSlParams` bundle carries the 12 TP/SL + option fields the entry struct already supports (`take_profit`, `stop_loss`, `tp/sl_trigger_by`, `tp/sl_order_type`, `tp/sl_limit_price`, `tpsl_mode`, `close_on_trigger`, `order_iv`, `mmp`). The Rust `BybitHttpClient::submit_order` takes it as a trailing `Option<&...>`, mirrors the WS path's TP/SL-implies-`Full`-mode default, and threads each populated field onto the entry builder. The PyO3 binding exposes it as a pyclass mirror with string-typed enum fields (matching `BybitWsPlaceOrderParams`), parsed at the boundary. Both the Rust `execution.rs` and Python `execution.py` demo branches drop the deny gate and pass the bundle through.

## Related Issues/PRs

<!-- Closes #<issue> -->

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

`BybitHttpClient::submit_order` gains a trailing `native_tp_sl: Option<&BybitNativeTpSlParams>` arg; existing callers must pass `None` (the PyO3 binding defaults it to `None`). `tp_trigger_price` / `sl_trigger_price` are still silently ignored on the demo HTTP path — the `/v5/order/create` entry doesn't carry them. Same behavior as before the fix (where they were also denied), but worth flagging as a known limitation.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Rewrote the stale `test_submit_order_with_tp_sl_in_demo_mode_emits_order_denied` as `..._routes_to_http` — now asserts the HTTP path is called with the `native_tp_sl` bundle populated from the `tp_sl` command params. `cargo check -p nautilus-bybit` and `cargo test -p nautilus-bybit --no-run` are clean.
