### PR TITLE
Fix Lighter AccountState to include perp-side margin_balance 

### DIFF
--- a/crates/adapters/lighter/src/execution.rs
+++ b/crates/adapters/lighter/src/execution.rs
@@ -546,16 +546,22 @@ impl LighterExecutionClient {
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to set Lighter execution context: {e}"))?;
 
-                // Subscribe to the four account-scoped streams the consumption
+                // Subscribe to the five account-scoped streams the consumption
                 // loop converts into typed reports. `account_all_orders` carries
                 // OrderStatusReport-shaped events; `account_all_trades` carries
                 // discrete fills; `account_all_positions` carries position
-                // snapshots; `account_all_assets` carries balance snapshots.
+                // snapshots; `account_all_assets` carries per-asset balances
+                // (spot + perp `margin_balance`); `user_stats` carries the
+                // perp-account rollup (collateral, available_balance,
+                // margin_usage). The handler's `account_state_reconciler`
+                // merges `assets` and `user_stats` into a single AccountState
+                // — see websocket/account_state.rs.
                 let channels = [
                     LighterWsChannel::AccountAllOrders(account_index),
                     LighterWsChannel::AccountAllTrades(account_index),
                     LighterWsChannel::AccountAllPositions(account_index),
                     LighterWsChannel::AccountAllAssets(account_index),
+                    LighterWsChannel::UserStats(account_index),
                 ];
 
                 for channel in channels {
@@ -811,6 +817,9 @@ impl LighterExecutionClient {
                                     AccountStream::Assets => {
                                         dispatch.account_streams_ready.mark_assets();
                                     }
+                                    AccountStream::UserStats => {
+                                        dispatch.account_streams_ready.mark_user_stats();
+                                    }
                                 }
                             }
                             // Public market data variants reach the execution
@@ -866,6 +875,7 @@ impl LighterExecutionClient {
             LighterWsChannel::AccountAllTrades(account_index),
             LighterWsChannel::AccountAllPositions(account_index),
             LighterWsChannel::AccountAllAssets(account_index),
+            LighterWsChannel::UserStats(account_index),
         ];
 
         get_runtime().spawn(async move {
@@ -4607,6 +4617,7 @@ mod tests {
         ready.mark_trades();
         ready.mark_positions();
         ready.mark_assets();
+        ready.mark_user_stats();
     }
 
     #[tokio::test]
@@ -4646,6 +4657,7 @@ mod tests {
             ready.mark_trades();
             ready.mark_positions();
             ready.mark_assets();
+            ready.mark_user_stats();
         };
 
         let (result, ()) = tokio::join!(wait, seed);
@@ -4691,6 +4703,10 @@ mod tests {
             "pending list missing positions: {msg}",
         );
         assert!(msg.contains("assets"), "pending list missing assets: {msg}");
+        assert!(
+            msg.contains("user_stats"),
+            "pending list missing user_stats: {msg}",
+        );
     }
 
     fn test_market_order(

--- a/crates/adapters/lighter/src/websocket/account_state.rs
+++ b/crates/adapters/lighter/src/websocket/account_state.rs
@@ -1,0 +1,376 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Unified account-state reconciler for Lighter.
+//!
+//! Lighter publishes the account-state inputs across two WS streams:
+//!
+//! - `account_all_assets` — per-asset spot `balance`, spot `locked_balance`,
+//!   and perp `margin_balance` (collateral pledged to the perp side).
+//! - `user_stats`         — perp-account rollup: `collateral`,
+//!   `available_balance`, `margin_usage`.
+//!
+//! Both share the same `account_id` and both legitimately update
+//! `AccountState`. Emitting one per stream produces flip-flopping balances
+//! (see the design report for the full failure mode). This reconciler
+//! holds the latest snapshot of each input and emits **one merged
+//! `AccountState`** per update from either source.
+//!
+//! Output contract:
+//! - `AccountType::Margin` (Lighter is a unified margin venue — see
+//!   `MarginAccount` superset-of-`CashAccount` notes in the design report).
+//! - `base_currency = Some(USDC)` — Lighter is USDC-collateralized.
+//! - `balances`: one `AccountBalance` per asset reported by
+//!   `account_all_assets`, with `total = balance + margin_balance` and
+//!   `locked = locked_balance + margin_balance` (perp collateral is
+//!   unspendable as spot until withdrawn).
+//! - `margins`:  one cross-margin `MarginBalance(currency=USDC, instrument_id=None)`
+//!   with `initial = collateral − available_balance`.
+//!
+//! Emission gate: the reconciler refuses to emit until BOTH streams have
+//! delivered at least one frame. This prevents emitting half-formed state
+//! during startup that would then immediately flip when the other stream
+//! lands.
+
+use std::sync::Mutex;
+
+use ahash::AHashMap;
+use nautilus_core::UnixNanos;
+use nautilus_model::{events::AccountState, identifiers::AccountId};
+use ustr::Ustr;
+
+use super::{
+    messages::{LighterAsset, LighterUserStats},
+    parse::{
+        account_balance_from_lighter_asset, build_unified_account_state,
+        margin_balance_from_user_stats,
+    },
+};
+
+/// In-handler snapshot store for the two account-state input streams.
+///
+/// `assets` is keyed by the venue's asset-id string (matches the wire's
+/// outer map key in `account_all_assets`). Updates upsert per-key so a
+/// delta-style frame that touches only USDC doesn't wipe out a previously
+/// known ETH entry. Lighter sends full snapshots in practice today, but
+/// the upsert semantics keep us correct if that ever changes.
+#[derive(Debug, Default)]
+pub(crate) struct LighterAccountStateReconciler {
+    inner: Mutex<ReconcilerInner>,
+}
+
+#[derive(Debug, Default)]
+struct ReconcilerInner {
+    assets: AHashMap<Ustr, LighterAsset>,
+    user_stats: Option<LighterUserStats>,
+    assets_seen: bool,
+    user_stats_seen: bool,
+}
+
+impl LighterAccountStateReconciler {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clear all cached state. Use before re-subscribing on a new WS
+    /// session so the next emission reflects only fresh frames.
+    pub(crate) fn reset(&self) {
+        let mut inner = self.inner.lock().expect("reconciler mutex poisoned");
+        inner.assets.clear();
+        inner.user_stats = None;
+        inner.assets_seen = false;
+        inner.user_stats_seen = false;
+    }
+
+    /// Update the asset snapshot from an `account_all_assets` frame.
+    ///
+    /// Upsert per-key: each entry in `assets` overwrites any prior entry
+    /// with the same key; keys absent from this frame are retained.
+    /// Returns `true` once both streams have delivered, signalling the
+    /// caller to call [`Self::build_state`].
+    pub(crate) fn update_assets(&self, assets: &AHashMap<Ustr, LighterAsset>) -> bool {
+        let mut inner = self.inner.lock().expect("reconciler mutex poisoned");
+        for (key, asset) in assets {
+            inner.assets.insert(*key, asset.clone());
+        }
+        inner.assets_seen = true;
+        inner.both_seen()
+    }
+
+    /// Update the perp-rollup snapshot from a `user_stats` frame.
+    /// Returns `true` once both streams have delivered.
+    pub(crate) fn update_user_stats(&self, stats: &LighterUserStats) -> bool {
+        let mut inner = self.inner.lock().expect("reconciler mutex poisoned");
+        inner.user_stats = Some(stats.clone());
+        inner.user_stats_seen = true;
+        inner.both_seen()
+    }
+
+    /// Build the unified [`AccountState`] from the current snapshots.
+    ///
+    /// Returns `None` when either stream has not yet delivered. Returns
+    /// `Some(Err)` if any per-asset balance or the margin balance fails
+    /// to construct (negative numbers, currency mismatch, etc).
+    pub(crate) fn build_state(
+        &self,
+        account_id: AccountId,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> Option<anyhow::Result<AccountState>> {
+        let inner = self.inner.lock().expect("reconciler mutex poisoned");
+        if !inner.both_seen() {
+            return None;
+        }
+
+        let mut balances = Vec::with_capacity(inner.assets.len());
+        for asset in inner.assets.values() {
+            match account_balance_from_lighter_asset(asset) {
+                Ok(balance) => balances.push(balance),
+                Err(e) => return Some(Err(e)),
+            }
+        }
+
+        let margin = match inner
+            .user_stats
+            .as_ref()
+            .map(margin_balance_from_user_stats)
+        {
+            Some(Ok(m)) => Some(m),
+            Some(Err(e)) => return Some(Err(e)),
+            None => None,
+        };
+
+        Some(Ok(build_unified_account_state(
+            balances, margin, account_id, ts_event, ts_init,
+        )))
+    }
+}
+
+impl ReconcilerInner {
+    fn both_seen(&self) -> bool {
+        self.assets_seen && self.user_stats_seen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use nautilus_model::{
+        enums::AccountType,
+        identifiers::AccountId,
+        types::{Currency, Money},
+    };
+    use rstest::rstest;
+    use rust_decimal::Decimal;
+
+    use super::*;
+    use crate::websocket::messages::LighterUserStats;
+
+    fn account_id() -> AccountId {
+        AccountId::from("LIGHTER-728422")
+    }
+
+    fn asset_map(asset: LighterAsset) -> AHashMap<Ustr, LighterAsset> {
+        let mut map = AHashMap::new();
+        map.insert(Ustr::from(&asset.asset_id.to_string()), asset);
+        map
+    }
+
+    fn usdc_asset(spot: &str, locked: &str, perp: &str) -> LighterAsset {
+        LighterAsset {
+            symbol: Ustr::from("USDC"),
+            asset_id: 3,
+            balance: Decimal::from_str(spot).unwrap(),
+            locked_balance: Decimal::from_str(locked).unwrap(),
+            margin_balance: Decimal::from_str(perp).unwrap(),
+            margin_mode: Ustr::from("disabled"),
+        }
+    }
+
+    fn user_stats(collateral: &str, available: &str, margin_usage: &str) -> LighterUserStats {
+        LighterUserStats {
+            account_trading_mode: 0,
+            available_balance: Decimal::from_str(available).unwrap(),
+            buying_power: Decimal::ZERO,
+            collateral: Decimal::from_str(collateral).unwrap(),
+            leverage: Decimal::ZERO,
+            margin_usage: Decimal::from_str(margin_usage).unwrap(),
+            portfolio_value: Decimal::from_str(collateral).unwrap(),
+            cross_stats: None,
+            total_stats: None,
+        }
+    }
+
+    #[rstest]
+    fn reconciler_refuses_emit_until_both_streams_seen() {
+        let r = LighterAccountStateReconciler::new();
+        assert!(
+            r.build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+                .is_none()
+        );
+
+        // Only assets so far: still no emit.
+        r.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        assert!(
+            r.build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+                .is_none()
+        );
+
+        // user_stats lands → emit unblocked.
+        r.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+        let state = r
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+        assert_eq!(state.account_type, AccountType::Margin);
+    }
+
+    #[rstest]
+    fn reconciler_emits_unchanged_when_only_one_stream_updates() {
+        // Stream-ordering invariance: assets-first-then-stats and
+        // stats-first-then-assets must both produce the same merged state.
+        let r1 = LighterAccountStateReconciler::new();
+        r1.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        r1.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+        let s1 = r1
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+
+        let r2 = LighterAccountStateReconciler::new();
+        r2.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+        r2.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        let s2 = r2
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+
+        assert_eq!(s1.balances, s2.balances);
+        assert_eq!(s1.margins, s2.margins);
+        assert_eq!(s1.account_type, s2.account_type);
+        assert_eq!(s1.base_currency, s2.base_currency);
+    }
+
+    #[rstest]
+    fn reconciler_merges_spot_and_perp_into_one_balance() {
+        // 10 spot + 40 perp, no positions, no resting spot orders.
+        // Unified-margin shape: both legs are deployable equity, so
+        // total=50, locked=0, free=50. MarginBalance carries the
+        // (zero) margin-in-use breakdown.
+        let r = LighterAccountStateReconciler::new();
+        r.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        r.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+
+        let state = r
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+
+        let usdc = Currency::get_or_create_crypto("USDC");
+        assert_eq!(state.base_currency, Some(usdc));
+        assert_eq!(state.balances.len(), 1);
+        let bal = &state.balances[0];
+        assert_eq!(bal.currency, usdc);
+        assert_eq!(bal.total, Money::from("50.000000 USDC"));
+        assert_eq!(bal.locked, Money::from("0 USDC"));
+        assert_eq!(bal.free, Money::from("50.000000 USDC"));
+
+        assert_eq!(state.margins.len(), 1);
+        let margin = &state.margins[0];
+        assert_eq!(margin.currency, usdc);
+        assert_eq!(margin.initial, Money::from("0 USDC"));
+        assert!(margin.instrument_id.is_none());
+    }
+
+    #[rstest]
+    fn reconciler_tracks_position_open_via_user_stats_drift() {
+        // After opening a perp position: collateral unchanged at 40,
+        // available_balance drops to 35 (5 USDC margin in use).
+        // AccountBalance is unchanged — margin-in-use lives on
+        // MarginBalance, not in `locked`. Maintenance stays 0 because
+        // Lighter doesn't publish maintenance on `user_stats`.
+        let r = LighterAccountStateReconciler::new();
+        r.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        r.update_user_stats(&user_stats("40.0", "35.0", "12.50"));
+
+        let state = r
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+
+        let bal = &state.balances[0];
+        assert_eq!(bal.total, Money::from("50.000000 USDC"));
+        assert_eq!(bal.locked, Money::from("0 USDC"));
+        assert_eq!(bal.free, Money::from("50.000000 USDC"));
+
+        let margin = &state.margins[0];
+        assert_eq!(margin.initial, Money::from("5.000000 USDC"));
+        assert_eq!(margin.maintenance, Money::from("0 USDC"));
+    }
+
+    #[rstest]
+    fn reconciler_upserts_assets_preserves_unrelated_entries() {
+        // ETH spot reported once; later USDC-only frame must not evict ETH.
+        let mut first_frame = AHashMap::new();
+        first_frame.insert(Ustr::from("3"), usdc_asset("10.0", "0.0", "40.0"));
+        first_frame.insert(
+            Ustr::from("1"),
+            LighterAsset {
+                symbol: Ustr::from("ETH"),
+                asset_id: 1,
+                balance: Decimal::from_str("2.5").unwrap(),
+                locked_balance: Decimal::ZERO,
+                margin_balance: Decimal::ZERO,
+                margin_mode: Ustr::default(),
+            },
+        );
+        let r = LighterAccountStateReconciler::new();
+        r.update_assets(&first_frame);
+        r.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+
+        let mut second_frame = AHashMap::new();
+        second_frame.insert(Ustr::from("3"), usdc_asset("12.0", "0.0", "40.0"));
+        r.update_assets(&second_frame);
+
+        let state = r
+            .build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+            .expect("ready")
+            .expect("ok");
+
+        assert_eq!(
+            state.balances.len(),
+            2,
+            "ETH must survive the USDC-only update"
+        );
+    }
+
+    #[rstest]
+    fn reconciler_reset_clears_snapshots() {
+        let r = LighterAccountStateReconciler::new();
+        r.update_assets(&asset_map(usdc_asset("10.0", "0.0", "40.0")));
+        r.update_user_stats(&user_stats("40.0", "40.0", "0.0"));
+        assert!(
+            r.build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+                .is_some()
+        );
+
+        r.reset();
+        assert!(
+            r.build_state(account_id(), UnixNanos::default(), UnixNanos::default())
+                .is_none()
+        );
+    }
+}

--- a/crates/adapters/lighter/src/websocket/dispatch.rs
+++ b/crates/adapters/lighter/src/websocket/dispatch.rs
@@ -303,6 +303,7 @@ pub(crate) struct AccountStreamsReady {
     trades: AtomicBool,
     positions: AtomicBool,
     assets: AtomicBool,
+    user_stats: AtomicBool,
     notify: tokio::sync::Notify,
 }
 
@@ -313,6 +314,7 @@ impl AccountStreamsReady {
             trades: AtomicBool::new(false),
             positions: AtomicBool::new(false),
             assets: AtomicBool::new(false),
+            user_stats: AtomicBool::new(false),
             notify: tokio::sync::Notify::new(),
         }
     }
@@ -324,6 +326,7 @@ impl AccountStreamsReady {
         self.trades.store(false, Ordering::Release);
         self.positions.store(false, Ordering::Release);
         self.assets.store(false, Ordering::Release);
+        self.user_stats.store(false, Ordering::Release);
     }
 
     /// Mark the `account_all_orders` stream as having delivered a frame.
@@ -350,6 +353,12 @@ impl AccountStreamsReady {
         self.mark("assets", &self.assets);
     }
 
+    /// Mark the `user_stats` stream as having delivered a frame.
+    /// Idempotent: only the first call logs and notifies waiters.
+    pub(crate) fn mark_user_stats(&self) {
+        self.mark("user_stats", &self.user_stats);
+    }
+
     fn mark(&self, name: &str, flag: &AtomicBool) {
         if !flag.swap(true, Ordering::AcqRel) {
             log::debug!("Lighter {name}: first frame received");
@@ -363,6 +372,7 @@ impl AccountStreamsReady {
             && self.trades.load(Ordering::Acquire)
             && self.positions.load(Ordering::Acquire)
             && self.assets.load(Ordering::Acquire)
+            && self.user_stats.load(Ordering::Acquire)
     }
 
     fn pending(&self) -> Vec<&'static str> {
@@ -381,6 +391,10 @@ impl AccountStreamsReady {
 
         if !self.assets.load(Ordering::Acquire) {
             pending.push("assets");
+        }
+
+        if !self.user_stats.load(Ordering::Acquire) {
+            pending.push("user_stats");
         }
 
         pending
@@ -2368,7 +2382,7 @@ mod tests {
         assert!(!ready.all_ready());
         assert_eq!(
             ready.pending(),
-            vec!["orders", "trades", "positions", "assets"]
+            vec!["orders", "trades", "positions", "assets", "user_stats"]
         );
     }
 
@@ -2379,6 +2393,7 @@ mod tests {
         ready.mark_trades();
         ready.mark_positions();
         ready.mark_assets();
+        ready.mark_user_stats();
         assert!(ready.all_ready());
         assert!(ready.pending().is_empty());
     }
@@ -2389,7 +2404,7 @@ mod tests {
         ready.mark_orders();
         ready.mark_positions();
         assert!(!ready.all_ready());
-        assert_eq!(ready.pending(), vec!["trades", "assets"]);
+        assert_eq!(ready.pending(), vec!["trades", "assets", "user_stats"]);
     }
 
     #[tokio::test]
@@ -2399,6 +2414,7 @@ mod tests {
         ready.mark_trades();
         ready.mark_positions();
         ready.mark_assets();
+        ready.mark_user_stats();
         ready
             .await_all(Duration::from_millis(50))
             .await
@@ -2418,6 +2434,7 @@ mod tests {
             producer.mark_trades();
             producer.mark_positions();
             producer.mark_assets();
+            producer.mark_user_stats();
         });
 
         ready
@@ -2504,13 +2521,14 @@ mod tests {
         ready.mark_trades();
         ready.mark_positions();
         ready.mark_assets();
+        ready.mark_user_stats();
         assert!(ready.all_ready());
 
         ready.reset();
         assert!(!ready.all_ready());
         assert_eq!(
             ready.pending(),
-            vec!["orders", "trades", "positions", "assets"]
+            vec!["orders", "trades", "positions", "assets", "user_stats"]
         );
     }
 }

--- a/crates/adapters/lighter/src/websocket/handler.rs
+++ b/crates/adapters/lighter/src/websocket/handler.rs
@@ -37,17 +37,18 @@ use tokio_tungstenite::tungstenite::Message;
 use ustr::Ustr;
 
 use super::{
+    account_state::LighterAccountStateReconciler,
     error::LighterWsError,
     messages::{
-        AccountStream, ExecutionReport, LighterAsset, LighterPosition, LighterWsCandle,
-        LighterWsChannel, LighterWsChannelKind, LighterWsFrame, LighterWsOrderBook,
-        LighterWsRequest, NautilusWsMessage, SendTxRejectionSource,
+        AccountStream, ExecutionReport, LighterAsset, LighterPosition, LighterUserStats,
+        LighterWsCandle, LighterWsChannel, LighterWsChannelKind, LighterWsFrame,
+        LighterWsOrderBook, LighterWsRequest, NautilusWsMessage, SendTxRejectionSource,
     },
     parse::{
-        parse_ws_account_state, parse_ws_bar, parse_ws_funding_rate_update,
-        parse_ws_index_price_update, parse_ws_mark_price_update, parse_ws_order_book_deltas,
-        parse_ws_order_book_depth10, parse_ws_position_status_report, parse_ws_quote_tick,
-        parse_ws_spot_index_price_update, parse_ws_trade_tick,
+        parse_ws_bar, parse_ws_funding_rate_update, parse_ws_index_price_update,
+        parse_ws_mark_price_update, parse_ws_order_book_deltas, parse_ws_order_book_depth10,
+        parse_ws_position_status_report, parse_ws_quote_tick, parse_ws_spot_index_price_update,
+        parse_ws_trade_tick,
     },
 };
 use crate::{
@@ -201,6 +202,7 @@ pub(super) struct FeedHandler {
     book_states: AHashMap<i16, CachedOrderBook>,
     last_candles: AHashMap<(i16, LighterCandleResolution), LighterWsCandle>,
     exec_account: Option<(AccountId, i64)>,
+    account_state_reconciler: LighterAccountStateReconciler,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +236,7 @@ impl FeedHandler {
             book_states: AHashMap::new(),
             last_candles: AHashMap::new(),
             exec_account: None,
+            account_state_reconciler: LighterAccountStateReconciler::new(),
         }
     }
 
@@ -454,6 +457,7 @@ impl FeedHandler {
                                 self.book_states.clear();
                                 // Resubscribe replays a fresh `subscribed/candle`; pre-disconnect cache is stale.
                                 self.last_candles.clear();
+                                self.account_state_reconciler.reset();
                                 return Some(NautilusWsMessage::Reconnected);
                             }
 
@@ -738,6 +742,20 @@ impl FeedHandler {
                 let mut msgs = self.handle_account_assets(assets, timestamp, ts_init);
                 msgs.push(NautilusWsMessage::AccountStreamFirstFrame(
                     AccountStream::Assets,
+                ));
+                msgs
+            }
+            LighterWsFrame::UserStats {
+                ref stats,
+                timestamp,
+                ..
+            } => {
+                if self.exec_account.is_none() {
+                    return raw_message(&frame);
+                }
+                let mut msgs = self.handle_user_stats(stats, timestamp, ts_init);
+                msgs.push(NautilusWsMessage::AccountStreamFirstFrame(
+                    AccountStream::UserStats,
                 ));
                 msgs
             }
@@ -1220,13 +1238,53 @@ impl FeedHandler {
             }
         };
 
-        let assets_vec: Vec<&LighterAsset> = assets.values().collect();
-        match parse_ws_account_state(&assets_vec, account_id, ts_event, ts_init) {
-            Ok(state) => vec![NautilusWsMessage::AccountState(Box::new(state))],
+        self.account_state_reconciler.update_assets(assets);
+        self.emit_unified_account_state(account_id, ts_event, ts_init)
+    }
+
+    fn handle_user_stats(
+        &self,
+        stats: &LighterUserStats,
+        timestamp_ms: u64,
+        ts_init: UnixNanos,
+    ) -> Vec<NautilusWsMessage> {
+        let Some((account_id, _)) = self.exec_account else {
+            log::debug!("Lighter user_stats frame skipped: no execution context set");
+            return Vec::new();
+        };
+
+        let ts_event = match crate::common::parse::parse_millis_to_nanos(timestamp_ms) {
+            Ok(ts) => ts,
             Err(e) => {
-                log::error!("Error parsing Lighter account state: {e}");
+                log::error!("Invalid Lighter user_stats timestamp {timestamp_ms}: {e}");
+                return Vec::new();
+            }
+        };
+
+        self.account_state_reconciler.update_user_stats(stats);
+        self.emit_unified_account_state(account_id, ts_event, ts_init)
+    }
+
+    /// Asks the reconciler for a merged [`AccountState`] and wraps it as a
+    /// `NautilusWsMessage`. Returns an empty vec when the second stream
+    /// hasn't arrived yet — the AccountStreamFirstFrame marker still gets
+    /// pushed by the caller so the startup gate progresses.
+    fn emit_unified_account_state(
+        &self,
+        account_id: AccountId,
+        ts_event: UnixNanos,
+        ts_init: UnixNanos,
+    ) -> Vec<NautilusWsMessage> {
+        match self
+            .account_state_reconciler
+            .build_state(account_id, ts_event, ts_init)
+        {
+            Some(Ok(state)) => vec![NautilusWsMessage::AccountState(Box::new(state))],
+            Some(Err(e)) => {
+                log::error!("Error building unified Lighter account state: {e}");
                 Vec::new()
             }
+            None => Vec::new(),
         }
     }
 }
@@ -1348,6 +1406,7 @@ fn frame_topic(frame: &LighterWsFrame) -> String {
         | LighterWsFrame::AccountAllTrades { channel, .. }
         | LighterWsFrame::AccountAllPositions { channel, .. }
         | LighterWsFrame::AccountAllAssets { channel, .. }
+        | LighterWsFrame::UserStats { channel, .. }
         | LighterWsFrame::Height { channel, .. }
         | LighterWsFrame::CandleSnapshot { channel, .. }
         | LighterWsFrame::Candle { channel, .. } => channel.as_str().to_string(),
@@ -1404,6 +1463,7 @@ mod tests {
     use std::time::Duration;
 
     use nautilus_model::{
+        enums::AccountType,
         identifiers::{InstrumentId, Symbol, Venue},
         instruments::{CryptoPerpetual, CurrencyPair},
         types::{Currency, Money, Price, Quantity},
@@ -1426,6 +1486,11 @@ mod tests {
         include_str!("../../test_data/ws_account_all_positions_update.json");
     const WS_ACCOUNT_ALL_ASSETS_UPDATE: &str =
         include_str!("../../test_data/ws_account_all_assets_update.json");
+    const WS_USER_STATS_UPDATE: &str = include_str!("../../test_data/ws_user_stats_update.json");
+    const WS_ACCOUNT_ALL_ASSETS_WITH_POSITION: &str =
+        include_str!("../../test_data/ws_account_all_assets_with_position.json");
+    const WS_USER_STATS_WITH_POSITION: &str =
+        include_str!("../../test_data/ws_user_stats_with_position.json");
     const WS_MARKET_STATS_UPDATE_SINGLE: &str =
         include_str!("../../test_data/ws_market_stats_update_single.json");
     const WS_MARKET_STATS_UPDATE_ALL: &str =
@@ -1816,22 +1881,104 @@ mod tests {
     }
 
     #[rstest]
-    fn handle_frame_routes_account_assets_to_account_state() {
+    fn handle_frame_emits_no_account_state_until_both_streams_seen() {
+        // Reconciler refuses to emit until both `account_all_assets` and
+        // `user_stats` have delivered. An assets frame alone produces only
+        // the AccountStreamFirstFrame marker — no AccountState payload.
         let mut handler = make_handler_with_account();
-        let frame: super::LighterWsFrame =
+        let assets_only: super::LighterWsFrame =
             serde_json::from_str(WS_ACCOUNT_ALL_ASSETS_UPDATE).unwrap();
 
-        let messages = strip_account_marker(handler.handle_frame(frame, UnixNanos::from(11)));
+        let messages = strip_account_marker(handler.handle_frame(assets_only, UnixNanos::from(11)));
+
+        assert!(
+            messages.is_empty(),
+            "expected no AccountState before user_stats arrives, received {messages:?}"
+        );
+    }
+
+    #[rstest]
+    fn handle_frame_routes_account_assets_and_user_stats_to_unified_state() {
+        // Fixture is the captured production no-position payload (10 USDC
+        // on spot, 40 USDC pledged as perp collateral, no resting orders).
+        // Lighter runs unified margin: both legs are deployable equity, so
+        // total = balance + margin_balance, locked = locked_balance only,
+        // and MarginBalance.initial = 0 because user_stats.collateral ==
+        // available_balance (no margin in use).
+        let mut handler = make_handler_with_account();
+        let assets_frame: super::LighterWsFrame =
+            serde_json::from_str(WS_ACCOUNT_ALL_ASSETS_UPDATE).unwrap();
+        let user_stats_frame: super::LighterWsFrame =
+            serde_json::from_str(WS_USER_STATS_UPDATE).unwrap();
+
+        let _ = handler.handle_frame(assets_frame, UnixNanos::from(11));
+        let messages =
+            strip_account_marker(handler.handle_frame(user_stats_frame, UnixNanos::from(12)));
 
         assert_eq!(messages.len(), 1);
         match &messages[0] {
             NautilusWsMessage::AccountState(state) => {
-                assert_eq!(state.balances.len(), 1);
                 let usdc = Currency::get_or_create_crypto("USDC");
+                assert_eq!(state.account_type, AccountType::Margin);
+                assert_eq!(state.base_currency, Some(usdc));
+                assert_eq!(state.balances.len(), 1);
                 assert_eq!(state.balances[0].currency, usdc);
-                assert_eq!(state.balances[0].total, Money::from("100.000000 USDC"));
-                assert_eq!(state.balances[0].locked, Money::from("1.000000 USDC"));
+                // balance 10 + margin_balance 40 = 50 total; locked = 0
+                // (no resting spot orders); free = 50 (all deployable).
+                assert_eq!(state.balances[0].total, Money::from("50.000000 USDC"));
+                assert_eq!(state.balances[0].locked, Money::from("0 USDC"));
+                assert_eq!(state.balances[0].free, Money::from("50.000000 USDC"));
+                assert_eq!(state.margins.len(), 1);
+                assert_eq!(state.margins[0].currency, usdc);
+                assert_eq!(state.margins[0].initial, Money::from("0 USDC"));
+                assert_eq!(state.margins[0].maintenance, Money::from("0 USDC"));
+                assert!(state.margins[0].instrument_id.is_none());
                 assert!(state.is_reported);
+            }
+            other => panic!("expected account state, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn handle_frame_unified_state_reflects_open_position() {
+        // Fixture pair captured live with one open ETH-LONG position:
+        //   account_all_assets[USDC] = {balance:10, locked:0, margin_balance:39.995369556}
+        //   user_stats              = {collateral:39.995369, available:39.168314, margin_usage:2.07}
+        //
+        // The 5 mUSDC haircut on margin_balance is the entry fee. The
+        // 0.827055 USDC gap between collateral and available_balance is
+        // the initial margin pledged to the open position. AccountBalance
+        // is unchanged in shape — perp-margin-in-use lives on
+        // MarginBalance, not in `locked`. Maintenance is zero because
+        // Lighter doesn't publish a maintenance value on user_stats.
+        let mut handler = make_handler_with_account();
+        let assets_frame: super::LighterWsFrame =
+            serde_json::from_str(WS_ACCOUNT_ALL_ASSETS_WITH_POSITION).unwrap();
+        let user_stats_frame: super::LighterWsFrame =
+            serde_json::from_str(WS_USER_STATS_WITH_POSITION).unwrap();
+
+        let _ = handler.handle_frame(assets_frame, UnixNanos::from(11));
+        let messages =
+            strip_account_marker(handler.handle_frame(user_stats_frame, UnixNanos::from(12)));
+
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            NautilusWsMessage::AccountState(state) => {
+                let usdc = Currency::get_or_create_crypto("USDC");
+                assert_eq!(state.account_type, AccountType::Margin);
+                assert_eq!(state.base_currency, Some(usdc));
+                assert_eq!(state.balances.len(), 1);
+                // total = 10 + 39.995369556 = 49.99536956 (Money truncates
+                // the trailing digit to 8 decimals — matches what the
+                // production log showed).
+                assert_eq!(state.balances[0].total, Money::from("49.99536956 USDC"));
+                assert_eq!(state.balances[0].locked, Money::from("0 USDC"));
+                assert_eq!(state.balances[0].free, Money::from("49.99536956 USDC"));
+                assert_eq!(state.margins.len(), 1);
+                // initial = collateral 39.995369 − available 39.168314 = 0.827055
+                assert_eq!(state.margins[0].initial, Money::from("0.82705500 USDC"));
+                assert_eq!(state.margins[0].maintenance, Money::from("0 USDC"));
+                assert!(state.margins[0].instrument_id.is_none());
             }
             other => panic!("expected account state, was {other:?}"),
         }
@@ -1853,12 +2000,15 @@ mod tests {
             serde_json::from_str(WS_ACCOUNT_ALL_POSITIONS_UPDATE).unwrap();
         let assets_frame: super::LighterWsFrame =
             serde_json::from_str(WS_ACCOUNT_ALL_ASSETS_UPDATE).unwrap();
+        let user_stats_frame: super::LighterWsFrame =
+            serde_json::from_str(WS_USER_STATS_UPDATE).unwrap();
 
         let cases = [
             (orders_frame, AccountStream::Orders),
             (trades_frame, AccountStream::Trades),
             (positions_frame, AccountStream::Positions),
             (assets_frame, AccountStream::Assets),
+            (user_stats_frame, AccountStream::UserStats),
         ];
 
         for (frame, expected) in cases {

--- a/crates/adapters/lighter/src/websocket/messages.rs
+++ b/crates/adapters/lighter/src/websocket/messages.rs
@@ -82,7 +82,7 @@ pub enum NautilusWsMessage {
     AccountStreamFirstFrame(AccountStream),
 }
 
-/// Identifier for one of the four account-scoped WebSocket streams the
+/// Identifier for one of the five account-scoped WebSocket streams the
 /// execution client subscribes to on connect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AccountStream {
@@ -90,6 +90,7 @@ pub enum AccountStream {
     Trades,
     Positions,
     Assets,
+    UserStats,
 }
 
 /// Origin of a Lighter `sendTx` rejection signal.
@@ -221,6 +222,7 @@ pub enum LighterWsChannelKind {
     AccountAllTrades,
     AccountAllPositions,
     AccountAllAssets,
+    UserStats,
     Height,
 }
 
@@ -241,6 +243,7 @@ impl LighterWsChannelKind {
             Self::AccountAllTrades => "account_all_trades",
             Self::AccountAllPositions => "account_all_positions",
             Self::AccountAllAssets => "account_all_assets",
+            Self::UserStats => "user_stats",
             Self::Height => "height",
         }
     }
@@ -261,6 +264,7 @@ impl LighterWsChannelKind {
             "account_all_trades" => Some(Self::AccountAllTrades),
             "account_all_positions" => Some(Self::AccountAllPositions),
             "account_all_assets" => Some(Self::AccountAllAssets),
+            "user_stats" => Some(Self::UserStats),
             "height" => Some(Self::Height),
             _ => None,
         }
@@ -287,6 +291,7 @@ pub enum LighterWsChannel {
     AccountAllTrades(i64),
     AccountAllPositions(i64),
     AccountAllAssets(i64),
+    UserStats(i64),
     Height,
 }
 
@@ -307,6 +312,7 @@ impl LighterWsChannel {
             Self::AccountAllTrades(_) => LighterWsChannelKind::AccountAllTrades,
             Self::AccountAllPositions(_) => LighterWsChannelKind::AccountAllPositions,
             Self::AccountAllAssets(_) => LighterWsChannelKind::AccountAllAssets,
+            Self::UserStats(_) => LighterWsChannelKind::UserStats,
             Self::Height => LighterWsChannelKind::Height,
         }
     }
@@ -330,7 +336,8 @@ impl LighterWsChannel {
             | Self::AccountAllOrders(account_index)
             | Self::AccountAllTrades(account_index)
             | Self::AccountAllPositions(account_index)
-            | Self::AccountAllAssets(account_index) => format!("{kind}/{account_index}"),
+            | Self::AccountAllAssets(account_index)
+            | Self::UserStats(account_index) => format!("{kind}/{account_index}"),
             Self::AccountOrders {
                 market_index,
                 account_index,
@@ -362,6 +369,7 @@ impl LighterWsChannel {
                 | Self::AccountAllTrades(_)
                 | Self::AccountAllPositions(_)
                 | Self::AccountAllAssets(_)
+                | Self::UserStats(_)
         )
     }
 }
@@ -504,6 +512,12 @@ pub enum LighterWsFrame {
     AccountAllAssets {
         assets: AHashMap<Ustr, LighterAsset>,
         channel: Ustr,
+        timestamp: u64,
+    },
+    #[serde(rename = "update/user_stats", alias = "subscribed/user_stats")]
+    UserStats {
+        channel: Ustr,
+        stats: LighterUserStats,
         timestamp: u64,
     },
     #[serde(rename = "update/height")]
@@ -679,14 +693,66 @@ pub struct LighterPoolShares {
     pub entry_timestamp: u64,
 }
 
+/// Inner shape of the `user_stats.stats.cross_stats` and `.total_stats`
+/// substructs. Every field is a stringified decimal on the wire and
+/// denominated in USDC.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LighterUserStatsScoped {
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub available_balance: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub buying_power: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub collateral: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub leverage: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub margin_usage: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub portfolio_value: Decimal,
+}
+
+/// Body of the `user_stats` frame. Top-level equity numbers mirror
+/// `total_stats`; `cross_stats` reports cross-margin equity only.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LighterUserStats {
+    #[serde(default)]
+    pub account_trading_mode: i32,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub available_balance: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub buying_power: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub collateral: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub leverage: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub margin_usage: Decimal,
+    #[serde(deserialize_with = "deserialize_decimal_from_str")]
+    pub portfolio_value: Decimal,
+    pub cross_stats: Option<LighterUserStatsScoped>,
+    pub total_stats: Option<LighterUserStatsScoped>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct LighterAsset {
     pub symbol: Ustr,
     pub asset_id: i16,
+    /// Spot-side balance for this asset (USDC sitting in the wallet bucket,
+    /// non-USDC spot holdings, etc).
     #[serde(deserialize_with = "deserialize_decimal_from_str")]
     pub balance: Decimal,
+    /// Spot-side amount reserved by resting spot orders.
     #[serde(deserialize_with = "deserialize_decimal_from_str")]
     pub locked_balance: Decimal,
+    /// Perp-side collateral for this asset. USDC on Lighter today; defaults
+    /// to zero when the wire omits the field (spot-only frames).
+    #[serde(default, deserialize_with = "deserialize_decimal_from_str")]
+    pub margin_balance: Decimal,
+    /// Per-asset margin treatment. Observed values: "disabled" (asset not
+    /// pledged as collateral). Defaults to empty when the wire omits it.
+    #[serde(default)]
+    pub margin_mode: Ustr,
 }
 
 fn deserialize_trade_vec<'de, D>(deserializer: D) -> Result<Vec<LighterTrade>, D::Error>
@@ -1218,6 +1284,9 @@ mod tests {
 
     #[rstest]
     fn test_account_all_assets_frame_deserializes() {
+        // Fixture is the captured production no-position payload: USDC
+        // sits at asset_id=3, balance=10 on spot, margin_balance=40 on
+        // perp, margin_mode="disabled", no spot-order reservation.
         let frame: LighterWsFrame = serde_json::from_str(WS_ACCOUNT_ALL_ASSETS_UPDATE).unwrap();
 
         match frame {
@@ -1227,10 +1296,17 @@ mod tests {
                 timestamp,
             } => {
                 assert_eq!(channel, Ustr::from("account_all_assets:1234"));
-                let asset = assets.get(&Ustr::from("0")).unwrap();
+                let asset = assets.get(&Ustr::from("3")).unwrap();
                 assert_eq!(asset.symbol, Ustr::from("USDC"));
-                assert_eq!(asset.locked_balance, Decimal::from_str("1.000000").unwrap());
-                assert_eq!(timestamp, 1_774_883_844_933);
+                assert_eq!(asset.asset_id, 3);
+                assert_eq!(asset.balance, Decimal::from_str("10.000000").unwrap());
+                assert_eq!(asset.locked_balance, Decimal::ZERO);
+                assert_eq!(
+                    asset.margin_balance,
+                    Decimal::from_str("40.000000").unwrap()
+                );
+                assert_eq!(asset.margin_mode, Ustr::from("disabled"));
+                assert_eq!(timestamp, 1_781_161_199_648);
             }
             _ => panic!("expected account all assets frame"),
         }

--- a/crates/adapters/lighter/src/websocket/mod.rs
+++ b/crates/adapters/lighter/src/websocket/mod.rs
@@ -15,6 +15,7 @@
 
 //! WebSocket client surface for Lighter streaming endpoints.
 
+pub(crate) mod account_state;
 pub mod client;
 pub(crate) mod dispatch;
 pub mod error;

--- a/crates/adapters/lighter/src/websocket/parse.rs
+++ b/crates/adapters/lighter/src/websocket/parse.rs
@@ -57,7 +57,7 @@ use crate::{
         dispatch::{OrderIdentity, OrderShapeSnapshot},
         messages::{
             LighterAsset, LighterMarketStats, LighterPosition, LighterSpotMarketStats,
-            LighterTicker, LighterWsCandle, LighterWsOrderBook,
+            LighterTicker, LighterUserStats, LighterWsCandle, LighterWsOrderBook,
         },
     },
 };
@@ -1011,43 +1011,97 @@ pub fn parse_ws_position_status_report(
     ))
 }
 
-/// Parses a Lighter `account_all_assets` payload into an [`AccountState`].
+/// Builds the per-asset [`AccountBalance`] for one Lighter wallet entry.
 ///
-/// Lighter publishes per-asset balances with `balance` (total) and
-/// `locked_balance` (reserved for open orders or open positions). Margin is
-/// reported separately on the position stream and is not folded into this
-/// state.
+/// Lighter is a unified-margin venue: spot-side `balance` and perp-side
+/// `margin_balance` are both deployable equity. The split shows where the
+/// money currently sits, not whether it's usable. The only true lock on
+/// the trading side is `locked_balance` (resting spot orders); perp
+/// margin currently in use is tracked separately via [`MarginBalance`],
+/// not via `AccountBalance.locked`.
+///
+/// We map:
+/// - `total  = balance + margin_balance` — every unit of that currency
+///   the account owns at the venue
+/// - `locked = locked_balance` — only spot-order reservations
+/// - `free   = total - locked` (derived by `from_total_and_locked`) —
+///   all deployable equity, whether currently sitting on spot or perp
+///
+/// Perp-side margin currently allocated to positions is **not** folded
+/// into `locked`. It lives on [`MarginBalance`] and the portfolio's
+/// risk engine consumes it from there. See
+/// [`margin_balance_from_user_stats`].
 ///
 /// # Errors
 ///
-/// Returns an error if any balance value cannot be parsed.
-pub fn parse_ws_account_state(
-    assets: &[&LighterAsset],
+/// Returns an error if `AccountBalance::from_total_and_locked` rejects
+/// the computed values.
+pub fn account_balance_from_lighter_asset(asset: &LighterAsset) -> anyhow::Result<AccountBalance> {
+    let currency = Currency::get_or_create_crypto(asset.symbol.as_str());
+    let total = asset.balance + asset.margin_balance;
+    let locked = asset.locked_balance;
+    AccountBalance::from_total_and_locked(total, locked, currency)
+        .context("failed to construct Lighter account balance")
+}
+
+/// Builds the cross-margin [`MarginBalance`] from a `user_stats` frame.
+///
+/// Lighter is USDC-collateralized end-to-end. `user_stats` is the perp-side
+/// rollup; we derive:
+/// - `initial = max(collateral - available_balance, 0)` — collateral
+///   currently allocated to open positions/orders
+/// - `maintenance = 0` — Lighter does not publish maintenance margin on
+///   `user_stats`. `margin_usage` looks like a maintenance ratio but is
+///   actually the initial-margin-usage percentage
+///   (`(collateral - available) / collateral * 100`), so it carries no
+///   information about maintenance. Computing maintenance per-position
+///   from the positions stream would be more accurate; until that's
+///   wired we report zero rather than fabricate a value.
+///
+/// `instrument_id = None` routes this into `MarginAccount.account_margins`
+/// (cross margin keyed by currency), which is what the portfolio reads for
+/// venues running unified cross-margin mode.
+///
+/// # Errors
+///
+/// Returns an error if either `Money::from_decimal` call rejects the value.
+pub fn margin_balance_from_user_stats(stats: &LighterUserStats) -> anyhow::Result<MarginBalance> {
+    let usdc = Currency::get_or_create_crypto("USDC");
+    let initial_dec = (stats.collateral - stats.available_balance).max(Decimal::ZERO);
+    let initial = Money::from_decimal(initial_dec, usdc)
+        .map_err(|e| anyhow::anyhow!("failed to construct initial margin: {e}"))?;
+    let maintenance = Money::from_decimal(Decimal::ZERO, usdc)
+        .map_err(|e| anyhow::anyhow!("failed to construct maintenance margin: {e}"))?;
+    Ok(MarginBalance::new(initial, maintenance, None))
+}
+
+/// Assembles the unified [`AccountState`] from already-parsed components.
+///
+/// The reconciler in the `websocket::account_state` module owns the latest
+/// snapshot of each input stream and calls this once per emission.
+/// `AccountType::Margin` and `base_currency = Some(USDC)` are invariant for
+/// Lighter — see the design note in the adapter's account-state report.
+#[must_use]
+pub fn build_unified_account_state(
+    balances: Vec<AccountBalance>,
+    margin: Option<MarginBalance>,
     account_id: AccountId,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
-) -> anyhow::Result<AccountState> {
-    let mut balances = Vec::with_capacity(assets.len());
-
-    for asset in assets {
-        let currency = Currency::get_or_create_crypto(asset.symbol.as_str());
-        balances.push(
-            AccountBalance::from_total_and_locked(asset.balance, asset.locked_balance, currency)
-                .context("failed to construct Lighter account balance")?,
-        );
-    }
-
-    Ok(AccountState::new(
+) -> AccountState {
+    let usdc = Currency::get_or_create_crypto("USDC");
+    let margins = margin.map(|m| vec![m]).unwrap_or_default();
+    AccountState::new(
         account_id,
         AccountType::Margin,
         balances,
-        Vec::<MarginBalance>::new(),
-        true, // is_reported
+        margins,
+        true,
         UUID4::new(),
         ts_event,
         ts_init,
-        None, // base_currency: Lighter accounts are multi-currency
-    ))
+        Some(usdc),
+    )
 }
 
 fn parse_optional_event_millis(millis: i64) -> anyhow::Result<UnixNanos> {
@@ -1170,7 +1224,6 @@ fn client_order_id_from(str_field: Option<&str>, numeric_fallback: i64) -> Optio
 mod tests {
     use std::str::FromStr;
 
-    use ahash::AHashMap;
     use nautilus_model::{
         enums::{BarAggregation, ContingencyType, PriceType},
         identifiers::{InstrumentId, StrategyId, Symbol, Venue},
@@ -1710,7 +1763,7 @@ mod tests {
             trigger_price: Decimal::ZERO,
             order_expiry: 1_780_360_584_479,
             status,
-            trigger_status: crate::common::enums::LighterTriggerStatus::Na,
+            trigger_status: LighterTriggerStatus::Na,
             trigger_time: 0,
             parent_order_index: 0,
             parent_order_id: "0".to_string(),
@@ -2211,76 +2264,163 @@ mod tests {
     }
 
     #[rstest]
-    fn test_parse_ws_account_state_uses_venue_balances() {
+    fn test_account_balance_from_lighter_asset_spot_only() {
+        // Asset with only a spot balance (margin_balance=0): perp leg is
+        // empty so total == spot balance, locked == locked_balance only.
         let asset = LighterAsset {
             symbol: Ustr::from("USDC"),
             asset_id: 0,
             balance: Decimal::from_str("100.000000").unwrap(),
             locked_balance: Decimal::from_str("1.000000").unwrap(),
+            margin_balance: Decimal::ZERO,
+            margin_mode: Ustr::default(),
         };
 
-        let state = parse_ws_account_state(
-            &[&asset],
-            account_id(),
-            UnixNanos::from(1_000),
-            UnixNanos::from(1_001),
-        )
-        .unwrap();
-
-        assert_eq!(state.account_id, account_id());
-        assert_eq!(state.account_type, AccountType::Margin);
-        assert_eq!(state.balances.len(), 1);
+        let balance = account_balance_from_lighter_asset(&asset).unwrap();
         let usdc = Currency::get_or_create_crypto("USDC");
-        assert_eq!(state.balances[0].currency, usdc);
-        assert_eq!(state.balances[0].total, Money::from("100.000000 USDC"));
-        assert_eq!(state.balances[0].locked, Money::from("1.000000 USDC"));
-        assert_eq!(state.balances[0].free, Money::from("99.000000 USDC"));
-        assert!(state.is_reported);
+        assert_eq!(balance.currency, usdc);
+        assert_eq!(balance.total, Money::from("100.000000 USDC"));
+        assert_eq!(balance.locked, Money::from("1.000000 USDC"));
+        assert_eq!(balance.free, Money::from("99.000000 USDC"));
     }
 
     #[rstest]
-    fn test_parse_ws_account_state_handles_multi_asset() {
-        let usdc = LighterAsset {
+    fn test_account_balance_from_lighter_asset_combines_spot_and_perp() {
+        // Worked example: 10 USDC sitting on spot, 40 USDC pledged as
+        // perp collateral, no resting spot orders. Lighter runs unified
+        // margin — both legs are deployable equity, so the merged view
+        // is total=50, locked=0, free=50. Perp margin currently in use
+        // is tracked separately via MarginBalance, not via locked here.
+        let asset = LighterAsset {
             symbol: Ustr::from("USDC"),
-            asset_id: 0,
-            balance: Decimal::from_str("100.000000").unwrap(),
-            locked_balance: Decimal::from_str("1.000000").unwrap(),
-        };
-        let eth = LighterAsset {
-            symbol: Ustr::from("ETH"),
-            asset_id: 1,
-            balance: Decimal::from_str("2.500000").unwrap(),
+            asset_id: 3,
+            balance: Decimal::from_str("10.000000").unwrap(),
             locked_balance: Decimal::ZERO,
+            margin_balance: Decimal::from_str("40.000000").unwrap(),
+            margin_mode: Ustr::from("disabled"),
         };
 
-        let state = parse_ws_account_state(
-            &[&usdc, &eth],
+        let balance = account_balance_from_lighter_asset(&asset).unwrap();
+        assert_eq!(balance.total, Money::from("50.000000 USDC"));
+        assert_eq!(balance.locked, Money::from("0 USDC"));
+        assert_eq!(balance.free, Money::from("50.000000 USDC"));
+    }
+
+    #[rstest]
+    fn test_account_balance_from_lighter_asset_locks_only_spot_order_reservation() {
+        // A resting spot limit order locks 1 USDC. total still reflects
+        // both legs (10 + 40 = 50); locked tracks the spot reservation
+        // only, free = 49.
+        let asset = LighterAsset {
+            symbol: Ustr::from("USDC"),
+            asset_id: 3,
+            balance: Decimal::from_str("10.000000").unwrap(),
+            locked_balance: Decimal::from_str("1.000000").unwrap(),
+            margin_balance: Decimal::from_str("40.000000").unwrap(),
+            margin_mode: Ustr::from("disabled"),
+        };
+
+        let balance = account_balance_from_lighter_asset(&asset).unwrap();
+        assert_eq!(balance.total, Money::from("50.000000 USDC"));
+        assert_eq!(balance.locked, Money::from("1.000000 USDC"));
+        assert_eq!(balance.free, Money::from("49.000000 USDC"));
+    }
+
+    #[rstest]
+    fn test_margin_balance_from_user_stats_no_positions() {
+        // 40 USDC collateral, 40 available, no positions open: both initial
+        // and maintenance must be zero — strategies should see "full
+        // collateral free to deploy".
+        let stats = LighterUserStats {
+            account_trading_mode: 0,
+            available_balance: Decimal::from_str("40.000000").unwrap(),
+            buying_power: Decimal::ZERO,
+            collateral: Decimal::from_str("40.000000").unwrap(),
+            leverage: Decimal::ZERO,
+            margin_usage: Decimal::ZERO,
+            portfolio_value: Decimal::from_str("40.000000").unwrap(),
+            cross_stats: None,
+            total_stats: None,
+        };
+
+        let margin = margin_balance_from_user_stats(&stats).unwrap();
+        let usdc = Currency::get_or_create_crypto("USDC");
+        assert_eq!(margin.currency, usdc);
+        assert_eq!(margin.initial, Money::from("0 USDC"));
+        assert_eq!(margin.maintenance, Money::from("0 USDC"));
+        assert_eq!(margin.instrument_id, None);
+    }
+
+    #[rstest]
+    fn test_margin_balance_from_user_stats_with_position() {
+        // 40 USDC collateral, 35 available → 5 USDC initial margin in use.
+        // Maintenance is always 0 here: Lighter's `margin_usage` is an
+        // initial-margin-usage percent, not a maintenance ratio, so we
+        // don't derive maintenance from `user_stats` at all (see comment
+        // on `margin_balance_from_user_stats`).
+        let stats = LighterUserStats {
+            account_trading_mode: 0,
+            available_balance: Decimal::from_str("35.000000").unwrap(),
+            buying_power: Decimal::from_str("100.000000").unwrap(),
+            collateral: Decimal::from_str("40.000000").unwrap(),
+            leverage: Decimal::from_str("5.00").unwrap(),
+            margin_usage: Decimal::from_str("12.50").unwrap(),
+            portfolio_value: Decimal::from_str("40.000000").unwrap(),
+            cross_stats: None,
+            total_stats: None,
+        };
+
+        let margin = margin_balance_from_user_stats(&stats).unwrap();
+        assert_eq!(margin.initial, Money::from("5.000000 USDC"));
+        assert_eq!(margin.maintenance, Money::from("0 USDC"));
+    }
+
+    #[rstest]
+    fn test_build_unified_account_state_emits_margin_account() {
+        let asset = LighterAsset {
+            symbol: Ustr::from("USDC"),
+            asset_id: 3,
+            balance: Decimal::from_str("10.000000").unwrap(),
+            locked_balance: Decimal::ZERO,
+            margin_balance: Decimal::from_str("40.000000").unwrap(),
+            margin_mode: Ustr::from("disabled"),
+        };
+        let balances = vec![account_balance_from_lighter_asset(&asset).unwrap()];
+
+        let stats = LighterUserStats {
+            account_trading_mode: 0,
+            available_balance: Decimal::from_str("40.000000").unwrap(),
+            buying_power: Decimal::ZERO,
+            collateral: Decimal::from_str("40.000000").unwrap(),
+            leverage: Decimal::ZERO,
+            margin_usage: Decimal::ZERO,
+            portfolio_value: Decimal::from_str("40.000000").unwrap(),
+            cross_stats: None,
+            total_stats: None,
+        };
+        let margin = margin_balance_from_user_stats(&stats).unwrap();
+
+        let state = build_unified_account_state(
+            balances,
+            Some(margin),
             account_id(),
             UnixNanos::from(1_000),
             UnixNanos::from(1_001),
-        )
-        .unwrap();
+        );
 
-        assert_eq!(state.balances.len(), 2);
-        let usdc_currency = Currency::get_or_create_crypto("USDC");
-        let eth_currency = Currency::get_or_create_crypto("ETH");
-        let by_currency: AHashMap<_, _> = state.balances.iter().map(|b| (b.currency, b)).collect();
-        assert_eq!(
-            by_currency[&usdc_currency].total,
-            Money::from("100.000000 USDC"),
-        );
-        assert_eq!(
-            by_currency[&usdc_currency].locked,
-            Money::from("1.000000 USDC"),
-        );
-        assert_eq!(
-            by_currency[&eth_currency].total,
-            Money::from("2.500000 ETH"),
-        );
-        assert_eq!(
-            by_currency[&eth_currency].locked,
-            Money::from("0.000000 ETH"),
-        );
+        let usdc = Currency::get_or_create_crypto("USDC");
+        assert_eq!(state.account_id, account_id());
+        assert_eq!(state.account_type, AccountType::Margin);
+        assert_eq!(state.base_currency, Some(usdc));
+        assert!(state.is_reported);
+        assert_eq!(state.balances.len(), 1);
+        assert_eq!(state.balances[0].total, Money::from("50.000000 USDC"));
+        assert_eq!(state.balances[0].locked, Money::from("0 USDC"));
+        assert_eq!(state.balances[0].free, Money::from("50.000000 USDC"));
+        assert_eq!(state.margins.len(), 1);
+        assert_eq!(state.margins[0].currency, usdc);
+        assert_eq!(state.margins[0].initial, Money::from("0 USDC"));
+        assert!(state.margins[0].instrument_id.is_none());
     }
 
     fn stub_candle() -> LighterWsCandle {

--- a/crates/adapters/lighter/test_data/ws_account_all_assets_with_position.json
+++ b/crates/adapters/lighter/test_data/ws_account_all_assets_with_position.json
@@ -6,10 +6,10 @@
       "balance": "10.000000",
       "locked_balance": "0.000000",
       "margin_mode": "disabled",
-      "margin_balance": "40.000000"
+      "margin_balance": "39.995369556"
     }
   },
   "channel": "account_all_assets:1234",
-  "timestamp": 1781161199648,
+  "timestamp": 1781161854676,
   "type": "subscribed/account_all_assets"
 }

--- a/crates/adapters/lighter/test_data/ws_user_stats_update.json
+++ b/crates/adapters/lighter/test_data/ws_user_stats_update.json
@@ -1,0 +1,30 @@
+{
+  "channel": "user_stats:1234",
+  "stats": {
+    "account_trading_mode": 0,
+    "available_balance": "40.000000",
+    "buying_power": "0",
+    "collateral": "40.000000",
+    "leverage": "0.00",
+    "margin_usage": "0.00",
+    "portfolio_value": "40.000000",
+    "cross_stats": {
+      "available_balance": "40.000000",
+      "buying_power": "0",
+      "collateral": "40.000000",
+      "leverage": "0.00",
+      "margin_usage": "0.00",
+      "portfolio_value": "40.000000"
+    },
+    "total_stats": {
+      "available_balance": "40.000000",
+      "buying_power": "0",
+      "collateral": "40.000000",
+      "leverage": "0.00",
+      "margin_usage": "0.00",
+      "portfolio_value": "40.000000"
+    }
+  },
+  "timestamp": 1781161199649,
+  "type": "subscribed/user_stats"
+}

--- a/crates/adapters/lighter/test_data/ws_user_stats_with_position.json
+++ b/crates/adapters/lighter/test_data/ws_user_stats_with_position.json
@@ -1,0 +1,30 @@
+{
+  "channel": "user_stats:1234",
+  "stats": {
+    "account_trading_mode": 0,
+    "available_balance": "39.168314",
+    "buying_power": "0",
+    "collateral": "39.995369",
+    "leverage": "0.41",
+    "margin_usage": "2.07",
+    "portfolio_value": "39.995169",
+    "cross_stats": {
+      "available_balance": "39.168314",
+      "buying_power": "0",
+      "collateral": "39.995369",
+      "leverage": "0.41",
+      "margin_usage": "2.07",
+      "portfolio_value": "39.995169"
+    },
+    "total_stats": {
+      "available_balance": "39.168314",
+      "buying_power": "0",
+      "collateral": "39.995369",
+      "leverage": "0.41",
+      "margin_usage": "2.07",
+      "portfolio_value": "39.995169"
+    }
+  },
+  "timestamp": 1781161854677,
+  "type": "subscribed/user_stats"
+}

--- a/crates/adapters/lighter/tests/exec_client.rs
+++ b/crates/adapters/lighter/tests/exec_client.rs
@@ -370,6 +370,21 @@ fn account_subscribed_frame(channel: &str) -> Option<Value> {
             "assets": {},
             "timestamp": 1_700_000_000_000_u64,
         }))
+    } else if channel.starts_with("user_stats:") {
+        Some(json!({
+            "type": "subscribed/user_stats",
+            "channel": channel,
+            "stats": {
+                "account_trading_mode": 0,
+                "available_balance": "0",
+                "buying_power": "0",
+                "collateral": "0",
+                "leverage": "0",
+                "margin_usage": "0",
+                "portfolio_value": "0"
+            },
+            "timestamp": 1_700_000_000_000_u64,
+        }))
     } else {
         None
     }
@@ -1261,14 +1276,20 @@ async fn test_connect_disconnect_lifecycle() {
 
     // Drive the strict-await readiness gate manually so the test pins the
     // ordering contract: `connect()` must remain pending until each of the
-    // four account streams has delivered a first frame.
+    // five account streams has delivered a first frame.
     state
         .auto_emit_account_subscribed_frames
         .store(false, Ordering::Relaxed);
 
     assert!(!client.is_connected());
 
-    let channel_for = |stream: &str| format!("account_all_{stream}:{TEST_ACCOUNT_INDEX}");
+    let channel_for = |stream: &str| -> String {
+        if stream == "user_stats" {
+            format!("user_stats:{TEST_ACCOUNT_INDEX}")
+        } else {
+            format!("account_all_{stream}:{TEST_ACCOUNT_INDEX}")
+        }
+    };
     let orders_frame =
         account_subscribed_frame(&channel_for("orders")).expect("orders frame template");
     let trades_frame =
@@ -1277,22 +1298,25 @@ async fn test_connect_disconnect_lifecycle() {
         account_subscribed_frame(&channel_for("positions")).expect("positions frame template");
     let assets_frame =
         account_subscribed_frame(&channel_for("assets")).expect("assets frame template");
+    let user_stats_frame =
+        account_subscribed_frame(&channel_for("user_stats")).expect("user_stats frame template");
 
     {
         let mut connect_fut = std::pin::pin!(client.connect());
 
-        // Race connect against the first three frames; connect must stay
+        // Race connect against the first four frames; connect must stay
         // pending after each push since the strict-await gate requires all
-        // four streams to land.
-        let push_three = {
+        // five streams to land.
+        let push_four = {
             let state = Arc::clone(&state);
             let frames = [
                 orders_frame.clone(),
                 trades_frame.clone(),
                 positions_frame.clone(),
+                assets_frame.clone(),
             ];
             async move {
-                await_subscribe_count(&state, 4).await;
+                await_subscribe_count(&state, 5).await;
                 for frame in frames {
                     state.push_frame(&frame);
                     tokio::time::sleep(Duration::from_millis(80)).await;
@@ -1305,16 +1329,16 @@ async fn test_connect_disconnect_lifecycle() {
 
         tokio::select! {
             result = &mut connect_fut => {
-                panic!("connect returned with fewer than four account frames: {result:?}");
+                panic!("connect returned with fewer than five account frames: {result:?}");
             }
-            () = push_three => {}
+            () = push_four => {}
         }
 
-        // Push the fourth frame; connect must now return promptly.
-        state.push_frame(&assets_frame);
+        // Push the fifth frame; connect must now return promptly.
+        state.push_frame(&user_stats_frame);
         tokio::time::timeout(Duration::from_secs(2), &mut connect_fut)
             .await
-            .expect("connect did not return after the fourth account frame")
+            .expect("connect did not return after the fifth account frame")
             .expect("connect");
     }
 
@@ -1331,8 +1355,8 @@ async fn test_connect_disconnect_lifecycle() {
 
     let subs = state.subscribes().await;
     assert!(
-        subs.len() >= 4,
-        "expected at least 4 account subscribes, was {}",
+        subs.len() >= 5,
+        "expected at least 5 account subscribes, was {}",
         subs.len(),
     );
     let channels: Vec<&str> = subs
@@ -1343,6 +1367,7 @@ async fn test_connect_disconnect_lifecycle() {
     assert!(channels.iter().any(|c| c == &"account_all_trades/12345"));
     assert!(channels.iter().any(|c| c == &"account_all_positions/12345"));
     assert!(channels.iter().any(|c| c == &"account_all_assets/12345"));
+    assert!(channels.iter().any(|c| c == &"user_stats/12345"));
 
     // Subscribe frames must carry the L2 auth token; the data-client tests
     // pin the token shape via the REST `auth=` parameter, here the same
@@ -1456,8 +1481,8 @@ async fn connect_bails_when_integrator_auto_approval_reports_unapproved() {
 
 /// Pins the per-stream marker dispatch in the execution consumption loop.
 ///
-/// Each parametric case drives a different stream as the FOURTH (last) frame.
-/// A regression that crosses any of the four `AccountStreamFirstFrame` arms
+/// Each parametric case drives a different stream as the FIFTH (last) frame.
+/// A regression that crosses any of the five `AccountStreamFirstFrame` arms
 /// (for example, the `Assets` arm calling `mark_orders()` instead of
 /// `mark_assets()`) would leave the named stream unmarked even after its
 /// frame lands. The final `connect_fut` await would then time out, failing
@@ -1467,6 +1492,7 @@ async fn connect_bails_when_integrator_auto_approval_reports_unapproved() {
 #[case::trades_last("trades")]
 #[case::positions_last("positions")]
 #[case::assets_last("assets")]
+#[case::user_stats_last("user_stats")]
 #[tokio::test(flavor = "multi_thread")]
 async fn connect_returns_only_after_each_distinct_stream_marks_its_own_flag(
     #[case] last_stream: &str,
@@ -1478,15 +1504,21 @@ async fn connect_returns_only_after_each_distinct_stream_marks_its_own_flag(
         .auto_emit_account_subscribed_frames
         .store(false, Ordering::Relaxed);
 
-    let channel_for = |stream: &str| format!("account_all_{stream}:{TEST_ACCOUNT_INDEX}");
+    // `user_stats` uses a flat channel name; the other four share the
+    // `account_all_*` prefix.
+    let channel_for = |stream: &str| -> String {
+        if stream == "user_stats" {
+            format!("user_stats:{TEST_ACCOUNT_INDEX}")
+        } else {
+            format!("account_all_{stream}:{TEST_ACCOUNT_INDEX}")
+        }
+    };
     let frame_for =
         |stream: &str| account_subscribed_frame(&channel_for(stream)).expect("frame template");
+    let all_streams = ["orders", "trades", "positions", "assets", "user_stats"];
     let frames: std::collections::HashMap<&str, Value> =
-        ["orders", "trades", "positions", "assets"]
-            .iter()
-            .map(|s| (*s, frame_for(s)))
-            .collect();
-    let first_three: Vec<Value> = ["orders", "trades", "positions", "assets"]
+        all_streams.iter().map(|s| (*s, frame_for(s))).collect();
+    let first_four: Vec<Value> = all_streams
         .iter()
         .filter(|s| **s != last_stream)
         .map(|s| frames[*s].clone())
@@ -1496,11 +1528,11 @@ async fn connect_returns_only_after_each_distinct_stream_marks_its_own_flag(
     {
         let mut connect_fut = std::pin::pin!(client.connect());
 
-        let push_first_three = {
+        let push_first_four = {
             let state = Arc::clone(&state);
             async move {
-                await_subscribe_count(&state, 4).await;
-                for frame in first_three {
+                await_subscribe_count(&state, 5).await;
+                for frame in first_four {
                     state.push_frame(&frame);
                     tokio::time::sleep(Duration::from_millis(80)).await;
                 }
@@ -1514,7 +1546,7 @@ async fn connect_returns_only_after_each_distinct_stream_marks_its_own_flag(
                     "connect returned before {last_stream} frame landed: {result:?}",
                 );
             }
-            () = push_first_three => {}
+            () = push_first_four => {}
         }
 
         state.push_frame(&last_frame);
@@ -2466,18 +2498,18 @@ async fn test_batch_cancel_orders_sends_one_cancel_order_batch() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reconnect_replays_authenticated_account_subscriptions() {
     // The WS layer auto-reconnects on a server-initiated close. After the
-    // reconnect the 4 account-stream subscribes must replay with their
+    // reconnect the 5 account-stream subscribes must replay with their
     // auth token; otherwise the typed execution stream would silently
     // drop. The data-client variant of this test pins the public-channel
     // replay; this pins the authenticated path.
     let (addr, state) = start_server().await;
     let (mut client, _rx, _cache) = build_client(addr);
     client.connect().await.expect("connect");
-    await_subscribe_count(&state, 4).await;
+    await_subscribe_count(&state, 5).await;
 
     // Arm the server-side close. The next inbound frame from the client
     // closes the socket; we then send a no-op cancel to fire that frame.
-    // Reconnect drives a full replay of the 4 tracked subscriptions.
+    // Reconnect drives a full replay of the 5 tracked subscriptions.
     state.close_after_next_frame.store(true, Ordering::Relaxed);
     let _ = client.cancel_order(CancelOrder::new(
         trader_id(),
@@ -2502,6 +2534,7 @@ async fn test_reconnect_replays_authenticated_account_subscriptions() {
                     "account_all_trades",
                     "account_all_positions",
                     "account_all_assets",
+                    "user_stats",
                 ]
                 .iter()
                 .all(|prefix| {
@@ -2519,11 +2552,8 @@ async fn test_reconnect_replays_authenticated_account_subscriptions() {
     // Sanity-check that every replayed subscribe still carries auth.
     let subs = state.subscribes().await;
     for sub in &subs {
-        if sub["channel"]
-            .as_str()
-            .unwrap_or("")
-            .starts_with("account_all_")
-        {
+        let channel = sub["channel"].as_str().unwrap_or("");
+        if channel.starts_with("account_all_") || channel.starts_with("user_stats") {
             assert!(
                 sub.get("auth").and_then(Value::as_str).is_some(),
                 "account-stream subscribe missing auth: {sub:?}",


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices


## Summary

The Lighter adapter previously had no `user_stats` channel and treated `account_all_assets` as the sole source of account state. On Lighter, account balances are split across two WS streams: per-asset wallet figures (`account_all_assets`) and a perp-side rollup (`user_stats`). Subscribing to either alone produces an incomplete `AccountState` — strategies see USDC=0 because Lighter parks user funds on the perp side as `margin_balance`, which the current `LighterAsset` deserializer silently drops.

This PR adds the `user_stats` subscription, extends `LighterAsset` to capture `margin_balance` + `margin_mode`, and introduces a reconciler that merges the two streams into a single unified `AccountState` so the cache never flip-flops between two competing emitters with the same `account_id`. The merged shape matches the cross-margin convention already established by Bybit, OKX, Deribit, and BitMEX.

## Context: the wire shape

Sampled directly from a Lighter mainnet account holding 10 USDC on the spot side and 40 USDC pledged as perp collateral:

```jsonc
// account_all_assets — per-asset wallet view
{
  "assets": {
    "3": {
      "symbol": "USDC",
      "asset_id": 3,
      "balance": "10.000000",          // spot side
      "locked_balance": "0.000000",    // reserved by resting spot orders
      "margin_mode": "disabled",
      "margin_balance": "40.000000"    // perp-side collateral
    }
  }
}

// user_stats — perp-account rollup
{
  "stats": {
    "collateral":        "40.000000",  // sum of margin_balance per asset
    "available_balance": "40.000000",  // collateral - margin_in_use
    "margin_usage":      "0.00",       // initial-margin-usage percent
    "portfolio_value":   "40.000000",  // collateral + unrealized PnL
    "leverage":          "0.00",
    "buying_power":      "0",
    "account_trading_mode": 0,
    "cross_stats":  { /* same shape */ },
    "total_stats":  { /* same shape */ }
  }
}
```

Pre-PR, the parser only saw `balance` and `locked_balance` — `margin_balance` was silently dropped. Account state read `total=10 USDC` while the user owned 50 and the strategy had 40 USDC of perp margin to deploy.

## Design

A single emitter, single shape:

- **`AccountType::Margin`** unconditionally. Lighter is a unified-margin venue and `MarginAccount` is a strict superset of `CashAccount` for trading purposes — its `calculate_balance_locked` / `calculate_pnls` accept spot `CurrencyPair` instruments as easily as `CryptoPerpetual`. Choosing Cash would discard the `MarginBalance` table the portfolio reads.
- **`base_currency = Some(USDC)`** unconditionally. Lighter is single-collateral USDC end-to-end; there is no alternative quote-side collateral. See "Consistency with other adapters" below for why this differs from Bybit/OKX which use `None`.
- **`account_id = LIGHTER-{account_index}`** — one account per credential, no spot/perp suffix.
- **Per-asset `AccountBalance`** with:
  - `total  = balance + margin_balance` — every unit of that currency the account owns at the venue
  - `locked = locked_balance` — **only** spot-order reservations; perp collateral is not a lock, it's where the money sits
  - `free   = total - locked` (derived) — deployable equity, whether currently sitting on spot or perp
- **Cross-margin `MarginBalance(currency=USDC, instrument_id=None)`** with:
  - `initial     = max(collateral - available_balance, 0)` — collateral currently allocated to open positions/orders
  - `maintenance = 0` — Lighter does not publish maintenance on `user_stats`. `margin_usage` superficially looks like a maintenance ratio but is actually an initial-margin-usage percent (`(collateral - available) / collateral * 100`), so it carries no information about maintenance. Reporting zero rather than fabricating.
- **One emission** per merged update. The reconciler holds the latest snapshot of each input and only emits after both streams have delivered. Subscribing to one stream without the other would deadlock the wait.

This avoids the failure mode where two emitters compete on the same `account_id` and the cache (`common/src/cache/mod.rs::update_account_state`) flip-flops USDC values between them — `MarginAccount::apply` is upsert-by-currency-key and would never reconcile the conflict.


## Implementation

| File | Change |
|---|---|
| `messages.rs` | New `LighterUserStats` / `LighterUserStatsScoped` typed payloads; new `LighterWsFrame::UserStats`; new `LighterWsChannel::UserStats(i64)` + `LighterWsChannelKind::UserStats`; new `AccountStream::UserStats` enum variant; **extend `LighterAsset` with `margin_balance: Decimal` and `margin_mode: Ustr`** (both `#[serde(default, ...)]` for backward compat with older snapshots) |
| `parse.rs` | Component builders: `account_balance_from_lighter_asset`, `margin_balance_from_user_stats`, `build_unified_account_state`. The old `parse_ws_account_state` (which emitted `AccountState` with `AccountType::Margin` and `base_currency=None` from `account_all_assets` alone) is removed |
| `account_state.rs` *(new)* | `LighterAccountStateReconciler` — mutex-guarded snapshot store + `build_state()` that returns `None` until both streams have delivered, then `Some(Ok(AccountState))`. Asset map upserts per-key so a delta frame that touches USDC doesn't wipe a tracked ETH entry |
| `handler.rs` | `FeedHandler` owns the reconciler; `handle_account_assets` + `handle_user_stats` feed it; `emit_unified_account_state` is the single emission point. Reconciler resets on the `RECONNECTED` sentinel so a new session waits for both streams. `frame_topic` covers UserStats |
| `dispatch.rs` | `AccountStreamsReady` gains a `user_stats` flag — startup gate now waits for all five streams |
| `execution.rs` | Subscribes the execution client to `UserStats(account_index)` alongside the existing four account-scoped streams; dispatches `mark_user_stats()` on `AccountStreamFirstFrame(UserStats)` |
| `tests/exec_client.rs` | Integration tests updated for the five-stream gate (parametric per-stream marker test, lifecycle, reconnect replay) |
| `test_data/` | Two captured production payload pairs: `ws_account_all_assets_update.json` + `ws_user_stats_update.json` (no positions) and the same with `_with_position` suffix (open ETH-LONG, real numbers including the 5 mUSDC entry fee on `margin_balance` and the unrealized-PnL drift on `user_stats.available_balance`) |

## Worked example (real wire data, mainnet)

**No positions, no resting orders** — 10 USDC spot + 40 USDC perp collateral:

```
AccountState {
    account_id: "LIGHTER-728422",
    account_type: Margin,
    base_currency: Some(USDC),
    balances: [
        AccountBalance(total=50.00 USDC, locked=0.00, free=50.00),
    ],
    margins: [
        MarginBalance(initial=0.00 USDC, maintenance=0.00, instrument_id=None),
    ],
}
```

**One open ETH-LONG position** consuming ~0.83 USDC initial margin (`collateral=39.995369, available_balance=39.168314`):

```
AccountState {
    balances: [
        AccountBalance(total=49.99536956 USDC, locked=0.00, free=49.99536956),
    ],
    margins: [
        MarginBalance(initial=0.82705500 USDC, maintenance=0.00, instrument_id=None),
    ],
}
```

The position consumes margin via `MarginBalance.initial`; `AccountBalance` shape is unchanged because the funds still belong to the account, just reallocated within the perp side. The 5 mUSDC haircut on `AccountBalance.total` (49.995 vs 50.000) is the entry fee deducted from `margin_balance` on the wire. As ETH ticks up, `MarginBalance.initial` drops towards 0.82031 as the unrealized profit covers some of its own margin requirement — pinned by the `reconciler_tracks_position_open_via_user_stats_drift` test.

## Consistency with other adapters

Surveyed `AccountState` construction across Bybit, OKX, Deribit, Binance, dYdX, Hyperliquid, BitMEX, Kraken, Coinbase, and Polymarket. Lighter aligns on every core decision with one stylistic difference and one architectural difference, both forced by the venue.

**Matches the prevailing convention:**

| Decision | Matches |
|---|---|
| `AccountType::Margin` (fixed) | Bybit, OKX, Deribit, dYdX, BitMEX, Hyperliquid, Kraken-Futures |
| `MarginBalance` with `instrument_id = None` (cross-margin keyed by currency) | Bybit, OKX, Deribit, BitMEX |
| `MarginBalance.initial` derived from a wire field (not computed) | Bybit (`position_im + order_im`), OKX (`imr`), Deribit (`initial_margin`), BitMEX (`init_margin / divisor`) |
| Per-asset `AccountBalance` via `from_total_and_locked` / `from_total_and_free` | Bybit, OKX, Coinbase, BitMEX |
| `is_reported = true` | All margin venues |
| `account_id` format `{VENUE}-{id}` | All adapters |

**Intentional divergences:**

1. **`base_currency = Some(USDC)`** vs `None` on every other adapter. Bybit, OKX etc. use `None` because they allow multiple quote currencies (USDT, USDC, BTC for inverse) and the portfolio falls back to per-instrument `settlement_currency()`. Lighter has only USDC as collateral, so `Some(USDC)` is strictly accurate and functionally equivalent to `None` (every Lighter instrument's `settlement_currency()` is USDC anyway). Happy to switch to `None` if the maintainer prefers stylistic alignment.

2. **Two-stream reconciliation** vs single-source on every other adapter. Bybit, OKX, Deribit, BitMEX, Coinbase, dYdX all build `AccountState` from one HTTP wallet endpoint or one WS message. Lighter has no equivalent HTTP `request_account_state()` — the venue's account-state surface is exclusively WS, split across `account_all_assets` (per-asset wallet + perp collateral) and `user_stats` (perp-account rollup). Neither alone has the full picture: without `user_stats`, `MarginBalance.initial` is always zero; without `account_all_assets`, non-USDC balances and the spot/perp split are missing. The reconciler is the only way to map this venue onto Nautilus' single-`AccountState` contract. Closest precedent is dYdX (`http/parse.rs:1468`) which combines HTTP subaccount + positions + oracle prices, also multi-source assembly, just synchronous over HTTP rather than via WS-stream reconciliation.

Cross-margin (`instrument_id = None`) is correct here because `user_stats` is an account-level rollup, not per-instrument. dYdX is the one outlier — it emits `MarginBalance` per-instrument because its margin model is per-position rather than aggregated.


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore