### PR TITLE
Add Kraken spot WebSocket idle timeout to detect dead connections

### DIFF
--- a/crates/adapters/kraken/src/config.rs
+++ b/crates/adapters/kraken/src/config.rs
@@ -59,6 +59,27 @@ pub struct KrakenDataClientConfig {
     pub timeout_secs: u64,
     #[builder(default = 30)]
     pub heartbeat_interval_secs: u64,
+    /// Idle timeout (milliseconds) for the spot v2 WebSocket.
+    ///
+    /// If no application data (any text or binary frame) is received within this
+    /// window, the connection is treated as dead and the client reconnects and
+    /// resubscribes. This recovers from a backend that acknowledges a
+    /// subscription but never attaches the data fan-out: the socket stays open
+    /// with no close frame or transport error, so nothing else detects it.
+    ///
+    /// Kraken sends a `heartbeat` text frame once per second while at least one
+    /// subscription is active, so a live subscribed connection resets this timer
+    /// well within the window. Note the client's keepalive `ping` is answered
+    /// with a `pong` *text* frame, which also resets the timer roughly every
+    /// `heartbeat_interval_secs`; the default below is therefore kept short
+    /// enough to rely on the 1/s heartbeats rather than the keepalive, which
+    /// assumes the connection carries at least one subscription. A connection
+    /// held open without any subscription should disable this (`0`) or raise it
+    /// above `heartbeat_interval_secs`.
+    ///
+    /// `0` disables the idle timeout.
+    #[builder(default = 10_000)]
+    pub ws_idle_timeout_ms: u64,
     pub max_requests_per_second: Option<u32>,
     #[builder(default)]
     pub transport_backend: TransportBackend,
@@ -281,6 +302,19 @@ validate_l3_checksum = false
         assert_eq!(config.environment, KrakenEnvironment::Live);
         assert_eq!(config.timeout_secs, 45);
         assert!(!config.validate_l3_checksum);
+    }
+
+    #[rstest]
+    fn test_data_config_ws_idle_timeout_default() {
+        let config = KrakenDataClientConfig::default();
+        assert_eq!(config.ws_idle_timeout_ms, 10_000);
+    }
+
+    #[rstest]
+    fn test_data_config_ws_idle_timeout_override() {
+        let config: KrakenDataClientConfig = toml::from_str("ws_idle_timeout_ms = 0").unwrap();
+
+        assert_eq!(config.ws_idle_timeout_ms, 0);
     }
 
     #[rstest]

--- a/crates/adapters/kraken/src/execution/spot.rs
+++ b/crates/adapters/kraken/src/execution/spot.rs
@@ -161,6 +161,9 @@ impl KrakenSpotExecutionClient {
             proxy_url: config.proxy_url.clone(),
             timeout_secs: config.timeout_secs,
             heartbeat_interval_secs: config.heartbeat_interval_secs,
+            // The authenticated order-routing WS keeps its prior behavior (no
+            // idle timeout); issue #4255 concerns the public spot data WS.
+            ws_idle_timeout_ms: 0,
             max_requests_per_second: config.max_requests_per_second,
             transport_backend: config.transport_backend,
         };

--- a/crates/adapters/kraken/src/python/config.rs
+++ b/crates/adapters/kraken/src/python/config.rs
@@ -45,6 +45,7 @@ impl KrakenDataClientConfig {
         proxy_url = None,
         timeout_secs = None,
         heartbeat_interval_secs = None,
+        ws_idle_timeout_ms = None,
         max_requests_per_second = None,
     ))]
     #[expect(clippy::too_many_arguments)]
@@ -61,6 +62,7 @@ impl KrakenDataClientConfig {
         proxy_url: Option<String>,
         timeout_secs: Option<u64>,
         heartbeat_interval_secs: Option<u64>,
+        ws_idle_timeout_ms: Option<u64>,
         max_requests_per_second: Option<u32>,
     ) -> Self {
         let defaults = Self::default();
@@ -78,6 +80,7 @@ impl KrakenDataClientConfig {
             timeout_secs: timeout_secs.unwrap_or(defaults.timeout_secs),
             heartbeat_interval_secs: heartbeat_interval_secs
                 .unwrap_or(defaults.heartbeat_interval_secs),
+            ws_idle_timeout_ms: ws_idle_timeout_ms.unwrap_or(defaults.ws_idle_timeout_ms),
             max_requests_per_second,
             transport_backend: defaults.transport_backend,
         }

--- a/crates/adapters/kraken/src/websocket/spot_v2/client.rs
+++ b/crates/adapters/kraken/src/websocket/spot_v2/client.rs
@@ -259,7 +259,10 @@ impl KrakenSpotWebSocketClient {
             reconnect_backoff_factor: Some(1.5),
             reconnect_jitter_ms: Some(250),
             reconnect_max_attempts: None,
-            idle_timeout_ms: None,
+            // Treat a silent connection as dead so the reconnect + resubscribe
+            // path runs. `0` disables; see `ws_idle_timeout_ms` docs (issue #4255).
+            idle_timeout_ms: (self.config.ws_idle_timeout_ms != 0)
+                .then_some(self.config.ws_idle_timeout_ms),
             backend: self.transport_backend,
             proxy_url: self.proxy_url.clone(),
         };

--- a/python/nautilus_trader/adapters/kraken/__init__.pyi
+++ b/python/nautilus_trader/adapters/kraken/__init__.pyi
@@ -56,6 +56,7 @@ class KrakenDataClientConfig:
         proxy_url: str | None = None,
         timeout_secs: int | None = None,
         heartbeat_interval_secs: int | None = None,
+        ws_idle_timeout_ms: int | None = None,
         max_requests_per_second: int | None = None,
     ) -> None: ...
 


### PR DESCRIPTION
## Summary

Fixes #4255.

`KrakenSpotWebSocketClient::connect` hardcoded `idle_timeout_ms: None`. Intermittently, Kraken's spot WS v2 accepts a subscription (acks with `success: true`) and then never delivers data on that connection — the socket stays open (no close frame, no transport error, no reconnect), so nothing detects it and the strategy silently receives no data indefinitely.

## Changes

- Add `ws_idle_timeout_ms` to `KrakenDataClientConfig` (default `10_000`) and wire it into the spot v2 `WebSocketConfig`. `0` disables it.
- Thread the field through the PyO3 config constructor and `.pyi` stub.
- The authenticated execution WS opts out (`0`) to preserve its current behavior — this issue concerns the public data WS.

## Why 10s

The network read loop resets its idle timer only on **application** frames (text/binary), not ping/pong. Kraken sends a `heartbeat` text frame **once per second** while at least one subscription is active, so a live subscribed connection resets the timer well within 10s, while a silent (acked-but-no-fan-out) connection trips it and runs the existing reconnect + resubscribe path.

The default is deliberately shorter than the client's keepalive interval: the keepalive `ping` is answered with a `pong` *text* frame that also resets the timer (~every `heartbeat_interval_secs`, default 30s), so a longer timeout would be masked by the keepalive and never fire. Relying on the 1/s heartbeats assumes the connection carries at least one subscription; this trade-off is documented on the field, and a connection deliberately held open without any subscription can disable it (`0`) or raise it above `heartbeat_interval_secs`.

## Tests

- Added config unit tests (default value and `0` override).
- `cargo test -p nautilus-kraken --lib config::tests` passes; `cargo check -p nautilus-kraken --features python` is clean.