### PR TITLE
Fix reconciliation canceling live orders on cancel-replace venues

### DIFF
--- a/crates/execution/src/reconciliation/orders.rs
+++ b/crates/execution/src/reconciliation/orders.rs
@@ -116,6 +116,14 @@ pub fn generate_reconciliation_order_events(
 /// Returns `None` for pending venue states (`PendingUpdate`, `PendingCancel`)
 /// regardless of local state, since an unconfirmed amend or cancel must not
 /// drive any local mutation until the venue surfaces a confirmed status.
+///
+/// Returns `None` for `Canceled` reports when:
+/// - the local order is mid-command (`PendingUpdate`, `PendingCancel`) — the
+///   adapter's primary lifecycle stream (WebSocket or HTTP) must confirm the
+///   outcome before a terminal event can be applied;
+/// - the report references a previously-promoted `venue_order_id` whose
+///   successor is still live in the cache (the cancel-half of a cancel-replace
+///   modify on venues like Hyperliquid).
 #[must_use]
 pub fn reconcile_order_report(
     order: &OrderAny,
@@ -174,7 +182,47 @@ pub fn reconcile_order_report(
                 None
             }
         }
-        OrderStatus::Canceled => Some(create_reconciliation_canceled(order, report, ts_now)),
+        OrderStatus::Canceled => {
+            // Defer when locally awaiting venue confirmation of an issued
+            // command. The adapter's primary lifecycle stream is the source of truth;
+            // a Canceled report arriving mid-command is more likely the cancel-half of
+            // a cancel-replace modify than an authoritative termination.
+            if matches!(
+                order.status(),
+                OrderStatus::PendingUpdate | OrderStatus::PendingCancel,
+            ) {
+                log::info!(
+                    "Deferring Canceled for {} during local {:?}: awaiting venue confirmation",
+                    order.client_order_id(),
+                    order.status(),
+                );
+                return None;
+            }
+
+            // Stale cancel-half of a cancel-replace modify: the cache has
+            // already been promoted to the new `venue_order_id` and the
+            // report references a previously-tracked leg whose successor
+            // is still live.
+            let report_venue_order_id = report.venue_order_id;
+            if let Some(cached_venue_order_id) = order.venue_order_id()
+                && cached_venue_order_id != report_venue_order_id
+                && order
+                    .venue_order_ids()
+                    .iter()
+                    .any(|v| **v == report_venue_order_id)
+            {
+                log::info!(
+                    "Suppressing Canceled for {} on previously-promoted venue_order_id {}: \
+                     current venue_order_id is {}",
+                    order.client_order_id(),
+                    report_venue_order_id,
+                    cached_venue_order_id,
+                );
+                return None;
+            }
+
+            Some(create_reconciliation_canceled(order, report, ts_now))
+        }
         OrderStatus::Expired => Some(create_reconciliation_expired(order, report, ts_now)),
 
         OrderStatus::PartiallyFilled | OrderStatus::Filled => {

--- a/crates/live/src/node.rs
+++ b/crates/live/src/node.rs
@@ -1258,7 +1258,10 @@ impl LiveNode {
                                 | OrderEventAny::Rejected(_)
                                 | OrderEventAny::Canceled(_)
                                 | OrderEventAny::Expired(_)
-                                | OrderEventAny::Denied(_) => {
+                                | OrderEventAny::Denied(_)
+                                | OrderEventAny::Updated(_)
+                                | OrderEventAny::ModifyRejected(_)
+                                | OrderEventAny::CancelRejected(_) => {
                                     self.exec_manager.clear_recon_tracking(
                                         &order_evt.client_order_id(), true,
                                     );


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

### Overview

On venues that implement `modify_order` as atomic cancel-replace (Hyperliquid, dYdX), the HTTP reconciliation path can synthesize a phantom `OrderCanceled` for an order that is still resting at the venue. Strategies react by clearing tracking and replenishing — leaving two live orders on the venue for the same `client_order_id`.

Two complementary guards: stop probing confirmed-modified orders (root cause), and refuse to synthesize a terminal event while mid-command or while the report references a previously-promoted `venue_order_id` (backstop).

### Problem

Observed in production: `OrderCanceled` events delivered to strategies for orders that subsequently traded as makers on the same `venue_order_id`. Four cancel-then-fill collisions in a 12-minute window on one instrument, each causing the strategy to submit a replacement — silent double exposure.

The phantom requires three conditions to align:

1. **Cancel-replace modify venue** (single-voi venues are never affected).
2. **`client_order_id` quiet ≥ `inflight_check_threshold`** (default 5 s) after its last command.
3. **Venue HTTP snapshot returns the cancel-half of a recent modify-replace** (eventual consistency or a transient flake).

Active liquid instruments rarely hit gate 2. The phantoms concentrate on illiquid perpetuals during periods of venue HTTP stress.

### Root cause

Two parallel paths deliver venue state: the adapter's lifecycle stream (WS dispatch — source of truth, has GH-3827 modify-replace awareness) and a periodic HTTP reconciliation (safety net). The reconciliation path was written under a single-voi mental model and **does not have the equivalent guard**.

Two mirror-image failure modes both produce a phantom:

- **Case A — cache-advanced.** WS dispatch already promoted `cache.venue_order_id` to NEW; HTTP report arrives referencing OLD. Distinguishable by `report.voi != cache.voi`.
- **Case B — cache-stale.** WS lag/drop means the promotion never arrived; HTTP report arrives referencing OLD, which matches the stale cache. Distinguishable only by `order.status() == PendingUpdate`.

**Why HTTP fires at all on healthy orders:** `LiveNode` clears the inflight reconciliation tracking on terminal events but not on `Updated`, `ModifyRejected`, or `CancelRejected`. After a confirmed modify the `client_order_id` lingers in `inflight_checks`; the next quiet window past threshold triggers a `QueryOrder`. 

### The fix

### Commit 1 — crates/live/src/node.rs

Add `Updated`, `ModifyRejected`, `CancelRejected` to the match arm that clears `clear_recon_tracking`. Once the lifecycle stream confirms the command outcome, periodic reconciliation probes must stop.

### Commit 2 — crates/execution/src/reconciliation/orders.rs

Two guards in the `Canceled` branch of `reconcile_order_report`:

1. **Defer** when `order.status()` is `PendingUpdate` or `PendingCancel`. The adapter's lifecycle stream must confirm the command outcome before a terminal event can be applied.
2. **Suppress** when `report.venue_order_id` differs from the cached one and is present in `order.venue_order_ids()` — i.e., a previously-promoted leg whose successor is still live. Mirrors the GH-3827 Rule 1 suppression already in the HL WS dispatch.

Function docstring extended to list both new `None`-returning conditions.

Both new log lines are `info` — these events are rare under normal venue conditions but operationally meaningful; `debug` hides them by default, `warn` is wrong (nothing is broken).

### Non-regression

Walked every realistic scenario in which a `Canceled` report reaches `reconcile_order_report`:

| scenario | result |
|---|---|
| Real cancel of a live order (post-only crossed, margin, user UI, …) | forwarded |
| `Strategy::cancel_order` → WS confirms → HTTP echoes | forwarded (engine de-dups) |
| External venue cancel of a `venue_order_id` we never tracked | forwarded |
| Single-voi venue, ordinary cancel | forwarded (history check trivially never matches) |
| Brand-new submission, no `Accepted` yet | forwarded |
| **Modify-replace race, cache advanced (Case A)** | **suppressed** |
| **Modify-replace race, cache stale (Case B)** | **deferred** |
| Multi-step modify chain, report on an old leg | suppressed |

**Single-`venue_order_id` venues unaffected.** The suppress guard's `in_history && != current` clause cannot be satisfied. The defer guard does fire briefly but introduces at most one reconciliation cycle of latency on cancels arriving inside the in-flight window.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore