### PR TITLE
Fix Binance futures leverage initialization aborting execution client connect

### DIFF
--- a/nautilus_trader/adapters/binance/futures/execution.py
+++ b/nautilus_trader/adapters/binance/futures/execution.py
@@ -25,6 +25,7 @@ from nautilus_trader.adapters.binance.common.enums import BinanceAccountType
 from nautilus_trader.adapters.binance.common.enums import BinanceEnvironment
 from nautilus_trader.adapters.binance.common.enums import BinanceErrorCode
 from nautilus_trader.adapters.binance.common.enums import BinanceExecutionType
+from nautilus_trader.adapters.binance.common.symbol import BinanceSymbol
 from nautilus_trader.adapters.binance.config import BinanceExecClientConfig
 from nautilus_trader.adapters.binance.execution import BinanceCommonExecutionClient
 from nautilus_trader.adapters.binance.futures.enums import BinanceFuturesEnumParser
@@ -167,6 +168,9 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
             self._log.info("TRADE_LITE events will be used", LogColor.BLUE)
 
         self._leverages = config.futures_leverages
+        # Symbols already warned about a failed best-effort leverage set, so the
+        # warning is emitted at most once (this runs on every account query).
+        self._set_leverage_warned: set[str] = set()
         self._margin_types = config.futures_margin_types
 
         self._decoder_futures_user_msg = msgspec.json.Decoder(BinanceFuturesUserMsgData)
@@ -175,7 +179,7 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
         self._decoder_futures_trade_lite = msgspec.json.Decoder(BinanceFuturesTradeLiteMsg)
         self._decoder_futures_algo_update = msgspec.json.Decoder(BinanceFuturesAlgoUpdateMsg)
 
-    async def _update_account_state(self) -> None:
+    async def _update_account_state(self) -> None:  # noqa: C901 (too complex)
         account_info: BinanceFuturesAccountInfo = (
             await self._futures_http_account.query_futures_account_info(recv_window=str(5000))
         )
@@ -206,14 +210,32 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
         await self._await_account_registered(log_registered=False)
 
         if self._leverages:
+            # Leverage initialization is best-effort and must not block startup.
+            # A per-symbol `set_leverage` venue rejection (for example -4028
+            # leverage too large, when a symbol's venue cap is below the requested
+            # value) must not abort `_connect`, so catch per task: one rejected
+            # symbol cannot tear down the TaskGroup. Only `BinanceError` (a venue
+            # reject) is caught deliberately; a transport error means the
+            # connection itself is unhealthy and should still surface. This runs
+            # on every account query, so each symbol is warned at most once.
+            async def _set_default_leverage(symbol: BinanceSymbol, leverage: int) -> None:
+                try:
+                    res: BinanceFuturesLeverage = await self._futures_http_account.set_leverage(
+                        symbol,
+                        leverage,
+                    )
+                    self._log.info(f"Set default leverage {res.symbol} {res.leverage}X")
+                except BinanceError as e:
+                    if symbol not in self._set_leverage_warned:
+                        self._set_leverage_warned.add(symbol)
+                        self._log.warning(
+                            f"Unable to set leverage for {symbol} to {leverage}x: "
+                            f"{e.message}; skipping (leverage init is best-effort)",
+                        )
+
             async with TaskGroup() as tg:
-                leverage_tasks = [
-                    tg.create_task(self._futures_http_account.set_leverage(symbol, leverage))
-                    for symbol, leverage in self._leverages.items()
-                ]
-            for task in leverage_tasks:
-                res: BinanceFuturesLeverage = task.result()
-                self._log.info(f"Set default leverage {res.symbol} {res.leverage}X")
+                for sym, lev in self._leverages.items():
+                    tg.create_task(_set_default_leverage(sym, lev))
 
         if self._margin_types:
             async with TaskGroup() as tg:
@@ -234,8 +256,14 @@ class BinanceFuturesExecutionClient(BinanceCommonExecutionClient):
         symbol_configs = await self._futures_http_account.query_futures_symbol_config()
         for config in symbol_configs:
             try:
-                instrument_id: InstrumentId = self._get_cached_instrument_id(config.symbol)
                 leverage = Decimal(config.leverage)
+                if leverage < 1:
+                    # Binance testnet/demo returns leverage=0 for symbols the
+                    # account has not configured; `MarginAccount.set_leverage`
+                    # requires leverage >= 1, so skip these (they are not a
+                    # tradable leverage config for this client anyway).
+                    continue
+                instrument_id: InstrumentId = self._get_cached_instrument_id(config.symbol)
                 account.set_leverage(instrument_id, leverage)
                 self._log.debug(f"Set leverage {config.symbol} {leverage}X")
             except KeyError:

--- a/tests/integration_tests/adapters/binance/test_execution_futures.py
+++ b/tests/integration_tests/adapters/binance/test_execution_futures.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 from decimal import Decimal
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -3059,3 +3060,109 @@ class TestBinanceFuturesExecutionClient:
 
         # Assert - should NOT generate cancel rejected for "Unknown order sent"
         mock_generate_cancel_rejected.assert_not_called()
+
+
+# Best-effort leverage initialization in `_update_account_state`: a `set_leverage`
+# venue reject or a symbolConfig entry with leverage=0 (Binance testnet/demo
+# returns 0 for every untraded symbol) must not abort `_connect`. Exercised as a
+# bound call on a lightweight stub so the tests do not need the full live
+# exec-client / event-loop fixture.
+
+
+def _account_info_stub():
+    info = MagicMock()
+    info.canTrade = True
+    info.updateTime = 0
+    info.parse_to_account_balances = MagicMock(return_value=[])
+    info.parse_to_margin_balances = MagicMock(return_value=[])
+    return info
+
+
+class _UpdateAccountStateStub:
+    """
+    Minimal stand-in exposing only what `_update_account_state` touches.
+    """
+
+    def __init__(self, *, leverages, set_leverage, symbol_configs):
+        self._log = MagicMock()
+        self._http_client = MagicMock()
+        self._leverages = leverages
+        self._set_leverage_warned = set()
+        self._margin_types = {}
+        self._futures_http_account = MagicMock()
+        self._futures_http_account.query_futures_account_info = AsyncMock(
+            return_value=_account_info_stub(),
+        )
+        self._futures_http_account.set_leverage = set_leverage
+        self._futures_http_account.query_futures_symbol_config = AsyncMock(
+            return_value=symbol_configs,
+        )
+        self.generate_account_state = MagicMock()
+        self._await_account_registered = AsyncMock()
+        self.account = MagicMock()
+        self.get_account = MagicMock(return_value=self.account)
+        self._get_cached_instrument_id = MagicMock(side_effect=lambda s: f"id-{s}")
+
+
+def test_update_account_state_set_leverage_failure_is_non_fatal():
+    """
+    A per-symbol `set_leverage` rejection must not abort `_update_account_state`.
+    """
+    from nautilus_trader.adapters.binance.http.error import BinanceError
+
+    set_leverage = AsyncMock(
+        side_effect=BinanceError(400, {"code": -4028, "msg": "leverage too large"}, {}),
+    )
+    stub = _UpdateAccountStateStub(
+        leverages={"BTCUSDT": 10},
+        set_leverage=set_leverage,
+        symbol_configs=[],
+    )
+
+    # Must NOT raise. Before the fix the TaskGroup propagated an ExceptionGroup.
+    asyncio.run(BinanceFuturesExecutionClient._update_account_state(stub))
+
+    set_leverage.assert_awaited_once()
+    stub._log.warning.assert_called()  # warned, then continued
+
+
+def test_update_account_state_skips_zero_leverage_symbol_config():
+    """
+    SymbolConfig entries with leverage<1 are skipped before mirroring.
+
+    Uses a real `MarginAccount` so that, before the fix, mirroring the leverage=0
+    entry would hit the `leverage >= 1` assertion in `MarginAccount.set_leverage`.
+
+    """
+    from types import SimpleNamespace
+
+    from nautilus_trader.model.identifiers import InstrumentId
+    from nautilus_trader.test_kit.stubs.execution import TestExecStubs
+
+    account = TestExecStubs.margin_account()
+    ids = {
+        "BTCUSDT": InstrumentId.from_str("BTCUSDT-PERP.BINANCE"),
+        "SNTUSDT": InstrumentId.from_str("SNTUSDT-PERP.BINANCE"),
+        "MSTRUSDT": InstrumentId.from_str("MSTRUSDT-PERP.BINANCE"),
+    }
+    configs = [
+        SimpleNamespace(symbol="BTCUSDT", leverage=10),
+        SimpleNamespace(symbol="SNTUSDT", leverage=0),  # untraded symbol on demo
+        SimpleNamespace(symbol="MSTRUSDT", leverage=5),
+    ]
+    stub = _UpdateAccountStateStub(
+        leverages={},  # skip the venue-push branch, exercise the symbolConfig mirror
+        set_leverage=AsyncMock(),
+        symbol_configs=configs,
+    )
+    stub.get_account = MagicMock(return_value=account)
+    stub._get_cached_instrument_id = MagicMock(side_effect=lambda s: ids[s])
+
+    # Must not raise. Before the fix, mirroring SNTUSDT leverage=0 raised
+    # ValueError from MarginAccount.set_leverage's `leverage >= 1` assertion.
+    asyncio.run(BinanceFuturesExecutionClient._update_account_state(stub))
+
+    # leverage=0 SNTUSDT skipped; only the two valid symbols are mirrored.
+    assert account.leverage(ids["BTCUSDT"]) == Decimal(10)
+    assert account.leverage(ids["MSTRUSDT"]) == Decimal(5)
+    assert account.leverage(ids["SNTUSDT"]) is None  # skipped, never mirrored


### PR DESCRIPTION
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`BinanceFuturesExecutionClient._update_account_state` could abort `_connect` during leverage initialization in two ways. Both are now best-effort, so a leverage-init issue never prevents the execution client from connecting. This surfaced when connecting a futures testnet/demo account whose `symbolConfig` lists every venue symbol with `leverage=0` for the untraded ones.

**1. A single `set_leverage` rejection tears down the whole `TaskGroup`.** The per-symbol `set_leverage` calls run inside a `TaskGroup`; any failure propagates as an unhandled `ExceptionGroup`. A symbol whose venue leverage cap is below the requested value (for example `-4028 leverage too large`) aborts `_connect` and leaves the client unable to connect. Each `set_leverage` is now caught per symbol (logged as a warning) and the connect proceeds.

**2. `symbolConfig` with `leverage=0` raises in `MarginAccount.set_leverage`.** The leverage mirror calls `account.set_leverage(instrument_id, 0)` for symbols the account has not configured. Binance testnet/demo returns `leverage=0` for every untraded symbol (hundreds of them), and `MarginAccount.set_leverage` asserts `leverage >= 1`, raising `ValueError`. The `except KeyError` was dead code because `_get_cached_instrument_id` fabricates instrument IDs rather than raising. Entries with `leverage < 1` are now skipped before mirroring.

## Related Issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A.

## Documentation

- [x] N/A — no documentation changes.

## Release notes

- [ ] Happy to add a `RELEASES.md` entry if preferred.

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] I added/updated tests to cover new or changed logic

Added two regression tests in `tests/integration_tests/adapters/binance/test_execution_futures.py` exercising `_update_account_state`:
- a `set_leverage` `BinanceError` is non-fatal (warns and continues) — fails before the fix via `TaskGroup` propagation;
- `symbolConfig` `leverage < 1` entries are skipped (not mirrored into account leverage state) — fails before the fix when `set_leverage(id, 0)` hits the `leverage >= 1` assertion.
