### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/OVERVIEW.md
+++ b/.github/OVERVIEW.md
@@ -42,6 +42,8 @@ CI/CD, testing, publishing, and automation within the NautilusTrader repository.
 - **performance.yml**: Rust/Python benchmarks on `nightly`, reporting to CodSpeed.
 - **security-audit.yml**: nightly supply chain security checks (cargo-audit, cargo-deny,
   cargo-vet, pip-audit, osv-scanner, and Zizmor).
+- **scorecard.yml**: OpenSSF Scorecard posture scan on `develop` pushes, weekly schedule, and
+  manual dispatch. Publishes badge/API results and uploads SARIF to code scanning.
 
 ## Security
 
@@ -74,6 +76,8 @@ CI/CD, testing, publishing, and automation within the NautilusTrader repository.
 - **Code scanning**: CodeQL analyzes Python and Rust code on PRs to `master`, pushes to `nightly`,
   and manual dispatch. Zizmor runs in `security-audit.yml` and uploads SARIF when token
   permissions allow it.
+- **OpenSSF Scorecard**: `scorecard.yml` publishes repository posture results for the public
+  badge/API and uploads SARIF to code scanning.
 
 ### Build and publish controls
 
@@ -170,7 +174,8 @@ All workflows read these GitHub variables:
 - `SECURITY_AUDIT_ALLOWED_ENDPOINTS`: Extra endpoints needed by the security audit jobs.
 
 Some workflows add job-specific endpoints inline (e.g., `upload.pypi.org:443` for publishing,
-`auth.docker.io:443` and `registry-1.docker.io:443` for Docker builds).
+`auth.docker.io:443` and `registry-1.docker.io:443` for Docker builds, and
+`api.scorecard.dev:443` for Scorecard result publishing).
 
 Security audit jobs do not use deployment environments. They do not need environment secrets, and
 environment branch policies block same-repo contributor PRs before the audit steps can start.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,64 @@
+name: scorecard
+
+# OpenSSF Scorecard posture scan.
+#
+# Triggers:
+#   - Pushes to develop refresh the public Scorecard badge/API result.
+#   - Weekly schedule keeps the result fresh even without source changes.
+#   - Manual dispatch lets maintainers refresh the result from develop after repo-setting changes.
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  push:
+    branches: [develop]
+  schedule:
+    - cron: "30 12 * * 6" # Weekly on Saturdays at 12:30 UTC.
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    name: scorecard
+    if: >-
+      github.repository == 'nautechsystems/nautilus_trader' &&
+      github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+      id-token: write
+    steps:
+      # https://github.com/step-security/harden-runner
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'block' }}
+          allowed-endpoints: >-
+            ${{ vars.COMMON_ALLOWED_ENDPOINTS }}
+            ghcr.io:443
+            api.scorecard.dev:443
+
+      - name: Checkout repository
+        # https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Run OpenSSF Scorecard
+        # https://github.com/ossf/scorecard-action
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard SARIF
+        if: always() && hashFiles('scorecard.sarif') != ''
+        # https://github.com/github/codeql-action
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: scorecard.sarif
+          category: openssf-scorecard

--- a/README.md
+++ b/README.md
@@ -572,8 +572,17 @@ developer looking to contribute or just want to learn more about the platform, a
 
 ## Security
 
-To report a vulnerability, see our [Security Policy](SECURITY.md).
-For full security policies including supply chain security, see <https://nautilustrader.io/security/>.
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/nautechsystems/nautilus_trader/badge)](https://scorecard.dev/viewer/?uri=github.com/nautechsystems/nautilus_trader)
+
+The OpenSSF Scorecard badge tracks automated repository-health signals. It complements manual
+review, CI hardening, and security audits rather than replacing them.
+
+NautilusTrader uses layered supply-chain and code-security controls, including CodeQL static
+analysis, pinned GitHub Actions, dependency auditing, cargo-vet, OSV scanning, fuzzing for
+selected adapter and signing surfaces, and signed release provenance for official artifacts.
+
+To report a vulnerability, see our [Security Policy](SECURITY.md). For full security policies
+including supply chain security, see <https://nautilustrader.io/security/>.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,12 @@ do our best to properly recognize and credit your contributions.
 NautilusTrader employs multiple layers of security across the development and
 release lifecycle:
 
+### Public posture
+
+- **OpenSSF Scorecard**: The repository publishes Scorecard results for the public badge and API,
+  and uploads SARIF to GitHub code scanning. Scorecard is an automated repository-health signal
+  that complements manual review and security audits.
+
 ### Source and review controls
 
 - **CODEOWNERS**: Critical infrastructure files, dependency manifests, and lock files require Core
@@ -109,6 +115,8 @@ release lifecycle:
   and OSV Scanner (Rust), pip-audit (Python), and Zizmor (GitHub Actions).
 - **Supply chain provenance**: cargo-vet verifies Rust dependency provenance by importing trusted
   audit data from organizations including Bytecode Alliance, Google, Mozilla, and Embark Studios.
+- **Fuzzing**: cargo-fuzz targets cover selected adapter and signing surfaces, including Derive
+  wire-model/signing internals and Lighter cryptographic/signing internals.
 - **Code scanning**: CodeQL static analysis covers Python and Rust code on PRs to `master`,
   pushes to `nightly`, and manual dispatch. The scheduled security audit also uploads Zizmor SARIF
   results for GitHub Actions workflow findings when token permissions allow it.


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Adds a dedicated OpenSSF Scorecard workflow that publishes public badge/API results and uploads SARIF to GitHub code scanning. The README, security policy, and GitHub Actions overview now document Scorecard as an automated repository-health signal alongside existing supply-chain controls.

## Related Issues/PRs

None.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

Not applicable; this updates security/CI posture documentation and workflow configuration only.

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

No runtime code paths changed.

Validated with:

- `prek run --files .github/workflows/scorecard.yml README.md SECURITY.md .github/OVERVIEW.md`
- `git diff --check`
