### PR TITLE
Add missing PortfolioStatistic trait methods returning None

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -84,6 +84,7 @@ Released on TBD (UTC).
 - Fixed `BacktestEngine` losing latency-deferred commands at shutdown (Rust) (#4062), thanks for reporting @zhanghaoda
 - Fixed `BacktestEngine` duplicate account state events on reset, thanks for reporting @dfjmax
 - Fixed `PortfolioStatistic.downsample_to_daily_bins` to compound sub-daily returns (#4141), thanks @mahimn01
+- Fixed `MaxDrawdown`, `CAGR`, and `CalmarRatio` Rust trait impls panicking on `calculate_from_realized_pnls` and `calculate_from_positions` (#4174), thanks @mahimn01
 - Fixed matching engine not canceling unmatched IOC/FOK limit orders (Rust) (#4112), thanks for reporting @Jonah-Chan
 - Fixed matching engine L1 slip-through for market orders exhausting top-of-book volume (Rust)
 - Fixed NETTING reconciliation opening phantom reduce-only positions (#4106), thanks for reporting @M-at-ti-a

--- a/crates/analysis/src/statistics/cagr.rs
+++ b/crates/analysis/src/statistics/cagr.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 
 use nautilus_core::UnixNanos;
+use nautilus_model::position::Position;
 
 use crate::statistic::PortfolioStatistic;
 
@@ -84,6 +85,13 @@ impl PortfolioStatistic for CAGR {
         } else {
             Some(0.0)
         }
+    }
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
     }
 }
 

--- a/crates/analysis/src/statistics/calmar_ratio.rs
+++ b/crates/analysis/src/statistics/calmar_ratio.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 
 use nautilus_core::UnixNanos;
+use nautilus_model::position::Position;
 
 use crate::{
     statistic::PortfolioStatistic,
@@ -92,6 +93,13 @@ impl PortfolioStatistic for CalmarRatio {
         } else {
             Some(f64::NAN)
         }
+    }
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
     }
 }
 

--- a/crates/analysis/src/statistics/max_drawdown.rs
+++ b/crates/analysis/src/statistics/max_drawdown.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 
 use nautilus_core::UnixNanos;
+use nautilus_model::position::Position;
 
 use crate::statistic::PortfolioStatistic;
 
@@ -84,6 +85,13 @@ impl PortfolioStatistic for MaxDrawdown {
 
         // Return as negative percentage
         Some(-max_drawdown)
+    }
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
     }
 }
 


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`MaxDrawdown`, `CAGR`, and `CalmarRatio` only override `calculate_from_returns()` in their `PortfolioStatistic` trait impls. `calculate_from_realized_pnls()` and `calculate_from_positions()` inherit the default panicking impls, so a Rust caller that registers one of these with `PortfolioAnalyzer` and calls `get_performance_stats_pnls()` or `get_performance_stats_general()` panics on dispatch (both iterate every registered statistic).

The PyO3 wrappers already return `None` from these methods after #3941, so Python users are insulated. This PR mirrors that fix to the underlying Rust trait impls, matching the existing stub pattern used by `SharpeRatio`, `SortinoRatio`, and `ReturnsVolatility` (which also have no per-stat tests for the stubs).