### PR TITLE
Derive Serialize/Deserialize on PositionEvent

### DIFF
--- a/crates/model/src/events/position/mod.rs
+++ b/crates/model/src/events/position/mod.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     events::{PositionAdjusted, PositionChanged, PositionClosed, PositionOpened},
     identifiers::{AccountId, InstrumentId},
@@ -23,7 +25,7 @@ pub mod closed;
 pub mod opened;
 pub mod snapshot;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PositionEvent {
     PositionOpened(PositionOpened),
     PositionChanged(PositionChanged),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- Derives `Serialize` and `Deserialize` on `PositionEvent`, the polymorphic wrapper enum in `crates/model/src/events/position/mod.rs.` 
- All four variants (PositionOpened, PositionChanged, PositionClosed, PositionAdjusted) and the sibling PositionSnapshot already derive both traits — the wrapper enum was the only gap, leaving it impossible to serialize a `PositionEvent` directly even though every payload it can hold is serializable.                                      
- This brings `PositionEvent` in line with `OrderEventAny`, which is the analogous polymorphic event wrapper and already derives Serialize, Deserialize.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
