### PR TITLE
Support IB trailing stop basis point offsets

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core_orders.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_orders.rs
@@ -291,7 +291,12 @@ impl InteractiveBrokersExecutionClient {
         }
 
         if let Some(trigger_price) = cmd.trigger_price {
-            ib_order.aux_price = Some(trigger_price.as_f64() / price_magnifier);
+            let converted_trigger_price = trigger_price.as_f64() / price_magnifier;
+            if matches!(ib_order.order_type.as_str(), "TRAIL" | "TRAIL LIMIT") {
+                ib_order.trail_stop_price = Some(converted_trigger_price);
+            } else {
+                ib_order.aux_price = Some(converted_trigger_price);
+            }
         }
     }
 
@@ -529,5 +534,73 @@ impl InteractiveBrokersExecutionClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_model::identifiers::Symbol;
+
+    use super::*;
+
+    fn modify_trigger_cmd() -> ModifyOrder {
+        ModifyOrder::new(
+            TraderId::from("TRADER-001"),
+            Some(ClientId::from("CLIENT-001")),
+            StrategyId::from("S-001"),
+            InstrumentId::new(Symbol::from("AAPL"), Venue::from("NASDAQ")),
+            ClientOrderId::from("O-001"),
+            Some(VenueOrderId::from("1")),
+            None,
+            None,
+            Some(Price::from("149.50")),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        )
+    }
+
+    fn instrument_provider() -> Arc<InteractiveBrokersInstrumentProvider> {
+        Arc::new(InteractiveBrokersInstrumentProvider::new(
+            crate::config::InteractiveBrokersInstrumentProviderConfig::default(),
+        ))
+    }
+
+    #[rstest::rstest]
+    fn modify_trailing_stop_routes_trigger_to_trail_stop_price() {
+        let mut ib_order = ibapi::orders::Order {
+            order_type: "TRAIL".to_string(),
+            aux_price: Some(0.5),
+            trailing_percent: Some(0.25),
+            ..Default::default()
+        };
+
+        InteractiveBrokersExecutionClient::apply_modify_fields_to_ib_order(
+            &modify_trigger_cmd(),
+            &mut ib_order,
+            &instrument_provider(),
+        );
+
+        assert_eq!(ib_order.aux_price, Some(0.5));
+        assert_eq!(ib_order.trailing_percent, Some(0.25));
+        assert_eq!(ib_order.trail_stop_price, Some(149.5));
+    }
+
+    #[rstest::rstest]
+    fn modify_stop_order_routes_trigger_to_aux_price() {
+        let mut ib_order = ibapi::orders::Order {
+            order_type: "STP".to_string(),
+            ..Default::default()
+        };
+
+        InteractiveBrokersExecutionClient::apply_modify_fields_to_ib_order(
+            &modify_trigger_cmd(),
+            &mut ib_order,
+            &instrument_provider(),
+        );
+
+        assert_eq!(ib_order.aux_price, Some(149.5));
+        assert_eq!(ib_order.trail_stop_price, None);
     }
 }

--- a/crates/adapters/interactive_brokers/src/execution/transform.rs
+++ b/crates/adapters/interactive_brokers/src/execution/transform.rs
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_trailing_stop_rejects_non_price_offset() {
+    fn test_trailing_stop_market_uses_trailing_percent_for_basis_points() {
         let order = OrderTestBuilder::new(OrderType::TrailingStopMarket)
             .instrument_id(InstrumentId::new(
                 NautilusSymbol::from("AAPL"),
@@ -672,7 +672,7 @@ mod tests {
             .side(OrderSide::Sell)
             .quantity(Quantity::from(100))
             .trigger_price(Price::from("149.50"))
-            .trailing_offset(dec!(0.5))
+            .trailing_offset(dec!(25))
             .trailing_offset_type(TrailingOffsetType::BasisPoints)
             .build();
         let contract = Contract {
@@ -687,14 +687,45 @@ mod tests {
             InteractiveBrokersInstrumentProviderConfig::default(),
         );
 
-        let result = nautilus_order_to_ib_order(&order, &contract, &provider, 1, "TEST-001");
+        let ib_order = nautilus_order_to_ib_order(&order, &contract, &provider, 1, "TEST-001")
+            .expect("order transform should succeed");
 
-        assert!(result.is_err());
-        assert!(
-            result
-                .expect_err("transform should reject unsupported trailing offset type")
-                .to_string()
-                .contains("only PRICE is supported")
+        assert_eq!(ib_order.aux_price, None);
+        assert_eq!(ib_order.trailing_percent, Some(0.25));
+        assert_eq!(ib_order.trail_stop_price, Some(149.5));
+    }
+
+    #[rstest]
+    fn test_trailing_stop_market_rejects_unsupported_trailing_offset_type() {
+        let order = OrderTestBuilder::new(OrderType::TrailingStopMarket)
+            .instrument_id(InstrumentId::new(
+                NautilusSymbol::from("AAPL"),
+                Venue::from("NASDAQ"),
+            ))
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(100))
+            .trigger_price(Price::from("149.50"))
+            .trailing_offset(dec!(5))
+            .trailing_offset_type(TrailingOffsetType::Ticks)
+            .build();
+        let contract = Contract {
+            contract_id: 0,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("NASDAQ"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(
+            InteractiveBrokersInstrumentProviderConfig::default(),
+        );
+
+        let err = nautilus_order_to_ib_order(&order, &contract, &provider, 1, "TEST-001")
+            .expect_err("unsupported trailing offset type should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "`TrailingOffsetType` Ticks is not supported"
         );
     }
 

--- a/crates/adapters/interactive_brokers/src/execution/transform/policy.rs
+++ b/crates/adapters/interactive_brokers/src/execution/transform/policy.rs
@@ -63,19 +63,20 @@ pub(super) fn apply_trailing_order_policy(
         return Ok(());
     }
 
-    match order.trailing_offset_type() {
-        Some(TrailingOffsetType::Price | TrailingOffsetType::NoTrailingOffset) | None => {}
-        Some(other) => anyhow::bail!(
-            "`TrailingOffsetType` {:?} is not supported (only PRICE is supported)",
-            other
-        ),
-    }
-
     if let Some(trailing_offset) = order.trailing_offset() {
         let trailing_offset_f64 = trailing_offset.to_string().parse::<f64>().map_err(|e| {
             anyhow::anyhow!("Failed to convert trailing offset {trailing_offset} to f64: {e}")
         })?;
-        ib_order.aux_price = Some(trailing_offset_f64);
+
+        match order.trailing_offset_type() {
+            Some(TrailingOffsetType::BasisPoints) => {
+                ib_order.trailing_percent = Some(trailing_offset_f64 / 100.0);
+            }
+            Some(TrailingOffsetType::Price | TrailingOffsetType::NoTrailingOffset) | None => {
+                ib_order.aux_price = Some(trailing_offset_f64);
+            }
+            Some(other) => anyhow::bail!("`TrailingOffsetType` {:?} is not supported", other),
+        }
     }
 
     if let Some(trigger_price) = order.trigger_price() {

--- a/nautilus_trader/adapters/interactive_brokers/execution.py
+++ b/nautilus_trader/adapters/interactive_brokers/execution.py
@@ -1180,16 +1180,17 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             converted_price = nautilus_price_to_ib_price(command.price.as_double(), price_magnifier)
             ib_order.lmtPrice = converted_price
 
-        if command.trigger_price and command.trigger_price.as_double() != getattr(
-            ib_order,
-            "auxPrice",
-            None,
-        ):
+        if command.trigger_price:
             converted_trigger_price = nautilus_price_to_ib_price(
                 command.trigger_price.as_double(),
                 price_magnifier,
             )
-            ib_order.auxPrice = converted_trigger_price
+
+            if isinstance(nautilus_order, TrailingStopLimitOrder | TrailingStopMarketOrder):
+                if converted_trigger_price != getattr(ib_order, "trailStopPrice", None):
+                    ib_order.trailStopPrice = converted_trigger_price
+            elif converted_trigger_price != getattr(ib_order, "auxPrice", None):
+                ib_order.auxPrice = converted_trigger_price
 
         self._log.info(f"Placing {ib_order!r}")
         self._client.place_order(ib_order)
@@ -1231,12 +1232,14 @@ class InteractiveBrokersExecutionClient(LiveExecutionClient):
             ib_order.totalQuantity = 0
 
         if isinstance(order, TrailingStopLimitOrder | TrailingStopMarketOrder):
-            if order.trailing_offset_type != TrailingOffsetType.PRICE:
+            if order.trailing_offset_type == TrailingOffsetType.PRICE:
+                ib_order.auxPrice = float(order.trailing_offset)
+            elif order.trailing_offset_type == TrailingOffsetType.BASIS_POINTS:
+                ib_order.trailingPercent = float(order.trailing_offset) / 100.0
+            else:
                 raise ValueError(
                     f"`TrailingOffsetType` {trailing_offset_type_to_str(order.trailing_offset_type)} is not supported",
                 )
-
-            ib_order.auxPrice = float(order.trailing_offset)
 
             if order.trigger_price:
                 converted_trigger_price = nautilus_price_to_ib_price(

--- a/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py
@@ -13,19 +13,27 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+from decimal import Decimal
+
 import pytest
+from ibapi.const import UNSET_DOUBLE
 
 from nautilus_trader.adapters.interactive_brokers.common import ComboLeg
 from nautilus_trader.adapters.interactive_brokers.common import IBContract
 from nautilus_trader.adapters.interactive_brokers.common import IBOrderTags
+from nautilus_trader.common.component import TestClock
+from nautilus_trader.common.factories import OrderFactory
 from nautilus_trader.core.uuid import UUID4
 from nautilus_trader.model.enums import ContingencyType
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.enums import TrailingOffsetType
 from nautilus_trader.model.enums import TriggerType
 from nautilus_trader.model.identifiers import ClientOrderId
 from nautilus_trader.model.identifiers import OrderListId
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
 from nautilus_trader.model.orders.limit import LimitOrder
 from nautilus_trader.model.orders.stop_market import StopMarketOrder
 from nautilus_trader.test_kit.stubs.data import TestInstrumentProvider
@@ -165,6 +173,31 @@ async def test_transform_order_to_ib_order_exchange_param(exec_client):
     assert ib_order.contract.conId == cached_contract.conId
     assert cached_contract.exchange == "SMART"
     assert ib_order.contract is not cached_contract
+
+
+@pytest.mark.asyncio
+async def test_transform_trailing_stop_market_basis_points_uses_trailing_percent(exec_client):
+    order_factory = OrderFactory(
+        trader_id=TestIdStubs.trader_id(),
+        strategy_id=TestIdStubs.strategy_id(),
+        clock=TestClock(),
+    )
+    order = order_factory.trailing_stop_market(
+        instrument_id=_AAPL.id,
+        order_side=OrderSide.SELL,
+        quantity=Quantity.from_int(100),
+        trailing_offset=Decimal(25),
+        trigger_price=Price.from_str("149.50"),
+        trailing_offset_type=TrailingOffsetType.BASIS_POINTS,
+        trigger_type=TriggerType.LAST_PRICE,
+    )
+    await exec_client._instrument_provider.load_async(order.instrument_id)
+
+    ib_order = exec_client._transform_order_to_ib_order(order)
+
+    assert ib_order.trailingPercent == 0.25
+    assert ib_order.trailStopPrice == 149.5
+    assert ib_order.auxPrice == UNSET_DOUBLE
 
 
 def test_contract_with_routing_exchange_preserves_combo_legs(exec_client):


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixed Interactive Brokers trailing stop order transforms to accept `TrailingOffsetType.BASIS_POINTS`.
- Mapped Nautilus basis points to IB `trailingPercent` by dividing by `100`.
- Preserved `TrailingOffsetType.PRICE` behavior by continuing to map price offsets to IB `auxPrice`.
- Fixed Python trailing stop modifications so trigger price updates write IB `trailStopPrice` instead of `auxPrice`.
- Fixed Rust trailing stop modifications so trigger price updates write IB `trail_stop_price` instead of clobbering `aux_price`.
- Added Python and Rust regression coverage for basis-point trailing stop market orders, modify trigger routing, and unsupported trailing offset rejection.

### Design decisions

- Kept the transform change inside existing order-transform branches instead of adding helper adapter abstraction.
- Matched existing IB parse behavior, where `trailingPercent` converts back to Nautilus basis points by multiplying by `100`.
- Used `trailStopPrice` only for trailing order trigger updates, leaving stop and touched order trigger prices on `auxPrice`.
- Used the rebuilt IB order type in the Rust modify helper so cached-order and open-order fallback modifies share the same trailing-stop routing.
- Left unsupported trailing offset types rejected through the existing error path.

### Order transform flow

```mermaid
flowchart TD
    A[Nautilus trailing stop order] --> B{Trailing offset type}
    B -->|PRICE| C[IB auxPrice = trailing offset]
    B -->|BASIS_POINTS| D[IB trailingPercent = trailing offset / 100]
    C --> E[IB trailStopPrice = trigger price]
    D --> E
    E --> F[Submit or modify IB order]
```

### Files changed

- `nautilus_trader/adapters/interactive_brokers/execution.py`.
- `crates/adapters/interactive_brokers/src/execution/core_orders.rs`.
- `crates/adapters/interactive_brokers/src/execution/transform/policy.rs`.
- `crates/adapters/interactive_brokers/src/execution/transform.rs`.
- `tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py`.

### Verification

- `make build-debug`.
- `make format`.
- `cargo test -p nautilus-interactive-brokers modify_ --lib`.
- `cargo test -p nautilus-interactive-brokers trailing_stop_market --lib`.
- `cargo test -p nautilus-interactive-brokers execution::transform::tests::test_trailing_stop_market_uses_trailing_percent_for_basis_points`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py -k basis_points`.
- `uv run --no-sync pytest tests/integration_tests/adapters/interactive_brokers/test_execution_order_transform.py -k trailing_stop_market_basis_points`.
- `make pre-commit` was started after the follow-up fix but interrupted before completion.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4291

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
