### PR TITLE
Harden IB PERM order reconciliation and commission handling

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -1706,6 +1706,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let exec_sender = get_exec_event_sender();
         let clock = get_atomic_clock_realtime();
         let account_id = self.core.account_id;
+        let request_timeout_secs = self.config.request_timeout;
 
         let handle = get_runtime().spawn(async move {
             if let Err(e) = Self::handle_cancel_all_orders_async(
@@ -1718,6 +1719,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 &exec_sender,
                 clock.get_time_ns(),
                 account_id,
+                request_timeout_secs,
                 orders_to_cancel,
             )
             .await
@@ -1976,13 +1978,9 @@ impl InteractiveBrokersExecutionClient {
                     .context("No IB order ID mapping found for client order ID")?,
             )
         };
-        let ib_order_id = Self::resolve_ib_order_id_for_cancel(
-            client,
-            order_selector,
-            account_id,
-            request_timeout_secs,
-        )
-        .await?;
+        let ib_order_id =
+            Self::resolve_ib_order_id(client, order_selector, account_id, request_timeout_secs)
+                .await?;
 
         let _cancel_subscription = client
             .cancel_order(ib_order_id, "")
@@ -2004,7 +2002,7 @@ impl InteractiveBrokersExecutionClient {
         Ok(())
     }
 
-    async fn resolve_ib_order_id_for_cancel(
+    async fn resolve_ib_order_id(
         client: &Arc<Client>,
         order_selector: IbOrderSelector,
         account_id: AccountId,
@@ -2039,14 +2037,14 @@ impl InteractiveBrokersExecutionClient {
 
             if data.order_id == 0 {
                 anyhow::bail!(
-                    "Cannot cancel PERM-{target_perm_id}: matching open order has no IB order_id"
+                    "Cannot resolve PERM-{target_perm_id}: matching open order has no IB order_id"
                 );
             }
 
             return Ok(data.order_id);
         }
 
-        anyhow::bail!("No open order found for PERM-{target_perm_id}")
+        anyhow::bail!("Cannot resolve PERM-{target_perm_id}: no matching open order found")
     }
 
     async fn handle_cancel_all_orders_async(
@@ -2059,10 +2057,11 @@ impl InteractiveBrokersExecutionClient {
         exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
         ts_init: UnixNanos,
         account_id: AccountId,
+        request_timeout_secs: u64,
         orders_to_cancel: Vec<(ClientOrderId, Option<VenueOrderId>)>,
     ) -> anyhow::Result<()> {
-        // Get all IB order IDs first, then drop the guard before awaiting
-        let ib_order_ids: Vec<(ClientOrderId, i32)> = {
+        // Get all IB order selectors first, then drop the guard before awaiting
+        let order_selectors: Vec<(ClientOrderId, IbOrderSelector)> = {
             let order_id_map_guard = order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?;
@@ -2071,23 +2070,44 @@ impl InteractiveBrokersExecutionClient {
                 .into_iter()
                 .filter_map(|(client_order_id, venue_order_id)| {
                     if let Some(venue_order_id) = venue_order_id {
-                        return venue_order_id
-                            .as_str()
-                            .parse::<i32>()
-                            .ok()
-                            .map(|ib_order_id| (client_order_id, ib_order_id));
+                        match IbOrderSelector::from_venue_order_id(&venue_order_id) {
+                            Ok(order_selector) => return Some((client_order_id, order_selector)),
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed resolve cancel-all order {} from venue order ID {}: {e}",
+                                    client_order_id,
+                                    venue_order_id
+                                );
+                                return None;
+                            }
+                        }
                     }
 
                     order_id_map_guard
                         .get(&client_order_id)
                         .copied()
-                        .map(|ib_order_id| (client_order_id, ib_order_id))
+                        .map(|ib_order_id| (client_order_id, IbOrderSelector::OrderId(ib_order_id)))
                 })
                 .collect()
         };
 
         // Now cancel each order (guard is dropped, so we can await)
-        for (client_order_id, ib_order_id) in ib_order_ids {
+        for (client_order_id, order_selector) in order_selectors {
+            let ib_order_id = match Self::resolve_ib_order_id(
+                client,
+                order_selector,
+                account_id,
+                request_timeout_secs,
+            )
+            .await
+            {
+                Ok(ib_order_id) => ib_order_id,
+                Err(e) => {
+                    tracing::error!("Failed resolve cancel-all order {client_order_id}: {e}");
+                    continue;
+                }
+            };
+
             if let Err(e) = client.cancel_order(ib_order_id, "").await {
                 tracing::error!(
                     "Failed to cancel order {} (IB order ID: {}): {e}",

--- a/crates/adapters/interactive_brokers/src/execution/core_orders.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_orders.rs
@@ -196,11 +196,18 @@ impl InteractiveBrokersExecutionClient {
         instrument_provider: &Arc<InteractiveBrokersInstrumentProvider>,
         _exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
         _clock: &'static AtomicTime,
-        _account_id: AccountId,
+        account_id: AccountId,
         original_order: Option<&Arc<OrderAny>>,
         request_timeout_secs: u64,
     ) -> anyhow::Result<()> {
-        let target_ib_order_id = Self::target_ib_order_id_for_modify(cmd, order_id_map)?;
+        let target_ib_order_id = Self::target_ib_order_id_for_modify(
+            cmd,
+            client,
+            order_id_map,
+            account_id,
+            request_timeout_secs,
+        )
+        .await?;
 
         if let Some(original_order) = original_order {
             let ib_order_id = target_ib_order_id.context("Order ID not found in mapping")?;
@@ -247,15 +254,18 @@ impl InteractiveBrokersExecutionClient {
         .await
     }
 
-    fn target_ib_order_id_for_modify(
+    async fn target_ib_order_id_for_modify(
         cmd: &ModifyOrder,
+        client: &Arc<Client>,
         order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
+        account_id: AccountId,
+        request_timeout_secs: u64,
     ) -> anyhow::Result<Option<i32>> {
         if let Some(venue_order_id) = &cmd.venue_order_id {
-            let order_id = venue_order_id
-                .as_str()
-                .parse()
-                .context("Failed to parse venue_order_id as IB order id")?;
+            let order_selector = IbOrderSelector::from_venue_order_id(venue_order_id)?;
+            let order_id =
+                Self::resolve_ib_order_id(client, order_selector, account_id, request_timeout_secs)
+                    .await?;
             return Ok(Some(order_id));
         }
 

--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -108,8 +108,8 @@ pub fn parse_execution_to_fill_report(
     let last_qty = Quantity::new(execution.shares, instrument.size_precision());
     let last_px = Price::new(execution_price, instrument.price_precision());
 
-    // Create commission — clamp IB's -1 pending sentinel to 0.0 to avoid invalid Money values
-    let commission_clamped = if commission < 0.0 { 0.0 } else { commission };
+    // Clamp only IB's -1 pending sentinel to 0.0 to preserve rebates
+    let commission_clamped = if commission == -1.0 { 0.0 } else { commission };
     let commission_money = Money::new(commission_clamped, Currency::from_str(commission_currency)?);
 
     // Parse execution time
@@ -428,6 +428,7 @@ mod tests {
     use nautilus_model::{
         enums::TrailingOffsetType,
         identifiers::{Symbol, Venue},
+        instruments::{InstrumentAny, stubs::equity_aapl},
     };
     use rust_decimal::Decimal;
 
@@ -963,6 +964,56 @@ mod tests {
                 assert_eq!(fill.order_side, OrderSide::Buy);
                 assert_eq!(fill.trade_id.to_string(), "EXEC-001");
             }
+        }
+    }
+
+    #[rstest]
+    fn test_parse_execution_to_fill_report_clamps_only_pending_commission_sentinel() {
+        let instrument_provider = create_test_instrument_provider();
+        let instrument = equity_aapl();
+        let instrument_id = instrument.id();
+        instrument_provider.insert_test_instrument(InstrumentAny::from(instrument), 265598, 1);
+        let account_id = AccountId::from("IB-001");
+        let contract = Contract::default();
+
+        for (commission, expected) in [(-1.0, 0.0), (-0.25, -0.25)] {
+            let execution = Execution {
+                order_id: 12345,
+                client_id: 0,
+                execution_id: format!("EXEC-{commission}"),
+                time: String::from("20230223 00:43:36 Universal"),
+                account_number: String::new(),
+                exchange: String::new(),
+                side: ExecutionSide::Bought,
+                shares: 100.0,
+                price: 150.25,
+                perm_id: 0,
+                liquidation: 0,
+                cumulative_quantity: 100.0,
+                average_price: 150.25,
+                order_reference: String::from("ORDER-REF-001"),
+                ev_rule: String::new(),
+                ev_multiplier: None,
+                model_code: String::new(),
+                last_liquidity: Liquidity::None,
+                pending_price_revision: false,
+                submitter: String::new(),
+            };
+
+            let report = parse_execution_to_fill_report(
+                &execution,
+                &contract,
+                commission,
+                "USD",
+                instrument_id,
+                account_id,
+                &instrument_provider,
+                UnixNanos::new(0),
+                None,
+            )
+            .unwrap();
+
+            assert_eq!(report.commission, Money::new(expected, Currency::USD()));
         }
     }
 

--- a/nautilus_trader/adapters/interactive_brokers/client/order.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/order.py
@@ -291,6 +291,13 @@ class InteractiveBrokersClientOrderMixin(BaseMixin):
             order_id=order.orderRef,
         )
 
+        if order.permId != 0 and order.orderId != 0:
+            self._set_order_id_ref(
+                venue_order_id=VenueOrderId(str(order.orderId)),
+                account_id=order.account,
+                order_id=order.orderRef,
+            )
+
         # Handle response to on-demand request
         if request := self._requests.get(name="OpenOrders"):
             request.result.append(order)

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -390,6 +390,11 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         """
         try:
             positions = await self._client.get_positions(self.account_id.get_id())
+            if positions is None:
+                self._log.warning(
+                    "Skipping initial position tracking because get_positions() did not complete",
+                )
+                return
 
             if positions:
                 for position in positions:
@@ -451,7 +456,8 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # since IB's openOrder callback doesn't include accurate filledQuantity.
         # Use venue_order_id as key since orderRef may be empty for external orders.
         venue_order_id = get_venue_order_id(ib_order.orderId, ib_order.permId)
-        cached_filled = self._order_filled_qty.get(venue_order_id)
+        client_order_id = ClientOrderId(ib_order.orderRef) if ib_order.orderRef else None
+        cached_filled = self._cached_order_filled_qty(venue_order_id, client_order_id)
         if cached_filled is not None:
             filled_qty = Quantity.from_str(str(cached_filled))
         elif ib_order.filledQuantity == UNSET_DECIMAL:
@@ -1592,6 +1598,12 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         if client_order_id is None:
             return None
 
+        return self._raw_ib_order_id_for_client_order_id(client_order_id)
+
+    def _raw_ib_order_id_for_client_order_id(
+        self,
+        client_order_id: ClientOrderId,
+    ) -> int | None:
         for raw_venue_order_id, order_ref in self._client._order_id_to_order_ref.items():
             if order_ref.order_id != client_order_id.value:
                 continue
@@ -1602,6 +1614,33 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
                 continue
 
         return None
+
+    def _cached_order_filled_qty(
+        self,
+        venue_order_id: VenueOrderId,
+        client_order_id: ClientOrderId | None,
+    ) -> Decimal | None:
+        cached_filled = self._order_filled_qty.get(venue_order_id)
+
+        if cached_filled is not None or client_order_id is None:
+            return cached_filled
+
+        raw_ib_order_id = self._raw_ib_order_id_for_client_order_id(client_order_id)
+
+        if raw_ib_order_id is None:
+            return None
+
+        raw_venue_order_id = VenueOrderId(str(raw_ib_order_id))
+
+        if raw_venue_order_id == venue_order_id:
+            return None
+
+        cached_filled = self._order_filled_qty.pop(raw_venue_order_id, None)
+
+        if cached_filled is not None:
+            self._order_filled_qty[venue_order_id] = cached_filled
+
+        return cached_filled
 
     async def _batch_cancel_orders(self, command: BatchCancelOrders) -> None:
         for order in command.cancels:
@@ -1876,6 +1915,19 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
         # Convert to Decimal defensively in case IB API sends it as a string (IB API bug/edge case)
         filled_decimal = Decimal(filled) if not isinstance(filled, Decimal) else filled
         if filled_decimal > 0 and venue_order_id is not None:
+            if order_ref:
+                raw_ib_order_id = self._raw_ib_order_id_for_client_order_id(
+                    ClientOrderId(order_ref),
+                )
+
+                if raw_ib_order_id is not None:
+                    raw_venue_order_id = VenueOrderId(str(raw_ib_order_id))
+
+                    if raw_venue_order_id != venue_order_id:
+                        raw_filled = self._order_filled_qty.pop(raw_venue_order_id, None)
+
+                        if raw_filled is not None and raw_filled > filled_decimal:
+                            filled_decimal = raw_filled
             self._order_filled_qty[venue_order_id] = filled_decimal
 
         ignore_order_event = False

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py
@@ -181,6 +181,10 @@ async def test_openOrder(ib_client):
     # Assert
     venue_order_id = get_venue_order_id(order.orderId, order.permId)
     assert ib_client._order_id_to_order_ref[venue_order_id]
+    assert (
+        ib_client._order_id_to_order_ref[VenueOrderId(str(order_id))]
+        == (ib_client._order_id_to_order_ref[venue_order_id])
+    )
     assert mock_request.result == [order]
     handler_mock.assert_not_called()
 

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution.py
@@ -17,6 +17,7 @@ import asyncio
 from decimal import Decimal
 from functools import partial
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from ibapi.order_state import OrderState as IBOrderState
@@ -201,6 +202,10 @@ def on_cancel_order_setup(exec_client, client, status, order_id, manual_cancel_o
 
 def test_resolve_ib_order_id_uses_raw_mapping_for_perm_venue_order_id(exec_client):
     client_order_id = ClientOrderId("O-IB-PERM-001")
+    exec_client._client._order_id_to_order_ref[VenueOrderId("PERM-987654")] = AccountOrderRef(
+        account_id="DU123456",
+        order_id=client_order_id.value,
+    )
     exec_client._client._order_id_to_order_ref[VenueOrderId("1514")] = AccountOrderRef(
         account_id="DU123456",
         order_id=client_order_id.value,
@@ -212,6 +217,39 @@ def test_resolve_ib_order_id_uses_raw_mapping_for_perm_venue_order_id(exec_clien
     )
 
     assert ib_order_id == 1514
+
+
+def test_order_status_migrates_raw_filled_qty_to_perm_venue_order_id(exec_client):
+    client_order_id = ClientOrderId("O-IB-PERM-FILLED")
+    raw_venue_order_id = VenueOrderId("1514")
+    perm_venue_order_id = VenueOrderId("PERM-987654")
+    exec_client._client._order_id_to_order_ref[raw_venue_order_id] = AccountOrderRef(
+        account_id="DU123456",
+        order_id=client_order_id.value,
+    )
+    exec_client._order_filled_qty[raw_venue_order_id] = Decimal(2)
+
+    exec_client._on_order_status(
+        order_ref=client_order_id.value,
+        order_status="Submitted",
+        avg_fill_price=0.0,
+        filled=Decimal(1),
+        remaining=Decimal(99),
+        venue_order_id=perm_venue_order_id,
+    )
+
+    assert raw_venue_order_id not in exec_client._order_filled_qty
+    assert exec_client._order_filled_qty[perm_venue_order_id] == Decimal(2)
+
+
+@pytest.mark.asyncio
+async def test_initialize_position_tracking_skips_none_position_snapshot(exec_client):
+    exec_client._known_positions[123] = Decimal(1)
+    exec_client._client.get_positions = AsyncMock(return_value=None)
+
+    await exec_client._initialize_position_tracking()
+
+    assert exec_client._known_positions == {123: Decimal(1)}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Updated Rust v2 cancel and modify paths to resolve `PERM-{perm_id}` venue order IDs back to the active IB session `order_id` before sending API requests.
- Preserved legitimate negative IB commissions in Rust fill parsing by clamping only the exact `-1.0` pending-commission sentinel.
- Added Python raw-order-id bridge state for `openOrder` callbacks with `permId`, so reconnect-discovered orders can still be canceled or modified through APIs requiring the session `orderId`.
- Migrated Python filled-quantity cache entries from raw numeric order IDs to stable `PERM-*` IDs when later callbacks provide the permanent ID.
- Treated `None` from the initial positions request as an unavailable snapshot rather than confirmed zero positions.

### Design decisions

- Reused the existing `IbOrderSelector` abstraction instead of adding ad hoc `PERM-*` parsing to modify and cancel-all.
- Renamed the Rust single-cancel resolver to `resolve_ib_order_id` because it now serves cancel, cancel-all, and modify.
- Kept raw numeric venue IDs supported as a fallback for pre-`permId` orders and older cached state.
- Registered both `PERM-*` and raw numeric mappings in Python only when IB supplies both `permId` and `orderId`.
- Kept the filled-quantity migration conservative: direct `PERM-*` cache hits win, and raw entries are moved only when the client order ID matches.

### Rust order resolution

```mermaid
flowchart TD
    A[VenueOrderId from command] --> B{Format}
    B -->|Numeric| C[IbOrderSelector::OrderId]
    B -->|PERM-*| D[IbOrderSelector::PermId]
    C --> E[Use IB order_id directly]
    D --> F[Request open orders]
    F --> G[Match perm_id and account]
    G --> H[Return active IB order_id]
    E --> I[Cancel, cancel-all, or modify]
    H --> I
```

### Python reconnect bridge

```mermaid
sequenceDiagram
    participant IB as IB openOrder
    participant Client as IB client cache
    participant Exec as Execution client
    IB->>Client: orderId=1514, permId=987654, orderRef=O-1
    Client->>Client: store PERM-987654 -> O-1
    Client->>Client: store 1514 -> O-1
    Exec->>Client: resolve PERM-987654 for cancel or modify
    Client-->>Exec: raw orderId 1514
    Exec->>IB: send API request using 1514
```

### Filled quantity migration

```mermaid
flowchart LR
    A[Early orderStatus uses raw 1514] --> B[_order_filled_qty 1514 = filled]
    C[Later callback/report uses PERM-987654] --> D{PERM cache hit?}
    D -->|Yes| E[Use PERM value]
    D -->|No| F[Find raw id by client_order_id]
    F --> G[Move 1514 value to PERM-987654]
    G --> E
```

### Files changed

- `crates/adapters/interactive_brokers/src/execution/core.rs`
- `crates/adapters/interactive_brokers/src/execution/core_orders.rs`
- `crates/adapters/interactive_brokers/src/execution/parse.rs`
- `nautilus_trader/adapters/interactive_brokers/client/order.py`
- `nautilus_trader/adapters/interactive_brokers/execution.py`
- `tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py`
- `tests/integration_tests/adapters/interactive_brokers/test_execution.py`

### Verification

- `cargo test -p nautilus-interactive-brokers --lib test_parse_execution_to_fill_report_clamps_only_pending_commission_sentinel`.
- `cargo test -p nautilus-interactive-brokers --lib ib_order_selector_parses_perm_venue_order_id`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/client/test_client_order.py::test_openOrder tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_resolve_ib_order_id_uses_raw_mapping_for_perm_venue_order_id tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_order_status_migrates_raw_filled_qty_to_perm_venue_order_id tests/integration_tests/adapters/interactive_brokers/test_execution.py::test_initialize_position_tracking_skips_none_position_snapshot`.
- `make build-debug`.
- `make format`.
- `make pre-commit` was run and remains blocked by unrelated repo-wide Rust checks in `crates/persistence`, including `check-formatting-rs` blank-line failures and `cargo clippy` failures in `nautilus-persistence`. Python formatting and the touched-file focused tests pass.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

#4230 #4276 

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
