### PR TITLE
Fix NETTING account-currency trade PnL stats

### DIFF
--- a/crates/analysis/src/analyzer.rs
+++ b/crates/analysis/src/analyzer.rs
@@ -62,7 +62,7 @@ pub struct PortfolioAnalyzer {
     pub account_balances: IndexMap<Currency, Money>,
     pub positions: Vec<Position>,
     pub realized_pnls: AHashMap<Currency, Vec<(PositionId, f64)>>,
-    pub recorded_realized_pnls: AHashMap<Currency, IndexMap<PositionId, f64>>,
+    pub recorded_realized_pnls: AHashMap<Currency, Vec<(PositionId, f64)>>,
     pub position_returns: Returns,
     pub portfolio_returns: Returns,
     /// Alias for the primary returns source.
@@ -225,7 +225,7 @@ impl PortfolioAnalyzer {
     pub fn record_trade(&mut self, position_id: &PositionId, pnl: &Money) {
         let currency = pnl.currency;
         let entry = self.recorded_realized_pnls.entry(currency).or_default();
-        entry.insert(*position_id, pnl.as_f64());
+        entry.push((*position_id, pnl.as_f64()));
     }
 
     /// Records a position return at a specific timestamp.
@@ -333,12 +333,14 @@ impl PortfolioAnalyzer {
         (!returns.is_empty()).then_some(returns)
     }
 
-    /// Retrieves realized PnLs for a specific currency.
+    /// Retrieves trade PnL records for a specific currency.
+    ///
+    /// Duplicate position IDs are preserved for NETTING position cycles.
     ///
     /// Returns `None` if no PnLs exist, or if multiple currencies exist
     /// without an explicit currency specified.
     #[must_use]
-    pub fn realized_pnls(&self, currency: Option<&Currency>) -> Option<Vec<(PositionId, f64)>> {
+    pub fn trade_pnl_records(&self, currency: Option<&Currency>) -> Option<Vec<(PositionId, f64)>> {
         if self.realized_pnls.is_empty() && self.recorded_realized_pnls.is_empty() {
             return None;
         }
@@ -365,22 +367,31 @@ impl PortfolioAnalyzer {
         match (realized_pnls, recorded_realized_pnls) {
             (None, None) => None,
             (Some(realized_pnls), None) => Some(realized_pnls.clone()),
-            (None, Some(recorded_realized_pnls)) => Some(
-                recorded_realized_pnls
-                    .iter()
-                    .map(|(position_id, pnl)| (*position_id, *pnl))
-                    .collect(),
-            ),
+            (None, Some(recorded_realized_pnls)) => Some(recorded_realized_pnls.clone()),
             (Some(realized_pnls), Some(recorded_realized_pnls)) => {
-                let mut output: IndexMap<PositionId, f64> = realized_pnls.iter().copied().collect();
+                let recorded_position_ids: IndexSet<PositionId> = recorded_realized_pnls
+                    .iter()
+                    .map(|(position_id, _)| *position_id)
+                    .collect();
+                let mut output: Vec<(PositionId, f64)> = realized_pnls
+                    .iter()
+                    .copied()
+                    .filter(|(position_id, _)| !recorded_position_ids.contains(position_id))
+                    .collect();
+                output.extend(recorded_realized_pnls.iter().copied());
 
-                for (position_id, pnl) in recorded_realized_pnls {
-                    output.insert(*position_id, *pnl);
-                }
-
-                Some(output.into_iter().collect())
+                Some(output)
             }
         }
+    }
+
+    /// Retrieves realized PnLs for a specific currency.
+    ///
+    /// Returns `None` if no PnLs exist, or if multiple currencies exist
+    /// without an explicit currency specified.
+    #[must_use]
+    pub fn realized_pnls(&self, currency: Option<&Currency>) -> Option<Vec<(PositionId, f64)>> {
+        self.trade_pnl_records(currency)
     }
 
     /// Calculates total PnL including unrealized PnL if provided.
@@ -512,10 +523,10 @@ impl PortfolioAnalyzer {
             self.total_pnl_percentage(currency, unrealized_pnl)?,
         );
 
-        if let Some(realized_pnls) = self.realized_pnls(currency) {
+        if let Some(trade_pnl_records) = self.trade_pnl_records(currency) {
             for (name, stat) in &self.statistics {
                 if let Some(value) = stat.calculate_from_realized_pnls(
-                    &realized_pnls
+                    &trade_pnl_records
                         .iter()
                         .map(|(_, pnl)| *pnl)
                         .collect::<Vec<f64>>(),
@@ -1059,6 +1070,22 @@ mod tests {
     }
 
     #[rstest]
+    fn test_add_positions_records_open_position_realized_pnl() {
+        let mut analyzer = PortfolioAnalyzer::new();
+        let currency = Currency::USD();
+        let mut position = create_mock_position("AUD/USD", 100.0, 0.1, currency);
+        position.ts_closed = None;
+        let position_id = position.id;
+
+        analyzer.add_positions(&[position]);
+
+        let records = analyzer.trade_pnl_records(Some(&currency)).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], (position_id, 100.0));
+        assert!(analyzer.position_returns().is_empty());
+    }
+
+    #[rstest]
     fn test_performance_stats_calculation() {
         let mut analyzer = PortfolioAnalyzer::new();
         let currency = Currency::USD();
@@ -1143,6 +1170,32 @@ mod tests {
         assert_eq!(*pnl_stats.get("test_stat").unwrap(), 90.0);
     }
 
+    #[rstest]
+    fn test_record_trade_preserves_duplicate_position_ids() {
+        let mut analyzer = PortfolioAnalyzer::new();
+        let account_currency = Currency::EUR();
+        let stat: Arc<dyn PortfolioStatistic<Item = f64> + Send + Sync> =
+            Arc::new(MockStatistic::new("test_stat"));
+        let position_id = PositionId::new("pos1");
+
+        analyzer.register_statistic(Arc::clone(&stat));
+        analyzer.record_trade(&position_id, &Money::new(90.0, account_currency));
+        analyzer.record_trade(&position_id, &Money::new(-45.0, account_currency));
+
+        let records = analyzer.trade_pnl_records(Some(&account_currency)).unwrap();
+        let recorded_pnls = analyzer.realized_pnls(Some(&account_currency)).unwrap();
+        let pnl_stats = analyzer
+            .get_performance_stats_pnls(Some(&account_currency), None)
+            .unwrap();
+
+        assert_eq!(records[0], (position_id, 90.0));
+        assert_eq!(records[1], (position_id, -45.0));
+        assert_eq!(
+            recorded_pnls,
+            vec![(position_id, 90.0), (position_id, -45.0)]
+        );
+        assert_eq!(*pnl_stats.get("test_stat").unwrap(), 45.0);
+    }
     #[rstest]
     fn test_formatted_output() {
         let mut analyzer = PortfolioAnalyzer::new();

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -1551,38 +1551,38 @@ fn test_get_result_includes_snapshot_position_history(crypto_perpetual_ethusdt: 
 
     let cache_rc = engine.kernel().cache();
     let (
-        expected_total,
+        expected_currency,
+        mut expected_pnls,
         cached_positions_count,
-        cache_realized_count,
         snapshots_realized,
-        snapshots_realized_count,
         snapshot_positions_count,
     ) = {
         let cache = cache_rc.borrow();
         let positions = cache.positions(None, None, None, None, None);
 
-        let cache_realized: f64 = positions
+        let mut expected_pnls: Vec<(PositionId, Currency, f64)> = positions
             .iter()
-            .filter_map(|p| p.realized_pnl.as_ref().map(|m| m.as_f64()))
-            .sum();
-        let cache_realized_count = positions
-            .iter()
-            .filter(|p| p.realized_pnl.is_some())
-            .count() as f64;
+            .filter_map(|p| {
+                p.realized_pnl
+                    .as_ref()
+                    .map(|m| (p.id, m.currency, m.as_f64()))
+            })
+            .collect();
 
         let snapshot_positions: Vec<Position> = positions
             .iter()
             .flat_map(|p| cache.position_snapshots(Some(&p.id), None))
             .collect();
         let snapshot_positions_count = snapshot_positions.len();
+        expected_pnls.extend(snapshot_positions.iter().filter_map(|p| {
+            p.realized_pnl
+                .as_ref()
+                .map(|m| (p.id, m.currency, m.as_f64()))
+        }));
         let snapshots_realized: f64 = snapshot_positions
             .iter()
             .filter_map(|p| p.realized_pnl.as_ref().map(|m| m.as_f64()))
             .sum();
-        let snapshots_realized_count = snapshot_positions
-            .iter()
-            .filter(|p| p.realized_pnl.is_some())
-            .count() as f64;
 
         assert!(
             snapshot_positions_count > 0,
@@ -1593,17 +1593,43 @@ fn test_get_result_includes_snapshot_position_history(crypto_perpetual_ethusdt: 
             "expected non-zero snapshot realized history"
         );
 
+        let expected_currency = expected_pnls
+            .first()
+            .map(|(_, currency, _)| *currency)
+            .expect("expected realized PnL history");
+        let expected_pnls = expected_pnls
+            .into_iter()
+            .filter_map(|(position_id, currency, pnl)| {
+                (currency == expected_currency).then_some((position_id, pnl))
+            })
+            .collect::<Vec<_>>();
+
         (
-            cache_realized + snapshots_realized,
+            expected_currency,
+            expected_pnls,
             positions.len(),
-            cache_realized_count,
             snapshots_realized,
-            snapshots_realized_count,
             snapshot_positions_count,
         )
     };
 
-    let expected_expectancy = expected_total / (cache_realized_count + snapshots_realized_count);
+    if let Some(recorded_pnls) = engine
+        .kernel()
+        .portfolio
+        .borrow()
+        .recorded_realized_pnls()
+        .get(&expected_currency)
+    {
+        expected_pnls.retain(|(position_id, _)| {
+            !recorded_pnls
+                .iter()
+                .any(|(recorded_position_id, _)| recorded_position_id == position_id)
+        });
+        expected_pnls.extend(recorded_pnls.iter().copied());
+    }
+
+    let expected_expectancy =
+        expected_pnls.iter().map(|(_, pnl)| pnl).sum::<f64>() / expected_pnls.len() as f64;
 
     let bt_result = engine.get_result();
     assert_eq!(

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -27,7 +27,7 @@ use nautilus_common::{
     msgbus::{self, MessagingSwitchboard, TypedHandler, TypedIntoHandler},
     timer::{TimeEvent, TimeEventCallback},
 };
-use nautilus_core::{UUID4, WeakCell, datetime::NANOSECONDS_IN_MILLISECOND};
+use nautilus_core::{UUID4, UnixNanos, WeakCell, datetime::NANOSECONDS_IN_MILLISECOND};
 use nautilus_model::{
     accounts::{Account, AccountAny},
     data::{Bar, MarkPriceUpdate, QuoteTick},
@@ -53,6 +53,7 @@ struct PortfolioState {
     analyzer: PortfolioAnalyzer,
     unrealized_pnls: IndexMap<InstrumentId, Money>,
     realized_pnls: IndexMap<InstrumentId, Money>,
+    recorded_closed_position_cycles: AHashSet<(PositionId, UnixNanos)>,
     snapshot_sum_per_position: AHashMap<PositionId, Money>,
     snapshot_last_per_position: AHashMap<PositionId, Money>,
     snapshot_processed_counts: AHashMap<PositionId, usize>,
@@ -90,6 +91,7 @@ impl PortfolioState {
             analyzer: PortfolioAnalyzer::default(),
             unrealized_pnls: IndexMap::new(),
             realized_pnls: IndexMap::new(),
+            recorded_closed_position_cycles: AHashSet::new(),
             snapshot_sum_per_position: AHashMap::new(),
             snapshot_last_per_position: AHashMap::new(),
             snapshot_processed_counts: AHashMap::new(),
@@ -112,6 +114,7 @@ impl PortfolioState {
         self.net_positions.clear();
         self.unrealized_pnls.clear();
         self.realized_pnls.clear();
+        self.recorded_closed_position_cycles.clear();
         self.snapshot_sum_per_position.clear();
         self.snapshot_last_per_position.clear();
         self.snapshot_processed_counts.clear();
@@ -1479,7 +1482,7 @@ impl Portfolio {
 
     /// Returns realized PnLs recorded during portfolio event processing.
     #[must_use]
-    pub fn recorded_realized_pnls(&self) -> AHashMap<Currency, IndexMap<PositionId, f64>> {
+    pub fn recorded_realized_pnls(&self) -> AHashMap<Currency, Vec<(PositionId, f64)>> {
         self.inner.borrow().analyzer.recorded_realized_pnls.clone()
     }
 
@@ -2617,20 +2620,39 @@ fn record_closed_position_pnl(
         return;
     };
 
-    inner
-        .borrow_mut()
-        .analyzer
-        .record_trade(&position.id, &realized_pnl);
+    let mut inner_ref = inner.borrow_mut();
 
-    let Some(account) = cache_ref.account(&event.account_id()) else {
+    if !inner_ref
+        .recorded_closed_position_cycles
+        .insert((position.id, position.ts_opened))
+    {
         return;
-    };
-    let Some(base_currency) = account.base_currency() else {
-        return;
-    };
+    }
+
+    let converted_pnl =
+        converted_realized_pnl(&cache_ref, config, event, position_id, realized_pnl);
+
+    inner_ref.analyzer.record_trade(&position.id, &realized_pnl);
+
+    if let Some(converted_pnl) = converted_pnl {
+        inner_ref
+            .analyzer
+            .record_trade(&position.id, &converted_pnl);
+    }
+}
+
+fn converted_realized_pnl(
+    cache_ref: &Cache,
+    config: PortfolioConfig,
+    event: &PositionEvent,
+    position_id: PositionId,
+    realized_pnl: Money,
+) -> Option<Money> {
+    let account = cache_ref.account(&event.account_id())?;
+    let base_currency = account.base_currency()?;
 
     if realized_pnl.currency == base_currency {
-        return;
+        return None;
     }
 
     let xrate = if config.use_mark_xrates {
@@ -2651,22 +2673,17 @@ fn record_closed_position_pnl(
             "Cannot record account-currency realized PnL for {position_id}: conversion failed from {} to {base_currency}",
             realized_pnl.currency
         );
-        return;
+        return None;
     };
 
     let amount = (realized_pnl.as_decimal() * xrate).round_dp(u32::from(base_currency.precision));
-    let amount = match Money::from_decimal(amount, base_currency) {
-        Ok(amount) => amount,
+    match Money::from_decimal(amount, base_currency) {
+        Ok(amount) => Some(amount),
         Err(e) => {
             log::warn!("Cannot record account-currency realized PnL for {position_id}: {e}");
-            return;
+            None
         }
-    };
-
-    inner
-        .borrow_mut()
-        .analyzer
-        .record_trade(&position.id, &amount);
+    }
 }
 
 fn update_account(

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -2363,6 +2363,9 @@ fn test_market_value_when_insufficient_data_for_xrate_returns_none(
         .borrow_mut()
         .add_position(&position, OmsType::Hedging)
         .unwrap();
+    portfolio.update_position(&PositionEvent::PositionOpened(get_open_position(&position)));
+    assert!(portfolio.recorded_realized_pnls().is_empty());
+
     portfolio
         .cache()
         .borrow_mut()
@@ -2906,7 +2909,7 @@ fn test_closing_position_updates_portfolio(
 }
 
 #[rstest]
-fn test_closed_position_records_account_currency_realized_pnl(
+fn test_position_records_account_currency_realized_pnl(
     mut simple_cache: Cache,
     clock: TestClock,
     instrument_audusd: InstrumentAny,
@@ -2954,6 +2957,7 @@ fn test_closed_position_records_account_currency_realized_pnl(
         side: PositionSide::Flat,
         signed_qty: 0.0,
         quantity: Quantity::from("0"),
+        ts_last: UnixNanos::from(1),
         ts_closed: Some(UnixNanos::from(1)),
         realized_pnl: Some(Money::from("12.34 USD")),
         ..position.clone()
@@ -2969,25 +2973,24 @@ fn test_closed_position_records_account_currency_realized_pnl(
         .borrow_mut()
         .update_position(&closed_position)
         .unwrap();
-    portfolio.update_position(&PositionEvent::PositionClosed(get_closed_position(
-        &closed_position,
-    )));
+    let position_closed = PositionEvent::PositionClosed(get_closed_position(&closed_position));
+    portfolio.update_position(&position_closed);
+    portfolio.update_position(&position_closed);
 
     let recorded = portfolio.recorded_realized_pnls();
-    assert_eq!(
-        recorded
-            .get(&Currency::USD())
-            .and_then(|pnls| pnls.get(&position_id))
-            .copied(),
-        Some(12.34),
-    );
-    assert_eq!(
-        recorded
-            .get(&Currency::EUR())
-            .and_then(|pnls| pnls.get(&position_id))
-            .copied(),
-        Some(11.11),
-    );
+    assert_eq!(recorded.get(&Currency::USD()).unwrap().len(), 1);
+    assert_eq!(recorded.get(&Currency::EUR()).unwrap().len(), 1);
+    let usd_record = recorded
+        .get(&Currency::USD())
+        .and_then(|pnls| pnls.first())
+        .unwrap();
+    assert_eq!(*usd_record, (position_id, 12.34));
+
+    let eur_record = recorded
+        .get(&Currency::EUR())
+        .and_then(|pnls| pnls.first())
+        .unwrap();
+    assert_eq!(*eur_record, (position_id, 11.11));
 }
 
 #[rstest]

--- a/crates/trading/src/strategy/api.rs
+++ b/crates/trading/src/strategy/api.rs
@@ -923,7 +923,7 @@ impl<'a> PortfolioApi<'a> {
     ///
     /// Panics if the portfolio is already mutably borrowed.
     #[must_use]
-    pub fn recorded_realized_pnls(&self) -> AHashMap<Currency, IndexMap<PositionId, f64>> {
+    pub fn recorded_realized_pnls(&self) -> AHashMap<Currency, Vec<(PositionId, f64)>> {
         self.portfolio.borrow().recorded_realized_pnls()
     }
 }

--- a/nautilus_trader/analysis/analyzer.py
+++ b/nautilus_trader/analysis/analyzer.py
@@ -239,8 +239,15 @@ class PortfolioAnalyzer:
 
         """
         currency = realized_pnl.currency
-        realized_pnls = self._recorded_realized_pnls.get(currency, pd.Series(dtype=float64))
-        realized_pnls.loc[position_id.value] = realized_pnl.as_double()
+        trade_pnl = pd.Series(
+            [realized_pnl.as_double()],
+            index=[position_id.value],
+            dtype=float64,
+        )
+        realized_pnls = self._recorded_realized_pnls.get(currency)
+        realized_pnls = (
+            trade_pnl if realized_pnls is None else pd.concat([realized_pnls, trade_pnl])
+        )
         self._recorded_realized_pnls[currency] = realized_pnls
 
     def add_position_return(self, timestamp: datetime, value: float) -> None:
@@ -316,11 +323,11 @@ class PortfolioAnalyzer:
         if recorded_realized_pnls is None:
             return realized_pnls
 
-        output = realized_pnls.copy()
-        for position_id, pnl in recorded_realized_pnls.items():
-            output.loc[position_id] = pnl
-
-        return output
+        output = realized_pnls.drop(
+            recorded_realized_pnls.index.unique(),
+            errors="ignore",
+        )
+        return pd.concat([output, recorded_realized_pnls])
 
     def total_pnl(
         self,

--- a/tests/unit_tests/analysis/test_analyzer.py
+++ b/tests/unit_tests/analysis/test_analyzer.py
@@ -184,6 +184,23 @@ class TestPortfolioAnalyzer:
         assert stats[stat.name] == 1.0
         assert stat.last_realized_pnls_input == [90.0]
 
+    def test_record_trade_preserves_duplicate_position_ids(self):
+        # Arrange
+        stat = _RecordingPyo3Statistic()
+        self.analyzer.register_statistic(stat)
+
+        # Act
+        self.analyzer.record_trade(PositionId("P-1"), Money(90.0, EUR))
+        self.analyzer.record_trade(PositionId("P-1"), Money(-45.0, EUR))
+        recorded_pnls = self.analyzer.realized_pnls(EUR)
+        stats = self.analyzer.get_performance_stats_pnls(currency=EUR)
+
+        # Assert
+        assert recorded_pnls.tolist() == [90.0, -45.0]
+        assert recorded_pnls.index.tolist() == ["P-1", "P-1"]
+        assert stat.last_realized_pnls_input == [90.0, -45.0]
+        assert stats[stat.name] == 1.0
+
     def test_get_performance_stats_returns_converts_pyo3_statistics_input(self):
         # Arrange
         stat = _RecordingPyo3Statistic()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes account-currency `stats_pnls` for NETTING accounts where repeated closed trade cycles reuse the same `PositionId`.
- Preserves duplicate `PositionId` trade PnL records instead of overwriting earlier NETTING cycles.
- Keeps Rust aligned with the existing Python/Cython behavior: record one full realized PnL per closed cycle, preserve duplicate position IDs in order, and prefer recorded entries over native entries for matching position IDs.
- Keeps the recorded trade PnL shape simple in both implementations: Python stores a `pd.Series` indexed by position ID, and Rust stores `(PositionId, f64)` tuples keyed by currency.
- Keeps Rust portfolio recording gated on closed positions to avoid fragmenting one trade cycle into open/change/close PnL records.
- Adds a Rust closed-cycle dedupe set keyed by `(PositionId, ts_opened)` to skip duplicate or stale close events.

### Design

The earlier account-currency PnL fix recorded converted close-time trade PnLs under `PositionId`. That worked for HEDGING because closed trades generally have unique position IDs, but NETTING can reuse the same position ID across multiple open/close cycles. A map keyed by `PositionId` collapsed those cycles into the last trade.

The fix changes recorded realized PnLs from unique-by-position storage to ordered trade storage, while keeping the recording point as one closed cycle:

- Python analyzer recorded PnLs append to a `pd.Series`, preserving duplicate index labels for repeated NETTING `PositionId` values.
- Python portfolio recording remains gated on `updated_position.is_closed_c()` and records the full closed-cycle realized PnL.
- Rust analyzer recorded PnLs use `Vec<(PositionId, f64)>` rather than `IndexMap<PositionId, f64>`.
- Rust portfolio recording remains gated on `position.is_closed()` and records the full closed-cycle realized PnL.
- Rust tracks recorded closed cycles by `(PositionId, ts_opened)` to skip duplicate or stale close events.
- When native calculated PnLs and recorded PnLs both exist for a currency, recorded entries still take precedence for matching position IDs, while duplicate recorded rows are preserved.

### Python flow

```mermaid
flowchart TD
    A[Position event] --> B{updated_position.is_closed_c?}
    B -- no --> C[Do not record trade PnL]
    B -- yes --> D[Read full realized_pnl for closed cycle]
    D --> E[PortfolioAnalyzer.record_trade]
    E --> F[Create one-row pd.Series indexed by PositionId]
    F --> G[pd.concat appends to currency series]
    G --> H[Duplicate PositionId index labels are preserved]
    I[Native realized_pnls from positions] --> J[realized_pnls currency merge]
    H --> J
    J --> K[Drop native rows whose PositionId appears in recorded index]
    K --> L[Concat native remainder plus recorded series]
    L --> M[stats_pnls consumes one PnL per closed cycle]
```

### Rust flow

```mermaid
flowchart TD
    A[PositionEvent] --> B[Load Position from cache]
    B --> C{position.is_closed?}
    C -- no --> D[Do not record trade PnL]
    C -- yes --> E{realized_pnl exists?}
    E -- no --> D
    E -- yes --> F[Build closed-cycle key: PositionId plus ts_opened]
    F --> G{Cycle key already recorded?}
    G -- yes --> H[Skip duplicate or stale close event]
    G -- no --> I[Record full native closed-cycle PnL tuple]
    I --> J[Convert full PnL to account currency when needed]
    J --> K[Push PositionId and PnL tuples into currency Vecs]
    K --> L[Analyzer merge drops native rows for recorded PositionIds]
    L --> M[stats_pnls consumes one PnL per closed cycle]
```

### Files changed

- `crates/analysis/src/analyzer.rs`.
- `crates/analysis/src/python/analyzer.rs`.
- `crates/portfolio/src/portfolio.rs`.
- `crates/portfolio/tests/portfolio.rs`.
- `crates/trading/src/strategy/api.rs`.
- `crates/backtest/tests/backtest_engine.rs`.
- `nautilus_trader/analysis/analyzer.py`.
- `tests/unit_tests/analysis/test_analyzer.py`.

### Verification

- `cargo test -p nautilus-analysis test_record_trade_preserves_duplicate_position_ids`.
- `cargo test -p nautilus-portfolio test_position_records_account_currency_realized_pnl`.
- `cargo test -p nautilus-backtest test_get_result_uses_recorded_account_currency_pnls`.
- `cargo test -p nautilus-backtest test_get_result_includes_snapshot_position_history`.
- `cargo test -p nautilus-analysis`.
- `cargo test -p nautilus-portfolio`.
- `uv run --active --no-sync pytest tests/unit_tests/analysis/test_analyzer.py -k "record_trade_preserves_duplicate_position_ids or calculate_statistics_preserves_recorded_realized_pnls" -q`.
- `make build-debug`.
- `make format`.
- `make pre-commit`.






## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4205

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
