### PR TITLE
Fix account-currency trade PnL stats for foreign-currency instruments

### DIFF
--- a/crates/analysis/src/analyzer.rs
+++ b/crates/analysis/src/analyzer.rs
@@ -16,7 +16,7 @@
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use ahash::AHashMap;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use nautilus_core::{UnixNanos, datetime::NANOSECONDS_IN_DAY};
 use nautilus_model::{
     accounts::Account,
@@ -62,6 +62,7 @@ pub struct PortfolioAnalyzer {
     pub account_balances: IndexMap<Currency, Money>,
     pub positions: Vec<Position>,
     pub realized_pnls: AHashMap<Currency, Vec<(PositionId, f64)>>,
+    pub recorded_realized_pnls: AHashMap<Currency, IndexMap<PositionId, f64>>,
     pub position_returns: Returns,
     pub portfolio_returns: Returns,
     /// Alias for the primary returns source.
@@ -108,6 +109,7 @@ impl PortfolioAnalyzer {
             account_balances: IndexMap::new(),
             positions: Vec::new(),
             realized_pnls: AHashMap::new(),
+            recorded_realized_pnls: AHashMap::new(),
             position_returns: BTreeMap::new(),
             portfolio_returns: BTreeMap::new(),
             returns: BTreeMap::new(),
@@ -135,6 +137,7 @@ impl PortfolioAnalyzer {
         self.account_balances.clear();
         self.positions.clear();
         self.realized_pnls.clear();
+        self.recorded_realized_pnls.clear();
         self.position_returns.clear();
         self.portfolio_returns.clear();
         self.returns.clear();
@@ -175,8 +178,8 @@ impl PortfolioAnalyzer {
 
     /// Calculates statistics based on account and position data.
     ///
-    /// This clears all previous state before calculating, so can be called
-    /// multiple times without accumulating stale data.
+    /// This clears calculated state before calculating, while preserving
+    /// close-time PnLs recorded during portfolio processing.
     pub fn calculate_statistics(&mut self, account: &dyn Account, positions: &[Position]) {
         self.account_balances_starting = account.starting_balances().into_iter().collect();
         self.account_balances = account.balances_total().into_iter().collect();
@@ -216,6 +219,13 @@ impl PortfolioAnalyzer {
         let currency = pnl.currency;
         let entry = self.realized_pnls.entry(currency).or_default();
         entry.push((*position_id, pnl.as_f64()));
+    }
+
+    /// Records a trade's PnL observed during portfolio processing.
+    pub fn record_trade(&mut self, position_id: &PositionId, pnl: &Money) {
+        let currency = pnl.currency;
+        let entry = self.recorded_realized_pnls.entry(currency).or_default();
+        entry.insert(*position_id, pnl.as_f64());
     }
 
     /// Records a position return at a specific timestamp.
@@ -329,18 +339,48 @@ impl PortfolioAnalyzer {
     /// without an explicit currency specified.
     #[must_use]
     pub fn realized_pnls(&self, currency: Option<&Currency>) -> Option<Vec<(PositionId, f64)>> {
-        if self.realized_pnls.is_empty() {
+        if self.realized_pnls.is_empty() && self.recorded_realized_pnls.is_empty() {
             return None;
         }
 
         // Require explicit currency for multi-currency portfolios to avoid nondeterminism
         let currency = match currency {
-            Some(c) => c,
-            None if self.account_balances.len() == 1 => self.account_balances.keys().next()?,
-            None => return None,
+            Some(c) => *c,
+            None if self.account_balances.len() == 1 => *self.account_balances.keys().next()?,
+            None => {
+                let mut currencies: IndexSet<Currency> =
+                    self.realized_pnls.keys().copied().collect();
+                currencies.extend(self.recorded_realized_pnls.keys().copied());
+                if currencies.len() != 1 {
+                    return None;
+                }
+
+                *currencies.first()?
+            }
         };
 
-        self.realized_pnls.get(currency).cloned()
+        let realized_pnls = self.realized_pnls.get(&currency);
+        let recorded_realized_pnls = self.recorded_realized_pnls.get(&currency);
+
+        match (realized_pnls, recorded_realized_pnls) {
+            (None, None) => None,
+            (Some(realized_pnls), None) => Some(realized_pnls.clone()),
+            (None, Some(recorded_realized_pnls)) => Some(
+                recorded_realized_pnls
+                    .iter()
+                    .map(|(position_id, pnl)| (*position_id, *pnl))
+                    .collect(),
+            ),
+            (Some(realized_pnls), Some(recorded_realized_pnls)) => {
+                let mut output: IndexMap<PositionId, f64> = realized_pnls.iter().copied().collect();
+
+                for (position_id, pnl) in recorded_realized_pnls {
+                    output.insert(*position_id, *pnl);
+                }
+
+                Some(output.into_iter().collect())
+            }
+        }
     }
 
     /// Calculates total PnL including unrealized PnL if provided.
@@ -1039,6 +1079,46 @@ mod tests {
     }
 
     #[rstest]
+    fn test_calculate_statistics_preserves_recorded_realized_pnls() {
+        let mut analyzer = PortfolioAnalyzer::new();
+        let account_currency = Currency::EUR();
+        let native_currency = Currency::USD();
+        let stat: Arc<dyn PortfolioStatistic<Item = f64> + Send + Sync> =
+            Arc::new(MockStatistic::new("test_stat"));
+        analyzer.register_statistic(Arc::clone(&stat));
+        analyzer.record_trade(
+            &PositionId::new("pos1"),
+            &Money::new(90.0, account_currency),
+        );
+
+        let positions = vec![create_mock_position("pos1", 100.0, 0.1, native_currency)];
+
+        let mut starting_balances = AHashMap::new();
+        starting_balances.insert(account_currency, Money::new(1000.0, account_currency));
+
+        let mut current_balances = AHashMap::new();
+        current_balances.insert(account_currency, Money::new(1100.0, account_currency));
+
+        let account = MockAccount {
+            starting_balances,
+            current_balances,
+            events: vec![],
+        };
+
+        analyzer.calculate_statistics(&account, &positions);
+
+        let native_pnls = analyzer.realized_pnls(Some(&native_currency)).unwrap();
+        let recorded_pnls = analyzer.realized_pnls(Some(&account_currency)).unwrap();
+        let pnl_stats = analyzer
+            .get_performance_stats_pnls(Some(&account_currency), None)
+            .unwrap();
+
+        assert_eq!(native_pnls[0].1, 100.0);
+        assert_eq!(recorded_pnls[0].1, 90.0);
+        assert_eq!(*pnl_stats.get("test_stat").unwrap(), 90.0);
+    }
+
+    #[rstest]
     fn test_formatted_output() {
         let mut analyzer = PortfolioAnalyzer::new();
         let currency = Currency::USD();
@@ -1106,6 +1186,7 @@ mod tests {
         assert!(analyzer.account_balances.is_empty());
         assert!(analyzer.positions.is_empty());
         assert!(analyzer.realized_pnls.is_empty());
+        assert!(analyzer.recorded_realized_pnls.is_empty());
         assert!(analyzer.position_returns.is_empty());
         assert!(analyzer.portfolio_returns.is_empty());
         assert!(analyzer.returns.is_empty());

--- a/crates/analysis/src/python/analyzer.rs
+++ b/crates/analysis/src/python/analyzer.rs
@@ -330,6 +330,16 @@ impl PortfolioAnalyzer {
         self.add_trade(position_id, realized_pnl);
     }
 
+    /// Records a trade's PnL observed during portfolio processing.
+    #[pyo3(name = "record_trade")]
+    #[allow(
+        clippy::trivially_copy_pass_by_ref,
+        reason = "matches underlying record_trade signature"
+    )]
+    fn py_record_trade(&mut self, position_id: &PositionId, realized_pnl: &Money) {
+        self.record_trade(position_id, realized_pnl);
+    }
+
     // Note: calculate_statistics is not exposed to Python because it requires
     // complex conversions of Account and dict types. Use the Python analyzer.py wrapper instead.
 

--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -1004,7 +1004,8 @@ impl BacktestEngine {
             snapshot_positions,
         );
 
-        let analyzer = self.build_analyzer(&cache, &positions);
+        let mut analyzer = self.build_analyzer(&cache, &positions);
+        analyzer.recorded_realized_pnls = self.kernel.portfolio.borrow().recorded_realized_pnls();
         let mut stats_pnls = AHashMap::new();
 
         for currency in analyzer.currencies() {
@@ -1707,7 +1708,8 @@ impl BacktestEngine {
             return;
         }
 
-        let analyzer = self.build_analyzer(&cache, &positions);
+        let mut analyzer = self.build_analyzer(&cache, &positions);
+        analyzer.recorded_realized_pnls = self.kernel.portfolio.borrow().recorded_realized_pnls();
         log_portfolio_performance(&analyzer);
     }
 

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -39,7 +39,7 @@ use nautilus_model::{
     position::Position,
     types::{AccountBalance, Currency, MarginBalance, Money, Price},
 };
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, prelude::ToPrimitive};
 
 use crate::{config::PortfolioConfig, manager::AccountsManager};
 
@@ -1479,6 +1479,12 @@ impl Portfolio {
         );
     }
 
+    /// Returns realized PnLs recorded during portfolio event processing.
+    #[must_use]
+    pub fn recorded_realized_pnls(&self) -> AHashMap<Currency, IndexMap<PositionId, f64>> {
+        self.inner.borrow().analyzer.recorded_realized_pnls.clone()
+    }
+
     /// Updates portfolio calculations based on a position event.
     ///
     /// Recalculates net positions, unrealized PnL, and margin requirements.
@@ -2479,6 +2485,8 @@ fn update_position(
         portfolio_clone.update_net_position(&instrument_id, &positions);
     }
 
+    record_closed_position_pnl(cache, inner, config, event);
+
     if let Some(calculated_unrealized_pnl) =
         portfolio_clone.calculate_unrealized_pnl(&instrument_id, None)
     {
@@ -2567,6 +2575,83 @@ fn update_position(
             &account_state,
         );
     }
+}
+
+fn record_closed_position_pnl(
+    cache: &Rc<RefCell<Cache>>,
+    inner: &Rc<RefCell<PortfolioState>>,
+    config: PortfolioConfig,
+    event: &PositionEvent,
+) {
+    let position_id = match event {
+        PositionEvent::PositionOpened(event) => event.position_id,
+        PositionEvent::PositionChanged(event) => event.position_id,
+        PositionEvent::PositionClosed(event) => event.position_id,
+        PositionEvent::PositionAdjusted(event) => event.position_id,
+    };
+
+    let cache_ref = cache.borrow();
+    let Some(position) = cache_ref.position(&position_id) else {
+        return;
+    };
+
+    if !position.is_closed() {
+        return;
+    }
+
+    let Some(realized_pnl) = position.realized_pnl else {
+        return;
+    };
+
+    inner
+        .borrow_mut()
+        .analyzer
+        .record_trade(&position.id, &realized_pnl);
+
+    let Some(account) = cache_ref.account(&event.account_id()) else {
+        return;
+    };
+    let Some(base_currency) = account.base_currency() else {
+        return;
+    };
+
+    if realized_pnl.currency == base_currency {
+        return;
+    }
+
+    let xrate = if config.use_mark_xrates {
+        cache_ref
+            .get_mark_xrate(realized_pnl.currency, base_currency)
+            .and_then(|xrate| Decimal::try_from(xrate).ok())
+    } else {
+        cache_ref.get_xrate(
+            event.instrument_id().venue,
+            realized_pnl.currency,
+            base_currency,
+            PriceType::Mid,
+        )
+    };
+
+    let Some(xrate) = xrate else {
+        log::warn!(
+            "Cannot record account-currency realized PnL for {position_id}: conversion failed from {} to {base_currency}",
+            realized_pnl.currency
+        );
+        return;
+    };
+
+    let amount = (realized_pnl.as_decimal() * xrate).round_dp(u32::from(base_currency.precision));
+    let Some(amount) = amount.to_f64() else {
+        log::warn!(
+            "Cannot record account-currency realized PnL for {position_id}: converted amount is outside f64 range"
+        );
+        return;
+    };
+
+    inner
+        .borrow_mut()
+        .analyzer
+        .record_trade(&position.id, &Money::new(amount, base_currency));
 }
 
 fn update_account(

--- a/nautilus_trader/analysis/analyzer.py
+++ b/nautilus_trader/analysis/analyzer.py
@@ -47,6 +47,7 @@ class PortfolioAnalyzer:
         self._account_balances: dict[Currency, Money] = {}
         self._positions: list[Position] = []
         self._realized_pnls: dict[Currency, pd.Series] = {}
+        self._recorded_realized_pnls: dict[Currency, pd.Series] = {}
         self._position_returns: pd.Series = self._empty_returns()
         self._portfolio_returns: pd.Series = self._empty_returns()
         self._returns: pd.Series = self._empty_returns()
@@ -88,6 +89,7 @@ class PortfolioAnalyzer:
         self._account_balances = {}
         self._positions = []
         self._realized_pnls = {}
+        self._recorded_realized_pnls = {}
         self._position_returns = self._empty_returns()
         self._portfolio_returns = self._empty_returns()
         self._returns = self._empty_returns()
@@ -224,6 +226,23 @@ class PortfolioAnalyzer:
         realized_pnls.loc[position_id.value] = realized_pnl.as_double()
         self._realized_pnls[currency] = realized_pnls
 
+    def record_trade(self, position_id: PositionId, realized_pnl: Money) -> None:
+        """
+        Record realized PnL observed during portfolio processing.
+
+        Parameters
+        ----------
+        position_id : PositionId
+            The position ID for the trade.
+        realized_pnl : Money
+            The realized PnL for the trade.
+
+        """
+        currency = realized_pnl.currency
+        realized_pnls = self._recorded_realized_pnls.get(currency, pd.Series(dtype=float64))
+        realized_pnls.loc[position_id.value] = realized_pnl.as_double()
+        self._recorded_realized_pnls[currency] = realized_pnls
+
     def add_position_return(self, timestamp: datetime, value: float) -> None:
         """
         Add position return data to the analyzer.
@@ -273,20 +292,35 @@ class PortfolioAnalyzer:
         -------
         pd.Series or ``None``
 
-        Raises
-        ------
-        ValueError
-            If `currency` is ``None`` when analyzing multi-currency portfolios.
+        Returns ``None`` when no unambiguous currency can be selected.
 
         """
-        if not self._realized_pnls:
+        if not self._realized_pnls and not self._recorded_realized_pnls:
             return None
         if currency is None:
-            if len(self._account_balances) > 1:
-                raise ValueError("`currency` was `None` for multi-currency portfolio")
-            currency = next(iter(self._account_balances.keys()))
+            if len(self._account_balances) == 1:
+                currency = next(iter(self._account_balances.keys()))
+            else:
+                currencies = set(self._realized_pnls) | set(self._recorded_realized_pnls)
+                if len(currencies) != 1:
+                    return None
 
-        return self._realized_pnls.get(currency)
+                currency = next(iter(currencies))
+
+        realized_pnls = self._realized_pnls.get(currency)
+        recorded_realized_pnls = self._recorded_realized_pnls.get(currency)
+
+        if realized_pnls is None:
+            return recorded_realized_pnls
+
+        if recorded_realized_pnls is None:
+            return realized_pnls
+
+        output = realized_pnls.copy()
+        for position_id, pnl in recorded_realized_pnls.items():
+            output.loc[position_id] = pnl
+
+        return output
 
     def total_pnl(
         self,

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -2209,8 +2209,9 @@ cdef class BacktestEngine:
 
             # Calculate statistics
             self._kernel.portfolio.analyzer.calculate_statistics(account, venue_positions)
+            venue_currencies.update(self._kernel.portfolio.analyzer.currencies)
 
-            # Present PnL performance stats per asset
+            # Present PnL performance stats per asset and account currency
             for currency in sorted(list(venue_currencies), key=lambda x: x.code):
                 self._log.info(f" PnL Statistics ({str(currency)})")
                 self._log.info(f"{color}-----------------------------------------------------------------")

--- a/nautilus_trader/portfolio/portfolio.pyx
+++ b/nautilus_trader/portfolio/portfolio.pyx
@@ -662,6 +662,28 @@ cdef class Portfolio(PortfolioFacade):
         if account is None or instrument is None:
             return
 
+        cdef Money converted_pnl
+        if updated_position is not None and updated_position.is_closed_c() and updated_position.realized_pnl is not None:
+            self.analyzer.record_trade(updated_position.id, updated_position.realized_pnl)
+
+            if (
+                account.base_currency is not None
+                and updated_position.realized_pnl.currency != account.base_currency
+            ):
+                converted_pnl = self._convert_money_if_needed(
+                    updated_position.realized_pnl,
+                    account.base_currency,
+                    venue=event.instrument_id.venue,
+                )
+                if converted_pnl is not None:
+                    self.analyzer.record_trade(updated_position.id, converted_pnl)
+                else:
+                    self._log.warning(
+                        f"Cannot record account-currency realized PnL for {updated_position.id}: "
+                        f"conversion failed from {updated_position.realized_pnl.currency} "
+                        f"to {account.base_currency}",
+                    )
+
         if account.type != AccountType.MARGIN or not account.calculate_account_state:
             return  # Nothing to calculate
 

--- a/tests/unit_tests/analysis/test_analyzer.py
+++ b/tests/unit_tests/analysis/test_analyzer.py
@@ -32,6 +32,7 @@ from nautilus_trader.common.component import TestClock
 from nautilus_trader.common.factories import OrderFactory
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model.currencies import AUD
+from nautilus_trader.model.currencies import EUR
 from nautilus_trader.model.currencies import USD
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OrderSide
@@ -109,6 +110,17 @@ class TestPortfolioAnalyzer:
         # Assert
         assert result is None
 
+    def test_get_realized_pnls_without_currency_when_currency_ambiguous_returns_none(self):
+        # Arrange
+        self.analyzer.add_trade(PositionId("P-1"), Money(10.0, USD))
+        self.analyzer.add_trade(PositionId("P-2"), Money(20.0, EUR))
+
+        # Act
+        result = self.analyzer.realized_pnls()
+
+        # Assert
+        assert result is None
+
     def test_is_pyo3_statistic_matches_exact_module(self):
         # Arrange
         stat = _FakePyo3Statistic()
@@ -142,6 +154,33 @@ class TestPortfolioAnalyzer:
         # Assert
         assert stats[stat.name] == 1.0
         assert stat.last_realized_pnls_input == [10.0]
+
+    def test_calculate_statistics_preserves_recorded_realized_pnls(self):
+        # Arrange
+        stat = _RecordingPyo3Statistic()
+        account = _create_cash_account([("2024-01-01", 1_000.0)], currency=EUR)
+        positions = [
+            _create_closed_position(
+                position_id="P-1",
+                realized_pnl=100.0,
+                realized_return=0.10,
+                ts_closed="2024-01-31",
+            ),
+        ]
+        self.analyzer.register_statistic(stat)
+        self.analyzer.record_trade(PositionId("P-1"), Money(90, EUR))
+
+        # Act
+        self.analyzer.calculate_statistics(account, positions)
+        native_pnls = self.analyzer.realized_pnls(USD)
+        recorded_pnls = self.analyzer.realized_pnls(EUR)
+        stats = self.analyzer.get_performance_stats_pnls(currency=EUR)
+
+        # Assert
+        assert native_pnls["P-1"] == 100.0
+        assert recorded_pnls["P-1"] == 90.0
+        assert stats[stat.name] == 1.0
+        assert stat.last_realized_pnls_input == [90.0]
 
     def test_get_performance_stats_returns_converts_pyo3_statistics_input(self):
         # Arrange
@@ -336,6 +375,51 @@ class TestPortfolioAnalyzer:
         assert portfolio_returns.loc[pd.Timestamp("2024-01-11", tz="UTC")] == pytest.approx(0.0)
         pd.testing.assert_series_equal(self.analyzer.returns(), portfolio_returns)
 
+    def test_calculate_statistics_uses_recorded_account_currency_realized_pnls(self):
+        # Arrange
+        stat = _RecordingPyo3Statistic()
+        self.analyzer.register_statistic(stat)
+        account = _create_cash_account(
+            [
+                ("2024-01-01", 1_000.0),
+                ("2024-01-31", 1_090.0),
+                ("2024-02-01", 1_045.0),
+            ],
+            currency=EUR,
+        )
+        positions = [
+            _create_closed_position(
+                position_id="P-1",
+                realized_pnl=100.0,
+                realized_return=0.10,
+                ts_closed="2024-01-31",
+                currency=USD,
+            ),
+            _create_closed_position(
+                position_id="P-2",
+                realized_pnl=-50.0,
+                realized_return=-0.05,
+                ts_closed="2024-02-01",
+                currency=USD,
+            ),
+        ]
+        self.analyzer.record_trade(PositionId("P-1"), Money(90.0, EUR))
+        self.analyzer.record_trade(PositionId("P-2"), Money(-45.0, EUR))
+
+        # Act
+        self.analyzer.calculate_statistics(account, positions)
+        native_pnls = self.analyzer.realized_pnls(USD)
+        recorded_pnls = self.analyzer.realized_pnls(EUR)
+        stats = self.analyzer.get_performance_stats_pnls(currency=EUR)
+
+        # Assert
+        assert native_pnls["P-1"] == 100.0
+        assert native_pnls["P-2"] == -50.0
+        assert recorded_pnls["P-1"] == 90.0
+        assert recorded_pnls["P-2"] == -45.0
+        assert stats["PnL (total)"] == 45.0
+        assert stat.last_realized_pnls_input == [90.0, -45.0]
+
     def test_get_performance_stats_returns_prefers_portfolio_returns(self):
         # Arrange
         self.analyzer.register_statistic(ReturnsAverage())
@@ -451,7 +535,7 @@ class TestPortfolioAnalyzer:
         assert portfolio_returns.loc[pd.Timestamp("2024-01-31", tz="UTC")] == pytest.approx(0.05)
 
 
-def _create_cash_account(events: list[tuple[str, float]]) -> CashAccount:
+def _create_cash_account(events: list[tuple[str, float]], currency=USD) -> CashAccount:
     account_id = TestIdStubs.account_id()
     first_date, first_total = events[0]
     account = CashAccount(
@@ -459,6 +543,7 @@ def _create_cash_account(events: list[tuple[str, float]]) -> CashAccount:
             account_id=account_id,
             total=first_total,
             ts_event=pd.Timestamp(first_date, tz="UTC").value,
+            currency=currency,
         ),
         calculate_account_state=False,
     )
@@ -469,6 +554,7 @@ def _create_cash_account(events: list[tuple[str, float]]) -> CashAccount:
                 account_id=account_id,
                 total=total,
                 ts_event=pd.Timestamp(date_str, tz="UTC").value,
+                currency=currency,
             ),
         )
 
@@ -479,17 +565,18 @@ def _create_cash_account_state(
     account_id,
     total: float,
     ts_event: int,
+    currency=USD,
 ) -> AccountState:
     return AccountState(
         account_id=account_id,
         account_type=AccountType.CASH,
-        base_currency=USD,
+        base_currency=currency,
         reported=True,
         balances=[
             AccountBalance(
-                Money(total, USD),
-                Money(0, USD),
-                Money(total, USD),
+                Money(total, currency),
+                Money(0, currency),
+                Money(total, currency),
             ),
         ],
         margins=[],
@@ -505,10 +592,11 @@ def _create_closed_position(
     realized_pnl: float,
     realized_return: float,
     ts_closed: str,
+    currency=USD,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=PositionId(position_id),
-        realized_pnl=Money(realized_pnl, USD),
+        realized_pnl=Money(realized_pnl, currency),
         realized_return=realized_return,
         ts_closed=pd.Timestamp(ts_closed, tz="UTC").value,
     )

--- a/tests/unit_tests/portfolio/test_conversion.py
+++ b/tests/unit_tests/portfolio/test_conversion.py
@@ -541,9 +541,9 @@ def test_portfolio_realized_pnl_with_conversion():
     state = AccountState(
         account_id=account_id,
         account_type=AccountType.CASH,
-        base_currency=USD,
+        base_currency=EUR,
         reported=True,
-        balances=[AccountBalance(Money(100000, USD), Money(0, USD), Money(100000, USD))],
+        balances=[AccountBalance(Money(100000, EUR), Money(0, EUR), Money(100000, EUR))],
         margins=[],
         info={},
         event_id=UUID4(),
@@ -592,10 +592,15 @@ def test_portfolio_realized_pnl_with_conversion():
 
     # Realized PnL: 55000 - 50000 = 5000 USDT
     # Converted to EUR using the xrate from cache
+    portfolio.update_position(TestEventStubs.position_closed(pos))
+
     realized = portfolio.realized_pnl(btcusdt.id, account_id=account_id, target_currency=EUR)
+    analyzer_pnls = portfolio.analyzer.realized_pnls(EUR)
+
     assert realized is not None
     assert realized.currency == EUR
     assert realized == Money(4405.50, EUR)
+    assert analyzer_pnls["P-123"] == 4405.50
 
 
 def test_portfolio_total_pnl_with_currency_mismatch():


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes per-trade `stats_pnls` when an account base currency differs from a position's native realized PnL currency.
- Records realized PnL at position close time in both native currency and account base currency, using the portfolio/cache FX conversion path that is already available during backtest or live event processing.
- Keeps the analyzer as a consumer of recorded close-time PnLs instead of inferring historical FX from portfolio snapshots or account balance deltas.
- Preserves native realized PnL stats while allowing account-currency stats such as win rate, average winner, average loser, expectancy, and total PnL to use the converted close-time values.
- Returns no PnL stats for an implicit ambiguous multi-currency analyzer request instead of raising, matching the Rust analyzer behavior and preserving existing backtest rerun flows that compare analyzer outputs without specifying a currency.
- Includes analyzer/account currencies in Python post-run PnL logging so foreign account-currency stats are visible in logs as well as `BacktestResult.stats_pnls`.
- Adds Python and Rust regression coverage for recorded realized PnLs, plus a portfolio conversion regression for a EUR account trading USD-denominated positions.

### Design

The previous failing path stored closed-position `realized_pnl` only under the instrument settlement currency. For example, a EUR account trading a USD-settled instrument could produce correct total account PnL through account balances, while `get_performance_stats_pnls(EUR)` had no EUR trade PnL series to analyze.

This change uses one solution: record the account-currency trade PnL while the portfolio processes the close event. At that point the portfolio knows the closed position, the account base currency, the venue, and the cache FX conversion methods. If a conversion rate is available, the analyzer receives both:

- Native realized PnL, such as `5000 USD`.
- Account-base realized PnL, such as `4405.50 EUR`.

The analyzer no longer derives converted trade PnLs from account balance deltas. That avoids timestamp grouping assumptions, avoids depending on portfolio snapshots for historical FX reconstruction, and keeps conversion responsibility with the portfolio layer where FX lookup already exists.

When callers omit a currency and the analyzer cannot select one unambiguously, `realized_pnls(None)` returns `None`. Explicit currency requests still return the native or recorded account-currency series, and single-currency analyzer state still selects that currency automatically.

The Rust portfolio implementation queries open positions as borrowed cache references for net-position and account-state updates. The close-time PnL recording is layered after `update_net_position`, so the conversion path does not require cloning open positions or rebuilding analyzer data from account snapshots.

### Component flow

```mermaid
flowchart TD
    Fill[Order fills] --> PositionEvent[Position events]
    PositionEvent --> Portfolio[Portfolio.update_position]
    Portfolio --> Cache[Cache]
    Cache --> ClosedPosition[Closed position with native realized_pnl]
    Cache --> Account[Account with base currency]
    Cache --> FxRate[FX rate lookup<br/>direct or triangular when available]

    ClosedPosition --> NativeRecord[Record native PnL<br/>PositionId -> USD amount]
    Account --> NeedsConversion{Native currency differs<br/>from account base?}
    NeedsConversion -- No --> NativeRecord
    NeedsConversion -- Yes --> FxRate
    FxRate --> ConvertedRecord[Record account-base PnL<br/>PositionId -> EUR amount]

    NativeRecord --> Analyzer[PortfolioAnalyzer]
    ConvertedRecord --> Analyzer
    Analyzer --> RealizedPnls[realized_pnls currency view]
    RealizedPnls --> PnlStats[stats_pnls]

    Portfolio --> BacktestEngine[BacktestEngine result/logging]
    BacktestEngine --> AnalyzerCopy[Copy recorded close-time PnLs]
    AnalyzerCopy --> PnlStats
```

### Foreign account currency example

For a EUR account closing a USD position:

- The closed position keeps its native realized PnL, for example `5000 USD`.
- The portfolio asks the cache for the USD to EUR conversion at close processing time. If there is no direct pair but a valid triangle exists, such as USD/EUR and USD/GBP for a GBP conversion, the existing portfolio/cache conversion path can provide the cross rate.
- The analyzer records the converted close-time value, for example `4405.50 EUR`, under the same `PositionId`.
- Later analysis requests `realized_pnls(EUR)` or `stats_pnls["EUR"]` and receives the account-currency series directly.

If no FX rate is available at close time, the portfolio logs a warning and leaves the native PnL record intact. The analyzer does not attempt a later reconstruction from snapshots.

### Files

- `nautilus_trader/portfolio/portfolio.pyx` records native and account-base realized PnL during Python portfolio close processing.
- `crates/portfolio/src/portfolio.rs` mirrors the close-time recording flow in Rust and exposes recorded realized PnLs for backtest analysis.
- `nautilus_trader/analysis/analyzer.py` and `crates/analysis/src/analyzer.rs` merge recorded close-time PnLs with calculated native PnLs, with recorded values taking precedence for the same position and currency.
- `crates/backtest/src/engine.rs` copies recorded realized PnLs from the portfolio into end-of-run and post-run Rust analyzers.
- `nautilus_trader/backtest/engine.pyx` includes analyzer/account currencies when printing post-run PnL statistics.
- `crates/analysis/src/python/analyzer.rs` exposes `record_trade` through the PyO3 analyzer binding.

### Verification

- `make build-debug`.
- `uv run --no-sync pytest tests/unit_tests/analysis/test_analyzer.py -k recorded_realized_pnls`.
- `uv run --no-sync pytest tests/unit_tests/analysis/test_analyzer.py -k "realized_pnls or account_currency_realized_pnls or recorded_realized_pnls" -q`.
- `uv run --no-sync pytest tests/unit_tests/analysis/test_analyzer.py -q`.
- `uv run --no-sync pytest tests/acceptance_tests/test_backtest.py::TestBacktestAcceptanceTestsUSDJPY::test_rerun_ema_cross_strategy_returns_identical_performance -q`.
- `uv run --no-sync pytest tests/unit_tests/portfolio/test_conversion.py -k realized_pnl_with_conversion`.
- `cargo test -p nautilus-analysis test_calculate_statistics_preserves_recorded_realized_pnls`.
- `uv run --no-sync ruff check nautilus_trader/analysis/analyzer.py tests/unit_tests/analysis/test_analyzer.py tests/unit_tests/portfolio/test_conversion.py`.
- `make format`.
- `make pre-commit`.
- `cargo check -p nautilus-analysis -p nautilus-portfolio -p nautilus-backtest`.
- `cargo +nightly fmt --package nautilus-portfolio`.
- `cargo check -p nautilus-portfolio`.




## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4205

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
