### PR TITLE
Harden Interactive Brokers reconnect startup handling

### DIFF
--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -245,6 +245,7 @@ class InteractiveBrokersClient(
                         f"Attempt {self._connection_attempts}: attempting to reconnect in {reconnect_delay} seconds...",
                     )
                     await asyncio.sleep(reconnect_delay)
+
                     if self._is_shutting_down or self.state in _SHUTDOWN_STATES:
                         break
 

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -16,6 +16,7 @@
 import asyncio
 import functools
 import os
+import secrets
 import traceback
 from collections.abc import Callable
 from collections.abc import Coroutine
@@ -121,6 +122,7 @@ class InteractiveBrokersClient(
         self._cache = cache
         self._host = host
         self._port = port
+        self._configured_client_id = client_id
         self._client_id = client_id
         self._fetch_all_open_orders = fetch_all_open_orders
         self._request_timeout_secs = request_timeout_secs
@@ -166,8 +168,11 @@ class InteractiveBrokersClient(
         self._max_connection_attempts: int = int(os.getenv("IB_MAX_CONNECTION_ATTEMPTS", "0"))
         self._indefinite_reconnect: bool = not self._max_connection_attempts
         self._reconnect_delay: int = 5  # seconds
+        self._reconnect_delay_max: int = 300  # seconds
+        self._reconnect_jitter_secs: int = secrets.randbelow(4)
         self._had_ib_connection: bool = False
         self._last_disconnection_ns: int | None = None
+        self._randomize_client_id_on_next_connect: bool = False
 
         # MarketDataMixin
         self._bar_type_to_last_bar: dict[str, BarData | None] = {}
@@ -220,6 +225,10 @@ class InteractiveBrokersClient(
 
         while not self._is_ib_connected.is_set():
             try:
+                if self.state in _SHUTDOWN_STATES:
+                    break
+
+                self._is_shutting_down = False
                 self._connection_attempts += 1
 
                 if (
@@ -231,10 +240,13 @@ class InteractiveBrokersClient(
                     break
 
                 if self._connection_attempts > 1:
+                    reconnect_delay = self._get_reconnect_delay()
                     self._log.info(
-                        f"Attempt {self._connection_attempts}: attempting to reconnect in {self._reconnect_delay} seconds...",
+                        f"Attempt {self._connection_attempts}: attempting to reconnect in {reconnect_delay} seconds...",
                     )
-                    await asyncio.sleep(self._reconnect_delay)
+                    await asyncio.sleep(reconnect_delay)
+                    if self._is_shutting_down or self.state in _SHUTDOWN_STATES:
+                        break
 
                 await self._connect()
                 if not self._eclient.isConnected():
@@ -256,9 +268,51 @@ class InteractiveBrokersClient(
 
             except TimeoutError:
                 self._log.error("Client failed to initialize; connection timeout")
+                await self._cleanup_failed_startup_attempt()
             except Exception as e:
                 self._log.exception("Unhandled exception in client startup", e)
-                self._stop()
+                await self._cleanup_failed_startup_attempt()
+
+    def _get_reconnect_delay(self) -> int:
+        exponential_delay = self._reconnect_delay * 2 ** (self._connection_attempts - 2)
+        return min(exponential_delay, self._reconnect_delay_max) + self._reconnect_jitter_secs
+
+    async def _cleanup_failed_startup_attempt(self) -> None:
+        # A failed handshake is not a user shutdown; clean up this socket attempt
+        # without leaving `_is_shutting_down` set for the next reconnect loop.
+        if self._is_client_ready.is_set():
+            self._is_client_ready.clear()
+            self._log.debug(
+                "`_is_client_ready` unset by `_cleanup_failed_startup_attempt`",
+                LogColor.BLUE,
+            )
+
+        if self._is_ib_connected.is_set():
+            self._is_ib_connected.clear()
+            self._log.debug(
+                "`_is_ib_connected` unset by `_cleanup_failed_startup_attempt`",
+                LogColor.BLUE,
+            )
+
+        tasks = [
+            self._connection_watchdog_task,
+            self._tws_incoming_msg_reader_task,
+            self._internal_msg_queue_processor_task,
+            self._msg_handler_processor_task,
+        ]
+
+        for task in tasks:
+            if task and not task.done():
+                task.cancel()
+
+        tasks = [task for task in tasks if task is not None]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        await self._clear_bar_tracking_state()
+        if self._eclient.conn:
+            self._eclient.conn.disconnect()
+        self._is_shutting_down = False
 
     def _start_tws_incoming_msg_reader(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -525,7 +525,10 @@ class BaseMixin:
     _msgbus: MessageBus
     _host: str
     _port: int
+    _configured_client_id: int
     _client_id: int
+    _randomize_client_id_on_next_connect: bool
+    _fetch_all_open_orders: bool
     _request_timeout_secs: int
     _requests: Requests
     _instrument_provider: (
@@ -554,6 +557,8 @@ class BaseMixin:
     # Connection
     _reconnect_attempts: int
     _reconnect_delay: int
+    _reconnect_delay_max: int
+    _reconnect_jitter_secs: int
     _max_reconnect_attempts: int
     _indefinite_reconnect: bool
     _last_disconnection_ns: int | None

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import functools
+import secrets
 
 from ibapi import comm
 from ibapi import decoder
@@ -140,9 +141,23 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
 
         """
         self._eclient.reset()
+        if self._randomize_client_id_on_next_connect:
+            self._client_id = self._generate_random_client_id()
+            self._randomize_client_id_on_next_connect = False
+        else:
+            self._client_id = self._configured_client_id
         self._eclient.host = self._host
         self._eclient.port = self._port
         self._eclient.clientId = self._client_id
+
+    def _generate_random_client_id(self) -> int:
+        reserved_client_ids = {self._configured_client_id, self._client_id}
+        client_id = self._client_id
+
+        while client_id in reserved_client_ids:
+            client_id = 1000 + secrets.randbelow(9000)
+
+        return client_id
 
     async def _connect_socket(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -112,6 +112,13 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
             else:
                 self._log.warning(f"Unhandled error: {error_code} for req_id {req_id}")
         elif error_code in self.CLIENT_ERRORS or error_code in self.CONNECTIVITY_LOST_CODES:
+            if error_code == 326:
+                self._randomize_client_id_on_next_connect = True
+                self._fetch_all_open_orders = True
+                self._log.warning(
+                    "Enabling `fetch_all_open_orders` for client ID fallback after IB error 326",
+                )
+
             if self._is_ib_connected.is_set():
                 self._log.debug(
                     f"`_is_ib_connected` unset by code {error_code} in `_process_error`",

--- a/nautilus_trader/adapters/interactive_brokers/factories.py
+++ b/nautilus_trader/adapters/interactive_brokers/factories.py
@@ -172,7 +172,7 @@ def get_cached_interactive_brokers_instrument_provider(
     # Create a cache key based on client connection info and config
     # We use the client's connection parameters rather than the client object itself
     # to ensure consistent caching across different client instances with same connection
-    client_key = (client._host, client._port, client._client_id)
+    client_key = (client._host, client._port, client._configured_client_id)
     provider_key = (client_key, hash(config))
 
     if provider_key not in IB_INSTRUMENT_PROVIDERS:

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client.py
@@ -91,6 +91,130 @@ async def test_stop_clears_bar_tracking_state(ib_client_running):
     assert ib_client_running._bar_type_to_last_bar == {}
 
 
+@pytest.mark.asyncio
+async def test_cleanup_failed_startup_attempt_disconnects_and_cancels_tasks(ib_client):
+    # Arrange
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    ib_client._connection_watchdog_task = asyncio.create_task(wait_forever())
+    ib_client._tws_incoming_msg_reader_task = asyncio.create_task(wait_forever())
+    ib_client._internal_msg_queue_processor_task = asyncio.create_task(wait_forever())
+    ib_client._msg_handler_processor_task = asyncio.create_task(wait_forever())
+    ib_client._is_client_ready.set()
+    ib_client._is_ib_connected.set()
+    ib_client._is_shutting_down = True
+    ib_client._eclient = MagicMock()
+
+    # Act
+    await ib_client._cleanup_failed_startup_attempt()
+
+    # Assert
+    assert ib_client._connection_watchdog_task.cancelled()
+    assert ib_client._tws_incoming_msg_reader_task.cancelled()
+    assert ib_client._internal_msg_queue_processor_task.cancelled()
+    assert ib_client._msg_handler_processor_task.cancelled()
+    assert not ib_client._is_client_ready.is_set()
+    assert not ib_client._is_ib_connected.is_set()
+    assert ib_client._is_shutting_down is False
+    ib_client._eclient.conn.disconnect.assert_called_once()
+    ib_client._eclient.disconnect.assert_not_called()
+
+
+def test_get_reconnect_delay_uses_exponential_backoff_with_jitter(ib_client):
+    # Arrange
+    ib_client._reconnect_delay = 5
+    ib_client._reconnect_delay_max = 300
+    ib_client._reconnect_jitter_secs = 2
+    expected_delays = {
+        2: 7,
+        3: 12,
+        4: 22,
+        5: 42,
+        6: 82,
+        7: 162,
+        8: 302,
+        9: 302,
+    }
+
+    for attempt, expected_delay in expected_delays.items():
+        # Act
+        ib_client._connection_attempts = attempt
+
+        # Assert
+        assert ib_client._get_reconnect_delay() == expected_delay
+
+
+@pytest.mark.asyncio
+async def test_start_async_timeout_cleans_up_and_retries(ib_client, monkeypatch):
+    # Arrange
+    wait_calls = 0
+    cleanup_calls = 0
+
+    async def fake_wait_for(coro, timeout):
+        nonlocal wait_calls
+
+        if hasattr(coro, "close"):
+            coro.close()
+
+        wait_calls += 1
+        assert timeout == 15
+
+        if wait_calls == 1:
+            raise TimeoutError
+
+        ib_client._is_ib_connected.set()
+
+    async def cleanup_failed_startup_attempt():
+        nonlocal cleanup_calls
+
+        cleanup_calls += 1
+        ib_client._is_shutting_down = True
+
+    ib_client._connect = AsyncMock()
+    ib_client._cleanup_failed_startup_attempt = cleanup_failed_startup_attempt
+    ib_client._eclient = MagicMock()
+    ib_client._eclient.isConnected.return_value = True
+    ib_client._eclient.startApi = MagicMock()
+    ib_client._reconnect_jitter_secs = 0
+    ib_client._start_tws_incoming_msg_reader = MagicMock()
+    ib_client._start_internal_msg_queue_processor = MagicMock()
+    ib_client._start_connection_watchdog = MagicMock()
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+    sleep = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    # Act
+    await ib_client._start_async()
+
+    # Assert
+    assert wait_calls == 2
+    assert cleanup_calls == 1
+    assert ib_client._connect.await_count == 2
+    assert ib_client._is_shutting_down is False
+    assert ib_client._is_client_ready.is_set()
+    assert ib_client._connection_attempts == 0
+    sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.asyncio
+async def test_start_async_does_not_reconnect_after_shutdown_during_backoff(ib_client, monkeypatch):
+    # Arrange
+    async def stop_during_backoff(_):
+        ib_client._is_shutting_down = True
+
+    ib_client._connect = AsyncMock()
+    ib_client._connection_attempts = 1
+    ib_client._reconnect_jitter_secs = 0
+    monkeypatch.setattr(asyncio, "sleep", stop_during_backoff)
+
+    # Act
+    await ib_client._start_async()
+
+    # Assert
+    ib_client._connect.assert_not_awaited()
+
+
 def test_dispose_sets_shutdown_flag(ib_client):
     # Arrange
 

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
@@ -16,6 +16,7 @@
 import asyncio
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from ibapi.const import NO_VALID_ID
@@ -69,6 +70,38 @@ async def test_connect_fail(ib_client):
     assert call_args[2] == CONNECT_FAIL.code()
     assert call_args[3] == CONNECT_FAIL.msg()
     ib_client._handle_reconnect.assert_not_awaited()
+
+
+def test_initialize_connection_params_uses_configured_client_id(ib_client):
+    # Arrange
+    ib_client._configured_client_id = 0
+    ib_client._client_id = 8765
+
+    # Act
+    ib_client._initialize_connection_params()
+
+    # Assert
+    assert ib_client._client_id == 0
+    assert ib_client._eclient.clientId == 0
+
+
+def test_initialize_connection_params_randomizes_client_id_after_326(ib_client):
+    # Arrange
+    ib_client._configured_client_id = 4321
+    ib_client._client_id = 8765
+    ib_client._randomize_client_id_on_next_connect = True
+
+    # Act
+    with patch(
+        "nautilus_trader.adapters.interactive_brokers.client.connection.secrets.randbelow",
+        side_effect=[3321, 7765, 1357],
+    ):
+        ib_client._initialize_connection_params()
+
+    # Assert
+    assert ib_client._client_id == 2357
+    assert ib_client._eclient.clientId == 2357
+    assert ib_client._randomize_client_id_on_next_connect is False
 
 
 # Test for successful reconnection

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
@@ -58,6 +58,8 @@ async def test_ib_is_not_ready_by_error_326(ib_client):
     """
     # Arrange
     ib_client._is_ib_connected.set()
+    ib_client._randomize_client_id_on_next_connect = False
+    ib_client._fetch_all_open_orders = False
 
     # Act
     await ib_client.process_error(
@@ -69,6 +71,29 @@ async def test_ib_is_not_ready_by_error_326(ib_client):
 
     # Assert
     assert not ib_client._is_ib_connected.is_set()
+    assert ib_client._randomize_client_id_on_next_connect is True
+    assert ib_client._fetch_all_open_orders is True
+
+
+@pytest.mark.asyncio
+async def test_error_326_arms_random_client_id_when_not_connected(ib_client):
+    # Arrange
+    ib_client._is_ib_connected.clear()
+    ib_client._randomize_client_id_on_next_connect = False
+    ib_client._fetch_all_open_orders = False
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=326,
+        error_string="Unable to connect as the client id is already in use",
+    )
+
+    # Assert
+    assert not ib_client._is_ib_connected.is_set()
+    assert ib_client._randomize_client_id_on_next_connect is True
+    assert ib_client._fetch_all_open_orders is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Close the raw IB socket transport during failed Python startup attempts so `EClient.disconnect()` does not synchronously trigger `connectionClosed()` and start a competing reconnect loop.
- Add capped exponential reconnect backoff using the existing `_reconnect_delay` as the base delay and a per-client jitter of 0-3 seconds.
- Preserve the configured IB Gateway client ID for normal connects and reconnects, including `ibg_client_id=0` behavior.
- Add a one-shot temporary client ID fallback only after IB error 326, when Gateway still reports the previous client ID as in use.
- Force `fetch_all_open_orders=True` when the 326 fallback is activated so recovery uses `reqAllOpenOrders()` under the temporary client ID.
- Stop reconnect startup from proceeding after shutdown or dispose is requested during reconnect backoff.

### Design decisions
- Failed startup cleanup now calls `self._eclient.conn.disconnect()` only when a raw connection exists. Normal explicit stop and disconnect paths still call `self._eclient.disconnect()`.
- `_configured_client_id` keeps the originally configured Nautilus identity stable for component naming and provider cache keys.
- Runtime `_client_id` uses `_configured_client_id` by default so `reqOpenOrders()` continues to target the configured session scope during normal recovery.
- IB error 326 sets a one-shot `_randomize_client_id_on_next_connect` flag. The next `_initialize_connection_params()` call consumes the flag, chooses a 1000-9999 client ID that differs from both the configured and current stale IDs, and then clears the flag.
- The 326 fallback also enables `_fetch_all_open_orders` because a temporary client ID cannot safely recover orders placed under the configured client ID with `reqOpenOrders()`.
- Reconnect backoff follows 5, 10, 20, 40, 80, 160, then a 300 second cap, plus fixed per-client jitter.
- After any reconnect sleep, startup checks shutdown/dispose state before opening a new socket so stop/dispose cannot reconnect later.

### Files covered
- `nautilus_trader/adapters/interactive_brokers/client/client.py`
- `nautilus_trader/adapters/interactive_brokers/client/common.py`
- `nautilus_trader/adapters/interactive_brokers/client/connection.py`
- `nautilus_trader/adapters/interactive_brokers/client/error.py`
- `nautilus_trader/adapters/interactive_brokers/factories.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py`

### Verification
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py tests/integration_tests/adapters/interactive_brokers/client/test_client.py tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py`
- `make format`




## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4193

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
