### PR TITLE
Fix deterministic catalog directory registration order

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -79,6 +79,7 @@ use datafusion::arrow::{
     record_batch::RecordBatch,
 };
 use futures::StreamExt;
+use indexmap::IndexSet;
 use itertools::Itertools;
 use nautilus_common::live::get_runtime;
 use nautilus_core::{
@@ -1586,7 +1587,7 @@ impl ParquetDataCatalog {
             // Use directory-based registration for efficiency. DataFusion handles
             // reading all files in each directory, which is more memory-efficient
             // than registering many individual file tables.
-            let directories: HashSet<String> = files_list
+            let directories: IndexSet<String> = files_list
                 .iter()
                 .filter_map(|file_uri| {
                     // Extract directory path (everything except the filename)
@@ -1796,7 +1797,7 @@ impl ParquetDataCatalog {
         let mut all_records = Vec::new();
 
         if optimize_file_loading {
-            let directories: HashSet<String> = files_list
+            let directories: IndexSet<String> = files_list
                 .iter()
                 .filter_map(|file_uri| {
                     Path::new(file_uri)
@@ -2031,6 +2032,7 @@ impl ParquetDataCatalog {
                 }
             })
             .collect();
+        file_paths.sort();
 
         // Apply identifier filtering if provided
         if let Some(identifiers) = identifiers {

--- a/crates/persistence/src/backend/catalog_operations.rs
+++ b/crates/persistence/src/backend/catalog_operations.rs
@@ -20,6 +20,7 @@
 
 use ahash::{AHashMap, AHashSet};
 use futures::StreamExt;
+use indexmap::IndexSet;
 use nautilus_core::UnixNanos;
 use nautilus_model::data::{
     Bar, CustomData, Data, HasTsInit, IndexPriceUpdate, MarkPriceUpdate, OrderBookDelta,
@@ -1680,7 +1681,7 @@ impl ParquetDataCatalog {
 
         let leaf_dirs = self.execute_async(async {
             let mut all_paths = AHashSet::new();
-            let mut directories = AHashSet::new();
+            let mut directories = IndexSet::new();
             let mut files_in_dirs = AHashMap::new();
 
             // List all objects under the data directory
@@ -1721,6 +1722,7 @@ impl ParquetDataCatalog {
                 }
             }
 
+            leaf_dirs.sort();
             Ok::<Vec<String>, anyhow::Error>(leaf_dirs)
         })?;
 

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -992,6 +992,11 @@ fn test_rust_query_files_with_multiple_files() {
         .unwrap();
 
     assert_eq!(files.len(), 3);
+    assert_eq!(files, {
+        let mut sorted = files.clone();
+        sorted.sort();
+        sorted
+    });
 }
 
 #[rstest]

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -1830,7 +1830,7 @@ class ParquetDataCatalog(BaseDataCatalog):
             else:
                 file_list = self._query_files(data_cls, identifiers, start, end)
 
-            directories = {os.path.dirname(file) for file in file_list}
+            directories = dict.fromkeys(os.path.dirname(file) for file in file_list)
             for directory in directories:
                 self._register_directory_table(
                     session=session,

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -16,6 +16,7 @@
 import datetime
 import sys
 import tempfile
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
@@ -3016,6 +3017,38 @@ def test_backend_session_table_naming_multiple_instruments(catalog: ParquetDataC
     assert len(instrument_ids) == 2
     assert instrument1.id.value in instrument_ids
     assert instrument2.id.value in instrument_ids
+
+
+def test_backend_session_directory_registration_preserves_file_order(
+    catalog: ParquetDataCatalog,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = [
+        "/catalog/data/trades/ETHUSDT.BINANCE/0_0.parquet",
+        "/catalog/data/trades/AUDUSD.SIM/0_0.parquet",
+        "/catalog/data/trades/ETHUSDT.BINANCE/1_1.parquet",
+    ]
+    registered_directories: list[str] = []
+
+    def capture_register_directory_table(**kwargs: Any) -> None:
+        registered_directories.append(kwargs["directory"])
+
+    monkeypatch.setattr(
+        catalog,
+        "_register_directory_table",
+        capture_register_directory_table,
+    )
+
+    catalog.backend_session(
+        data_cls=TradeTick,
+        files=files,
+        optimize_file_loading=True,
+    )
+
+    assert registered_directories == [
+        "/catalog/data/trades/ETHUSDT.BINANCE",
+        "/catalog/data/trades/AUDUSD.SIM",
+    ]
 
 
 def test_backend_session_table_naming_special_characters(catalog: ParquetDataCatalog) -> None:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Preserves first-seen directory order when Python `ParquetDataCatalog.backend_session` deduplicates file directories for optimized directory-based registration.
- Uses `IndexSet` on the Rust catalog query paths so directory deduplication keeps the order from the sorted file list.
- Sorts Rust catalog file discovery results before filtering and registration, and returns stable leaf data directory ordering for catalog operations.
- Adds regression coverage for Python directory registration order and Rust query file ordering.

### Design decisions

- Python uses `dict.fromkeys(...)` as an ordered deduplication primitive. The dict values are unused; iterating the dict yields unique directories in first-seen order on Python 3.7+.
- Rust uses `IndexSet` instead of `HashSet` in directory registration paths because query ordering must not depend on hash iteration order.
- Rust file paths are sorted before directory deduplication so object store listing order does not leak into query registration behavior.

### Verification

- Ran `cargo test -p nautilus-persistence test_rust_query_files_with_multiple_files`.
- Ran `make build-debug`.
- Ran `uv run --no-sync pytest tests/unit_tests/persistence/test_catalog.py::test_backend_session_directory_registration_preserves_file_order`.
- Ran `make format`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4203

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
