### PR TITLE
Fix Lighter concurrent batch nonce-ordering race

### DIFF
--- a/crates/adapters/lighter/src/execution.rs
+++ b/crates/adapters/lighter/src/execution.rs
@@ -152,6 +152,7 @@ pub struct LighterExecutionClient {
     http_client: LighterHttpClient,
     ws_client: LighterWebSocketClient,
     tx_rate_limiter: Arc<LighterTxRateLimiter>,
+    http_batch_serializer: Arc<tokio::sync::Mutex<()>>,
     registry: Arc<MarketRegistry>,
     pending_tasks: Mutex<Vec<JoinHandle<()>>>,
     ws_stream_handle: Mutex<Option<JoinHandle<()>>>,
@@ -234,6 +235,7 @@ impl LighterExecutionClient {
             http_client,
             ws_client,
             tx_rate_limiter,
+            http_batch_serializer: Arc::new(tokio::sync::Mutex::new(())),
             registry,
             pending_tasks: Mutex::new(Vec::new()),
             ws_stream_handle: Mutex::new(None),
@@ -2444,12 +2446,16 @@ impl ExecutionClient for LighterExecutionClient {
         let credential = credential.clone();
         let emitter = self.emitter.clone();
         let clock = self.clock;
+        let http_batch_serializer = self.http_batch_serializer.clone();
 
         self.spawn_task("submit_order_list", async move {
             log::debug!(
                 "Lighter submit_order_list: queueing {} CreateOrder txs",
                 prepared_orders.len(),
             );
+
+            // Serialize batch sends — venue rejects out-of-order nonces (21104).
+            let _send_guard = http_batch_serializer.lock().await;
 
             match http_client.send_tx_batch(&request).await {
                 Ok(_) => {
@@ -2593,12 +2599,16 @@ impl ExecutionClient for LighterExecutionClient {
         let credential = credential.clone();
         let emitter = self.emitter.clone();
         let clock = self.clock;
+        let http_batch_serializer = self.http_batch_serializer.clone();
 
         self.spawn_task("batch_cancel_orders", async move {
             log::debug!(
                 "Lighter batch_cancel_orders: queueing {} CancelOrder txs",
                 prepared_cancels.len(),
             );
+
+            // Serialize batch sends — venue rejects out-of-order nonces (21104).
+            let _send_guard = http_batch_serializer.lock().await;
 
             match http_client.send_tx_batch(&request).await {
                 Ok(_) => {


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

## Problem

When multiple strategies submit orders concurrently against a single `LighterExecutionClient`, the venue's REST endpoint frequently rejects batches with venue error code **21104 ("invalid nonce")** — losing all orders in the affected batches and forcing a hard nonce resync.

Sequence we observed in production:

1. 5 child strategies fire `SubmitOrderList` in the same tick (10 orders total, all on the same `(account_index, api_key_index)`).
2. Each `submit_order_list` allocates its nonces synchronously, then spawns a task that calls `http_client.send_tx_batch(...).await`.
3. The five spawned tasks race through the rate limiter (a token bucket that issues tokens to multiple awaiters concurrently) and then race each other through the connection pool.
4. The venue receives the five batches in *some* TCP write order — which is not the nonce-issuance order. The first batch to land defines the sequencer's expected next-nonce; every subsequent batch whose first nonce isn't the next expected one is rejected with `21104`.

In a representative bad run, 2 of 5 strategies succeeded (the ones that happened to win the TCP race) and 3 failed; in the next run with the same code, 5 of 5 succeeded because the natural inter-instrument quote-tick latency staggered the submissions and they never overlapped at the venue. That non-determinism made the bug hard to attribute.

## Root cause

`tx_rate_limiter` is a throttle (token bucket), not a serializer. It bounds *aggregate* HTTP+WS sendTx rate per account but lets multiple awaiters proceed in parallel once tokens are available. There is no existing mechanism that guarantees the venue sees HTTP batches in nonce-ascending order on a single client instance.

The WS `sendTx` path is unaffected — outbound WS frames are funnelled through the WS handler's single command channel, which serializes them naturally.

## Fix

Add a per-client `tokio::sync::Mutex<()>` and hold it across the `send_tx_batch().await` call in `submit_order_list` and `batch_cancel_orders`. Concurrent batch submits now queue at the mutex (FIFO under contention), and the venue receives exactly one HTTP batch at a time from this client, in lock-acquisition order. Each batch carries a contiguous nonce range, so 21104-from-our-own-race is eliminated.

The token-bucket throttle is still acquired first (unchanged), and the existing batch-success baseline advance (`advance_baseline_for_batch`) and `resync_nonce_after_invalid_nonce` recovery paths remain as-is — the resync becomes a safety net for *external* drift only (e.g. the account doing something outside this process) rather than the per-client race that it was previously catching after the fact.

## Scope

- One file: `crates/adapters/lighter/src/execution.rs`.
- One field on `LighterExecutionClient`, initialized in `new()`.
- Two `lock().await` sites — both immediately before the existing `http_client.send_tx_batch(&request).await` calls.
- No public-API change, no nonce-manager change, no WS-path change.

## Alternatives considered

- **Doing nothing and relying on `resync_nonce_after_invalid_nonce`**: works in steady state, but the first burst still loses orders. With bursty strategy startup (cluster-deploy) this is repeatedly visible to users.
- **Serializing inside `LighterTxRateLimiter`**: changes the limiter's semantics from "rate cap" to "rate cap + mutual exclusion". Would also affect the WS path, which doesn't need it.
- **Per-strategy stagger above the adapter**: pushes adapter-internal invariants up into strategy code; brittle.

The mutex is the smallest change that restores the invariant the venue actually requires (HTTP batches in nonce-ascending 


## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore