### PR TITLE
Harden Polymarket execution lookup retention

### DIFF
--- a/crates/adapters/polymarket/src/execution/lifecycle.rs
+++ b/crates/adapters/polymarket/src/execution/lifecycle.rs
@@ -18,17 +18,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 use anyhow::Context;
 use nautilus_common::{
-    cache::Cache,
     live::{runner::get_exec_event_sender, runtime::get_runtime},
     msgbus::{self, TypedHandler},
 };
-use nautilus_core::{MUTEX_POISONED, UnixNanos, collections::AtomicMap, time::AtomicTime};
+use nautilus_core::{MUTEX_POISONED, collections::AtomicMap, time::AtomicTime};
 use nautilus_model::{
-    events::PositionEvent,
-    identifiers::{AccountId, InstrumentId},
+    events::{OrderEventAny, PositionEvent},
+    identifiers::InstrumentId,
     instruments::{Instrument, InstrumentAny},
 };
 use ustr::Ustr;
@@ -43,6 +42,39 @@ use crate::{
 };
 
 impl PolymarketExecutionClient {
+    fn ensure_order_event_subscription(&mut self) {
+        if self.order_event_handler.is_some() {
+            return;
+        }
+
+        let core = self.core.clone();
+        let clock = self.clock;
+        let shared_token_instruments = self.shared_token_instruments.clone();
+        let neg_risk_index = self.neg_risk_index.clone();
+        let handler = TypedHandler::from(move |event: &OrderEventAny| {
+            if !is_terminal_order_event(event) || event.instrument_id().venue != core.venue {
+                return;
+            }
+
+            sync_execution_lookup_for_instrument(
+                &core,
+                clock,
+                &shared_token_instruments,
+                &neg_risk_index,
+                event.instrument_id(),
+            );
+        });
+
+        msgbus::subscribe_order_events("events.order.*".into(), handler.clone(), Some(10));
+        self.order_event_handler = Some(handler);
+    }
+
+    fn clear_order_event_subscription(&mut self) {
+        if let Some(handler) = self.order_event_handler.take() {
+            msgbus::unsubscribe_order_events("events.order.*".into(), &handler);
+        }
+    }
+
     fn ensure_position_event_subscription(&mut self) {
         if self.position_event_handler.is_some() {
             return;
@@ -246,26 +278,6 @@ impl PolymarketExecutionClient {
         neg_risk_index.get(instrument_id).copied().unwrap_or(false)
     }
 
-    fn should_retain_execution_lookup(
-        &self,
-        cache: &Cache,
-        instrument: &InstrumentAny,
-        now_ns: UnixNanos,
-        account_id: AccountId,
-    ) -> bool {
-        if !crate::filters::is_expired(instrument, now_ns) {
-            return true;
-        }
-
-        cache.has_positions_open(
-            Some(&self.core.venue),
-            Some(&instrument.id()),
-            None,
-            Some(&account_id),
-            None,
-        )
-    }
-
     fn upsert_execution_lookup(&self, instrument: &InstrumentAny) {
         upsert_execution_lookup(
             &self.shared_token_instruments,
@@ -274,41 +286,19 @@ impl PolymarketExecutionClient {
         );
     }
 
-    fn remove_execution_lookup(&self, instrument_id: InstrumentId) {
-        remove_execution_lookup(
-            &self.shared_token_instruments,
-            &self.neg_risk_index,
-            instrument_id,
-        );
-    }
-
     pub(super) fn load_instruments_from_cache(&self) {
         let cache = self.core.cache();
-        let now_ns = self.clock.get_time_ns();
-        let account_id = self.core.account_id;
         let instruments: Vec<InstrumentAny> = cache
             .instruments(&self.core.venue, None)
             .into_iter()
             .cloned()
             .collect();
-        let mut retained_instrument_ids = AHashSet::new();
 
-        for inst in instruments
-            .iter()
-            .filter(|inst| self.should_retain_execution_lookup(&cache, inst, now_ns, account_id))
-        {
-            retained_instrument_ids.insert(inst.id());
+        for inst in &instruments {
             self.upsert_execution_lookup(inst);
         }
 
-        drop(cache);
-
-        self.prune_execution_lookup_not_in_retained(&retained_instrument_ids);
-
-        log::info!(
-            "Loaded {} retained instruments from cache",
-            retained_instrument_ids.len()
-        );
+        log::info!("Loaded {} instruments from cache", instruments.len());
     }
 
     pub(super) fn start_client(&mut self) {
@@ -336,6 +326,7 @@ impl PolymarketExecutionClient {
         log::info!("Stopping Polymarket execution client");
 
         self.stopping.store(true, Ordering::Release);
+        self.clear_order_event_subscription();
         self.clear_position_event_subscription();
 
         if let Some(handle) = self.ws_stream_handle.lock().expect(MUTEX_POISONED).take() {
@@ -364,6 +355,7 @@ impl PolymarketExecutionClient {
         self.core.set_instruments_initialized();
 
         self.start_ws_stream().await?;
+        self.ensure_order_event_subscription();
         self.ensure_position_event_subscription();
 
         let post_ws = async {
@@ -375,6 +367,7 @@ impl PolymarketExecutionClient {
         if let Err(e) = post_ws.await {
             log::warn!("Connect failed after WS started, tearing down: {e}");
             self.stopping.store(true, Ordering::Release);
+            self.clear_order_event_subscription();
             self.clear_position_event_subscription();
             let _ = self.ws_client.disconnect().await;
             self.abort_pending_tasks();
@@ -395,6 +388,7 @@ impl PolymarketExecutionClient {
         log::info!("Disconnecting Polymarket execution client");
 
         self.stopping.store(true, Ordering::Release);
+        self.clear_order_event_subscription();
         self.clear_position_event_subscription();
 
         self.ws_client.disconnect().await?;
@@ -411,45 +405,7 @@ impl PolymarketExecutionClient {
     }
 
     pub(super) fn on_instrument_update(&self, instrument: &InstrumentAny) {
-        let cache = self.core.cache();
-        let now_ns = self.clock.get_time_ns();
-        let account_id = self.core.account_id;
-        let instrument_id = instrument.id();
-
-        if self.should_retain_execution_lookup(&cache, instrument, now_ns, account_id) {
-            self.upsert_execution_lookup(instrument);
-        } else {
-            self.remove_execution_lookup(instrument_id);
-        }
-    }
-
-    fn prune_execution_lookup_not_in_retained(
-        &self,
-        retained_instrument_ids: &AHashSet<InstrumentId>,
-    ) {
-        let token_ids: Vec<Ustr> = self
-            .shared_token_instruments
-            .load()
-            .keys()
-            .copied()
-            .collect();
-
-        for token_id in token_ids {
-            if let Some(instrument) = self.shared_token_instruments.get_cloned(&token_id)
-                && !retained_instrument_ids.contains(&instrument.id())
-            {
-                self.remove_execution_lookup(instrument.id());
-            }
-        }
-
-        let instrument_ids: Vec<InstrumentId> =
-            self.neg_risk_index.load().keys().copied().collect();
-
-        for instrument_id in instrument_ids {
-            if !retained_instrument_ids.contains(&instrument_id) {
-                self.neg_risk_index.remove(&instrument_id);
-            }
-        }
+        self.upsert_execution_lookup(instrument);
     }
 }
 
@@ -510,7 +466,13 @@ fn sync_execution_lookup_for_instrument(
                 return true;
             }
 
-            cache.has_positions_open(
+            cache.has_orders_open(
+                Some(&core.venue),
+                Some(&instrument_id),
+                None,
+                Some(&account_id),
+                None,
+            ) || cache.has_positions_open(
                 Some(&core.venue),
                 Some(&instrument_id),
                 None,
@@ -528,21 +490,36 @@ fn sync_execution_lookup_for_instrument(
     }
 }
 
+fn is_terminal_order_event(event: &OrderEventAny) -> bool {
+    matches!(
+        event,
+        OrderEventAny::Canceled(_)
+            | OrderEventAny::Expired(_)
+            | OrderEventAny::Rejected(_)
+            | OrderEventAny::Filled(_)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::{cell::RefCell, rc::Rc};
 
-    use nautilus_common::{cache::Cache, live::runner::set_exec_event_sender};
-    use nautilus_core::{UUID4, nanos::DurationNanos};
+    use nautilus_common::{
+        cache::Cache,
+        live::runner::set_exec_event_sender,
+        msgbus::{publish_order_event, publish_position_event},
+    };
+    use nautilus_core::{UUID4, UnixNanos, nanos::DurationNanos};
     use nautilus_live::ExecutionClientCore;
     use nautilus_model::{
         enums::{AccountType, OmsType, OrderSide, PositionSide, TimeInForce},
         events::{OrderEventAny, PositionClosed, PositionEvent},
         identifiers::{
             AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Symbol, TraderId,
+            VenueOrderId,
         },
         instruments::stubs::binary_option,
-        orders::{LimitOrder, OrderAny, stubs::TestOrderEventStubs},
+        orders::{LimitOrder, Order, OrderAny, stubs::TestOrderEventStubs},
         position::Position,
         types::{Currency, Money, Price, Price as ModelPrice, Quantity, Quantity as ModelQuantity},
     };
@@ -642,6 +619,21 @@ mod tests {
         ))
     }
 
+    fn cache_accepted_open_order(cache: &mut Cache, instrument_id: InstrumentId) -> OrderAny {
+        let mut order = open_limit_order(instrument_id);
+        cache.add_order(order.clone(), None, None, false).unwrap();
+
+        let submitted = TestOrderEventStubs::submitted(&order, AccountId::from("POLYMARKET-001"));
+        order = cache.update_order(&submitted).unwrap();
+
+        let accepted = TestOrderEventStubs::accepted(
+            &order,
+            AccountId::from("POLYMARKET-001"),
+            VenueOrderId::from("V-001"),
+        );
+        cache.update_order(&accepted).unwrap()
+    }
+
     fn open_position(instrument: &InstrumentAny) -> Position {
         let order = open_limit_order(instrument.id());
         let filled = match TestOrderEventStubs::filled(
@@ -705,7 +697,7 @@ mod tests {
     }
 
     #[rstest]
-    fn load_instruments_from_cache_prunes_expired_execution_lookup_state() {
+    fn load_instruments_from_cache_preloads_expired_execution_lookup_state() {
         let (client, cache) = test_client();
         let active = test_binary_option("0xACTIVE", false, true);
         let expired = test_binary_option("0xEXPIRED", true, true);
@@ -716,11 +708,6 @@ mod tests {
             cache.add_instrument(expired.clone()).unwrap();
         }
 
-        client
-            .shared_token_instruments
-            .insert(Ustr::from(expired.raw_symbol().as_str()), expired.clone());
-        client.neg_risk_index.insert(expired.id(), true);
-
         client.load_instruments_from_cache();
 
         assert!(
@@ -730,41 +717,19 @@ mod tests {
         );
         assert!(client.neg_risk_index.contains_key(&active.id()));
         assert!(
-            !client
+            client
                 .shared_token_instruments
                 .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
         );
-        assert!(!client.neg_risk_index.contains_key(&expired.id()));
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
     }
 
     #[rstest]
-    fn on_instrument_update_skips_expired_execution_lookup_state() {
+    fn on_instrument_update_upserts_expired_execution_lookup_state() {
         let (client, _cache) = test_client();
         let expired = test_binary_option("0xEXPIRED_ONLY", true, true);
 
         client.on_instrument_update(&expired);
-
-        assert!(
-            !client
-                .shared_token_instruments
-                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
-        );
-        assert!(!client.neg_risk_index.contains_key(&expired.id()));
-    }
-
-    #[rstest]
-    fn load_instruments_from_cache_keeps_expired_lookup_state_with_open_position() {
-        let (client, cache) = test_client();
-        let expired = test_binary_option("0xEXPIRED_POSITION", true, true);
-        let position = open_position(&expired);
-
-        {
-            let mut cache = cache.borrow_mut();
-            cache.add_instrument(expired.clone()).unwrap();
-            cache.add_position(&position, OmsType::Netting).unwrap();
-        }
-
-        client.load_instruments_from_cache();
 
         assert!(
             client
@@ -775,7 +740,62 @@ mod tests {
     }
 
     #[rstest]
-    fn sync_execution_lookup_prunes_expired_lookup_after_position_closes() {
+    fn sync_execution_lookup_keeps_expired_lookup_state_with_open_position() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_POSITION", true, true);
+        let position = open_position(&expired);
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            cache.add_position(&position, OmsType::Netting).unwrap();
+        }
+
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            expired.id(),
+        );
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn sync_execution_lookup_keeps_expired_lookup_state_with_open_order() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_ORDER", true, true);
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            let _order = cache_accepted_open_order(&mut cache, expired.id());
+        }
+
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            expired.id(),
+        );
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn position_event_subscription_prunes_expired_lookup_after_position_closes() {
         let (client, cache) = test_client();
         let expired = test_binary_option("0xEXPIRED_CLOSED", true, true);
         let position = open_position(&expired);
@@ -787,7 +807,13 @@ mod tests {
             cache.add_position(&position, OmsType::Netting).unwrap();
         }
 
-        client.load_instruments_from_cache();
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            expired.id(),
+        );
         assert!(
             client
                 .shared_token_instruments
@@ -800,15 +826,11 @@ mod tests {
             cache.update_position(&closed).unwrap();
         }
 
+        let mut client = client;
+        client.ensure_position_event_subscription();
         let event = position_closed_event(&closed);
         assert!(matches!(event, PositionEvent::PositionClosed(_)));
-        sync_execution_lookup_for_instrument(
-            &client.core,
-            client.clock,
-            &client.shared_token_instruments,
-            &client.neg_risk_index,
-            event.instrument_id(),
-        );
+        publish_position_event("events.position.TEST".into(), &event);
 
         assert!(
             !client
@@ -819,19 +841,149 @@ mod tests {
     }
 
     #[rstest]
-    fn position_event_subscription_can_be_reinstalled_after_disconnect_cleanup() {
+    fn order_event_subscription_prunes_expired_lookup_after_terminal_order() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_ORDER_CLOSED", true, true);
+        let mut order;
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            order = cache_accepted_open_order(&mut cache, expired.id());
+        }
+
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            expired.id(),
+        );
+
+        let canceled = TestOrderEventStubs::canceled(
+            &order,
+            AccountId::from("POLYMARKET-001"),
+            order.venue_order_id(),
+        );
+        order.apply(canceled.clone()).unwrap();
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.update_order(&canceled).unwrap();
+        }
+
+        let mut client = client;
+        client.ensure_order_event_subscription();
+        publish_order_event("events.order.TEST".into(), &canceled);
+
+        assert!(
+            !client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(!client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn order_event_subscription_keeps_expired_lookup_after_filled_when_position_remains_open() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_FILLED_OPEN", true, true);
+        let order;
+        let position;
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            order = cache_accepted_open_order(&mut cache, expired.id());
+        }
+
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            expired.id(),
+        );
+
+        let filled = TestOrderEventStubs::filled(
+            &order,
+            &expired,
+            None,
+            None,
+            Some(ModelPrice::from("0.5000")),
+            None,
+            None,
+            None,
+            None,
+            Some(AccountId::from("POLYMARKET-001")),
+        );
+
+        position = match filled.clone() {
+            OrderEventAny::Filled(filled) => Position::new(&expired, filled),
+            other => panic!("expected filled event, was {other:?}"),
+        };
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.update_order(&filled).unwrap();
+            cache.add_position(&position, OmsType::Netting).unwrap();
+        }
+
+        let mut client = client;
+        client.ensure_order_event_subscription();
+        publish_order_event("events.order.TEST".into(), &filled);
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn position_event_subscription_ignores_other_venue_events() {
+        let (mut client, _cache) = test_client();
+        let expired = test_binary_option("0xOTHER_VENUE", true, true);
+        client.upsert_execution_lookup(&expired);
+        client.ensure_position_event_subscription();
+
+        let mut event = position_closed_event(&closed_position(&open_position(&expired)));
+        if let PositionEvent::PositionClosed(ref mut closed) = event {
+            closed.instrument_id = InstrumentId::from("0xOTHER.OTHER");
+        }
+
+        publish_position_event("events.position.TEST".into(), &event);
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn event_subscriptions_can_be_reinstalled_after_disconnect_cleanup() {
         let (mut client, _cache) = test_client();
 
         client.start_client();
+        assert!(client.order_event_handler.is_none());
         assert!(client.position_event_handler.is_none());
 
+        client.ensure_order_event_subscription();
         client.ensure_position_event_subscription();
+        assert!(client.order_event_handler.is_some());
         assert!(client.position_event_handler.is_some());
 
+        client.clear_order_event_subscription();
         client.clear_position_event_subscription();
+        assert!(client.order_event_handler.is_none());
         assert!(client.position_event_handler.is_none());
 
+        client.ensure_order_event_subscription();
         client.ensure_position_event_subscription();
+        assert!(client.order_event_handler.is_some());
         assert!(client.position_event_handler.is_some());
     }
 }

--- a/crates/adapters/polymarket/src/execution/lifecycle.rs
+++ b/crates/adapters/polymarket/src/execution/lifecycle.rs
@@ -18,12 +18,17 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use anyhow::Context;
-use nautilus_common::live::{runner::get_exec_event_sender, runtime::get_runtime};
-use nautilus_core::MUTEX_POISONED;
+use nautilus_common::{
+    cache::Cache,
+    live::{runner::get_exec_event_sender, runtime::get_runtime},
+    msgbus::{self, TypedHandler},
+};
+use nautilus_core::{MUTEX_POISONED, UnixNanos, collections::AtomicMap, time::AtomicTime};
 use nautilus_model::{
-    identifiers::InstrumentId,
+    events::PositionEvent,
+    identifiers::{AccountId, InstrumentId},
     instruments::{Instrument, InstrumentAny},
 };
 use ustr::Ustr;
@@ -38,6 +43,43 @@ use crate::{
 };
 
 impl PolymarketExecutionClient {
+    fn ensure_position_event_subscription(&mut self) {
+        if self.position_event_handler.is_some() {
+            return;
+        }
+
+        let core = self.core.clone();
+        let clock = self.clock;
+        let shared_token_instruments = self.shared_token_instruments.clone();
+        let neg_risk_index = self.neg_risk_index.clone();
+        let handler = TypedHandler::from(move |event: &PositionEvent| {
+            if !matches!(event, PositionEvent::PositionClosed(_)) {
+                return;
+            }
+
+            if event.instrument_id().venue != core.venue {
+                return;
+            }
+
+            sync_execution_lookup_for_instrument(
+                &core,
+                clock,
+                &shared_token_instruments,
+                &neg_risk_index,
+                event.instrument_id(),
+            );
+        });
+
+        msgbus::subscribe_position_events("events.position.*".into(), handler.clone(), Some(10));
+        self.position_event_handler = Some(handler);
+    }
+
+    fn clear_position_event_subscription(&mut self) {
+        if let Some(handler) = self.position_event_handler.take() {
+            msgbus::unsubscribe_position_events("events.position.*".into(), &handler);
+        }
+    }
+
     pub(super) fn spawn_task<F>(&self, description: &'static str, fut: F)
     where
         F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
@@ -204,32 +246,69 @@ impl PolymarketExecutionClient {
         neg_risk_index.get(instrument_id).copied().unwrap_or(false)
     }
 
+    fn should_retain_execution_lookup(
+        &self,
+        cache: &Cache,
+        instrument: &InstrumentAny,
+        now_ns: UnixNanos,
+        account_id: AccountId,
+    ) -> bool {
+        if !crate::filters::is_expired(instrument, now_ns) {
+            return true;
+        }
+
+        cache.has_positions_open(
+            Some(&self.core.venue),
+            Some(&instrument.id()),
+            None,
+            Some(&account_id),
+            None,
+        )
+    }
+
+    fn upsert_execution_lookup(&self, instrument: &InstrumentAny) {
+        upsert_execution_lookup(
+            &self.shared_token_instruments,
+            &self.neg_risk_index,
+            instrument,
+        );
+    }
+
+    fn remove_execution_lookup(&self, instrument_id: InstrumentId) {
+        remove_execution_lookup(
+            &self.shared_token_instruments,
+            &self.neg_risk_index,
+            instrument_id,
+        );
+    }
+
     pub(super) fn load_instruments_from_cache(&self) {
         let cache = self.core.cache();
+        let now_ns = self.clock.get_time_ns();
+        let account_id = self.core.account_id;
         let instruments: Vec<InstrumentAny> = cache
             .instruments(&self.core.venue, None)
             .into_iter()
             .cloned()
             .collect();
+        let mut retained_instrument_ids = AHashSet::new();
+
+        for inst in instruments
+            .iter()
+            .filter(|inst| self.should_retain_execution_lookup(&cache, inst, now_ns, account_id))
+        {
+            retained_instrument_ids.insert(inst.id());
+            self.upsert_execution_lookup(inst);
+        }
+
         drop(cache);
 
-        for inst in &instruments {
-            self.shared_token_instruments
-                .insert(Ustr::from(inst.raw_symbol().as_str()), inst.clone());
-        }
+        self.prune_execution_lookup_not_in_retained(&retained_instrument_ids);
 
-        for inst in &instruments {
-            if let InstrumentAny::BinaryOption(bo) = inst {
-                let neg_risk = bo
-                    .info
-                    .as_ref()
-                    .and_then(|i| i.get_bool("neg_risk"))
-                    .unwrap_or(false);
-                self.neg_risk_index.insert(bo.id, neg_risk);
-            }
-        }
-
-        log::info!("Loaded {} instruments from cache", instruments.len());
+        log::info!(
+            "Loaded {} retained instruments from cache",
+            retained_instrument_ids.len()
+        );
     }
 
     pub(super) fn start_client(&mut self) {
@@ -257,6 +336,7 @@ impl PolymarketExecutionClient {
         log::info!("Stopping Polymarket execution client");
 
         self.stopping.store(true, Ordering::Release);
+        self.clear_position_event_subscription();
 
         if let Some(handle) = self.ws_stream_handle.lock().expect(MUTEX_POISONED).take() {
             handle.abort();
@@ -284,6 +364,7 @@ impl PolymarketExecutionClient {
         self.core.set_instruments_initialized();
 
         self.start_ws_stream().await?;
+        self.ensure_position_event_subscription();
 
         let post_ws = async {
             self.refresh_account_state().await?;
@@ -294,6 +375,7 @@ impl PolymarketExecutionClient {
         if let Err(e) = post_ws.await {
             log::warn!("Connect failed after WS started, tearing down: {e}");
             self.stopping.store(true, Ordering::Release);
+            self.clear_position_event_subscription();
             let _ = self.ws_client.disconnect().await;
             self.abort_pending_tasks();
             return Err(e);
@@ -313,6 +395,7 @@ impl PolymarketExecutionClient {
         log::info!("Disconnecting Polymarket execution client");
 
         self.stopping.store(true, Ordering::Release);
+        self.clear_position_event_subscription();
 
         self.ws_client.disconnect().await?;
 
@@ -327,16 +410,428 @@ impl PolymarketExecutionClient {
         Ok(())
     }
 
-    pub(super) fn on_instrument_update(&self, instrument: InstrumentAny) {
-        let token_id = Ustr::from(instrument.raw_symbol().as_str());
-        if let InstrumentAny::BinaryOption(bo) = &instrument {
-            let neg_risk = bo
-                .info
-                .as_ref()
-                .and_then(|i| i.get_bool("neg_risk"))
-                .unwrap_or(false);
-            self.neg_risk_index.insert(bo.id, neg_risk);
+    pub(super) fn on_instrument_update(&self, instrument: &InstrumentAny) {
+        let cache = self.core.cache();
+        let now_ns = self.clock.get_time_ns();
+        let account_id = self.core.account_id;
+        let instrument_id = instrument.id();
+
+        if self.should_retain_execution_lookup(&cache, instrument, now_ns, account_id) {
+            self.upsert_execution_lookup(instrument);
+        } else {
+            self.remove_execution_lookup(instrument_id);
         }
-        self.shared_token_instruments.insert(token_id, instrument);
+    }
+
+    fn prune_execution_lookup_not_in_retained(
+        &self,
+        retained_instrument_ids: &AHashSet<InstrumentId>,
+    ) {
+        let token_ids: Vec<Ustr> = self
+            .shared_token_instruments
+            .load()
+            .keys()
+            .copied()
+            .collect();
+
+        for token_id in token_ids {
+            if let Some(instrument) = self.shared_token_instruments.get_cloned(&token_id)
+                && !retained_instrument_ids.contains(&instrument.id())
+            {
+                self.remove_execution_lookup(instrument.id());
+            }
+        }
+
+        let instrument_ids: Vec<InstrumentId> =
+            self.neg_risk_index.load().keys().copied().collect();
+
+        for instrument_id in instrument_ids {
+            if !retained_instrument_ids.contains(&instrument_id) {
+                self.neg_risk_index.remove(&instrument_id);
+            }
+        }
+    }
+}
+
+fn upsert_execution_lookup(
+    shared_token_instruments: &AtomicMap<Ustr, InstrumentAny>,
+    neg_risk_index: &AtomicMap<InstrumentId, bool>,
+    instrument: &InstrumentAny,
+) {
+    let token_id = Ustr::from(instrument.raw_symbol().as_str());
+    shared_token_instruments.insert(token_id, instrument.clone());
+
+    if let InstrumentAny::BinaryOption(bo) = instrument {
+        let neg_risk = bo
+            .info
+            .as_ref()
+            .and_then(|i| i.get_bool("neg_risk"))
+            .unwrap_or(false);
+        neg_risk_index.insert(bo.id, neg_risk);
+    }
+}
+
+fn remove_execution_lookup(
+    shared_token_instruments: &AtomicMap<Ustr, InstrumentAny>,
+    neg_risk_index: &AtomicMap<InstrumentId, bool>,
+    instrument_id: InstrumentId,
+) {
+    let token_ids = shared_token_instruments
+        .load()
+        .iter()
+        .filter_map(|(token_id, instrument)| {
+            (instrument.id() == instrument_id).then_some(*token_id)
+        })
+        .collect::<Vec<_>>();
+
+    for token_id in token_ids {
+        shared_token_instruments.remove(&token_id);
+    }
+
+    neg_risk_index.remove(&instrument_id);
+}
+
+fn sync_execution_lookup_for_instrument(
+    core: &nautilus_live::ExecutionClientCore,
+    clock: &'static AtomicTime,
+    shared_token_instruments: &AtomicMap<Ustr, InstrumentAny>,
+    neg_risk_index: &AtomicMap<InstrumentId, bool>,
+    instrument_id: InstrumentId,
+) {
+    let now_ns = clock.get_time_ns();
+    let account_id = core.account_id;
+    let cache = core.cache();
+
+    let retained = cache
+        .instrument(&instrument_id)
+        .cloned()
+        .filter(|instrument| {
+            if !crate::filters::is_expired(instrument, now_ns) {
+                return true;
+            }
+
+            cache.has_positions_open(
+                Some(&core.venue),
+                Some(&instrument_id),
+                None,
+                Some(&account_id),
+                None,
+            )
+        });
+
+    drop(cache);
+
+    if let Some(instrument) = retained {
+        upsert_execution_lookup(shared_token_instruments, neg_risk_index, &instrument);
+    } else {
+        remove_execution_lookup(shared_token_instruments, neg_risk_index, instrument_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use nautilus_common::{cache::Cache, live::runner::set_exec_event_sender};
+    use nautilus_core::{UUID4, nanos::DurationNanos};
+    use nautilus_live::ExecutionClientCore;
+    use nautilus_model::{
+        enums::{AccountType, OmsType, OrderSide, PositionSide, TimeInForce},
+        events::{OrderEventAny, PositionClosed, PositionEvent},
+        identifiers::{
+            AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Symbol, TraderId,
+        },
+        instruments::stubs::binary_option,
+        orders::{LimitOrder, OrderAny, stubs::TestOrderEventStubs},
+        position::Position,
+        types::{Currency, Money, Price, Price as ModelPrice, Quantity, Quantity as ModelQuantity},
+    };
+    use rstest::rstest;
+    use serde_json::Value;
+
+    use super::*;
+
+    const TEST_PRIVATE_KEY: &str =
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    const TEST_API_SECRET_B64: &str = "dGVzdF9zZWNyZXRfa2V5XzMyYnl0ZXNfcGFkMTIzNDU=";
+
+    fn test_client() -> (PolymarketExecutionClient, Rc<RefCell<Cache>>) {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let core = ExecutionClientCore::new(
+            TraderId::from("TESTER-001"),
+            ClientId::from("POLYMARKET"),
+            *crate::common::consts::POLYMARKET_VENUE,
+            OmsType::Netting,
+            AccountId::from("POLYMARKET-001"),
+            AccountType::Cash,
+            None,
+            cache.clone(),
+        );
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        set_exec_event_sender(tx);
+        let client = PolymarketExecutionClient::new(
+            core,
+            crate::config::PolymarketExecClientConfig {
+                private_key: Some(TEST_PRIVATE_KEY.to_string()),
+                api_key: Some("test_api_key".to_string()),
+                api_secret: Some(TEST_API_SECRET_B64.to_string()),
+                passphrase: Some("test_pass".to_string()),
+                funder: None,
+                base_url_http: Some("http://127.0.0.1:3000".to_string()),
+                base_url_ws: Some("ws://127.0.0.1:3000/ws".to_string()),
+                base_url_data_api: Some("http://127.0.0.1:3000".to_string()),
+                ..crate::config::PolymarketExecClientConfig::default()
+            },
+        )
+        .expect("test client should construct");
+
+        (client, cache)
+    }
+
+    fn test_binary_option(raw_symbol: &str, expired: bool, neg_risk: bool) -> InstrumentAny {
+        let clock = nautilus_core::time::get_atomic_clock_realtime();
+        let mut binary = binary_option();
+        binary.id = InstrumentId::from(format!("{raw_symbol}.POLYMARKET").as_str());
+        binary.raw_symbol = Symbol::new(raw_symbol);
+        binary.currency = Currency::pUSD();
+        binary.expiration_ns = if expired {
+            UnixNanos::from(clock.get_time_ns().as_u64().saturating_sub(1_000_000_000))
+        } else {
+            UnixNanos::from(
+                clock
+                    .get_time_ns()
+                    .as_u64()
+                    .saturating_add(86_400_000_000_000),
+            )
+        };
+
+        let mut info = nautilus_core::Params::new();
+        info.insert("neg_risk".to_string(), Value::Bool(neg_risk));
+        binary.info = Some(info);
+
+        InstrumentAny::BinaryOption(binary)
+    }
+
+    fn open_limit_order(instrument_id: InstrumentId) -> OrderAny {
+        OrderAny::Limit(LimitOrder::new(
+            TraderId::from("TESTER-001"),
+            StrategyId::from("S-001"),
+            instrument_id,
+            ClientOrderId::from("O-RETAIN"),
+            OrderSide::Buy,
+            ModelQuantity::new(10.0, 0),
+            ModelPrice::from("0.5000"),
+            TimeInForce::Gtc,
+            None,
+            false,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+        ))
+    }
+
+    fn open_position(instrument: &InstrumentAny) -> Position {
+        let order = open_limit_order(instrument.id());
+        let filled = match TestOrderEventStubs::filled(
+            &order,
+            instrument,
+            None,
+            None,
+            Some(ModelPrice::from("0.5000")),
+            None,
+            None,
+            None,
+            None,
+            Some(AccountId::from("POLYMARKET-001")),
+        ) {
+            OrderEventAny::Filled(filled) => filled,
+            other => panic!("expected filled event, was {other:?}"),
+        };
+
+        Position::new(instrument, filled)
+    }
+
+    fn closed_position(position: &Position) -> Position {
+        let mut closed = position.clone();
+        closed.side = PositionSide::Flat;
+        closed.signed_qty = 0.0;
+        closed.quantity = Quantity::zero(position.size_precision);
+        closed.ts_closed = Some(position.ts_last);
+        closed.duration_ns = 1;
+        closed
+    }
+
+    fn position_closed_event(position: &Position) -> PositionEvent {
+        PositionEvent::PositionClosed(PositionClosed {
+            trader_id: position.trader_id,
+            strategy_id: position.strategy_id,
+            instrument_id: position.instrument_id,
+            position_id: position.id,
+            account_id: position.account_id,
+            opening_order_id: position.opening_order_id,
+            closing_order_id: position.closing_order_id,
+            entry: position.entry,
+            side: PositionSide::Flat,
+            signed_qty: 0.0,
+            quantity: Quantity::zero(position.size_precision),
+            peak_quantity: position.peak_qty,
+            last_qty: Quantity::zero(position.size_precision),
+            last_px: Price::zero(position.price_precision),
+            currency: position.quote_currency,
+            avg_px_open: position.avg_px_open,
+            avg_px_close: position.avg_px_close,
+            realized_return: position.realized_return,
+            realized_pnl: position.realized_pnl,
+            unrealized_pnl: Money::zero(position.quote_currency),
+            duration: DurationNanos::from(1_u64),
+            event_id: UUID4::new(),
+            ts_opened: position.ts_opened,
+            ts_closed: position.ts_closed.or(Some(position.ts_last)),
+            ts_event: position.ts_last,
+            ts_init: position.ts_last,
+        })
+    }
+
+    #[rstest]
+    fn load_instruments_from_cache_prunes_expired_execution_lookup_state() {
+        let (client, cache) = test_client();
+        let active = test_binary_option("0xACTIVE", false, true);
+        let expired = test_binary_option("0xEXPIRED", true, true);
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(active.clone()).unwrap();
+            cache.add_instrument(expired.clone()).unwrap();
+        }
+
+        client
+            .shared_token_instruments
+            .insert(Ustr::from(expired.raw_symbol().as_str()), expired.clone());
+        client.neg_risk_index.insert(expired.id(), true);
+
+        client.load_instruments_from_cache();
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(active.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&active.id()));
+        assert!(
+            !client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(!client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn on_instrument_update_skips_expired_execution_lookup_state() {
+        let (client, _cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_ONLY", true, true);
+
+        client.on_instrument_update(&expired);
+
+        assert!(
+            !client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(!client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn load_instruments_from_cache_keeps_expired_lookup_state_with_open_position() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_POSITION", true, true);
+        let position = open_position(&expired);
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            cache.add_position(&position, OmsType::Netting).unwrap();
+        }
+
+        client.load_instruments_from_cache();
+
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn sync_execution_lookup_prunes_expired_lookup_after_position_closes() {
+        let (client, cache) = test_client();
+        let expired = test_binary_option("0xEXPIRED_CLOSED", true, true);
+        let position = open_position(&expired);
+        let closed = closed_position(&position);
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.add_instrument(expired.clone()).unwrap();
+            cache.add_position(&position, OmsType::Netting).unwrap();
+        }
+
+        client.load_instruments_from_cache();
+        assert!(
+            client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(client.neg_risk_index.contains_key(&expired.id()));
+
+        {
+            let mut cache = cache.borrow_mut();
+            cache.update_position(&closed).unwrap();
+        }
+
+        let event = position_closed_event(&closed);
+        assert!(matches!(event, PositionEvent::PositionClosed(_)));
+        sync_execution_lookup_for_instrument(
+            &client.core,
+            client.clock,
+            &client.shared_token_instruments,
+            &client.neg_risk_index,
+            event.instrument_id(),
+        );
+
+        assert!(
+            !client
+                .shared_token_instruments
+                .contains_key(&Ustr::from(expired.raw_symbol().as_str()))
+        );
+        assert!(!client.neg_risk_index.contains_key(&expired.id()));
+    }
+
+    #[rstest]
+    fn position_event_subscription_can_be_reinstalled_after_disconnect_cleanup() {
+        let (mut client, _cache) = test_client();
+
+        client.start_client();
+        assert!(client.position_event_handler.is_none());
+
+        client.ensure_position_event_subscription();
+        assert!(client.position_event_handler.is_some());
+
+        client.clear_position_event_subscription();
+        assert!(client.position_event_handler.is_none());
+
+        client.ensure_position_event_subscription();
+        assert!(client.position_event_handler.is_some());
     }
 }

--- a/crates/adapters/polymarket/src/execution/mod.rs
+++ b/crates/adapters/polymarket/src/execution/mod.rs
@@ -41,6 +41,7 @@ use nautilus_common::{
         GenerateOrderStatusReport, GenerateOrderStatusReports, GeneratePositionStatusReports,
         ModifyOrder, QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
     },
+    msgbus::TypedHandler,
 };
 use nautilus_core::{
     MUTEX_POISONED, UnixNanos,
@@ -51,6 +52,7 @@ use nautilus_live::{ExecutionClientCore, ExecutionEventEmitter};
 use nautilus_model::{
     accounts::AccountAny,
     enums::{AccountType, LiquiditySide, OmsType},
+    events::PositionEvent,
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue, VenueOrderId,
     },
@@ -95,6 +97,7 @@ pub struct PolymarketExecutionClient {
     pending_tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
     stopping: Arc<AtomicBool>,
     ws_stream_handle: Mutex<Option<JoinHandle<()>>>,
+    position_event_handler: Option<TypedHandler<PositionEvent>>,
     shared_token_instruments: Arc<AtomicMap<Ustr, InstrumentAny>>,
     neg_risk_index: Arc<AtomicMap<InstrumentId, bool>>,
     fill_tracker: Arc<OrderFillTrackerMap>,
@@ -227,6 +230,7 @@ impl PolymarketExecutionClient {
             pending_tasks: Arc::new(Mutex::new(Vec::new())),
             stopping: Arc::new(AtomicBool::new(false)),
             ws_stream_handle: Mutex::new(None),
+            position_event_handler: None,
             shared_token_instruments: Arc::new(AtomicMap::new()),
             neg_risk_index: Arc::new(AtomicMap::new()),
             fill_tracker: Arc::new(OrderFillTrackerMap::new()),
@@ -336,7 +340,7 @@ impl ExecutionClient for PolymarketExecutionClient {
     }
 
     fn on_instrument(&mut self, instrument: InstrumentAny) {
-        self.on_instrument_update(instrument);
+        self.on_instrument_update(&instrument);
     }
 
     fn calculate_commission(

--- a/crates/adapters/polymarket/src/execution/mod.rs
+++ b/crates/adapters/polymarket/src/execution/mod.rs
@@ -52,7 +52,7 @@ use nautilus_live::{ExecutionClientCore, ExecutionEventEmitter};
 use nautilus_model::{
     accounts::AccountAny,
     enums::{AccountType, LiquiditySide, OmsType},
-    events::PositionEvent,
+    events::{OrderEventAny, PositionEvent},
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue, VenueOrderId,
     },
@@ -97,6 +97,7 @@ pub struct PolymarketExecutionClient {
     pending_tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
     stopping: Arc<AtomicBool>,
     ws_stream_handle: Mutex<Option<JoinHandle<()>>>,
+    order_event_handler: Option<TypedHandler<OrderEventAny>>,
     position_event_handler: Option<TypedHandler<PositionEvent>>,
     shared_token_instruments: Arc<AtomicMap<Ustr, InstrumentAny>>,
     neg_risk_index: Arc<AtomicMap<InstrumentId, bool>>,
@@ -230,6 +231,7 @@ impl PolymarketExecutionClient {
             pending_tasks: Arc::new(Mutex::new(Vec::new())),
             stopping: Arc::new(AtomicBool::new(false)),
             ws_stream_handle: Mutex::new(None),
+            order_event_handler: None,
             position_event_handler: None,
             shared_token_instruments: Arc::new(AtomicMap::new()),
             neg_risk_index: Arc::new(AtomicMap::new()),


### PR DESCRIPTION
## Summary

Related to #4253.

This PR addresses the execution-client portion of the inactive-instrument retention chain described in #4253.

Specifically, it hardens Polymarket execution-side lookup retention so expired instruments are retained only while live execution flows still need them, and are pruned once both order and position state have reached terminal conditions.

In scope:
- `shared_token_instruments`
- `neg_risk_index`
- execution-client lifecycle for lookup-retention subscriptions

Out of scope:
- sandbox / matchengine behavior
- global cache pruning
- data-client retention redesign
- periodic execution sweep timers
- reconnect-time stale lookup sweeping

## Problem

As described in #4253, Polymarket continuously creates short-dated markets, so long-running sessions can accumulate inactive instrument state across multiple layers.

On the execution side, the relevant retained owners are:
- `shared_token_instruments`
- `neg_risk_index`

Before this change, those lookup maps were effectively append-only within a connection lifetime:
- `load_instruments_from_cache()` populated execution lookup state on connect
- `on_instrument()` kept inserting newly seen instruments
- expired instruments were not later re-evaluated once execution-side order/position state became terminal

That meant expired markets could remain retained in execution-local lookup state even after execution flows no longer needed them.

## What This PR Changes

This PR adds a single execution-local retention policy:
- retain active instruments
- retain expired instruments while an open order or open position still exists
- prune expired instruments once neither open orders nor open positions remain

The policy is applied through execution-side lifecycle events rather than connect-time pruning:

1. `load_instruments_from_cache()`
   - on connect / reconnect, preload execution lookup state from cache
   - do not prune here, so startup reconciliation and late venue state cannot lose required lookup entries prematurely

2. `on_instrument_update()`
   - newly seen instruments are upserted into execution lookup state
   - do not prune here, so mid-session updates do not remove lookup state while venue events may still arrive

3. terminal execution events
   - while connected, the execution client subscribes to:
     - `PositionClosed`
     - terminal order events (`Canceled`, `Expired`, `Rejected`, `Filled`)
   - each event re-evaluates lookup retention for that single instrument
   - expired lookup state is pruned only when no open order and no open position remain

This also makes the subscription lifecycle symmetric:
- install on connect
- remove on disconnect
- remove on stop
- remove on connect-failure teardown
- allow clean reinstall after disconnect cleanup

## Why This Shape

This PR intentionally keeps the PR2 scope narrow.

It does not try to solve the entire retention chain from #4253 in one patch. Instead, it closes the execution-client part of that chain without introducing broader lifecycle changes.

In particular, this PR intentionally does not:
- add a periodic execution sweep timer
- expand data-client-local ownership
- introduce sandbox / matchengine cleanup changes
- change global cache purge behavior
- promise expiry-time shrink for never-traded instruments

The intended behavior here is convergence, not immediate expiry-time shrink.

Execution lookup state is no longer permanently append-only for traded instruments:
- it is preloaded on connect / reconnect
- it converges after terminal order / position events for expired instruments

This means:
- traded expired instruments can contract once execution state is fully terminal
- expired instruments that were only loaded / discovered and never reach execution terminal events are not pruned by this PR

That is the execution-side piece of the larger inactive-instrument cleanup plan in #4253.

## Testing

- `cargo test -p nautilus-polymarket execution::lifecycle --lib`
- `pre-commit run --files crates/adapters/polymarket/src/execution/lifecycle.rs crates/adapters/polymarket/src/execution/mod.rs`

Added lifecycle coverage for:
- preloading expired lookup state during cache load without connect-time pruning
- retaining expired lookup state while an open order remains
- retaining expired lookup state while an open position remains
- pruning expired lookup state after terminal order events
- retaining expired lookup state after `Filled` when the position remains open
- pruning expired lookup state after `PositionClosed`
- ignoring other-venue position events
- reinstalling order / position event subscriptions after disconnect cleanup
