### PR TITLE
Fix CurrencyPair asset_class for crypto pairs

### DIFF
--- a/crates/model/src/instruments/currency_pair.rs
+++ b/crates/model/src/instruments/currency_pair.rs
@@ -25,7 +25,7 @@ use ustr::Ustr;
 
 use super::{Instrument, any::InstrumentAny};
 use crate::{
-    enums::{AssetClass, InstrumentClass, OptionKind},
+    enums::{AssetClass, CurrencyType, InstrumentClass, OptionKind},
     identifiers::{InstrumentId, Symbol},
     types::{
         currency::Currency,
@@ -263,7 +263,13 @@ impl Instrument for CurrencyPair {
     }
 
     fn asset_class(&self) -> AssetClass {
-        AssetClass::FX
+        if self.base_currency.currency_type == CurrencyType::Crypto
+            || self.quote_currency.currency_type == CurrencyType::Crypto
+        {
+            AssetClass::Cryptocurrency
+        } else {
+            AssetClass::FX
+        }
     }
 
     fn instrument_class(&self) -> InstrumentClass {
@@ -403,7 +409,10 @@ mod tests {
             currency_pair_btcusdt.id(),
             InstrumentId::from("BTCUSDT.BINANCE")
         );
-        assert_eq!(currency_pair_btcusdt.asset_class(), AssetClass::FX);
+        assert_eq!(
+            currency_pair_btcusdt.asset_class(),
+            AssetClass::Cryptocurrency
+        );
         assert_eq!(
             currency_pair_btcusdt.instrument_class(),
             InstrumentClass::Spot


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`CurrencyPair::asset_class()` was hardcoded to return `AssetClass::FX`, so every spot crypto pair (e.g. Bybit `ENAUSDT-SPOT`, Binance `BTCUSDT`, OKX, Coinbase, Kraken, Hyperliquid, BitMEX, Deribit, Tardis…) was reporting `FX` instead of `Cryptocurrency`. The Cython `CurrencyPair.__init__` already infers this correctly from `currency_type` on the base/quote `Currency` — the Rust side just never matched.

This ports the same inference into the Rust `asset_class()` method.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic