### PR TITLE
Fix DonchianChannel period window

### DIFF
--- a/crates/indicators/src/volatility/dc.rs
+++ b/crates/indicators/src/volatility/dc.rs
@@ -104,6 +104,14 @@ impl DonchianChannel {
     }
 
     pub fn update_raw(&mut self, high: f64, low: f64) {
+        if self.upper_prices.len() == self.period {
+            let _ = self.upper_prices.pop_front();
+        }
+
+        if self.lower_prices.len() == self.period {
+            let _ = self.lower_prices.pop_front();
+        }
+
         let _ = self.upper_prices.push_back(high);
         let _ = self.lower_prices.push_back(low);
 
@@ -181,8 +189,23 @@ mod tests {
         }
 
         assert_eq!(dc_10.upper, 15.0);
-        assert_eq!(dc_10.middle, 7.95);
-        assert_eq!(dc_10.lower, 0.9);
+        assert_eq!(dc_10.middle, 10.45);
+        assert_eq!(dc_10.lower, 5.9);
+    }
+
+    #[rstest]
+    fn test_value_respects_period_window() {
+        let mut dc = DonchianChannel::new(3);
+
+        dc.update_raw(1.0, 0.0);
+        dc.update_raw(100.0, 0.0);
+        dc.update_raw(2.0, 0.0);
+        dc.update_raw(3.0, 0.0);
+        dc.update_raw(4.0, 0.0);
+
+        assert_eq!(dc.upper, 4.0);
+        assert_eq!(dc.middle, 2.0);
+        assert_eq!(dc.lower, 0.0);
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes the Rust/PyO3 `DonchianChannel` rolling-window behavior so `upper`, `lower`, and `middle` are computed over the configured `period`, not all retained values up to `MAX_PERIOD`.

This aligns the Rust implementation with the legacy Cython indicator behavior and prevents stale highs/lows from affecting the channel after they leave the active window.

## Related Issues/PRs

Closes #4238

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No documentation changes were needed.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

No release notes entry was added.

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added a regression test for stale values leaving the Donchian window and updated the existing period-10 expectations.

Validation run locally:

```text
rustfmt --check crates/indicators/src/volatility/dc.rs
git diff --check
cargo test -p nautilus-indicators volatility::dc::tests -- --nocapture
prek run --all-files
```

The targeted Rust test run passed with 7 tests passed, 0 failed. The full local pre-commit run also passed.
