### PR TITLE
Fix mixed-precision order book delta catalog writes

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -364,6 +364,22 @@ class ParquetDataCatalog(BaseDataCatalog):
         if isinstance(data[0], CustomData):
             data = [d.data for d in data]
 
+        if data_cls == OrderBookDelta:
+            precision_runs = self._order_book_delta_precision_runs(data)
+            if len(precision_runs) > 1:
+                for index, precision_run in enumerate(precision_runs):
+                    run_start = start if index == 0 else None
+                    run_end = end if index == len(precision_runs) - 1 else None
+                    self._write_chunk(
+                        data=precision_run,
+                        data_cls=data_cls,
+                        identifier=identifier,
+                        start=run_start,
+                        end=run_end,
+                        skip_disjoint_check=skip_disjoint_check,
+                    )
+                return
+
         table = self._objects_to_table(data, data_cls=data_cls)
         directory = self._make_path(data_cls=data_cls, identifier=identifier)
         self.fs.mkdirs(directory, exist_ok=True)
@@ -392,6 +408,60 @@ class ParquetDataCatalog(BaseDataCatalog):
             filesystem=self.fs,
             row_group_size=self.max_rows_per_group,
         )
+
+    @staticmethod
+    def _order_book_delta_precision_key(delta: OrderBookDelta) -> tuple[int, int] | None:
+        if delta.order is None:
+            return None
+
+        price_precision = delta.order.price.precision
+        size_precision = delta.order.size.precision
+
+        if price_precision == 0 and size_precision == 0:
+            return None
+
+        return price_precision, size_precision
+
+    @classmethod
+    def _order_book_delta_precision_runs(
+        cls,
+        data: list[Data],
+    ) -> list[list[Data]]:
+        runs: list[list[Data]] = []
+        pending_sentinels: list[Data] = []
+        current_run: list[Data] = []
+        current_key: tuple[int, int] | None = None
+
+        for delta in data:
+            key = cls._order_book_delta_precision_key(delta)
+
+            if key is None:
+                if current_run:
+                    current_run.append(delta)
+                else:
+                    pending_sentinels.append(delta)
+                continue
+
+            if current_key is None:
+                current_key = key
+                current_run = [*pending_sentinels, delta]
+                pending_sentinels = []
+                continue
+
+            if key == current_key:
+                current_run.append(delta)
+                continue
+
+            runs.append(current_run)
+            current_key = key
+            current_run = [delta]
+
+        if current_run:
+            runs.append(current_run)
+        elif pending_sentinels:
+            runs.append(pending_sentinels)
+
+        return runs
 
     def _objects_to_table(self, data: list[Data], data_cls: type) -> pa.Table:
         PyCondition.not_empty(data, "data")
@@ -1807,10 +1877,19 @@ class ParquetDataCatalog(BaseDataCatalog):
         if self.fs_protocol != "file":
             self._register_object_store_with_session(session)
 
-        if files is not None and not optimize_file_loading:
-            # Register files individually only when optimization is disabled
-            # (e.g., for consolidation operations requiring precise file control)
-            for file in files:
+        register_files_individually = (
+            files is not None and not optimize_file_loading
+        ) or (data_cls == OrderBookDelta and not optimize_file_loading)
+
+        if register_files_individually:
+            # OrderBookDelta stores precision in file metadata, so mixed-precision
+            # files must be decoded separately instead of merged as one directory.
+            if files is not None:
+                file_list = files
+            else:
+                file_list = self._query_files(data_cls, identifiers, start, end)
+
+            for file in file_list:
                 self._register_file_table(
                     session=session,
                     file=file,

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
+import pyarrow.parquet as pq
 import pytest
 
 from nautilus_trader import TEST_DATA_DIR
@@ -162,6 +163,78 @@ def test_catalog_instrument_ids_correctly_unmapped(catalog: ParquetDataCatalog) 
     # Assert
     assert instrument.id.value == "AUD/USD.SIM"
     assert trade_tick.instrument_id.value == "AUD/USD.SIM"
+
+
+def test_catalog_preserves_mixed_precision_order_book_delta_runs(
+    catalog: ParquetDataCatalog,
+) -> None:
+    # Arrange
+    instrument = TestInstrumentProvider.default_fx_ccy("AUD/USD", venue=Venue("SIM"))
+    deltas = [
+        OrderBookDelta(
+            instrument_id=instrument.id,
+            action=BookAction.UPDATE,
+            order=BookOrder(
+                OrderSide.BUY,
+                Price(1.11, 2),
+                Quantity(10.0001, 4),
+                1,
+            ),
+            flags=0,
+            sequence=0,
+            ts_event=100,
+            ts_init=100,
+        ),
+        OrderBookDelta(
+            instrument_id=instrument.id,
+            action=BookAction.UPDATE,
+            order=BookOrder(
+                OrderSide.BUY,
+                Price(1.123, 3),
+                Quantity(10.000001, 6),
+                2,
+            ),
+            flags=0,
+            sequence=0,
+            ts_event=200,
+            ts_init=200,
+        ),
+        OrderBookDelta(
+            instrument_id=instrument.id,
+            action=BookAction.UPDATE,
+            order=BookOrder(
+                OrderSide.BUY,
+                Price(1.12, 2),
+                Quantity(10.0002, 4),
+                3,
+            ),
+            flags=0,
+            sequence=0,
+            ts_event=300,
+            ts_init=300,
+        ),
+    ]
+
+    # Act
+    catalog.write_data(deltas)
+
+    # Assert
+    stored = sorted(catalog.order_book_deltas(["AUD/USD.SIM"]), key=lambda d: d.ts_init)
+    assert [delta.order.price.precision for delta in stored] == [2, 3, 2]
+    assert [delta.order.size.precision for delta in stored] == [4, 6, 4]
+    assert [str(delta.order.price) for delta in stored] == ["1.11", "1.123", "1.12"]
+    assert [str(delta.order.size) for delta in stored] == ["10.0001", "10.000001", "10.0002"]
+
+    files = catalog._query_files(OrderBookDelta, [str(instrument.id)], None, None)
+    assert len(files) == 3
+    assert [
+        pq.ParquetFile(file, filesystem=catalog.fs).schema_arrow.metadata
+        for file in files
+    ] == [
+        {b"instrument_id": b"AUD/USD.SIM", b"price_precision": b"2", b"size_precision": b"4"},
+        {b"instrument_id": b"AUD/USD.SIM", b"price_precision": b"3", b"size_precision": b"6"},
+        {b"instrument_id": b"AUD/USD.SIM", b"price_precision": b"2", b"size_precision": b"4"},
+    ]
 
 
 def test_enforce_monotonic_ts_already_sorted_returns_unchanged() -> None:


### PR DESCRIPTION
## Summary
- split OrderBookDelta writes into contiguous precision-compatible Parquet runs
- decode OrderBookDelta files individually so each file keeps its own precision metadata
- add a regression covering alternating price/size precision round-trip and per-file metadata

Fixes #3549.

## Tests
- BUILD_MODE=debug CARGO_TARGET_DIR=target uvx --from uv==0.11.21 uv run --no-sync python build.py
- uvx --from uv==0.11.21 uv run --no-sync pytest tests/unit_tests/persistence/test_catalog.py -q
- uvx --from uv==0.11.21 uv run --no-sync ruff check nautilus_trader/persistence/catalog/parquet.py tests/unit_tests/persistence/test_catalog.py
- uvx --from uv==0.11.21 uv run --no-sync python -m py_compile nautilus_trader/persistence/catalog/parquet.py tests/unit_tests/persistence/test_catalog.py
- git diff --check