### PR TITLE
Fix raw value boundary constants in Rust

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -91,6 +91,7 @@ Released on TBD (UTC).
 
 ### Fixes
 - Fixed `OrderMatchingEngine` panicking on `PriceType::Mark` bars during bar execution, now logs a warning and skips the bar (Rust)
+- Fixed `PRICE_RAW_MAX`/`MIN`, `QUANTITY_RAW_MAX`, and `MONEY_RAW_MAX`/`MIN` computed with lossy `f64` scaling, which rounded the bound below the representable maximum and could panic `from_raw` at the limits (Rust)
 - Fixed unbounded Cache `VecDeque` memory leak (Rust) (#4107), thanks @filipmacek
 - Fixed `Cache.reset` clearing FX rate lookup for retained instruments (#4159), thanks for reporting @dfjmax
 - Fixed `BacktestEngine` option positions remaining open when data stops before expiry

--- a/crates/model/src/types/money.rs
+++ b/crates/model/src/types/money.rs
@@ -92,25 +92,25 @@ pub type MoneyRaw = i64;
 ///
 /// # Safety
 ///
-/// This value is computed at compile time from `MONEY_MAX` * `FIXED_SCALAR`.
-/// The multiplication is guaranteed not to overflow because `MONEY_MAX` and `FIXED_SCALAR`
-/// are chosen such that their product fits within `MoneyRaw`'s range in both
-/// high-precision (i128) and standard-precision (i64) modes.
+/// `MONEY_MAX` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+/// scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+/// fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+/// (i64) modes, so the multiplication cannot overflow.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
-pub static MONEY_RAW_MAX: MoneyRaw = (MONEY_MAX * FIXED_SCALAR) as MoneyRaw;
+pub static MONEY_RAW_MAX: MoneyRaw = (MONEY_MAX as MoneyRaw) * (FIXED_SCALAR as MoneyRaw);
 
 /// The minimum raw money integer value.
 ///
 /// # Safety
 ///
-/// This value is computed at compile time from `MONEY_MIN` * `FIXED_SCALAR`.
-/// The multiplication is guaranteed not to overflow because `MONEY_MIN` and `FIXED_SCALAR`
-/// are chosen such that their product fits within `MoneyRaw`'s range in both
-/// high-precision (i128) and standard-precision (i64) modes.
+/// `MONEY_MIN` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+/// scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+/// fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+/// (i64) modes, so the multiplication cannot overflow.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
-pub static MONEY_RAW_MIN: MoneyRaw = (MONEY_MIN * FIXED_SCALAR) as MoneyRaw;
+pub static MONEY_RAW_MIN: MoneyRaw = (MONEY_MIN as MoneyRaw) * (FIXED_SCALAR as MoneyRaw);
 
 // -----------------------------------------------------------------------------
 // MONEY_MAX
@@ -745,6 +745,19 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::*;
+
+    #[rstest]
+    fn test_extreme_money_round_trips_through_raw() {
+        // Regression: a lossy `f64` scalar previously left `MONEY_RAW_MAX`/`MONEY_RAW_MIN`
+        // beyond the raw produced by `new` at the bounds, causing spurious panics and errors.
+        let max = Money::new(MONEY_MAX, Currency::USD());
+        let min = Money::new(MONEY_MIN, Currency::USD());
+
+        assert_eq!(max.raw, MONEY_RAW_MAX);
+        assert_eq!(min.raw, MONEY_RAW_MIN);
+        assert!(Money::from_raw_checked(max.raw, Currency::USD()).is_ok());
+        assert!(Money::from_raw_checked(min.raw, Currency::USD()).is_ok());
+    }
 
     #[rstest]
     fn test_debug() {

--- a/crates/model/src/types/price.rs
+++ b/crates/model/src/types/price.rs
@@ -87,25 +87,25 @@ pub type PriceRaw = i64;
 ///
 /// # Safety
 ///
-/// This value is computed at compile time from `PRICE_MAX` * `FIXED_SCALAR`.
-/// The multiplication is guaranteed not to overflow because `PRICE_MAX` and `FIXED_SCALAR`
-/// are chosen such that their product fits within `PriceRaw`'s range in both
-/// high-precision (i128) and standard-precision (i64) modes.
+/// `PRICE_MAX` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+/// scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+/// fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+/// (i64) modes, so the multiplication cannot overflow.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
-pub static PRICE_RAW_MAX: PriceRaw = (PRICE_MAX * FIXED_SCALAR) as PriceRaw;
+pub static PRICE_RAW_MAX: PriceRaw = (PRICE_MAX as PriceRaw) * (FIXED_SCALAR as PriceRaw);
 
 /// The minimum raw price integer value.
 ///
 /// # Safety
 ///
-/// This value is computed at compile time from `PRICE_MIN` * `FIXED_SCALAR`.
-/// The multiplication is guaranteed not to overflow because `PRICE_MIN` and `FIXED_SCALAR`
-/// are chosen such that their product fits within `PriceRaw`'s range in both
-/// high-precision (i128) and standard-precision (i64) modes.
+/// `PRICE_MIN` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+/// scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+/// fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+/// (i64) modes, so the multiplication cannot overflow.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
-pub static PRICE_RAW_MIN: PriceRaw = (PRICE_MIN * FIXED_SCALAR) as PriceRaw;
+pub static PRICE_RAW_MIN: PriceRaw = (PRICE_MIN as PriceRaw) * (FIXED_SCALAR as PriceRaw);
 
 /// The sentinel value for an unset or null price.
 pub const PRICE_UNDEF: PriceRaw = PriceRaw::MAX;
@@ -850,6 +850,19 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::*;
+
+    #[rstest]
+    fn test_extreme_prices_round_trip_through_raw() {
+        // Regression: a lossy `f64` scalar previously left `PRICE_RAW_MAX`/`PRICE_RAW_MIN`
+        // beyond the raw produced by `new` at the bounds, causing spurious panics and errors.
+        let max = Price::new(PRICE_MAX, 0);
+        let min = Price::new(PRICE_MIN, 0);
+
+        assert_eq!(max.raw, PRICE_RAW_MAX);
+        assert_eq!(min.raw, PRICE_RAW_MIN);
+        assert!(Price::from_raw_checked(max.raw, 0).is_ok());
+        assert!(Price::from_raw_checked(min.raw, 0).is_ok());
+    }
 
     #[rstest]
     #[cfg(all(not(feature = "defi"), not(feature = "high-precision")))]

--- a/crates/model/src/types/quantity.rs
+++ b/crates/model/src/types/quantity.rs
@@ -81,9 +81,15 @@ pub type QuantityRaw = u64;
 // -----------------------------------------------------------------------------
 
 /// The maximum raw quantity integer value.
+///
+/// `QUANTITY_MAX` and `FIXED_SCALAR` are cast to `QuantityRaw` before multiplying, so the
+/// scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+/// fits within `QuantityRaw`'s range in both high-precision (u128) and standard-precision
+/// (u64) modes, so the multiplication cannot overflow.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
-pub static QUANTITY_RAW_MAX: QuantityRaw = (QUANTITY_MAX * FIXED_SCALAR) as QuantityRaw;
+pub static QUANTITY_RAW_MAX: QuantityRaw =
+    (QUANTITY_MAX as QuantityRaw) * (FIXED_SCALAR as QuantityRaw);
 
 /// The sentinel value for an unset or null quantity.
 pub const QUANTITY_UNDEF: QuantityRaw = QuantityRaw::MAX;
@@ -905,6 +911,17 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::*;
+
+    #[rstest]
+    fn test_max_quantity_round_trips_through_raw() {
+        // Regression: a lossy `f64` scalar previously left `QUANTITY_RAW_MAX` below the raw
+        // produced by `new` at the maximum, causing spurious panics and overflow errors.
+        let qty = Quantity::new(QUANTITY_MAX, 0);
+
+        assert_eq!(qty.raw, QUANTITY_RAW_MAX);
+        assert!(Quantity::from_raw_checked(qty.raw, 0).is_ok());
+        assert!(qty.checked_add(Quantity::zero(0)).is_some());
+    }
 
     #[rstest]
     fn test_check_quantity_positive() {

--- a/crates/serialization/src/arrow/quote.rs
+++ b/crates/serialization/src/arrow/quote.rs
@@ -478,10 +478,12 @@ mod tests {
 
     #[rstest]
     fn test_decode_batch_invalid_ask_size_returns_error() {
-        use nautilus_model::types::quantity::QUANTITY_RAW_MAX;
+        use nautilus_model::types::{fixed::FIXED_PRECISION, quantity::QUANTITY_RAW_MAX};
 
         let instrument_id = InstrumentId::from("AAPL.XNAS");
-        let metadata = QuoteTick::get_metadata(&instrument_id, 2, 0);
+        // Decode the size at full precision so the out-of-range raw value bypasses the
+        // precision-0 correction, which would otherwise round it back within the bound.
+        let metadata = QuoteTick::get_metadata(&instrument_id, 2, FIXED_PRECISION);
 
         let valid_price = (100.00 * FIXED_SCALAR) as PriceRaw;
         let bid_price = FixedSizeBinaryArray::from(vec![&valid_price.to_le_bytes()]);

--- a/crates/serialization/src/arrow/trade.rs
+++ b/crates/serialization/src/arrow/trade.rs
@@ -503,10 +503,12 @@ mod tests {
 
     #[rstest]
     fn test_decode_batch_invalid_size_returns_error() {
-        use nautilus_model::types::quantity::QUANTITY_RAW_MAX;
+        use nautilus_model::types::{fixed::FIXED_PRECISION, quantity::QUANTITY_RAW_MAX};
 
         let instrument_id = InstrumentId::from("AAPL.XNAS");
-        let metadata = TradeTick::get_metadata(&instrument_id, 2, 0);
+        // Decode the size at full precision so the out-of-range raw value bypasses the
+        // precision-0 correction, which would otherwise round it back within the bound.
+        let metadata = TradeTick::get_metadata(&instrument_id, 2, FIXED_PRECISION);
 
         let raw_price = (100.00 * FIXED_SCALAR) as PriceRaw;
         let price = FixedSizeBinaryArray::from(vec![&raw_price.to_le_bytes()]);

--- a/nautilus_trader/core/includes/model.h
+++ b/nautilus_trader/core/includes/model.h
@@ -1944,10 +1944,10 @@ extern const uint8_t HIGH_PRECISION_MODE;
  *
  * # Safety
  *
- * This value is computed at compile time from `MONEY_MAX` * `FIXED_SCALAR`.
- * The multiplication is guaranteed not to overflow because `MONEY_MAX` and `FIXED_SCALAR`
- * are chosen such that their product fits within `MoneyRaw`'s range in both
- * high-precision (i128) and standard-precision (i64) modes.
+ * `MONEY_MAX` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+ * scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+ * fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+ * (i64) modes, so the multiplication cannot overflow.
  */
 extern const MoneyRaw MONEY_RAW_MAX;
 
@@ -1956,10 +1956,10 @@ extern const MoneyRaw MONEY_RAW_MAX;
  *
  * # Safety
  *
- * This value is computed at compile time from `MONEY_MIN` * `FIXED_SCALAR`.
- * The multiplication is guaranteed not to overflow because `MONEY_MIN` and `FIXED_SCALAR`
- * are chosen such that their product fits within `MoneyRaw`'s range in both
- * high-precision (i128) and standard-precision (i64) modes.
+ * `MONEY_MIN` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+ * scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+ * fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+ * (i64) modes, so the multiplication cannot overflow.
  */
 extern const MoneyRaw MONEY_RAW_MIN;
 
@@ -1968,10 +1968,10 @@ extern const MoneyRaw MONEY_RAW_MIN;
  *
  * # Safety
  *
- * This value is computed at compile time from `PRICE_MAX` * `FIXED_SCALAR`.
- * The multiplication is guaranteed not to overflow because `PRICE_MAX` and `FIXED_SCALAR`
- * are chosen such that their product fits within `PriceRaw`'s range in both
- * high-precision (i128) and standard-precision (i64) modes.
+ * `PRICE_MAX` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+ * scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+ * fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+ * (i64) modes, so the multiplication cannot overflow.
  */
 extern const PriceRaw PRICE_RAW_MAX;
 
@@ -1980,15 +1980,20 @@ extern const PriceRaw PRICE_RAW_MAX;
  *
  * # Safety
  *
- * This value is computed at compile time from `PRICE_MIN` * `FIXED_SCALAR`.
- * The multiplication is guaranteed not to overflow because `PRICE_MIN` and `FIXED_SCALAR`
- * are chosen such that their product fits within `PriceRaw`'s range in both
- * high-precision (i128) and standard-precision (i64) modes.
+ * `PRICE_MIN` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+ * scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+ * fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+ * (i64) modes, so the multiplication cannot overflow.
  */
 extern const PriceRaw PRICE_RAW_MIN;
 
 /**
  * The maximum raw quantity integer value.
+ *
+ * `QUANTITY_MAX` and `FIXED_SCALAR` are cast to `QuantityRaw` before multiplying, so the
+ * scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+ * fits within `QuantityRaw`'s range in both high-precision (u128) and standard-precision
+ * (u64) modes, so the multiplication cannot overflow.
  */
 extern const QuantityRaw QUANTITY_RAW_MAX;
 

--- a/nautilus_trader/core/rust/model.pxd
+++ b/nautilus_trader/core/rust/model.pxd
@@ -1083,43 +1083,48 @@ cdef extern from "../includes/model.h":
     #
     # # Safety
     #
-    # This value is computed at compile time from `MONEY_MAX` * `FIXED_SCALAR`.
-    # The multiplication is guaranteed not to overflow because `MONEY_MAX` and `FIXED_SCALAR`
-    # are chosen such that their product fits within `MoneyRaw`'s range in both
-    # high-precision (i128) and standard-precision (i64) modes.
+    # `MONEY_MAX` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+    # scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+    # fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+    # (i64) modes, so the multiplication cannot overflow.
     extern const MoneyRaw MONEY_RAW_MAX;
 
     # The minimum raw money integer value.
     #
     # # Safety
     #
-    # This value is computed at compile time from `MONEY_MIN` * `FIXED_SCALAR`.
-    # The multiplication is guaranteed not to overflow because `MONEY_MIN` and `FIXED_SCALAR`
-    # are chosen such that their product fits within `MoneyRaw`'s range in both
-    # high-precision (i128) and standard-precision (i64) modes.
+    # `MONEY_MIN` and `FIXED_SCALAR` are cast to `MoneyRaw` before multiplying, so the
+    # scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+    # fits within `MoneyRaw`'s range in both high-precision (i128) and standard-precision
+    # (i64) modes, so the multiplication cannot overflow.
     extern const MoneyRaw MONEY_RAW_MIN;
 
     # The maximum raw price integer value.
     #
     # # Safety
     #
-    # This value is computed at compile time from `PRICE_MAX` * `FIXED_SCALAR`.
-    # The multiplication is guaranteed not to overflow because `PRICE_MAX` and `FIXED_SCALAR`
-    # are chosen such that their product fits within `PriceRaw`'s range in both
-    # high-precision (i128) and standard-precision (i64) modes.
+    # `PRICE_MAX` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+    # scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+    # fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+    # (i64) modes, so the multiplication cannot overflow.
     extern const PriceRaw PRICE_RAW_MAX;
 
     # The minimum raw price integer value.
     #
     # # Safety
     #
-    # This value is computed at compile time from `PRICE_MIN` * `FIXED_SCALAR`.
-    # The multiplication is guaranteed not to overflow because `PRICE_MIN` and `FIXED_SCALAR`
-    # are chosen such that their product fits within `PriceRaw`'s range in both
-    # high-precision (i128) and standard-precision (i64) modes.
+    # `PRICE_MIN` and `FIXED_SCALAR` are cast to `PriceRaw` before multiplying, so the
+    # scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+    # fits within `PriceRaw`'s range in both high-precision (i128) and standard-precision
+    # (i64) modes, so the multiplication cannot overflow.
     extern const PriceRaw PRICE_RAW_MIN;
 
     # The maximum raw quantity integer value.
+    #
+    # `QUANTITY_MAX` and `FIXED_SCALAR` are cast to `QuantityRaw` before multiplying, so the
+    # scaling uses exact integer arithmetic rather than a lossy `f64` product. The result
+    # fits within `QuantityRaw`'s range in both high-precision (u128) and standard-precision
+    # (u64) modes, so the multiplication cannot overflow.
     extern const QuantityRaw QUANTITY_RAW_MAX;
 
     # Clones a data instance.


### PR DESCRIPTION
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`PRICE_RAW_MAX`/`MIN`, `QUANTITY_RAW_MAX`, and `MONEY_RAW_MAX`/`MIN` were computed with an `f64` multiply by `FIXED_SCALAR`, which rounded the constant below the true representable maximum (e.g. by 11,161,508,380,672 raw units in high-precision mode, and 512 in standard mode). A value built by `new` at the bound then exceeded the constant, so `from_raw` panicked and `from_raw_checked`/`checked_add` spuriously rejected valid boundary values. The fix casts both operands to the raw integer type before multiplying, so scaling stays exact in all feature modes.

## Related Issues/PRs

N/A

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions

## Testing

- [x] I added/updated tests to cover new or changed logic

Added boundary round-trip regression tests in `crates/model/src/types/{price,quantity,money}.rs`. Verified with `cargo test -p nautilus-model --lib types::` in both default (591 passed) and `--features high-precision` (609 passed) modes; `cargo fmt --check` and `cargo clippy` are clean on the touched files.
