### PR TITLE
Finalize sandbox expired engine retention

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -303,7 +303,7 @@ impl SandboxInner {
         // with the already-initialized matching engine.
         if let Some(engine) = self.matching_engines.get_mut(&instrument_id) {
             engine.get_engine_mut().process_instrument_close(*close);
-            self.try_finalize_expired_instrument(instrument_id);
+            self.sync_expired_cleanup(instrument_id);
         } else {
             log::warn!(
                 "Ignoring instrument close for {instrument_id}: no existing matching engine",
@@ -311,12 +311,21 @@ impl SandboxInner {
         }
     }
 
-    fn try_finalize_expired_instrument(&mut self, instrument_id: InstrumentId) {
+    fn is_expired_now(&self, instrument_id: InstrumentId) -> bool {
         let Some(engine) = self.matching_engines.get(&instrument_id) else {
-            return;
+            return false;
         };
 
-        if !engine.get_engine().is_expiration_processed() {
+        let now_ns = self.clock.borrow().timestamp_ns();
+        engine
+            .get_engine()
+            .instrument
+            .expiration_ns()
+            .is_some_and(|ns| now_ns >= ns)
+    }
+
+    fn sync_expired_cleanup(&mut self, instrument_id: InstrumentId) {
+        if !self.is_expired_now(instrument_id) {
             return;
         }
 
@@ -333,20 +342,9 @@ impl SandboxInner {
         }
 
         self.matching_engines.remove(&instrument_id);
-
-        let has_open_orders = self.cache.borrow().has_orders_open(
-            Some(&self.config.venue),
-            Some(&instrument_id),
-            None,
-            None,
-            None,
-        );
-
-        if has_open_orders {
-            return;
-        }
-
-        self.cache.borrow_mut().purge_instrument(instrument_id);
+        self.cache
+            .borrow_mut()
+            .purge_instrument_skip_order_guard(instrument_id);
     }
 }
 
@@ -561,9 +559,11 @@ impl SandboxExecutionClient {
                     && position_closed.account_id == account_id
                     && let Some(inner_rc) = inner_weak.upgrade()
                 {
+                    // ExecutionEngine updates the cached position state before publishing
+                    // PositionClosed, so this retry observes the post-settlement cache view.
                     inner_rc
                         .borrow_mut()
-                        .try_finalize_expired_instrument(position_closed.instrument_id);
+                        .sync_expired_cleanup(position_closed.instrument_id);
                 }
             })
         };
@@ -961,6 +961,7 @@ impl ExecutionClient for SandboxExecutionClient {
             engine
                 .get_engine_mut()
                 .process_order(&mut order, account_id);
+            inner.sync_expired_cleanup(instrument_id);
         }
 
         Ok(())
@@ -1022,6 +1023,7 @@ impl ExecutionClient for SandboxExecutionClient {
                     engine
                         .get_engine_mut()
                         .process_order(&mut order_clone, account_id);
+                    inner.sync_expired_cleanup(instrument_id);
                 }
             }
         }

--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -346,6 +346,12 @@ impl SandboxInner {
             .borrow_mut()
             .purge_instrument_skip_order_guard(instrument_id);
     }
+
+    fn sync_expired_cleanup_many(&mut self, instrument_ids: &[InstrumentId]) {
+        for &instrument_id in instrument_ids {
+            self.sync_expired_cleanup(instrument_id);
+        }
+    }
 }
 
 /// Registered message handlers for later deregistration.
@@ -561,9 +567,14 @@ impl SandboxExecutionClient {
                 {
                     // ExecutionEngine updates the cached position state before publishing
                     // PositionClosed, so this retry observes the post-settlement cache view.
-                    inner_rc
-                        .borrow_mut()
-                        .sync_expired_cleanup(position_closed.instrument_id);
+                    if let Ok(mut inner) = inner_rc.try_borrow_mut() {
+                        inner.sync_expired_cleanup(position_closed.instrument_id);
+                    } else {
+                        log::debug!(
+                            "Skipping immediate expired cleanup retry for {} due to active sandbox borrow",
+                            position_closed.instrument_id,
+                        );
+                    }
                 }
             })
         };
@@ -969,6 +980,7 @@ impl ExecutionClient for SandboxExecutionClient {
 
     fn submit_order_list(&self, cmd: SubmitOrderList) -> anyhow::Result<()> {
         let ts_init = self.clock.borrow().timestamp_ns();
+        let mut cleanup_instrument_ids = Vec::new();
 
         let orders: Vec<OrderAny> = self
             .cache
@@ -993,6 +1005,9 @@ impl ExecutionClient for SandboxExecutionClient {
             }
 
             let instrument_id = order.instrument_id();
+            if !cleanup_instrument_ids.contains(&instrument_id) {
+                cleanup_instrument_ids.push(instrument_id);
+            }
             let instrument = self.cache.borrow().instrument(&instrument_id).cloned();
 
             if let Some(instrument) = instrument {
@@ -1023,9 +1038,14 @@ impl ExecutionClient for SandboxExecutionClient {
                     engine
                         .get_engine_mut()
                         .process_order(&mut order_clone, account_id);
-                    inner.sync_expired_cleanup(instrument_id);
                 }
             }
+        }
+
+        if !cleanup_instrument_ids.is_empty() {
+            self.inner
+                .borrow_mut()
+                .sync_expired_cleanup_many(&cleanup_instrument_ids);
         }
 
         Ok(())

--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -48,7 +48,7 @@ use nautilus_model::{
     accounts::AccountAny,
     data::{Bar, InstrumentClose, InstrumentStatus, OrderBookDeltas, QuoteTick, TradeTick},
     enums::OmsType,
-    events::OrderEventAny,
+    events::{OrderEventAny, PositionEvent},
     identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
@@ -303,11 +303,50 @@ impl SandboxInner {
         // with the already-initialized matching engine.
         if let Some(engine) = self.matching_engines.get_mut(&instrument_id) {
             engine.get_engine_mut().process_instrument_close(*close);
+            self.try_finalize_expired_instrument(instrument_id);
         } else {
             log::warn!(
                 "Ignoring instrument close for {instrument_id}: no existing matching engine",
             );
         }
+    }
+
+    fn try_finalize_expired_instrument(&mut self, instrument_id: InstrumentId) {
+        let Some(engine) = self.matching_engines.get(&instrument_id) else {
+            return;
+        };
+
+        if !engine.get_engine().is_expiration_processed() {
+            return;
+        }
+
+        let has_open_positions = self.cache.borrow().has_positions_open(
+            Some(&self.config.venue),
+            Some(&instrument_id),
+            None,
+            None,
+            None,
+        );
+
+        if has_open_positions {
+            return;
+        }
+
+        self.matching_engines.remove(&instrument_id);
+
+        let has_open_orders = self.cache.borrow().has_orders_open(
+            Some(&self.config.venue),
+            Some(&instrument_id),
+            None,
+            None,
+            None,
+        );
+
+        if has_open_orders {
+            return;
+        }
+
+        self.cache.borrow_mut().purge_instrument(instrument_id);
     }
 }
 
@@ -325,6 +364,8 @@ struct RegisteredHandlers {
     status_handler: ShareableMessageHandler,
     close_pattern: MStr<Pattern>,
     close_handler: ShareableMessageHandler,
+    position_pattern: MStr<Pattern>,
+    position_handler: TypedHandler<PositionEvent>,
 }
 
 /// A sandbox execution client for paper trading against live market data.
@@ -438,6 +479,7 @@ impl SandboxExecutionClient {
 
         let inner_weak = WeakCell::from(Rc::downgrade(&self.inner));
         let venue = self.config.venue;
+        let account_id = self.core.borrow().account_id;
 
         // Order book deltas handler
         let deltas_handler = {
@@ -499,11 +541,29 @@ impl SandboxExecutionClient {
         };
 
         let close_handler = {
+            let inner = inner_weak.clone();
             ShareableMessageHandler::from_typed(move |close: &InstrumentClose| {
                 if close.instrument_id.venue == venue
-                    && let Some(inner_rc) = inner_weak.upgrade()
+                    && let Some(inner_rc) = inner.upgrade()
                 {
                     inner_rc.borrow_mut().process_instrument_close(close);
+                }
+            })
+        };
+
+        let position_handler = {
+            TypedHandler::from(move |event: &PositionEvent| {
+                let PositionEvent::PositionClosed(position_closed) = event else {
+                    return;
+                };
+
+                if position_closed.instrument_id.venue == venue
+                    && position_closed.account_id == account_id
+                    && let Some(inner_rc) = inner_weak.upgrade()
+                {
+                    inner_rc
+                        .borrow_mut()
+                        .try_finalize_expired_instrument(position_closed.instrument_id);
                 }
             })
         };
@@ -515,6 +575,7 @@ impl SandboxExecutionClient {
         let bar_pattern: MStr<Pattern> = "data.bars.*".into();
         let status_pattern: MStr<Pattern> = format!("data.status.{venue}.*").into();
         let close_pattern: MStr<Pattern> = format!("data.close.{venue}.*").into();
+        let position_pattern: MStr<Pattern> = "events.position.*".into();
 
         msgbus::subscribe_book_deltas(deltas_pattern, deltas_handler.clone(), Some(10));
         msgbus::subscribe_quotes(quote_pattern, quote_handler.clone(), Some(10));
@@ -522,6 +583,7 @@ impl SandboxExecutionClient {
         msgbus::subscribe_bars(bar_pattern, bar_handler.clone(), Some(10));
         msgbus::subscribe_any(status_pattern, status_handler.clone(), Some(10));
         msgbus::subscribe_instrument_close(close_pattern, close_handler.clone(), Some(10));
+        msgbus::subscribe_position_events(position_pattern, position_handler.clone(), Some(10));
 
         // Store handlers for later deregistration
         *self.handlers.borrow_mut() = Some(RegisteredHandlers {
@@ -537,6 +599,8 @@ impl SandboxExecutionClient {
             status_handler,
             close_pattern,
             close_handler,
+            position_pattern,
+            position_handler,
         });
 
         log::info!(
@@ -554,6 +618,10 @@ impl SandboxExecutionClient {
             msgbus::unsubscribe_bars(handlers.bar_pattern, &handlers.bar_handler);
             msgbus::unsubscribe_any(handlers.status_pattern, &handlers.status_handler);
             msgbus::unsubscribe_instrument_close(handlers.close_pattern, &handlers.close_handler);
+            msgbus::unsubscribe_position_events(
+                handlers.position_pattern,
+                &handlers.position_handler,
+            );
 
             log::info!(
                 "Sandbox deregistered message handlers for venue={}",

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -24,11 +24,11 @@ use nautilus_common::{
     live::set_exec_event_sender,
     messages::{
         ExecutionEvent,
-        execution::{SubmitOrder, TradingCommand},
+        execution::{SubmitOrder, SubmitOrderList, TradingCommand},
     },
     msgbus::{
         self, MessageBus, MessagingSwitchboard, TypedHandler,
-        stubs::get_typed_into_message_saving_handler,
+        stubs::get_typed_into_message_saving_handler, typed_handler::TypedIntoHandler,
     },
 };
 use nautilus_core::{UUID4, UnixNanos};
@@ -46,12 +46,15 @@ use nautilus_model::{
         OrderSide, OrderType, PositionSide,
     },
     events::{AccountState, OrderEventAny, OrderFilled, PositionClosed, PositionEvent},
-    identifiers::{AccountId, ClientId, InstrumentId, PositionId, TradeId, TraderId, Venue},
+    identifiers::{
+        AccountId, ClientId, ClientOrderId, InstrumentId, OrderListId, PositionId, TradeId,
+        TraderId, Venue,
+    },
     instruments::{
         CryptoPerpetual, Instrument, InstrumentAny,
         stubs::{binary_option, crypto_perpetual_ethusdt},
     },
-    orders::OrderTestBuilder,
+    orders::{Order, OrderAny, OrderList, OrderTestBuilder},
     position::Position,
     types::{Currency, Money, Price, Quantity},
 };
@@ -366,6 +369,44 @@ fn apply_order_events_from_channel(
     }
 
     order_events
+}
+
+fn create_submit_order_list(
+    trader_id: TraderId,
+    client_id: ClientId,
+    instrument_id: InstrumentId,
+    orders: &[OrderAny],
+) -> SubmitOrderList {
+    let strategy_id = orders
+        .first()
+        .expect("expected non-empty order list")
+        .strategy_id();
+    let order_list = OrderList::new(
+        OrderListId::from("OL-SANDBOX-001"),
+        instrument_id,
+        strategy_id,
+        orders.iter().map(OrderAny::client_order_id).collect(),
+        UnixNanos::default(),
+    );
+
+    SubmitOrderList {
+        trader_id,
+        client_id: Some(client_id),
+        strategy_id,
+        instrument_id,
+        order_list,
+        order_inits: orders
+            .iter()
+            .map(|order| order.init_event().clone())
+            .collect(),
+        exec_algorithm_id: None,
+        position_id: None,
+        params: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    }
 }
 
 fn seed_binary_option_position_from_fill(
@@ -1472,6 +1513,268 @@ fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_a
     );
 
     harness.client.stop().unwrap();
+}
+
+#[rstest]
+fn test_submit_order_list_keeps_processing_all_expired_legs_before_cleanup(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id,
+        account_id,
+        "0xORDER-LIST",
+        "0xYES",
+        "Yes",
+        100,
+    );
+    let client_id = harness.client.client_id();
+
+    let _ = harness
+        .test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let first = OrderTestBuilder::new(OrderType::Limit)
+        .trader_id(trader_id)
+        .instrument_id(harness.instrument.id())
+        .client_order_id(ClientOrderId::from("O-EXPIRED-LIST-001"))
+        .side(OrderSide::Buy)
+        .price(Price::from("0.400"))
+        .quantity(Quantity::from("1"))
+        .build();
+    let second = OrderTestBuilder::new(OrderType::Limit)
+        .trader_id(trader_id)
+        .instrument_id(harness.instrument.id())
+        .client_order_id(ClientOrderId::from("O-EXPIRED-LIST-002"))
+        .side(OrderSide::Buy)
+        .price(Price::from("0.450"))
+        .quantity(Quantity::from("1"))
+        .build();
+    let orders = vec![first, second];
+
+    for order in &orders {
+        harness
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(client_id), false)
+            .unwrap();
+    }
+
+    harness
+        .client
+        .submit_order_list(create_submit_order_list(
+            trader_id,
+            client_id,
+            harness.instrument.id(),
+            &orders,
+        ))
+        .unwrap();
+
+    let order_events = apply_order_events_from_channel(&harness.cache, &mut harness.rx);
+
+    for order in &orders {
+        assert!(
+            order_events.iter().any(|event| {
+                event.client_order_id() == order.client_order_id()
+                    && matches!(event, OrderEventAny::Rejected(_))
+            }),
+            "expired order-list leg should emit a terminal rejection, not stay SUBMITTED",
+        );
+    }
+
+    assert_eq!(harness.client.matching_engine_count(), 0);
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_none()
+    );
+
+    harness.client.stop().unwrap();
+}
+
+#[rstest]
+fn test_instrument_close_sync_cleanup_handles_synchronous_position_closed_reentry(
+    trader_id: TraderId,
+) {
+    std::thread::spawn(move || {
+        *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+        let venue = Venue::new("BINANCE");
+        let account_id = AccountId::from("BINANCE-001");
+        let client_id = ClientId::new("SANDBOX");
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let test_clock = Rc::new(RefCell::new(TestClock::new()));
+        let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+
+        let mut binary = binary_option();
+        binary.id = InstrumentId::from("YES.BINANCE");
+        binary.raw_symbol = "YES".into();
+        binary.activation_ns = UnixNanos::from(1);
+        binary.expiration_ns = UnixNanos::from(100);
+        let instrument = InstrumentAny::BinaryOption(binary);
+
+        cache
+            .borrow_mut()
+            .add_instrument(instrument.clone())
+            .unwrap();
+        cache
+            .borrow_mut()
+            .add_quote(create_binary_option_quote(instrument.id()))
+            .unwrap();
+
+        let cache_for_handler = cache.clone();
+        let order_events = Rc::new(RefCell::new(Vec::<OrderEventAny>::new()));
+        let order_events_for_handler = order_events.clone();
+        let opening_fill = Rc::new(RefCell::new(None::<OrderFilled>));
+        let opening_fill_for_handler = opening_fill.clone();
+        let instrument_for_position = instrument.clone();
+        let instrument_for_handler = instrument.clone();
+        let order_handler = TypedIntoHandler::from(move |event: OrderEventAny| {
+            order_events_for_handler.borrow_mut().push(event.clone());
+            let _ = cache_for_handler.borrow_mut().update_order(&event);
+
+            let OrderEventAny::Filled(mut fill) = event else {
+                return;
+            };
+
+            if fill.client_order_id.as_str().starts_with("EXPIRATION-") {
+                let position = cache_for_handler
+                    .borrow()
+                    .positions_open(
+                        Some(&venue),
+                        Some(&instrument_for_handler.id()),
+                        None,
+                        Some(&account_id),
+                        None,
+                    )
+                    .into_iter()
+                    .next()
+                    .expect("expected open position before expiration fill")
+                    .clone();
+                fill.position_id = Some(position.id);
+
+                let mut closed = position;
+                closed.apply(&fill);
+                cache_for_handler
+                    .borrow_mut()
+                    .update_position(&closed)
+                    .unwrap();
+
+                let position_closed =
+                    PositionClosed::create(&closed, &fill, UUID4::new(), fill.ts_event);
+                msgbus::publish_position_event(
+                    "events.position.TEST".into(),
+                    &PositionEvent::PositionClosed(position_closed),
+                );
+            } else {
+                *opening_fill_for_handler.borrow_mut() = Some(fill);
+            }
+        });
+        msgbus::register_order_event_endpoint(
+            MessagingSwitchboard::exec_engine_process(),
+            order_handler,
+        );
+
+        let usd = Currency::USD();
+        let config = SandboxExecutionClientConfig {
+            trader_id,
+            account_id,
+            venue,
+            starting_balances: vec![Money::new(100_000.0, usd)],
+            base_currency: Some(usd),
+            oms_type: OmsType::Netting,
+            account_type: AccountType::Margin,
+            default_leverage: Decimal::ONE,
+            leverages: ahash::AHashMap::new(),
+            book_type: BookType::L1_MBP,
+            fee_model: None,
+            frozen_account: false,
+            bar_execution: false,
+            trade_execution: false,
+            reject_stop_orders: true,
+            support_gtd_orders: true,
+            support_contingent_orders: true,
+            use_position_ids: true,
+            use_random_ids: false,
+            use_reduce_only: true,
+        };
+        let core = ExecutionClientCore::new(
+            trader_id,
+            client_id,
+            venue,
+            config.oms_type,
+            config.account_id,
+            config.account_type,
+            config.base_currency,
+            cache.clone(),
+        );
+        let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+        client.start().unwrap();
+
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .trader_id(trader_id)
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::from("O-SYNC-REENTRY-001"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.00"))
+            .build();
+        cache
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(client_id), false)
+            .unwrap();
+
+        let ts = test_clock.borrow().timestamp_ns();
+        client
+            .submit_order(SubmitOrder::from_order(
+                &order,
+                trader_id,
+                Some(client_id),
+                None,
+                UUID4::new(),
+                ts,
+            ))
+            .unwrap();
+
+        assert!(
+            order_events
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, OrderEventAny::Filled(_))),
+            "expected opening fill event, found {:?}",
+            order_events.borrow(),
+        );
+
+        let mut opening_fill = opening_fill
+            .borrow_mut()
+            .take()
+            .expect("expected opening fill before expiration");
+        opening_fill.position_id = Some(PositionId::new("P-SYNC-REENTRY"));
+        let position = Position::new(&instrument_for_position, opening_fill);
+        cache
+            .borrow_mut()
+            .add_position(&position, OmsType::Netting)
+            .unwrap();
+
+        assert!(cache.borrow().has_positions_open(
+            Some(&venue),
+            Some(&instrument.id()),
+            None,
+            Some(&account_id),
+            None,
+        ));
+
+        publish_expired_close(&test_clock, &instrument, Price::from("1.000"), 200);
+
+        assert_eq!(client.matching_engine_count(), 0);
+        assert!(cache.borrow().instrument(&instrument.id()).is_none());
+        client.stop().unwrap();
+    })
+    .join()
+    .unwrap();
 }
 
 #[rstest]

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -415,6 +415,83 @@ fn submit_market_open_order(
         .unwrap();
 }
 
+struct BinaryOptionLifecycleHarness {
+    client: SandboxExecutionClient,
+    cache: Rc<RefCell<Cache>>,
+    test_clock: Rc<RefCell<TestClock>>,
+    instrument: InstrumentAny,
+    rx: tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+}
+
+fn setup_binary_option_lifecycle_harness(
+    trader_id: TraderId,
+    account_id: AccountId,
+    condition_id: &str,
+    token_id: &str,
+    outcome: &str,
+    expiration_ns: u64,
+) -> BinaryOptionLifecycleHarness {
+    let instrument = make_binary_option_instrument(condition_id, token_id, outcome, expiration_ns);
+    let venue = instrument.id().venue;
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let test_clock = Rc::new(RefCell::new(TestClock::new()));
+    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+    let config = create_config(trader_id, account_id, venue);
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+
+    set_exec_event_sender(tx);
+    cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    client.start().unwrap();
+    client
+        .process_quote_tick(&create_binary_option_quote(instrument.id()))
+        .unwrap();
+
+    BinaryOptionLifecycleHarness {
+        client,
+        cache,
+        test_clock,
+        instrument,
+        rx,
+    }
+}
+
+fn publish_expired_close(
+    test_clock: &Rc<RefCell<TestClock>>,
+    instrument: &InstrumentAny,
+    close_price: Price,
+    ts_ns: u64,
+) {
+    let _ = test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(ts_ns), true);
+
+    let close = InstrumentClose::new(
+        instrument.id(),
+        close_price,
+        InstrumentCloseType::ContractExpired,
+        UnixNanos::from(ts_ns),
+        UnixNanos::from(ts_ns),
+    );
+    msgbus::publish_any(
+        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
+        &close,
+    );
+}
+
 struct PendingResolutionHarness {
     context: TestContext,
     instrument: InstrumentAny,
@@ -459,7 +536,7 @@ fn setup_pending_resolution_harness(
         .borrow_mut()
         .advance_time(UnixNanos::from(50), true);
 
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
     nautilus_common::live::runner::replace_exec_event_sender(tx);
     client.start().unwrap();
 
@@ -474,14 +551,19 @@ fn setup_pending_resolution_harness(
     );
     client.process_quote_tick(&quote).unwrap();
 
-    submit_market_open_order(
+    let position = submit_open_position_and_seed_cache(
         &client,
         &cache,
         trader_id,
         &instrument,
         &format!("OPEN-{client_order_suffix}"),
-        10,
+        &format!("P-{client_order_suffix}"),
+        &mut rx,
     );
+    cache
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
 
     let resting_order = OrderTestBuilder::new(OrderType::Limit)
         .instrument_id(instrument.id())
@@ -545,29 +627,15 @@ fn setup_pending_resolution_harness(
 
 fn assert_pending_resolution_transition(
     harness: &mut PendingResolutionHarness,
-    opening_order_id: &str,
     resting_order_id: &str,
     probe_order_id: &str,
-    position_id: &str,
 ) {
     let mut seen_resting_canceled = false;
     let mut seen_probe_rejected = false;
-    let mut seeded_position = false;
 
     for event in std::iter::from_fn(|| harness.rx.try_recv().ok()) {
         if let ExecutionEvent::Order(order_event) = event {
             match order_event {
-                OrderEventAny::Filled(fill)
-                    if fill.client_order_id.as_str() == opening_order_id =>
-                {
-                    seed_binary_option_position_from_fill(
-                        &harness.context.cache,
-                        &harness.instrument,
-                        fill,
-                        position_id,
-                    );
-                    seeded_position = true;
-                }
                 OrderEventAny::Canceled(c) if c.client_order_id.as_str() == resting_order_id => {
                     seen_resting_canceled = true;
                 }
@@ -586,10 +654,6 @@ fn assert_pending_resolution_transition(
     assert!(
         seen_probe_rejected,
         "expected probe order rejection with pending resolution reason"
-    );
-    assert!(
-        seeded_position,
-        "expected opening fill so a position can be settled on InstrumentClose"
     );
 }
 
@@ -952,13 +1016,7 @@ fn test_paper_binary_option_pending_resolution_then_close_settlement(
     account_id: AccountId,
 ) {
     let mut harness = setup_pending_resolution_harness(trader_id, account_id, "BO-PAPER");
-    assert_pending_resolution_transition(
-        &mut harness,
-        "OPEN-BO-PAPER",
-        "REST-BO-PAPER",
-        "PROBE-BO-PAPER",
-        "P-BO-PAPER",
-    );
+    assert_pending_resolution_transition(&mut harness, "REST-BO-PAPER", "PROBE-BO-PAPER");
 
     let close = InstrumentClose::new(
         harness.instrument.id(),
@@ -1001,13 +1059,7 @@ fn test_paper_binary_option_pending_resolution_then_close_settlement_via_data_en
         None,
     )));
     DataEngine::register_msgbus_handlers(&data_engine);
-    assert_pending_resolution_transition(
-        &mut harness,
-        "OPEN-BO-DE",
-        "REST-BO-DE",
-        "PROBE-BO-DE",
-        "P-BO-DE",
-    );
+    assert_pending_resolution_transition(&mut harness, "REST-BO-DE", "PROBE-BO-DE");
 
     let close = InstrumentClose::new(
         harness.instrument.id(),
@@ -1104,54 +1156,33 @@ fn test_instrument_close_finalizes_expired_engine_without_open_state(
     *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
     setup_order_event_handler();
 
-    let instrument = make_binary_option_instrument("0xFINALIZE", "0xYES", "Yes", 100);
-    let venue = instrument.id().venue;
-    let cache = Rc::new(RefCell::new(Cache::default()));
-    let test_clock = Rc::new(RefCell::new(TestClock::new()));
-    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
-    let config = create_config(trader_id, account_id, venue);
-    let core = ExecutionClientCore::new(
-        config.trader_id,
-        ClientId::new("SANDBOX"),
-        config.venue,
-        config.oms_type,
-        config.account_id,
-        config.account_type,
-        config.base_currency,
-        cache.clone(),
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id,
+        account_id,
+        "0xFINALIZE",
+        "0xYES",
+        "Yes",
+        100,
     );
-    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    assert_eq!(harness.client.matching_engine_count(), 1);
 
-    cache
-        .borrow_mut()
-        .add_instrument(instrument.clone())
-        .unwrap();
-    client.start().unwrap();
-    client
-        .process_quote_tick(&create_binary_option_quote(instrument.id()))
-        .unwrap();
-    assert_eq!(client.matching_engine_count(), 1);
-
-    let _ = test_clock
-        .borrow_mut()
-        .advance_time(UnixNanos::from(200), true);
-
-    let close = InstrumentClose::new(
-        instrument.id(),
+    publish_expired_close(
+        &harness.test_clock,
+        &harness.instrument,
         Price::from("1.000"),
-        InstrumentCloseType::ContractExpired,
-        UnixNanos::from(200),
-        UnixNanos::from(200),
-    );
-    msgbus::publish_any(
-        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
-        &close,
+        200,
     );
 
-    assert_eq!(client.matching_engine_count(), 0);
-    assert!(cache.borrow().instrument(&instrument.id()).is_none());
+    assert_eq!(harness.client.matching_engine_count(), 0);
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_none()
+    );
 
-    client.stop().unwrap();
+    harness.client.stop().unwrap();
 }
 
 #[rstest]
@@ -1162,80 +1193,54 @@ fn test_instrument_close_keeps_engine_until_position_closed(
     *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
     setup_order_event_handler();
 
-    let instrument = make_binary_option_instrument("0xSETTLE", "0xYES", "Yes", 100);
-    let venue = instrument.id().venue;
-    let cache = Rc::new(RefCell::new(Cache::default()));
-    let test_clock = Rc::new(RefCell::new(TestClock::new()));
-    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
-    let config = create_config(trader_id, account_id, venue);
-    let core = ExecutionClientCore::new(
-        config.trader_id,
-        ClientId::new("SANDBOX"),
-        config.venue,
-        config.oms_type,
-        config.account_id,
-        config.account_type,
-        config.base_currency,
-        cache.clone(),
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id, account_id, "0xSETTLE", "0xYES", "Yes", 100,
     );
-    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
-
-    set_exec_event_sender(tx);
-    cache
-        .borrow_mut()
-        .add_instrument(instrument.clone())
-        .unwrap();
-    client.start().unwrap();
-    client
-        .process_quote_tick(&create_binary_option_quote(instrument.id()))
-        .unwrap();
-    assert_eq!(client.matching_engine_count(), 1);
+    let venue = harness.instrument.id().venue;
+    assert_eq!(harness.client.matching_engine_count(), 1);
 
     let position = submit_open_position_and_seed_cache(
-        &client,
-        &cache,
+        &harness.client,
+        &harness.cache,
         trader_id,
-        &instrument,
+        &harness.instrument,
         "OPEN-POSITION",
         "P-OPEN-POSITION",
-        &mut rx,
+        &mut harness.rx,
     );
-    cache
+    harness
+        .cache
         .borrow_mut()
         .add_position(&position, OmsType::Netting)
         .unwrap();
 
-    let _ = test_clock
-        .borrow_mut()
-        .advance_time(UnixNanos::from(200), true);
-
-    let close = InstrumentClose::new(
-        instrument.id(),
+    publish_expired_close(
+        &harness.test_clock,
+        &harness.instrument,
         Price::from("1.000"),
-        InstrumentCloseType::ContractExpired,
-        UnixNanos::from(200),
-        UnixNanos::from(200),
-    );
-    msgbus::publish_any(
-        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
-        &close,
+        200,
     );
 
-    assert_eq!(client.matching_engine_count(), 1);
-    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+    assert_eq!(harness.client.matching_engine_count(), 1);
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_some()
+    );
 
-    let closed = settle_position_from_expiration_fill(&cache, &position, &mut rx);
-    assert!(!cache.borrow().has_orders_open(
+    let closed = settle_position_from_expiration_fill(&harness.cache, &position, &mut harness.rx);
+    assert!(!harness.cache.borrow().has_orders_open(
         Some(&venue),
-        Some(&instrument.id()),
+        Some(&harness.instrument.id()),
         None,
         None,
         None,
     ));
-    assert!(!cache.borrow().has_positions_open(
+    assert!(!harness.cache.borrow().has_positions_open(
         Some(&venue),
-        Some(&instrument.id()),
+        Some(&harness.instrument.id()),
         None,
         None,
         None,
@@ -1245,9 +1250,9 @@ fn test_instrument_close_keeps_engine_until_position_closed(
         &position_closed_event(&closed, account_id),
     );
 
-    assert_eq!(client.matching_engine_count(), 0);
+    assert_eq!(harness.client.matching_engine_count(), 0);
 
-    client.stop().unwrap();
+    harness.client.stop().unwrap();
 }
 
 #[rstest]
@@ -1255,75 +1260,106 @@ fn test_position_closed_finalize_ignores_other_account(trader_id: TraderId, acco
     *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
     setup_order_event_handler();
 
-    let instrument = make_binary_option_instrument("0xACCOUNT", "0xYES", "Yes", 100);
-    let venue = instrument.id().venue;
-    let cache = Rc::new(RefCell::new(Cache::default()));
-    let test_clock = Rc::new(RefCell::new(TestClock::new()));
-    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
-    let config = create_config(trader_id, account_id, venue);
-    let core = ExecutionClientCore::new(
-        config.trader_id,
-        ClientId::new("SANDBOX"),
-        config.venue,
-        config.oms_type,
-        config.account_id,
-        config.account_type,
-        config.base_currency,
-        cache.clone(),
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id,
+        account_id,
+        "0xACCOUNT",
+        "0xYES",
+        "Yes",
+        100,
     );
-    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
-
-    set_exec_event_sender(tx);
-    cache
-        .borrow_mut()
-        .add_instrument(instrument.clone())
-        .unwrap();
-    client.start().unwrap();
-    client
-        .process_quote_tick(&create_binary_option_quote(instrument.id()))
-        .unwrap();
 
     let position = submit_open_position_and_seed_cache(
-        &client,
-        &cache,
+        &harness.client,
+        &harness.cache,
         trader_id,
-        &instrument,
+        &harness.instrument,
         "OPEN-ACCOUNT",
         "P-OPEN-ACCOUNT",
-        &mut rx,
+        &mut harness.rx,
     );
-    cache
+    harness
+        .cache
         .borrow_mut()
         .add_position(&position, OmsType::Netting)
         .unwrap();
 
-    let _ = test_clock
-        .borrow_mut()
-        .advance_time(UnixNanos::from(200), true);
-
-    let close = InstrumentClose::new(
-        instrument.id(),
+    publish_expired_close(
+        &harness.test_clock,
+        &harness.instrument,
         Price::from("1.000"),
-        InstrumentCloseType::ContractExpired,
-        UnixNanos::from(200),
-        UnixNanos::from(200),
-    );
-    msgbus::publish_any(
-        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
-        &close,
+        200,
     );
 
-    let closed = settle_position_from_expiration_fill(&cache, &position, &mut rx);
+    let closed = settle_position_from_expiration_fill(&harness.cache, &position, &mut harness.rx);
     msgbus::publish_position_event(
         "events.position.TEST".into(),
         &position_closed_event(&closed, AccountId::from("OTHER-001")),
     );
 
-    assert_eq!(client.matching_engine_count(), 1);
-    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+    assert_eq!(harness.client.matching_engine_count(), 1);
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_some()
+    );
 
-    client.stop().unwrap();
+    harness.client.stop().unwrap();
+}
+
+#[rstest]
+fn test_position_closed_does_not_purge_non_expired_instrument(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id, account_id, "0xACTIVE", "0xYES", "Yes", 1_000,
+    );
+
+    let position = submit_open_position_and_seed_cache(
+        &harness.client,
+        &harness.cache,
+        trader_id,
+        &harness.instrument,
+        "OPEN-ACTIVE",
+        "P-ACTIVE",
+        &mut harness.rx,
+    );
+    harness
+        .cache
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
+
+    let mut closed = position;
+    closed.side = PositionSide::Flat;
+    closed.ts_closed = Some(closed.ts_last);
+    harness.cache.borrow_mut().update_position(&closed).unwrap();
+
+    msgbus::publish_position_event(
+        "events.position.TEST".into(),
+        &position_closed_event(&closed, account_id),
+    );
+
+    assert_eq!(
+        harness.client.matching_engine_count(),
+        1,
+        "non-expired position close should not release sandbox matching engines",
+    );
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_some()
+    );
+
+    harness.client.stop().unwrap();
 }
 
 #[rstest]
@@ -1334,38 +1370,19 @@ fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_a
     *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
     setup_order_event_handler();
 
-    let instrument = make_binary_option_instrument("0xRESTING", "0xYES", "Yes", 100);
-    let venue = instrument.id().venue;
-    let cache = Rc::new(RefCell::new(Cache::default()));
-    let test_clock = Rc::new(RefCell::new(TestClock::new()));
-    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
-    let config = create_config(trader_id, account_id, venue);
-    let core = ExecutionClientCore::new(
-        config.trader_id,
-        ClientId::new("SANDBOX"),
-        config.venue,
-        config.oms_type,
-        config.account_id,
-        config.account_type,
-        config.base_currency,
-        cache.clone(),
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id,
+        account_id,
+        "0xRESTING",
+        "0xYES",
+        "Yes",
+        100,
     );
-    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
-
-    set_exec_event_sender(tx);
-    cache
-        .borrow_mut()
-        .add_instrument(instrument.clone())
-        .unwrap();
-    client.start().unwrap();
-    client
-        .process_quote_tick(&create_binary_option_quote(instrument.id()))
-        .unwrap();
-    assert_eq!(client.matching_engine_count(), 1);
+    let venue = harness.instrument.id().venue;
+    assert_eq!(harness.client.matching_engine_count(), 1);
 
     let resting_order = OrderTestBuilder::new(OrderType::Limit)
-        .instrument_id(instrument.id())
+        .instrument_id(harness.instrument.id())
         .side(OrderSide::Buy)
         .price(Price::from("0.050"))
         .quantity(Quantity::from("1.00"))
@@ -1373,22 +1390,24 @@ fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_a
         .ts_init(UnixNanos::from(20))
         .submit(true)
         .build();
-    cache
+    harness
+        .cache
         .borrow_mut()
         .add_order(resting_order.clone(), None, None, false)
         .unwrap();
-    client
+    harness
+        .client
         .submit_order(SubmitOrder::from_order(
             &resting_order,
             trader_id,
-            Some(client.client_id()),
+            Some(harness.client.client_id()),
             None,
             UUID4::new(),
             UnixNanos::from(20),
         ))
         .unwrap();
 
-    let order_events = apply_order_events_from_channel(&cache, &mut rx);
+    let order_events = apply_order_events_from_channel(&harness.cache, &mut harness.rx);
     assert!(
         order_events
             .iter()
@@ -1396,36 +1415,35 @@ fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_a
                 if accepted.client_order_id.as_str() == "REST-CLOSE-ONLY")),
         "expected resting order acceptance before expiration",
     );
-    assert!(
-        cache
-            .borrow()
-            .has_orders_open(Some(&venue), Some(&instrument.id()), None, None, None,)
-    );
+    assert!(harness.cache.borrow().has_orders_open(
+        Some(&venue),
+        Some(&harness.instrument.id()),
+        None,
+        None,
+        None,
+    ));
 
-    let _ = test_clock
-        .borrow_mut()
-        .advance_time(UnixNanos::from(200), true);
-
-    let close = InstrumentClose::new(
-        instrument.id(),
+    publish_expired_close(
+        &harness.test_clock,
+        &harness.instrument,
         Price::from("1.000"),
-        InstrumentCloseType::ContractExpired,
-        UnixNanos::from(200),
-        UnixNanos::from(200),
-    );
-    msgbus::publish_any(
-        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
-        &close,
+        200,
     );
 
     assert_eq!(
-        client.matching_engine_count(),
+        harness.client.matching_engine_count(),
         0,
         "order-only expired instruments should release their matching engine immediately",
     );
-    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_none()
+    );
 
-    let order_events = apply_order_events_from_channel(&cache, &mut rx);
+    let order_events = apply_order_events_from_channel(&harness.cache, &mut harness.rx);
     assert!(
         order_events
             .iter()
@@ -1433,21 +1451,160 @@ fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_a
                 if canceled.client_order_id.as_str() == "REST-CLOSE-ONLY")),
         "expected expiration to cancel the resting order",
     );
-    assert!(!cache.borrow().has_orders_open(
+    assert!(!harness.cache.borrow().has_orders_open(
         Some(&venue),
-        Some(&instrument.id()),
+        Some(&harness.instrument.id()),
         None,
         None,
         None,
     ));
     assert_eq!(
-        client.matching_engine_count(),
+        harness.client.matching_engine_count(),
         0,
         "cancellation replay should not recreate engine retention after close",
     );
-    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_none()
+    );
 
-    client.stop().unwrap();
+    harness.client.stop().unwrap();
+}
+
+#[rstest]
+fn test_local_expiry_removes_resting_order_only_engine_before_cancel_event_applies(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let mut harness = setup_binary_option_lifecycle_harness(
+        trader_id,
+        account_id,
+        "0xLOCAL-REST",
+        "0xYES",
+        "Yes",
+        100,
+    );
+    let venue = harness.instrument.id().venue;
+    assert_eq!(harness.client.matching_engine_count(), 1);
+
+    let resting_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(harness.instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("0.050"))
+        .quantity(Quantity::from("1.00"))
+        .client_order_id("REST-LOCAL-ONLY".into())
+        .ts_init(UnixNanos::from(20))
+        .submit(true)
+        .build();
+    harness
+        .cache
+        .borrow_mut()
+        .add_order(resting_order.clone(), None, None, false)
+        .unwrap();
+    harness
+        .client
+        .submit_order(SubmitOrder::from_order(
+            &resting_order,
+            trader_id,
+            Some(harness.client.client_id()),
+            None,
+            UUID4::new(),
+            UnixNanos::from(20),
+        ))
+        .unwrap();
+
+    let order_events = apply_order_events_from_channel(&harness.cache, &mut harness.rx);
+    assert!(
+        order_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Accepted(accepted)
+                if accepted.client_order_id.as_str() == "REST-LOCAL-ONLY")),
+        "expected resting order acceptance before local expiry",
+    );
+    assert!(harness.cache.borrow().has_orders_open(
+        Some(&venue),
+        Some(&harness.instrument.id()),
+        None,
+        None,
+        None,
+    ));
+
+    let _ = harness
+        .test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let probe_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(harness.instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("0.050"))
+        .quantity(Quantity::from("1.00"))
+        .client_order_id("PROBE-LOCAL-ONLY".into())
+        .ts_init(UnixNanos::from(200))
+        .submit(true)
+        .build();
+    harness
+        .cache
+        .borrow_mut()
+        .add_order(probe_order.clone(), None, None, false)
+        .unwrap();
+    harness
+        .client
+        .submit_order(SubmitOrder::from_order(
+            &probe_order,
+            trader_id,
+            Some(harness.client.client_id()),
+            None,
+            UUID4::new(),
+            UnixNanos::from(200),
+        ))
+        .unwrap();
+
+    assert_eq!(
+        harness.client.matching_engine_count(),
+        0,
+        "local expiry should release the engine before cancel/reject events apply",
+    );
+    assert!(
+        harness
+            .cache
+            .borrow()
+            .instrument(&harness.instrument.id())
+            .is_none()
+    );
+
+    let order_events = apply_order_events_from_channel(&harness.cache, &mut harness.rx);
+    assert!(
+        order_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Canceled(canceled)
+                if canceled.client_order_id.as_str() == "REST-LOCAL-ONLY")),
+        "expected local expiry to cancel the resting order",
+    );
+    assert!(
+        order_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Rejected(rejected)
+                if rejected.client_order_id.as_str() == "PROBE-LOCAL-ONLY"
+                    && rejected.reason.as_str().contains("pending resolution"))),
+        "expected local expiry to reject new orders while pending resolution",
+    );
+    assert!(!harness.cache.borrow().has_orders_open(
+        Some(&venue),
+        Some(&harness.instrument.id()),
+        None,
+        None,
+        None,
+    ));
+    assert_eq!(harness.client.matching_engine_count(), 0);
+
+    harness.client.stop().unwrap();
 }
 
 #[rstest]

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -43,9 +43,9 @@ use nautilus_model::{
     data::{Bar, BarType, Data, InstrumentClose, InstrumentStatus, QuoteTick, TradeTick},
     enums::{
         AccountType, AggressorSide, BookType, InstrumentCloseType, MarketStatusAction, OmsType,
-        OrderSide, OrderType,
+        OrderSide, OrderType, PositionSide,
     },
-    events::{AccountState, OrderEventAny, OrderFilled},
+    events::{AccountState, OrderEventAny, OrderFilled, PositionClosed, PositionEvent},
     identifiers::{AccountId, ClientId, InstrumentId, PositionId, TradeId, TraderId, Venue},
     instruments::{
         CryptoPerpetual, Instrument, InstrumentAny,
@@ -244,6 +244,128 @@ fn make_binary_option_instrument(
     binary.expiration_ns = UnixNanos::from(expiration_ns);
     binary.outcome = Some(Ustr::from(outcome));
     InstrumentAny::BinaryOption(binary)
+}
+
+fn create_binary_option_quote(instrument_id: InstrumentId) -> QuoteTick {
+    QuoteTick::new(
+        instrument_id,
+        Price::new(0.40, 3),
+        Price::new(0.41, 3),
+        Quantity::new(100.0, 2),
+        Quantity::new(100.0, 2),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
+}
+
+fn submit_open_position_and_seed_cache(
+    client: &SandboxExecutionClient,
+    cache: &Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    instrument: &InstrumentAny,
+    client_order_id: &str,
+    position_id: &str,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+) -> Position {
+    submit_market_open_order(client, cache, trader_id, instrument, client_order_id, 10);
+
+    let mut filled = None;
+
+    for event in std::iter::from_fn(|| rx.try_recv().ok()) {
+        let ExecutionEvent::Order(OrderEventAny::Filled(fill)) = event else {
+            continue;
+        };
+
+        if fill.client_order_id.as_str() == client_order_id {
+            filled = Some(fill);
+            break;
+        }
+    }
+
+    let fill_event =
+        OrderEventAny::Filled(filled.expect("expected opening fill from sandbox market order"));
+    cache.borrow_mut().update_order(&fill_event).unwrap();
+
+    let OrderEventAny::Filled(mut filled) = fill_event else {
+        unreachable!("constructed filled order event");
+    };
+    filled.position_id = Some(PositionId::new(position_id));
+    Position::new(instrument, filled)
+}
+
+fn position_closed_event(position: &Position, account_id: AccountId) -> PositionEvent {
+    PositionEvent::PositionClosed(PositionClosed {
+        trader_id: position.trader_id,
+        strategy_id: position.strategy_id,
+        instrument_id: position.instrument_id,
+        position_id: position.id,
+        account_id,
+        opening_order_id: position.opening_order_id,
+        closing_order_id: position.closing_order_id,
+        entry: position.entry,
+        side: PositionSide::Flat,
+        signed_qty: 0.0,
+        quantity: Quantity::zero(position.size_precision),
+        peak_quantity: position.peak_qty,
+        last_qty: Quantity::zero(position.size_precision),
+        last_px: Price::zero(position.price_precision),
+        currency: position.quote_currency,
+        avg_px_open: position.avg_px_open,
+        avg_px_close: position.avg_px_close,
+        realized_return: position.realized_return,
+        realized_pnl: position.realized_pnl,
+        unrealized_pnl: Money::zero(position.quote_currency),
+        duration: 1,
+        event_id: UUID4::new(),
+        ts_opened: position.ts_opened,
+        ts_closed: position.ts_closed.or(Some(position.ts_last)),
+        ts_event: position.ts_last,
+        ts_init: position.ts_last,
+    })
+}
+
+fn settle_position_from_expiration_fill(
+    cache: &Rc<RefCell<Cache>>,
+    position: &Position,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+) -> Position {
+    let mut expiration_fill = None;
+
+    for event in std::iter::from_fn(|| rx.try_recv().ok()) {
+        let ExecutionEvent::Order(OrderEventAny::Filled(fill)) = event else {
+            continue;
+        };
+
+        if fill.client_order_id.as_str().starts_with("EXPIRATION-") {
+            expiration_fill = Some(fill);
+            break;
+        }
+    }
+
+    let expiration_fill = expiration_fill.expect("expected expiration fill after InstrumentClose");
+
+    let mut closed = position.clone();
+    closed.apply(&expiration_fill);
+    cache.borrow_mut().update_position(&closed).unwrap();
+    closed
+}
+
+fn apply_order_events_from_channel(
+    cache: &Rc<RefCell<Cache>>,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+) -> Vec<OrderEventAny> {
+    let mut order_events = Vec::new();
+
+    for event in std::iter::from_fn(|| rx.try_recv().ok()) {
+        let ExecutionEvent::Order(order_event) = event else {
+            continue;
+        };
+
+        let _ = cache.borrow_mut().update_order(&order_event);
+        order_events.push(order_event);
+    }
+
+    order_events
 }
 
 fn seed_binary_option_position_from_fill(
@@ -972,6 +1094,360 @@ fn test_instrument_status_lazy_creates_but_close_requires_existing_engine(
         1,
         "InstrumentClose should not lazy-create a matching engine from cache",
     );
+}
+
+#[rstest]
+fn test_instrument_close_finalizes_expired_engine_without_open_state(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let instrument = make_binary_option_instrument("0xFINALIZE", "0xYES", "Yes", 100);
+    let venue = instrument.id().venue;
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let test_clock = Rc::new(RefCell::new(TestClock::new()));
+    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+    let config = create_config(trader_id, account_id, venue);
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+
+    cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    client.start().unwrap();
+    client
+        .process_quote_tick(&create_binary_option_quote(instrument.id()))
+        .unwrap();
+    assert_eq!(client.matching_engine_count(), 1);
+
+    let _ = test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let close = InstrumentClose::new(
+        instrument.id(),
+        Price::from("1.000"),
+        InstrumentCloseType::ContractExpired,
+        UnixNanos::from(200),
+        UnixNanos::from(200),
+    );
+    msgbus::publish_any(
+        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
+        &close,
+    );
+
+    assert_eq!(client.matching_engine_count(), 0);
+    assert!(cache.borrow().instrument(&instrument.id()).is_none());
+
+    client.stop().unwrap();
+}
+
+#[rstest]
+fn test_instrument_close_keeps_engine_until_position_closed(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let instrument = make_binary_option_instrument("0xSETTLE", "0xYES", "Yes", 100);
+    let venue = instrument.id().venue;
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let test_clock = Rc::new(RefCell::new(TestClock::new()));
+    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+    let config = create_config(trader_id, account_id, venue);
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+
+    set_exec_event_sender(tx);
+    cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    client.start().unwrap();
+    client
+        .process_quote_tick(&create_binary_option_quote(instrument.id()))
+        .unwrap();
+    assert_eq!(client.matching_engine_count(), 1);
+
+    let position = submit_open_position_and_seed_cache(
+        &client,
+        &cache,
+        trader_id,
+        &instrument,
+        "OPEN-POSITION",
+        "P-OPEN-POSITION",
+        &mut rx,
+    );
+    cache
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
+
+    let _ = test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let close = InstrumentClose::new(
+        instrument.id(),
+        Price::from("1.000"),
+        InstrumentCloseType::ContractExpired,
+        UnixNanos::from(200),
+        UnixNanos::from(200),
+    );
+    msgbus::publish_any(
+        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
+        &close,
+    );
+
+    assert_eq!(client.matching_engine_count(), 1);
+    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+
+    let closed = settle_position_from_expiration_fill(&cache, &position, &mut rx);
+    assert!(!cache.borrow().has_orders_open(
+        Some(&venue),
+        Some(&instrument.id()),
+        None,
+        None,
+        None,
+    ));
+    assert!(!cache.borrow().has_positions_open(
+        Some(&venue),
+        Some(&instrument.id()),
+        None,
+        None,
+        None,
+    ));
+    msgbus::publish_position_event(
+        "events.position.TEST".into(),
+        &position_closed_event(&closed, account_id),
+    );
+
+    assert_eq!(client.matching_engine_count(), 0);
+
+    client.stop().unwrap();
+}
+
+#[rstest]
+fn test_position_closed_finalize_ignores_other_account(trader_id: TraderId, account_id: AccountId) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let instrument = make_binary_option_instrument("0xACCOUNT", "0xYES", "Yes", 100);
+    let venue = instrument.id().venue;
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let test_clock = Rc::new(RefCell::new(TestClock::new()));
+    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+    let config = create_config(trader_id, account_id, venue);
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+
+    set_exec_event_sender(tx);
+    cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    client.start().unwrap();
+    client
+        .process_quote_tick(&create_binary_option_quote(instrument.id()))
+        .unwrap();
+
+    let position = submit_open_position_and_seed_cache(
+        &client,
+        &cache,
+        trader_id,
+        &instrument,
+        "OPEN-ACCOUNT",
+        "P-OPEN-ACCOUNT",
+        &mut rx,
+    );
+    cache
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
+
+    let _ = test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let close = InstrumentClose::new(
+        instrument.id(),
+        Price::from("1.000"),
+        InstrumentCloseType::ContractExpired,
+        UnixNanos::from(200),
+        UnixNanos::from(200),
+    );
+    msgbus::publish_any(
+        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
+        &close,
+    );
+
+    let closed = settle_position_from_expiration_fill(&cache, &position, &mut rx);
+    msgbus::publish_position_event(
+        "events.position.TEST".into(),
+        &position_closed_event(&closed, AccountId::from("OTHER-001")),
+    );
+
+    assert_eq!(client.matching_engine_count(), 1);
+    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+
+    client.stop().unwrap();
+}
+
+#[rstest]
+fn test_instrument_close_removes_resting_order_only_engine_before_cancel_event_applies(
+    trader_id: TraderId,
+    account_id: AccountId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    setup_order_event_handler();
+
+    let instrument = make_binary_option_instrument("0xRESTING", "0xYES", "Yes", 100);
+    let venue = instrument.id().venue;
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let test_clock = Rc::new(RefCell::new(TestClock::new()));
+    let clock: Rc<RefCell<dyn Clock>> = test_clock.clone();
+    let config = create_config(trader_id, account_id, venue);
+    let core = ExecutionClientCore::new(
+        config.trader_id,
+        ClientId::new("SANDBOX"),
+        config.venue,
+        config.oms_type,
+        config.account_id,
+        config.account_type,
+        config.base_currency,
+        cache.clone(),
+    );
+    let mut client = SandboxExecutionClient::new(core, config, clock, cache.clone());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+
+    set_exec_event_sender(tx);
+    cache
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    client.start().unwrap();
+    client
+        .process_quote_tick(&create_binary_option_quote(instrument.id()))
+        .unwrap();
+    assert_eq!(client.matching_engine_count(), 1);
+
+    let resting_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("0.050"))
+        .quantity(Quantity::from("1.00"))
+        .client_order_id("REST-CLOSE-ONLY".into())
+        .ts_init(UnixNanos::from(20))
+        .submit(true)
+        .build();
+    cache
+        .borrow_mut()
+        .add_order(resting_order.clone(), None, None, false)
+        .unwrap();
+    client
+        .submit_order(SubmitOrder::from_order(
+            &resting_order,
+            trader_id,
+            Some(client.client_id()),
+            None,
+            UUID4::new(),
+            UnixNanos::from(20),
+        ))
+        .unwrap();
+
+    let order_events = apply_order_events_from_channel(&cache, &mut rx);
+    assert!(
+        order_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Accepted(accepted)
+                if accepted.client_order_id.as_str() == "REST-CLOSE-ONLY")),
+        "expected resting order acceptance before expiration",
+    );
+    assert!(
+        cache
+            .borrow()
+            .has_orders_open(Some(&venue), Some(&instrument.id()), None, None, None,)
+    );
+
+    let _ = test_clock
+        .borrow_mut()
+        .advance_time(UnixNanos::from(200), true);
+
+    let close = InstrumentClose::new(
+        instrument.id(),
+        Price::from("1.000"),
+        InstrumentCloseType::ContractExpired,
+        UnixNanos::from(200),
+        UnixNanos::from(200),
+    );
+    msgbus::publish_any(
+        nautilus_common::msgbus::switchboard::get_instrument_close_topic(instrument.id()),
+        &close,
+    );
+
+    assert_eq!(
+        client.matching_engine_count(),
+        0,
+        "order-only expired instruments should release their matching engine immediately",
+    );
+    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+
+    let order_events = apply_order_events_from_channel(&cache, &mut rx);
+    assert!(
+        order_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Canceled(canceled)
+                if canceled.client_order_id.as_str() == "REST-CLOSE-ONLY")),
+        "expected expiration to cancel the resting order",
+    );
+    assert!(!cache.borrow().has_orders_open(
+        Some(&venue),
+        Some(&instrument.id()),
+        None,
+        None,
+        None,
+    ));
+    assert_eq!(
+        client.matching_engine_count(),
+        0,
+        "cancellation replay should not recreate engine retention after close",
+    );
+    assert!(cache.borrow().instrument(&instrument.id()).is_some());
+
+    client.stop().unwrap();
 }
 
 #[rstest]

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -1474,7 +1474,7 @@ impl Cache {
     /// other actor, strategy, or engine still relies on may cause incorrect behavior
     /// (missing instrument lookups, lost market-data history). The caller is
     /// responsible for ensuring the instrument is no longer in use before purging.
-    pub fn purge_instrument(&mut self, instrument_id: InstrumentId) {
+    fn purge_instrument_inner(&mut self, instrument_id: InstrumentId, skip_order_guard: bool) {
         #[cfg(feature = "defi")]
         let defi_found = self.defi.pools.contains_key(&instrument_id)
             || self.defi.pool_profilers.contains_key(&instrument_id);
@@ -1490,7 +1490,8 @@ impl Cache {
             return;
         }
 
-        if let Some(orders) = self.index.instrument_orders.get(&instrument_id) {
+        if !skip_order_guard && let Some(orders) = self.index.instrument_orders.get(&instrument_id)
+        {
             let has_non_terminal = orders
                 .iter()
                 .any(|client_order_id| !self.index.orders_closed.contains(client_order_id));
@@ -1542,6 +1543,21 @@ impl Cache {
         self.index.instrument_positions.remove(&instrument_id);
 
         log::info!("Purged instrument {instrument_id}");
+    }
+
+    pub fn purge_instrument(&mut self, instrument_id: InstrumentId) {
+        self.purge_instrument_inner(instrument_id, false);
+    }
+
+    /// Purges the instrument with the `instrument_id` from the cache while skipping the
+    /// non-terminal order guard.
+    ///
+    /// This still refuses to purge when any associated position is non-closed. Intended
+    /// for actors which own an instrument-expiration lifecycle and have already invalidated
+    /// any remaining order state externally, but may still observe order-terminal events
+    /// arriving later than the cleanup decision.
+    pub fn purge_instrument_skip_order_guard(&mut self, instrument_id: InstrumentId) {
+        self.purge_instrument_inner(instrument_id, true);
     }
 
     /// Purges all account state events which are outside the lookback window.

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -1545,6 +1545,10 @@ impl Cache {
         log::info!("Purged instrument {instrument_id}");
     }
 
+    /// Purges the instrument with the `instrument_id` from the cache.
+    ///
+    /// This refuses to purge when associated orders or positions remain in
+    /// non-terminal state.
     pub fn purge_instrument(&mut self, instrument_id: InstrumentId) {
         self.purge_instrument_inner(instrument_id, false);
     }
@@ -1555,7 +1559,8 @@ impl Cache {
     /// This still refuses to purge when any associated position is non-closed. Intended
     /// for actors which own an instrument-expiration lifecycle and have already invalidated
     /// any remaining order state externally, but may still observe order-terminal events
-    /// arriving later than the cleanup decision.
+    /// arriving later than the cleanup decision. During that window, the order objects may
+    /// still exist even though `instrument_orders` is removed from the cache index.
     pub fn purge_instrument_skip_order_guard(&mut self, instrument_id: InstrumentId) {
         self.purge_instrument_inner(instrument_id, true);
     }

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -3878,6 +3878,42 @@ fn test_purge_instrument_refuses_when_orders_open() {
 }
 
 #[rstest]
+fn test_purge_instrument_skip_order_guard_allows_orders_open() {
+    let mut cache = Cache::default();
+    let audusd_sim = audusd_sim();
+    let instrument_id = audusd_sim.id;
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+
+    cache.add_instrument(instrument).unwrap();
+
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+
+    update_order_with_event(
+        &mut cache,
+        &mut order,
+        OrderEventAny::Submitted(OrderSubmitted::default()),
+    );
+    update_order_with_event(
+        &mut cache,
+        &mut order,
+        OrderEventAny::Accepted(OrderAccepted::default()),
+    );
+    assert!(order.is_open());
+
+    cache.purge_instrument_skip_order_guard(instrument_id);
+
+    assert!(cache.instrument(&instrument_id).is_none());
+    assert!(!cache.index.instrument_orders.contains_key(&instrument_id));
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
 fn test_purge_instrument_refuses_when_orders_initialized_but_not_open() {
     // Regression: orders in non-terminal states like INITIALIZED/SUBMITTED are not in
     // `orders_open`, but purging would still leave them dangling without an instrument.

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -1834,6 +1834,109 @@ fn test_process_same_side_fill_publishes_position_changed_after_order_topic(
 }
 
 #[rstest]
+fn test_process_closing_fill_updates_cache_before_publishing_position_closed(
+    mut execution_engine: ExecutionEngine,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let (instrument, opening_order) = prepare_accepted_order(&mut execution_engine);
+    let opening_fill = OrderEventAny::Filled(build_order_filled(
+        opening_order.trader_id(),
+        opening_order.strategy_id(),
+        instrument.id(),
+        opening_order.client_order_id(),
+        VenueOrderId::from("V-001"),
+        AccountId::test_default(),
+        TradeId::new("T-OPEN"),
+        opening_order.order_side(),
+        opening_order.order_type(),
+        opening_order.quantity(),
+        Price::from_str("1.0").unwrap(),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        Some(Money::from("1 USD")),
+    ));
+    execution_engine.process(&opening_fill);
+
+    let closing_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(opening_order.trader_id())
+        .strategy_id(opening_order.strategy_id())
+        .instrument_id(instrument.id())
+        .client_order_id(ClientOrderId::from("O-19700101-000000-001-001-2"))
+        .side(OrderSide::Sell)
+        .quantity(opening_order.quantity())
+        .build();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            closing_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+
+    let closing_submitted =
+        TestOrderEventStubs::submitted(&closing_order, AccountId::test_default());
+    execution_engine.process(&closing_submitted);
+    let closing_accepted = TestOrderEventStubs::accepted(
+        &closing_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-002"),
+    );
+    execution_engine.process(&closing_accepted);
+
+    let position_topic = switchboard::get_event_positions_topic(closing_order.strategy_id());
+    let instrument_id = instrument.id();
+    let venue = instrument_id.venue;
+    let account_id = AccountId::test_default();
+    let observed_cache_open = Rc::new(RefCell::new(Vec::<bool>::new()));
+    let position_handler = TypedHandler::from({
+        let cache = Rc::clone(execution_engine.cache());
+        let observed_cache_open = observed_cache_open.clone();
+        move |event: &PositionEvent| {
+            if matches!(event, PositionEvent::PositionClosed(_)) {
+                observed_cache_open
+                    .borrow_mut()
+                    .push(cache.borrow().has_positions_open(
+                        Some(&venue),
+                        Some(&instrument_id),
+                        None,
+                        Some(&account_id),
+                        None,
+                    ));
+            }
+        }
+    });
+    msgbus::subscribe_position_events(position_topic.into(), position_handler.clone(), None);
+
+    let closing_fill = OrderEventAny::Filled(build_order_filled(
+        closing_order.trader_id(),
+        closing_order.strategy_id(),
+        instrument_id,
+        closing_order.client_order_id(),
+        VenueOrderId::from("V-002"),
+        account_id,
+        TradeId::new("T-CLOSE"),
+        closing_order.order_side(),
+        closing_order.order_type(),
+        closing_order.quantity(),
+        Price::from_str("1.0").unwrap(),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        Some(Money::from("1 USD")),
+    ));
+
+    execution_engine.process(&closing_fill);
+    msgbus::unsubscribe_position_events(position_topic.into(), &position_handler);
+
+    assert_eq!(observed_cache_open.borrow().as_slice(), &[false]);
+}
+
+#[rstest]
 fn test_process_leg_fill_without_order_updates_position_and_publishes_order_before_position(
     mut execution_engine: ExecutionEngine,
 ) {


### PR DESCRIPTION
Related to #4253

## Summary
- clean up sandbox expired instruments immediately once they are expired and have no open positions
- retain expired instruments with open positions until settlement completes, then retry cleanup on `PositionClosed`
- treat delayed order-terminal cache updates as non-owning in the sandbox expiry path via a narrow `purge_instrument_skip_order_guard(...)` cache helper
- add regression coverage across sandbox, cache, and execution-engine layers for expiry cleanup and position-close ordering

## Why
PR2 narrowed Polymarket adapter retention boundaries. PR3 closes the equivalent sandbox paper-trading lifecycle gap without introducing an extra `events.order.*` retry path.

In the sandbox expiry pipeline:
- `InstrumentClose` (or local expiry fallback) cancels resting orders and blocks new orders
- order state may still be converging asynchronously in the cache
- open positions remain the real owner until settlement closes them

So this PR draws the owner boundary explicitly:
- expired + no open position: release the matching engine and purge the instrument immediately
- expired + open position: keep the instrument alive until settlement, then retry cleanup on `PositionClosed`
- order state no longer blocks expired cleanup in the no-position path

## Design Notes
- sandbox cleanup now keys off factual instrument expiry (`expiration_ns <= now`) rather than matching-engine internal expiration-processing state
- `PositionClosed` retry remains guarded by the execution-engine contract that cache position state is updated before the event is published
- cache-level `purge_instrument_skip_order_guard(...)` is intentionally narrow and still preserves the position guard

## Tests
- `cargo test -p nautilus-common test_purge_instrument_skip_order_guard_allows_orders_open -- --nocapture`
- `cargo test -p nautilus-execution --test exec_engine test_process_closing_fill_updates_cache_before_publishing_position_closed -- --nocapture`
- `cargo test -p nautilus-sandbox --test execution -- --nocapture`
- `pre-commit run --files crates/adapters/sandbox/src/execution.rs crates/adapters/sandbox/tests/execution.rs crates/common/src/cache/mod.rs crates/common/src/cache/tests.rs crates/execution/tests/exec_engine.rs`
