### PR TITLE
Shard dYdX Indexer WebSocket into a per-channel connection pool

### DIFF
--- a/crates/adapters/dydx/src/config.rs
+++ b/crates/adapters/dydx/src/config.rs
@@ -165,6 +165,14 @@ fn default_data_retry_delay_max_ms() -> u64 {
     5000
 }
 
+fn default_max_ws_connections() -> usize {
+    8
+}
+
+fn default_per_channel_subscription_limit() -> usize {
+    32
+}
+
 impl DydxAdapterConfig {
     /// Creates a config with URLs and chain ID resolved for the given network.
     ///
@@ -278,6 +286,22 @@ pub struct DydxDataClientConfig {
     #[serde(default)]
     #[builder(default)]
     pub transport_backend: TransportBackend,
+    /// Maximum number of WebSocket connections in the Indexer pool.
+    ///
+    /// New connections are spun up lazily once the per-channel subscription
+    /// limit (32 by default on hosted Indexer) is reached on every existing
+    /// connection. Default `8` supports up to 256 markets per 32-limit channel.
+    #[serde(default = "default_max_ws_connections")]
+    #[builder(default = default_max_ws_connections())]
+    pub max_ws_connections: usize,
+    /// Per-connection subscription limit for each rate-limited Indexer channel
+    /// (`v4_trades`, `v4_candles`, `v4_orderbook`, `v4_markets`).
+    ///
+    /// Defaults to `32`, matching the hosted Indexer. Self-hosted Indexer
+    /// deployments may raise this.
+    #[serde(default = "default_per_channel_subscription_limit")]
+    #[builder(default = default_per_channel_subscription_limit())]
+    pub per_channel_subscription_limit: usize,
 }
 
 impl DydxDataClientConfig {

--- a/crates/adapters/dydx/src/factories.rs
+++ b/crates/adapters/dydx/src/factories.rs
@@ -127,12 +127,14 @@ impl DataClientFactory for DydxDataClientFactory {
             retry_config,
         )?;
 
-        let ws_client = DydxWebSocketClient::new_public_with_cache(
+        let ws_client = DydxWebSocketClient::new_public_with_cache_and_pool(
             ws_url,
             Arc::new(InstrumentCache::new()),
             Some(20),
             dydx_config.transport_backend,
             dydx_config.proxy_url.clone(),
+            dydx_config.max_ws_connections,
+            dydx_config.per_channel_subscription_limit,
         );
 
         let client = DydxDataClient::new(client_id, dydx_config, http_client, ws_client)?;

--- a/crates/adapters/dydx/src/websocket/client.rs
+++ b/crates/adapters/dydx/src/websocket/client.rs
@@ -25,6 +25,17 @@
 //! - **Private channels** (subaccounts) only require the wallet address in the subscription message.
 //! - No signature or API key is needed for WebSocket connections themselves.
 //!
+//! # Connection pool
+//!
+//! The Indexer caps each WebSocket connection at 32 subscriptions per channel
+//! (`v4_trades`, `v4_candles`, `v4_orderbook`, `v4_markets`). To scale past that
+//! limit the client maintains a small pool of connection slots and routes each
+//! new subscription to the first slot with capacity, lazily spawning additional
+//! connections up to `max_ws_connections`. The shape mirrors
+//! `BinanceFuturesWebSocketClient` — including its `connect_lock` race fix —
+//! adapted so capacity is tracked per channel kind rather than as a single flat
+//! stream count.
+//!
 //! # References
 //!
 //! <https://docs.dydx.trade/developers/indexer/websockets>
@@ -44,15 +55,22 @@ pub static DYDX_WS_SUBSCRIPTION_QUOTA: LazyLock<Quota> = LazyLock::new(|| {
     Quota::per_second(NonZeroU32::new(2).expect("non-zero")).expect("valid constant")
 });
 
+/// Default maximum number of WebSocket connections in the Indexer pool.
+pub const DEFAULT_MAX_WS_CONNECTIONS: usize = 8;
+
+/// Default per-connection subscription limit for sharded channels.
+pub const DEFAULT_PER_CHANNEL_SUBSCRIPTION_LIMIT: usize = 32;
+
 use std::{
     num::NonZeroU32,
     sync::{
-        Arc, LazyLock,
+        Arc, LazyLock, Mutex,
         atomic::{AtomicBool, AtomicU8, Ordering},
     },
     time::Duration,
 };
 
+use ahash::AHashMap;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use nautilus_common::live::get_runtime;
@@ -83,6 +101,29 @@ use crate::{
     execution::encoder::ClientOrderIdEncoder,
 };
 
+/// Identifies a dYdX channel for per-channel capacity accounting in the pool.
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+enum ChannelKind {
+    Trades = 0,
+    Candles = 1,
+    Orderbook = 2,
+    Markets = 3,
+}
+
+const CHANNEL_KIND_COUNT: usize = 4;
+
+/// Per-connection state inside the pool.
+#[derive(Debug)]
+struct ConnectionSlot {
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<HandlerCommand>,
+    topics: AHashMap<String, u32>,
+    channel_counts: [u16; CHANNEL_KIND_COUNT],
+    subscriptions_state: SubscriptionState,
+    handler_task: Option<tokio::task::JoinHandle<()>>,
+    connection_mode: Arc<AtomicU8>,
+}
+
 /// WebSocket client for dYdX v4 market data and account streams.
 ///
 /// # Authentication
@@ -99,13 +140,10 @@ use crate::{
 ///
 /// # Architecture
 ///
-/// This client follows a two-layer architecture:
-/// - **Outer client** (this struct): Orchestrates connection and maintains Python-accessible state
-/// - **Inner handler**: Owns WebSocketClient exclusively and processes messages in a dedicated task
-///
-/// Communication uses lock-free channels:
-/// - Commands flow from client → handler via `cmd_tx`
-/// - Parsed events flow from handler → client via `out_rx`
+/// The client owns a small pool of connection slots. Each slot has its own
+/// `WebSocketClient`, [`FeedHandler`] task, command channel, and
+/// [`SubscriptionState`]. All slots write parsed events into a single shared
+/// output channel so callers see one merged stream.
 #[derive(Debug)]
 #[cfg_attr(
     feature = "python",
@@ -120,21 +158,23 @@ pub struct DydxWebSocketClient {
     credential: Option<Arc<DydxCredential>>,
     requires_auth: bool,
     auth_tracker: AuthTracker,
-    subscriptions: SubscriptionState,
+    slots: Arc<Mutex<Vec<ConnectionSlot>>>,
+    connect_lock: Arc<tokio::sync::Mutex<()>>,
     connection_mode: Arc<ArcSwap<AtomicU8>>,
     signal: Arc<AtomicBool>,
     instrument_cache: Arc<InstrumentCache>,
     account_id: Option<AccountId>,
     heartbeat: Option<u64>,
-    cmd_tx: Arc<tokio::sync::RwLock<tokio::sync::mpsc::UnboundedSender<HandlerCommand>>>,
-    out_rx: Option<tokio::sync::mpsc::UnboundedReceiver<DydxWsOutputMessage>>,
-    handler_task: Option<Arc<tokio::task::JoinHandle<()>>>,
+    out_tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<DydxWsOutputMessage>>>>,
+    out_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<DydxWsOutputMessage>>>>,
     encoder: Arc<ClientOrderIdEncoder>,
     bar_types: Arc<DashMap<String, BarType>>,
     bars_timestamp_on_close: Arc<AtomicBool>,
     ws_dispatch_state: Arc<DydxWsDispatchState>,
     transport_backend: TransportBackend,
     proxy_url: Option<String>,
+    max_ws_connections: usize,
+    per_channel_limit: usize,
 }
 
 impl Clone for DydxWebSocketClient {
@@ -144,21 +184,23 @@ impl Clone for DydxWebSocketClient {
             credential: self.credential.clone(),
             requires_auth: self.requires_auth,
             auth_tracker: self.auth_tracker.clone(),
-            subscriptions: self.subscriptions.clone(),
+            slots: self.slots.clone(),
+            connect_lock: self.connect_lock.clone(),
             connection_mode: self.connection_mode.clone(),
             signal: self.signal.clone(),
             instrument_cache: self.instrument_cache.clone(),
             account_id: self.account_id,
             heartbeat: self.heartbeat,
-            cmd_tx: self.cmd_tx.clone(),
-            out_rx: None,       // Cannot clone receiver - only one owner allowed
-            handler_task: None, // Cannot clone task handle
+            out_tx: self.out_tx.clone(),
+            out_rx: self.out_rx.clone(),
             encoder: self.encoder.clone(),
             bar_types: self.bar_types.clone(),
             bars_timestamp_on_close: self.bars_timestamp_on_close.clone(),
             ws_dispatch_state: self.ws_dispatch_state.clone(),
             transport_backend: self.transport_backend,
             proxy_url: self.proxy_url.clone(),
+            max_ws_connections: self.max_ws_connections,
+            per_channel_limit: self.per_channel_limit,
         }
     }
 }
@@ -190,32 +232,40 @@ impl DydxWebSocketClient {
         transport_backend: TransportBackend,
         proxy_url: Option<String>,
     ) -> Self {
-        // Create dummy command channel (will be replaced on connect)
-        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
-
-        Self {
+        Self::new_public_with_cache_and_pool(
             url,
-            credential: None,
-            requires_auth: false,
-            auth_tracker: AuthTracker::new(),
-            subscriptions: SubscriptionState::new(DYDX_WS_TOPIC_DELIMITER),
-            connection_mode: Arc::new(ArcSwap::from_pointee(AtomicU8::new(
-                ConnectionMode::Closed as u8,
-            ))),
-            signal: Arc::new(AtomicBool::new(false)),
             instrument_cache,
-            account_id: None,
             heartbeat,
-            cmd_tx: Arc::new(tokio::sync::RwLock::new(cmd_tx)),
-            out_rx: None,
-            handler_task: None,
-            encoder: Arc::new(ClientOrderIdEncoder::new()),
-            bar_types: Arc::new(DashMap::new()),
-            bars_timestamp_on_close: Arc::new(AtomicBool::new(true)),
-            ws_dispatch_state: Arc::new(DydxWsDispatchState::default()),
             transport_backend,
             proxy_url,
-        }
+            DEFAULT_MAX_WS_CONNECTIONS,
+            DEFAULT_PER_CHANNEL_SUBSCRIPTION_LIMIT,
+        )
+    }
+
+    /// Creates a new public WebSocket client with full pool configuration.
+    #[must_use]
+    pub fn new_public_with_cache_and_pool(
+        url: String,
+        instrument_cache: Arc<InstrumentCache>,
+        heartbeat: Option<u64>,
+        transport_backend: TransportBackend,
+        proxy_url: Option<String>,
+        max_ws_connections: usize,
+        per_channel_limit: usize,
+    ) -> Self {
+        Self::new_inner(
+            url,
+            None,
+            false,
+            instrument_cache,
+            None,
+            heartbeat,
+            transport_backend,
+            proxy_url,
+            max_ws_connections,
+            per_channel_limit,
+        )
     }
 
     /// Creates a new private WebSocket client for account updates.
@@ -254,31 +304,57 @@ impl DydxWebSocketClient {
         transport_backend: TransportBackend,
         proxy_url: Option<String>,
     ) -> Self {
-        // Create dummy command channel (will be replaced on connect)
-        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
+        Self::new_inner(
+            url,
+            Some(Arc::new(credential)),
+            true,
+            instrument_cache,
+            Some(account_id),
+            heartbeat,
+            transport_backend,
+            proxy_url,
+            DEFAULT_MAX_WS_CONNECTIONS,
+            DEFAULT_PER_CHANNEL_SUBSCRIPTION_LIMIT,
+        )
+    }
 
+    #[allow(clippy::too_many_arguments)]
+    fn new_inner(
+        url: String,
+        credential: Option<Arc<DydxCredential>>,
+        requires_auth: bool,
+        instrument_cache: Arc<InstrumentCache>,
+        account_id: Option<AccountId>,
+        heartbeat: Option<u64>,
+        transport_backend: TransportBackend,
+        proxy_url: Option<String>,
+        max_ws_connections: usize,
+        per_channel_limit: usize,
+    ) -> Self {
         Self {
             url,
-            credential: Some(Arc::new(credential)),
-            requires_auth: true,
+            credential,
+            requires_auth,
             auth_tracker: AuthTracker::new(),
-            subscriptions: SubscriptionState::new(DYDX_WS_TOPIC_DELIMITER),
+            slots: Arc::new(Mutex::new(Vec::new())),
+            connect_lock: Arc::new(tokio::sync::Mutex::new(())),
             connection_mode: Arc::new(ArcSwap::from_pointee(AtomicU8::new(
                 ConnectionMode::Closed as u8,
             ))),
             signal: Arc::new(AtomicBool::new(false)),
             instrument_cache,
-            account_id: Some(account_id),
+            account_id,
             heartbeat,
-            cmd_tx: Arc::new(tokio::sync::RwLock::new(cmd_tx)),
-            out_rx: None,
-            handler_task: None,
+            out_tx: Arc::new(Mutex::new(None)),
+            out_rx: Arc::new(Mutex::new(None)),
             encoder: Arc::new(ClientOrderIdEncoder::new()),
             bar_types: Arc::new(DashMap::new()),
             bars_timestamp_on_close: Arc::new(AtomicBool::new(true)),
             ws_dispatch_state: Arc::new(DydxWsDispatchState::default()),
             transport_backend,
             proxy_url,
+            max_ws_connections: max_ws_connections.max(1),
+            per_channel_limit: per_channel_limit.max(1),
         }
     }
 
@@ -288,15 +364,15 @@ impl DydxWebSocketClient {
         self.credential.as_ref()
     }
 
-    /// Returns `true` when the client is connected.
+    /// Returns `true` when any connection in the pool is connected.
     #[must_use]
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
     pub fn is_connected(&self) -> bool {
-        let mode = self.connection_mode.load();
-        let mode_u8 = mode.load(Ordering::Relaxed);
-        matches!(
-            mode_u8,
-            x if x == ConnectionMode::Active as u8 || x == ConnectionMode::Reconnect as u8
-        )
+        let slots = self.slots.lock().expect("slots lock poisoned");
+        slots.iter().any(|s| {
+            let mode = s.connection_mode.load(Ordering::Relaxed);
+            mode == ConnectionMode::Active as u8 || mode == ConnectionMode::Reconnect as u8
+        })
     }
 
     /// Returns the URL of this WebSocket client.
@@ -307,10 +383,30 @@ impl DydxWebSocketClient {
 
     /// Returns a clone of the connection mode atomic reference.
     ///
-    /// This is primarily used for Python bindings that need to monitor connection state.
+    /// With sharding, the returned atomic tracks the **primary** slot (slot 0)
+    /// only; use [`Self::is_connected`] for a pool-wide check.
     #[must_use]
     pub fn connection_mode_atomic(&self) -> Arc<ArcSwap<AtomicU8>> {
         self.connection_mode.clone()
+    }
+
+    /// Returns the current number of active slots in the pool.
+    #[must_use]
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
+    pub fn pool_size(&self) -> usize {
+        self.slots.lock().expect("slots lock poisoned").len()
+    }
+
+    /// Returns the configured maximum number of pool connections.
+    #[must_use]
+    pub const fn max_ws_connections(&self) -> usize {
+        self.max_ws_connections
+    }
+
+    /// Returns the configured per-channel subscription limit.
+    #[must_use]
+    pub const fn per_channel_limit(&self) -> usize {
+        self.per_channel_limit
     }
 
     /// Sets the account ID for account message parsing.
@@ -417,10 +513,11 @@ impl DydxWebSocketClient {
 
     /// Takes ownership of the inbound message receiver.
     /// Returns None if the receiver has already been taken or not connected.
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
     pub fn take_receiver(
         &mut self,
     ) -> Option<tokio::sync::mpsc::UnboundedReceiver<DydxWsOutputMessage>> {
-        self.out_rx.take()
+        self.out_rx.lock().expect("out_rx lock poisoned").take()
     }
 
     /// Returns a stream of venue-specific WebSocket messages.
@@ -429,12 +526,14 @@ impl DydxWebSocketClient {
     ///
     /// # Panics
     ///
-    /// Panics if the receiver has already been taken.
+    /// Panics if the receiver has already been taken or the receiver mutex is poisoned.
     pub fn stream(
         &mut self,
     ) -> impl futures_util::Stream<Item = DydxWsOutputMessage> + Send + 'static {
         let mut rx = self
             .out_rx
+            .lock()
+            .expect("out_rx lock poisoned")
             .take()
             .expect("Message stream receiver already taken or not connected");
 
@@ -445,22 +544,97 @@ impl DydxWebSocketClient {
         }
     }
 
-    /// Connects the websocket client in handler mode with automatic reconnection.
+    /// Connects the websocket client and opens the primary pool slot.
     ///
-    /// Spawns a background handler task that owns the WebSocketClient and processes
-    /// raw messages into venue-specific [`DydxWsOutputMessage`] values.
+    /// Additional slots are spawned lazily by `subscribe_*` methods once the
+    /// per-channel limit is reached on every existing slot.
     ///
     /// # Errors
     ///
     /// Returns an error if the connection cannot be established.
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
     pub async fn connect(&mut self) -> DydxWsResult<()> {
         if self.is_connected() {
             return Ok(());
         }
 
-        // Reset stop signal from any previous disconnect
         self.signal.store(false, Ordering::Release);
 
+        let (out_tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<DydxWsOutputMessage>();
+        {
+            let mut guard = self.out_tx.lock().expect("out_tx lock poisoned");
+            *guard = Some(out_tx);
+        }
+        {
+            let mut guard = self.out_rx.lock().expect("out_rx lock poisoned");
+            *guard = Some(out_rx);
+        }
+
+        let slot = self.create_connection().await?;
+        self.connection_mode.store(slot.connection_mode.clone());
+        self.slots.lock().expect("slots lock poisoned").push(slot);
+
+        log::info!("Connected dYdX WebSocket pool: {}", self.url);
+        Ok(())
+    }
+
+    /// Disconnects all websocket connections in the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying clients cannot be accessed.
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
+    pub async fn disconnect(&mut self) -> DydxWsResult<()> {
+        self.signal.store(true, Ordering::Release);
+
+        let slots: Vec<ConnectionSlot> = {
+            let mut guard = self.slots.lock().expect("slots lock poisoned");
+            guard.drain(..).collect()
+        };
+
+        for mut slot in slots {
+            let _ = slot.cmd_tx.send(HandlerCommand::Disconnect);
+            if let Some(task) = slot.handler_task.take() {
+                let abort_handle = task.abort_handle();
+                match tokio::time::timeout(Duration::from_secs(2), task).await {
+                    Ok(Ok(())) => log::debug!("Handler task completed"),
+                    Ok(Err(e)) => log::error!("Handler task error: {e:?}"),
+                    Err(_) => {
+                        log::warn!("Timeout waiting for handler task, aborting");
+                        abort_handle.abort();
+                    }
+                }
+            }
+        }
+
+        self.connection_mode
+            .store(Arc::new(AtomicU8::new(ConnectionMode::Closed as u8)));
+
+        *self.out_tx.lock().expect("out_tx lock poisoned") = None;
+        *self.out_rx.lock().expect("out_rx lock poisoned") = None;
+
+        log::debug!("Disconnected dYdX WebSocket pool");
+        Ok(())
+    }
+
+    /// Sends a command directly to the primary slot (slot 0).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no slot exists or the handler task has terminated.
+    #[expect(clippy::missing_panics_doc, reason = "mutex poisoning is not expected")]
+    pub fn send_command(&self, cmd: HandlerCommand) -> DydxWsResult<()> {
+        let slots = self.slots.lock().expect("slots lock poisoned");
+        let slot = slots
+            .first()
+            .ok_or_else(|| DydxWsError::Transport("No pool slots available".to_string()))?;
+        slot.cmd_tx.send(cmd).map_err(|e| {
+            DydxWsError::Transport(format!("Failed to send command to slot 0: {e}"))
+        })?;
+        Ok(())
+    }
+
+    async fn create_connection(&self) -> DydxWsResult<ConnectionSlot> {
         let (message_handler, raw_rx) = channel_message_handler();
 
         let cfg = WebSocketConfig {
@@ -490,23 +664,20 @@ impl DydxWebSocketClient {
         .await
         .map_err(|e| DydxWsError::Transport(e.to_string()))?;
 
-        // Update connection state atomically
-        self.connection_mode.store(client.connection_mode_atomic());
+        let connection_mode = client.connection_mode_atomic();
+        let subscriptions_state = SubscriptionState::new(DYDX_WS_TOPIC_DELIMITER);
 
-        // Create fresh channels for this connection
         let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
-        let (out_tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<DydxWsOutputMessage>();
 
-        // Update the shared cmd_tx so all clones see the new sender
-        {
-            let mut guard = self.cmd_tx.write().await;
-            *guard = cmd_tx;
-        }
-        self.out_rx = Some(out_rx);
+        let out_tx = self
+            .out_tx
+            .lock()
+            .expect("out_tx lock poisoned")
+            .clone()
+            .ok_or_else(|| DydxWsError::Transport("Output channel not initialized".to_string()))?;
 
-        // Spawn handler task
         let signal = self.signal.clone();
-        let subscriptions = self.subscriptions.clone();
+        let subscriptions = subscriptions_state.clone();
 
         let handler_task = get_runtime().spawn(async move {
             let mut handler =
@@ -514,86 +685,14 @@ impl DydxWebSocketClient {
             handler.run().await;
         });
 
-        self.handler_task = Some(Arc::new(handler_task));
-        log::info!("Connected dYdX WebSocket: {}", self.url);
-        Ok(())
-    }
-
-    /// Disconnects the websocket client gracefully.
-    ///
-    /// Sends a disconnect command to the handler, sets the stop signal, then
-    /// awaits the handler task with a timeout before aborting.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the underlying client cannot be accessed.
-    pub async fn disconnect(&mut self) -> DydxWsResult<()> {
-        // 1. Send disconnect command so the handler can close the WS connection
-        if let Err(e) = self.cmd_tx.read().await.send(HandlerCommand::Disconnect) {
-            log::debug!("Failed to send disconnect command: {e}");
-        }
-
-        // 2. Set stop signal with Release ordering
-        self.signal.store(true, Ordering::Release);
-
-        // 3. Await handler task with timeout, abort if stuck
-        if let Some(task_handle) = self.handler_task.take() {
-            match Arc::try_unwrap(task_handle) {
-                Ok(handle) => {
-                    let abort_handle = handle.abort_handle();
-                    match tokio::time::timeout(Duration::from_secs(2), handle).await {
-                        Ok(Ok(())) => log::debug!("Handler task completed"),
-                        Ok(Err(e)) => log::error!("Handler task error: {e:?}"),
-                        Err(_) => {
-                            log::warn!("Timeout waiting for handler task, aborting");
-                            abort_handle.abort();
-                        }
-                    }
-                }
-                Err(arc_handle) => {
-                    log::debug!("Cannot unwrap task handle, aborting");
-                    arc_handle.abort();
-                }
-            }
-        }
-
-        // Reset connection mode to Closed
-        self.connection_mode
-            .store(Arc::new(AtomicU8::new(ConnectionMode::Closed as u8)));
-
-        self.out_rx = None;
-
-        log::debug!("Disconnected dYdX WebSocket");
-        Ok(())
-    }
-
-    async fn send_text_inner(&self, text: &str) -> DydxWsResult<()> {
-        self.cmd_tx
-            .read()
-            .await
-            .send(HandlerCommand::SendText(text.to_string()))
-            .map_err(|e| {
-                DydxWsError::Transport(format!("Failed to send command to handler: {e}"))
-            })?;
-        Ok(())
-    }
-
-    /// Sends a command to the handler.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the handler task has terminated.
-    pub fn send_command(&self, cmd: HandlerCommand) -> DydxWsResult<()> {
-        if let Ok(guard) = self.cmd_tx.try_read() {
-            guard.send(cmd).map_err(|e| {
-                DydxWsError::Transport(format!("Failed to send command to handler: {e}"))
-            })?;
-        } else {
-            return Err(DydxWsError::Transport(
-                "Failed to acquire lock on command channel".to_string(),
-            ));
-        }
-        Ok(())
+        Ok(ConnectionSlot {
+            cmd_tx,
+            topics: AHashMap::new(),
+            channel_counts: [0; CHANNEL_KIND_COUNT],
+            subscriptions_state,
+            handler_task: Some(handler_task),
+            connection_mode,
+        })
     }
 
     fn ticker_from_instrument_id(instrument_id: &InstrumentId) -> String {
@@ -611,48 +710,117 @@ impl DydxWebSocketClient {
         }
     }
 
-    async fn send_and_track_subscribe(
+    async fn subscribe_topic(
         &self,
-        sub: DydxSubscription,
-        topic: &str,
+        channel: ChannelKind,
+        topic: String,
+        sub_msg: DydxSubscription,
     ) -> DydxWsResult<()> {
-        self.subscriptions.mark_subscribe(topic);
+        let _connect_guard = self.connect_lock.lock().await;
 
-        if let Ok(cmd_tx) = self.cmd_tx.try_read() {
-            let _ = cmd_tx.send(HandlerCommand::RegisterSubscription {
-                topic: topic.to_string(),
-                subscription: sub.clone(),
+        {
+            let mut slots = self.slots.lock().expect("slots lock poisoned");
+            if let Some(slot) = slots.iter_mut().find(|s| s.topics.contains_key(&topic)) {
+                *slot.topics.get_mut(&topic).expect("topic refcount present") += 1;
+                return Ok(());
+            }
+        }
+
+        let target_idx = loop {
+            {
+                let slots = self.slots.lock().expect("slots lock poisoned");
+                if let Some(idx) = slots.iter().position(|s| {
+                    (s.channel_counts[channel as usize] as usize) < self.per_channel_limit
+                }) {
+                    break idx;
+                }
+
+                if slots.len() >= self.max_ws_connections {
+                    return Err(DydxWsError::Subscription(format!(
+                        "Pool exhausted: {} connections x {} {:?} subscriptions",
+                        self.max_ws_connections, self.per_channel_limit, channel,
+                    )));
+                }
+            }
+
+            let new_slot = self.create_connection().await?;
+            let new_idx = {
+                let mut slots = self.slots.lock().expect("slots lock poisoned");
+                slots.push(new_slot);
+                slots.len() - 1
+            };
+            log::info!(
+                "dYdX pool slot {new_idx} connected: url={}, channel={:?}",
+                self.url,
+                channel,
+            );
+        };
+
+        let mut slots = self.slots.lock().expect("slots lock poisoned");
+        let slot = &mut slots[target_idx];
+
+        slot.subscriptions_state.mark_subscribe(&topic);
+        slot.cmd_tx
+            .send(HandlerCommand::RegisterSubscription {
+                topic: topic.clone(),
+                subscription: sub_msg.clone(),
+            })
+            .map_err(|e| {
+                slot.subscriptions_state.mark_failure(&topic);
+                DydxWsError::Transport(format!("Slot {target_idx} unavailable: {e}"))
+            })?;
+
+        let payload = serde_json::to_string(&sub_msg)?;
+        if let Err(e) = slot.cmd_tx.send(HandlerCommand::SendText(payload)) {
+            slot.subscriptions_state.mark_failure(&topic);
+            let _ = slot.cmd_tx.send(HandlerCommand::UnregisterSubscription {
+                topic: topic.clone(),
             });
+            return Err(DydxWsError::Transport(format!(
+                "Slot {target_idx} send failed: {e}"
+            )));
         }
 
-        let payload = serde_json::to_string(&sub)?;
-        if let Err(e) = self.send_text_inner(&payload).await {
-            self.subscriptions.mark_failure(topic);
-            self.subscriptions.remove_reference(topic);
-            return Err(e);
-        }
+        slot.topics.insert(topic, 1);
+        slot.channel_counts[channel as usize] =
+            slot.channel_counts[channel as usize].saturating_add(1);
+
         Ok(())
     }
 
-    async fn send_and_track_unsubscribe(
+    async fn unsubscribe_topic(
         &self,
-        sub: DydxSubscription,
-        topic: &str,
+        channel: ChannelKind,
+        topic: String,
+        unsub_msg: DydxSubscription,
     ) -> DydxWsResult<()> {
-        self.subscriptions.mark_unsubscribe(topic);
+        let mut slots = self.slots.lock().expect("slots lock poisoned");
+        let Some(slot_idx) = slots.iter().position(|s| s.topics.contains_key(&topic)) else {
+            return Ok(());
+        };
 
-        let payload = serde_json::to_string(&sub)?;
-        if let Err(e) = self.send_text_inner(&payload).await {
-            self.subscriptions.add_reference(topic);
-            self.subscriptions.mark_subscribe(topic);
-            return Err(e);
+        let slot = &mut slots[slot_idx];
+        let refcount = slot.topics.get_mut(&topic).expect("topic present");
+        if *refcount > 1 {
+            *refcount -= 1;
+            return Ok(());
         }
 
-        if let Ok(cmd_tx) = self.cmd_tx.try_read() {
-            let _ = cmd_tx.send(HandlerCommand::UnregisterSubscription {
-                topic: topic.to_string(),
-            });
+        slot.subscriptions_state.mark_unsubscribe(&topic);
+        let payload = serde_json::to_string(&unsub_msg)?;
+        if let Err(e) = slot.cmd_tx.send(HandlerCommand::SendText(payload)) {
+            slot.subscriptions_state.mark_subscribe(&topic);
+            return Err(DydxWsError::Transport(format!(
+                "Slot {slot_idx} send failed: {e}"
+            )));
         }
+        let _ = slot.cmd_tx.send(HandlerCommand::UnregisterSubscription {
+            topic: topic.clone(),
+        });
+
+        slot.topics.remove(&topic);
+        slot.channel_counts[channel as usize] =
+            slot.channel_counts[channel as usize].saturating_sub(1);
 
         Ok(())
     }
@@ -669,17 +837,12 @@ impl DydxWebSocketClient {
     pub async fn subscribe_trades(&self, instrument_id: InstrumentId) -> DydxWsResult<()> {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let topic = Self::topic(DydxWsChannel::Trades, Some(&ticker));
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::Trades,
             id: Some(ticker),
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_topic(ChannelKind::Trades, topic, sub).await
     }
 
     /// Unsubscribes from public trade updates for a specific instrument.
@@ -690,17 +853,13 @@ impl DydxWebSocketClient {
     pub async fn unsubscribe_trades(&self, instrument_id: InstrumentId) -> DydxWsResult<()> {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let topic = Self::topic(DydxWsChannel::Trades, Some(&ticker));
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::Trades,
             id: Some(ticker),
         };
-
-        self.send_and_track_unsubscribe(sub, &topic).await
+        self.unsubscribe_topic(ChannelKind::Trades, topic, sub)
+            .await
     }
 
     /// Subscribes to orderbook updates for a specific instrument.
@@ -715,17 +874,13 @@ impl DydxWebSocketClient {
     pub async fn subscribe_orderbook(&self, instrument_id: InstrumentId) -> DydxWsResult<()> {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let topic = Self::topic(DydxWsChannel::Orderbook, Some(&ticker));
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::Orderbook,
             id: Some(ticker),
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_topic(ChannelKind::Orderbook, topic, sub)
+            .await
     }
 
     /// Unsubscribes from orderbook updates for a specific instrument.
@@ -736,17 +891,13 @@ impl DydxWebSocketClient {
     pub async fn unsubscribe_orderbook(&self, instrument_id: InstrumentId) -> DydxWsResult<()> {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let topic = Self::topic(DydxWsChannel::Orderbook, Some(&ticker));
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::Orderbook,
             id: Some(ticker),
         };
-
-        self.send_and_track_unsubscribe(sub, &topic).await
+        self.unsubscribe_topic(ChannelKind::Orderbook, topic, sub)
+            .await
     }
 
     /// Subscribes to candle/kline updates for a specific instrument.
@@ -766,17 +917,12 @@ impl DydxWebSocketClient {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let id = format!("{ticker}/{resolution}");
         let topic = Self::topic(DydxWsChannel::Candles, Some(&id));
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::Candles,
             id: Some(id),
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_topic(ChannelKind::Candles, topic, sub).await
     }
 
     /// Unsubscribes from candle/kline updates for a specific instrument.
@@ -792,17 +938,13 @@ impl DydxWebSocketClient {
         let ticker = Self::ticker_from_instrument_id(&instrument_id);
         let id = format!("{ticker}/{resolution}");
         let topic = Self::topic(DydxWsChannel::Candles, Some(&id));
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::Candles,
             id: Some(id),
         };
-
-        self.send_and_track_unsubscribe(sub, &topic).await
+        self.unsubscribe_topic(ChannelKind::Candles, topic, sub)
+            .await
     }
 
     /// Subscribes to market updates for all instruments.
@@ -816,17 +958,12 @@ impl DydxWebSocketClient {
     /// <https://docs.dydx.trade/developers/indexer/websockets#markets-channel>
     pub async fn subscribe_markets(&self) -> DydxWsResult<()> {
         let topic = Self::topic(DydxWsChannel::Markets, None);
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::Markets,
             id: None,
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_topic(ChannelKind::Markets, topic, sub).await
     }
 
     /// Unsubscribes from market updates.
@@ -836,23 +973,22 @@ impl DydxWebSocketClient {
     /// Returns an error if the unsubscription request fails.
     pub async fn unsubscribe_markets(&self) -> DydxWsResult<()> {
         let topic = Self::topic(DydxWsChannel::Markets, None);
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::Markets,
             id: None,
         };
-
-        self.send_and_track_unsubscribe(sub, &topic).await
+        self.unsubscribe_topic(ChannelKind::Markets, topic, sub)
+            .await
     }
 
     /// Subscribes to subaccount updates (orders, fills, positions, balances).
     ///
     /// This requires authentication and will only work for private WebSocket clients
-    /// created with [`Self::new_private`].
+    /// created with [`Self::new_private`]. Subaccount streams stay pinned to the
+    /// primary slot — the Indexer caps them at 256 per connection, which is well
+    /// above realistic per-process usage and keeps related fill/position events
+    /// on a single in-order stream.
     ///
     /// # Errors
     ///
@@ -874,17 +1010,12 @@ impl DydxWebSocketClient {
         }
         let id = format!("{address}/{subaccount_number}");
         let topic = Self::topic(DydxWsChannel::Subaccounts, Some(&id));
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::Subaccounts,
             id: Some(id),
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_pinned(topic, sub).await
     }
 
     /// Unsubscribes from subaccount updates.
@@ -899,17 +1030,12 @@ impl DydxWebSocketClient {
     ) -> DydxWsResult<()> {
         let id = format!("{address}/{subaccount_number}");
         let topic = Self::topic(DydxWsChannel::Subaccounts, Some(&id));
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::Subaccounts,
             id: Some(id),
         };
-
-        self.send_and_track_unsubscribe(sub, &topic).await
+        self.unsubscribe_pinned(topic, sub).await
     }
 
     /// Subscribes to block height updates.
@@ -923,17 +1049,12 @@ impl DydxWebSocketClient {
     /// <https://docs.dydx.trade/developers/indexer/websockets#block-height-channel>
     pub async fn subscribe_block_height(&self) -> DydxWsResult<()> {
         let topic = Self::topic(DydxWsChannel::BlockHeight, None);
-        if !self.subscriptions.add_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Subscribe,
             channel: DydxWsChannel::BlockHeight,
             id: None,
         };
-
-        self.send_and_track_subscribe(sub, &topic).await
+        self.subscribe_pinned(topic, sub).await
     }
 
     /// Unsubscribes from block height updates.
@@ -943,16 +1064,89 @@ impl DydxWebSocketClient {
     /// Returns an error if the unsubscription request fails.
     pub async fn unsubscribe_block_height(&self) -> DydxWsResult<()> {
         let topic = Self::topic(DydxWsChannel::BlockHeight, None);
-        if !self.subscriptions.remove_reference(&topic) {
-            return Ok(());
-        }
-
         let sub = DydxSubscription {
             op: DydxWsOperation::Unsubscribe,
             channel: DydxWsChannel::BlockHeight,
             id: None,
         };
+        self.unsubscribe_pinned(topic, sub).await
+    }
 
-        self.send_and_track_unsubscribe(sub, &topic).await
+    async fn subscribe_pinned(&self, topic: String, sub_msg: DydxSubscription) -> DydxWsResult<()> {
+        let _connect_guard = self.connect_lock.lock().await;
+
+        {
+            let mut slots = self.slots.lock().expect("slots lock poisoned");
+            if let Some(slot) = slots.iter_mut().find(|s| s.topics.contains_key(&topic)) {
+                *slot.topics.get_mut(&topic).expect("topic refcount present") += 1;
+                return Ok(());
+            }
+        }
+
+        if self.slots.lock().expect("slots lock poisoned").is_empty() {
+            let new_slot = self.create_connection().await?;
+            self.connection_mode.store(new_slot.connection_mode.clone());
+            self.slots
+                .lock()
+                .expect("slots lock poisoned")
+                .push(new_slot);
+        }
+
+        let mut slots = self.slots.lock().expect("slots lock poisoned");
+        let slot = slots.first_mut().expect("primary slot exists");
+        slot.subscriptions_state.mark_subscribe(&topic);
+        slot.cmd_tx
+            .send(HandlerCommand::RegisterSubscription {
+                topic: topic.clone(),
+                subscription: sub_msg.clone(),
+            })
+            .map_err(|e| {
+                slot.subscriptions_state.mark_failure(&topic);
+                DydxWsError::Transport(format!("Primary slot unavailable: {e}"))
+            })?;
+        let payload = serde_json::to_string(&sub_msg)?;
+        if let Err(e) = slot.cmd_tx.send(HandlerCommand::SendText(payload)) {
+            slot.subscriptions_state.mark_failure(&topic);
+            let _ = slot.cmd_tx.send(HandlerCommand::UnregisterSubscription {
+                topic: topic.clone(),
+            });
+            return Err(DydxWsError::Transport(format!(
+                "Primary slot send failed: {e}"
+            )));
+        }
+        slot.topics.insert(topic, 1);
+        Ok(())
+    }
+
+    async fn unsubscribe_pinned(
+        &self,
+        topic: String,
+        unsub_msg: DydxSubscription,
+    ) -> DydxWsResult<()> {
+        let mut slots = self.slots.lock().expect("slots lock poisoned");
+        let Some(slot) = slots.first_mut() else {
+            return Ok(());
+        };
+        let Some(refcount) = slot.topics.get_mut(&topic) else {
+            return Ok(());
+        };
+
+        if *refcount > 1 {
+            *refcount -= 1;
+            return Ok(());
+        }
+        slot.subscriptions_state.mark_unsubscribe(&topic);
+        let payload = serde_json::to_string(&unsub_msg)?;
+        if let Err(e) = slot.cmd_tx.send(HandlerCommand::SendText(payload)) {
+            slot.subscriptions_state.mark_subscribe(&topic);
+            return Err(DydxWsError::Transport(format!(
+                "Primary slot send failed: {e}"
+            )));
+        }
+        let _ = slot.cmd_tx.send(HandlerCommand::UnregisterSubscription {
+            topic: topic.clone(),
+        });
+        slot.topics.remove(&topic);
+        Ok(())
     }
 }

--- a/crates/adapters/dydx/tests/websocket.rs
+++ b/crates/adapters/dydx/tests/websocket.rs
@@ -3258,3 +3258,180 @@ async fn test_orderbook_produces_update() {
 
     client.disconnect().await.unwrap();
 }
+
+#[rstest]
+#[tokio::test]
+async fn test_pool_shards_trades_across_connections_when_channel_full() {
+    use std::sync::Arc;
+
+    use nautilus_dydx::common::instrument_cache::InstrumentCache;
+    use nautilus_network::websocket::TransportBackend;
+
+    let (addr, state) = start_test_server().await.unwrap();
+    let ws_url = format!("ws://{addr}/v4/ws");
+
+    let mut client = DydxWebSocketClient::new_public_with_cache_and_pool(
+        ws_url,
+        Arc::new(InstrumentCache::new()),
+        Some(30),
+        TransportBackend::default(),
+        None,
+        4,
+        3,
+    );
+    client.connect().await.unwrap();
+    wait_until_async(|| async { client.is_connected() }, Duration::from_secs(5)).await;
+    assert_eq!(client.pool_size(), 1);
+
+    let tickers = ["BTC-USD", "ETH-USD", "SOL-USD", "AVAX-USD"];
+    for t in tickers {
+        client
+            .subscribe_trades(InstrumentId::from(format!("{t}.DYDX").as_str()))
+            .await
+            .unwrap();
+    }
+
+    wait_until_async(
+        || async { *state.connection_count.lock().await >= 2 },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(*state.connection_count.lock().await, 2);
+    assert_eq!(client.pool_size(), 2);
+
+    wait_until_async(
+        || async {
+            state
+                .subscriptions
+                .lock()
+                .await
+                .iter()
+                .filter(|s| s.contains("v4_trades"))
+                .count()
+                == tickers.len()
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let trade_sub_count = state
+        .subscriptions
+        .lock()
+        .await
+        .iter()
+        .filter(|s| s.contains("v4_trades"))
+        .count();
+    assert_eq!(trade_sub_count, tickers.len());
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pool_returns_error_when_cap_reached() {
+    use std::sync::Arc;
+
+    use nautilus_dydx::common::instrument_cache::InstrumentCache;
+    use nautilus_network::websocket::TransportBackend;
+
+    let (addr, _state) = start_test_server().await.unwrap();
+    let ws_url = format!("ws://{addr}/v4/ws");
+
+    let mut client = DydxWebSocketClient::new_public_with_cache_and_pool(
+        ws_url,
+        Arc::new(InstrumentCache::new()),
+        Some(30),
+        TransportBackend::default(),
+        None,
+        1,
+        2,
+    );
+    client.connect().await.unwrap();
+    wait_until_async(|| async { client.is_connected() }, Duration::from_secs(5)).await;
+
+    client
+        .subscribe_trades(InstrumentId::from("BTC-USD.DYDX"))
+        .await
+        .unwrap();
+    client
+        .subscribe_trades(InstrumentId::from("ETH-USD.DYDX"))
+        .await
+        .unwrap();
+
+    let err = client
+        .subscribe_trades(InstrumentId::from("SOL-USD.DYDX"))
+        .await
+        .expect_err("pool should be exhausted");
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("exhaust") || msg.to_lowercase().contains("subscription"),
+        "expected exhaustion error, was: {msg}"
+    );
+
+    assert_eq!(client.pool_size(), 1);
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pool_unsubscribe_does_not_shrink_pool() {
+    use std::sync::Arc;
+
+    use nautilus_dydx::common::instrument_cache::InstrumentCache;
+    use nautilus_network::websocket::TransportBackend;
+
+    let (addr, state) = start_test_server().await.unwrap();
+    let ws_url = format!("ws://{addr}/v4/ws");
+
+    let mut client = DydxWebSocketClient::new_public_with_cache_and_pool(
+        ws_url,
+        Arc::new(InstrumentCache::new()),
+        Some(30),
+        TransportBackend::default(),
+        None,
+        4,
+        2,
+    );
+    client.connect().await.unwrap();
+    wait_until_async(|| async { client.is_connected() }, Duration::from_secs(5)).await;
+
+    for t in ["BTC-USD", "ETH-USD", "SOL-USD"] {
+        client
+            .subscribe_trades(InstrumentId::from(format!("{t}.DYDX").as_str()))
+            .await
+            .unwrap();
+    }
+
+    wait_until_async(
+        || async { *state.connection_count.lock().await >= 2 },
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(client.pool_size(), 2);
+
+    client
+        .unsubscribe_trades(InstrumentId::from("SOL-USD.DYDX"))
+        .await
+        .unwrap();
+
+    wait_until_async(
+        || async {
+            state
+                .subscriptions
+                .lock()
+                .await
+                .iter()
+                .filter(|s| s.contains("v4_trades"))
+                .count()
+                == 2
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(client.pool_size(), 2, "empty slots should not be reaped");
+
+    client.disconnect().await.unwrap();
+}


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

- The hosted dYdX Indexer caps each WebSocket connection at **32 subscriptions per channel** for `v4_trades`, `v4_candles`, `v4_orderbook`, and `v4_markets`. Strategies that watch more than 32 markets (e.g. our 119-instrument `VolumeRankingWss` candle subscribe) silently lose every subscription past 32.
- Wrap `DydxWebSocketClient` in a lazy-growing `Vec<ConnectionSlot>` pool. New subscriptions route to the first slot with capacity on the requested channel; if every slot is full and the cap isn't reached, an extra connection is opened up to `max_ws_connections` (default 8 → 256-market capacity per 32-limit channel).
- Pattern follows `BinanceFuturesWebSocketClient` — including its `connect_lock` race fix — but tracks capacity **per channel kind** (`[u16; 4]`) instead of a single flat stream count, matching dYdX's per-channel-per-connection model.
- Subaccount and block-height streams stay pinned to slot 0 (their 256-per-connection cap is unreachable in practice and keeps related fill/position events in a single ordered stream).
- Two new `DydxDataClientConfig` fields, `max_ws_connections` and `per_channel_subscription_limit`, let self-hosted Indexer deployments raise the defaults.

## Notes

- `connection_mode_atomic()` now reflects slot 0 only (documented). Use `is_connected()` for the pool-wide check.
- `disconnect()` tears down slots sequentially with a 2 s timeout each — fine for typical shutdown, could be parallelized later if needed.
- The pre-existing per-connection rate-limit quota (2 msg/s) is kept. Multiple slots × 2 msg/s stays under the 100 req / 10 s IP-level budget for `max_ws_connections ≤ 8`.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore
