### PR TITLE
Use Interactive Brokers permId for stable IB order identity

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -49,10 +49,10 @@ pub(crate) fn should_use_avg_fill_price(avg_fill_price: f64, instrument_id: &Ins
 }
 
 pub(crate) fn ib_venue_order_id(order_id: i32, perm_id: i64) -> VenueOrderId {
-    if order_id != 0 {
-        VenueOrderId::new(order_id.to_string())
-    } else {
+    if perm_id != 0 {
         VenueOrderId::new(format!("PERM-{perm_id}"))
+    } else {
+        VenueOrderId::new(order_id.to_string())
     }
 }
 
@@ -692,9 +692,9 @@ mod tests {
     }
 
     #[rstest]
-    fn test_ib_venue_order_id_prefers_order_id_and_falls_back_to_perm_id() {
-        assert_eq!(ib_venue_order_id(123, 456).to_string(), "123");
-        assert_eq!(ib_venue_order_id(0, 456).to_string(), "PERM-456");
+    fn test_ib_venue_order_id_prefers_perm_id_and_falls_back_to_order_id() {
+        assert_eq!(ib_venue_order_id(123, 456).to_string(), "PERM-456");
+        assert_eq!(ib_venue_order_id(123, 0).to_string(), "123");
     }
 
     #[rstest]

--- a/crates/common/src/messages/mod.rs
+++ b/crates/common/src/messages/mod.rs
@@ -40,7 +40,7 @@ pub use data::{DataResponse, SubscribeCommand, UnsubscribeCommand};
 pub use execution::ExecutionReport;
 
 // TODO: Refine this to reduce disparity between enum sizes
-#[expect(
+#[allow(
     clippy::large_enum_variant,
     reason = "event enum keeps all data variants in one routing type"
 )]

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -47,11 +47,11 @@ class AccountOrderRef(NamedTuple):
 
 def get_venue_order_id(order_id: int, perm_id: int) -> VenueOrderId:
     """
-    Get venue order ID, using permId for external orders (orderId=0).
+    Get venue order ID, preferring IB's permanent order ID.
 
-    IB assigns orderId=0 to external orders (placed via TWS or other clients) and
-    completed orders. Since multiple orders can have orderId=0, we use the unique
-    permId to identify them.
+    IB order IDs are only unique within an API client/session, so once a permId
+    is available it is used as the stable venue order ID. A raw orderId is only
+    used as a temporary fallback while IB has not yet assigned a permId.
 
     Parameters
     ----------
@@ -65,9 +65,9 @@ def get_venue_order_id(order_id: int, perm_id: int) -> VenueOrderId:
     VenueOrderId
 
     """
-    if order_id != 0:
-        return VenueOrderId(str(order_id))
-    return VenueOrderId(f"PERM-{perm_id}")
+    if perm_id != 0:
+        return VenueOrderId(f"PERM-{perm_id}")
+    return VenueOrderId(str(order_id))
 
 
 class IBPosition(NamedTuple):

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -337,6 +337,16 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
         venue_order_id = get_venue_order_id(order_id, perm_id)
         order_ref = self._order_id_to_order_ref.get(venue_order_id, None)
 
+        if order_ref is None and perm_id != 0 and order_id != 0:
+            raw_venue_order_id = VenueOrderId(str(order_id))
+            order_ref = self._order_id_to_order_ref.get(raw_venue_order_id, None)
+            if order_ref is not None:
+                self._set_order_id_ref(
+                    venue_order_id=venue_order_id,
+                    account_id=order_ref.account_id,
+                    order_id=order_ref.order_id,
+                )
+
         if order_ref is None:
             order_ref = self._resolve_order_ref_from_cache(venue_order_id)
 

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1089,7 +1089,7 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 order=client_id_to_orders[order_ref],
             )
 
-    async def _modify_order(self, command: ModifyOrder) -> None:
+    async def _modify_order(self, command: ModifyOrder) -> None:  # noqa: C901
         PyCondition.not_none(command, "command")
         if not (command.quantity or command.price or command.trigger_price):
             return
@@ -1123,13 +1123,41 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             )
             return
 
-        ib_order.orderId = int(command.venue_order_id.value)
+        ib_order_id = self._resolve_ib_order_id(
+            venue_order_id=command.venue_order_id,
+            client_order_id=command.client_order_id,
+        )
+
+        if ib_order_id is None:
+            self.generate_order_modify_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=command.venue_order_id,
+                reason=f"Cannot resolve IB orderId for venue_order_id={command.venue_order_id}",
+                ts_event=self._clock.timestamp_ns(),
+            )
+            return
+
+        ib_order.orderId = ib_order_id
 
         if ib_order.parentId:
             parent_nautilus_order = self._cache.order(ClientOrderId(ib_order.parentId))
 
             if parent_nautilus_order and parent_nautilus_order.venue_order_id is not None:
-                ib_order.parentId = int(parent_nautilus_order.venue_order_id.value)
+                parent_ib_order_id = self._resolve_ib_order_id(
+                    venue_order_id=parent_nautilus_order.venue_order_id,
+                    client_order_id=parent_nautilus_order.client_order_id,
+                )
+
+                if parent_ib_order_id is not None:
+                    ib_order.parentId = parent_ib_order_id
+                else:
+                    self._log.warning(
+                        f"Parent order {ib_order.parentId!r} has no resolved IB order ID; "
+                        "modifying child order without parentId",
+                    )
+                    ib_order.parentId = 0
             else:
                 self._log.warning(
                     f"Parent order {ib_order.parentId!r} has no venue order ID yet; "
@@ -1492,7 +1520,18 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         venue_order_id = command.venue_order_id
 
         if venue_order_id:
-            self._client.cancel_order(int(venue_order_id.value))
+            ib_order_id = self._resolve_ib_order_id(
+                venue_order_id=venue_order_id,
+                client_order_id=command.client_order_id,
+            )
+
+            if ib_order_id is not None:
+                self._client.cancel_order(ib_order_id)
+            else:
+                self._log.error(
+                    f"Cannot resolve IB orderId for {command.client_order_id} "
+                    f"with venue_order_id={venue_order_id}",
+                )
         else:
             self._log.error(f"VenueOrderId not found for {command.client_order_id}")
 
@@ -1525,9 +1564,44 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             venue_order_id = order.venue_order_id
 
             if venue_order_id:
-                self._client.cancel_order(int(venue_order_id.value))
+                ib_order_id = self._resolve_ib_order_id(
+                    venue_order_id=venue_order_id,
+                    client_order_id=order.client_order_id,
+                )
+
+                if ib_order_id is not None:
+                    self._client.cancel_order(ib_order_id)
+                else:
+                    self._log.error(
+                        f"Cannot resolve IB orderId for {order.client_order_id} "
+                        f"with venue_order_id={venue_order_id}",
+                    )
             else:
                 self._log.error(f"VenueOrderId not found for {order.client_order_id}")
+
+    def _resolve_ib_order_id(
+        self,
+        venue_order_id: VenueOrderId,
+        client_order_id: ClientOrderId | None = None,
+    ) -> int | None:
+        try:
+            return int(venue_order_id.value)
+        except ValueError:
+            pass
+
+        if client_order_id is None:
+            return None
+
+        for raw_venue_order_id, order_ref in self._client._order_id_to_order_ref.items():
+            if order_ref.order_id != client_order_id.value:
+                continue
+
+            try:
+                return int(raw_venue_order_id.value)
+            except ValueError:
+                continue
+
+        return None
 
     async def _batch_cancel_orders(self, command: BatchCancelOrders) -> None:
         for order in command.cancels:

--- a/nautilus_trader/live/execution_engine.py
+++ b/nautilus_trader/live/execution_engine.py
@@ -2230,6 +2230,15 @@ class LiveExecutionEngine(ExecutionEngine):
                 )
                 return False  # Failed
 
+        if report.client_order_id is not None and report.client_order_id != order.client_order_id:
+            self._log.warning(
+                f"Skipping fill reconciliation for {report.trade_id!r}: "
+                f"report.client_order_id={report.client_order_id!r} does not match "
+                f"order.client_order_id={order.client_order_id!r} resolved from "
+                f"venue_order_id={report.venue_order_id!r}",
+            )
+            return True  # Mismatched owner; skip without retry storm
+
         # Log external order processing for better visibility
         if order.strategy_id.value == "EXTERNAL":
             self._log.debug(

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
@@ -31,6 +31,11 @@ from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTest
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestExecStubs
 
 
+def test_get_venue_order_id_prefers_perm_id():
+    assert get_venue_order_id(order_id=123, perm_id=456) == VenueOrderId("PERM-456")
+    assert get_venue_order_id(order_id=123, perm_id=0) == VenueOrderId("123")
+
+
 def test_place_order(ib_client):
     """
     Test case for placing an order with the Interactive Brokers client.
@@ -215,9 +220,9 @@ async def test_process_open_order_when_request_not_present(ib_client):
 @pytest.mark.asyncio
 async def test_orderStatus(ib_client):
     # Arrange
-    venue_order_id = VenueOrderId("1")
+    venue_order_id = get_venue_order_id(1, 1916994655)
     ib_client._order_id_to_order_ref = {
-        venue_order_id: AccountOrderRef(
+        VenueOrderId("1"): AccountOrderRef(
             order_id="O-20240102-1754-001-000-1",
             account_id="DU123456",
         ),
@@ -242,6 +247,10 @@ async def test_orderStatus(ib_client):
     )
 
     # Assert
+    assert ib_client._order_id_to_order_ref[venue_order_id] == AccountOrderRef(
+        order_id="O-20240102-1754-001-000-1",
+        account_id="DU123456",
+    )
     ib_client._event_subscriptions.get.assert_called_with("orderStatus-DU123456", None)
     handler_func.assert_called_with(
         venue_order_id=venue_order_id,
@@ -257,7 +266,7 @@ async def test_orderStatus(ib_client):
 @pytest.mark.asyncio
 async def test_orderStatus_with_zero_avg_fill_price(ib_client):
     # Arrange
-    venue_order_id = VenueOrderId("1")
+    venue_order_id = get_venue_order_id(1, 1916994655)
     ib_client._order_id_to_order_ref = {
         venue_order_id: AccountOrderRef(
             order_id="O-20240102-1754-001-000-1",

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 import pytest
 from ibapi.order_state import OrderState as IBOrderState
 
+from nautilus_trader.adapters.interactive_brokers.client.common import AccountOrderRef
 from nautilus_trader.adapters.interactive_brokers.common import IBOrderTags
 from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveExecClientFactory,
@@ -53,6 +54,16 @@ from nautilus_trader.test_kit.stubs.identifiers import TestIdStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestContractStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestDataStubs
 from tests.integration_tests.adapters.interactive_brokers.test_kit import IBTestExecStubs
+
+
+def make_ib_execution_for_venue_order_id(venue_order_id: VenueOrderId):
+    value = venue_order_id.value
+    if value.startswith("PERM-"):
+        execution = IBTestExecStubs.execution(order_id=1, perm_id=int(value.removeprefix("PERM-")))
+    else:
+        execution = IBTestExecStubs.execution(order_id=int(value), perm_id=0)
+
+    return execution
 
 
 @pytest.fixture
@@ -186,6 +197,21 @@ def on_cancel_order_setup(exec_client, client, status, order_id, manual_cancel_o
             remaining=Decimal(100),
             venue_order_id=venue_order_id,
         )
+
+
+def test_resolve_ib_order_id_uses_raw_mapping_for_perm_venue_order_id(exec_client):
+    client_order_id = ClientOrderId("O-IB-PERM-001")
+    exec_client._client._order_id_to_order_ref[VenueOrderId("1514")] = AccountOrderRef(
+        account_id="DU123456",
+        order_id=client_order_id.value,
+    )
+
+    ib_order_id = exec_client._resolve_ib_order_id(
+        venue_order_id=VenueOrderId("PERM-987654"),
+        client_order_id=client_order_id,
+    )
+
+    assert ib_order_id == 1514
 
 
 @pytest.mark.asyncio
@@ -992,9 +1018,9 @@ async def test_on_exec_details(
 
     # Call process_exec_details directly to bypass message queue
     # The execution's orderRef must match the order's client_order_id
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     # Set the orderRef to match the client_order_id (with order_id suffix as IB does)
-    execution.orderRef = f"{client_order_id.value}:{venue_order_id.value}"
+    execution.orderRef = f"{client_order_id.value}:{execution.orderId}"
     # Use the contract from contract_details - process_exec_details expects a Contract, not IBContract
     from ibapi.contract import Contract
 
@@ -1184,7 +1210,7 @@ async def test_on_exec_details_resolves_cached_external_order_by_venue_order_id(
     )
     cache.add_venue_order_id(order.client_order_id, venue_order_id)
 
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     execution.orderRef = ""
     commission_report = IBTestExecStubs.commission()
 
@@ -1255,9 +1281,9 @@ async def test_on_exec_details_uses_stored_avg_px(
 
     # Call process_exec_details directly to bypass message queue
     # The execution's orderRef must match the order's client_order_id
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     # Set the orderRef to match the client_order_id (with order_id suffix as IB does)
-    execution.orderRef = f"{client_order_id.value}:{venue_order_id.value}"
+    execution.orderRef = f"{client_order_id.value}:{execution.orderId}"
     # Execution price is 50.0 (from IBTestExecStubs.execution default)
     # Use the contract from contract_details - process_exec_details expects a Contract, not IBContract
     from ibapi.contract import Contract
@@ -1327,7 +1353,7 @@ async def test_spread_combo_fill_waits_for_order_status_avg_px(mocker, exec_clie
 
     generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
 
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     execution.orderRef = str(client_order_id)
     execution.execId = "combo-fill-1"
     execution.shares = Decimal(1)
@@ -1403,7 +1429,7 @@ async def test_spread_combo_fill_allows_negative_avg_px_credit(
 
     generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
 
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     execution.orderRef = str(client_order_id)
     execution.execId = "combo-credit-fill-1"
     execution.shares = Decimal(1)
@@ -1486,7 +1512,7 @@ async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
 
     generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
 
-    execution1 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution1 = make_ib_execution_for_venue_order_id(venue_order_id)
     execution1.orderRef = str(client_order_id)
     execution1.execId = "combo-fill-1"
     execution1.shares = Decimal(1)
@@ -1501,7 +1527,7 @@ async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
         commission_report=commission_report1,
         contract=put_contract,
     )
-    execution1_leg2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution1_leg2 = make_ib_execution_for_venue_order_id(venue_order_id)
     execution1_leg2.orderRef = str(client_order_id)
     execution1_leg2.execId = "combo-fill-1-leg-2"
     execution1_leg2.shares = Decimal(1)
@@ -1525,7 +1551,7 @@ async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
         venue_order_id=venue_order_id,
     )
 
-    execution2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution2 = make_ib_execution_for_venue_order_id(venue_order_id)
     execution2.orderRef = str(client_order_id)
     execution2.execId = "combo-fill-2"
     execution2.shares = Decimal(2)
@@ -1540,7 +1566,7 @@ async def test_spread_combo_fill_uses_incremental_avg_px_for_multiple_fills(
         commission_report=commission_report2,
         contract=put_contract,
     )
-    execution2_leg2 = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution2_leg2 = make_ib_execution_for_venue_order_id(venue_order_id)
     execution2_leg2.orderRef = str(client_order_id)
     execution2_leg2.execId = "combo-fill-2-leg-2"
     execution2_leg2.shares = Decimal(2)
@@ -1620,7 +1646,7 @@ async def test_spread_execution_handles_exec_details_before_open_order(mocker, e
     generate_order_accepted = mocker.spy(exec_client, "generate_order_accepted")
     generate_order_filled = mocker.patch.object(exec_client, "generate_order_filled")
 
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     execution.orderRef = str(client_order_id)
     execution.execId = "race-fill-1"
     execution.shares = Decimal(1)
@@ -1689,7 +1715,7 @@ async def test_exec_details_does_not_accept_rejected_order(
     generate_order_accepted = mocker.spy(exec_client, "generate_order_accepted")
     mocker.patch.object(exec_client, "generate_order_filled")
 
-    execution = IBTestExecStubs.execution(order_id=int(venue_order_id.value))
+    execution = make_ib_execution_for_venue_order_id(venue_order_id)
     execution.orderRef = str(client_order_id)
     commission_report = IBTestExecStubs.commission()
     commission_report.execId = execution.execId

--- a/tests/integration_tests/adapters/interactive_brokers/test_kit.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_kit.py
@@ -821,6 +821,7 @@ class IBTestExecStubs:
     def execution(
         order_id: int,
         account_id: str = "DU123456",
+        perm_id: int = 0,
         exec_timestamp: dt.datetime | None = None,
         tz: str = "US/Eastern",
     ) -> Execution:
@@ -835,7 +836,7 @@ class IBTestExecStubs:
             "side": "BOT",
             "shares": Decimal(100),
             "price": 50.0,
-            "permId": 395704644,
+            "permId": perm_id,
             "clientId": 1,
             "orderId": order_id,
             "liquidation": 0,

--- a/tests/integration_tests/live/test_live_reconciliation.py
+++ b/tests/integration_tests/live/test_live_reconciliation.py
@@ -321,6 +321,63 @@ async def test_missed_fill_reconciliation_scenario(
 
 
 @pytest.mark.asyncio
+async def test_fill_reconciliation_skips_client_order_id_mismatch(
+    exec_engine,
+    cache,
+    clock,
+    account_id,
+    order_factory,
+):
+    # Arrange
+    order = order_factory.limit(
+        instrument_id=AUDUSD_SIM.id,
+        order_side=OrderSide.SELL,
+        quantity=Quantity.from_int(2),
+        price=AUDUSD_SIM.make_price(1.00000),
+    )
+    cache.add_order(order)
+
+    submitted_event = TestEventStubs.order_submitted(order, account_id=account_id)
+    order.apply(submitted_event)
+    exec_engine.process(submitted_event)
+
+    venue_order_id = VenueOrderId("V-COLLIDED-001")
+    accepted_event = TestEventStubs.order_accepted(
+        order,
+        account_id=account_id,
+        venue_order_id=venue_order_id,
+    )
+    order.apply(accepted_event)
+    exec_engine.process(accepted_event)
+    cache.add_venue_order_id(order.client_order_id, venue_order_id, overwrite=True)
+
+    fill_report = FillReport(
+        account_id=account_id,
+        instrument_id=AUDUSD_SIM.id,
+        client_order_id=ClientOrderId("O-TRUE-OWNER-001"),
+        venue_order_id=venue_order_id,
+        trade_id=TradeId("T-COLLIDED-001"),
+        order_side=OrderSide.BUY,
+        last_qty=Quantity.from_int(1),
+        last_px=Price.from_str("1.00000"),
+        commission=Money(1.00, USD),
+        liquidity_side=LiquiditySide.TAKER,
+        report_id=UUID4(),
+        ts_event=clock.timestamp_ns(),
+        ts_init=clock.timestamp_ns(),
+    )
+
+    # Act
+    result = exec_engine._reconcile_fill_report_single(fill_report)
+
+    # Assert
+    assert result is True
+    assert order.status == OrderStatus.ACCEPTED
+    assert order.filled_qty == Quantity.from_int(0)
+    assert TradeId("T-COLLIDED-001") not in order.trade_ids
+
+
+@pytest.mark.asyncio
 async def test_order_state_discrepancy_reconciliation(
     exec_engine,
     exec_client,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

Issue: Interactive Brokers `orderId` values are scoped to an API client/session and can be reused across sessions. Nautilus was using `orderId` as the primary `VenueOrderId` whenever it was non-zero, so a historical fill or status report from a different IB session could resolve through the cache to the wrong local order.

```mermaid
sequenceDiagram
    participant IB as Interactive Brokers
    participant Adapter as IB adapter
    participant Cache as Nautilus cache
    participant Recon as Live reconciliation

    IB->>Adapter: Fill(orderId=101, permId=9001, orderRef=O-A)
    Adapter->>Cache: VenueOrderId("101") -> O-A
    IB->>Adapter: Later fill(orderId=101, permId=9444, orderRef=O-B)
    Adapter->>Recon: FillReport(venue_order_id="101", client_order_id=O-B)
    Recon->>Cache: client_order_id("101")
    Cache-->>Recon: O-A
    Recon-->>Recon: Risk: apply O-B fill to O-A
```

### Solution

The Python and Rust Interactive Brokers adapters now prefer `permId` whenever IB provides a non-zero value, producing stable IDs like `PERM-9444`. Raw `orderId` remains a temporary fallback while a just-submitted order has not yet received a `permId`.

```mermaid
flowchart TD
    A[IB callback or execution report] --> B{permId != 0?}
    B -- yes --> C[VenueOrderId = PERM-permId]
    B -- no --> D[VenueOrderId = raw orderId fallback]
    C --> E[Order status and fill reports use stable account-wide identity]
    D --> F[Temporary local routing before IB assigns permId]
    F --> G[First PERM-backed status can inherit raw orderId mapping]
```

The Python execution client also resolves `PERM-*` venue IDs back to the raw IB `orderId` for modify/cancel requests when it has the local order mapping, because the IB API still requires the session order ID for those commands. If no raw order ID can be resolved, modify is rejected and cancel logs an error instead of attempting `int("PERM-*")`.

### Reconciliation guard

Live fill reconciliation now checks that a fill report’s explicit `client_order_id`, when present, matches the order found by `venue_order_id`. If they disagree, reconciliation skips the fill and logs a warning instead of applying it to the wrong order.

```mermaid
flowchart LR
    Fill[FillReport] --> Lookup[Lookup order by venue_order_id]
    Lookup --> Match{report.client_order_id set and different?}
    Match -- yes --> Skip[Skip fill and warn]
    Match -- no --> Apply[Apply fill to resolved order]
```

### Files changed

- `nautilus_trader/adapters/interactive_brokers/client/common.py`: Prefer `PERM-{permId}` in `get_venue_order_id`.
- `crates/adapters/interactive_brokers/src/execution/parse.rs`: Mirror the same `permId` preference in the Rust IB adapter.
- `nautilus_trader/adapters/interactive_brokers/client/order.py`: Carry temporary raw order-id routing forward when the first `permId`-backed status arrives.
- `nautilus_trader/adapters/interactive_brokers/execution.py`: Resolve raw IB order IDs for modify/cancel when Nautilus stores a `PERM-*` venue ID.
- `nautilus_trader/live/execution_engine.py`: Defensively skip mismatched fill attribution.
- `crates/common/src/messages/mod.rs`: Replace a stale clippy `expect` with `allow` so the IB adapter clippy run is not blocked by an unfulfilled dependency lint.

### Verification

- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py::test_get_venue_order_id_prefers_perm_id tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py::test_orderStatus tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py::test_orderStatus_with_zero_avg_fill_price tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_resolve_ib_order_id_uses_raw_mapping_for_perm_venue_order_id tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_on_exec_details_resolves_cached_external_order_by_venue_order_id tests/integration_tests/live/test_live_reconciliation.py::test_fill_reconciliation_skips_client_order_id_mismatch`
- `cargo test -p nautilus-interactive-brokers test_ib_venue_order_id_prefers_perm_id_and_falls_back_to_order_id --lib`
- `make format`
- `git diff --check`
- `make build-debug`
- `cargo clippy -p nautilus-interactive-brokers --all-targets -- -D warnings`
- `make pre-commit` was rerun after patch-local fixes. Python hooks and the IB-focused clippy path are clean, but the all-files pre-commit gate remains blocked by unrelated `nautilus-persistence` clippy findings and an existing Rust formatting issue in persistence files outside this patch.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4247

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
