### PR TITLE
Fix sandbox cached account configuration after initial AccountState

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -579,6 +579,23 @@ impl SandboxExecutionClient {
         self.get_account_balances()
     }
 
+    fn sync_cached_account_config(&self) -> anyhow::Result<()> {
+        let Some(mut account) = self.get_account() else {
+            return Ok(());
+        };
+
+        account.set_calculate_account_state(!self.config.frozen_account);
+
+        if let AccountAny::Margin(margin_account) = &mut account {
+            margin_account.set_default_leverage(self.config.default_leverage);
+            for (instrument_id, leverage) in &self.config.leverages {
+                margin_account.set_leverage(*instrument_id, *leverage);
+            }
+        }
+
+        self.cache.borrow_mut().update_account(&account)
+    }
+
     /// Processes a quote tick through the matching engine.
     ///
     /// # Errors
@@ -776,6 +793,7 @@ impl ExecutionClient for SandboxExecutionClient {
             .generate_account_state(balances, margins, reported, ts_event, ts_init);
         let endpoint = MessagingSwitchboard::portfolio_update_account();
         msgbus::send_account_state(endpoint, &state);
+        self.sync_cached_account_config()?;
         Ok(())
     }
 

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -26,18 +26,22 @@ use nautilus_common::{
         ExecutionEvent,
         execution::{SubmitOrder, TradingCommand},
     },
-    msgbus::{self, MessagingSwitchboard, stubs::get_typed_into_message_saving_handler},
+    msgbus::{
+        self, MessageBus, MessagingSwitchboard, TypedHandler,
+        stubs::get_typed_into_message_saving_handler,
+    },
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_data::engine::DataEngine;
 use nautilus_execution::{client::core::ExecutionClientCore, engine::ExecutionEngine};
 use nautilus_model::{
+    accounts::AccountAny,
     data::{Bar, BarType, Data, InstrumentClose, InstrumentStatus, QuoteTick, TradeTick},
     enums::{
         AccountType, AggressorSide, BookType, InstrumentCloseType, MarketStatusAction, OmsType,
         OrderSide, OrderType,
     },
-    events::{OrderEventAny, OrderFilled},
+    events::{AccountState, OrderEventAny, OrderFilled},
     identifiers::{AccountId, ClientId, InstrumentId, PositionId, TradeId, TraderId, Venue},
     instruments::{
         CryptoPerpetual, Instrument, InstrumentAny,
@@ -480,6 +484,16 @@ fn setup_order_event_handler() {
     msgbus::register_order_event_endpoint(MessagingSwitchboard::exec_engine_process(), handler);
 }
 
+fn setup_account_state_handler(cache: Rc<RefCell<Cache>>) {
+    let handler = TypedHandler::from(move |state: &AccountState| {
+        cache.borrow_mut().update_account_state(state).unwrap();
+    });
+    msgbus::register_account_state_endpoint(
+        MessagingSwitchboard::portfolio_update_account(),
+        handler,
+    );
+}
+
 #[rstest]
 fn test_config_default() {
     let config = SandboxExecutionClientConfig::default();
@@ -604,6 +618,70 @@ async fn test_client_connect(mut execution_client: SandboxExecutionClient) {
 
     assert!(result.is_ok());
     assert!(execution_client.is_connected());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_client_connect_syncs_cached_margin_account_config(
+    trader_id: TraderId,
+    account_id: AccountId,
+    venue: Venue,
+    instrument: InstrumentAny,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let leverage = Decimal::from(5);
+    let instrument_id = instrument.id();
+    let context = create_test_context_with(trader_id, account_id, venue, |config| {
+        config.default_leverage = leverage;
+        config.leverages.insert(instrument_id, leverage);
+    });
+    setup_account_state_handler(context.cache.clone());
+
+    let mut execution_client = context.client;
+    execution_client.connect().await.unwrap();
+
+    let cache = context.cache.borrow();
+    let account = cache
+        .account(&account_id)
+        .expect("expected cached account after initial AccountState");
+
+    let AccountAny::Margin(margin) = &*account else {
+        panic!("expected margin account");
+    };
+
+    assert!(margin.base.calculate_account_state);
+    assert_eq!(margin.default_leverage, leverage);
+    assert_eq!(margin.get_leverage(&instrument_id), leverage);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_client_connect_respects_frozen_account_config(
+    trader_id: TraderId,
+    account_id: AccountId,
+    venue: Venue,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let context = create_test_context_with(trader_id, account_id, venue, |config| {
+        config.frozen_account = true;
+    });
+    setup_account_state_handler(context.cache.clone());
+
+    let mut execution_client = context.client;
+    execution_client.connect().await.unwrap();
+
+    let cache = context.cache.borrow();
+    let account = cache
+        .account(&account_id)
+        .expect("expected cached account after initial AccountState");
+
+    let AccountAny::Margin(margin) = &*account else {
+        panic!("expected margin account");
+    };
+
+    assert!(!margin.base.calculate_account_state);
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary
- sync the cached sandbox account configuration immediately after the initial `AccountState` is published
- enable calculated account state for non-frozen sandbox accounts and propagate configured margin leverage values into the cached account
- add focused regression tests covering the synced margin-account path and the frozen-account path

## Problem
Rust sandbox creates the cached account from the initial `AccountState`, but that cached account keeps the default `calculate_account_state=false` configuration. As a result, subsequent fills do not drive account balance updates, even though the sandbox account has already been connected.

## Solution
After publishing the initial `AccountState`, the sandbox execution client now reloads the cached account, applies the sandbox configuration (`calculate_account_state` and margin leverage settings), and writes the configured account back to the cache.

## Testing
- `pre-commit run --files crates/adapters/sandbox/src/execution.rs crates/adapters/sandbox/tests/execution.rs`
- `cargo test -p nautilus-sandbox`

Fixes #4190.
