### PR TITLE
Share Lighter WebSocket rate limiter across client

### DIFF
--- a/crates/adapters/lighter/src/common/consts.rs
+++ b/crates/adapters/lighter/src/common/consts.rs
@@ -86,8 +86,5 @@ pub const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
 /// Default HTTP request timeout.
 pub const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Maximum WebSocket inflight messages per connection (venue-imposed).
-pub const INFLIGHT_MAX: usize = 50;
-
 /// Outbound command queue depth before backpressure kicks in.
 pub const QUEUE_MAX: usize = 1000;

--- a/crates/adapters/lighter/src/common/rate_limit.rs
+++ b/crates/adapters/lighter/src/common/rate_limit.rs
@@ -24,13 +24,12 @@
 
 use std::{
     num::NonZeroU32,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Mutex},
 };
 
+use ahash::AHashMap;
 use nautilus_network::ratelimiter::{RateLimiter, clock::MonotonicClock, quota::Quota};
 use ustr::Ustr;
-
-use crate::common::consts::INFLIGHT_MAX;
 
 /// Conservative Lighter REST rate limit for standard accounts.
 ///
@@ -53,14 +52,23 @@ pub const LIGHTER_TX_BUCKET: &str = "lighter:tx";
 /// Rate-limit bucket key for non-transaction WebSocket client messages.
 pub const LIGHTER_WS_MESSAGE_BUCKET: &str = "lighter:ws:messages";
 
+/// Sustained WS message rate, set below the documented 200/min to leave headroom
+/// for the venue's rolling-window misalignment with our token bucket and for
+/// network jitter that can stamp adjacent messages into different venue windows.
+pub const LIGHTER_WS_MESSAGE_RATE_PER_MIN: u32 = 180;
+
+/// Burst capacity, set strictly below the venue's documented 50 inflight cap
+/// so even a full burst plus a slow venue ACK stays under it.
+pub const LIGHTER_WS_MESSAGE_BURST: u32 = 40;
+
 /// Lighter WebSocket client-message limit, excluding `sendTx` / `sendTxBatch`.
 ///
 /// The venue documents 200 client messages per minute and 50 inflight messages.
-/// The adapter applies the 200/min rate and caps the token burst at 50 so
-/// subscription and unsubscribe floods cannot be emitted in a single burst.
+/// We pace below both caps — see [`LIGHTER_WS_MESSAGE_RATE_PER_MIN`] and
+/// [`LIGHTER_WS_MESSAGE_BURST`].
 pub static LIGHTER_WS_MESSAGE_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
-    Quota::per_minute(NonZeroU32::new(200).expect("non-zero"))
-        .allow_burst(NonZeroU32::new(INFLIGHT_MAX as u32).expect("non-zero"))
+    Quota::per_minute(NonZeroU32::new(LIGHTER_WS_MESSAGE_RATE_PER_MIN).expect("non-zero"))
+        .allow_burst(NonZeroU32::new(LIGHTER_WS_MESSAGE_BURST).expect("non-zero"))
 });
 
 /// Pre-interned rate-limit key for non-transaction WebSocket client messages.
@@ -70,6 +78,43 @@ pub static LIGHTER_WS_MESSAGE_RATE_LIMIT_KEY: LazyLock<[Ustr; 1]> =
 /// Per-account transaction rate limiter, shared across the HTTP and WebSocket
 /// `sendTx` paths so their combined rate honours the single venue bucket.
 pub type LighterTxRateLimiter = RateLimiter<Ustr, MonotonicClock>;
+
+/// Shared WebSocket message limiter, keyed by venue WS URL. Both data and
+/// execution clients (and the backend balance poller) draw from one bucket
+/// per URL so their combined send rate honours the venue's per-IP cap.
+pub type LighterWsMessageRateLimiter = Arc<RateLimiter<Ustr, MonotonicClock>>;
+
+// Process-global registry of Lighter WS message limiters, keyed by resolved
+// WS URL. Clients on the same URL (a network's data, execution, and backend
+// poller) share one bucket honouring the venue per-IP cap; distinct URLs
+// (testnet, or a custom endpoint in tests) stay isolated so unrelated traffic
+// never contends for the same tokens.
+static LIGHTER_WS_MESSAGE_LIMITERS: LazyLock<Mutex<AHashMap<String, LighterWsMessageRateLimiter>>> =
+    LazyLock::new(|| Mutex::new(AHashMap::new()));
+
+/// Returns the shared WS message limiter for `url`, creating it on first
+/// access. Subsequent calls with the same `url` return the same `Arc`.
+///
+/// # Panics
+///
+/// Panics if the registry mutex is poisoned by a prior panic while holding the lock.
+#[must_use]
+pub fn ws_message_rate_limiter(url: &str) -> LighterWsMessageRateLimiter {
+    LIGHTER_WS_MESSAGE_LIMITERS
+        .lock()
+        .expect("Lighter WS message rate limiter registry mutex poisoned")
+        .entry(url.to_string())
+        .or_insert_with(|| {
+            Arc::new(RateLimiter::new_with_quota(
+                None,
+                vec![(
+                    Ustr::from(LIGHTER_WS_MESSAGE_BUCKET),
+                    *LIGHTER_WS_MESSAGE_QUOTA,
+                )],
+            ))
+        })
+        .clone()
+}
 
 /// Resolves a per-minute override to a quota, falling back to the conservative
 /// standard-account quota when unset or zero.
@@ -89,15 +134,6 @@ pub fn build_tx_rate_limiter(sendtx_per_min: Option<u32>) -> Arc<LighterTxRateLi
         None,
         vec![(Ustr::from(LIGHTER_TX_BUCKET), resolve_quota(sendtx_per_min))],
     ))
-}
-
-/// Builds keyed quotas for the WebSocket client's non-transaction message bucket.
-#[must_use]
-pub fn build_ws_rate_limit_quotas() -> Vec<(String, Quota)> {
-    vec![(
-        LIGHTER_WS_MESSAGE_BUCKET.to_string(),
-        *LIGHTER_WS_MESSAGE_QUOTA,
-    )]
 }
 
 /// Awaits transaction-bucket capacity before a `sendTx` on either transport.
@@ -141,21 +177,16 @@ mod tests {
     }
 
     #[rstest]
-    fn test_ws_message_quota_uses_documented_limit_and_inflight_burst() {
-        let expected = Quota::per_minute(NonZeroU32::new(200).unwrap())
-            .allow_burst(NonZeroU32::new(INFLIGHT_MAX as u32).unwrap());
+    fn test_ws_message_quota_stays_under_venue_caps() {
+        const { assert!(LIGHTER_WS_MESSAGE_RATE_PER_MIN < 200) };
+        const { assert!(LIGHTER_WS_MESSAGE_BURST < 50) };
+        let expected = Quota::per_minute(NonZeroU32::new(LIGHTER_WS_MESSAGE_RATE_PER_MIN).unwrap())
+            .allow_burst(NonZeroU32::new(LIGHTER_WS_MESSAGE_BURST).unwrap());
         assert_eq!(*LIGHTER_WS_MESSAGE_QUOTA, expected);
     }
 
     #[rstest]
-    fn test_build_ws_rate_limit_quotas_uses_message_bucket() {
-        assert_eq!(
-            build_ws_rate_limit_quotas(),
-            vec![(
-                LIGHTER_WS_MESSAGE_BUCKET.to_string(),
-                *LIGHTER_WS_MESSAGE_QUOTA
-            )],
-        );
+    fn test_ws_message_rate_limit_key_matches_bucket() {
         assert_eq!(
             LIGHTER_WS_MESSAGE_RATE_LIMIT_KEY.as_slice(),
             [Ustr::from(LIGHTER_WS_MESSAGE_BUCKET)].as_slice(),
@@ -163,15 +194,29 @@ mod tests {
     }
 
     #[rstest]
+    fn test_ws_message_rate_limiter_shared_per_url() {
+        let shared_a = ws_message_rate_limiter("wss://example.invalid/share");
+        let shared_b = ws_message_rate_limiter("wss://example.invalid/share");
+        let isolated = ws_message_rate_limiter("wss://example.invalid/isolated");
+
+        // Same URL: data, execution, and backend poller share one bucket.
+        assert!(Arc::ptr_eq(&shared_a, &shared_b));
+        // Distinct URL: testnet and custom endpoints stay isolated.
+        assert!(!Arc::ptr_eq(&shared_a, &isolated));
+    }
+
+    #[rstest]
     fn test_ws_message_rate_limiter_enforces_inflight_burst() {
-        let quotas = build_ws_rate_limit_quotas()
-            .into_iter()
-            .map(|(key, quota)| (Ustr::from(&key), quota))
-            .collect();
-        let limiter = RateLimiter::new_with_quota(None, quotas);
+        let limiter = RateLimiter::new_with_quota(
+            None,
+            vec![(
+                Ustr::from(LIGHTER_WS_MESSAGE_BUCKET),
+                *LIGHTER_WS_MESSAGE_QUOTA,
+            )],
+        );
         let key = LIGHTER_WS_MESSAGE_RATE_LIMIT_KEY[0];
 
-        for _ in 0..INFLIGHT_MAX {
+        for _ in 0..LIGHTER_WS_MESSAGE_BURST {
             assert!(limiter.check_key(&key).is_ok());
         }
         assert!(limiter.check_key(&key).is_err());

--- a/crates/adapters/lighter/src/websocket/client.rs
+++ b/crates/adapters/lighter/src/websocket/client.rs
@@ -43,7 +43,7 @@ use crate::{
     common::{
         consts::{HEARTBEAT_INTERVAL, RECONNECT_BASE_BACKOFF, RECONNECT_MAX_BACKOFF},
         enums::{LighterCandleResolution, LighterEnvironment},
-        rate_limit::build_ws_rate_limit_quotas,
+        rate_limit::ws_message_rate_limiter,
         symbol::MarketRegistry,
         urls::lighter_ws_url,
     },
@@ -276,13 +276,12 @@ impl LighterWebSocketClient {
             backend: self.transport_backend,
             proxy_url: self.proxy_url.clone(),
         };
-        let client = WebSocketClient::connect(
+        let client = WebSocketClient::connect_with_rate_limiter(
             cfg,
             Some(message_handler),
             None,
             None,
-            build_ws_rate_limit_quotas(),
-            None,
+            ws_message_rate_limiter(&self.url),
         )
         .await?;
 

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -1580,7 +1580,44 @@ impl WebSocketClient {
         keyed_quotas: Vec<(String, Quota)>,
         default_quota: Option<Quota>,
     ) -> Result<Self, TransportError> {
-        // Validate that handler mode has a message handler
+        let keyed_quotas = keyed_quotas
+            .into_iter()
+            .map(|(key, quota)| (Ustr::from(&key), quota))
+            .collect();
+        let rate_limiter = Arc::new(RateLimiter::new_with_quota(default_quota, keyed_quotas));
+        Self::connect_with_rate_limiter(
+            config,
+            message_handler,
+            ping_handler,
+            post_reconnection,
+            rate_limiter,
+        )
+        .await
+    }
+
+    /// Creates a websocket client in **handler mode** sharing an externally-owned rate limiter.
+    ///
+    /// Use this constructor to share a single [`RateLimiter`] across multiple
+    /// [`WebSocketClient`] instances (for example, the WebSocket clients owned
+    /// by an exchange adapter's data and execution clients). All quota state
+    /// lives inside the limiter, so passing the same `Arc` produces a single
+    /// shared bucket — the only way to honour a venue's per-IP / per-account
+    /// WS message cap when more than one connection is opened in-process.
+    ///
+    /// Behavior otherwise matches [`Self::connect`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The connection cannot be established.
+    /// - `message_handler` is `None` (use `connect_stream` instead).
+    pub async fn connect_with_rate_limiter(
+        config: WebSocketConfig,
+        message_handler: Option<MessageHandler>,
+        ping_handler: Option<PingHandler>,
+        post_reconnection: Option<Arc<dyn Fn() + Send + Sync>>,
+        rate_limiter: Arc<RateLimiter<Ustr, MonotonicClock>>,
+    ) -> Result<Self, TransportError> {
         if message_handler.is_none() {
             return Err(TransportError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -1605,12 +1642,6 @@ impl WebSocketClient {
             post_reconnection,
             Arc::clone(&auth_tracker),
         );
-
-        let keyed_quotas = keyed_quotas
-            .into_iter()
-            .map(|(key, quota)| (Ustr::from(&key), quota))
-            .collect();
-        let rate_limiter = Arc::new(RateLimiter::new_with_quota(default_quota, keyed_quotas));
 
         Ok(Self {
             controller_task,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

The Lighter adapter opens two `LighterWebSocketClient` instances against the same venue from a single process — one in `LighterDataClient` and one in `LighterExecutionClient`. Until now each owned a private `RateLimiter` built from `build_ws_rate_limit_quotas()`, so the local 200/min + 50-burst quota was being enforced **twice in parallel against a venue per-IP cap of 200/min + 50 inflight**. Under any subscription burst the combined send rate exceeded the venue caps, surfacing as `30009 "Too Many Websocket Messages!"` and `30010 "Too Many Inflight Messages!"` error frames. The local limiter could not see the cap being violated because neither bucket knew about the other.

This mirrors the same fix already shipped on the HTTP side in https://github.com/nautechsystems/nautilus_trader/pull/4265

1. **`nautilus_network`** — add `WebSocketClient::connect_with_rate_limiter(...)` accepting an externally-owned `Arc<RateLimiter<Ustr, MonotonicClock>>`. Existing `connect(...)` becomes a thin wrapper that builds the Arc from quotas and forwards. Mirrors `HttpClient::new` / `HttpClient::new_with_rate_limiter`.

2. **`adapters/lighter/src/common/rate_limit.rs`** — add a process-global registry keyed by resolved WS URL:

   ```rust
   pub fn ws_message_rate_limiter(url: &str) -> Arc<RateLimiter<Ustr, MonotonicClock>>
   ```

   Backed by `LazyLock<Mutex<AHashMap<String, _>>>`. Entry-or-insert per URL — same shape as `dydx::http::client::rest_rate_limiter`. Mainnet / testnet / mock endpoints stay isolated automatically.

   Tighten the quota at the same time:
   - **Sustained**: `200/min → 180/min`. ~10% headroom for the venue's rolling-window misalignment with the local token bucket and for network jitter that can stamp adjacent messages into different venue windows.
   - **Burst**: `50 → 40`. Strictly below the 50-inflight cap so a full burst plus a slow venue ACK stays under it. The local limiter constrains *send rate* only; the venue's inflight check counts un-acked messages, so burst equal to the cap had zero safety margin.
   - Inlines the now-obsolete `INFLIGHT_MAX` constant.

3. **`adapters/lighter/src/websocket/client.rs`** — wire `LighterWebSocketClient::connect()` through the new constructor:

   ```rust
   WebSocketClient::connect_with_rate_limiter(cfg, …, ws_message_rate_limiter(&self.url))
   ```

   Data and execution clients both construct through `LighterWebSocketClient::new` → `.connect()` → registry, so they automatically share the same bucket per URL with no caller-side changes.

The previous `build_ws_rate_limit_quotas()` helper is removed because the registry is now the only construction path.

## Verification

Reproduced the original failure mode under a subscription storm: with two independent limiters, the combined outbound rate crossed the venue caps within ~50 s and the venue returned 30009 / 30010 frames repeatedly. After this change, an equivalent run over a multi-minute window produces zero `30009` / `30010` frames; order submission, cancels, and account streams continue to function normally throughout.

## Tests

- `test_ws_message_rate_limiter_shared_per_url` — `Arc::ptr_eq` regression covering both share (same URL) and isolate (different URL) invariants. Same shape as the dYdX equivalent.
- `test_ws_message_quota_stays_under_venue_caps` — asserts the local quota strictly under the venue's 200/min + 50 inflight caps so future bumps can't accidentally remove the headroom.
- `test_ws_message_rate_limiter_enforces_inflight_burst` — updated to use the new burst constant directly.
- All 7 rate-limit tests pass under `cargo nextest run -p nautilus-lighter -E 'test(rate_limit::)'`.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
