### PR TITLE
Fix Lighter maker-only key lookup authentication

### DIFF
--- a/crates/adapters/lighter/README.md
+++ b/crates/adapters/lighter/README.md
@@ -54,6 +54,15 @@ L2 account. See the
 [Lighter integration guide](https://nautilustrader.io/docs/nightly/integrations/lighter.html#integrator-attribution)
 for approval and revocation details.
 
+### Maker-only API keys
+
+Lighter restricts maker-only API keys to the 0ms speed-bump lane (PostOnly orders, modifies on
+ALO orders, and cancels), so they cannot submit `ApproveIntegrator` themselves. The execution
+client detects maker-only keys at startup via `getMakerOnlyApiKeys` and skips the approval with
+a WARN log. Approval is account-scoped: a single `ApproveIntegrator` from any non-maker-only
+key on the same account permanently unlocks orders for every key on that account, including
+maker-only ones.
+
 ## L2 transaction signer
 
 The crate ships an in-tree implementation of the Lighter L2 signer (Schnorr

--- a/crates/adapters/lighter/src/execution.rs
+++ b/crates/adapters/lighter/src/execution.rs
@@ -76,6 +76,7 @@ use crate::{
     config::LighterExecClientConfig,
     http::{
         client::{LIGHTER_REST_PAGE_SIZE, LighterHttpClient, LighterRawHttpClient},
+        error::LighterHttpError,
         models::{LighterSendTxBatchRequest, LighterSendTxRequest},
         query::{
             LighterAccountActiveOrdersQuery, LighterAccountInactiveOrdersQuery,
@@ -411,10 +412,46 @@ impl LighterExecutionClient {
         }
     }
 
+    /// Returns `Ok(true)` if this credential's `api_key_index` is maker-only.
+    /// Maker-only keys cannot submit `ApproveIntegrator`, so the caller skips
+    /// the integrator auto-approval when `true`.
+    async fn is_maker_only_api_key(&self, credential: &Credential) -> anyhow::Result<bool> {
+        let auth_token = build_auth_token_for(credential)
+            .context("failed to mint Lighter auth token for maker-only check")?;
+        let response = self
+            .http_client
+            .get_maker_only_api_keys(credential.account_index(), auth_token)
+            .await
+            .context("failed to query getMakerOnlyApiKeys")?;
+        let api_key_index = i64::from(credential.api_key_index());
+        Ok(response.api_key_indexes.contains(&api_key_index))
+    }
+
     async fn submit_integrator_auto_approval(&self) -> anyhow::Result<()> {
         let Some(credential) = &self.credential else {
             return Ok(());
         };
+
+        let mut maker_only_check_failed = false;
+
+        match self.is_maker_only_api_key(credential).await {
+            Ok(true) => {
+                log::warn!(
+                    "Skipping Lighter integrator auto-approval: api_key_index={} is maker-only; \
+                     ensure the account has been approved by a non-maker-only key",
+                    credential.api_key_index(),
+                );
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(e) => {
+                maker_only_check_failed = true;
+                log::debug!(
+                    "Lighter maker-only api key check failed; attempting integrator approval \
+                     anyway: {e:?}"
+                );
+            }
+        }
 
         let approval = self.prepare_integrator_auto_approval(credential)?;
         let request = LighterSendTxRequest::new(
@@ -422,8 +459,14 @@ impl LighterExecutionClient {
             approval.tx_info.clone(),
         );
         let response = self.http_client.send_tx(&request).await.with_context(|| {
+            let hint = if maker_only_check_failed {
+                " (maker-only pre-flight check failed earlier; venue may reject with 62007 \
+                 if this key is maker-only)"
+            } else {
+                ""
+            };
             format!(
-                "failed to submit Lighter integrator approval nonce={} api_key_index={}",
+                "failed to submit Lighter integrator approval nonce={} api_key_index={}{hint}",
                 approval.nonce, approval.api_key_index,
             )
         })?;
@@ -1877,7 +1920,24 @@ impl ExecutionClient for LighterExecutionClient {
         self.detect_account_tier().await;
 
         if let Err(e) = self.submit_integrator_auto_approval().await {
-            log::debug!("Lighter integrator approval failed; continuing startup: {e:?}");
+            // Bail on venue 21149 ("integrator is not approved") so the
+            // operator catches it at startup rather than at first order.
+            // Other failures are tolerated: approval is account-scoped and
+            // may already be in place, or a reconnect can retry.
+            let is_unapproved = e.chain().any(|cause| {
+                matches!(
+                    cause.downcast_ref::<LighterHttpError>(),
+                    Some(LighterHttpError::Venue { code: 21149, .. }),
+                )
+            });
+
+            if is_unapproved {
+                return Err(e.context(
+                    "Lighter account is not integrator-approved (venue 21149); \
+                     orders cannot be placed",
+                ));
+            }
+            log::error!("Lighter integrator approval failed; continuing startup: {e:?}");
         }
 
         if let Err(e) = self.refresh_nonce().await {

--- a/crates/adapters/lighter/src/http/client.rs
+++ b/crates/adapters/lighter/src/http/client.rs
@@ -52,10 +52,10 @@ use crate::{
         },
         models::{
             LighterAccountDetail, LighterAccountsResponse, LighterCandle, LighterCandles,
-            LighterFundings, LighterNextNonce, LighterOrderBookDetails, LighterOrderBookOrders,
-            LighterOrderBooks, LighterOrders, LighterResultCode, LighterSendTxBatchRequest,
-            LighterSendTxBatchResponse, LighterSendTxRequest, LighterSendTxResponse, LighterTrade,
-            LighterTrades,
+            LighterFundings, LighterMakerOnlyApiKeys, LighterNextNonce, LighterOrderBookDetails,
+            LighterOrderBookOrders, LighterOrderBooks, LighterOrders, LighterResultCode,
+            LighterSendTxBatchRequest, LighterSendTxBatchResponse, LighterSendTxRequest,
+            LighterSendTxResponse, LighterTrade, LighterTrades,
         },
         parse::{
             parse_candle_bar, parse_funding_rate_update,
@@ -66,8 +66,9 @@ use crate::{
         query::{
             LighterAccountActiveOrdersQuery, LighterAccountInactiveOrdersQuery,
             LighterAccountLookup, LighterAccountQuery, LighterCandlesQuery, LighterFundingsQuery,
-            LighterNextNonceQuery, LighterOrderBookDetailsQuery, LighterOrderBookOrdersQuery,
-            LighterOrderBooksQuery, LighterRecentTradesQuery, LighterTradesQuery,
+            LighterMakerOnlyApiKeysQuery, LighterNextNonceQuery, LighterOrderBookDetailsQuery,
+            LighterOrderBookOrdersQuery, LighterOrderBooksQuery, LighterRecentTradesQuery,
+            LighterTradesQuery,
         },
     },
 };
@@ -78,6 +79,7 @@ const ENDPOINT_ACCOUNT_ACTIVE_ORDERS: &str = "/api/v1/accountActiveOrders";
 const ENDPOINT_ACCOUNT_INACTIVE_ORDERS: &str = "/api/v1/accountInactiveOrders";
 const ENDPOINT_CANDLES: &str = "/api/v1/candles";
 const ENDPOINT_FUNDINGS: &str = "/api/v1/fundings";
+const ENDPOINT_MAKER_ONLY_API_KEYS: &str = "/api/v1/getMakerOnlyApiKeys";
 const ENDPOINT_NEXT_NONCE: &str = "/api/v1/nextNonce";
 const ENDPOINT_ORDER_BOOK_DETAILS: &str = "/api/v1/orderBookDetails";
 const ENDPOINT_ORDER_BOOK_ORDERS: &str = "/api/v1/orderBookOrders";
@@ -124,6 +126,7 @@ impl_lighter_response_check!(
     LighterAccountsResponse,
     LighterCandles,
     LighterFundings,
+    LighterMakerOnlyApiKeys,
     LighterNextNonce,
     LighterOrderBookDetails,
     LighterOrderBookOrders,
@@ -375,6 +378,19 @@ impl LighterRawHttpClient {
         query: &LighterNextNonceQuery,
     ) -> LighterHttpResult<LighterNextNonce> {
         self.send_get_request(ENDPOINT_NEXT_NONCE, Some(query))
+            .await
+    }
+
+    /// Calls `GET /api/v1/getMakerOnlyApiKeys`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_maker_only_api_keys(
+        &self,
+        query: &LighterMakerOnlyApiKeysQuery,
+    ) -> LighterHttpResult<LighterMakerOnlyApiKeys> {
+        self.send_get_request(ENDPOINT_MAKER_ONLY_API_KEYS, Some(query))
             .await
     }
 
@@ -816,6 +832,27 @@ impl LighterHttpClient {
             api_key_index,
         };
         self.inner.get_next_nonce(&query).await
+    }
+
+    /// Calls `GET /api/v1/getMakerOnlyApiKeys` for `account_index`.
+    ///
+    /// `auth_token` is the canonical Lighter auth string minted from the
+    /// caller's credential.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_maker_only_api_keys(
+        &self,
+        account_index: i64,
+        auth_token: impl Into<String>,
+    ) -> LighterHttpResult<LighterMakerOnlyApiKeys> {
+        let query = LighterMakerOnlyApiKeysQuery {
+            authorization: None,
+            auth: Some(auth_token.into()),
+            account_index,
+        };
+        self.inner.get_maker_only_api_keys(&query).await
     }
 
     /// Calls `POST /api/v1/sendTx`.

--- a/crates/adapters/lighter/src/http/models.rs
+++ b/crates/adapters/lighter/src/http/models.rs
@@ -70,6 +70,22 @@ pub struct LighterAccountsResponse {
     pub accounts: Vec<LighterAccountDetail>,
 }
 
+/// Response payload of `GET /api/v1/getMakerOnlyApiKeys`.
+///
+/// Lighter restricts maker-only keys to the 0ms speed-bump lane (PostOnly
+/// creates, modifies on ALO orders, cancel / cancel-all). Any tx kind outside
+/// that allowlist — for example `ApproveIntegrator` (tx_type 45) — is rejected
+/// with venue code `62007`. The adapter pre-flights this endpoint before
+/// submitting the integrator auto-approval so it can skip the doomed tx with
+/// a clear log line instead of swallowing the misleading 62007.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct LighterMakerOnlyApiKeys {
+    pub code: i32,
+    pub message: Option<String>,
+    #[serde(default)]
+    pub api_key_indexes: Vec<i64>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct LighterSendTxRequest {
     pub tx_type: u8,

--- a/crates/adapters/lighter/src/http/query.rs
+++ b/crates/adapters/lighter/src/http/query.rs
@@ -117,6 +117,20 @@ pub struct LighterNextNonceQuery {
     pub api_key_index: u8,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, Builder, PartialEq, Eq)]
+#[builder(setter(strip_option))]
+pub struct LighterMakerOnlyApiKeysQuery {
+    #[builder(default)]
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<String>,
+    #[builder(default)]
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth: Option<String>,
+    pub account_index: i64,
+}
+
 #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum LighterAccountLookup {
@@ -419,6 +433,21 @@ mod tests {
         assert_eq!(value["auth"], "auth-token");
         assert_eq!(value["account_index"], 123);
         assert_eq!(value["market_id"], 0);
+        assert!(value.get("authorization").is_none());
+    }
+
+    #[rstest]
+    fn test_maker_only_api_keys_query_serializes_auth_and_account_index() {
+        let query = LighterMakerOnlyApiKeysQueryBuilder::default()
+            .auth("auth-token")
+            .account_index(42)
+            .build()
+            .unwrap();
+
+        let value = serde_json::to_value(query).unwrap();
+
+        assert_eq!(value["auth"], "auth-token");
+        assert_eq!(value["account_index"], 42);
         assert!(value.get("authorization").is_none());
     }
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

## Problem

Execution client emitted a misleading ERROR at every startup on accounts using a maker-only API key:

```
[ERROR] nautilus_lighter::execution: Lighter integrator approval failed; continuing startup
Caused by: venue error 62007: maker-only api key can only send 0ms delay transactions
```

The wording "0ms delay transactions" suggests a tx-timing parameter is wrong. It is actually a **scheduling-lane restriction**.

## Root cause

Per [Lighter API docs](https://apidocs.lighter.xyz/docs/api-keys#maker-only-api-keys), maker-only keys are pinned to the 0ms speed-bump lane and may only send PostOnly orders, modifies on ALO orders, and cancels. `ApproveIntegrator` (tx_type 45) is not on that allowlist, so the venue rejects every submit with `62007`. The adapter was unconditionally submitting it during `connect()`.

## Adapter contract

Every `CreateOrder` / `ModifyOrder` the adapter sends carries `integrator_attributes()` in `L2TxAttributes`. Without prior `ApproveIntegrator`, the venue rejects orders with `21149` ("integrator is not approved"). The approval is **account-scoped**: a single submit from any non-maker-only key permanently unlocks orders for every key on the account, including maker-only ones.

## Changes

- **HTTP**: new `GET /api/v1/getMakerOnlyApiKeys` plumbing — `LighterMakerOnlyApiKeysQuery`, `LighterMakerOnlyApiKeys` response model, raw + domain client methods, `LighterResponseCheck` impl, serialization test.
- **Execution**: pre-flight check in `submit_integrator_auto_approval` calls `getMakerOnlyApiKeys`; if the configured `api_key_index` is on the maker-only list, skip with a **WARN** log instead of the doomed submit. If the pre-flight check itself fails, fall through but tag the error context. `connect()` now bails (`anyhow`) when submit returns venue code `21149` (would otherwise fail every order at runtime); other failures log ERROR and continue.
- **Docs**: new `### Maker-only API keys` subsection in `crates/adapters/lighter/README.md`.

## Case matrix

| # | Key | Approved? | Startup behavior |
|---|---|---|---|
| 1 | non-maker | yes | submit succeeds (refresh) — DEBUG |
| 2 | non-maker | no | submit succeeds (creates approval) — DEBUG |
| 3 | maker-only | yes | skip — WARN |
| 4 | maker-only | no | skip — WARN, first order rejected with 21149 at runtime |
| 5 | non-maker | n/a, venue 21149 | startup bails |
| 6 | maker-only | any, pre-flight HTTP error | submit returns 62007 — ERROR with pre-flight hint |

Case 4 cannot be detected at startup — Lighter exposes no "is approved?" query. The WARN log explicitly tells the operator to ensure the account has been approved by a non-maker-only key.

## Verification

Before:
```
[ERROR] nautilus_lighter::execution: Lighter integrator approval failed; continuing startup
Caused by: venue error 62007: maker-only api key can only send 0ms delay transactions
```

After:
```
[INFO]  nautilus_lighter::execution: Lighter execution account 728422 reported tier Standard
[WARN]  nautilus_lighter::execution: Skipping Lighter integrator auto-approval: api_key_index=6 is maker-only; ensure the account has been approved by a non-maker-only key
[INFO]  nautilus_lighter::execution: Connected: client_id=LIGHTER
[INFO]  nautilus_live::node: All engine clients connected
```

## References

- [Lighter API keys — maker-only section](https://apidocs.lighter.xyz/docs/api-keys#maker-only-api-keys)
- [`getMakerOnlyApiKeys` OpenAPI](https://apidocs.lighter.xyz/reference/getmakeronlyapikeys)
- Venue codes: `62007` (maker-only lane restriction), `21149` (integrator not approved)


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore