### PR TITLE
Fix Throttler silently dropping buffered messages

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -152,6 +152,7 @@ Released on TBD (UTC).
 - Fixed Polymarket adapter treating encoded-empty `clob_token_ids` as terminal instead of transient (Rust)
 - Fixed Polymarket PyO3 bootstrap to honor `instrument_config` (#4127), thanks @graceyangfan
 - Fixed Tardis CSV delta loaders missing book resets between consecutive snapshots
+- Fixed `Throttler` silently dropping buffered messages when re-arming the drip timer in buffer mode
 
 ### Internal Improvements
 - Added `cargo machete` pre-commit hook to detect unused workspace dependencies

--- a/nautilus_trader/common/component.pyx
+++ b/nautilus_trader/common/component.pyx
@@ -3170,9 +3170,11 @@ cdef class Throttler:
         cdef int64_t delta_next
         while self._buffer:
             delta_next = self._delta_next()
-            msg = self._buffer.pop()
 
             if delta_next <= 0:
+                # Only remove from the buffer once cleared to send, otherwise the
+                # message would be dropped when re-arming the timer below
+                msg = self._buffer.pop()
                 self._send_msg(msg)
             else:
                 self._set_timer(self._process)

--- a/tests/unit_tests/common/test_throttler.py
+++ b/tests/unit_tests/common/test_throttler.py
@@ -187,6 +187,33 @@ class TestBufferingThrottler:
         assert self.throttler.recv_count == 7
         assert self.throttler.sent_count == 7
 
+    def test_buffered_burst_delivers_all_messages_in_order(self):
+        # Regression test: in buffer mode (no `output_drop`) a burst far exceeding
+        # the rate must be fully delivered in order. Previously `_process` popped a
+        # message before the rate check and, when re-arming the timer, returned
+        # without sending or restoring it, silently dropping one buffered message
+        # per refill.
+
+        # Arrange: distinct messages so completeness and order are both verifiable
+        messages = [f"MESSAGE-{i}" for i in range(20)]
+
+        # Act: Send a burst of 20 (limit is 5 per interval)
+        for message in messages:
+            self.throttler.send(message)
+
+        # Drain the buffer one interval at a time until empty
+        while self.throttler.qsize > 0:
+            events = self.clock.advance_time(self.clock.timestamp_ns() + 1_000_000_000)
+            for event in events:
+                event.handle()
+
+        # Assert: Every message delivered exactly once, in order, none dropped
+        assert self.handler == messages
+        assert self.throttler.qsize == 0
+        assert self.throttler.is_limiting is False
+        assert self.throttler.recv_count == 20
+        assert self.throttler.sent_count == 20
+
 
 class TestDroppingThrottler:
     def setup(self):


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

In buffer mode (no `output_drop` handler), `Throttler._process` popped a message from the internal buffer *before* the rate check. When the rate limit was hit with messages still buffered, it re-armed the drip timer and returned without sending or restoring that popped message, silently dropping it (every other buffered message at `limit=1`). This fix only removes a message from the buffer once the rate clears it to send, so buffered messages are never lost.

## Related Issues/PRs

_None._

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A — the drip-release timing and the drop-mode path (`output_drop` set) are unchanged; only the loss of buffered messages is fixed.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

_No documentation changes required._

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_buffered_burst_delivers_all_messages_in_order` in `tests/unit_tests/common/test_throttler.py`: it sends a burst of 20 messages at `limit=5` in buffer mode and asserts all 20 are delivered, in order, with none dropped. Verified against a full debug build — all 14 throttler unit tests pass, including the existing `TestDroppingThrottler` cases (drop mode unaffected).
