### PR TITLE
Fix calculated account state flag for cash and margin accounts

### DIFF
--- a/crates/model/src/accounts/cash.rs
+++ b/crates/model/src/accounts/cash.rs
@@ -211,7 +211,7 @@ impl Account for CashAccount {
     }
 
     fn calculated_account_state(&self) -> bool {
-        false // TODO (implement this logic)
+        self.calculate_account_state
     }
 
     fn balance_total(&self, currency: Option<Currency>) -> Option<Money> {
@@ -392,6 +392,14 @@ mod tests {
             format!("{cash_account}"),
             "CashAccount(id=SIM-001, type=CASH, base=USD)"
         );
+    }
+
+    #[rstest]
+    fn test_calculated_account_state_returns_field_value(cash_account_state: AccountState) {
+        assert!(
+            CashAccount::new(cash_account_state.clone(), true, false).calculated_account_state()
+        );
+        assert!(!CashAccount::new(cash_account_state, false, false).calculated_account_state());
     }
 
     #[rstest]

--- a/crates/model/src/accounts/margin.rs
+++ b/crates/model/src/accounts/margin.rs
@@ -556,7 +556,7 @@ impl Account for MarginAccount {
     }
 
     fn calculated_account_state(&self) -> bool {
-        false // TODO (implement this logic)
+        self.calculate_account_state
     }
 
     fn balance_total(&self, currency: Option<Currency>) -> Option<Money> {
@@ -761,6 +761,12 @@ mod tests {
             margin_account.to_string(),
             "MarginAccount(id=SIM-001, type=MARGIN, base=USD)"
         );
+    }
+
+    #[rstest]
+    fn test_calculated_account_state_returns_field_value(margin_account_state: AccountState) {
+        assert!(MarginAccount::new(margin_account_state.clone(), true).calculated_account_state());
+        assert!(!MarginAccount::new(margin_account_state, false).calculated_account_state());
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Closing https://github.com/nautechsystems/nautilus_trader/pull/4103 PR

This PR fixes the Rust `Account::calculated_account_state` implementation for `CashAccount` and `MarginAccount`.

Both account types previously returned a hardcoded `false`, so callers using the trait API could observe stale behavior even when the account was constructed or updated with `calculate_account_state = true`. The implementations now return the underlying `BaseAccount.calculate_account_state` field, matching `BettingAccount`.

### Design

The change is intentionally narrow:

- `CashAccount::calculated_account_state` now returns `self.calculate_account_state`.
- `MarginAccount::calculated_account_state` now returns `self.calculate_account_state`.
- Focused Rust unit tests cover both `true` and `false` constructor values for each account type.

No release-note update is included in this patch.

### Validation

- `cargo test -p nautilus-model test_calculated_account_state_returns_field_value`.
- `make pre-commit`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
