### PR TITLE
Refine Rust data engine to match Cython behavior

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -254,6 +254,7 @@ impl BacktestEngine {
         let exchange =
             SimulatedExchange::new(config, self.kernel.cache.clone(), self.kernel.clock.clone())?;
         let exchange = Rc::new(RefCell::new(exchange));
+        SimulatedExchange::register_spread_quote_endpoint(&exchange);
         self.venues.insert(venue, exchange.clone());
 
         let account_id = AccountId::from(format!("{venue}-001").as_str());

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -29,7 +29,7 @@ use nautilus_common::{
     clients::ExecutionClient,
     clock::{Clock, TestClock},
     messages::execution::{ModifyOrder, TradingCommand},
-    msgbus::{self, MessagingSwitchboard, switchboard},
+    msgbus::{self, MessagingSwitchboard, TypedHandler, switchboard},
 };
 use nautilus_core::{
     UUID4, UnixNanos,
@@ -254,6 +254,19 @@ impl SimulatedExchange {
     /// Registers the execution client for the exchange.
     pub fn register_client(&mut self, client: Rc<dyn ExecutionClient>) {
         self.exec_client = Some(client);
+    }
+
+    /// Registers the spread quote endpoint used by the data engine.
+    pub fn register_spread_quote_endpoint(exchange: &Rc<RefCell<Self>>) {
+        let venue = exchange.borrow().id;
+        let endpoint = format!("SimulatedExchange.process_new_quote.{venue}");
+        let handler_id = endpoint.clone();
+        let exchange = Rc::clone(exchange);
+        let handler = TypedHandler::from_with_id(handler_id, move |quote: &QuoteTick| {
+            exchange.borrow_mut().process_quote_tick(quote);
+        });
+
+        msgbus::register_quote_endpoint(endpoint.into(), handler);
     }
 
     /// Sets the fill model for the exchange.

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -93,6 +93,7 @@ fn get_exchange(
     let exchange = Rc::new(RefCell::new(
         SimulatedExchange::new(config, cache.clone(), clock).unwrap(),
     ));
+    SimulatedExchange::register_spread_quote_endpoint(&exchange);
 
     let clock = TestClock::new();
     let execution_client = BacktestExecutionClient::new(
@@ -201,6 +202,45 @@ fn test_exchange_process_quote_tick(crypto_perpetual_ethusdt: CryptoPerpetual) {
         .borrow()
         .best_ask_price(crypto_perpetual_ethusdt.id);
     assert_eq!(best_ask_price, Some(Price::from("1001.00")));
+}
+
+#[rstest]
+fn test_exchange_process_quote_tick_endpoint(crypto_perpetual_ethusdt: CryptoPerpetual) {
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        None,
+    );
+    let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    exchange.borrow_mut().add_instrument(instrument).unwrap();
+
+    let quote_tick = QuoteTick::new(
+        crypto_perpetual_ethusdt.id,
+        Price::from("1000.00"),
+        Price::from("1001.00"),
+        Quantity::from("1.000"),
+        Quantity::from("1.000"),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    );
+    msgbus::send_quote(
+        "SimulatedExchange.process_new_quote.BINANCE".into(),
+        &quote_tick,
+    );
+
+    assert_eq!(
+        exchange
+            .borrow()
+            .best_bid_price(crypto_perpetual_ethusdt.id),
+        Some(Price::from("1000.00"))
+    );
+    assert_eq!(
+        exchange
+            .borrow()
+            .best_ask_price(crypto_perpetual_ethusdt.id),
+        Some(Price::from("1001.00"))
+    );
 }
 
 #[rstest]

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -951,6 +951,15 @@ impl DataEngine {
     /// Returns an error if the subscription is invalid (e.g., synthetic instrument for book data),
     /// or if the underlying client operation fails.
     pub fn execute_subscribe(&mut self, cmd: SubscribeCommand) -> anyhow::Result<()> {
+        if let Some(client_id) = cmd.client_id()
+            && self.external_clients.contains(client_id)
+        {
+            if self.config.debug {
+                log::debug!("Skipping subscribe command for external client {client_id}: {cmd:?}");
+            }
+            return Ok(());
+        }
+
         // Update internal engine state
         match &cmd {
             SubscribeCommand::BookDeltas(cmd) if !self.subscribe_book_deltas(cmd)? => {
@@ -964,7 +973,12 @@ impl DataEngine {
             SubscribeCommand::Bars(cmd) if has_continuous_future_params(cmd.params.as_ref()) => {
                 return self.subscribe_continuous_future_bars(cmd);
             }
-            SubscribeCommand::Bars(cmd) => self.subscribe_bars(cmd)?,
+            SubscribeCommand::Bars(cmd) => {
+                self.subscribe_bars(cmd)?;
+                if cmd.bar_type.is_internally_aggregated() {
+                    return Ok(());
+                }
+            }
             SubscribeCommand::OptionChain(cmd) => {
                 self.subscribe_option_chain(cmd);
                 return Ok(());
@@ -998,15 +1012,6 @@ impl DataEngine {
             _ => {} // Do nothing else
         }
 
-        if let Some(client_id) = cmd.client_id()
-            && self.external_clients.contains(client_id)
-        {
-            if self.config.debug {
-                log::debug!("Skipping subscribe command for external client {client_id}: {cmd:?}");
-            }
-            return Ok(());
-        }
-
         #[cfg(feature = "streaming")]
         let cmd = self.subscribe_command_with_prefilled_start_ns(cmd)?;
 
@@ -1029,6 +1034,17 @@ impl DataEngine {
     ///
     /// Returns an error if the underlying client operation fails.
     pub fn execute_unsubscribe(&mut self, cmd: &UnsubscribeCommand) -> anyhow::Result<()> {
+        if let Some(client_id) = cmd.client_id()
+            && self.external_clients.contains(client_id)
+        {
+            if self.config.debug {
+                log::debug!(
+                    "Skipping unsubscribe command for external client {client_id}: {cmd:?}",
+                );
+            }
+            return Ok(());
+        }
+
         match &cmd {
             UnsubscribeCommand::BookDeltas(cmd) if !self.unsubscribe_book_deltas(cmd) => {
                 return Ok(());
@@ -1049,7 +1065,12 @@ impl DataEngine {
                 self.unsubscribe_continuous_future_bars(cmd);
                 return Ok(());
             }
-            UnsubscribeCommand::Bars(cmd) => self.unsubscribe_bars(cmd),
+            UnsubscribeCommand::Bars(cmd) => {
+                self.unsubscribe_bars(cmd);
+                if cmd.bar_type.is_internally_aggregated() {
+                    return Ok(());
+                }
+            }
             UnsubscribeCommand::OptionChain(cmd) => {
                 self.unsubscribe_option_chain(cmd);
                 return Ok(());
@@ -1085,17 +1106,6 @@ impl DataEngine {
                 anyhow::bail!("Cannot unsubscribe from synthetic instrument `OptionGreeks` data");
             }
             _ => {}
-        }
-
-        if let Some(client_id) = cmd.client_id()
-            && self.external_clients.contains(client_id)
-        {
-            if self.config.debug {
-                log::debug!(
-                    "Skipping unsubscribe command for external client {client_id}: {cmd:?}",
-                );
-            }
-            return Ok(());
         }
 
         // Keep client subscribed while exact-topic subscribers remain
@@ -2985,18 +2995,7 @@ impl DataEngine {
 
     fn subscribe_bars(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
         match cmd.bar_type.aggregation_source() {
-            AggregationSource::Internal => {
-                let key = bar_aggregator_key(cmd.bar_type, None);
-
-                if self
-                    .bar_aggregators
-                    .get(&key)
-                    .is_none_or(|aggregator| !aggregator.borrow().is_running())
-                    || !self.bar_aggregator_handlers.contains_key(&key)
-                {
-                    self.start_bar_aggregator(cmd.bar_type, None)?;
-                }
-            }
+            AggregationSource::Internal => self.start_live_bar_aggregator(cmd)?,
             AggregationSource::External => {
                 if cmd.bar_type.instrument_id().is_synthetic() {
                     anyhow::bail!(
@@ -3110,6 +3109,12 @@ impl DataEngine {
 
         let cache = self.cache.clone();
         let handler = Box::new(move |quote: QuoteTick| {
+            let exchange_endpoint = format!(
+                "SimulatedExchange.process_new_quote.{}",
+                quote.instrument_id.venue
+            );
+            msgbus::send_quote(exchange_endpoint.into(), &quote);
+
             if let Err(e) = cache.borrow_mut().add_quote(quote) {
                 log_error_on_cache_insert(&e);
             }
@@ -3303,9 +3308,11 @@ impl DataEngine {
         if self
             .bar_aggregators
             .contains_key(&bar_aggregator_key(bar_type, None))
-            && let Err(e) = self.stop_bar_aggregator(bar_type, None)
         {
-            log::error!("Error stopping bar aggregator for {bar_type}: {e}");
+            match self.stop_bar_aggregator(bar_type, None) {
+                Ok(()) => self.unsubscribe_bar_aggregator(cmd),
+                Err(e) => log::error!("Error stopping bar aggregator for {bar_type}: {e}"),
+            }
         }
 
         // After stopping a composite, check if the source aggregator is now orphaned
@@ -4204,6 +4211,28 @@ impl DataEngine {
         Ok(())
     }
 
+    fn start_live_bar_aggregator(&mut self, cmd: &SubscribeBars) -> anyhow::Result<()> {
+        let key = bar_aggregator_key(cmd.bar_type, None);
+
+        if self
+            .bar_aggregators
+            .get(&key)
+            .is_some_and(|aggregator| aggregator.borrow().is_running())
+            && self.bar_aggregator_handlers.contains_key(&key)
+        {
+            log::warn!(
+                "Aggregator for {} is currently in use, subscription can't be started",
+                cmd.bar_type,
+            );
+            return Ok(());
+        }
+
+        self.start_bar_aggregator(cmd.bar_type, None)?;
+        self.subscribe_bar_aggregator(cmd);
+
+        Ok(())
+    }
+
     fn start_bar_aggregator(
         &mut self,
         bar_type: BarType,
@@ -4283,6 +4312,55 @@ impl DataEngine {
         Ok(())
     }
 
+    fn subscribe_bar_aggregator(&mut self, cmd: &SubscribeBars) {
+        let key = bar_aggregator_key(cmd.bar_type, None);
+        if !self.bar_aggregators.contains_key(&key) {
+            log::error!(
+                "Cannot subscribe bar aggregator: no aggregator found for {}",
+                cmd.bar_type,
+            );
+            return;
+        }
+
+        if cmd.bar_type.is_composite() {
+            let composite_bar_type = cmd.bar_type.composite();
+            if composite_bar_type.is_externally_aggregated() {
+                let subscribe = SubscribeBars::new(
+                    composite_bar_type,
+                    cmd.client_id,
+                    cmd.venue,
+                    UUID4::new(),
+                    cmd.ts_init,
+                    Some(cmd.command_id),
+                    cmd.params.clone(),
+                );
+                self.execute(DataCommand::Subscribe(SubscribeCommand::Bars(subscribe)));
+            }
+        } else if cmd.bar_type.spec().price_type == PriceType::Last {
+            let subscribe = SubscribeTrades::new(
+                cmd.bar_type.instrument_id(),
+                cmd.client_id,
+                cmd.venue,
+                UUID4::new(),
+                cmd.ts_init,
+                Some(cmd.command_id),
+                cmd.params.clone(),
+            );
+            self.execute(DataCommand::Subscribe(SubscribeCommand::Trades(subscribe)));
+        } else {
+            let subscribe = SubscribeQuotes::new(
+                cmd.bar_type.instrument_id(),
+                cmd.client_id,
+                cmd.venue,
+                UUID4::new(),
+                cmd.ts_init,
+                Some(cmd.command_id),
+                cmd.params.clone(),
+            );
+            self.execute(DataCommand::Subscribe(SubscribeCommand::Quotes(subscribe)));
+        }
+    }
+
     /// Sets up a bar aggregator, matching Cython `_setup_bar_aggregator` logic.
     ///
     /// This method handles historical mode, message bus subscriptions, and time bar aggregator setup.
@@ -4330,6 +4408,52 @@ impl DataEngine {
         }
 
         Ok(())
+    }
+
+    fn unsubscribe_bar_aggregator(&mut self, cmd: &UnsubscribeBars) {
+        if cmd.bar_type.is_composite() {
+            let composite_bar_type = cmd.bar_type.composite();
+            if composite_bar_type.is_externally_aggregated() {
+                let unsubscribe = UnsubscribeBars::new(
+                    composite_bar_type,
+                    cmd.client_id,
+                    cmd.venue,
+                    UUID4::new(),
+                    cmd.ts_init,
+                    Some(cmd.command_id),
+                    cmd.params.clone(),
+                );
+                self.execute(DataCommand::Unsubscribe(UnsubscribeCommand::Bars(
+                    unsubscribe,
+                )));
+            }
+        } else if cmd.bar_type.spec().price_type == PriceType::Last {
+            let unsubscribe = UnsubscribeTrades::new(
+                cmd.bar_type.instrument_id(),
+                cmd.client_id,
+                cmd.venue,
+                UUID4::new(),
+                cmd.ts_init,
+                Some(cmd.command_id),
+                cmd.params.clone(),
+            );
+            self.execute(DataCommand::Unsubscribe(UnsubscribeCommand::Trades(
+                unsubscribe,
+            )));
+        } else {
+            let unsubscribe = UnsubscribeQuotes::new(
+                cmd.bar_type.instrument_id(),
+                cmd.client_id,
+                cmd.venue,
+                UUID4::new(),
+                cmd.ts_init,
+                Some(cmd.command_id),
+                cmd.params.clone(),
+            );
+            self.execute(DataCommand::Unsubscribe(UnsubscribeCommand::Quotes(
+                unsubscribe,
+            )));
+        }
     }
 
     fn stop_bar_aggregator(
@@ -4962,13 +5086,13 @@ fn build_continuous_future_subscribe_inner(
     source: ContinuousFutureSource,
     segment_instrument_id: InstrumentId,
     client_id: Option<ClientId>,
-    venue: Option<Venue>,
+    _venue: Option<Venue>,
     child_params: Params,
     correlation_id: UUID4,
     ts_init: UnixNanos,
 ) -> DataCommand {
     let command_id = UUID4::new();
-    let child_venue = venue.or(Some(segment_instrument_id.venue));
+    let child_venue = Some(segment_instrument_id.venue);
 
     match source {
         ContinuousFutureSource::Bars(source_bar_type) => {
@@ -5011,7 +5135,7 @@ fn build_continuous_future_unsubscribe_command(
     source: ContinuousFutureSource,
     segment_instrument_id: InstrumentId,
     client_id: Option<ClientId>,
-    venue: Option<Venue>,
+    _venue: Option<Venue>,
     parent_params: Option<&Params>,
     correlation_id: UUID4,
     ts_init: UnixNanos,
@@ -5023,7 +5147,7 @@ fn build_continuous_future_unsubscribe_command(
     child_params.shift_remove("first_pre_instrument_id");
     child_params.shift_remove("bar_types");
     let command_id = UUID4::new();
-    let child_venue = venue.or(Some(segment_instrument_id.venue));
+    let child_venue = Some(segment_instrument_id.venue);
 
     match source {
         ContinuousFutureSource::Bars(source_bar_type) => {

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -2975,7 +2975,7 @@ fn test_subscribe_continuous_future_bars_dispatches_child_trade_subscription(
     let sub = SubscribeBars::new(
         target_bar_type,
         Some(client_id),
-        Some(Venue::from("GLBX")),
+        Some(Venue::from("XNAS")),
         parent_id,
         UnixNanos::default(),
         None,
@@ -2994,6 +2994,7 @@ fn test_subscribe_continuous_future_bars_dispatches_child_trade_subscription(
         );
     };
     assert_eq!(child.instrument_id, pre_id);
+    assert_eq!(child.venue, Some(Venue::from("GLBX")));
     assert_eq!(child.correlation_id, Some(parent_id));
     let child_params = child.params.as_ref().unwrap();
     assert!(!child_params.contains_key("continuous_future_transitions"));
@@ -3160,7 +3161,7 @@ fn test_unsubscribe_continuous_future_bars_tears_down_subscription(
     let sub = SubscribeBars::new(
         target_bar_type,
         Some(client_id),
-        Some(Venue::from("GLBX")),
+        Some(Venue::from("XNAS")),
         UUID4::new(),
         UnixNanos::default(),
         None,
@@ -3174,7 +3175,7 @@ fn test_unsubscribe_continuous_future_bars_tears_down_subscription(
     let unsub = UnsubscribeBars::new(
         target_bar_type,
         Some(client_id),
-        Some(Venue::from("GLBX")),
+        Some(Venue::from("XNAS")),
         UUID4::new(),
         UnixNanos::default(),
         None,
@@ -3193,6 +3194,7 @@ fn test_unsubscribe_continuous_future_bars_tears_down_subscription(
         );
     };
     assert_eq!(child.instrument_id, pre_id);
+    assert_eq!(child.venue, Some(Venue::from("GLBX")));
 
     let leftover_roll_timers = test_clock
         .borrow()
@@ -6018,26 +6020,31 @@ fn test_catalog_start_ns_prefill_skips_internal_bars(
 
     let bar_type = BarType::from("AUD/USD.SIM-1-MINUTE-LAST-INTERNAL");
     let _catalog_dir = register_bar_catalog(&mut data_engine, bar_type, 4_000);
+    let command_id = UUID4::new();
 
     let sub = SubscribeBars::new(
         bar_type,
         Some(client_id),
         Some(venue),
-        UUID4::new(),
+        command_id,
         UnixNanos::default(),
         None,
         None,
     );
     data_engine.execute(DataCommand::Subscribe(SubscribeCommand::Bars(sub)));
 
-    let SubscribeCommand::Bars(recorded) = recorded_subscribe_command(&recorder) else {
-        panic!("expected bars subscribe");
+    let SubscribeCommand::Trades(recorded) =
+        recorded_subscribe_command_with_correlation(&recorder, command_id)
+    else {
+        panic!("expected source trades subscribe");
     };
-    assert!(
+    assert_eq!(recorded.instrument_id, bar_type.instrument_id());
+    assert_eq!(
         recorded
             .params
             .as_ref()
-            .is_none_or(|params| !params.contains_key("start_ns"))
+            .and_then(|params| params.get("start_ns")),
+        Some(&json!(null))
     );
 }
 
@@ -6320,6 +6327,12 @@ fn test_subscribe_spread_quotes_default_interval_publishes_on_timer(
         get_typed_message_saving_handler::<QuoteTick>(Some(Ustr::from("spread-quotes-timer")));
     let spread_topic = switchboard::get_quotes_topic(spread_id);
     msgbus::subscribe_quotes(spread_topic.into(), handler, None);
+    let (exchange_handler, exchange_saver) =
+        get_typed_message_saving_handler::<QuoteTick>(Some(Ustr::from("spread-exchange-timer")));
+    msgbus::register_quote_endpoint(
+        format!("SimulatedExchange.process_new_quote.{}", spread_id.venue).into(),
+        exchange_handler,
+    );
 
     let sub = SubscribeQuotes::new(
         spread_id,
@@ -6376,6 +6389,10 @@ fn test_subscribe_spread_quotes_default_interval_publishes_on_timer(
     assert_eq!(spread_quotes[0].bid_size, Quantity::from(5));
     assert_eq!(spread_quotes[0].ask_size, Quantity::from(6));
     assert_eq!(spread_quotes[0].ts_event, UnixNanos::from(1_000_000_000));
+
+    let exchange_quotes = exchange_saver.get_messages();
+    assert_eq!(exchange_quotes.len(), 1);
+    assert_eq!(exchange_quotes[0], spread_quotes[0]);
 }
 
 #[rstest]
@@ -6408,6 +6425,12 @@ fn test_subscribe_spread_quotes_with_zero_interval_publishes_spread_quote(
         get_typed_message_saving_handler::<QuoteTick>(Some(Ustr::from("spread-quotes")));
     let spread_topic = switchboard::get_quotes_topic(spread_id);
     msgbus::subscribe_quotes(spread_topic.into(), handler, None);
+    let (exchange_handler, exchange_saver) =
+        get_typed_message_saving_handler::<QuoteTick>(Some(Ustr::from("spread-exchange")));
+    msgbus::register_quote_endpoint(
+        format!("SimulatedExchange.process_new_quote.{}", spread_id.venue).into(),
+        exchange_handler,
+    );
 
     let sub = SubscribeQuotes::new(
         spread_id,
@@ -6460,6 +6483,10 @@ fn test_subscribe_spread_quotes_with_zero_interval_publishes_spread_quote(
     assert_eq!(spread_quotes[0].ask_price, Price::from("3.00"));
     assert_eq!(spread_quotes[0].bid_size, Quantity::from(5));
     assert_eq!(spread_quotes[0].ask_size, Quantity::from(6));
+
+    let exchange_quotes = exchange_saver.get_messages();
+    assert_eq!(exchange_quotes.len(), 1);
+    assert_eq!(exchange_quotes[0], spread_quotes[0]);
 }
 
 #[rstest]
@@ -6906,7 +6933,7 @@ fn test_unsubscribe_trades_ignores_wildcard_observers(
 }
 
 #[rstest]
-fn test_execute_subscribe_bars(
+fn test_execute_subscribe_internal_bars_stays_local(
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     clock: Rc<RefCell<TestClock>>,
@@ -6930,43 +6957,64 @@ fn test_execute_subscribe_bars(
     data_engine.process(&inst_any as &dyn Any);
 
     let bar_type = BarType::from("AUD/USD.SIM-1-MINUTE-LAST-INTERNAL");
+    let trade_topic = switchboard::get_trades_topic(bar_type.instrument_id());
+    let subscribe_command_id = UUID4::new();
 
     let sub = SubscribeBars::new(
         bar_type,
         Some(client_id),
         Some(venue),
-        UUID4::new(),
+        subscribe_command_id,
         UnixNanos::default(),
         None,
         None,
     );
     let sub_cmd = DataCommand::Subscribe(SubscribeCommand::Bars(sub));
-    data_engine.execute(sub_cmd.clone());
+    data_engine.execute(sub_cmd);
 
-    assert!(data_engine.subscribed_bars().contains(&bar_type));
+    assert_eq!(msgbus::exact_subscriber_count_trades(trade_topic), 1);
     {
-        assert_eq!(recorder.borrow().as_slice(), std::slice::from_ref(&sub_cmd));
+        let recorded = recorder.borrow();
+        assert_eq!(recorded.len(), 1);
+        match &recorded[0] {
+            DataCommand::Subscribe(SubscribeCommand::Trades(cmd)) => {
+                assert_eq!(cmd.instrument_id, bar_type.instrument_id());
+                assert_eq!(cmd.correlation_id, Some(subscribe_command_id));
+            }
+            other => panic!("expected source trade subscription, was {other:?}"),
+        }
     }
 
+    let unsubscribe_command_id = UUID4::new();
     let unsub = UnsubscribeBars::new(
         bar_type,
         Some(client_id),
         Some(venue),
-        UUID4::new(),
+        unsubscribe_command_id,
         UnixNanos::default(),
         None,
         None,
     );
     let unsub_cmd = DataCommand::Unsubscribe(UnsubscribeCommand::Bars(unsub));
-    data_engine.execute(unsub_cmd.clone());
+    data_engine.execute(unsub_cmd);
 
     assert_eq!(audusd_sim.id(), bar_type.instrument_id());
-    assert!(!data_engine.subscribed_bars().contains(&bar_type));
-    assert_eq!(recorder.borrow().as_slice(), &[sub_cmd, unsub_cmd]);
+    assert_eq!(msgbus::exact_subscriber_count_trades(trade_topic), 0);
+    {
+        let recorded = recorder.borrow();
+        assert_eq!(recorded.len(), 2);
+        match &recorded[1] {
+            DataCommand::Unsubscribe(UnsubscribeCommand::Trades(cmd)) => {
+                assert_eq!(cmd.instrument_id, bar_type.instrument_id());
+                assert_eq!(cmd.correlation_id, Some(unsubscribe_command_id));
+            }
+            other => panic!("expected source trade unsubscription, was {other:?}"),
+        }
+    }
 }
 
 #[rstest]
-fn test_unsubscribe_bars_forwards_to_client_with_remaining_exact_subscribers(
+fn test_unsubscribe_internal_bars_stays_local_with_remaining_exact_subscribers(
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     clock: Rc<RefCell<TestClock>>,
@@ -6974,7 +7022,8 @@ fn test_unsubscribe_bars_forwards_to_client_with_remaining_exact_subscribers(
     client_id: ClientId,
     venue: Venue,
 ) {
-    // Bars excluded from the gate; venue unsubscribe must forward even with exact subscribers
+    // Matches the Cython DataEngine: internal aggregation is local to the engine,
+    // and exact subscribers keep the aggregator active without forwarding to the client.
     let mut data_engine = data_engine.borrow_mut();
     let recorder: Rc<RefCell<Vec<DataCommand>>> = Rc::new(RefCell::new(Vec::new()));
     register_mock_client(
@@ -6994,31 +7043,116 @@ fn test_unsubscribe_bars_forwards_to_client_with_remaining_exact_subscribers(
     let bar_topic = switchboard::get_bars_topic(bar_type);
     let (handler, _saver) =
         get_typed_message_saving_handler::<Bar>(Some(Ustr::from("exact-bar-subscriber")));
-    msgbus::subscribe_bars(bar_topic.into(), handler, None);
+    msgbus::subscribe_bars(bar_topic.into(), handler.clone(), None);
 
+    let subscribe_command_id = UUID4::new();
     let sub_cmd = DataCommand::Subscribe(SubscribeCommand::Bars(SubscribeBars::new(
         bar_type,
         Some(client_id),
         Some(venue),
-        UUID4::new(),
+        subscribe_command_id,
         UnixNanos::default(),
         None,
         None,
     )));
-    data_engine.execute(sub_cmd.clone());
+    data_engine.execute(sub_cmd);
 
+    let unsubscribe_command_id = UUID4::new();
     let unsub_cmd = DataCommand::Unsubscribe(UnsubscribeCommand::Bars(UnsubscribeBars::new(
         bar_type,
         Some(client_id),
         Some(venue),
-        UUID4::new(),
+        unsubscribe_command_id,
         UnixNanos::default(),
         None,
         None,
     )));
-    data_engine.execute(unsub_cmd.clone());
+    data_engine.execute(unsub_cmd);
 
-    assert_eq!(recorder.borrow().as_slice(), &[sub_cmd, unsub_cmd]);
+    {
+        let recorded = recorder.borrow();
+        assert_eq!(recorded.len(), 1);
+        match &recorded[0] {
+            DataCommand::Subscribe(SubscribeCommand::Trades(cmd)) => {
+                assert_eq!(cmd.instrument_id, bar_type.instrument_id());
+                assert_eq!(cmd.correlation_id, Some(subscribe_command_id));
+            }
+            other => panic!("expected source trade subscription, was {other:?}"),
+        }
+    }
+
+    msgbus::unsubscribe_bars(bar_topic.into(), &handler);
+    data_engine.execute(DataCommand::Unsubscribe(UnsubscribeCommand::Bars(
+        UnsubscribeBars::new(
+            bar_type,
+            Some(client_id),
+            Some(venue),
+            unsubscribe_command_id,
+            UnixNanos::default(),
+            None,
+            None,
+        ),
+    )));
+
+    {
+        let recorded = recorder.borrow();
+        assert_eq!(recorded.len(), 2);
+        assert!(matches!(
+            &recorded[1],
+            DataCommand::Unsubscribe(UnsubscribeCommand::Trades(_))
+        ));
+    }
+}
+
+#[rstest]
+fn test_external_client_internal_bar_subscription_skips_local_aggregator(
+    audusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+    venue: Venue,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    cache.borrow_mut().add_instrument(instrument).unwrap();
+
+    let config = DataEngineConfig {
+        external_clients: Some(vec![client_id]),
+        ..DataEngineConfig::default()
+    };
+    let mut data_engine = DataEngine::new(clock, cache.clone(), Some(config));
+
+    let test_clock: Rc<RefCell<TestClock>> = Rc::new(RefCell::new(TestClock::new()));
+    let recorder: Rc<RefCell<Vec<DataCommand>>> = Rc::new(RefCell::new(Vec::new()));
+    register_mock_client(
+        test_clock,
+        cache,
+        client_id,
+        venue,
+        None,
+        &recorder,
+        &mut data_engine,
+    );
+
+    let bar_type = BarType::from("AUD/USD.SIM-1-MINUTE-LAST-INTERNAL");
+    let trade_topic = switchboard::get_trades_topic(bar_type.instrument_id());
+
+    data_engine.execute(DataCommand::Subscribe(SubscribeCommand::Bars(
+        SubscribeBars::new(
+            bar_type,
+            Some(client_id),
+            Some(venue),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ),
+    )));
+
+    assert_eq!(msgbus::exact_subscriber_count_trades(trade_topic), 0);
+    assert_eq!(recorder.borrow().as_slice(), &[]);
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

This PR refines the Rust `DataEngine` subscription paths to better match the Cython data engine while keeping Rust's typed helper structure.

- Move external-client subscribe and unsubscribe skips ahead of local state mutation, matching Cython's early-return behavior.
- Keep internally aggregated bar subscriptions local to the Rust data engine and avoid forwarding parent `SubscribeBars` or `UnsubscribeBars` commands to clients.
- Add live internal bar aggregator source subscription helpers so Rust now emits child quote, trade, or composite bar commands with parent correlation ids, matching Cython's `_subscribe_bar_aggregator` and `_unsubscribe_bar_aggregator` logic.
- Align continuous-future child subscribe and unsubscribe commands with Cython by routing them through the active segment instrument venue.
- Match Cython spread quote handling by sending generated spread quotes to `SimulatedExchange.process_new_quote.{venue}` before the Rust data-engine cache/publish path.
- Update streaming catalog-prefill coverage so internal bar subscriptions assert against the emitted source subscription, matching the new local parent bar behavior.

### Design decisions

- The Rust request-based continuous-future path remains more direct than Cython: child responses are fed into request-scoped aggregators without temporary historical topic subscriptions. This is intentional Rust structure rather than a behavior gap.
- Spread quote aggregation now matches Cython for live create, setup, leg subscribe, simulated exchange delivery, timer/no-timer publish, handler teardown, and leg unsubscribe behavior.
- The new internal bar aggregator helpers sit next to existing bar aggregator setup/teardown functions to keep the same organization as Cython's create, setup, subscribe, stop, and unsubscribe split.
- Internal bar subscriptions deliberately bypass bar-catalog `start_ns` prefill on the parent command. Under streaming, the forwarded source quote/trade subscription receives normal source-data prefill semantics instead.

```mermaid
flowchart LR
    Parent[Internal SubscribeBars] --> Local[Start local aggregator]
    Local --> Source{Source type}
    Source -->|LAST| Trades[Child SubscribeTrades]
    Source -->|Bid/Ask/Mid| Quotes[Child SubscribeQuotes]
    Source -->|Composite external| Bars[Child SubscribeBars]
    Trades --> Client[Market data client]
    Quotes --> Client
    Bars --> Client
```

### Files

- `crates/data/src/engine/mod.rs`
- `crates/data/tests/engine.rs`
- `crates/backtest/src/engine.rs`
- `crates/backtest/src/exchange.rs`
- `crates/backtest/tests/exchange.rs`

### Verification

- `cargo test -p nautilus-data --test engine continuous_future -- --nocapture`.
- `cargo test -p nautilus-data --test engine spread_quotes -- --nocapture`.
- `cargo test -p nautilus-backtest --test exchange test_exchange_process_quote_tick_endpoint -- --nocapture`.
- `cargo test -p nautilus-data --test engine bar_aggregator -- --nocapture`.
- `cargo test -p nautilus-data --test engine --features "ffi,python,high-precision,streaming,defi" test_catalog_start_ns_prefill_skips_internal_bars -- --nocapture`.
- `make format`.
- `make cargo-test-core`.
- `make pre-commit`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

Continuing https://github.com/nautechsystems/nautilus_trader/pull/4200

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
