### PR TITLE
Fix Deribit chart bar volume for inverse perpetuals

### DIFF
--- a/crates/adapters/deribit/src/common/parse.rs
+++ b/crates/adapters/deribit/src/common/parse.rs
@@ -25,12 +25,12 @@ use nautilus_core::{
 };
 use nautilus_model::{
     data::{Bar, BarType, BookOrder, TradeTick},
-    enums::{AccountType, AggressorSide, BookType, OptionKind, OrderSide},
+    enums::{AccountType, AggressorSide, BookType, InstrumentClass, OptionKind, OrderSide},
     events::AccountState,
     identifiers::{AccountId, InstrumentId, Symbol, TradeId},
     instruments::{
         CryptoFuture, CryptoFuturesSpread, CryptoOption, CryptoOptionSpread, CryptoPerpetual,
-        CurrencyPair, any::InstrumentAny,
+        CurrencyPair, Instrument, any::InstrumentAny,
     },
     orderbook::OrderBook,
     types::{AccountBalance, Currency, MarginBalance, Money, Price, Quantity},
@@ -860,10 +860,34 @@ pub fn parse_trade_tick(
     ))
 }
 
+/// Returns true when `Bar.volume` should be populated from the chart `cost` field (USD) instead
+/// of the `volume` field (base currency).
+///
+/// Deribit's `trades.{instrument}` channel reports each trade's `amount` in USD for inverse
+/// perpetuals and inverse futures, and in the underlying base currency for options and linear
+/// futures. To keep `Bar.volume` and `TradeTick.size` on a single unit per instrument, route
+/// inverse non-option products through `cost`. Options and option spreads stay on `volume` even
+/// when flagged `is_inverse`, because their trade `amount` is reported in base currency.
+///
+/// Reference: <https://docs.deribit.com/api-reference/market-data/public-get_last_trades_by_currency>
+#[must_use]
+pub fn use_cost_for_bar_volume(instrument: &InstrumentAny) -> bool {
+    if !instrument.is_inverse() {
+        return false;
+    }
+    !matches!(
+        instrument.instrument_class(),
+        InstrumentClass::Option | InstrumentClass::OptionSpread
+    )
+}
+
 /// Parses Deribit TradingView chart data into Nautilus [`Bar`]s.
 ///
 /// Converts OHLCV arrays from the `public/get_tradingview_chart_data` endpoint
 /// into a vector of [`Bar`] objects.
+///
+/// When `use_cost_for_volume` is true, `Bar.volume` is populated from `chart_data.cost` (USD)
+/// instead of `chart_data.volume` (base currency) — see [`use_cost_for_bar_volume`].
 ///
 /// # Errors
 ///
@@ -876,6 +900,7 @@ pub fn parse_bars(
     bar_type: BarType,
     price_precision: u8,
     size_precision: u8,
+    use_cost_for_volume: bool,
     ts_init: UnixNanos,
 ) -> anyhow::Result<Vec<Bar>> {
     // Check status
@@ -894,7 +919,8 @@ pub fn parse_bars(
             && chart_data.high.len() == num_bars
             && chart_data.low.len() == num_bars
             && chart_data.close.len() == num_bars
-            && chart_data.volume.len() == num_bars,
+            && chart_data.volume.len() == num_bars
+            && chart_data.cost.len() == num_bars,
         "Inconsistent array lengths in chart data"
     );
 
@@ -913,7 +939,12 @@ pub fn parse_bars(
             .with_context(|| format!("Invalid low price at index {i}"))?;
         let close = Price::new_checked(chart_data.close[i], price_precision)
             .with_context(|| format!("Invalid close price at index {i}"))?;
-        let volume = Quantity::new_checked(chart_data.volume[i], size_precision)
+        let raw_volume = if use_cost_for_volume {
+            chart_data.cost[i]
+        } else {
+            chart_data.volume[i]
+        };
+        let volume = Quantity::new_checked(raw_volume, size_precision)
             .with_context(|| format!("Invalid volume at index {i}"))?;
 
         // Convert timestamp from milliseconds to nanoseconds
@@ -1402,7 +1433,56 @@ mod tests {
     }
 
     #[rstest]
-    fn test_parse_bars() {
+    fn test_use_cost_for_bar_volume() {
+        // Inverse perpetual: BTC-PERPETUAL → cost (USD)
+        let perp_json = load_test_json("http_get_instrument.json");
+        let perp_response: DeribitJsonRpcResponse<DeribitInstrument> =
+            serde_json::from_str(&perp_json).unwrap();
+        let perp_inst = perp_response.result.expect("Test data must have result");
+        let perp =
+            parse_deribit_instrument_any(&perp_inst, UnixNanos::default(), UnixNanos::default())
+                .unwrap()
+                .expect("Should parse perpetual");
+        assert!(perp.is_inverse());
+        assert!(use_cost_for_bar_volume(&perp));
+
+        // BTC inverse option: is_inverse, but trade amount is in BTC, so stay on volume
+        let instruments_json = load_test_json("http_get_instruments.json");
+        let instruments_response: DeribitJsonRpcResponse<Vec<DeribitInstrument>> =
+            serde_json::from_str(&instruments_json).unwrap();
+        let instruments = instruments_response
+            .result
+            .expect("Test data must have result");
+
+        let option_inst = instruments
+            .iter()
+            .find(|i| i.instrument_name.as_str() == "BTC-27DEC24-100000-C")
+            .expect("Test data must contain BTC-27DEC24-100000-C");
+        let option =
+            parse_deribit_instrument_any(option_inst, UnixNanos::default(), UnixNanos::default())
+                .unwrap()
+                .expect("Should parse option");
+        assert!(option.is_inverse());
+        assert!(
+            !use_cost_for_bar_volume(&option),
+            "options report trade amount in base currency, must keep using volume",
+        );
+
+        // Inverse future: same convention as perp — cost (USD)
+        let future_inst = instruments
+            .iter()
+            .find(|i| i.instrument_name.as_str() == "BTC-27DEC24")
+            .expect("Test data must contain BTC-27DEC24");
+        let future =
+            parse_deribit_instrument_any(future_inst, UnixNanos::default(), UnixNanos::default())
+                .unwrap()
+                .expect("Should parse future");
+        assert!(future.is_inverse());
+        assert!(use_cost_for_bar_volume(&future));
+    }
+
+    #[rstest]
+    fn test_parse_bars_uses_volume_field() {
         let json_data = load_test_json("http_get_tradingview_chart_data.json");
         let response: DeribitJsonRpcResponse<DeribitTradingViewChartData> =
             serde_json::from_str(&json_data).unwrap();
@@ -1411,7 +1491,8 @@ mod tests {
         let bar_type = BarType::from("BTC-PERPETUAL.DERIBIT-1-MINUTE-LAST-EXTERNAL");
         let ts_init = UnixNanos::from(1766487086146245_u64 * NANOSECONDS_IN_MICROSECOND);
 
-        let bars = parse_bars(&chart_data, bar_type, 1, 8, ts_init).expect("Should parse bars");
+        let bars =
+            parse_bars(&chart_data, bar_type, 1, 8, false, ts_init).expect("Should parse bars");
 
         assert_eq!(bars.len(), 5, "Should parse 5 bars");
 
@@ -1440,6 +1521,24 @@ mod tests {
             last_bar.ts_event,
             UnixNanos::from(1766483700000_u64 * NANOSECONDS_IN_MILLISECOND)
         );
+    }
+
+    #[rstest]
+    fn test_parse_bars_cost_path() {
+        let json_data = load_test_json("http_get_tradingview_chart_data.json");
+        let response: DeribitJsonRpcResponse<DeribitTradingViewChartData> =
+            serde_json::from_str(&json_data).unwrap();
+        let chart_data = response.result.expect("Test data must have result");
+
+        let bar_type = BarType::from("BTC-PERPETUAL.DERIBIT-1-MINUTE-LAST-EXTERNAL");
+        let ts_init = UnixNanos::from(1766487086146245_u64 * NANOSECONDS_IN_MICROSECOND);
+
+        // Cost path picks `cost` (USD), matching trade `amount` on inverse perps/futures.
+        let bars =
+            parse_bars(&chart_data, bar_type, 1, 0, true, ts_init).expect("Should parse bars");
+        assert_eq!(bars.len(), 5);
+        assert_eq!(bars[0].volume, Quantity::from("257490"));
+        assert_eq!(bars[4].volume, Quantity::from("8910"));
     }
 
     #[rstest]

--- a/crates/adapters/deribit/src/http/client.rs
+++ b/crates/adapters/deribit/src/http/client.rs
@@ -79,6 +79,7 @@ use crate::{
         parse::{
             extract_server_timestamp, parse_account_state, parse_bars,
             parse_deribit_instrument_any, parse_order_book, parse_trade_tick,
+            use_cost_for_bar_volume,
         },
         urls::get_http_base_url,
     },
@@ -1433,11 +1434,15 @@ impl DeribitHttpClient {
             return Ok(Vec::new());
         }
 
-        // Get instrument from cache to determine precisions
+        // Get instrument from cache to determine precisions and volume-field selection.
         let instrument_id = bar_type.instrument_id();
-        let (price_precision, size_precision) =
+        let (price_precision, size_precision, use_cost_for_volume) =
             if let Some(instrument) = self.get_instrument(&instrument_id.symbol.inner()) {
-                (instrument.price_precision(), instrument.size_precision())
+                (
+                    instrument.price_precision(),
+                    instrument.size_precision(),
+                    use_cost_for_bar_volume(&instrument),
+                )
             } else {
                 log::warn!("Instrument {instrument_id} not in cache, skipping bars request");
                 anyhow::bail!("Instrument {instrument_id} not in cache");
@@ -1449,6 +1454,7 @@ impl DeribitHttpClient {
             bar_type,
             price_precision,
             size_precision,
+            use_cost_for_volume,
             ts_init,
         )?;
 

--- a/crates/adapters/deribit/src/http/models.rs
+++ b/crates/adapters/deribit/src/http/models.rs
@@ -515,7 +515,6 @@ pub struct DeribitTradingViewChartData {
     /// List of prices at close (one per candle)
     pub close: Vec<f64>,
     /// List of cost bars (volume in quote currency, one per candle)
-    #[serde(default)]
     pub cost: Vec<f64>,
     /// List of highest price levels (one per candle)
     pub high: Vec<f64>,

--- a/crates/adapters/deribit/src/websocket/handler.rs
+++ b/crates/adapters/deribit/src/websocket/handler.rs
@@ -1935,12 +1935,14 @@ impl DeribitWsFeedHandler {
                                             Ok(bar_type) => {
                                                 let price_precision = instrument.price_precision();
                                                 let size_precision = instrument.size_precision();
+                                                let is_inverse = instrument.is_inverse();
 
                                                 match parse_chart_msg(
                                                     &chart_msg,
                                                     bar_type,
                                                     price_precision,
                                                     size_precision,
+                                                    is_inverse,
                                                     self.bars_timestamp_on_close,
                                                     ts_init,
                                                 ) {

--- a/crates/adapters/deribit/src/websocket/handler.rs
+++ b/crates/adapters/deribit/src/websocket/handler.rs
@@ -70,7 +70,7 @@ use crate::{
     common::{
         consts::{DERIBIT_POST_ONLY_ERROR_CODE, DERIBIT_RATE_LIMIT_KEY_ORDER, DERIBIT_VENUE},
         enums::DeribitInstrumentState,
-        parse::parse_portfolio_to_account_state,
+        parse::{parse_portfolio_to_account_state, use_cost_for_bar_volume},
     },
     data_types::DeribitVolatilityIndex,
 };
@@ -1935,14 +1935,15 @@ impl DeribitWsFeedHandler {
                                             Ok(bar_type) => {
                                                 let price_precision = instrument.price_precision();
                                                 let size_precision = instrument.size_precision();
-                                                let is_inverse = instrument.is_inverse();
+                                                let use_cost_for_volume =
+                                                    use_cost_for_bar_volume(instrument);
 
                                                 match parse_chart_msg(
                                                     &chart_msg,
                                                     bar_type,
                                                     price_precision,
                                                     size_precision,
-                                                    is_inverse,
+                                                    use_cost_for_volume,
                                                     self.bars_timestamp_on_close,
                                                     ts_init,
                                                 ) {

--- a/crates/adapters/deribit/src/websocket/parse.rs
+++ b/crates/adapters/deribit/src/websocket/parse.rs
@@ -659,6 +659,10 @@ pub fn resolution_to_bar_type(
 /// Converts a single OHLCV data point from the `chart.trades.{instrument}.{resolution}` channel
 /// into a Nautilus Bar object.
 ///
+/// Inverse instruments use `cost` (USD) for bar volume to match the
+/// `trades.{instrument}` channel where `amount` is in USD. Linear
+/// instruments use `volume` (base currency) directly.
+///
 /// # Errors
 ///
 /// Returns an error if:
@@ -669,6 +673,7 @@ pub fn parse_chart_msg(
     bar_type: BarType,
     price_precision: u8,
     size_precision: u8,
+    is_inverse: bool,
     timestamp_on_close: bool,
     ts_init: UnixNanos,
 ) -> anyhow::Result<Bar> {
@@ -677,8 +682,12 @@ pub fn parse_chart_msg(
     let low = Price::new_checked(chart_msg.low, price_precision).context("Invalid low price")?;
     let close =
         Price::new_checked(chart_msg.close, price_precision).context("Invalid close price")?;
-    let volume =
-        Quantity::new_checked(chart_msg.volume, size_precision).context("Invalid volume")?;
+    let raw_volume = if is_inverse {
+        chart_msg.cost
+    } else {
+        chart_msg.volume
+    };
+    let volume = Quantity::new_checked(raw_volume, size_precision).context("Invalid volume")?;
 
     // Convert timestamp from milliseconds to nanoseconds
     let mut ts_event = UnixNanos::from(chart_msg.tick * NANOSECONDS_IN_MILLISECOND);
@@ -1872,8 +1881,13 @@ mod tests {
     }
 
     #[rstest]
-    fn test_parse_chart_msg() {
+    fn test_parse_chart_msg_inverse() {
         let instrument = test_perpetual_instrument();
+        assert!(
+            instrument.is_inverse(),
+            "test fixture is expected to be an inverse perp"
+        );
+
         let json = load_test_json("ws_chart.json");
         let response: serde_json::Value = serde_json::from_str(&json).unwrap();
         let chart_msg: DeribitChartMsg =
@@ -1896,6 +1910,7 @@ mod tests {
             bar_type,
             instrument.price_precision(),
             instrument.size_precision(),
+            true, // is_inverse
             true,
             UnixNanos::default(),
         )
@@ -1906,10 +1921,36 @@ mod tests {
         assert_eq!(bar.high, instrument.make_price(87500.0));
         assert_eq!(bar.low, instrument.make_price(87465.0));
         assert_eq!(bar.close, instrument.make_price(87474.0));
-        assert_eq!(bar.volume, instrument.make_qty(1.0, None)); // Rounded to 1.0 with size_precision=0
+        assert_eq!(bar.volume, instrument.make_qty(83970.0, None));
 
         // ts_event should be close time (open + 1 minute)
         assert_eq!(bar.ts_event, UnixNanos::new(1_767_200_100_000_000_000));
+    }
+
+    #[rstest]
+    fn test_parse_chart_msg_linear_uses_volume() {
+        let instrument = test_perpetual_instrument();
+        let json = load_test_json("ws_chart.json");
+        let response: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let chart_msg: DeribitChartMsg =
+            serde_json::from_value(response["params"]["data"].clone()).unwrap();
+        let bar_type = resolution_to_bar_type(instrument.id(), "1").unwrap();
+
+        // Linear path: bar volume is the raw `volume` field (base currency),
+        // matching trade `amount` semantics on linear perps. With
+        // size_precision=0 (BTC-PERPETUAL fixture), 0.95978896 rounds to 1.0.
+        let bar = parse_chart_msg(
+            &chart_msg,
+            bar_type,
+            instrument.price_precision(),
+            instrument.size_precision(),
+            false, // is_inverse
+            true,  // timestamp_on_close
+            UnixNanos::default(),
+        )
+        .unwrap();
+
+        assert_eq!(bar.volume, instrument.make_qty(1.0, None));
     }
 
     #[rstest]

--- a/crates/adapters/deribit/src/websocket/parse.rs
+++ b/crates/adapters/deribit/src/websocket/parse.rs
@@ -659,9 +659,10 @@ pub fn resolution_to_bar_type(
 /// Converts a single OHLCV data point from the `chart.trades.{instrument}.{resolution}` channel
 /// into a Nautilus Bar object.
 ///
-/// Inverse instruments use `cost` (USD) for bar volume to match the
-/// `trades.{instrument}` channel where `amount` is in USD. Linear
-/// instruments use `volume` (base currency) directly.
+/// When `use_cost_for_volume` is true, `Bar.volume` is populated from `chart_msg.cost` (USD) to
+/// match instruments whose trade `amount` is in USD (inverse perpetuals / inverse futures).
+/// Otherwise `chart_msg.volume` (base currency) is used. Callers derive this from the instrument
+/// via [`crate::common::parse::use_cost_for_bar_volume`].
 ///
 /// # Errors
 ///
@@ -673,7 +674,7 @@ pub fn parse_chart_msg(
     bar_type: BarType,
     price_precision: u8,
     size_precision: u8,
-    is_inverse: bool,
+    use_cost_for_volume: bool,
     timestamp_on_close: bool,
     ts_init: UnixNanos,
 ) -> anyhow::Result<Bar> {
@@ -682,7 +683,7 @@ pub fn parse_chart_msg(
     let low = Price::new_checked(chart_msg.low, price_precision).context("Invalid low price")?;
     let close =
         Price::new_checked(chart_msg.close, price_precision).context("Invalid close price")?;
-    let raw_volume = if is_inverse {
+    let raw_volume = if use_cost_for_volume {
         chart_msg.cost
     } else {
         chart_msg.volume
@@ -1881,7 +1882,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_parse_chart_msg_inverse() {
+    fn test_parse_chart_msg_uses_cost() {
         let instrument = test_perpetual_instrument();
         assert!(
             instrument.is_inverse(),
@@ -1910,7 +1911,7 @@ mod tests {
             bar_type,
             instrument.price_precision(),
             instrument.size_precision(),
-            true, // is_inverse
+            true, // use_cost_for_volume
             true,
             UnixNanos::default(),
         )
@@ -1925,32 +1926,6 @@ mod tests {
 
         // ts_event should be close time (open + 1 minute)
         assert_eq!(bar.ts_event, UnixNanos::new(1_767_200_100_000_000_000));
-    }
-
-    #[rstest]
-    fn test_parse_chart_msg_linear_uses_volume() {
-        let instrument = test_perpetual_instrument();
-        let json = load_test_json("ws_chart.json");
-        let response: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let chart_msg: DeribitChartMsg =
-            serde_json::from_value(response["params"]["data"].clone()).unwrap();
-        let bar_type = resolution_to_bar_type(instrument.id(), "1").unwrap();
-
-        // Linear path: bar volume is the raw `volume` field (base currency),
-        // matching trade `amount` semantics on linear perps. With
-        // size_precision=0 (BTC-PERPETUAL fixture), 0.95978896 rounds to 1.0.
-        let bar = parse_chart_msg(
-            &chart_msg,
-            bar_type,
-            instrument.price_precision(),
-            instrument.size_precision(),
-            false, // is_inverse
-            true,  // timestamp_on_close
-            UnixNanos::default(),
-        )
-        .unwrap();
-
-        assert_eq!(bar.volume, instrument.make_qty(1.0, None));
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

On Deribit inverse perpetuals and inverse futures (e.g. `BTC-PERPETUAL`, `BTC-27DEC24`),
the chart channel's `volume` is in base currency (BTC) while the matching
`trades.{instrument}` channel reports each trade's `amount` in USD. As a result
`Bar.volume` and `TradeTick.size` were on incompatible scales. This routes those
products through the chart `cost` field (USD) — both on the live WebSocket feed
and the HTTP TradingView chart endpoint — so historical and live bars line up
with trade ticks.

Options are deliberately excluded: Deribit flags BTC/ETH options as `is_inverse`,
but per the API docs their trade `amount` is still reported in the underlying
base currency, so they keep using `volume`.

### Details

- New helper `use_cost_for_bar_volume(&InstrumentAny)` in `common/parse` centralises
  the decision: `true` only when `is_inverse() && instrument_class ∉ {Option, OptionSpread}`.
- `parse_chart_msg` (WS) and `parse_bars` (HTTP) take `use_cost_for_volume: bool`;
  `DeribitWsFeedHandler` and `DeribitHttpClient::request_bars` derive it from the
  cached instrument.
- `DeribitTradingViewChartData.cost` is no longer `#[serde(default)]` — it's a
  documented standard field of the response — and the existing length-parity
  check now covers it.
- Reference: Deribit API docs on the `amount` field — *"For perpetual and inverse
  futures the amount is in USD units. For options and linear futures it is the
  underlying base currency coin."* (https://docs.deribit.com/api-reference/market-data/public-get_last_trades_by_currency)
- Consistent with the cross-adapter invariant that `Bar.volume` and `TradeTick.size`
  share units per instrument (verified against `bitmex`, `bybit`, `binance`, `okx`,
  `hyperliquid`).

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore