### PR TITLE
Add default log color signature

### DIFF
--- a/crates/common/src/python/logging.rs
+++ b/crates/common/src/python/logging.rs
@@ -350,30 +350,35 @@ impl PyLogger {
 
     /// Emit a TRACE level record.
     #[pyo3(name = "trace")]
+    #[pyo3(signature = (message, color=None))]
     fn py_trace(&self, message: &str, color: Option<LogColor>) {
         self.log_message(LogLevel::Trace, color, message);
     }
 
     /// Emit a DEBUG level record.
     #[pyo3(name = "debug")]
+    #[pyo3(signature = (message, color=None))]
     fn py_debug(&self, message: &str, color: Option<LogColor>) {
         self.log_message(LogLevel::Debug, color, message);
     }
 
     /// Emit an INFO level record.
     #[pyo3(name = "info")]
+    #[pyo3(signature = (message, color=None))]
     fn py_info(&self, message: &str, color: Option<LogColor>) {
         self.log_message(LogLevel::Info, color, message);
     }
 
     /// Emit a WARNING level record.
     #[pyo3(name = "warning")]
+    #[pyo3(signature = (message, color=None))]
     fn py_warning(&self, message: &str, color: Option<LogColor>) {
         self.log_message(LogLevel::Warning, color, message);
     }
 
     /// Emit an ERROR level record.
     #[pyo3(name = "error")]
+    #[pyo3(signature = (message, color=None))]
     fn py_error(&self, message: &str, color: Option<LogColor>) {
         self.log_message(LogLevel::Error, color, message);
     }
@@ -406,6 +411,7 @@ impl PyLogger {
 
     /// Emit a log record at the given level (Python-facing helper).
     #[pyo3(name = "_log")]
+    #[pyo3(signature = (level, color=None, message=""))]
     fn py_log(&self, level: LogLevel, color: Option<LogColor>, message: &str) {
         self.log_message(level, color, message);
     }


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

PyO3 `Logger` methods (`trace`/`debug`/`info`/`warning`/`error`/`_log`) required `color` positionally because their `Option<LogColor>` arg lacked a `#[pyo3(signature = ...)]`. Added explicit signatures so `color` defaults to `None`, restoring optional behavior.

## Related Issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [x] Affected code paths are already covered by the test suite

Verified manually: `nautilus_pyo3.Logger("x").info("hello")` now succeeds instead of raising `TypeError: missing 1 required positional argument: 'color'`.
