### PR TITLE
Fix Kraken request_bars to keep the most recent bars on count-only requests

### DIFF
--- a/crates/adapters/kraken/src/http/futures/client.rs
+++ b/crates/adapters/kraken/src/http/futures/client.rs
@@ -1394,18 +1394,16 @@ impl KrakenFuturesHttpClient {
                         continue;
                     }
                     bars.push(bar);
-
-                    if let Some(limit_count) = limit
-                        && bars.len() >= limit_count as usize
-                    {
-                        return Ok(bars);
-                    }
                 }
                 Err(e) => {
                     log::warn!("Failed to parse futures bar: {e}");
                 }
             }
         }
+
+        // Kraken returns the page oldest-first; keep the most recent `limit`
+        // bars for count-only requests rather than the oldest (issue #4254).
+        crate::http::apply_bar_limit(&mut bars, start, limit);
 
         Ok(bars)
     }

--- a/crates/adapters/kraken/src/http/mod.rs
+++ b/crates/adapters/kraken/src/http/mod.rs
@@ -20,10 +20,38 @@
 //! - [`spot`]: Kraken Spot REST API
 //! - [`futures`]: Kraken Futures REST API
 
+use chrono::{DateTime, Utc};
+use nautilus_model::data::Bar;
+
 pub mod error;
 pub mod futures;
 pub mod models;
 pub mod spot;
+
+/// Applies a `limit` to OHLC `bars` returned oldest-first by Kraken.
+///
+/// Kraken's OHLC endpoints ignore any count parameter and always return their
+/// full page in ascending (oldest-first) order. When the caller anchors the
+/// window with `start`, the oldest `limit` bars from that anchor are the
+/// intended result, so the head of the page is kept. Otherwise a count-only
+/// request (`start` is `None`) means "the most recent `limit` bars", so the
+/// tail is kept rather than the head (see issue #4254).
+pub(crate) fn apply_bar_limit(
+    bars: &mut Vec<Bar>,
+    start: Option<DateTime<Utc>>,
+    limit: Option<u64>,
+) {
+    if let Some(limit) = limit {
+        let limit = limit as usize;
+        if bars.len() > limit {
+            if start.is_some() {
+                bars.truncate(limit);
+            } else {
+                bars.drain(..bars.len() - limit);
+            }
+        }
+    }
+}
 
 // Re-exports
 pub use error::KrakenHttpError;
@@ -40,3 +68,68 @@ pub use spot::{
     },
     query::*,
 };
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::UnixNanos;
+    use nautilus_model::{
+        data::{Bar, BarType},
+        types::{Price, Quantity},
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Builds `n` bars in ascending (oldest-first) order, as Kraken returns them,
+    /// with `ts_event` set to the 1-based index so ordering is easy to assert.
+    fn ascending_bars(n: u64) -> Vec<Bar> {
+        let bar_type = BarType::from("ETH/USD.KRAKEN-1-MINUTE-LAST-EXTERNAL");
+        let price = Price::from("100.0");
+        let volume = Quantity::from("1");
+        (1..=n)
+            .map(|i| {
+                Bar::new(
+                    bar_type,
+                    price,
+                    price,
+                    price,
+                    price,
+                    volume,
+                    UnixNanos::from(i),
+                    UnixNanos::default(),
+                )
+            })
+            .collect()
+    }
+
+    #[rstest]
+    fn test_apply_bar_limit_no_limit_keeps_all() {
+        let mut bars = ascending_bars(5);
+        apply_bar_limit(&mut bars, None, None);
+        assert_eq!(bars.len(), 5);
+    }
+
+    #[rstest]
+    fn test_apply_bar_limit_count_only_keeps_most_recent() {
+        let mut bars = ascending_bars(10);
+        apply_bar_limit(&mut bars, None, Some(3));
+        let ts: Vec<u64> = bars.iter().map(|b| b.ts_event.as_u64()).collect();
+        assert_eq!(ts, vec![8, 9, 10]);
+    }
+
+    #[rstest]
+    fn test_apply_bar_limit_with_start_keeps_oldest() {
+        let mut bars = ascending_bars(10);
+        let start = DateTime::<Utc>::from_timestamp(0, 0);
+        apply_bar_limit(&mut bars, start, Some(3));
+        let ts: Vec<u64> = bars.iter().map(|b| b.ts_event.as_u64()).collect();
+        assert_eq!(ts, vec![1, 2, 3]);
+    }
+
+    #[rstest]
+    fn test_apply_bar_limit_fewer_bars_than_limit() {
+        let mut bars = ascending_bars(2);
+        apply_bar_limit(&mut bars, None, Some(5));
+        assert_eq!(bars.len(), 2);
+    }
+}

--- a/crates/adapters/kraken/src/http/spot/client.rs
+++ b/crates/adapters/kraken/src/http/spot/client.rs
@@ -1549,12 +1549,6 @@ impl KrakenSpotHttpClient {
                             continue;
                         }
                         bars.push(bar);
-
-                        if let Some(limit_count) = limit
-                            && bars.len() >= limit_count as usize
-                        {
-                            return Ok(bars);
-                        }
                     }
                     Err(e) => {
                         log::warn!("Failed to parse bar: {e}");
@@ -1562,6 +1556,10 @@ impl KrakenSpotHttpClient {
                 }
             }
         }
+
+        // Kraken returns the page oldest-first; keep the most recent `limit`
+        // bars for count-only requests rather than the oldest (issue #4254).
+        crate::http::apply_bar_limit(&mut bars, start, limit);
 
         Ok(bars)
     }


### PR DESCRIPTION
## Summary

Fixes #4254.

Kraken's OHLC endpoints ignore any count parameter and always return their full page **oldest-first** (ascending). `request_bars` truncated to `limit` by returning early inside the ascending loop, so it kept the **oldest** `limit` bars of the page.

A count-only request — `RequestBars { start: None, end: None, limit: Some(N) }` — therefore returned a window ending hours in the past instead of the most recent N bars, silently (correct count and shape; only the timestamps reveal it). Everywhere else a count-only history request means "the most recent N bars" (Binance/Bybit kline endpoints, and the Python `request_bars(..., limit)` convention).

## Changes

- Add a shared `apply_bar_limit` helper in `http/mod.rs`:
  - `start` set → keep the oldest `limit` bars from that anchor (head of the page), so an explicit window is unaffected.
  - `start` is `None` → keep the **tail** of the ascending page, so a count-only request returns the most recent N bars.
- Apply it in both `http/spot/client.rs` and `http/futures/client.rs` `request_bars`, replacing the in-loop early return.

## Tests

- Added unit tests for `apply_bar_limit` covering: no limit, count-only (keeps most recent), `start`-anchored (keeps oldest), and fewer bars than the limit.
- `cargo test -p nautilus-kraken --lib http::tests` passes.