### PR TITLE
Share dYdX REST rate limiter across clients

### DIFF
--- a/crates/adapters/dydx/src/http/client.rs
+++ b/crates/adapters/dydx/src/http/client.rs
@@ -80,7 +80,7 @@ use nautilus_model::{
 };
 use nautilus_network::{
     http::{HttpClient, Method, USER_AGENT},
-    ratelimiter::quota::Quota,
+    ratelimiter::{RateLimiter, clock::MonotonicClock, quota::Quota},
     retry::{RetryConfig, RetryManager},
 };
 use rust_decimal::Decimal;
@@ -135,6 +135,17 @@ fn bar_type_to_resolution(bar_type: &BarType) -> anyhow::Result<DydxCandleResolu
 pub static DYDX_REST_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
     Quota::per_second(NonZeroU32::new(9).expect("non-zero")).expect("valid constant")
 });
+
+/// Process-global rate limiter for the dYdX Indexer REST API.
+///
+/// Shared across every [`DydxRawHttpClient`] (and therefore every
+/// [`DydxHttpClient`]) constructed in the process, so the data client and
+/// execution client draw from the same 9 req/s bucket instead of one each.
+/// dYdX mainnet vs testnet are treated as a single bucket here — at worst
+/// slightly over-conservative if both networks ran in the same process, which
+/// they never do in practice.
+pub static DYDX_REST_RATE_LIMITER: LazyLock<Arc<RateLimiter<Ustr, MonotonicClock>>> =
+    LazyLock::new(|| Arc::new(RateLimiter::new_with_quota(Some(*DYDX_REST_QUOTA), vec![])));
 
 static DYDX_RATE_LIMIT_KEY: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("dydx:rest"));
 
@@ -221,13 +232,12 @@ impl DydxRawHttpClient {
         let mut headers = HashMap::new();
         headers.insert(USER_AGENT.to_string(), NAUTILUS_USER_AGENT.to_string());
 
-        let client = HttpClient::new(
+        let client = HttpClient::new_with_rate_limiter(
             headers,
-            vec![], // No specific headers to extract from responses
-            vec![], // No keyed quotas (we use a single global quota)
-            Some(*DYDX_REST_QUOTA),
+            vec![],
             Some(timeout_secs),
             proxy_url,
+            Arc::clone(&DYDX_REST_RATE_LIMITER),
         )
         .map_err(|e| {
             DydxHttpError::ValidationError(format!("Failed to create HTTP client: {e}"))

--- a/crates/network/src/http/client.rs
+++ b/crates/network/src/http/client.rs
@@ -77,6 +77,35 @@ impl HttpClient {
         timeout_secs: Option<u64>,
         proxy_url: Option<String>,
     ) -> Result<Self, HttpClientError> {
+        let keyed_quotas = keyed_quotas
+            .into_iter()
+            .map(|(key, quota)| (Ustr::from(&key), quota))
+            .collect();
+
+        let rate_limiter = Arc::new(RateLimiter::new_with_quota(default_quota, keyed_quotas));
+
+        Self::new_with_rate_limiter(headers, header_keys, timeout_secs, proxy_url, rate_limiter)
+    }
+
+    /// Creates a new [`HttpClient`] instance sharing an externally-owned rate limiter.
+    ///
+    /// Use this constructor to share a single [`RateLimiter`] across multiple
+    /// [`HttpClient`] instances (for example, the HTTP clients owned by an
+    /// exchange adapter's data and execution clients). All quota state lives
+    /// inside the limiter, so passing the same `Arc` produces a single shared
+    /// bucket.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `InvalidProxy` if the proxy URL is malformed.
+    /// - Returns `ClientBuildError` if building the underlying `reqwest::Client` fails.
+    pub fn new_with_rate_limiter(
+        headers: HashMap<String, String>,
+        header_keys: Vec<String>,
+        timeout_secs: Option<u64>,
+        proxy_url: Option<String>,
+        rate_limiter: Arc<RateLimiter<Ustr, MonotonicClock>>,
+    ) -> Result<Self, HttpClientError> {
         install_cryptographic_provider();
 
         // Build default headers
@@ -133,13 +162,6 @@ impl HttpClient {
             header_keys: Arc::new(valid_keys),
             header_names: Arc::new(header_names),
         };
-
-        let keyed_quotas = keyed_quotas
-            .into_iter()
-            .map(|(key, quota)| (Ustr::from(&key), quota))
-            .collect();
-
-        let rate_limiter = Arc::new(RateLimiter::new_with_quota(default_quota, keyed_quotas));
 
         Ok(Self {
             client,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The dYdX adapter previously constructed two independent `DydxHttpClient` instances — one in `DydxDataClient` (`crates/adapters/dydx/src/factories.rs:122`) and one in `DydxExecutionClient` (`crates/adapters/dydx/src/execution/mod.rs:225`). Each owned its own `HttpClient`, and each `HttpClient` built its own `Arc<RateLimiter<Ustr, MonotonicClock>>` inside `HttpClient::new`. The dYdX Indexer enforces ~100 req / 10s per IP across all routes, but we capped locally at 9 req/s **per client** → up to ~18 req/s combined → server bucket drains → HTTP 429.

This was reproducible in production under normal trading load — both the data client paginating `/v4/trades/perpetualMarket/{ticker}` + `/v4/candles/perpetualMarkets/{ticker}` and the execution client polling `/v4/orders`, `/v4/fills`, and `/v4/addresses/.../subaccountNumber/N` would drain the same per-IP server bucket faster than it refilled.

Two commits:

1. **Add `HttpClient` constructor for injecting an external rate limiter**
   New `HttpClient::new_with_rate_limiter(headers, header_keys, timeout_secs, proxy_url, rate_limiter)` constructor on `nautilus-network`. Existing `HttpClient::new` now builds the limiter from quotas and delegates to it — single assembly path, no drift.

2. **Share a single rate limiter across dYdX data and execution HTTP clients**
   New process-global `pub static DYDX_REST_RATE_LIMITER: LazyLock<Arc<RateLimiter<Ustr, MonotonicClock>>>` built from the existing `DYDX_REST_QUOTA` (`crates/adapters/dydx/src/http/client.rs`). `DydxRawHttpClient::new` now calls `HttpClient::new_with_rate_limiter(..., Arc::clone(&DYDX_REST_RATE_LIMITER))`, so every `DydxHttpClient` constructed downstream of the data and execution factories shares the same 9 req/s bucket. `factories.rs`, `execution/mod.rs`, and `data.rs` are untouched — they flow through `DydxRawHttpClient::new` and pick up the shared limiter automatically.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore