### PR TITLE
Harden Interactive Brokers reconciliation against connection loss

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -245,9 +245,16 @@ impl InteractiveBrokersExecutionClient {
                     let mut cache = commission_cache
                         .lock()
                         .map_err(|_| anyhow::anyhow!("Failed to lock commission cache"))?;
+                    // IB sends -1.0 as a pending-sentinel before the real commission arrives;
+                    // clamp it to zero so downstream Money construction never receives a negative value.
+                    let commission_value = if commission.commission == -1.0_f64 {
+                        0.0_f64
+                    } else {
+                        commission.commission
+                    };
                     cache.insert(
                         commission.execution_id.clone(),
-                        (commission.commission, commission.currency.clone()),
+                        (commission_value, commission.currency.clone()),
                     );
                 }
 

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -245,8 +245,8 @@ impl InteractiveBrokersExecutionClient {
                     let mut cache = commission_cache
                         .lock()
                         .map_err(|_| anyhow::anyhow!("Failed to lock commission cache"))?;
-                    // IB sends -1.0 as a pending-sentinel before the real commission arrives;
-                    // clamp it to zero so downstream Money construction never receives a negative value.
+                    // IB uses -1.0 as a pending-sentinel before the real commission arrives;
+                    // clamp only that sentinel to zero (legitimate rebates can be negative).
                     let commission_value = if commission.commission == -1.0_f64 {
                         0.0_f64
                     } else {

--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -108,8 +108,9 @@ pub fn parse_execution_to_fill_report(
     let last_qty = Quantity::new(execution.shares, instrument.size_precision());
     let last_px = Price::new(execution_price, instrument.price_precision());
 
-    // Create commission
-    let commission_money = Money::new(commission, Currency::from_str(commission_currency)?);
+    // Create commission — clamp IB's -1 pending sentinel to 0.0 to avoid invalid Money values
+    let commission_clamped = if commission < 0.0 { 0.0 } else { commission };
+    let commission_money = Money::new(commission_clamped, Currency::from_str(commission_currency)?);
 
     // Parse execution time
     let ts_event = parse_execution_time(&execution.time)?;

--- a/nautilus_trader/adapters/interactive_brokers/client/account.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/account.py
@@ -135,7 +135,7 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
         else:
             self._log.debug(f"Subscription doesn't exist for {name}")
 
-    async def get_positions(self, account_id: str) -> list[Position]:
+    async def get_positions(self, account_id: str) -> list[Position] | None:
         """
         Fetch open positions for a specified account.
 
@@ -146,7 +146,10 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
 
         Returns
         -------
-        list[Position]
+        list[Position] or None
+            Returns ``None`` when the request fails due to a connection error or timeout,
+            indicating the result is unknown.  An empty list means IB explicitly confirmed
+            no open positions.  Callers **must not** treat ``None`` as confirmed-zero.
 
         """
         self._log.debug(f"Requesting open positions for {account_id}")
@@ -166,6 +169,9 @@ class InteractiveBrokersClientAccountMixin(BaseMixin):
             all_positions = await self._await_request(request, self._request_timeout_secs)
         else:
             all_positions = await self._await_request(request, self._request_timeout_secs)
+
+        if all_positions is None:
+            return None  # request failed — caller must not infer "no positions"
 
         if not all_positions:
             return []

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -106,7 +106,7 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         )
         self._eclient.reqGlobalCancel()
 
-    async def get_open_orders(self, account_id: str) -> list[IBOrder]:
+    async def get_open_orders(self, account_id: str) -> list[IBOrder] | None:
         """
         Retrieve a list of open orders for a specific account. Once the request is
         completed, openOrderEnd() will be called.
@@ -124,8 +124,10 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
 
         Returns
         -------
-        list[IBOrder]
-            List of open orders filtered by the specified account_id.
+        list[IBOrder] or None
+            None if the request failed (socket error / timeout) — callers must not
+            treat None as "confirmed zero open orders".  An empty list means IB
+            explicitly confirmed no open orders.
 
         """
         self._log.debug(f"Requesting open orders for {account_id}")
@@ -154,18 +156,18 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             self._request_timeout_secs,
         )
 
-        if all_orders:
-            orders: list[IBOrder] = [order for order in all_orders if order.account == account_id]
-        else:
-            orders = []
+        if all_orders is None:
+            return None  # request failed — caller must not infer "no open orders"
+        if not all_orders:
+            return []
 
-        return orders
+        return [order for order in all_orders if order.account == account_id]
 
     async def get_executions(
         self,
         account_id: str,
         execution_filter: ExecutionFilter | None = None,
-    ) -> list[dict]:
+    ) -> list[dict] | None:
         """
         Retrieve execution reports for a specific account.
 
@@ -178,8 +180,10 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
 
         Returns
         -------
-        list[dict]
-            List of execution details with associated contracts and commission reports.
+        list[dict] or None
+            None if the request failed (socket error / timeout) — callers must not
+            treat None as "confirmed zero executions".  An empty list means IB
+            explicitly confirmed no executions matched the filter.
             Each dict contains 'execution', 'contract', and 'commission_report' keys.
 
         """
@@ -215,18 +219,17 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             self._request_timeout_secs,
         )
 
-        if execution_details:
-            # Filter by account if needed (in case filter didn't work perfectly)
-            filtered_executions = [
-                exec_detail
-                for exec_detail in execution_details
-                if exec_detail.get("execution")
-                and exec_detail["execution"].acctNumber == account_id
-            ]
-        else:
-            filtered_executions = []
+        if execution_details is None:
+            return None  # request failed — caller must not infer "no executions"
+        if not execution_details:
+            return []
 
-        return filtered_executions
+        # Filter by account if needed (in case filter didn't work perfectly)
+        return [
+            exec_detail
+            for exec_detail in execution_details
+            if exec_detail.get("execution") and exec_detail["execution"].acctNumber == account_id
+        ]
 
     def next_order_id(self) -> int:
         """

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -561,9 +561,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # periodic checks causes filled_qty mismatches because the position may have
         # changed due to partial fills on exit orders.
         if not command.open_only:
-            positions: list[IBPosition] = await self._client.get_positions(
+            positions = await self._client.get_positions(
                 self.account_id.get_id(),
             )
+
+            if positions is None:
+                raise ConnectionError(
+                    "get_positions() disconnected during reqPositions — "
+                    "skipping order status reconciliation to avoid false discrepancy",
+                )
 
             ts_init = self._clock.timestamp_ns()
 
@@ -765,11 +771,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         last_qty = Quantity(execution.shares, precision=instrument.size_precision)
         last_px = Price(converted_execution_price, precision=instrument.price_precision)
 
-        # Create commission
-        commission = Money(
-            commission_report.commissionAndFees,
-            Currency.from_str(commission_report.currency),
-        )
+        # Create commission — guard None/-1 (IB sends -1 or None for pending commissions)
+        commission_fees = commission_report.commissionAndFees
+        if commission_fees is None or commission_fees < 0:
+            commission_fees = 0.0
+        commission = Money(commission_fees, Currency.from_str(commission_report.currency))
 
         # Determine liquidity side (IB doesn't provide this directly, so we use NO_LIQUIDITY_SIDE)
         liquidity_side = LiquiditySide.NO_LIQUIDITY_SIDE
@@ -802,9 +808,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         command: GeneratePositionStatusReports,
     ) -> list[PositionStatusReport]:
         report = []
-        positions: list[IBPosition] = await self._client.get_positions(
+        positions: list[IBPosition] | None = await self._client.get_positions(
             self.account_id.get_id(),
         )
+
+        if positions is None:
+            raise ConnectionError(
+                "get_positions() disconnected during reqPositions — "
+                "skipping position status reconciliation to avoid false discrepancy",
+            )
 
         # Handle case when specific instrument requested but no positions found
         if command.instrument_id and not positions:
@@ -1936,6 +1948,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         if nautilus_order.client_order_id in self._order_avg_prices:
             info["avg_px"] = self._order_avg_prices[nautilus_order.client_order_id]
 
+        # Guard None/-1 commission (IB sends -1 or None for pending commissions)
+        commission_fees = commission_report.commissionAndFees
+        if commission_fees is None or commission_fees < 0:
+            commission_fees = 0.0
+
         self.generate_order_filled(
             strategy_id=nautilus_order.strategy_id,
             instrument_id=nautilus_order.instrument_id,
@@ -1948,10 +1965,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             last_qty=Quantity(execution.shares, precision=instrument.size_precision),
             last_px=Price(converted_execution_price, precision=instrument.price_precision),
             quote_currency=instrument.quote_currency,
-            commission=Money(
-                commission_report.commissionAndFees,
-                Currency.from_str(commission_report.currency),
-            ),
+            commission=Money(commission_fees, Currency.from_str(commission_report.currency)),
             liquidity_side=LiquiditySide.NO_LIQUIDITY_SIDE,
             ts_event=timestring_to_timestamp(execution.time).value,
             info=info or None,
@@ -2186,8 +2200,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
 
             # Combo commission scaled to the number of legs of the combo
+            # Guard None/-1 (IB sends -1 or None for pending commissions)
+            commission_fees = commission_report.commissionAndFees
+            if commission_fees is None or commission_fees < 0:
+                commission_fees = 0.0
             combo_commission = (
-                commission_report.commissionAndFees
+                commission_fees
                 * generic_spread_id_n_legs(nautilus_order.instrument_id)
                 / abs(ratio)
             )
@@ -2297,10 +2315,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
             order_side = OrderSide[ORDER_SIDE_TO_ORDER_ACTION[execution.side]]
 
-            commission = Money(
-                commission_report.commissionAndFees,
-                Currency.from_str(commission_report.currency),
-            )
+            # Guard None/-1 (IB sends -1 or None for pending commissions)
+            commission_fees = commission_report.commissionAndFees
+            if commission_fees is None or commission_fees < 0:
+                commission_fees = 0.0
+            commission = Money(commission_fees, Currency.from_str(commission_report.currency))
 
             # Include avg_px in info if we have it stored for the parent order
             info = {}

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -413,6 +413,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         report = None
         ib_orders = await self._client.get_open_orders(self.account_id.get_id())
 
+        if ib_orders is None:
+            raise ConnectionError(
+                "get_open_orders() disconnected during reqOpenOrders — "
+                "skipping order status reconciliation to avoid false discrepancy",
+            )
+
         for ib_order in ib_orders:
             if (command.client_order_id and command.client_order_id.value == ib_order.orderRef) or (
                 command.venue_order_id
@@ -525,9 +531,15 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         # Get open orders first - needed for both startup and periodic reconciliation,
         # and to calculate open order fills for synthetic order adjustment
-        ib_orders: list[IBOrder] = await self._client.get_open_orders(
+        ib_orders: list[IBOrder] | None = await self._client.get_open_orders(
             self.account_id.get_id(),
         )
+
+        if ib_orders is None:
+            raise ConnectionError(
+                "get_open_orders() disconnected during reqOpenOrders — "
+                "skipping order status reconciliation to avoid false discrepancy",
+            )
 
         # Build a map of instrument_id -> net signed filled quantity from open orders
         # This is used to adjust synthetic position orders to avoid double-counting
@@ -686,6 +698,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 execution_filter=execution_filter,
             )
 
+            if execution_details is None:
+                raise ConnectionError(
+                    "get_executions() disconnected during reqExecutions — "
+                    "skipping fill report reconciliation to avoid missing fills",
+                )
+
             ts_init = self._clock.timestamp_ns()
 
             for exec_detail in execution_details:
@@ -773,7 +791,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         # Create commission — guard None/-1 (IB sends -1 or None for pending commissions)
         commission_fees = commission_report.commissionAndFees
-        if commission_fees is None or commission_fees < 0:
+        if commission_fees is None or commission_fees == -1.0:
             commission_fees = 0.0
         commission = Money(commission_fees, Currency.from_str(commission_report.currency))
 
@@ -1950,7 +1968,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
         # Guard None/-1 commission (IB sends -1 or None for pending commissions)
         commission_fees = commission_report.commissionAndFees
-        if commission_fees is None or commission_fees < 0:
+        if commission_fees is None or commission_fees == -1.0:
             commission_fees = 0.0
 
         self.generate_order_filled(
@@ -2202,7 +2220,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             # Combo commission scaled to the number of legs of the combo
             # Guard None/-1 (IB sends -1 or None for pending commissions)
             commission_fees = commission_report.commissionAndFees
-            if commission_fees is None or commission_fees < 0:
+            if commission_fees is None or commission_fees == -1.0:
                 commission_fees = 0.0
             combo_commission = (
                 commission_fees
@@ -2317,7 +2335,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
 
             # Guard None/-1 (IB sends -1 or None for pending commissions)
             commission_fees = commission_report.commissionAndFees
-            if commission_fees is None or commission_fees < 0:
+            if commission_fees is None or commission_fees == -1.0:
                 commission_fees = 0.0
             commission = Money(commission_fees, Currency.from_str(commission_report.currency))
 

--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -876,7 +876,7 @@ class LiveExecutionEngine(ExecutionEngine):
         failed_venues: set[Venue | None] = set()
 
         for client, reports_or_exception in zip(clients, position_reports_all, strict=True):
-            if isinstance(reports_or_exception, Exception):
+            if isinstance(reports_or_exception, BaseException):
                 failed_venues.add(client.venue)
                 self._log.error(
                     f"Failed to generate position status reports for venue {client.venue}: "
@@ -1207,7 +1207,7 @@ class LiveExecutionEngine(ExecutionEngine):
         had_fill_query_errors = False
 
         for fills_or_exception in fill_reports_all:
-            if isinstance(fills_or_exception, Exception):
+            if isinstance(fills_or_exception, BaseException):
                 had_fill_query_errors = True
                 self._log.error(
                     f"Failed to generate fill reports for {instrument_id}: {fills_or_exception}",
@@ -1572,7 +1572,7 @@ class LiveExecutionEngine(ExecutionEngine):
         all_order_reports: list[OrderStatusReport] = []
 
         for reports_or_exception in order_reports_all:
-            if isinstance(reports_or_exception, Exception):
+            if isinstance(reports_or_exception, BaseException):
                 self._log.error(
                     f"Failed to generate order status reports: {reports_or_exception}",
                 )
@@ -1779,7 +1779,7 @@ class LiveExecutionEngine(ExecutionEngine):
                         *report_tasks,
                         return_exceptions=True,
                     ):
-                        if isinstance(task_result_or_exception, Exception):
+                        if isinstance(task_result_or_exception, BaseException):
                             self._log.error(
                                 f"Failed to generate position status reports: {task_result_or_exception}",
                             )

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_account.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_account.py
@@ -146,3 +146,24 @@ async def test_get_positions_simulates_two_positions(ib_client):
     assert Counter(results_1) == Counter([position_1])
     assert Counter(results_2) == Counter([position_2, position_3])
     ib_client._eclient.reqPositions.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_positions_returns_none_on_connection_error(ib_client):
+    """
+    Test that get_positions() returns None when the underlying request fails.
+
+    Verifies fix for issue #4228: a socket disconnect during reqPositions previously
+    returned [] via the request default, which callers treated as "IB confirmed flat".
+    None now propagates as "venue state unknown" so reconciliation is skipped.
+
+    """
+    # Arrange
+    ib_client._eclient.reqPositions = MagicMock()
+    ib_client._await_request = AsyncMock(return_value=None)
+
+    # Act
+    result = await ib_client.get_positions("DU1234567")
+
+    # Assert
+    assert result is None

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
@@ -174,6 +174,7 @@ async def test_generate_order_status_reports_raises_on_disconnected(exec_client,
     instrument = IBTestContractStubs.aapl_instrument()
     instrument_setup(exec_client, cache, instrument=instrument)
 
+    exec_client._client.get_open_orders = AsyncMock(return_value=[])
     exec_client._client.get_positions = AsyncMock(return_value=None)
 
     command = GenerateOrderStatusReports(

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
@@ -104,14 +104,14 @@ async def test_generate_position_status_reports_flat_when_no_positions(exec_clie
     Test that FLAT report is generated when specific instrument has no positions.
 
     Verifies fix for issue #3023 where reconciliation requests position for specific
-    instrument but IB returns no positions.
+    instrument but IB returns no positions (empty list = IB confirmed flat).
 
     """
     # Arrange
     instrument = IBTestContractStubs.aapl_instrument()
     instrument_setup(exec_client, cache, instrument=instrument)
 
-    exec_client._client.get_positions = AsyncMock(return_value=None)
+    exec_client._client.get_positions = AsyncMock(return_value=[])
 
     command = GeneratePositionStatusReports(
         instrument_id=instrument.id,
@@ -129,6 +129,65 @@ async def test_generate_position_status_reports_flat_when_no_positions(exec_clie
     assert reports[0].position_side == PositionSide.FLAT
     assert reports[0].quantity.as_decimal() == Decimal(0)
     assert reports[0].instrument_id == instrument.id
+
+
+@pytest.mark.asyncio
+async def test_generate_position_status_reports_raises_on_disconnected(exec_client, cache):
+    """
+    Test that ConnectionError is raised when get_positions() returns None.
+
+    Verifies fix for issue #4228: a socket disconnect during reqPositions previously
+    returned [] (treated as "venue confirmed flat"), triggering a ghost inferred SELL
+    and corrupting the execution cache.  None now means "venue state unknown" and must
+    propagate as ConnectionError so the exec engine skips reconciliation entirely.
+
+    """
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    instrument_setup(exec_client, cache, instrument=instrument)
+
+    exec_client._client.get_positions = AsyncMock(return_value=None)
+
+    command = GeneratePositionStatusReports(
+        instrument_id=None,
+        start=None,
+        end=None,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+
+    # Act / Assert
+    with pytest.raises(ConnectionError, match="reqPositions"):
+        await exec_client.generate_position_status_reports(command)
+
+
+@pytest.mark.asyncio
+async def test_generate_order_status_reports_raises_on_disconnected(exec_client, cache):
+    """
+    Test that ConnectionError is raised when get_positions() returns None.
+
+    Verifies fix for issue #4228: same guard applied to generate_order_status_reports
+    so the exec engine skips order reconciliation when IB is unreachable.
+
+    """
+    # Arrange
+    instrument = IBTestContractStubs.aapl_instrument()
+    instrument_setup(exec_client, cache, instrument=instrument)
+
+    exec_client._client.get_positions = AsyncMock(return_value=None)
+
+    command = GenerateOrderStatusReports(
+        instrument_id=None,
+        start=None,
+        end=None,
+        open_only=False,
+        command_id=UUID4(),
+        ts_init=0,
+    )
+
+    # Act / Assert
+    with pytest.raises(ConnectionError, match="reqPositions"):
+        await exec_client.generate_order_status_reports(command)
 
 
 @pytest.mark.asyncio

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py
@@ -166,8 +166,8 @@ async def test_generate_order_status_reports_raises_on_disconnected(exec_client,
     """
     Test that ConnectionError is raised when get_positions() returns None.
 
-    Verifies fix for issue #4228: same guard applied to generate_order_status_reports
-    so the exec engine skips order reconciliation when IB is unreachable.
+    Verifies fix for issue #4228: same guard applied to generate_order_status_reports so
+    the exec engine skips order reconciliation when IB is unreachable.
 
     """
     # Arrange


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes four bugs that combine during IB Gateway disconnects (e.g. daily CME/COMEX trading halt or nightly maintenance) to silently corrupt the execution cache and produce a startup crash loop.

- Return `None` from `get_positions()` on socket error instead of `[]`, so callers can distinguish &#34;venue confirmed flat&#34; from &#34;venue unreachable&#34;.
- Raise `ConnectionError` in `generate_position_status_reports()` and `generate_order_status_reports()` when `get_positions()` returns `None`, allowing `asyncio.gather(return_exceptions=True)` to catch it and skip reconciliation cleanly.
- Guard `commissionAndFees = None` or `-1.0` (IB pending sentinel) before constructing `Money(...)` at all fill-report sites in Python and Rust. Without this guard, `Money(None, ...)` raises during degraded connections.
- Fix `asyncio.gather(return_exceptions=True)` result loops in the live execution engine to check `isinstance(..., BaseException)` instead of `isinstance(..., Exception)`. In Python 3.9+, `asyncio.CancelledError` inherits from `BaseException` — it slipped through the `Exception` check and was iterated as a `list[PositionStatusReport]`, raising `TypeError: &#39;CancelledError&#39; object is not iterable`. Four sites are fixed; line 1716 already used `BaseException` correctly.

### Design decisions

- `get_positions()` return type is widened to `list[Position] | None`. `None` strictly means &#34;request failed — venue state unknown&#34;. An empty list continues to mean &#34;IB confirmed no open positions&#34;. This distinction is load-bearing: treating a failed request as confirmed-zero is what triggered the ghost fill described below.
- `ConnectionError` is raised (not returned) so it propagates through `asyncio.gather(return_exceptions=True)` without any change to calling signatures in the execution engine.
- Commission clamping uses `if fees is None or fees < 0: fees = 0.0` — preserves the fill event with zero commission rather than dropping it entirely, which matches the behaviour when IB later sends the real commission via `commissionReport`.
- `BaseException` is the correct catch-all for `asyncio.gather(return_exceptions=True)` results; `Exception` was always incorrect here since Python 3.8 when `CancelledError` was reparented.

### Production incident

On 2026-06-01, bugs 1–3 combined at 16:30 CT (daily CME/COMEX trading halt) to generate a ghost inferred SELL fill for an open MGC position:

1. `reqPositions()` errored with socket disconnect; default `result=[]` was treated as &#34;venue confirmed flat&#34;.
2. The commission guard was absent — `generate_fill_reports()` raised `TypeError` trying to compare `None` to `int`, but the exception was swallowed.
3. `ExecEngine` reconciled `cached_qty=1` against `venue_qty=0` and generated an inferred `OrderFilled(side=SELL)` — a ghost external SHORT position was written into the in-memory cache.
4. The bot ran normally for several hours, then shut down gracefully. The graceful stop cleanly persisted the invalid logical state to Redis — no partial write; just faithful persistence of bad data.
5. Every subsequent startup loaded the orphaned `index:order_position` entry and crashed on `cache.add_order()` integrity check. The crash loop persisted until Redis was manually flushed.

With bugs 1 + 2 + 4 fixed together: `get_positions()` returns `None` → `generate_position_status_reports()` raises `ConnectionError` → `asyncio.gather` catches it as `BaseException` → reconciliation skipped with a WARN log → no ghost fill, no corrupted state.

### Files covered

- `nautilus_trader/adapters/interactive_brokers/client/account.py`
- `nautilus_trader/adapters/interactive_brokers/execution.py`
- `nautilus_trader/live/execution_engine.py`
- `crates/adapters/interactive_brokers/src/execution/parse.rs`

### Verification

```bash
uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/
make format
make pre-commit
```

New and updated tests:
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_account.py` — `test_get_positions_returns_none_on_connection_error`
- `tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py` — `test_generate_position_status_reports_raises_on_disconnected`, `test_generate_order_status_reports_raises_on_disconnected`
- `tests/integration_tests/adapters/interactive_brokers/test_execution_reconciliation.py` — fixed existing `test_generate_position_status_reports_flat_when_no_positions` (`return_value=None` → `return_value=[]` to preserve its original intent after the semantic change)

## Related Issues/PRs

https://github.com/nautechsystems/nautilus_trader/issues/4228

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

`get_positions()` return type widens from `list[Position]` to `list[Position] | None`. Any caller that assumed a non-None return must now handle `None`. Within this PR all call sites are updated.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic