### PR TITLE
Fix Binance Futures WebSocket connection pool race when subscribing

### DIFF
--- a/crates/adapters/binance/src/futures/websocket/streams/client.rs
+++ b/crates/adapters/binance/src/futures/websocket/streams/client.rs
@@ -261,7 +261,11 @@ impl BinanceFuturesWebSocketClient {
     /// Returns an error if the pool is exhausted or command delivery fails.
     #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
     pub async fn subscribe(&self, streams: Vec<String>) -> BinanceWsResult<()> {
-        // Phase 1: filter already-subscribed streams (brief lock)
+        // Serialize all phases so concurrent subscribers see a consistent
+        // pool state and can't trigger spurious `Pool exhausted`.
+        let _connect_guard = self.connect_lock.lock().await;
+
+        // Phase 1: filter already-subscribed streams (brief lock).
         let new_streams: Vec<String> = {
             let slots = self.slots.lock().expect("slots lock poisoned");
             streams
@@ -275,8 +279,6 @@ impl BinanceFuturesWebSocketClient {
         }
 
         // Phase 2: create connections if needed.
-        // Only one task grows the pool at a time so concurrent subscribers can't race past `MAX_CONNECTIONS`.
-        let _connect_guard = self.connect_lock.lock().await;
 
         loop {
             let (remaining_capacity, slot_count) = {
@@ -305,7 +307,6 @@ impl BinanceFuturesWebSocketClient {
                 self.product_type
             );
         }
-        drop(_connect_guard);
 
         // Phase 3: assign streams to slots and send commands (brief lock).
         // Stage assignments first so a capacity error leaves slots unchanged.

--- a/crates/adapters/binance/src/futures/websocket/streams/client.rs
+++ b/crates/adapters/binance/src/futures/websocket/streams/client.rs
@@ -93,6 +93,7 @@ pub struct BinanceFuturesWebSocketClient {
     heartbeat: Option<u64>,
     signal: Arc<AtomicBool>,
     slots: Arc<Mutex<Vec<ConnectionSlot>>>,
+    connect_lock: Arc<tokio::sync::Mutex<()>>,
     out_tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<BinanceFuturesWsStreamsMessage>>>>,
     out_rx:
         Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BinanceFuturesWsStreamsMessage>>>>,
@@ -153,6 +154,7 @@ impl BinanceFuturesWebSocketClient {
             heartbeat,
             signal: Arc::new(AtomicBool::new(false)),
             slots: Arc::new(Mutex::new(Vec::new())),
+            connect_lock: Arc::new(tokio::sync::Mutex::new(())),
             out_tx: Arc::new(Mutex::new(None)),
             out_rx: Arc::new(Mutex::new(None)),
             request_id_counter: Arc::new(AtomicU64::new(1)),
@@ -272,7 +274,10 @@ impl BinanceFuturesWebSocketClient {
             return Ok(());
         }
 
-        // Phase 2: create connections if needed (no lock held during async connect)
+        // Phase 2: create connections if needed.
+        // Only one task grows the pool at a time so concurrent subscribers can't race past `MAX_CONNECTIONS`.
+        let _connect_guard = self.connect_lock.lock().await;
+
         loop {
             let (remaining_capacity, slot_count) = {
                 let slots = self.slots.lock().expect("slots lock poisoned");
@@ -300,6 +305,7 @@ impl BinanceFuturesWebSocketClient {
                 self.product_type
             );
         }
+        drop(_connect_guard);
 
         // Phase 3: assign streams to slots and send commands (brief lock).
         // Stage assignments first so a capacity error leaves slots unchanged.

--- a/crates/adapters/binance/src/spot/websocket/streams/client.rs
+++ b/crates/adapters/binance/src/spot/websocket/streams/client.rs
@@ -83,6 +83,7 @@ pub struct BinanceSpotWebSocketClient {
     heartbeat: Option<u64>,
     signal: Arc<AtomicBool>,
     slots: Arc<Mutex<Vec<ConnectionSlot>>>,
+    connect_lock: Arc<tokio::sync::Mutex<()>>,
     out_tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<BinanceSpotWsMessage>>>>,
     out_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BinanceSpotWsMessage>>>>,
     request_id_counter: Arc<AtomicU64>,
@@ -140,6 +141,7 @@ impl BinanceSpotWebSocketClient {
             heartbeat,
             signal: Arc::new(AtomicBool::new(false)),
             slots: Arc::new(Mutex::new(Vec::new())),
+            connect_lock: Arc::new(tokio::sync::Mutex::new(())),
             out_tx: Arc::new(Mutex::new(None)),
             out_rx: Arc::new(Mutex::new(None)),
             request_id_counter: Arc::new(AtomicU64::new(1)),
@@ -244,7 +246,11 @@ impl BinanceSpotWebSocketClient {
     /// Returns an error if the pool is exhausted or command delivery fails.
     #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
     pub async fn subscribe(&self, streams: Vec<String>) -> BinanceWsResult<()> {
-        // Phase 1: filter already-subscribed streams (brief lock)
+        // Serialize all phases so concurrent subscribers see a consistent
+        // pool state and can't trigger spurious `Pool exhausted`.
+        let _connect_guard = self.connect_lock.lock().await;
+
+        // Phase 1: filter already-subscribed streams (brief lock).
         let new_streams: Vec<String> = {
             let slots = self.slots.lock().expect("slots lock poisoned");
             streams
@@ -257,7 +263,7 @@ impl BinanceSpotWebSocketClient {
             return Ok(());
         }
 
-        // Phase 2: create connections if needed (no lock held during async connect)
+        // Phase 2: create connections if needed.
         loop {
             let (remaining_capacity, slot_count) = {
                 let slots = self.slots.lock().expect("slots lock poisoned");


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`BinanceFuturesWebSocketClient::subscribe()` opens far more WebSocket connections than `MAX_CONNECTIONS = 20` when many subscriptions are dispatched concurrently. In a real run we observed **~200 connections** opened for a single client, which exhausted the process's file-descriptor budget on macOS and produced cascading `Too many open files (os error 24)` errors. The DNS lookup failures that surface to users (`failed to lookup address information: nodename nor servname provided`) are downstream symptoms of FD exhaustion — `getaddrinfo` itself cannot open a socket.

## Problem

`BinanceFuturesDataClient::subscribe_trades` / `subscribe_bars` / `subscribe_quotes` (and the mark/index/funding paths) dispatch each subscription to its own task via `get_runtime().spawn(...)`, calling `ws.subscribe(vec![one_stream])` per instrument. When a strategy subscribes hundreds of instruments at startup, the runtime ends up with hundreds of concurrent `subscribe()` calls against the same `BinanceFuturesWebSocketClient`.

The Phase 2 pool-growth loop in `subscribe()` reads `slots.len()` under a sync lock, releases the lock, then `await`s `create_connection()`, then re-acquires the lock to push the new slot:

```rust
loop {
    let (remaining_capacity, slot_count) = {
        let slots = self.slots.lock().expect("slots lock poisoned");
        // ... compute capacity ...
        (cap, slots.len())
    };  // lock released

    if remaining_capacity >= new_streams.len() || slot_count >= MAX_CONNECTIONS {
        break;
    }

    let new_slot = self.create_connection().await?;  // ~1s TLS handshake
    let slot_count = {
        let mut slots = self.slots.lock().expect("slots lock poisoned");
        slots.push(new_slot);
        slots.len()
    };
    // ...
}
```

Because the slots lock is released across the async `create_connection()` await, every concurrent `subscribe()` caller observes the same stale `(remaining_capacity = 0, slot_count = 0)`, each enters `create_connection()`, and each pushes its own slot ~1 second later. The `MAX_CONNECTIONS` gate is bypassed — concurrency, not the bound, decides how many connections are opened.

## Production observation

From a single strategy startup on `BinanceFuturesDataClient` (USD-M):

- 528 unique perpetual instruments
- 1,142 `Subscribe(Bars)` + `Subscribe(Trades)` commands dispatched in ~20 ms
- **199 connections** opened across the pool's first growth burst (well past the documented cap of 20)
- Connections were almost empty — each carried 1–2 streams instead of up to 200
- macOS FD soft limit reached → all subsequent connection attempts failed with `Too many open files`, which `getaddrinfo` reports as `nodename nor servname provided, or not known`

Expected behaviour: 1,142 streams should fit in `ceil(1142/200) = 6` connections; the pool should never exceed 20.

## Fix

Add a `tokio::sync::Mutex<()>` (`connect_lock`) and hold it from the start of `subscribe()` through the Phase 3 commit, so only one caller mutates pool state at a time. After the first caller's `create_connection()` returns and its Phase 3 commits, every other caller's capacity check sees the new slot/stream state and short-circuits.

```rust
let _connect_guard = self.connect_lock.lock().await;
// Phase 1: filter — sees committed slot.streams
// Phase 2: capacity check + create_connection
// Phase 3: assign streams + send commands
// guard dropped at end of function
```

An async mutex (not `std::sync::Mutex`) is required because the guarded region awaits `create_connection()`. Holding an async lock across `await` is normally an antipattern, but pool growth is a startup-time operation that we explicitly want serialized — the antipattern doesn't apply here. The hot path (`subscribe()` calls that find existing capacity) still exits the Phase 2 loop on its first iteration.

### Why the lock spans all three phases

An earlier version of this fix held `connect_lock` across Phase 2 only and released it before Phase 3 assigned streams to slots. That left a smaller but identical race: a concurrent subscriber acquiring the lock between Task A's Phase 2 exit and its Phase 3 commit would observe pre-commit `slot.streams` (still empty), decide no growth was needed, then collide with Task A in Phase 3 — producing a spurious `Pool exhausted` even though the pool had room. Phase 1's filter was likewise unsynchronized, so the same stream could be assigned to two slots across racing subscribers. The current fix holds the lock from the start of `subscribe()` through the final commit so every phase observes a consistent snapshot.

### Spot client

The Spot pool client (`crates/adapters/binance/src/spot/websocket/streams/client.rs`) had the identical Phase 1–3 race with no `connect_lock` at all. The same fix is applied there.

### Regression test

Skipped. The race is probabilistic under multi-threaded scheduling, so a non-deterministic test would flake on CI; making it deterministic would require either a local WS server harness or sync points wired into production code. The fix is small and the locking pattern reads cleanly — cost/value didn't favor adding the test.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
