### PR TITLE
Add check for internal aggregation in bar subscription

### DIFF
--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -964,7 +964,12 @@ impl DataEngine {
             SubscribeCommand::Bars(cmd) if has_continuous_future_params(cmd.params.as_ref()) => {
                 return self.subscribe_continuous_future_bars(cmd);
             }
-            SubscribeCommand::Bars(cmd) => self.subscribe_bars(cmd)?,
+            SubscribeCommand::Bars(cmd) => {
+                self.subscribe_bars(cmd)?;
+                if cmd.bar_type.is_internally_aggregated() {
+                    return Ok(());
+                }
+            }
             SubscribeCommand::OptionChain(cmd) => {
                 self.subscribe_option_chain(cmd);
                 return Ok(());
@@ -1049,7 +1054,12 @@ impl DataEngine {
                 self.unsubscribe_continuous_future_bars(cmd);
                 return Ok(());
             }
-            UnsubscribeCommand::Bars(cmd) => self.unsubscribe_bars(cmd),
+            UnsubscribeCommand::Bars(cmd) => {
+                self.unsubscribe_bars(cmd);
+                if cmd.bar_type.is_internally_aggregated() {
+                    return Ok(());
+                }
+            }
             UnsubscribeCommand::OptionChain(cmd) => {
                 self.unsubscribe_option_chain(cmd);
                 return Ok(());


### PR DESCRIPTION
`execute_subscribe`/`execute_unsubscribe` always forward the bars command to the data client even when the bar type is internally aggregated, causing an error if the client doesn't support that bar type or forwarding a request the venue can't satisfy. This adds an early return for internally-aggregated bars after the local subscribe/unsubscribe.

Tested in my workflow, but not rigorously.

May need some input on this one @cjdsellers 