### PR TITLE
Fix matching engine panic on mark price bars in Rust

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -88,6 +88,7 @@ Released on TBD (UTC).
 - Fixed `StackStr::from_c_ptr_checked` to return `None` for null C string pointers
 
 ### Fixes
+- Fixed `OrderMatchingEngine` panicking on `PriceType::Mark` bars during bar execution, now logs a warning and skips the bar (Rust)
 - Fixed unbounded Cache `VecDeque` memory leak (Rust) (#4107), thanks @filipmacek
 - Fixed `Cache.reset` clearing FX rate lookup for retained instruments (#4159), thanks for reporting @dfjmax
 - Fixed `BacktestEngine` option positions remaining open when data stops before expiry

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -1493,7 +1493,12 @@ impl OrderMatchingEngine {
                 self.last_bar_ask = Some(bar.to_owned());
                 self.process_quote_ticks_from_bar(bar);
             }
-            PriceType::Mark => panic!("Not implemented"),
+            PriceType::Mark => {
+                log::warn!(
+                    "Cannot process bar for {} with `PriceType::Mark`, mark price bars are not supported for bar execution",
+                    bar.instrument_id(),
+                );
+            }
         }
     }
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -4225,6 +4225,35 @@ fn test_protection_filtered_fills_do_not_consume_liquidity(
 }
 
 #[rstest]
+fn test_process_mark_bar_skipped_without_panic(instrument_eth_usdt: InstrumentAny) {
+    let config = OrderMatchingEngineConfig {
+        bar_execution: true,
+        ..Default::default()
+    };
+    let mut engine = get_order_matching_engine(instrument_eth_usdt, None, None, Some(config), None);
+
+    // Mark price bars are not supported for bar execution, they must be skipped rather than panic
+    let bar_type = BarType::from("ETHUSDT-PERP.BINANCE-1-MINUTE-MARK-EXTERNAL");
+    let mark_bar = Bar {
+        bar_type,
+        open: Price::from("1500.00"),
+        high: Price::from("1510.00"),
+        low: Price::from("1490.00"),
+        close: Price::from("1505.00"),
+        volume: Quantity::from("100000.000"),
+        ts_event: UnixNanos::from(1_000_000_000),
+        ts_init: UnixNanos::from(1_000_000_000),
+    };
+
+    engine.process_bar(&mark_bar);
+
+    assert!(
+        engine.get_core().last.is_none(),
+        "Mark price bar should be skipped and not update market state"
+    );
+}
+
+#[rstest]
 fn test_process_monthly_bar_not_skipped(instrument_eth_usdt: InstrumentAny) {
     let config = OrderMatchingEngineConfig {
         bar_execution: true,


### PR DESCRIPTION
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`OrderMatchingEngine::process_bar` matched `PriceType::Mark` to `panic!("Not implemented")`, so a mark-price bar reaching the matching engine in bar-execution mode crashed the node. This is reachable with default configuration: the sandbox execution client subscribes to `data.bars.*` and defaults to `bar_execution=true` with an `L1_MBP` book, and mark-price bars are routine on perpetual-futures venues. The fix logs a warning and skips the bar, consistent with how `process_bar` already handles precision mismatches.

## Related Issues/PRs

N/A

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions

## Testing

- [x] I added/updated tests to cover new or changed logic

Added `test_process_mark_bar_skipped_without_panic` in `crates/execution/tests/matching_engine.rs` (modeled on the existing `test_process_monthly_bar_not_skipped`), asserting a `MARK` bar is skipped without panicking and does not update market state. Verified with `cargo test -p nautilus-execution --test matching_engine` (179 passed); `cargo fmt --check` and `cargo clippy --all-targets` are clean on the touched files.
