### PR TITLE
Fix LatencyModelConfig base latency unit comment

### DIFF
--- a/nautilus_trader/backtest/config.py
+++ b/nautilus_trader/backtest/config.py
@@ -544,7 +544,7 @@ class LatencyModelConfig(NautilusConfig, frozen=True):
 
     """
 
-    base_latency_nanos: NonNegativeInt = 1_000_000_000  # 1 millisecond in nanoseconds
+    base_latency_nanos: NonNegativeInt = 1_000_000_000  # 1 second in nanoseconds
     insert_latency_nanos: NonNegativeInt = 0
     update_latency_nanos: NonNegativeInt = 0
     cancel_latency_nanos: NonNegativeInt = 0


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The inline comment on `LatencyModelConfig.base_latency_nanos` (`nautilus_trader/backtest/config.py:547`) reads `# 1 millisecond in nanoseconds`, but `1_000_000_000` nanoseconds is one second, not one millisecond. The fix flips the unit word so the documented default matches the value.

This is the same default surfaced in the docstring just above (`base_latency_nanos : int, default 1_000_000_000`), and in the sibling Cython model at `nautilus_trader/backtest/models/latency.pyx:38`, both of which already describe it as nanoseconds without a unit conversion claim. The buggy inline comment is the only site in the repo that asserts the wrong unit.

## Related Issues/PRs

Closes #4170. Reported by @phx000 with the exact line and fix.

## Type of change

- [x] Documentation update

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

Docs-only change in an inline comment, no executable code touched. No tests to add.