### PR TITLE
Align Derive and Lighter configs with the workspace convention

### DIFF
--- a/crates/adapters/derive/src/common/enums.rs
+++ b/crates/adapters/derive/src/common/enums.rs
@@ -26,6 +26,7 @@ use strum::{AsRefStr, Display, EnumIter, EnumString};
 /// Derive network selector. Drives REST/WS URLs and per-network protocol
 /// constants (`DOMAIN_SEPARATOR`, module addresses).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(

--- a/crates/adapters/derive/src/config.rs
+++ b/crates/adapters/derive/src/config.rs
@@ -19,11 +19,13 @@ use std::fmt::Debug;
 
 use nautilus_network::websocket::TransportBackend;
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 
 use crate::common::{enums::DeriveEnvironment, urls};
 
 /// Configuration for the Derive data client.
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, Debug, Serialize, Deserialize, bon::Builder)]
+#[serde(default, deny_unknown_fields)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.derive", from_py_object)
@@ -101,7 +103,8 @@ impl DeriveDataClientConfig {
 /// `Debug` is implemented manually so that `session_key` is redacted; the
 /// derived `Debug` would leak the raw secret through any logger or Python
 /// `__repr__`.
-#[derive(Clone, bon::Builder)]
+#[derive(Clone, Serialize, Deserialize, bon::Builder)]
+#[serde(default, deny_unknown_fields)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.derive", from_py_object)

--- a/crates/adapters/lighter/src/config.rs
+++ b/crates/adapters/lighter/src/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use nautilus_core::string::secret::REDACTED;
 use nautilus_model::identifiers::{AccountId, TraderId};
 use nautilus_network::websocket::TransportBackend;
+use serde::{Deserialize, Serialize};
 
 use crate::common::{
     credential::credential_env_vars,
@@ -28,7 +29,8 @@ use crate::common::{
 };
 
 /// Configuration for the Lighter data client.
-#[derive(Clone, bon::Builder)]
+#[derive(Clone, Serialize, Deserialize, bon::Builder)]
+#[serde(default, deny_unknown_fields)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.lighter", from_py_object,)
@@ -141,7 +143,8 @@ fn env_var_is_set(name: &str) -> bool {
 }
 
 /// Configuration for the Lighter execution client.
-#[derive(Clone, bon::Builder)]
+#[derive(Clone, Serialize, Deserialize, bon::Builder)]
+#[serde(default, deny_unknown_fields)]
 #[cfg_attr(
     feature = "python",
     pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.lighter", from_py_object,)
@@ -152,8 +155,10 @@ fn env_var_is_set(name: &str) -> bool {
 )]
 pub struct LighterExecClientConfig {
     /// Trader identifier.
+    #[builder(default = TraderId::from("TRADER-001"))]
     pub trader_id: TraderId,
     /// Account identifier on the venue.
+    #[builder(default = AccountId::from("LIGHTER-001"))]
     pub account_id: AccountId,
     /// Lighter account index (numeric, assigned at registration). Falls back
     /// to `LIGHTER_ACCOUNT_INDEX` / `LIGHTER_TESTNET_ACCOUNT_INDEX` when
@@ -192,6 +197,12 @@ pub struct LighterExecClientConfig {
     /// WebSocket transport backend.
     #[builder(default)]
     pub transport_backend: TransportBackend,
+}
+
+impl Default for LighterExecClientConfig {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 impl Debug for LighterExecClientConfig {


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Most adapter configs in `crates/adapters/*` derive `Serialize + Deserialize` with `#[serde(default, deny_unknown_fields)]` and provide an `impl Default` — Binance, Kraken, OKX, Coinbase, Deribit, Bybit, Hyperliquid, Bitmex, Polymarket, Tardis, and Betfair all follow this shape. Derive and Lighter are the only adapters in this family that don't, which makes them awkward to construct from JSON, round-trip through a config layer, or compare against on equal terms with their peers. This PR brings both in line.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore