### PR TITLE
Fix Interactive Brokers warmup last disconnection ns

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,6 +34,8 @@ Released on TBD (UTC).
 - Added portfolio PyO3 bindings and `Strategy.portfolio` access (#4085), thanks @ms32035
 - Added beta-weighted vega greeks against volatility index instruments (#4097), thanks @faysou
 - Added native `OptionGreeks` persistence and backtest replay support (#4132), thanks @Jonah-Chan
+- Added deterministic liquidation engine for backtests (#4077), thanks @abhishektang
+- Added configurable logging IO policies (#4158), thanks @sunlei
 - Added Binance Futures liquidation custom data subscriptions (#4095), thanks @graceyangfan
 - Added Binance Futures open interest request custom data (Rust) (#4109), thanks @graceyangfan
 - Added pending-resolution settlement pipeline for binary options (Rust) (#4101), thanks @graceyangfan
@@ -51,6 +53,7 @@ Released on TBD (UTC).
 - Added Hyperliquid HIP-4 outcome `BinaryOption.info` with parsed venue description and question metadata
 - Added Hyperliquid `HYPERLIQUID_ACCOUNT_ADDRESS` env var fallback for `HyperliquidExecClientConfig.account_address`
 - Added Hyperliquid live open interest custom data from `activeAssetCtx` (Rust) (#4120), thanks @graceyangfan
+- Added Hyperliquid `allDexsAssetCtxs` custom data subscriptions (#4136), thanks @graceyangfan
 - Added Kraken WebSocket rate limiting (#4093), thanks @filipmacek
 - Added OKX `on_instrument` write-through so data-client instrument updates refresh exec caches without restart
 - Added OKX spread instrument discovery as `CryptoFuturesSpread` instruments (Rust)
@@ -66,6 +69,7 @@ Released on TBD (UTC).
 - Changed Deribit `DeribitWebSocketClient.with_credentials` to accept `api_key`/`api_secret` after `environment`
 - Changed order event `reconciliation` and `due_post_only` from `u8` to `bool` (changes JSON/Arrow schemas)
 - Changed Deribit combos to land as `CryptoOptionSpread`/`CryptoFuturesSpread` instead of `OptionSpread`/`FuturesSpread`; `FuturesSpread`/`OptionSpread` once again guarantee whole-contract sizing
+- Renamed custom-data field marker `json` to `serde` (#4133), thanks @faysou
 
 ### Security
 - Fixed DataFFI PyCapsules to reject mismatched types and prevent repeated `CVec` drops
@@ -74,15 +78,17 @@ Released on TBD (UTC).
 - Fixed `StackStr::from_c_ptr_checked` to return `None` for null C string pointers
 
 ### Fixes
-- Fixed `PortfolioStatistic.downsample_to_daily_bins` arithmetic-sum aggregation producing incorrect `SharpeRatio`/`SortinoRatio`/`ReturnsVolatility`/`RiskReturnRatio`/`CAGR` for sub-daily returns; now compounds geometrically (Rust + Python)
 - Fixed unbounded Cache `VecDeque` memory leak (Rust) (#4107), thanks @filipmacek
+- Fixed `Cache.reset` clearing FX rate lookup for retained instruments (#4159), thanks for reporting @dfjmax
 - Fixed `BacktestEngine` option positions remaining open when data stops before expiry
 - Fixed `BacktestEngine` losing latency-deferred commands at shutdown (Rust) (#4062), thanks for reporting @zhanghaoda
 - Fixed `BacktestEngine` duplicate account state events on reset, thanks for reporting @dfjmax
+- Fixed `PortfolioStatistic.downsample_to_daily_bins` to compound sub-daily returns (#4141), thanks @mahimn01
 - Fixed matching engine not canceling unmatched IOC/FOK limit orders (Rust) (#4112), thanks for reporting @Jonah-Chan
 - Fixed matching engine L1 slip-through for market orders exhausting top-of-book volume (Rust)
 - Fixed NETTING reconciliation opening phantom reduce-only positions (#4106), thanks for reporting @M-at-ti-a
 - Fixed HEDGING margin scaling with fill count instead of net exposure (#4110), thanks for reporting @qaxayuan
+- Fixed multi-currency balance update violating `total == locked + free` (#4165), thanks for reporting @qaxayuan
 - Fixed `ExecTester` on_stop leaving INITIALIZED orders and bracket legs live across all cancel modes (Rust)
 - Fixed Aerodrome Slipstream `AmmType` from `StableSwap` to `CLAMM`
 - Fixed `PoolProfiler::update_position` to pre-validate active liquidity so failures leave pool state unchanged
@@ -107,6 +113,7 @@ Released on TBD (UTC).
 - Fixed Interactive Brokers order requests to guard on client readiness (Rust) (#4125), thanks @faysou
 - Fixed Interactive Brokers `request_instruments` returning cumulative cache (Rust) (#4114), thanks @faysou
 - Fixed Interactive Brokers Rust orders routing to exchange MIC venues (#4129), thanks @faysou
+- Fixed Interactive Brokers live bar reconnect tracking cleanup (#4169), thanks @faysou
 - Fixed Kraken Futures `feeScheduleUid` deserialization to tolerate absence ahead of the 2026-06-22 Fee Schedules deprecation
 - Fixed OKX `OKXExecutionClient` not forwarding config credentials to WebSocket clients (#4115), thanks @pusteckiy
 - Fixed OKX adapter to validate `clOrdId` rules before submission (#4116), thanks for reporting @pusteckiy
@@ -140,8 +147,13 @@ Released on TBD (UTC).
 - Removed dead Hyperliquid WebSocket codec module
 - Removed unused `async-stream` and `indexmap` from `nautilus-interactive-brokers` dependencies
 - Optimized common logging hot paths (#4150), thanks @sunlei
+- Optimized datetime and UUID formatting (#4161), thanks @sunlei
+- Optimized `AtomicMap` snapshot borrowing (#4162), thanks @sunlei
+- Optimized Derive signing and hot paths with benchmark report
 - Optimized Hyperliquid signing and hot paths with benchmark report
 - Optimized OKX hot paths with benchmark report
+- Upgraded `databento` crate to v0.52.0
+- Upgraded `redis` crate to v1.2.2
 
 ### Documentation Updates
 - Added plug-in concept guide covering the C-ABI boundary, manifest, lifecycle, and live-node integration
@@ -152,6 +164,7 @@ Released on TBD (UTC).
 - Refined Coinbase integration guide for instrument-status, funding rate backlog, and order rejection wording
 - Refined OKX integration guide with product capabilities and Nitro spread order notes
 - Fixed `NautilusKernelConfig` state flag default docs (#4144), thanks for reporting @trikafi
+- Fixed `LatencyModelConfig` base latency unit comment (1 second) (#4170), thanks for reporting @phx000
 - Fixed Polymarket crate README labelling separate Gamma and Data API endpoints
 - Fixed Polymarket integration guide inaccuracies (Gamma vs Data API split, `determine_trade_id` hash by adapter)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,8 +34,6 @@ Released on TBD (UTC).
 - Added portfolio PyO3 bindings and `Strategy.portfolio` access (#4085), thanks @ms32035
 - Added beta-weighted vega greeks against volatility index instruments (#4097), thanks @faysou
 - Added native `OptionGreeks` persistence and backtest replay support (#4132), thanks @Jonah-Chan
-- Added deterministic liquidation engine for backtests (#4077), thanks @abhishektang
-- Added configurable logging IO policies (#4158), thanks @sunlei
 - Added Binance Futures liquidation custom data subscriptions (#4095), thanks @graceyangfan
 - Added Binance Futures open interest request custom data (Rust) (#4109), thanks @graceyangfan
 - Added pending-resolution settlement pipeline for binary options (Rust) (#4101), thanks @graceyangfan
@@ -53,7 +51,6 @@ Released on TBD (UTC).
 - Added Hyperliquid HIP-4 outcome `BinaryOption.info` with parsed venue description and question metadata
 - Added Hyperliquid `HYPERLIQUID_ACCOUNT_ADDRESS` env var fallback for `HyperliquidExecClientConfig.account_address`
 - Added Hyperliquid live open interest custom data from `activeAssetCtx` (Rust) (#4120), thanks @graceyangfan
-- Added Hyperliquid `allDexsAssetCtxs` custom data subscriptions (#4136), thanks @graceyangfan
 - Added Kraken WebSocket rate limiting (#4093), thanks @filipmacek
 - Added OKX `on_instrument` write-through so data-client instrument updates refresh exec caches without restart
 - Added OKX spread instrument discovery as `CryptoFuturesSpread` instruments (Rust)
@@ -69,7 +66,6 @@ Released on TBD (UTC).
 - Changed Deribit `DeribitWebSocketClient.with_credentials` to accept `api_key`/`api_secret` after `environment`
 - Changed order event `reconciliation` and `due_post_only` from `u8` to `bool` (changes JSON/Arrow schemas)
 - Changed Deribit combos to land as `CryptoOptionSpread`/`CryptoFuturesSpread` instead of `OptionSpread`/`FuturesSpread`; `FuturesSpread`/`OptionSpread` once again guarantee whole-contract sizing
-- Renamed custom-data field marker `json` to `serde` (#4133), thanks @faysou
 
 ### Security
 - Fixed DataFFI PyCapsules to reject mismatched types and prevent repeated `CVec` drops
@@ -78,17 +74,15 @@ Released on TBD (UTC).
 - Fixed `StackStr::from_c_ptr_checked` to return `None` for null C string pointers
 
 ### Fixes
+- Fixed `PortfolioStatistic.downsample_to_daily_bins` arithmetic-sum aggregation producing incorrect `SharpeRatio`/`SortinoRatio`/`ReturnsVolatility`/`RiskReturnRatio`/`CAGR` for sub-daily returns; now compounds geometrically (Rust + Python)
 - Fixed unbounded Cache `VecDeque` memory leak (Rust) (#4107), thanks @filipmacek
-- Fixed `Cache.reset` clearing FX rate lookup for retained instruments (#4159), thanks for reporting @dfjmax
 - Fixed `BacktestEngine` option positions remaining open when data stops before expiry
 - Fixed `BacktestEngine` losing latency-deferred commands at shutdown (Rust) (#4062), thanks for reporting @zhanghaoda
 - Fixed `BacktestEngine` duplicate account state events on reset, thanks for reporting @dfjmax
-- Fixed `PortfolioStatistic.downsample_to_daily_bins` to compound sub-daily returns (#4141), thanks @mahimn01
 - Fixed matching engine not canceling unmatched IOC/FOK limit orders (Rust) (#4112), thanks for reporting @Jonah-Chan
 - Fixed matching engine L1 slip-through for market orders exhausting top-of-book volume (Rust)
 - Fixed NETTING reconciliation opening phantom reduce-only positions (#4106), thanks for reporting @M-at-ti-a
 - Fixed HEDGING margin scaling with fill count instead of net exposure (#4110), thanks for reporting @qaxayuan
-- Fixed multi-currency balance update violating `total == locked + free` (#4165), thanks for reporting @qaxayuan
 - Fixed `ExecTester` on_stop leaving INITIALIZED orders and bracket legs live across all cancel modes (Rust)
 - Fixed Aerodrome Slipstream `AmmType` from `StableSwap` to `CLAMM`
 - Fixed `PoolProfiler::update_position` to pre-validate active liquidity so failures leave pool state unchanged
@@ -113,7 +107,6 @@ Released on TBD (UTC).
 - Fixed Interactive Brokers order requests to guard on client readiness (Rust) (#4125), thanks @faysou
 - Fixed Interactive Brokers `request_instruments` returning cumulative cache (Rust) (#4114), thanks @faysou
 - Fixed Interactive Brokers Rust orders routing to exchange MIC venues (#4129), thanks @faysou
-- Fixed Interactive Brokers live bar reconnect tracking cleanup (#4169), thanks @faysou
 - Fixed Kraken Futures `feeScheduleUid` deserialization to tolerate absence ahead of the 2026-06-22 Fee Schedules deprecation
 - Fixed OKX `OKXExecutionClient` not forwarding config credentials to WebSocket clients (#4115), thanks @pusteckiy
 - Fixed OKX adapter to validate `clOrdId` rules before submission (#4116), thanks for reporting @pusteckiy
@@ -147,13 +140,8 @@ Released on TBD (UTC).
 - Removed dead Hyperliquid WebSocket codec module
 - Removed unused `async-stream` and `indexmap` from `nautilus-interactive-brokers` dependencies
 - Optimized common logging hot paths (#4150), thanks @sunlei
-- Optimized datetime and UUID formatting (#4161), thanks @sunlei
-- Optimized `AtomicMap` snapshot borrowing (#4162), thanks @sunlei
-- Optimized Derive signing and hot paths with benchmark report
 - Optimized Hyperliquid signing and hot paths with benchmark report
 - Optimized OKX hot paths with benchmark report
-- Upgraded `databento` crate to v0.52.0
-- Upgraded `redis` crate to v1.2.2
 
 ### Documentation Updates
 - Added plug-in concept guide covering the C-ABI boundary, manifest, lifecycle, and live-node integration
@@ -164,7 +152,6 @@ Released on TBD (UTC).
 - Refined Coinbase integration guide for instrument-status, funding rate backlog, and order rejection wording
 - Refined OKX integration guide with product capabilities and Nitro spread order notes
 - Fixed `NautilusKernelConfig` state flag default docs (#4144), thanks for reporting @trikafi
-- Fixed `LatencyModelConfig` base latency unit comment (1 second) (#4170), thanks for reporting @phx000
 - Fixed Polymarket crate README labelling separate Gamma and Data API endpoints
 - Fixed Polymarket integration guide inaccuracies (Gamma vs Data API split, `determine_trade_id` hash by adapter)
 

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -118,6 +118,12 @@ pub(super) async fn handle_historical_bars_subscription(
 
     let first_start_ns = resolve_historical_bar_start_ns(start_ns, clock.get_time_ns());
     let mut last_disconnection_ns = None;
+    // Only stamp last_disconnection_ns after a genuine prior connection, mirroring the
+    // Python adapter's _is_ib_connected guard in _handle_disconnection. Without this,
+    // a subscription creation failure during the pre-handshake window (client TCP-connected
+    // but IB session not yet ready) would cap the warmup window to now, delivering zero
+    // warmup bars on startup.
+    let mut had_connection = false;
 
     loop {
         if cancellation_token.is_cancelled() {
@@ -155,14 +161,19 @@ pub(super) async fn handle_historical_bars_subscription(
             )
             .await
         {
-            Ok(subscription) => subscription,
+            Ok(subscription) => {
+                had_connection = true;
+                subscription
+            }
             Err(e) => {
                 tracing::warn!(
                     "Failed to create historical bars subscription for {}: {:?}",
                     bar_type,
                     e
                 );
-                last_disconnection_ns = Some(clock.get_time_ns());
+                if had_connection {
+                    last_disconnection_ns = Some(clock.get_time_ns());
+                }
                 tokio::time::sleep(HISTORICAL_BAR_RETRY_DELAY).await;
                 continue;
             }
@@ -1302,6 +1313,29 @@ mod tests {
         );
 
         assert_eq!(replay_start_ns, last_disconnection_ns);
+    }
+
+    #[rstest]
+    fn test_resolve_historical_bar_replay_start_ns_uses_first_start_when_no_prior_disconnection() {
+        let first_start_ns = UnixNanos::from(1_000);
+
+        let replay_start_ns = super::resolve_historical_bar_replay_start_ns(first_start_ns, None);
+
+        assert_eq!(replay_start_ns, first_start_ns);
+    }
+
+    #[rstest]
+    fn test_resolve_historical_bar_replay_start_ns_uses_first_start_when_disconnection_before_start()
+     {
+        let first_start_ns = UnixNanos::from(1_000);
+        let last_disconnection_ns = UnixNanos::from(500);
+
+        let replay_start_ns = super::resolve_historical_bar_replay_start_ns(
+            first_start_ns,
+            Some(last_disconnection_ns),
+        );
+
+        assert_eq!(replay_start_ns, first_start_ns);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -171,9 +171,11 @@ pub(super) async fn handle_historical_bars_subscription(
                     bar_type,
                     e
                 );
+
                 if had_connection {
                     last_disconnection_ns = Some(clock.get_time_ns());
                 }
+
                 tokio::time::sleep(HISTORICAL_BAR_RETRY_DELAY).await;
                 continue;
             }

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -118,11 +118,10 @@ pub(super) async fn handle_historical_bars_subscription(
 
     let first_start_ns = resolve_historical_bar_start_ns(start_ns, clock.get_time_ns());
     let mut last_disconnection_ns = None;
-    // Only stamp last_disconnection_ns after a genuine prior connection, mirroring the
-    // Python adapter's _is_ib_connected guard in _handle_disconnection. Without this,
-    // a subscription creation failure during the pre-handshake window (client TCP-connected
-    // but IB session not yet ready) would cap the warmup window to now, delivering zero
-    // warmup bars on startup.
+    // Only stamp last_disconnection_ns after receiving real data, mirroring the Python
+    // adapter's _had_ib_connection guard. historical_data_streaming() returns Ok after
+    // sending the request — server-side errors arrive later via subscription.next(). A
+    // pre-data startup failure must not cap the warmup window to now.
     let mut had_connection = false;
 
     loop {
@@ -161,10 +160,7 @@ pub(super) async fn handle_historical_bars_subscription(
             )
             .await
         {
-            Ok(subscription) => {
-                had_connection = true;
-                subscription
-            }
+            Ok(subscription) => subscription,
             Err(e) => {
                 tracing::warn!(
                     "Failed to create historical bars subscription for {}: {:?}",
@@ -191,6 +187,7 @@ pub(super) async fn handle_historical_bars_subscription(
                 update = subscription.next() => {
                     match update {
                         Some(HistoricalBarUpdate::Historical(data)) => {
+                            had_connection = true;
                             for ib_bar in &data.bars {
                                 let bar = ib_bar_to_nautilus_bar(
                                     ib_bar,
@@ -207,6 +204,7 @@ pub(super) async fn handle_historical_bars_subscription(
                             }
                         }
                         Some(HistoricalBarUpdate::Update(ib_bar)) => {
+                            had_connection = true;
                             if !handle_revised_bars {
                                 continue;
                             }
@@ -243,7 +241,10 @@ pub(super) async fn handle_historical_bars_subscription(
                                 );
                             }
 
-                            last_disconnection_ns = Some(clock.get_time_ns());
+                            if had_connection {
+                                last_disconnection_ns = Some(clock.get_time_ns());
+                            }
+
                             break;
                         }
                     }

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -188,6 +188,7 @@ pub(super) async fn handle_historical_bars_subscription(
                     match update {
                         Some(HistoricalBarUpdate::Historical(data)) => {
                             had_connection = true;
+
                             for ib_bar in &data.bars {
                                 let bar = ib_bar_to_nautilus_bar(
                                     ib_bar,
@@ -205,6 +206,7 @@ pub(super) async fn handle_historical_bars_subscription(
                         }
                         Some(HistoricalBarUpdate::Update(ib_bar)) => {
                             had_connection = true;
+
                             if !handle_revised_bars {
                                 continue;
                             }

--- a/nautilus_trader/adapters/interactive_brokers/client/account.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/account.py
@@ -212,6 +212,7 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
         if self._next_valid_order_id >= 0 and not self._is_ib_connected.is_set():
             self._log.debug("`_is_ib_connected` set by `managedAccounts`", LogColor.BLUE)
             self._is_ib_connected.set()
+            self._had_ib_connection = True
 
     async def process_position(
         self,

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -166,6 +166,7 @@ class InteractiveBrokersClient(
         self._max_connection_attempts: int = int(os.getenv("IB_MAX_CONNECTION_ATTEMPTS", "0"))
         self._indefinite_reconnect: bool = not self._max_connection_attempts
         self._reconnect_delay: int = 5  # seconds
+        self._had_ib_connection: bool = False
         self._last_disconnection_ns: int | None = None
 
         # MarketDataMixin
@@ -439,6 +440,8 @@ class InteractiveBrokersClient(
         if self._is_ib_connected.is_set():
             self._log.debug("`_is_ib_connected` unset by `_handle_disconnection`", LogColor.BLUE)
             self._is_ib_connected.clear()
+
+        if self._had_ib_connection:
             self._last_disconnection_ns = self._clock.timestamp_ns()
         await self._clear_bar_tracking_state()
         await asyncio.sleep(5)

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -439,8 +439,7 @@ class InteractiveBrokersClient(
         if self._is_ib_connected.is_set():
             self._log.debug("`_is_ib_connected` unset by `_handle_disconnection`", LogColor.BLUE)
             self._is_ib_connected.clear()
-
-        self._last_disconnection_ns = self._clock.timestamp_ns()
+            self._last_disconnection_ns = self._clock.timestamp_ns()
         await self._clear_bar_tracking_state()
         await asyncio.sleep(5)
         await self._handle_reconnect()

--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -124,6 +124,7 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
                 LogColor.BLUE,
             )
             self._is_ib_connected.set()
+            self._had_ib_connection = True
 
     async def _handle_subscription_error(
         self,

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -265,6 +265,7 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         ):
             self._log.debug("`_is_ib_connected` set by `nextValidId`", LogColor.BLUE)
             self._is_ib_connected.set()
+            self._had_ib_connection = True
 
     async def process_open_order(
         self,

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -229,7 +229,9 @@ async def test_run_connection_watchdog_reconnect(ib_client):
 
 
 @pytest.mark.asyncio
-async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connected(ib_client_running):
+async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connected(
+    ib_client_running,
+):
     # Arrange - client is running and connected (_is_ib_connected is set by ib_client_running fixture)
     assert ib_client_running._is_ib_connected.is_set()
     assert ib_client_running._last_disconnection_ns is None
@@ -244,7 +246,9 @@ async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connecte
 
 
 @pytest.mark.asyncio
-async def test_handle_disconnection_does_not_set_last_disconnection_ns_when_not_connected(ib_client):
+async def test_handle_disconnection_does_not_set_last_disconnection_ns_when_not_connected(
+    ib_client,
+):
     # Arrange - client is NOT connected (_is_ib_connected is not set)
     # This simulates the watchdog firing during initial startup before the handshake completes,
     # which previously caused bar warmup start times to be capped at "now" instead of the

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -232,7 +232,9 @@ async def test_run_connection_watchdog_reconnect(ib_client):
 async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connected(
     ib_client_running,
 ):
-    # Arrange - client is running and connected (_is_ib_connected is set by ib_client_running fixture)
+    # Arrange - client had a genuine prior connection (_had_ib_connection=True) and is
+    # still marked connected (_is_ib_connected set). This is the normal watchdog path.
+    ib_client_running._had_ib_connection = True
     assert ib_client_running._is_ib_connected.is_set()
     assert ib_client_running._last_disconnection_ns is None
     ib_client_running._handle_reconnect = AsyncMock()
@@ -241,7 +243,29 @@ async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connecte
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await ib_client_running._handle_disconnection()
 
-    # Assert - timestamp recorded because client was connected before disconnection
+    # Assert - timestamp recorded because client had a genuine prior connection
+    assert ib_client_running._last_disconnection_ns is not None
+
+
+@pytest.mark.asyncio
+async def test_handle_disconnection_sets_last_disconnection_ns_when_flag_cleared_before_call(
+    ib_client_running,
+):
+    # Arrange - _is_ib_connected was cleared by another code path (e.g.
+    # _run_tws_incoming_msg_reader finally block) before the watchdog fires and calls
+    # _handle_disconnection. Previously the guard on _is_ib_connected.is_set() would
+    # silently skip the timestamp, causing reconnect warmup to miss bars from the downtime.
+    ib_client_running._had_ib_connection = True
+    ib_client_running._is_ib_connected.clear()
+    assert not ib_client_running._is_ib_connected.is_set()
+    assert ib_client_running._last_disconnection_ns is None
+    ib_client_running._handle_reconnect = AsyncMock()
+
+    # Act
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await ib_client_running._handle_disconnection()
+
+    # Assert - timestamp still recorded because _had_ib_connection is True
     assert ib_client_running._last_disconnection_ns is not None
 
 
@@ -249,11 +273,12 @@ async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connecte
 async def test_handle_disconnection_does_not_set_last_disconnection_ns_when_not_connected(
     ib_client,
 ):
-    # Arrange - client is NOT connected (_is_ib_connected is not set)
-    # This simulates the watchdog firing during initial startup before the handshake completes,
-    # which previously caused bar warmup start times to be capped at "now" instead of the
-    # requested warmup window (e.g. 4 hours back).
+    # Arrange - client is NOT connected and _had_ib_connection is False, simulating the
+    # watchdog firing during initial startup before the handshake completes. Previously
+    # this stamped _last_disconnection_ns=now, capping the bar warmup window to now and
+    # delivering zero warmup bars on startup.
     assert not ib_client._is_ib_connected.is_set()
+    assert not ib_client._had_ib_connection
     assert ib_client._last_disconnection_ns is None
     ib_client._handle_reconnect = AsyncMock()
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -229,6 +229,39 @@ async def test_run_connection_watchdog_reconnect(ib_client):
 
 
 @pytest.mark.asyncio
+async def test_handle_disconnection_sets_last_disconnection_ns_when_was_connected(ib_client_running):
+    # Arrange - client is running and connected (_is_ib_connected is set by ib_client_running fixture)
+    assert ib_client_running._is_ib_connected.is_set()
+    assert ib_client_running._last_disconnection_ns is None
+    ib_client_running._handle_reconnect = AsyncMock()
+
+    # Act
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await ib_client_running._handle_disconnection()
+
+    # Assert - timestamp recorded because client was connected before disconnection
+    assert ib_client_running._last_disconnection_ns is not None
+
+
+@pytest.mark.asyncio
+async def test_handle_disconnection_does_not_set_last_disconnection_ns_when_not_connected(ib_client):
+    # Arrange - client is NOT connected (_is_ib_connected is not set)
+    # This simulates the watchdog firing during initial startup before the handshake completes,
+    # which previously caused bar warmup start times to be capped at "now" instead of the
+    # requested warmup window (e.g. 4 hours back).
+    assert not ib_client._is_ib_connected.is_set()
+    assert ib_client._last_disconnection_ns is None
+    ib_client._handle_reconnect = AsyncMock()
+
+    # Act
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await ib_client._handle_disconnection()
+
+    # Assert - no timestamp recorded because client was never connected
+    assert ib_client._last_disconnection_ns is None
+
+
+@pytest.mark.asyncio
 async def test_handle_disconnection_clears_bar_tracking_state(ib_client_running):
     # Arrange
     task = asyncio.create_task(asyncio.sleep(60))


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Moves `_last_disconnection_ns = self._clock.timestamp_ns()` inside the existing
`_is_ib_connected.is_set()` guard in `_handle_disconnection`. The connection watchdog
fires when `_is_ib_connected` is not set, which includes the pre-handshake window on
initial startup — previously this stamped `_last_disconnection_ns = now` even with no
prior connection, causing `subscribe_historical_bars` to cap the warmup window to `now`
and silently deliver zero warmup bars to strategies at startup.

## Related Issues/PRs

Follows #4168 / #4169 (IB bar reconnect tracking cleanup, merged 2026-05-30).

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] I added/updated tests to cover new or changed logic

```bash
uv run --no-sync pytest \
  tests/integration_tests/adapters/interactive_brokers/client/test_client.py \
  -k "last_disconnection_ns or bar_tracking" -v
```

Two new regression tests added:

| Test | What it verifies |
|------|-----------------|
| `test_handle_disconnection_sets_last_disconnection_ns_when_was_connected` | Timestamp is recorded after a genuine disconnect (client was connected) |
| `test_handle_disconnection_does_not_set_last_disconnection_ns_when_not_connected` | No timestamp on watchdog pre-handshake fire (client never connected) |

### Root Cause Chain

```
1. _start_connection_watchdog() starts before _is_ib_connected is set
2. Watchdog wakes after 1 s: _is_ib_connected not set → calls _handle_disconnection()
3. _handle_disconnection() unconditionally sets _last_disconnection_ns = now
4. Strategy subscribes bars with start_ns = 4hr_ago
5. subscribe_historical_bars: _last_disconnection_ns (now) > first_start_ns (4hr_ago)
   → start = now  →  zero warmup bars fetched, indicators uninitialised
```

The `first_start_ns` addition in recent commits preserved the original start across
reconnects but did not prevent the incorrect stamp during initial startup. After this
fix `_last_disconnection_ns` is only recorded on genuine disconnects, preserving the
intended reconnect catch-up behaviour while allowing full warmup requests on initial
startup.
