### PR TITLE
Add benchmark-relative portfolio statistics

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@ Released on TBD (UTC).
 - Added negative price support for `Commodity` instruments in risk checks (#2330), thanks for reporting @fabz1
 - Added `add_native_exec_algorithm` and `ExecutionAlgorithmConfig` bindings to the Python v2 backtest engine
 - Added `Order::to_order_status_report` conversion in Rust
+- Added benchmark-relative portfolio statistics (Beta, Alpha, Information Ratio, Tracking Error, Treynor) (#4229), thanks @mahimn01
 
 ### Breaking Changes
 - Changed plug-in loader to reject build mismatches by default; opt out with `set_allow_build_mismatch` (Rust)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@ Released on TBD (UTC).
 - Added negative price support for `Commodity` instruments in risk checks (#2330), thanks for reporting @fabz1
 - Added `add_native_exec_algorithm` and `ExecutionAlgorithmConfig` bindings to the Python v2 backtest engine
 - Added `Order::to_order_status_report` conversion in Rust
-- Added benchmark-relative portfolio statistics (Beta, Alpha, Information Ratio, Tracking Error, Treynor) (#4229), thanks @mahimn01
+- Added benchmark-relative portfolio statistics (Beta, Alpha, Information Ratio, Tracking Error, Treynor Ratio) (#4251), thanks @mahimn01
 
 ### Breaking Changes
 - Changed plug-in loader to reject build mismatches by default; opt out with `set_allow_build_mismatch` (Rust)

--- a/crates/analysis/src/analyzer.rs
+++ b/crates/analysis/src/analyzer.rs
@@ -549,7 +549,7 @@ impl PortfolioAnalyzer {
     /// Gets all benchmark-relative return statistics for the primary returns.
     ///
     /// This is stateless: the `benchmark` series is supplied by the caller rather
-    /// than stored on the analyzer. Only statistics that implement
+    /// than stored on the analyzer. Only statistics that override
     /// [`PortfolioStatistic::calculate_from_returns_with_benchmark`] (the benchmark-relative
     /// statistics) contribute values; all others return `None` and are skipped.
     #[must_use]
@@ -714,6 +714,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::statistics::beta_ratio::BetaRatio;
 
     /// Mock implementation of `PortfolioStatistic` for testing.
     #[derive(Debug)]
@@ -1445,5 +1446,39 @@ mod tests {
             epsilon = 1e-9
         ));
         assert_eq!(returns_stats, portfolio_stats);
+    }
+
+    #[rstest]
+    fn test_get_performance_stats_returns_vs_benchmark() {
+        let mut analyzer = PortfolioAnalyzer::new();
+        analyzer.register_statistic(Arc::new(BetaRatio::new()));
+        analyzer.register_statistic(Arc::new(SharpeRatio::new(None)));
+
+        let one_day = 86_400_000_000_000_u64;
+        let start = 1_600_000_000_000_000_000_u64;
+        for (i, value) in [0.03, -0.01, 0.02, 0.04].iter().enumerate() {
+            analyzer.add_return(UnixNanos::from(start + i as u64 * one_day), *value);
+        }
+
+        let mut benchmark: Returns = BTreeMap::new();
+        for (i, value) in [0.01, 0.005, 0.005, 0.01].iter().enumerate() {
+            benchmark.insert(UnixNanos::from(start + i as u64 * one_day), *value);
+        }
+
+        let stats = analyzer.get_performance_stats_returns_vs_benchmark(&benchmark);
+
+        // r = [0.03, -0.01, 0.02, 0.04], b = [0.01, 0.005, 0.005, 0.01]:
+        //   mean_r = 0.02, mean_b = 0.0075
+        //   Cov = 1.5e-4 / 3 = 5e-5, Var(b) = 2.5e-5 / 3 -> beta = 6.0
+        // Only the benchmark-relative statistic contributes; SharpeRatio
+        // returns None from the default and is skipped.
+        assert_eq!(stats.len(), 1);
+        assert!(approx_eq!(
+            f64,
+            *stats.get("Beta").unwrap(),
+            6.0,
+            epsilon = 1e-9
+        ));
+        assert!(!stats.contains_key("Sharpe Ratio (252 days)"));
     }
 }

--- a/crates/analysis/src/analyzer.rs
+++ b/crates/analysis/src/analyzer.rs
@@ -546,6 +546,30 @@ impl PortfolioAnalyzer {
         self.calculate_returns_stats(self.portfolio_returns())
     }
 
+    /// Gets all benchmark-relative return statistics for the primary returns.
+    ///
+    /// This is stateless: the `benchmark` series is supplied by the caller rather
+    /// than stored on the analyzer. Only statistics that implement
+    /// [`PortfolioStatistic::calculate_from_returns_with_benchmark`] (the benchmark-relative
+    /// statistics) contribute values; all others return `None` and are skipped.
+    #[must_use]
+    pub fn get_performance_stats_returns_vs_benchmark(
+        &self,
+        benchmark: &Returns,
+    ) -> AHashMap<String, f64> {
+        let mut output = AHashMap::new();
+
+        for (name, stat) in &self.statistics {
+            if let Some(value) =
+                stat.calculate_from_returns_with_benchmark(self.returns(), benchmark)
+            {
+                output.insert(name.clone(), value);
+            }
+        }
+
+        output
+    }
+
     /// Gets general portfolio statistics.
     #[must_use]
     pub fn get_performance_stats_general(&self) -> AHashMap<String, f64> {

--- a/crates/analysis/src/python/analyzer.rs
+++ b/crates/analysis/src/python/analyzer.rs
@@ -217,12 +217,12 @@ impl PortfolioAnalyzer {
                 let stat = statistic.extract::<LongRatio>(py)?;
                 self.register_statistic(Arc::new(stat));
             }
-            "BetaRatio" => {
-                let stat = statistic.extract::<BetaRatio>(py)?;
-                self.register_statistic(Arc::new(stat));
-            }
             "Alpha" => {
                 let stat = statistic.extract::<Alpha>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
+            "BetaRatio" => {
+                let stat = statistic.extract::<BetaRatio>(py)?;
                 self.register_statistic(Arc::new(stat));
             }
             "InformationRatio" => {
@@ -325,12 +325,12 @@ impl PortfolioAnalyzer {
                 let stat = statistic.extract::<LongRatio>(py)?;
                 self.deregister_statistic(&(Arc::new(stat) as Statistic));
             }
-            "BetaRatio" => {
-                let stat = statistic.extract::<BetaRatio>(py)?;
-                self.deregister_statistic(&(Arc::new(stat) as Statistic));
-            }
             "Alpha" => {
                 let stat = statistic.extract::<Alpha>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "BetaRatio" => {
+                let stat = statistic.extract::<BetaRatio>(py)?;
                 self.deregister_statistic(&(Arc::new(stat) as Statistic));
             }
             "InformationRatio" => {

--- a/crates/analysis/src/python/analyzer.rs
+++ b/crates/analysis/src/python/analyzer.rs
@@ -13,7 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use nautilus_core::{UnixNanos, python::to_pyvalue_err};
 use nautilus_model::{
@@ -24,13 +27,16 @@ use nautilus_model::{
 use pyo3::prelude::*;
 
 use crate::{
+    Returns,
     analyzer::{PortfolioAnalyzer, Statistic},
     statistics::{
-        expectancy::Expectancy, long_ratio::LongRatio, loser_avg::AvgLoser, loser_max::MaxLoser,
-        loser_min::MinLoser, profit_factor::ProfitFactor, returns_avg::ReturnsAverage,
-        returns_avg_loss::ReturnsAverageLoss, returns_avg_win::ReturnsAverageWin,
-        returns_volatility::ReturnsVolatility, risk_return_ratio::RiskReturnRatio,
-        sharpe_ratio::SharpeRatio, sortino_ratio::SortinoRatio, win_rate::WinRate,
+        alpha::Alpha, beta_ratio::BetaRatio, expectancy::Expectancy,
+        information_ratio::InformationRatio, long_ratio::LongRatio, loser_avg::AvgLoser,
+        loser_max::MaxLoser, loser_min::MinLoser, profit_factor::ProfitFactor,
+        returns_avg::ReturnsAverage, returns_avg_loss::ReturnsAverageLoss,
+        returns_avg_win::ReturnsAverageWin, returns_volatility::ReturnsVolatility,
+        risk_return_ratio::RiskReturnRatio, sharpe_ratio::SharpeRatio, sortino_ratio::SortinoRatio,
+        tracking_error::TrackingError, treynor_ratio::TreynorRatio, win_rate::WinRate,
         winner_avg::AvgWinner, winner_max::MaxWinner, winner_min::MinWinner,
     },
 };
@@ -77,6 +83,21 @@ impl PortfolioAnalyzer {
     #[pyo3(name = "get_performance_stats_portfolio_returns")]
     fn py_get_performance_stats_portfolio_returns(&self) -> HashMap<String, f64> {
         self.get_performance_stats_portfolio_returns()
+            .into_iter()
+            .collect()
+    }
+
+    /// Gets all benchmark-relative return statistics for the primary returns.
+    #[pyo3(name = "get_performance_stats_returns_vs_benchmark")]
+    fn py_get_performance_stats_returns_vs_benchmark(
+        &self,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> HashMap<String, f64> {
+        let benchmark: Returns = benchmark
+            .into_iter()
+            .map(|(k, v)| (UnixNanos::from(k), v))
+            .collect();
+        self.get_performance_stats_returns_vs_benchmark(&benchmark)
             .into_iter()
             .collect()
     }
@@ -196,6 +217,26 @@ impl PortfolioAnalyzer {
                 let stat = statistic.extract::<LongRatio>(py)?;
                 self.register_statistic(Arc::new(stat));
             }
+            "BetaRatio" => {
+                let stat = statistic.extract::<BetaRatio>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
+            "Alpha" => {
+                let stat = statistic.extract::<Alpha>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
+            "InformationRatio" => {
+                let stat = statistic.extract::<InformationRatio>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
+            "TrackingError" => {
+                let stat = statistic.extract::<TrackingError>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
+            "TreynorRatio" => {
+                let stat = statistic.extract::<TreynorRatio>(py)?;
+                self.register_statistic(Arc::new(stat));
+            }
             _ => {
                 return Err(to_pyvalue_err(format!(
                     "Unknown statistic type: {type_name}"
@@ -282,6 +323,26 @@ impl PortfolioAnalyzer {
             }
             "LongRatio" => {
                 let stat = statistic.extract::<LongRatio>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "BetaRatio" => {
+                let stat = statistic.extract::<BetaRatio>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "Alpha" => {
+                let stat = statistic.extract::<Alpha>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "InformationRatio" => {
+                let stat = statistic.extract::<InformationRatio>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "TrackingError" => {
+                let stat = statistic.extract::<TrackingError>(py)?;
+                self.deregister_statistic(&(Arc::new(stat) as Statistic));
+            }
+            "TreynorRatio" => {
+                let stat = statistic.extract::<TreynorRatio>(py)?;
                 self.deregister_statistic(&(Arc::new(stat) as Statistic));
             }
             _ => {

--- a/crates/analysis/src/python/mod.rs
+++ b/crates/analysis/src/python/mod.rs
@@ -62,5 +62,12 @@ pub fn analysis(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Statistics - Position-based
     m.add_class::<crate::statistics::long_ratio::LongRatio>()?;
 
+    // Statistics - Benchmark-relative
+    m.add_class::<crate::statistics::alpha::Alpha>()?;
+    m.add_class::<crate::statistics::beta_ratio::BetaRatio>()?;
+    m.add_class::<crate::statistics::information_ratio::InformationRatio>()?;
+    m.add_class::<crate::statistics::tracking_error::TrackingError>()?;
+    m.add_class::<crate::statistics::treynor_ratio::TreynorRatio>()?;
+
     Ok(())
 }

--- a/crates/analysis/src/python/statistics/alpha.rs
+++ b/crates/analysis/src/python/statistics/alpha.rs
@@ -1,0 +1,74 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+
+use super::transform_returns;
+use crate::{statistic::PortfolioStatistic, statistics::alpha::Alpha};
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl Alpha {
+    /// Calculates Jensen's alpha of portfolio returns relative to a benchmark.
+    ///
+    /// `alpha = (mean_strategy - rf) - beta * (mean_benchmark - rf)` per period, then
+    /// annualized geometrically over `period` (default 252). The risk-free rate `rf`
+    /// is per period (default 0.0).
+    #[new]
+    #[pyo3(signature = (period=None, risk_free_rate=None))]
+    fn py_new(period: Option<usize>, risk_free_rate: Option<f64>) -> Self {
+        Self::new(period, risk_free_rate)
+    }
+
+    fn __repr__(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[pyo3(name = "calculate_from_returns")]
+    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_realized_pnls")]
+    fn py_calculate_from_realized_pnls(&self, _realized_pnls: Vec<f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_positions")]
+    fn py_calculate_from_positions(&self, _positions: Vec<Py<PyAny>>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_returns_with_benchmark")]
+    #[expect(clippy::needless_pass_by_value)]
+    fn py_calculate_from_returns_with_benchmark(
+        &self,
+        returns: BTreeMap<u64, f64>,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> Option<f64> {
+        self.calculate_from_returns_with_benchmark(
+            &transform_returns(&returns),
+            &transform_returns(&benchmark),
+        )
+    }
+}

--- a/crates/analysis/src/python/statistics/alpha.rs
+++ b/crates/analysis/src/python/statistics/alpha.rs
@@ -45,7 +45,7 @@ impl Alpha {
     }
 
     #[pyo3(name = "calculate_from_returns")]
-    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+    fn py_calculate_from_returns(&self, _returns: BTreeMap<u64, f64>) -> Option<f64> {
         None
     }
 

--- a/crates/analysis/src/python/statistics/beta_ratio.rs
+++ b/crates/analysis/src/python/statistics/beta_ratio.rs
@@ -34,7 +34,7 @@ impl BetaRatio {
     }
 
     fn __repr__(&self) -> String {
-        format!("BetaRatio({})", self.name())
+        self.to_string()
     }
 
     #[getter]

--- a/crates/analysis/src/python/statistics/beta_ratio.rs
+++ b/crates/analysis/src/python/statistics/beta_ratio.rs
@@ -1,0 +1,73 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+
+use super::transform_returns;
+use crate::{statistic::PortfolioStatistic, statistics::beta_ratio::BetaRatio};
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl BetaRatio {
+    /// Calculates the beta of portfolio returns relative to a benchmark.
+    ///
+    /// Beta measures the systematic risk (market sensitivity) of a portfolio:
+    /// `Beta = Cov(strategy, benchmark) / Var(benchmark)` using sample (`ddof = 1`)
+    /// covariance and variance. Beta is not annualized.
+    #[new]
+    fn py_new() -> Self {
+        Self::new()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("BetaRatio({})", self.name())
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[pyo3(name = "calculate_from_returns")]
+    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_realized_pnls")]
+    fn py_calculate_from_realized_pnls(&self, _realized_pnls: Vec<f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_positions")]
+    fn py_calculate_from_positions(&self, _positions: Vec<Py<PyAny>>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_returns_with_benchmark")]
+    #[expect(clippy::needless_pass_by_value)]
+    fn py_calculate_from_returns_with_benchmark(
+        &self,
+        returns: BTreeMap<u64, f64>,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> Option<f64> {
+        self.calculate_from_returns_with_benchmark(
+            &transform_returns(&returns),
+            &transform_returns(&benchmark),
+        )
+    }
+}

--- a/crates/analysis/src/python/statistics/beta_ratio.rs
+++ b/crates/analysis/src/python/statistics/beta_ratio.rs
@@ -44,7 +44,7 @@ impl BetaRatio {
     }
 
     #[pyo3(name = "calculate_from_returns")]
-    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+    fn py_calculate_from_returns(&self, _returns: BTreeMap<u64, f64>) -> Option<f64> {
         None
     }
 

--- a/crates/analysis/src/python/statistics/information_ratio.rs
+++ b/crates/analysis/src/python/statistics/information_ratio.rs
@@ -1,0 +1,73 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+
+use super::transform_returns;
+use crate::{statistic::PortfolioStatistic, statistics::information_ratio::InformationRatio};
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl InformationRatio {
+    /// Calculates the information ratio of portfolio returns relative to a benchmark.
+    ///
+    /// `IR = mean(active) / std(active) * sqrt(period)` where `active = strategy - benchmark`,
+    /// `std` uses Bessel's correction (`ddof = 1`), annualized over `period` (default 252).
+    #[new]
+    #[pyo3(signature = (period=None))]
+    fn py_new(period: Option<usize>) -> Self {
+        Self::new(period)
+    }
+
+    fn __repr__(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[pyo3(name = "calculate_from_returns")]
+    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_realized_pnls")]
+    fn py_calculate_from_realized_pnls(&self, _realized_pnls: Vec<f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_positions")]
+    fn py_calculate_from_positions(&self, _positions: Vec<Py<PyAny>>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_returns_with_benchmark")]
+    #[expect(clippy::needless_pass_by_value)]
+    fn py_calculate_from_returns_with_benchmark(
+        &self,
+        returns: BTreeMap<u64, f64>,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> Option<f64> {
+        self.calculate_from_returns_with_benchmark(
+            &transform_returns(&returns),
+            &transform_returns(&benchmark),
+        )
+    }
+}

--- a/crates/analysis/src/python/statistics/information_ratio.rs
+++ b/crates/analysis/src/python/statistics/information_ratio.rs
@@ -44,7 +44,7 @@ impl InformationRatio {
     }
 
     #[pyo3(name = "calculate_from_returns")]
-    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+    fn py_calculate_from_returns(&self, _returns: BTreeMap<u64, f64>) -> Option<f64> {
         None
     }
 

--- a/crates/analysis/src/python/statistics/mod.rs
+++ b/crates/analysis/src/python/statistics/mod.rs
@@ -15,9 +15,12 @@
 
 //! Python bindings for trading performance statistics.
 
+pub mod alpha;
+pub mod beta_ratio;
 pub mod cagr;
 pub mod calmar_ratio;
 pub mod expectancy;
+pub mod information_ratio;
 pub mod long_ratio;
 pub mod loser_avg;
 pub mod loser_max;
@@ -31,6 +34,8 @@ pub mod returns_volatility;
 pub mod risk_return_ratio;
 pub mod sharpe_ratio;
 pub mod sortino_ratio;
+pub mod tracking_error;
+pub mod treynor_ratio;
 pub mod win_rate;
 pub mod winner_avg;
 pub mod winner_max;

--- a/crates/analysis/src/python/statistics/tracking_error.rs
+++ b/crates/analysis/src/python/statistics/tracking_error.rs
@@ -44,7 +44,7 @@ impl TrackingError {
     }
 
     #[pyo3(name = "calculate_from_returns")]
-    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+    fn py_calculate_from_returns(&self, _returns: BTreeMap<u64, f64>) -> Option<f64> {
         None
     }
 

--- a/crates/analysis/src/python/statistics/tracking_error.rs
+++ b/crates/analysis/src/python/statistics/tracking_error.rs
@@ -1,0 +1,73 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+
+use super::transform_returns;
+use crate::{statistic::PortfolioStatistic, statistics::tracking_error::TrackingError};
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl TrackingError {
+    /// Calculates the tracking error of portfolio returns relative to a benchmark.
+    ///
+    /// `TE = std(active) * sqrt(period)` where `active = strategy - benchmark`,
+    /// `std` uses Bessel's correction (`ddof = 1`), annualized over `period` (default 252).
+    #[new]
+    #[pyo3(signature = (period=None))]
+    fn py_new(period: Option<usize>) -> Self {
+        Self::new(period)
+    }
+
+    fn __repr__(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[pyo3(name = "calculate_from_returns")]
+    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_realized_pnls")]
+    fn py_calculate_from_realized_pnls(&self, _realized_pnls: Vec<f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_positions")]
+    fn py_calculate_from_positions(&self, _positions: Vec<Py<PyAny>>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_returns_with_benchmark")]
+    #[expect(clippy::needless_pass_by_value)]
+    fn py_calculate_from_returns_with_benchmark(
+        &self,
+        returns: BTreeMap<u64, f64>,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> Option<f64> {
+        self.calculate_from_returns_with_benchmark(
+            &transform_returns(&returns),
+            &transform_returns(&benchmark),
+        )
+    }
+}

--- a/crates/analysis/src/python/statistics/treynor_ratio.rs
+++ b/crates/analysis/src/python/statistics/treynor_ratio.rs
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+
+use super::transform_returns;
+use crate::{statistic::PortfolioStatistic, statistics::treynor_ratio::TreynorRatio};
+
+#[pymethods]
+#[pyo3_stub_gen::derive::gen_stub_pymethods]
+impl TreynorRatio {
+    /// Calculates the Treynor ratio of portfolio returns relative to a benchmark.
+    ///
+    /// `Treynor = (annualized_return - rf_annual) / beta` where `annualized_return` is the
+    /// geometric (CAGR-style) annualization of the aligned strategy returns,
+    /// `rf_annual = (1 + rf)^period - 1`, and `beta` is the sample (`ddof = 1`) beta.
+    /// The period defaults to 252 and the per-period risk-free rate `rf` defaults to 0.0.
+    #[new]
+    #[pyo3(signature = (period=None, risk_free_rate=None))]
+    fn py_new(period: Option<usize>, risk_free_rate: Option<f64>) -> Self {
+        Self::new(period, risk_free_rate)
+    }
+
+    fn __repr__(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    #[pyo3(name = "name")]
+    fn py_name(&self) -> String {
+        self.name()
+    }
+
+    #[pyo3(name = "calculate_from_returns")]
+    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_realized_pnls")]
+    fn py_calculate_from_realized_pnls(&self, _realized_pnls: Vec<f64>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_positions")]
+    fn py_calculate_from_positions(&self, _positions: Vec<Py<PyAny>>) -> Option<f64> {
+        None
+    }
+
+    #[pyo3(name = "calculate_from_returns_with_benchmark")]
+    #[expect(clippy::needless_pass_by_value)]
+    fn py_calculate_from_returns_with_benchmark(
+        &self,
+        returns: BTreeMap<u64, f64>,
+        benchmark: BTreeMap<u64, f64>,
+    ) -> Option<f64> {
+        self.calculate_from_returns_with_benchmark(
+            &transform_returns(&returns),
+            &transform_returns(&benchmark),
+        )
+    }
+}

--- a/crates/analysis/src/python/statistics/treynor_ratio.rs
+++ b/crates/analysis/src/python/statistics/treynor_ratio.rs
@@ -46,7 +46,7 @@ impl TreynorRatio {
     }
 
     #[pyo3(name = "calculate_from_returns")]
-    fn py_calculate_from_returns(&self, _raw_returns: BTreeMap<u64, f64>) -> Option<f64> {
+    fn py_calculate_from_returns(&self, _returns: BTreeMap<u64, f64>) -> Option<f64> {
         None
     }
 

--- a/crates/analysis/src/statistic.rs
+++ b/crates/analysis/src/statistic.rs
@@ -75,10 +75,11 @@ pub trait PortfolioStatistic: Debug {
 
     /// Calculates the statistic from time-indexed strategy returns relative to a benchmark.
     ///
-    /// Benchmark-relative statistics (beta, alpha, information ratio, tracking error,
-    /// Treynor ratio) override this method. The default returns `None` so analyzer loops
-    /// can filter by `Option` (mirroring `calculate_from_positions`) rather than panicking
-    /// for statistics that are not benchmark-relative.
+    /// Defaults to `None`; only benchmark-relative statistics (beta, alpha, information
+    /// ratio, tracking error, Treynor ratio) override this method. The `None` default
+    /// lets analyzer loops filter results by `Option` — non-benchmark statistics are
+    /// simply skipped, as `get_performance_stats_general` already does with
+    /// `calculate_from_positions` results — rather than panicking.
     fn calculate_from_returns_with_benchmark(
         &self,
         returns: &Returns,

--- a/crates/analysis/src/statistic.rs
+++ b/crates/analysis/src/statistic.rs
@@ -73,6 +73,43 @@ pub trait PortfolioStatistic: Debug {
         panic!("`calculate_from_positions` {IMPL_ERR} `{}`", self.name());
     }
 
+    /// Calculates the statistic from time-indexed strategy returns relative to a benchmark.
+    ///
+    /// Benchmark-relative statistics (beta, alpha, information ratio, tracking error,
+    /// Treynor ratio) override this method. The default returns `None` so analyzer loops
+    /// can filter by `Option` (mirroring `calculate_from_positions`) rather than panicking
+    /// for statistics that are not benchmark-relative.
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        None
+    }
+
+    /// Aligns two returns series onto a common daily grid.
+    ///
+    /// Both series are first downsampled to daily bins (geometric compounding within each
+    /// UTC day), then inner-joined on shared timestamps. Timestamps present in only one
+    /// series are dropped (not zero-filled). Returns the aligned `(strategy, benchmark)`
+    /// value vectors, in ascending timestamp order.
+    fn align_returns(&self, a: &Returns, b: &Returns) -> (Vec<f64>, Vec<f64>) {
+        let a_daily = self.downsample_to_daily_bins(a);
+        let b_daily = self.downsample_to_daily_bins(b);
+
+        let mut aligned_a = Vec::new();
+        let mut aligned_b = Vec::new();
+
+        for (timestamp, &a_value) in &a_daily {
+            if let Some(&b_value) = b_daily.get(timestamp) {
+                aligned_a.push(a_value);
+                aligned_b.push(b_value);
+            }
+        }
+
+        (aligned_a, aligned_b)
+    }
+
     /// Validates that returns data is not empty.
     fn check_valid_returns(&self, returns: &Returns) -> bool {
         !returns.is_empty()

--- a/crates/analysis/src/statistics/alpha.rs
+++ b/crates/analysis/src/statistics/alpha.rs
@@ -177,6 +177,34 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = Alpha::new(Some(4), None);
+        assert_eq!(stat.name(), "Alpha (4 days)");
+    }
+
+    #[rstest]
+    fn test_known_value_nonzero_mean_benchmark() {
+        // Non-zero-mean benchmark and a non-trivial beta so the beta * (mean_b - rf)
+        // subtraction is exercised; small period = 4 makes the geometric annualization
+        // hand-checkable. rf = 0.001 per period.
+        //   r = [0.02, -0.01, 0.03, 0.005], b = [0.01, 0.0, 0.015, 0.01]
+        //   beta = 2.5789473684210527
+        //   mean_r = 0.01125, mean_b = 0.00875
+        //   alpha_period = (mean_r - rf) - beta * (mean_b - rf)
+        //                = 0.01025 - 2.5789473684210527 * 0.00775 = -0.009736842105263162
+        //   alpha_annual = (1 + alpha_period)^4 - 1 = -0.0383822153156389
+        // Dropping the beta term gives +0.041634..., and a sqrt-style annualization
+        // (alpha_period * sqrt(4)) gives -0.019473..., so this discriminates both.
+        let returns = create_returns(&[0.02, -0.01, 0.03, 0.005]);
+        let benchmark = create_returns(&[0.01, 0.0, 0.015, 0.01]);
+        let stat = Alpha::new(Some(4), Some(0.001));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, -0.0383822153156389, epsilon = 1e-9));
+    }
+
+    #[rstest]
     fn test_flat_benchmark_is_nan() {
         let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);
         let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);

--- a/crates/analysis/src/statistics/alpha.rs
+++ b/crates/analysis/src/statistics/alpha.rs
@@ -1,0 +1,209 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Jensen's alpha statistic (benchmark-relative).
+
+use std::fmt::Display;
+
+use nautilus_model::position::Position;
+
+use crate::{Returns, statistic::PortfolioStatistic, statistics::beta_ratio::beta};
+
+/// Calculates Jensen's alpha of portfolio returns relative to a benchmark.
+///
+/// Alpha measures the excess return of a portfolio over the return predicted by its
+/// beta exposure to the benchmark (CAPM). The per-period alpha is:
+///
+/// `alpha = (mean_strategy - rf) - beta * (mean_benchmark - rf)`
+///
+/// where `beta` is the sample (`ddof = 1`) beta of the strategy against the benchmark.
+/// The per-period alpha is then annualized geometrically over `period` (default 252):
+///
+/// `alpha_annual = (1 + alpha)^period - 1`
+///
+/// The risk-free rate `rf` is specified per period (default 0.0).
+///
+/// # References
+///
+/// - Jensen, M. C. (1968). "The Performance of Mutual Funds in the Period 1945-1964".
+///   *Journal of Finance*, 23(2), 389-416.
+/// - CFA Institute Investment Foundations, 3rd Edition
+#[repr(C)]
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.analysis", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.analysis")
+)]
+pub struct Alpha {
+    /// The annualization period (default: 252 for daily data).
+    period: usize,
+    /// The per-period risk-free rate (default: 0.0).
+    risk_free_rate: f64,
+}
+
+impl Alpha {
+    /// Creates a new [`Alpha`] instance.
+    #[must_use]
+    pub fn new(period: Option<usize>, risk_free_rate: Option<f64>) -> Self {
+        Self {
+            period: period.unwrap_or(252),
+            risk_free_rate: risk_free_rate.unwrap_or(0.0),
+        }
+    }
+}
+
+impl Display for Alpha {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Alpha ({} days)", self.period)
+    }
+}
+
+impl PortfolioStatistic for Alpha {
+    type Item = f64;
+
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    fn calculate_from_returns(&self, _returns: &Returns) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        let (r, b) = self.align_returns(returns, benchmark);
+        let n = r.len();
+        if n < 2 {
+            return Some(f64::NAN);
+        }
+
+        let beta = beta(&r, &b);
+        if beta.is_nan() {
+            return Some(f64::NAN);
+        }
+
+        let mean_r = r.iter().sum::<f64>() / n as f64;
+        let mean_b = b.iter().sum::<f64>() / n as f64;
+        let rf = self.risk_free_rate;
+
+        let alpha_period = (mean_r - rf) - beta * (mean_b - rf);
+        let alpha_annual = (1.0 + alpha_period).powf(self.period as f64) - 1.0;
+
+        Some(alpha_annual)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_returns(values: &[f64]) -> BTreeMap<UnixNanos, f64> {
+        let mut new_return = BTreeMap::new();
+        let one_day_in_nanos = 86_400_000_000_000;
+        let start_time = 1_600_000_000_000_000_000;
+
+        for (i, &value) in values.iter().enumerate() {
+            let timestamp = start_time + i as u64 * one_day_in_nanos;
+            new_return.insert(UnixNanos::from(timestamp), value);
+        }
+
+        new_return
+    }
+
+    #[rstest]
+    fn test_name() {
+        let stat = Alpha::new(None, None);
+        assert_eq!(stat.name(), "Alpha (252 days)");
+    }
+
+    #[rstest]
+    fn test_known_value_zero_alpha() {
+        // strategy == 2 * benchmark with rf = 0: beta = 2,
+        //   alpha_period = mean_r - 2 * mean_b = 0 (since mean_r = 2 * mean_b),
+        //   alpha_annual = (1 + 0)^period - 1 = 0.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005, 0.025]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = Alpha::new(Some(252), Some(0.0));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 0.0, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_known_value_constant_offset() {
+        // strategy = benchmark + 0.001 each day -> beta = 1, mean_r - mean_b = 0.001,
+        //   alpha_period = 0.001, alpha_annual = 1.001^period - 1 with period = 4.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005]);
+        let returns = create_returns(&[0.011, -0.019, 0.016, -0.004]);
+        let stat = Alpha::new(Some(4), Some(0.0));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        let expected = 1.001_f64.powf(4.0) - 1.0;
+        assert!(approx_eq!(f64, result, expected, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_flat_benchmark_is_nan() {
+        let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = Alpha::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_empty_returns_is_nan() {
+        let stat = Alpha::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&create_returns(&[]), &create_returns(&[]))
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_single_overlap_is_nan() {
+        let benchmark = create_returns(&[0.01, -0.02, 0.015]);
+        let returns = create_returns(&[0.02]);
+        let stat = Alpha::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+}

--- a/crates/analysis/src/statistics/alpha.rs
+++ b/crates/analysis/src/statistics/alpha.rs
@@ -26,9 +26,9 @@ use crate::{Returns, statistic::PortfolioStatistic, statistics::beta_ratio::beta
 /// Alpha measures the excess return of a portfolio over the return predicted by its
 /// beta exposure to the benchmark (CAPM). The per-period alpha is:
 ///
-/// `alpha = (mean_strategy - rf) - beta * (mean_benchmark - rf)`
+/// `alpha = (mean_portfolio - rf) - beta * (mean_benchmark - rf)`
 ///
-/// where `beta` is the sample (`ddof = 1`) beta of the strategy against the benchmark.
+/// where `beta` is the sample (`ddof = 1`) beta of the portfolio against the benchmark.
 /// The per-period alpha is then annualized geometrically over `period` (default 252):
 ///
 /// `alpha_annual = (1 + alpha)^period - 1`
@@ -149,6 +149,12 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = Alpha::new(Some(4), None);
+        assert_eq!(stat.name(), "Alpha (4 days)");
+    }
+
+    #[rstest]
     fn test_known_value_zero_alpha() {
         // strategy == 2 * benchmark with rf = 0: beta = 2,
         //   alpha_period = mean_r - 2 * mean_b = 0 (since mean_r = 2 * mean_b),
@@ -177,12 +183,6 @@ mod tests {
     }
 
     #[rstest]
-    fn test_name_non_default_period() {
-        let stat = Alpha::new(Some(4), None);
-        assert_eq!(stat.name(), "Alpha (4 days)");
-    }
-
-    #[rstest]
     fn test_known_value_nonzero_mean_benchmark() {
         // Non-zero-mean benchmark and a non-trivial beta so the beta * (mean_b - rf)
         // subtraction is exercised; small period = 4 makes the geometric annualization
@@ -194,7 +194,8 @@ mod tests {
         //                = 0.01025 - 2.5789473684210527 * 0.00775 = -0.009736842105263162
         //   alpha_annual = (1 + alpha_period)^4 - 1 = -0.0383822153156389
         // Dropping the beta term gives +0.041634..., and a sqrt-style annualization
-        // (alpha_period * sqrt(4)) gives -0.019473..., so this discriminates both.
+        // (alpha_period * sqrt(4)) gives -0.019473..., so this value discriminates
+        // against both.
         let returns = create_returns(&[0.02, -0.01, 0.03, 0.005]);
         let benchmark = create_returns(&[0.01, 0.0, 0.015, 0.01]);
         let stat = Alpha::new(Some(4), Some(0.001));

--- a/crates/analysis/src/statistics/beta_ratio.rs
+++ b/crates/analysis/src/statistics/beta_ratio.rs
@@ -24,17 +24,18 @@ use crate::{Returns, statistic::PortfolioStatistic};
 /// Calculates the beta of portfolio returns relative to a benchmark.
 ///
 /// Beta measures the systematic risk (market sensitivity) of a portfolio and is
-/// calculated as the covariance of the strategy and benchmark returns divided by
+/// calculated as the covariance of the portfolio and benchmark returns divided by
 /// the variance of the benchmark returns:
 ///
-/// `Beta = Cov(strategy, benchmark) / Var(benchmark)`
+/// `Beta = Cov(portfolio, benchmark) / Var(benchmark)`
 ///
 /// Sample (Bessel-corrected, `ddof = 1`) covariance and variance are used to match
 /// the standard deviation convention elsewhere in this crate. Beta is not annualized.
 ///
 /// # References
 ///
-/// - Sharpe, W. F. (1964). "Capital Asset Prices". *Journal of Finance*, 19(3), 425-442.
+/// - Sharpe, W. F. (1964). "Capital Asset Prices: A Theory of Market Equilibrium under
+///   Conditions of Risk". *Journal of Finance*, 19(3), 425-442.
 /// - CFA Institute Investment Foundations, 3rd Edition
 #[repr(C)]
 #[derive(Debug, Clone, Default)]

--- a/crates/analysis/src/statistics/beta_ratio.rs
+++ b/crates/analysis/src/statistics/beta_ratio.rs
@@ -1,0 +1,231 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Beta statistic (benchmark-relative).
+
+use std::fmt::Display;
+
+use nautilus_model::position::Position;
+
+use crate::{Returns, statistic::PortfolioStatistic};
+
+/// Calculates the beta of portfolio returns relative to a benchmark.
+///
+/// Beta measures the systematic risk (market sensitivity) of a portfolio and is
+/// calculated as the covariance of the strategy and benchmark returns divided by
+/// the variance of the benchmark returns:
+///
+/// `Beta = Cov(strategy, benchmark) / Var(benchmark)`
+///
+/// Sample (Bessel-corrected, `ddof = 1`) covariance and variance are used to match
+/// the standard deviation convention elsewhere in this crate. Beta is not annualized.
+///
+/// # References
+///
+/// - Sharpe, W. F. (1964). "Capital Asset Prices". *Journal of Finance*, 19(3), 425-442.
+/// - CFA Institute Investment Foundations, 3rd Edition
+#[repr(C)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.analysis", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.analysis")
+)]
+pub struct BetaRatio {}
+
+impl BetaRatio {
+    /// Creates a new [`BetaRatio`] instance.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Display for BetaRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Beta")
+    }
+}
+
+impl PortfolioStatistic for BetaRatio {
+    type Item = f64;
+
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    fn calculate_from_returns(&self, _returns: &Returns) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        let (r, b) = self.align_returns(returns, benchmark);
+        let n = r.len();
+        if n < 2 {
+            return Some(f64::NAN);
+        }
+
+        Some(beta(&r, &b))
+    }
+}
+
+/// Computes sample (`ddof = 1`) beta of `r` against `b`.
+///
+/// Returns `f64::NAN` when the benchmark variance is below `f64::EPSILON` (e.g. a flat
+/// benchmark), which would otherwise produce a division by zero. Callers must ensure
+/// `r.len() == b.len() >= 2`.
+pub(crate) fn beta(r: &[f64], b: &[f64]) -> f64 {
+    let n = r.len() as f64;
+    let mean_r = r.iter().sum::<f64>() / n;
+    let mean_b = b.iter().sum::<f64>() / n;
+
+    let covariance = r
+        .iter()
+        .zip(b.iter())
+        .map(|(&ri, &bi)| (ri - mean_r) * (bi - mean_b))
+        .sum::<f64>()
+        / (n - 1.0);
+    let variance_b = b.iter().map(|&bi| (bi - mean_b).powi(2)).sum::<f64>() / (n - 1.0);
+
+    if variance_b < f64::EPSILON {
+        return f64::NAN;
+    }
+
+    covariance / variance_b
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_returns(values: &[f64]) -> BTreeMap<UnixNanos, f64> {
+        let mut new_return = BTreeMap::new();
+        let one_day_in_nanos = 86_400_000_000_000;
+        let start_time = 1_600_000_000_000_000_000;
+
+        for (i, &value) in values.iter().enumerate() {
+            let timestamp = start_time + i as u64 * one_day_in_nanos;
+            new_return.insert(UnixNanos::from(timestamp), value);
+        }
+
+        new_return
+    }
+
+    #[rstest]
+    fn test_name() {
+        let stat = BetaRatio::new();
+        assert_eq!(stat.name(), "Beta");
+    }
+
+    #[rstest]
+    fn test_known_value() {
+        // strategy = 2 * benchmark exactly, so beta = 2.0.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005, 0.025]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 2.0, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_unit_beta() {
+        // Identical series -> beta of 1.0.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005, 0.025]);
+        let returns = create_returns(&[0.01, -0.02, 0.015, -0.005, 0.025]);
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 1.0, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_flat_benchmark_is_nan() {
+        let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_empty_returns_is_nan() {
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&create_returns(&[]), &create_returns(&[]))
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_single_overlap_is_nan() {
+        // Only one shared timestamp after inner join -> n < 2 -> NaN.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015]);
+        let returns = create_returns(&[0.02]);
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_partial_overlap_inner_join() {
+        // Strategy spans days 0..5, benchmark days 2..7 -> overlap on days 2,3,4 only.
+        let one_day = 86_400_000_000_000_u64;
+        let start = 1_600_000_000_000_000_000_u64;
+
+        let mut returns = BTreeMap::new();
+        for (i, v) in [0.02, -0.04, 0.030, -0.010, 0.050].iter().enumerate() {
+            returns.insert(UnixNanos::from(start + i as u64 * one_day), *v);
+        }
+        let mut benchmark = BTreeMap::new();
+        for (i, v) in [0.015, -0.005, 0.025, 0.01, -0.02].iter().enumerate() {
+            benchmark.insert(UnixNanos::from(start + (i as u64 + 2) * one_day), *v);
+        }
+
+        // Overlap: strategy[2,3,4] = [0.030, -0.010, 0.050];
+        //          benchmark[2,3,4] = [0.015, -0.005, 0.025] (here strategy == 2*benchmark).
+        let stat = BetaRatio::new();
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 2.0, epsilon = 1e-12));
+    }
+}

--- a/crates/analysis/src/statistics/information_ratio.rs
+++ b/crates/analysis/src/statistics/information_ratio.rs
@@ -144,6 +144,96 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = InformationRatio::new(Some(63));
+        assert_eq!(stat.name(), "Information Ratio (63 days)");
+    }
+
+    #[rstest]
+    fn test_known_value_nonzero_benchmark() {
+        // Both strategy and benchmark non-zero so the (r - b) subtraction is exercised.
+        //   r       = [0.03, -0.01, 0.02, 0.04]
+        //   b       = [0.01, 0.005, 0.005, 0.01]
+        //   active  = [0.02, -0.015, 0.015, 0.03]
+        //   mean(active)       = 0.0125
+        //   std(active, ddof=1)= 0.019364916731037084
+        //   IR = 0.0125 / 0.019364916731037084 * sqrt(252) = 10.246950765959598
+        // A formula dropping the benchmark (active = r) would yield 14.69693845669907,
+        // so this value discriminates against that bug.
+        let returns = create_returns(&[0.03, -0.01, 0.02, 0.04]);
+        let benchmark = create_returns(&[0.01, 0.005, 0.005, 0.01]);
+        let stat = InformationRatio::new(Some(252));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 10.246950765959598, epsilon = 1e-9));
+    }
+
+    #[rstest]
+    fn test_partial_overlap_inner_join() {
+        // Strategy on days 0..5, benchmark on days 2..7 -> overlap on days 2,3,4 only.
+        let one_day = 86_400_000_000_000_u64;
+        let start = 1_600_000_000_000_000_000_u64;
+
+        let mut returns = BTreeMap::new();
+        for (i, v) in [0.05, 0.06, 0.030, -0.010, 0.020].iter().enumerate() {
+            returns.insert(UnixNanos::from(start + i as u64 * one_day), *v);
+        }
+        let mut benchmark = BTreeMap::new();
+        for (i, v) in [0.005, 0.010, 0.015, 0.040, 0.050].iter().enumerate() {
+            benchmark.insert(UnixNanos::from(start + (i as u64 + 2) * one_day), *v);
+        }
+
+        // Overlap days 2,3,4: r = [0.030, -0.010, 0.020], b = [0.005, 0.010, 0.015].
+        //   active = [0.025, -0.020, 0.005]
+        //   IR = mean(active) / std(active, ddof=1) * sqrt(252) = 2.3469547761538725
+        let stat = InformationRatio::new(Some(252));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 2.3469547761538725, epsilon = 1e-9));
+    }
+
+    #[rstest]
+    fn test_intraday_compounds_before_join() {
+        // Day 0 carries two intraday strategy returns that must compound into one daily
+        // bin BEFORE the inner-join: (1.02)(1.03) - 1 = 0.0506. Day 1 carries 0.01.
+        // Benchmark is one daily return per day: [0.015, 0.004].
+        //   active = [0.0506 - 0.015, 0.01 - 0.004] = [0.0356, 0.006]
+        //   IR = mean(active) / std(active, ddof=1) * sqrt(252) = 15.775636549641483
+        // Arithmetic-summing the intraday day-0 returns (0.05) would change the result,
+        // so this confirms geometric compounding happens before the join.
+        let one_day = 86_400_000_000_000_u64;
+        let one_hour = 3_600_000_000_000_u64;
+        let start = 1_600_000_000_000_000_000_u64;
+
+        let mut returns = BTreeMap::new();
+        returns.insert(UnixNanos::from(start), 0.02);
+        returns.insert(UnixNanos::from(start + one_hour), 0.03);
+        returns.insert(UnixNanos::from(start + one_day), 0.01);
+
+        let mut benchmark = BTreeMap::new();
+        benchmark.insert(UnixNanos::from(start), 0.015);
+        benchmark.insert(UnixNanos::from(start + one_day), 0.004);
+
+        let active = [(1.02_f64 * 1.03 - 1.0) - 0.015, 0.01 - 0.004];
+        let mean_active = active.iter().sum::<f64>() / active.len() as f64;
+        let var = active
+            .iter()
+            .map(|&x| (x - mean_active).powi(2))
+            .sum::<f64>()
+            / (active.len() as f64 - 1.0);
+        let expected = mean_active / var.sqrt() * 252.0_f64.sqrt();
+
+        let stat = InformationRatio::new(Some(252));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, expected, epsilon = 1e-9));
+        assert!(approx_eq!(f64, result, 15.775636549641483, epsilon = 1e-9));
+    }
+
+    #[rstest]
     fn test_known_value() {
         // active = strategy - benchmark = [0.01, 0.02, 0.03] (a clean arithmetic case).
         // mean = 0.02, sample std (ddof=1) = 0.01, ir_period = 2.0,

--- a/crates/analysis/src/statistics/information_ratio.rs
+++ b/crates/analysis/src/statistics/information_ratio.rs
@@ -29,7 +29,7 @@ use crate::{
 ///
 /// `IR = mean(active) / std(active) * sqrt(period)`
 ///
-/// where `active_i = strategy_i - benchmark_i`, `std` uses Bessel's correction
+/// where `active_i = portfolio_i - benchmark_i`, `std` uses Bessel's correction
 /// (`ddof = 1`), and the ratio is annualized by the square root of the specified period
 /// (default: 252 trading days).
 ///

--- a/crates/analysis/src/statistics/information_ratio.rs
+++ b/crates/analysis/src/statistics/information_ratio.rs
@@ -19,7 +19,9 @@ use std::fmt::Display;
 
 use nautilus_model::position::Position;
 
-use crate::{Returns, statistic::PortfolioStatistic};
+use crate::{
+    Returns, statistic::PortfolioStatistic, statistics::tracking_error::active_return_stats,
+};
 
 /// Calculates the information ratio of portfolio returns relative to a benchmark.
 ///
@@ -91,21 +93,11 @@ impl PortfolioStatistic for InformationRatio {
         benchmark: &Returns,
     ) -> Option<Self::Item> {
         let (r, b) = self.align_returns(returns, benchmark);
-        let n = r.len();
-        if n < 2 {
+        if r.len() < 2 {
             return Some(f64::NAN);
         }
 
-        let active: Vec<f64> = r.iter().zip(b.iter()).map(|(&ri, &bi)| ri - bi).collect();
-        let nf = n as f64;
-        let mean_active = active.iter().sum::<f64>() / nf;
-        let variance = active
-            .iter()
-            .map(|&x| (x - mean_active).powi(2))
-            .sum::<f64>()
-            / (nf - 1.0);
-        let std_active = variance.sqrt();
-
+        let (mean_active, std_active) = active_return_stats(&r, &b);
         if std_active < f64::EPSILON {
             return Some(f64::NAN);
         }

--- a/crates/analysis/src/statistics/information_ratio.rs
+++ b/crates/analysis/src/statistics/information_ratio.rs
@@ -1,0 +1,191 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Information ratio statistic (benchmark-relative).
+
+use std::fmt::Display;
+
+use nautilus_model::position::Position;
+
+use crate::{Returns, statistic::PortfolioStatistic};
+
+/// Calculates the information ratio of portfolio returns relative to a benchmark.
+///
+/// The information ratio measures active return per unit of active risk (tracking error):
+///
+/// `IR = mean(active) / std(active) * sqrt(period)`
+///
+/// where `active_i = strategy_i - benchmark_i`, `std` uses Bessel's correction
+/// (`ddof = 1`), and the ratio is annualized by the square root of the specified period
+/// (default: 252 trading days).
+///
+/// # References
+///
+/// - Goodwin, T. H. (1998). "The Information Ratio". *Financial Analysts Journal*, 54(4), 34-43.
+/// - CFA Institute Investment Foundations, 3rd Edition
+#[repr(C)]
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.analysis", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.analysis")
+)]
+pub struct InformationRatio {
+    /// The annualization period (default: 252 for daily data).
+    period: usize,
+}
+
+impl InformationRatio {
+    /// Creates a new [`InformationRatio`] instance.
+    #[must_use]
+    pub fn new(period: Option<usize>) -> Self {
+        Self {
+            period: period.unwrap_or(252),
+        }
+    }
+}
+
+impl Display for InformationRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Information Ratio ({} days)", self.period)
+    }
+}
+
+impl PortfolioStatistic for InformationRatio {
+    type Item = f64;
+
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    fn calculate_from_returns(&self, _returns: &Returns) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        let (r, b) = self.align_returns(returns, benchmark);
+        let n = r.len();
+        if n < 2 {
+            return Some(f64::NAN);
+        }
+
+        let active: Vec<f64> = r.iter().zip(b.iter()).map(|(&ri, &bi)| ri - bi).collect();
+        let nf = n as f64;
+        let mean_active = active.iter().sum::<f64>() / nf;
+        let variance = active
+            .iter()
+            .map(|&x| (x - mean_active).powi(2))
+            .sum::<f64>()
+            / (nf - 1.0);
+        let std_active = variance.sqrt();
+
+        if std_active < f64::EPSILON {
+            return Some(f64::NAN);
+        }
+
+        let ir_period = mean_active / std_active;
+        Some(ir_period * (self.period as f64).sqrt())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_returns(values: &[f64]) -> BTreeMap<UnixNanos, f64> {
+        let mut new_return = BTreeMap::new();
+        let one_day_in_nanos = 86_400_000_000_000;
+        let start_time = 1_600_000_000_000_000_000;
+
+        for (i, &value) in values.iter().enumerate() {
+            let timestamp = start_time + i as u64 * one_day_in_nanos;
+            new_return.insert(UnixNanos::from(timestamp), value);
+        }
+
+        new_return
+    }
+
+    #[rstest]
+    fn test_name() {
+        let stat = InformationRatio::new(None);
+        assert_eq!(stat.name(), "Information Ratio (252 days)");
+    }
+
+    #[rstest]
+    fn test_known_value() {
+        // active = strategy - benchmark = [0.01, 0.02, 0.03] (a clean arithmetic case).
+        // mean = 0.02, sample std (ddof=1) = 0.01, ir_period = 2.0,
+        // annualized = 2.0 * sqrt(4) = 4.0.
+        let benchmark = create_returns(&[0.00, 0.00, 0.00]);
+        let returns = create_returns(&[0.01, 0.02, 0.03]);
+        let stat = InformationRatio::new(Some(4));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 4.0, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_zero_active_std_is_nan() {
+        // strategy - benchmark constant -> std(active) = 0 -> NaN.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005]);
+        let returns = create_returns(&[0.02, -0.01, 0.025, 0.005]);
+        let stat = InformationRatio::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_empty_returns_is_nan() {
+        let stat = InformationRatio::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&create_returns(&[]), &create_returns(&[]))
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_single_overlap_is_nan() {
+        let benchmark = create_returns(&[0.01, -0.02, 0.015]);
+        let returns = create_returns(&[0.02]);
+        let stat = InformationRatio::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+}

--- a/crates/analysis/src/statistics/mod.rs
+++ b/crates/analysis/src/statistics/mod.rs
@@ -15,9 +15,12 @@
 
 //! Trading performance statistics and portfolio metrics.
 
+pub mod alpha;
+pub mod beta_ratio;
 pub mod cagr;
 pub mod calmar_ratio;
 pub mod expectancy;
+pub mod information_ratio;
 pub mod long_ratio;
 pub mod loser_avg;
 pub mod loser_max;
@@ -31,6 +34,8 @@ pub mod returns_volatility;
 pub mod risk_return_ratio;
 pub mod sharpe_ratio;
 pub mod sortino_ratio;
+pub mod tracking_error;
+pub mod treynor_ratio;
 pub mod win_rate;
 pub mod winner_avg;
 pub mod winner_max;

--- a/crates/analysis/src/statistics/tracking_error.rs
+++ b/crates/analysis/src/statistics/tracking_error.rs
@@ -23,11 +23,11 @@ use crate::{Returns, statistic::PortfolioStatistic};
 
 /// Calculates the tracking error of portfolio returns relative to a benchmark.
 ///
-/// Tracking error is the volatility of the active return (strategy minus benchmark):
+/// Tracking error is the volatility of the active return (portfolio minus benchmark):
 ///
 /// `TE = std(active) * sqrt(period)`
 ///
-/// where `active_i = strategy_i - benchmark_i`, `std` uses Bessel's correction
+/// where `active_i = portfolio_i - benchmark_i`, `std` uses Bessel's correction
 /// (`ddof = 1`), and the result is annualized by the square root of the specified period
 /// (default: 252 trading days).
 ///

--- a/crates/analysis/src/statistics/tracking_error.rs
+++ b/crates/analysis/src/statistics/tracking_error.rs
@@ -1,0 +1,186 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Tracking error statistic (benchmark-relative).
+
+use std::fmt::Display;
+
+use nautilus_model::position::Position;
+
+use crate::{Returns, statistic::PortfolioStatistic};
+
+/// Calculates the tracking error of portfolio returns relative to a benchmark.
+///
+/// Tracking error is the volatility of the active return (strategy minus benchmark):
+///
+/// `TE = std(active) * sqrt(period)`
+///
+/// where `active_i = strategy_i - benchmark_i`, `std` uses Bessel's correction
+/// (`ddof = 1`), and the result is annualized by the square root of the specified period
+/// (default: 252 trading days).
+///
+/// # References
+///
+/// - Roll, R. (1992). "A Mean/Variance Analysis of Tracking Error".
+///   *Journal of Portfolio Management*, 18(4), 13-22.
+/// - CFA Institute Investment Foundations, 3rd Edition
+#[repr(C)]
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.analysis", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.analysis")
+)]
+pub struct TrackingError {
+    /// The annualization period (default: 252 for daily data).
+    period: usize,
+}
+
+impl TrackingError {
+    /// Creates a new [`TrackingError`] instance.
+    #[must_use]
+    pub fn new(period: Option<usize>) -> Self {
+        Self {
+            period: period.unwrap_or(252),
+        }
+    }
+}
+
+impl Display for TrackingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Tracking Error ({} days)", self.period)
+    }
+}
+
+impl PortfolioStatistic for TrackingError {
+    type Item = f64;
+
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    fn calculate_from_returns(&self, _returns: &Returns) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        let (r, b) = self.align_returns(returns, benchmark);
+        let n = r.len();
+        if n < 2 {
+            return Some(f64::NAN);
+        }
+
+        let active: Vec<f64> = r.iter().zip(b.iter()).map(|(&ri, &bi)| ri - bi).collect();
+        let nf = n as f64;
+        let mean_active = active.iter().sum::<f64>() / nf;
+        let variance = active
+            .iter()
+            .map(|&x| (x - mean_active).powi(2))
+            .sum::<f64>()
+            / (nf - 1.0);
+        let te_period = variance.sqrt();
+
+        Some(te_period * (self.period as f64).sqrt())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_returns(values: &[f64]) -> BTreeMap<UnixNanos, f64> {
+        let mut new_return = BTreeMap::new();
+        let one_day_in_nanos = 86_400_000_000_000;
+        let start_time = 1_600_000_000_000_000_000;
+
+        for (i, &value) in values.iter().enumerate() {
+            let timestamp = start_time + i as u64 * one_day_in_nanos;
+            new_return.insert(UnixNanos::from(timestamp), value);
+        }
+
+        new_return
+    }
+
+    #[rstest]
+    fn test_name() {
+        let stat = TrackingError::new(None);
+        assert_eq!(stat.name(), "Tracking Error (252 days)");
+    }
+
+    #[rstest]
+    fn test_known_value() {
+        // active = [0.01, 0.02, 0.03], sample std (ddof=1) = 0.01,
+        // annualized = 0.01 * sqrt(4) = 0.02.
+        let benchmark = create_returns(&[0.00, 0.00, 0.00]);
+        let returns = create_returns(&[0.01, 0.02, 0.03]);
+        let stat = TrackingError::new(Some(4));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 0.02, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_zero_active_is_zero() {
+        // Identical series -> active all zero -> TE = 0 (not NaN).
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005]);
+        let returns = create_returns(&[0.01, -0.02, 0.015, -0.005]);
+        let stat = TrackingError::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 0.0, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_empty_returns_is_nan() {
+        let stat = TrackingError::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&create_returns(&[]), &create_returns(&[]))
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_single_overlap_is_nan() {
+        let benchmark = create_returns(&[0.01, -0.02, 0.015]);
+        let returns = create_returns(&[0.02]);
+        let stat = TrackingError::new(None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+}

--- a/crates/analysis/src/statistics/tracking_error.rs
+++ b/crates/analysis/src/statistics/tracking_error.rs
@@ -92,23 +92,34 @@ impl PortfolioStatistic for TrackingError {
         benchmark: &Returns,
     ) -> Option<Self::Item> {
         let (r, b) = self.align_returns(returns, benchmark);
-        let n = r.len();
-        if n < 2 {
+        if r.len() < 2 {
             return Some(f64::NAN);
         }
 
-        let active: Vec<f64> = r.iter().zip(b.iter()).map(|(&ri, &bi)| ri - bi).collect();
-        let nf = n as f64;
-        let mean_active = active.iter().sum::<f64>() / nf;
-        let variance = active
-            .iter()
-            .map(|&x| (x - mean_active).powi(2))
-            .sum::<f64>()
-            / (nf - 1.0);
-        let te_period = variance.sqrt();
-
-        Some(te_period * (self.period as f64).sqrt())
+        let (_, std_active) = active_return_stats(&r, &b);
+        Some(std_active * (self.period as f64).sqrt())
     }
+}
+
+/// Computes the mean and sample (`ddof = 1`) standard deviation of the active
+/// return series `r - b`.
+///
+/// Callers must ensure `r.len() == b.len() >= 2`.
+pub(crate) fn active_return_stats(r: &[f64], b: &[f64]) -> (f64, f64) {
+    let n = r.len() as f64;
+    let mean = r
+        .iter()
+        .zip(b.iter())
+        .map(|(&ri, &bi)| ri - bi)
+        .sum::<f64>()
+        / n;
+    let variance = r
+        .iter()
+        .zip(b.iter())
+        .map(|(&ri, &bi)| (ri - bi - mean).powi(2))
+        .sum::<f64>()
+        / (n - 1.0);
+    (mean, variance.sqrt())
 }
 
 #[cfg(test)]

--- a/crates/analysis/src/statistics/tracking_error.rs
+++ b/crates/analysis/src/statistics/tracking_error.rs
@@ -140,6 +140,31 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = TrackingError::new(Some(63));
+        assert_eq!(stat.name(), "Tracking Error (63 days)");
+    }
+
+    #[rstest]
+    fn test_known_value_nonzero_benchmark() {
+        // Both strategy and benchmark non-zero so the (r - b) subtraction is exercised.
+        //   r       = [0.03, -0.01, 0.02, 0.04]
+        //   b       = [0.01, 0.005, 0.005, 0.01]
+        //   active  = [0.02, -0.015, 0.015, 0.03]
+        //   std(active, ddof=1) = 0.019364916731037084
+        //   TE = std(active, ddof=1) * sqrt(252) = 0.30740852297878796
+        // A formula dropping the benchmark (active = r) would yield 0.34292856398964494,
+        // so this value discriminates against that bug.
+        let returns = create_returns(&[0.03, -0.01, 0.02, 0.04]);
+        let benchmark = create_returns(&[0.01, 0.005, 0.005, 0.01]);
+        let stat = TrackingError::new(Some(252));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 0.30740852297878796, epsilon = 1e-9));
+    }
+
+    #[rstest]
     fn test_known_value() {
         // active = [0.01, 0.02, 0.03], sample std (ddof=1) = 0.01,
         // annualized = 0.01 * sqrt(4) = 0.02.

--- a/crates/analysis/src/statistics/treynor_ratio.rs
+++ b/crates/analysis/src/statistics/treynor_ratio.rs
@@ -27,11 +27,11 @@ use crate::{Returns, statistic::PortfolioStatistic, statistics::beta_ratio::beta
 ///
 /// `Treynor = (annualized_return - rf_annual) / beta`
 ///
-/// The strategy's annualized return is computed geometrically (CAGR-style) from the
+/// The portfolio's annualized return is computed geometrically (CAGR-style) from the
 /// aligned returns: `annualized_return = (prod(1 + r_i))^(period / n) - 1`. The
 /// per-period risk-free rate is annualized geometrically as
 /// `rf_annual = (1 + rf)^period - 1`. Beta is the sample (`ddof = 1`) beta of the
-/// strategy against the benchmark. The period defaults to 252 trading days and `rf`
+/// portfolio against the benchmark. The period defaults to 252 trading days and `rf`
 /// defaults to 0.0.
 ///
 /// # References
@@ -146,6 +146,12 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = TreynorRatio::new(Some(63), None);
+        assert_eq!(stat.name(), "Treynor Ratio (63 days)");
+    }
+
+    #[rstest]
     fn test_known_value() {
         // strategy = 2 * benchmark -> beta = 2 (rf = 0).
         // aligned strategy = [0.02, -0.04, 0.030, -0.010, 0.050], n = 5, period = 5.
@@ -161,12 +167,6 @@ mod tests {
         let growth = 1.02_f64 * 0.96 * 1.03 * 0.99 * 1.05;
         let expected = (growth - 1.0) / 2.0;
         assert!(approx_eq!(f64, result, expected, epsilon = 1e-12));
-    }
-
-    #[rstest]
-    fn test_name_non_default_period() {
-        let stat = TreynorRatio::new(Some(63), None);
-        assert_eq!(stat.name(), "Treynor Ratio (63 days)");
     }
 
     #[rstest]
@@ -191,10 +191,26 @@ mod tests {
     }
 
     #[rstest]
-    fn test_zero_beta_is_nan() {
+    fn test_flat_benchmark_is_nan() {
         // Flat benchmark -> beta NaN -> NaN.
         let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);
         let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = TreynorRatio::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_zero_beta_is_nan() {
+        // Hits the `beta.abs() < EPSILON` arm with a finite beta (not the
+        // flat-benchmark arm, where beta itself is NaN):
+        //   mean_r = 0, mean_b = 0
+        //   Cov = (0.0001 - 0.0001 - 0.0001 + 0.0001) / 3 = 0.0 exactly -> beta = 0
+        //   Var(b) = 4 * 0.0001 / 3 ~ 1.333e-4 > EPSILON
+        let returns = create_returns(&[0.01, -0.01, 0.01, -0.01]);
+        let benchmark = create_returns(&[0.01, 0.01, -0.01, -0.01]);
         let stat = TreynorRatio::new(None, None);
         let result = stat
             .calculate_from_returns_with_benchmark(&returns, &benchmark)

--- a/crates/analysis/src/statistics/treynor_ratio.rs
+++ b/crates/analysis/src/statistics/treynor_ratio.rs
@@ -164,6 +164,33 @@ mod tests {
     }
 
     #[rstest]
+    fn test_name_non_default_period() {
+        let stat = TreynorRatio::new(Some(63), None);
+        assert_eq!(stat.name(), "Treynor Ratio (63 days)");
+    }
+
+    #[rstest]
+    fn test_known_value_period_ne_n_and_nonzero_rf() {
+        // period != n (so the (period / n) exponent is not 1) and rf != 0 (so rf must be
+        // annualized geometrically). n = 4, period = 252, rf = 0.0001 per period.
+        //   r = [0.02, -0.01, 0.03, 0.005], b = [0.01, 0.0, 0.015, 0.01]
+        //   beta = 2.5789473684210527
+        //   growth = prod(1 + r) = 1.04529447
+        //   annualized_geom = growth^(252/4) - 1 = 15.294278229155484
+        //   rf_annual = (1 + 0.0001)^252 - 1 = 0.025518911987694626
+        //   treynor = (annualized_geom - rf_annual) / beta = 5.920539327065061
+        // A wrong exponent (^1) gives 0.0076..., and skipping rf-annualization gives
+        // 5.9303956..., so this value discriminates against both bugs.
+        let returns = create_returns(&[0.02, -0.01, 0.03, 0.005]);
+        let benchmark = create_returns(&[0.01, 0.0, 0.015, 0.01]);
+        let stat = TreynorRatio::new(Some(252), Some(0.0001));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(approx_eq!(f64, result, 5.920539327065061, epsilon = 1e-9));
+    }
+
+    #[rstest]
     fn test_zero_beta_is_nan() {
         // Flat benchmark -> beta NaN -> NaN.
         let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);

--- a/crates/analysis/src/statistics/treynor_ratio.rs
+++ b/crates/analysis/src/statistics/treynor_ratio.rs
@@ -1,0 +1,197 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Treynor ratio statistic (benchmark-relative).
+
+use std::fmt::Display;
+
+use nautilus_model::position::Position;
+
+use crate::{Returns, statistic::PortfolioStatistic, statistics::beta_ratio::beta};
+
+/// Calculates the Treynor ratio of portfolio returns relative to a benchmark.
+///
+/// The Treynor ratio measures excess return per unit of systematic risk (beta):
+///
+/// `Treynor = (annualized_return - rf_annual) / beta`
+///
+/// The strategy's annualized return is computed geometrically (CAGR-style) from the
+/// aligned returns: `annualized_return = (prod(1 + r_i))^(period / n) - 1`. The
+/// per-period risk-free rate is annualized geometrically as
+/// `rf_annual = (1 + rf)^period - 1`. Beta is the sample (`ddof = 1`) beta of the
+/// strategy against the benchmark. The period defaults to 252 trading days and `rf`
+/// defaults to 0.0.
+///
+/// # References
+///
+/// - Treynor, J. L. (1965). "How to Rate Management of Investment Funds".
+///   *Harvard Business Review*, 43(1), 63-75.
+/// - CFA Institute Investment Foundations, 3rd Edition
+#[repr(C)]
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.core.nautilus_pyo3.analysis", from_py_object)
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.analysis")
+)]
+pub struct TreynorRatio {
+    /// The annualization period (default: 252 for daily data).
+    period: usize,
+    /// The per-period risk-free rate (default: 0.0).
+    risk_free_rate: f64,
+}
+
+impl TreynorRatio {
+    /// Creates a new [`TreynorRatio`] instance.
+    #[must_use]
+    pub fn new(period: Option<usize>, risk_free_rate: Option<f64>) -> Self {
+        Self {
+            period: period.unwrap_or(252),
+            risk_free_rate: risk_free_rate.unwrap_or(0.0),
+        }
+    }
+}
+
+impl Display for TreynorRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Treynor Ratio ({} days)", self.period)
+    }
+}
+
+impl PortfolioStatistic for TreynorRatio {
+    type Item = f64;
+
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    fn calculate_from_returns(&self, _returns: &Returns) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_realized_pnls(&self, _realized_pnls: &[f64]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_positions(&self, _positions: &[Position]) -> Option<Self::Item> {
+        None
+    }
+
+    fn calculate_from_returns_with_benchmark(
+        &self,
+        returns: &Returns,
+        benchmark: &Returns,
+    ) -> Option<Self::Item> {
+        let (r, b) = self.align_returns(returns, benchmark);
+        let n = r.len();
+        if n < 2 {
+            return Some(f64::NAN);
+        }
+
+        let beta = beta(&r, &b);
+        if beta.is_nan() || beta.abs() < f64::EPSILON {
+            return Some(f64::NAN);
+        }
+
+        let period = self.period as f64;
+        let growth = r.iter().map(|&ri| 1.0 + ri).product::<f64>();
+        let annualized_return = growth.powf(period / n as f64) - 1.0;
+        let rf_annual = (1.0 + self.risk_free_rate).powf(period) - 1.0;
+
+        Some((annualized_return - rf_annual) / beta)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nautilus_core::{UnixNanos, approx_eq};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_returns(values: &[f64]) -> BTreeMap<UnixNanos, f64> {
+        let mut new_return = BTreeMap::new();
+        let one_day_in_nanos = 86_400_000_000_000;
+        let start_time = 1_600_000_000_000_000_000;
+
+        for (i, &value) in values.iter().enumerate() {
+            let timestamp = start_time + i as u64 * one_day_in_nanos;
+            new_return.insert(UnixNanos::from(timestamp), value);
+        }
+
+        new_return
+    }
+
+    #[rstest]
+    fn test_name() {
+        let stat = TreynorRatio::new(None, None);
+        assert_eq!(stat.name(), "Treynor Ratio (252 days)");
+    }
+
+    #[rstest]
+    fn test_known_value() {
+        // strategy = 2 * benchmark -> beta = 2 (rf = 0).
+        // aligned strategy = [0.02, -0.04, 0.030, -0.010, 0.050], n = 5, period = 5.
+        // growth = prod(1+r_i); annualized = growth^(5/5) - 1 = growth - 1.
+        // treynor = (growth - 1) / 2.
+        let benchmark = create_returns(&[0.01, -0.02, 0.015, -0.005, 0.025]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = TreynorRatio::new(Some(5), Some(0.0));
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+
+        let growth = 1.02_f64 * 0.96 * 1.03 * 0.99 * 1.05;
+        let expected = (growth - 1.0) / 2.0;
+        assert!(approx_eq!(f64, result, expected, epsilon = 1e-12));
+    }
+
+    #[rstest]
+    fn test_zero_beta_is_nan() {
+        // Flat benchmark -> beta NaN -> NaN.
+        let benchmark = create_returns(&[0.01, 0.01, 0.01, 0.01, 0.01]);
+        let returns = create_returns(&[0.02, -0.04, 0.030, -0.010, 0.050]);
+        let stat = TreynorRatio::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_empty_returns_is_nan() {
+        let stat = TreynorRatio::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&create_returns(&[]), &create_returns(&[]))
+            .unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[rstest]
+    fn test_single_overlap_is_nan() {
+        let benchmark = create_returns(&[0.01, -0.02, 0.015]);
+        let returns = create_returns(&[0.02]);
+        let stat = TreynorRatio::new(None, None);
+        let result = stat
+            .calculate_from_returns_with_benchmark(&returns, &benchmark)
+            .unwrap();
+        assert!(result.is_nan());
+    }
+}

--- a/nautilus_trader/analysis/__init__.py
+++ b/nautilus_trader/analysis/__init__.py
@@ -48,10 +48,13 @@ from nautilus_trader.analysis.themes import get_theme
 from nautilus_trader.analysis.themes import list_themes
 from nautilus_trader.analysis.themes import register_theme
 from nautilus_trader.core.nautilus_pyo3 import CAGR
+from nautilus_trader.core.nautilus_pyo3 import Alpha
 from nautilus_trader.core.nautilus_pyo3 import AvgLoser
 from nautilus_trader.core.nautilus_pyo3 import AvgWinner
+from nautilus_trader.core.nautilus_pyo3 import BetaRatio
 from nautilus_trader.core.nautilus_pyo3 import CalmarRatio
 from nautilus_trader.core.nautilus_pyo3 import Expectancy
+from nautilus_trader.core.nautilus_pyo3 import InformationRatio
 from nautilus_trader.core.nautilus_pyo3 import LongRatio
 from nautilus_trader.core.nautilus_pyo3 import MaxDrawdown
 from nautilus_trader.core.nautilus_pyo3 import MaxLoser
@@ -66,16 +69,21 @@ from nautilus_trader.core.nautilus_pyo3 import ReturnsVolatility
 from nautilus_trader.core.nautilus_pyo3 import RiskReturnRatio
 from nautilus_trader.core.nautilus_pyo3 import SharpeRatio
 from nautilus_trader.core.nautilus_pyo3 import SortinoRatio
+from nautilus_trader.core.nautilus_pyo3 import TrackingError
+from nautilus_trader.core.nautilus_pyo3 import TreynorRatio
 from nautilus_trader.core.nautilus_pyo3 import WinRate
 
 
 __all__ = [
     "CAGR",
+    "Alpha",
     "AvgLoser",
     "AvgWinner",
+    "BetaRatio",
     "CalmarRatio",
     "Expectancy",
     "GridLayout",
+    "InformationRatio",
     "LongRatio",
     "MaxDrawdown",
     "MaxLoser",
@@ -105,6 +113,8 @@ __all__ = [
     "TearsheetRunInfoChart",
     "TearsheetStatsTableChart",
     "TearsheetYearlyReturnsChart",
+    "TrackingError",
+    "TreynorRatio",
     "WinRate",
     "create_drawdown_chart",
     "create_equity_curve",

--- a/nautilus_trader/analysis/analyzer.py
+++ b/nautilus_trader/analysis/analyzer.py
@@ -532,12 +532,13 @@ class PortfolioAnalyzer:
         Parameters
         ----------
         benchmark_returns : pd.Series
-            The benchmark returns series for comparison.
+            The benchmark returns series for comparison. Must be indexed by
+            ``pd.Timestamp``.
         returns : pd.Series, optional
             The strategy returns series to evaluate against the benchmark. If
             ``None``, the primary `returns` series is used (portfolio returns
             when available, otherwise position returns). Callers that resolve a
-            specific series (e.g. the tearsheet's equity-curve series) should
+            specific series (e.g., the tearsheet's equity-curve series) should
             pass it explicitly so the metrics match that series.
 
         Returns
@@ -547,14 +548,21 @@ class PortfolioAnalyzer:
         """
         output: dict[str, Any] = {}
 
-        strategy_returns = self._returns if returns is None else returns
-        returns_dict = self._returns_to_dict(strategy_returns)
-        benchmark_dict = self._returns_to_dict(benchmark_returns)
+        returns_dict: dict[int, float] | None = None
+        benchmark_dict: dict[int, float] | None = None
 
         for name, stat in self._statistics.items():
+            if not _is_pyo3_statistic(stat):
+                continue  # Benchmark-relative statistics are pyo3-only
+
             calculate = getattr(stat, "calculate_from_returns_with_benchmark", None)
             if calculate is None:
                 continue  # Not a benchmark-relative statistic
+
+            if returns_dict is None or benchmark_dict is None:
+                strategy_returns = self._returns if returns is None else returns
+                returns_dict = self._returns_to_dict(strategy_returns)
+                benchmark_dict = self._returns_to_dict(benchmark_returns)
 
             value = calculate(returns_dict, benchmark_dict)
             if value is None:

--- a/nautilus_trader/analysis/analyzer.py
+++ b/nautilus_trader/analysis/analyzer.py
@@ -520,19 +520,25 @@ class PortfolioAnalyzer:
     def get_performance_stats_returns_vs_benchmark(
         self,
         benchmark_returns: pd.Series,
+        returns: pd.Series | None = None,
     ) -> dict[str, Any]:
         """
-        Return the benchmark-relative performance statistics for the primary returns.
+        Return the benchmark-relative performance statistics.
 
         Only registered benchmark-relative statistics (those exposing
         ``calculate_from_returns_with_benchmark``) contribute values; all other
-        statistics are skipped. The primary `returns` series is used (portfolio
-        returns when available, otherwise position returns).
+        statistics are skipped.
 
         Parameters
         ----------
         benchmark_returns : pd.Series
             The benchmark returns series for comparison.
+        returns : pd.Series, optional
+            The strategy returns series to evaluate against the benchmark. If
+            ``None``, the primary `returns` series is used (portfolio returns
+            when available, otherwise position returns). Callers that resolve a
+            specific series (e.g. the tearsheet's equity-curve series) should
+            pass it explicitly so the metrics match that series.
 
         Returns
         -------
@@ -541,7 +547,8 @@ class PortfolioAnalyzer:
         """
         output: dict[str, Any] = {}
 
-        returns_dict = self._returns_to_dict(self._returns)
+        strategy_returns = self._returns if returns is None else returns
+        returns_dict = self._returns_to_dict(strategy_returns)
         benchmark_dict = self._returns_to_dict(benchmark_returns)
 
         for name, stat in self._statistics.items():
@@ -733,13 +740,7 @@ class PortfolioAnalyzer:
 
         for name, stat in self._statistics.items():
             if _is_pyo3_statistic(stat):
-                returns_dict: dict[int, float] = {}
-
-                if not returns.empty:
-                    for timestamp, value in returns.items():
-                        returns_dict[timestamp.value] = float(value)
-
-                value = stat.calculate_from_returns(returns_dict)
+                value = stat.calculate_from_returns(self._returns_to_dict(returns))
             else:
                 value = stat.calculate_from_returns(returns)
 

--- a/nautilus_trader/analysis/analyzer.py
+++ b/nautilus_trader/analysis/analyzer.py
@@ -517,6 +517,49 @@ class PortfolioAnalyzer:
         """
         return self._calculate_returns_stats(self._portfolio_returns)
 
+    def get_performance_stats_returns_vs_benchmark(
+        self,
+        benchmark_returns: pd.Series,
+    ) -> dict[str, Any]:
+        """
+        Return the benchmark-relative performance statistics for the primary returns.
+
+        Only registered benchmark-relative statistics (those exposing
+        ``calculate_from_returns_with_benchmark``) contribute values; all other
+        statistics are skipped. The primary `returns` series is used (portfolio
+        returns when available, otherwise position returns).
+
+        Parameters
+        ----------
+        benchmark_returns : pd.Series
+            The benchmark returns series for comparison.
+
+        Returns
+        -------
+        dict[str, Any]
+
+        """
+        output: dict[str, Any] = {}
+
+        returns_dict = self._returns_to_dict(self._returns)
+        benchmark_dict = self._returns_to_dict(benchmark_returns)
+
+        for name, stat in self._statistics.items():
+            calculate = getattr(stat, "calculate_from_returns_with_benchmark", None)
+            if calculate is None:
+                continue  # Not a benchmark-relative statistic
+
+            value = calculate(returns_dict, benchmark_dict)
+            if value is None:
+                continue
+
+            if not isinstance(value, int | float | str | bool):
+                value = str(value)
+
+            output[name] = value
+
+        return output
+
     def get_performance_stats_general(self) -> dict[str, Any]:
         """
         Return the `general` performance statistics.
@@ -709,6 +752,15 @@ class PortfolioAnalyzer:
             output[name] = value
 
         return output
+
+    def _returns_to_dict(self, returns: pd.Series) -> dict[int, float]:
+        returns_dict: dict[int, float] = {}
+
+        if not returns.empty:
+            for timestamp, value in returns.items():
+                returns_dict[timestamp.value] = float(value)
+
+        return returns_dict
 
     def _format_stats(self, stats: dict[str, Any]) -> list[str]:
         max_length: int = self._get_max_length_name()

--- a/nautilus_trader/analysis/tearsheet.py
+++ b/nautilus_trader/analysis/tearsheet.py
@@ -340,6 +340,15 @@ def create_tearsheet(  # noqa: C901
         currency=currency,
     )
 
+    # Include benchmark-relative statistics (Beta, Alpha, etc.) when a benchmark
+    # is provided, computed from the same primary returns series that backs
+    # `stats_returns` so the two stat groups stay consistent.
+    if benchmark_returns is not None and not benchmark_returns.empty:
+        stats_returns = {
+            **stats_returns,
+            **analyzer.get_performance_stats_returns_vs_benchmark(benchmark_returns),
+        }
+
     # Build title with strategy name(s) and run time
     if title == "NautilusTrader Backtest Results":
         strategies = engine.trader.strategy_ids()

--- a/nautilus_trader/analysis/tearsheet.py
+++ b/nautilus_trader/analysis/tearsheet.py
@@ -308,7 +308,9 @@ def create_tearsheet(  # noqa: C901
         Configuration for tearsheet customization. If None, uses default configuration.
     benchmark_returns : pd.Series, optional
         Benchmark returns series for comparison. If provided, benchmark will be overlaid
-        on visualizations.
+        on visualizations. Benchmark-relative statistics (e.g., BetaRatio, Alpha,
+        InformationRatio, TrackingError, TreynorRatio) are included in the returns
+        statistics when registered on the analyzer.
     benchmark_name : str, default "Benchmark"
         Display name for the benchmark.
 

--- a/nautilus_trader/analysis/tearsheet.py
+++ b/nautilus_trader/analysis/tearsheet.py
@@ -341,12 +341,15 @@ def create_tearsheet(  # noqa: C901
     )
 
     # Include benchmark-relative statistics (Beta, Alpha, etc.) when a benchmark
-    # is provided, computed from the same primary returns series that backs
-    # `stats_returns` so the two stat groups stay consistent.
+    # is provided, computed from the same resolved `returns` series used for the
+    # equity curve so the metrics and the plotted series stay consistent.
     if benchmark_returns is not None and not benchmark_returns.empty:
         stats_returns = {
             **stats_returns,
-            **analyzer.get_performance_stats_returns_vs_benchmark(benchmark_returns),
+            **analyzer.get_performance_stats_returns_vs_benchmark(
+                benchmark_returns,
+                returns=returns,
+            ),
         }
 
     # Build title with strategy name(s) and run time

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -10649,8 +10649,12 @@ class MaxDrawdown:
     def name(self) -> str: ...
     def calculate_from_returns(self, returns: dict[int, float]) -> float | None: ...
 
-class BetaRatio:
-    def __init__(self) -> None: ...
+class Alpha:
+    def __init__(
+        self,
+        period: int | None = None,
+        risk_free_rate: float | None = None,
+    ) -> None: ...
     @property
     def name(self) -> str: ...
     def calculate_from_returns_with_benchmark(
@@ -10659,12 +10663,8 @@ class BetaRatio:
         benchmark: dict[int, float],
     ) -> float | None: ...
 
-class Alpha:
-    def __init__(
-        self,
-        period: int | None = None,
-        risk_free_rate: float | None = None,
-    ) -> None: ...
+class BetaRatio:
+    def __init__(self) -> None: ...
     @property
     def name(self) -> str: ...
     def calculate_from_returns_with_benchmark(

--- a/nautilus_trader/core/nautilus_pyo3.pyi
+++ b/nautilus_trader/core/nautilus_pyo3.pyi
@@ -10562,6 +10562,10 @@ class PortfolioAnalyzer:
     def get_performance_stats_returns(self) -> dict[str, float]: ...
     def get_performance_stats_position_returns(self) -> dict[str, float]: ...
     def get_performance_stats_portfolio_returns(self) -> dict[str, float]: ...
+    def get_performance_stats_returns_vs_benchmark(
+        self,
+        benchmark: dict[int, float],
+    ) -> dict[str, float]: ...
     def get_performance_stats_pnls(
         self,
         currency: Currency | None = None,
@@ -10644,6 +10648,64 @@ class MaxDrawdown:
     @property
     def name(self) -> str: ...
     def calculate_from_returns(self, returns: dict[int, float]) -> float | None: ...
+
+class BetaRatio:
+    def __init__(self) -> None: ...
+    @property
+    def name(self) -> str: ...
+    def calculate_from_returns_with_benchmark(
+        self,
+        returns: dict[int, float],
+        benchmark: dict[int, float],
+    ) -> float | None: ...
+
+class Alpha:
+    def __init__(
+        self,
+        period: int | None = None,
+        risk_free_rate: float | None = None,
+    ) -> None: ...
+    @property
+    def name(self) -> str: ...
+    def calculate_from_returns_with_benchmark(
+        self,
+        returns: dict[int, float],
+        benchmark: dict[int, float],
+    ) -> float | None: ...
+
+class InformationRatio:
+    def __init__(self, period: int | None = None) -> None: ...
+    @property
+    def name(self) -> str: ...
+    def calculate_from_returns_with_benchmark(
+        self,
+        returns: dict[int, float],
+        benchmark: dict[int, float],
+    ) -> float | None: ...
+
+class TrackingError:
+    def __init__(self, period: int | None = None) -> None: ...
+    @property
+    def name(self) -> str: ...
+    def calculate_from_returns_with_benchmark(
+        self,
+        returns: dict[int, float],
+        benchmark: dict[int, float],
+    ) -> float | None: ...
+
+class TreynorRatio:
+    def __init__(
+        self,
+        period: int | None = None,
+        risk_free_rate: float | None = None,
+    ) -> None: ...
+    @property
+    def name(self) -> str: ...
+    def calculate_from_returns_with_benchmark(
+        self,
+        returns: dict[int, float],
+        benchmark: dict[int, float],
+    ) -> float | None: ...
 
 class WinRate:
     def __init__(self) -> None: ...

--- a/tests/unit_tests/analysis/test_analyzer.py
+++ b/tests/unit_tests/analysis/test_analyzer.py
@@ -22,7 +22,9 @@ import pytest
 
 from nautilus_trader.accounting.accounts.cash import CashAccount
 from nautilus_trader.analysis import CAGR
+from nautilus_trader.analysis import BetaRatio
 from nautilus_trader.analysis import CalmarRatio
+from nautilus_trader.analysis import InformationRatio
 from nautilus_trader.analysis import MaxDrawdown
 from nautilus_trader.analysis import ReturnsAverage
 from nautilus_trader.analysis import SharpeRatio
@@ -474,6 +476,47 @@ class TestPortfolioAnalyzer:
         assert self.analyzer.portfolio_returns().empty
         assert position_stats["Average (Return)"] == pytest.approx(0.30)
         assert returns_stats == position_stats
+
+    def test_get_performance_stats_returns_vs_benchmark(self):
+        # Arrange
+        self.analyzer.register_statistic(BetaRatio())
+        self.analyzer.register_statistic(InformationRatio())
+        self.analyzer.register_statistic(ReturnsAverage())  # Not benchmark-relative
+
+        timestamps = [datetime(year=2024, month=1, day=day, tzinfo=UTC) for day in (1, 2, 3, 4)]
+        for timestamp, value in zip(timestamps, [0.03, -0.01, 0.02, 0.04], strict=True):
+            self.analyzer.add_position_return(timestamp, value)
+
+        benchmark_returns = pd.Series(
+            [0.01, 0.005, 0.005, 0.01],
+            index=[pd.Timestamp(t) for t in timestamps],
+        )
+
+        # Act
+        stats = self.analyzer.get_performance_stats_returns_vs_benchmark(benchmark_returns)
+
+        # Assert: only the benchmark-relative statistics contribute
+        assert "Average (Return)" not in stats
+        assert stats == {
+            "Beta": pytest.approx(6.0),
+            "Information Ratio (252 days)": pytest.approx(10.246950765959598),
+        }
+
+    def test_get_performance_stats_returns_vs_benchmark_with_explicit_returns(self):
+        # Arrange
+        self.analyzer.register_statistic(BetaRatio())
+
+        timestamps = [pd.Timestamp(f"2024-01-0{day}", tz="UTC") for day in (1, 2, 3, 4)]
+        benchmark_returns = pd.Series([0.01, 0.005, 0.005, 0.01], index=timestamps)
+
+        # Act: the benchmark evaluated against itself must have unit beta
+        stats = self.analyzer.get_performance_stats_returns_vs_benchmark(
+            benchmark_returns,
+            returns=benchmark_returns,
+        )
+
+        # Assert
+        assert stats["Beta"] == pytest.approx(1.0)
 
     def test_portfolio_returns_skips_empty_balance_snapshots(self):
         # Arrange


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Implements the benchmark-relative performance statistics agreed in #4229: `BetaRatio`, `Alpha` (Jensen's), `InformationRatio`, `TrackingError`, and `TreynorRatio`, as Rust-core `PortfolioStatistic`s with PyO3 bindings.

- Adds an optional trait method `calculate_from_returns_with_benchmark` (default `None`, so analyzer loops filter by `Option` like they already do for `calculate_from_positions` results) plus a shared `align_returns` helper that daily-bins both series and inner-joins on shared timestamps (non-overlapping points dropped, not zero-filled).
- Each statistic overrides the single-source methods to return `None` (panic-safe per the #3941/#4174 precedent) and is **not** default-registered — existing analyzer and tearsheet output is unchanged when no benchmark is provided.
- Adds a stateless `get_performance_stats_returns_vs_benchmark(benchmark)` to the Rust and PyO3 analyzers; the pure-Python `PortfolioAnalyzer` gains a thin getter that delegates to the registered PyO3 statistics (no parallel Python implementations).
- Thin tearsheet wiring: when `benchmark_returns` is provided, benchmark statistics are computed from the same resolved returns series used for the equity chart and merged into the returns stats.
- Includes PyO3 class registration, `nautilus_trader.analysis` exports, and stub updates.

### Conventions

| Statistic | Per-period | Annualization |
|---|---|---|
| `BetaRatio` | Cov(r, b) / Var(b), ddof=1 | none |
| `Alpha` | (mean_r − rf) − β·(mean_b − rf) | geometric: (1 + α)^period − 1 |
| `InformationRatio` | mean(r − b) / std(r − b, ddof=1) | × √period |
| `TrackingError` | std(r − b, ddof=1) | × √period |
| `TreynorRatio` | (CAGR − rf_annual) / β | CAGR numerator, rf annualized internally |

Per-period formulas match `empyrical`; IR and TE are annualized for consistency with `SharpeRatio` / `ReturnsVolatility`, with the period in the display name (e.g. `Information Ratio (252 days)`). Degenerate inputs (<2 aligned points, flat benchmark, zero active std for IR) return `NaN`, matching existing conventions.

Up/Down Capture is left as the follow-up discussed in #4229.

### Verification

- `cargo test -p nautilus-analysis --lib` — 175 passed; includes independently hand-derived known-value tests, partial-overlap inner-join, intraday-compounding, and analyzer-getter cases
- Python tests for the delegating `PortfolioAnalyzer` getter (including the resolved-series override)
- `cargo clippy -p nautilus-analysis --lib --tests --all-features --no-deps -- -D warnings`
- `cargo fmt -p nautilus-analysis --check`
- Built the PyO3 extension and smoke-tested end-to-end: all five classes construct and compute; `PortfolioAnalyzer.get_performance_stats_returns_vs_benchmark` returns values matching the Rust unit tests

Closes #4229.