### PR TITLE
Fix Config timeout default docs:

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -174,6 +174,7 @@ Released on TBD (UTC).
 - Refined OKX integration guide with product capabilities and Nitro spread order notes
 - Fixed `NautilusKernelConfig` state flag default docs (#4144), thanks for reporting @trikafi
 - Fixed `LatencyModelConfig` base latency unit comment (1 second) (#4170), thanks for reporting @phx000
+- Fixed `NautilusKernelConfig` timeout default docs (#4179), thanks for reporting @triyys
 - Fixed Polymarket crate README labelling separate Gamma and Data API endpoints
 - Fixed Polymarket integration guide inaccuracies (Gamma vs Data API split, `determine_trade_id` hash by adapter)
 

--- a/nautilus_trader/system/config.py
+++ b/nautilus_trader/system/config.py
@@ -82,7 +82,7 @@ class NautilusKernelConfig(NautilusConfig, frozen=True):
         If the asyncio event loop should be in debug mode.
     logging : LoggingConfig, optional
         The logging configuration for the kernel.
-    timeout_connection : PositiveFloat, default 60
+    timeout_connection : PositiveFloat, default 120
         The timeout (seconds) for all clients to connect and initialize.
     timeout_reconciliation : PositiveFloat, default 30
         The timeout (seconds) for execution state to reconcile.


### PR DESCRIPTION
- Correct `NautilusKernelConfig`'s `timeout_connection` default in the docstring
- Resolves #4179

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Correct `NautilusKernelConfig`'s `timeout_connection` default in the docstring

## Related Issues/PRs

Resolves #4179

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)
