### PR TITLE
Avoid per-event Position clone in portfolio update_position

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -182,6 +182,7 @@ Released on TBD (UTC).
 - Optimized Derive signing and hot paths with benchmark report
 - Optimized Hyperliquid signing and hot paths with benchmark report
 - Optimized OKX hot paths with benchmark report
+- Optimized portfolio `update_position` hot path by borrowing open positions instead of cloning per event (Rust)
 - Upgraded Rust (MSRV) to 1.96.0
 - Upgraded Cython to v3.2.5
 - Upgraded `databento` crate to v0.53.0

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -1342,7 +1342,8 @@ impl Portfolio {
                     .collect()
             };
 
-            self.update_net_position(&instrument_id, &positions_open);
+            let position_refs: Vec<&Position> = positions_open.iter().collect();
+            self.update_net_position(&instrument_id, &position_refs);
 
             if let Some(calculated_unrealized_pnl) =
                 self.calculate_unrealized_pnl(&instrument_id, None)
@@ -1485,11 +1486,11 @@ impl Portfolio {
         update_position(&self.cache, &self.clock, &self.inner, self.config, event);
     }
 
-    fn update_net_position(&self, instrument_id: &InstrumentId, positions_open: &[Position]) {
+    fn update_net_position(&self, instrument_id: &InstrumentId, positions: &[&Position]) {
         let mut net_position = Decimal::ZERO;
 
-        for open_position in positions_open {
-            log::debug!("open_position: {open_position}");
+        for open_position in positions {
+            log::debug!("open_position: {}", *open_position);
             net_position += open_position.signed_decimal_qty();
         }
 
@@ -2461,18 +2462,6 @@ fn update_position(
     let instrument_id = event.instrument_id();
     let account_id = event.account_id();
 
-    let positions_open: Vec<Position> = {
-        let cache_ref = cache.borrow();
-
-        cache_ref
-            .positions_open(None, Some(&instrument_id), None, None, None)
-            .iter()
-            .map(|o| (*o).clone())
-            .collect()
-    };
-
-    log::debug!("position fresh from cache -> {positions_open:?}");
-
     update_snapshot_timer_state(cache, clock, inner, config, &account_id);
 
     let portfolio_clone = Portfolio {
@@ -2482,7 +2471,13 @@ fn update_position(
         config,
     };
 
-    portfolio_clone.update_net_position(&instrument_id, &positions_open);
+    {
+        let cache_ref = cache.borrow();
+        let refs = cache_ref.positions_open(None, Some(&instrument_id), None, None, None);
+        log::debug!("position fresh from cache -> {refs:?}");
+        let positions: Vec<&Position> = refs.iter().map(|r| &**r).collect();
+        portfolio_clone.update_net_position(&instrument_id, &positions);
+    }
 
     if let Some(calculated_unrealized_pnl) =
         portfolio_clone.calculate_unrealized_pnl(&instrument_id, None)
@@ -2526,12 +2521,18 @@ fn update_position(
             if margin_account.calculate_account_state {
                 let instrument = { cache.borrow().instrument(&instrument_id).cloned() };
                 if let Some(instrument) = instrument {
-                    let result = inner.borrow_mut().accounts.update_positions(
-                        &margin_account,
-                        &instrument,
-                        positions_open.iter().collect(),
-                        clock.borrow().timestamp_ns(),
-                    );
+                    let result = {
+                        let cache_ref = cache.borrow();
+                        let refs =
+                            cache_ref.positions_open(None, Some(&instrument_id), None, None, None);
+                        let positions: Vec<&Position> = refs.iter().map(|r| &**r).collect();
+                        inner.borrow_mut().accounts.update_positions(
+                            &margin_account,
+                            &instrument,
+                            positions,
+                            clock.borrow().timestamp_ns(),
+                        )
+                    };
 
                     if let Some((margin_account, account_state)) = result {
                         cache

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -4637,6 +4637,81 @@ fn test_update_position_with_calculate_account_state_does_not_panic(
 }
 
 #[rstest]
+fn test_update_position_margin_state_across_multiple_open_positions(
+    mut portfolio: Portfolio,
+    instrument_audusd: InstrumentAny,
+) {
+    // Regression for the borrow-instead-of-clone refactor of `update_position`:
+    // the margin `calculate_account_state` path now borrows every open position
+    // straight from the cache (a non-trivial `Vec<&Position>` when more than one
+    // is open) and holds that shared borrow while computing the account state,
+    // then releases it before taking the exclusive borrow that persists the
+    // account. This exercises the borrow scoping end-to-end with >1 position and
+    // pins the borrowed-vs-cloned net-position equivalence.
+    let account_state = get_margin_account(None);
+    portfolio.update_account(&account_state);
+
+    let mut account = portfolio
+        .cache()
+        .borrow()
+        .account(&account_state.account_id)
+        .unwrap()
+        .clone();
+    account.set_calculate_account_state(true);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .update_account(&account)
+        .unwrap();
+
+    let last = get_quote_tick(&instrument_audusd, 10510.0, 10511.0, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(last).unwrap();
+    portfolio.update_quote_tick(&last);
+
+    // Two separate open BUY positions on the same instrument (hedging OMS).
+    let mut expected_net = Decimal::ZERO;
+
+    for position_id in ["PT-1", "PT-2"] {
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument_audusd.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("10.00"))
+            .build();
+        let mut fill = fill_order(&order);
+        fill.position_id = Some(PositionId::new(position_id));
+        let position = Position::new(&instrument_audusd, fill);
+        expected_net += position.signed_decimal_qty();
+        portfolio
+            .cache()
+            .borrow_mut()
+            .add_position(&position, OmsType::Hedging)
+            .unwrap();
+        let opened = get_open_position(&position);
+        portfolio.update_position(&PositionEvent::PositionOpened(opened));
+    }
+
+    // The borrowed open positions yield the same net as summing each leg directly.
+    assert_eq!(
+        portfolio.net_position(&instrument_audusd.id()),
+        expected_net
+    );
+    assert!(portfolio.is_net_long(&instrument_audusd.id()));
+
+    // Account state was computed and persisted without a RefCell double-borrow.
+    let cached = portfolio
+        .cache()
+        .borrow()
+        .account(&account_state.account_id)
+        .unwrap()
+        .clone();
+
+    match cached {
+        AccountAny::Margin(margin) => assert!(margin.base.calculate_account_state),
+        _ => panic!("Expected MarginAccount"),
+    }
+}
+
+#[rstest]
 fn test_initialize_positions_arms_snapshot_timer_for_reconciled_venues(
     mut simple_cache: Cache,
     clock: TestClock,


### PR DESCRIPTION
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Removes a deep clone of every open `Position` in the portfolio `update_position` handler, which runs on every position event (open/changed/closed, i.e. every fill). The open positions are now borrowed directly from the cache instead of cloned, since `update_net_position` reads only scalar fields and `AccountsManager::update_positions` already accepts `Vec<&Position>`. The borrowed references are built under a scoped shared cache borrow that is released before the exclusive `update_account` borrow in the margin branch. Behavior-preserving; eliminates per-event allocation that scaled with fills-per-position and, in hedging mode, with the number of open positions.

## Related Issues/PRs

N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A — `update_net_position` is a private method, so its signature change (`&[Position]` → `&[&Position]`) is internal only.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Adds `test_update_position_margin_state_across_multiple_open_positions`, which exercises the margin `calculate_account_state` path with multiple open positions (so the borrowed `Vec<&Position>` is non-trivial and held across the account-state update), and asserts the borrowed open positions yield the same net position as summing each leg. Verified locally with toolchain 1.96.0: `cargo test -p nautilus-portfolio` passes 112/112 (37 lib + 75 integration), `cargo clippy -p nautilus-portfolio --all-targets -- -D warnings` is clean, and `cargo +nightly fmt --check` is clean.
