### PR TITLE
Use slices for catalog writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,15 +4901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5269,12 +5260,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -6529,7 +6514,6 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.14.0",
- "itertools 0.15.0",
  "log",
  "nautilus-common",
  "nautilus-core",
@@ -7818,14 +7802,11 @@ dependencies = [
  "chrono",
  "indexmap 2.14.0",
  "inventory",
- "itertools 0.14.0",
  "log",
- "maplit",
  "num-complex",
  "pyo3",
  "pyo3-stub-gen-derive",
  "rust_decimal",
- "rustpython-parser",
  "serde",
  "serde_json",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,6 @@ http = "1.4.2"
 implied-vol = { version = "2.0.0" }
 indexmap = { version = "2.14.0", features = ["serde"] }
 itchy = "0.3"
-itertools = "0.15.0"
 libloading = "0.9.0"
 log = { version = "0.4.32", features = [
   "std",

--- a/crates/backtest/examples/node_ema_cross.rs
+++ b/crates/backtest/examples/node_ema_cross.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
     let catalog_path = temp_dir.path().to_str().unwrap().to_string();
     let catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
     catalog.write_instruments(vec![instrument])?;
-    catalog.write_to_parquet(quotes, None, None, None)?;
+    catalog.write_to_parquet(&quotes, None, None, None)?;
 
     println!("Wrote {num_quotes} quotes to catalog: {catalog_path}");
 

--- a/crates/backtest/tests/backtest_node.rs
+++ b/crates/backtest/tests/backtest_node.rs
@@ -72,7 +72,7 @@ fn create_catalog_with_quotes(
         })
         .collect();
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     (temp_dir, catalog_path)
 }
@@ -121,8 +121,8 @@ fn create_catalog_with_quotes_and_trades(
         })
         .collect();
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
-    catalog.write_to_parquet(trades, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&trades, None, None, None).unwrap();
 
     (temp_dir, catalog_path)
 }
@@ -158,7 +158,7 @@ fn create_catalog_with_funding_rates(
     ];
 
     catalog
-        .write_to_parquet(funding_rates.clone(), None, None, None)
+        .write_to_parquet(&funding_rates, None, None, None)
         .unwrap();
 
     (temp_dir, catalog_path, funding_rates)
@@ -1213,7 +1213,7 @@ fn test_streaming_same_timestamp_events(crypto_perpetual_ethusdt: CryptoPerpetua
         })
         .collect();
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     let data = data_config(&catalog_path, instrument_id);
     let config = BacktestRunConfig::builder()

--- a/crates/backtest/tests/backtest_node_itch.rs
+++ b/crates/backtest/tests/backtest_node_itch.rs
@@ -62,9 +62,7 @@ fn create_itch_catalog(quotes: &[QuoteTick], instrument: &InstrumentAny) -> (Tem
     let catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
 
     catalog.write_instruments(vec![instrument.clone()]).unwrap();
-    catalog
-        .write_to_parquet(quotes.to_vec(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(quotes, None, None, None).unwrap();
 
     (temp_dir, catalog_path)
 }

--- a/crates/backtest/tests/grid_mm_itch.rs
+++ b/crates/backtest/tests/grid_mm_itch.rs
@@ -114,9 +114,7 @@ fn test_grid_mm_itch_catalog_load() {
     // Write deltas to a temp catalog then query back
     let temp_dir = TempDir::new().unwrap();
     let catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
-    catalog
-        .write_to_parquet(deltas.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&deltas, None, None, None).unwrap();
     catalog.write_instruments(vec![instrument.clone()]).unwrap();
 
     let mut catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);

--- a/crates/backtest/tests/option_chain_backtest.rs
+++ b/crates/backtest/tests/option_chain_backtest.rs
@@ -227,29 +227,22 @@ fn build_catalog() -> (
     // metadata), so each instrument must be written separately or the put rows would be relabelled
     // as calls. Per-instrument batches stay ascending in `ts_init` and land in disjoint directories.
     for id in [call_id, put_id] {
+        let quotes_for_instrument = quotes
+            .iter()
+            .filter(|q| q.instrument_id == id)
+            .copied()
+            .collect::<Vec<_>>();
         catalog
-            .write_to_parquet(
-                quotes
-                    .iter()
-                    .filter(|q| q.instrument_id == id)
-                    .copied()
-                    .collect(),
-                None,
-                None,
-                None,
-            )
+            .write_to_parquet(&quotes_for_instrument, None, None, None)
             .unwrap();
+
+        let greeks_for_instrument = greeks
+            .iter()
+            .filter(|g| g.instrument_id == id)
+            .copied()
+            .collect::<Vec<_>>();
         catalog
-            .write_to_parquet(
-                greeks
-                    .iter()
-                    .filter(|g| g.instrument_id == id)
-                    .copied()
-                    .collect(),
-                None,
-                None,
-                None,
-            )
+            .write_to_parquet(&greeks_for_instrument, None, None, None)
             .unwrap();
     }
 

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -346,7 +346,7 @@ fn register_quote_catalog(
     let catalog = ParquetDataCatalog::new(catalog_dir.path(), None, None, None, None);
     catalog
         .write_to_parquet(
-            vec![QuoteTick::new(
+            &[QuoteTick::new(
                 instrument_id,
                 Price::from("1.0000"),
                 Price::from("1.0001"),
@@ -374,7 +374,7 @@ fn register_trade_catalog(
     let catalog = ParquetDataCatalog::new(catalog_dir.path(), None, None, None, None);
     catalog
         .write_to_parquet(
-            vec![TradeTick::new(
+            &[TradeTick::new(
                 instrument_id,
                 Price::from("1.0000"),
                 Quantity::from(1),
@@ -402,7 +402,7 @@ fn register_bar_catalog(
     let catalog = ParquetDataCatalog::new(catalog_dir.path(), None, None, None, None);
     catalog
         .write_to_parquet(
-            vec![Bar::new(
+            &[Bar::new(
                 bar_type,
                 Price::from("1.0000"),
                 Price::from("1.0001"),
@@ -16375,7 +16375,7 @@ fn test_time_range_pipeline_child_uses_catalog_client_fanin(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "time-range-split-quotes",
-        vec![split_quote(instrument_id, 1_500_000_000)],
+        &[split_quote(instrument_id, 1_500_000_000)],
         Some((1_000_000_000, 1_500_000_000)),
     );
     let recorder = register_time_range_recorder(&mut data_engine, clock, cache, client_id, venue);
@@ -18020,7 +18020,7 @@ fn test_request_join_all_empty_legs_emits_empty_parent(
 fn register_quote_catalog_with_quotes(
     data_engine: &mut DataEngine,
     label: &str,
-    quotes: Vec<QuoteTick>,
+    quotes: &[QuoteTick],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -18038,7 +18038,7 @@ fn register_quote_catalog_with_quotes(
 fn register_trade_catalog_with_trades(
     data_engine: &mut DataEngine,
     label: &str,
-    trades: Vec<TradeTick>,
+    trades: &[TradeTick],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -18056,7 +18056,7 @@ fn register_trade_catalog_with_trades(
 fn register_bar_catalog_with_bars(
     data_engine: &mut DataEngine,
     label: &str,
-    bars: Vec<Bar>,
+    bars: &[Bar],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -18187,7 +18187,7 @@ fn split_funding_rate(instrument_id: InstrumentId, ts: u64, rate: &str) -> Fundi
 fn register_funding_catalog_with_rates(
     data_engine: &mut DataEngine,
     label: &str,
-    rates: Vec<FundingRateUpdate>,
+    rates: &[FundingRateUpdate],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -18311,7 +18311,7 @@ fn test_request_quotes_catalog_only_serves_from_disk(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "catalog-only",
-        vec![
+        &[
             split_quote(instrument_id, 1_000),
             split_quote(instrument_id, 2_000),
         ],
@@ -18423,7 +18423,7 @@ fn test_request_quotes_catalog_plus_client_split(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "split-quotes",
-        vec![split_quote(instrument_id, 1_500)],
+        &[split_quote(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -18532,7 +18532,7 @@ fn test_request_quotes_skip_catalog_data_param_honored(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "skip-catalog",
-        vec![split_quote(instrument_id, 1_500)],
+        &[split_quote(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -18635,7 +18635,7 @@ fn test_request_bars_catalog_lookup_uses_bar_type_identifier(
     let _catalog_dir = register_bar_catalog_with_bars(
         &mut data_engine,
         "bars-by-bar-type",
-        vec![split_bar(bar_type, 2_000)],
+        &[split_bar(bar_type, 2_000)],
         Some((1_000, 3_000)),
     );
 
@@ -18687,7 +18687,7 @@ fn test_request_trades_catalog_plus_client_split(
     let _catalog_dir = register_trade_catalog_with_trades(
         &mut data_engine,
         "split-trades",
-        vec![split_trade(instrument_id, 1_500, "T-1")],
+        &[split_trade(instrument_id, 1_500, "T-1")],
         Some((1_000, 1_500)),
     );
 
@@ -18827,7 +18827,7 @@ fn test_request_pipeline_count_resets_after_catalog_split_fanin(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "pipeline-reset",
-        vec![split_quote(instrument_id, 1_500)],
+        &[split_quote(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -18893,7 +18893,7 @@ fn test_request_quotes_dispatch_failure_aborts_pipeline(
     let _catalog_dir = register_quote_catalog_with_quotes(
         &mut data_engine,
         "abort-pipeline",
-        vec![split_quote(instrument_id, 1_500)],
+        &[split_quote(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -18956,7 +18956,7 @@ fn test_request_trades_with_bar_types_param_sets_up_aggregation_through_streamin
     let _catalog_dir = register_trade_catalog_with_trades(
         &mut data_engine,
         "agg-trades",
-        vec![split_trade(instrument_id, 2_000, "agg-1")],
+        &[split_trade(instrument_id, 2_000, "agg-1")],
         Some((1_000, 2_000)),
     );
 
@@ -19006,7 +19006,7 @@ fn test_request_bars_catalog_plus_client_split(
     let _catalog_dir = register_bar_catalog_with_bars(
         &mut data_engine,
         "bars-split",
-        vec![split_bar(bar_type, 1_500)],
+        &[split_bar(bar_type, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -19097,7 +19097,7 @@ fn test_request_funding_rates_catalog_only_serves_from_disk(
     let _catalog_dir = register_funding_catalog_with_rates(
         &mut data_engine,
         "funding-catalog-only",
-        vec![
+        &[
             split_funding_rate(instrument_id, 1_000, "0.0001"),
             split_funding_rate(instrument_id, 2_000, "0.0002"),
         ],
@@ -19152,7 +19152,7 @@ fn test_request_funding_rates_catalog_plus_client_split(
     let _catalog_dir = register_funding_catalog_with_rates(
         &mut data_engine,
         "funding-split",
-        vec![split_funding_rate(instrument_id, 1_500, "0.0001")],
+        &[split_funding_rate(instrument_id, 1_500, "0.0001")],
         Some((1_000, 1_500)),
     );
 
@@ -20192,7 +20192,7 @@ fn split_delta(instrument_id: InstrumentId, ts: u64) -> OrderBookDelta {
 fn register_deltas_catalog_with_deltas(
     data_engine: &mut DataEngine,
     label: &str,
-    deltas: Vec<OrderBookDelta>,
+    deltas: &[OrderBookDelta],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -20224,7 +20224,7 @@ fn recorded_request_book_deltas(
 fn register_depth_catalog_with_depths(
     data_engine: &mut DataEngine,
     label: &str,
-    depths: Vec<OrderBookDepth10>,
+    depths: &[OrderBookDepth10],
     interval: Option<(u64, u64)>,
 ) -> CatalogTempDir {
     let catalog_dir = CatalogTempDir::new(label);
@@ -20267,7 +20267,7 @@ fn test_request_book_deltas_catalog_only_serves_from_disk(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-catalog-only",
-        vec![
+        &[
             split_delta(instrument_id, 1_000),
             split_delta(instrument_id, 2_000),
         ],
@@ -20321,7 +20321,7 @@ fn test_request_book_deltas_catalog_plus_client_split(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-split",
-        vec![split_delta(instrument_id, 1_500)],
+        &[split_delta(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -20515,7 +20515,7 @@ fn test_request_book_depth_catalog_only_serves_from_disk(
     let _catalog_dir = register_depth_catalog_with_depths(
         &mut data_engine,
         "depth-catalog-only",
-        vec![
+        &[
             book_depth_at(instrument_id, 1_000),
             book_depth_at(instrument_id, 2_000),
         ],
@@ -20570,7 +20570,7 @@ fn test_request_book_depth_catalog_plus_client_split(
     let _catalog_dir = register_depth_catalog_with_depths(
         &mut data_engine,
         "depth-split",
-        vec![book_depth_at(instrument_id, 1_500)],
+        &[book_depth_at(instrument_id, 1_500)],
         Some((1_000, 1_500)),
     );
 
@@ -20881,7 +20881,7 @@ fn test_book_deltas_request_replays_day_start_snapshot(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-assemble",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 500, 0, "1.00010", 2),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 3),
@@ -20957,7 +20957,7 @@ fn test_book_deltas_request_skips_replay_without_snapshot_flag(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-noflag",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, 0, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
             book_replay_delta(instrument_id, 2_000, f_last, "1.00030", 3),
@@ -21021,7 +21021,7 @@ fn test_book_deltas_request_skips_replay_when_snapshot_not_on_day_boundary(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-offboundary",
-        vec![
+        &[
             book_replay_delta(instrument_id, 500, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
             book_replay_delta(instrument_id, 2_000, f_last, "1.00030", 3),
@@ -21083,7 +21083,7 @@ fn test_book_deltas_request_skips_replay_when_start_at_day_boundary(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-atboundary",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
         ],
@@ -21145,7 +21145,7 @@ fn test_book_deltas_request_replays_end_snapshot_when_exhausted(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-exhausted",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 500, f_last, "1.00010", 2),
         ],
@@ -21206,7 +21206,7 @@ fn test_book_deltas_request_from_day_start_false_skips_floor(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-nofloor",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
             book_replay_delta(instrument_id, 2_000, f_last, "1.00030", 3),
@@ -21271,7 +21271,7 @@ fn test_book_deltas_replay_writes_assembled_snapshot_to_cache(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-cache",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
         ],
@@ -21361,7 +21361,7 @@ fn test_book_deltas_replay_respects_cache_ownership(
     let _catalog_dir = register_deltas_catalog_with_deltas(
         &mut data_engine,
         "deltas-replay-owned",
-        vec![
+        &[
             book_replay_delta(instrument_id, 0, f_snapshot | f_last, "1.00000", 1),
             book_replay_delta(instrument_id, 1_500, f_last, "1.00020", 2),
         ],

--- a/crates/event_store/src/replay/catalog.rs
+++ b/crates/event_store/src/replay/catalog.rs
@@ -241,7 +241,7 @@ mod tests {
             ),
         ];
         catalog
-            .write_to_parquet(quotes.clone(), None, None, None)
+            .write_to_parquet(&quotes, None, None, None)
             .expect("write quotes");
 
         let query = CatalogSliceQuery {
@@ -300,7 +300,7 @@ mod tests {
             ),
         ];
         catalog
-            .write_to_parquet(trades.clone(), None, None, None)
+            .write_to_parquet(&trades, None, None, None)
             .expect("write trades");
 
         let query = CatalogSliceQuery {
@@ -367,7 +367,7 @@ mod tests {
             ),
         ];
         catalog
-            .write_to_parquet(bars.clone(), None, None, None)
+            .write_to_parquet(&bars, None, None, None)
             .expect("write bars");
 
         let query = CatalogSliceQuery {

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -74,7 +74,6 @@ chrono-tz = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
-itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true }
 parquet = { workspace = true }

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -59,7 +59,7 @@
 //! );
 //!
 //! // Write data to the catalog
-//! // catalog.write_to_parquet(data, None, None)?;
+//! // catalog.write_to_parquet(&data, None, None)?;
 //! ```
 
 use std::{
@@ -80,7 +80,6 @@ use datafusion::arrow::{
 };
 use futures::StreamExt;
 use indexmap::IndexSet;
-use itertools::Itertools;
 use nautilus_common::live::get_runtime;
 use nautilus_core::{
     UnixNanos,
@@ -459,17 +458,17 @@ impl ParquetDataCatalog {
 
         // Instruments are handled separately via write_instruments method
 
-        self.write_to_parquet(deltas, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(depth10s, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(quotes, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(trades, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(bars, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(mark_prices, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(index_prices, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(funding_rates, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(statuses, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(option_greeks, start, end, skip_disjoint_check)?;
-        self.write_to_parquet(closes, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&deltas, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&depth10s, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&quotes, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&trades, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&bars, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&mark_prices, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&index_prices, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&funding_rates, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&statuses, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&option_greeks, start, end, skip_disjoint_check)?;
+        self.write_to_parquet(&closes, start, end, skip_disjoint_check)?;
 
         for (_, items) in custom_data {
             self.write_custom_data_batch(items, start, end, skip_disjoint_check)?;
@@ -490,7 +489,7 @@ impl ParquetDataCatalog {
     ///
     /// # Parameters
     ///
-    /// - `data`: Vector of data records to write (must be in ascending timestamp order).
+    /// - `data`: Data records to write (must be in ascending timestamp order).
     /// - `start`: Optional start timestamp to override the natural data range.
     /// - `end`: Optional end timestamp to override the natural data range.
     ///
@@ -523,13 +522,13 @@ impl ParquetDataCatalog {
     /// let catalog = ParquetDataCatalog::new(/* ... */);
     /// let quotes: Vec<QuoteTick> = vec![/* quote data */];
     ///
-    /// let path = catalog.write_to_parquet(quotes, None, None)?;
+    /// let path = catalog.write_to_parquet(&quotes, None, None)?;
     /// println!("Data written to: {:?}", path);
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn write_to_parquet<T>(
         &self,
-        data: Vec<T>,
+        data: &[T],
         start: Option<UnixNanos>,
         end: Option<UnixNanos>,
         skip_disjoint_check: Option<bool>,
@@ -542,7 +541,7 @@ impl ParquetDataCatalog {
         }
 
         let type_name = to_snake_case(std::any::type_name::<T>());
-        Self::check_ascending_timestamps(&data, &type_name)?;
+        Self::check_ascending_timestamps(data, &type_name)?;
 
         let start_ts = start.unwrap_or(data.first().unwrap().ts_init());
         let end_ts = end.unwrap_or(data.last().unwrap().ts_init());
@@ -759,7 +758,7 @@ impl ParquetDataCatalog {
             };
             let start_ts = HasTsInit::ts_init(first_instrument);
             let end_ts = HasTsInit::ts_init(last_instrument);
-            let batches = self.data_to_record_batches(instrument_group)?;
+            let batches = self.data_to_record_batches(&instrument_group)?;
             if batches.is_empty() {
                 continue;
             }
@@ -1126,7 +1125,7 @@ impl ParquetDataCatalog {
     ///
     /// # Parameters
     ///
-    /// - `data`: Vector of data records to convert.
+    /// - `data`: Data records to convert.
     ///
     /// # Returns
     ///
@@ -1135,16 +1134,15 @@ impl ParquetDataCatalog {
     /// # Errors
     ///
     /// Returns an error if record batch encoding fails for any chunk.
-    pub fn data_to_record_batches<T>(&self, data: Vec<T>) -> anyhow::Result<Vec<RecordBatch>>
+    pub fn data_to_record_batches<T>(&self, data: &[T]) -> anyhow::Result<Vec<RecordBatch>>
     where
         T: HasTsInit + EncodeToRecordBatch,
     {
         let mut batches = Vec::new();
 
-        for chunk in &data.into_iter().chunks(self.batch_size) {
-            let data = chunk.collect_vec();
-            let metadata = EncodeToRecordBatch::chunk_metadata(&data);
-            let record_batch = T::encode_batch(&metadata, &data)?;
+        for chunk in data.chunks(self.batch_size) {
+            let metadata = EncodeToRecordBatch::chunk_metadata(chunk);
+            let record_batch = T::encode_batch(&metadata, chunk)?;
             batches.push(record_batch);
         }
 

--- a/crates/persistence/src/backend/catalog_operations.rs
+++ b/crates/persistence/src/backend/catalog_operations.rs
@@ -907,7 +907,7 @@ impl ParquetDataCatalog {
             // Use skip_disjoint_check since we're managing file removal carefully
             let start_ts = UnixNanos::from(final_start_ns);
             let end_ts = UnixNanos::from(final_end_ns);
-            self.write_to_parquet(period_data, Some(start_ts), Some(end_ts), Some(true))?;
+            self.write_to_parquet(&period_data, Some(start_ts), Some(end_ts), Some(true))?;
 
             // Delete files fully consumed by this period; keep straddlers so no data is lost
             for file in existing_files.clone() {
@@ -1999,7 +1999,7 @@ impl ParquetDataCatalog {
                         let start_ts = UnixNanos::from(operation.file_start_ns);
                         let end_ts = UnixNanos::from(operation.file_end_ns);
                         self.write_to_parquet(
-                            before_data,
+                            &before_data,
                             Some(start_ts),
                             Some(end_ts),
                             Some(true),
@@ -2023,7 +2023,7 @@ impl ParquetDataCatalog {
                         let start_ts = UnixNanos::from(operation.file_start_ns);
                         let end_ts = UnixNanos::from(operation.file_end_ns);
                         self.write_to_parquet(
-                            after_data,
+                            &after_data,
                             Some(start_ts),
                             Some(end_ts),
                             Some(true),

--- a/crates/persistence/src/python/catalog.rs
+++ b/crates/persistence/src/python/catalog.rs
@@ -150,9 +150,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write quote ticks: {e}")))
     }
@@ -178,9 +184,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write trade ticks: {e}")))
     }
@@ -206,9 +218,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write order book deltas: {e}")))
     }
@@ -234,9 +252,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write bars: {e}")))
     }
@@ -262,9 +286,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write order book depths: {e}")))
     }
@@ -290,9 +320,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write mark price updates: {e}")))
     }
@@ -318,9 +354,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write index price updates: {e}")))
     }
@@ -346,9 +388,15 @@ impl PyParquetDataCatalog {
     ) -> PyResult<String> {
         let start_nanos = start.map(UnixNanos::from);
         let end_nanos = end.map(UnixNanos::from);
+        let data = data.into_boxed_slice();
 
         self.inner
-            .write_to_parquet(data, start_nanos, end_nanos, Some(skip_disjoint_check))
+            .write_to_parquet(
+                data.as_ref(),
+                start_nanos,
+                end_nanos,
+                Some(skip_disjoint_check),
+            )
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| PyIOError::new_err(format!("Failed to write option greeks: {e}")))
     }

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -463,9 +463,7 @@ fn test_rust_write_2_bars_to_catalog() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars = vec![create_bar(1), create_bar(2)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     let intervals = catalog.get_intervals("bars", Some(&bar_type)).unwrap();
@@ -477,12 +475,10 @@ fn test_rust_append_data_to_catalog() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1), create_bar(2)];
-    catalog
-        .write_to_parquet(bars1.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(3)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bar_type = bars1[0].bar_type.to_string();
     let intervals = catalog.get_intervals("bars", Some(&bar_type)).unwrap();
@@ -498,8 +494,10 @@ fn test_rust_get_intervals_without_identifier_aggregates_across_partitions() {
     let audusd = create_quote_ticks_for_instrument("AUD/USD.SIM", 1_000, 2);
     let ethusdt = create_quote_ticks_for_instrument("ETH/USDT.BINANCE", 5_000, 2);
 
-    catalog.write_to_parquet(audusd, None, None, None).unwrap();
-    catalog.write_to_parquet(ethusdt, None, None, None).unwrap();
+    catalog.write_to_parquet(&audusd, None, None, None).unwrap();
+    catalog
+        .write_to_parquet(&ethusdt, None, None, None)
+        .unwrap();
 
     let aud_intervals = catalog
         .get_intervals("quotes", Some("AUD/USD.SIM"))
@@ -524,8 +522,10 @@ fn test_rust_get_intervals_without_identifier_merges_overlapping_partitions() {
     let audusd = create_quote_ticks_for_instrument("AUD/USD.SIM", 1_000, 10);
     let ethusdt = create_quote_ticks_for_instrument("ETH/USDT.BINANCE", 5_000, 2);
 
-    catalog.write_to_parquet(audusd, None, None, None).unwrap();
-    catalog.write_to_parquet(ethusdt, None, None, None).unwrap();
+    catalog.write_to_parquet(&audusd, None, None, None).unwrap();
+    catalog
+        .write_to_parquet(&ethusdt, None, None, None)
+        .unwrap();
 
     let all_intervals = catalog.get_intervals("quotes", None).unwrap();
     assert_eq!(all_intervals, vec![(1_000, 10_000)]);
@@ -548,12 +548,10 @@ fn test_rust_consolidate_catalog() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1), create_bar(2)];
-    catalog
-        .write_to_parquet(bars1.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(3)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bar_type = bars1[0].bar_type.to_string();
     catalog
@@ -569,15 +567,13 @@ fn test_rust_consolidate_catalog_with_time_range() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1)];
-    catalog
-        .write_to_parquet(bars1.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(2)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bars3 = vec![create_bar(3)];
-    catalog.write_to_parquet(bars3, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars3, None, None, None).unwrap();
 
     let bar_type = bars1[0].bar_type.to_string();
     catalog
@@ -601,13 +597,11 @@ fn test_rust_consolidate_with_deduplication() {
 
     // Write bars [1, 2] and [2, 3] as separate files so ts=2 is duplicated
     let bars_a = vec![create_bar(1), create_bar(2)];
-    catalog
-        .write_to_parquet(bars_a.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars_a, None, None, None).unwrap();
 
     let bars_b = vec![create_bar(2), create_bar(3)];
     catalog
-        .write_to_parquet(bars_b, None, None, Some(true))
+        .write_to_parquet(&bars_b, None, None, Some(true))
         .unwrap();
 
     let bar_type = bars_a[0].bar_type.to_string();
@@ -664,13 +658,11 @@ fn test_rust_consolidate_index_with_deduplication() {
 
     // Write bars [1, 2] and [2, 3] as separate files so ts=2 is duplicated
     let bars_a = vec![create_index_bar(1), create_index_bar(2)];
-    catalog
-        .write_to_parquet(bars_a.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars_a, None, None, None).unwrap();
 
     let bars_b = vec![create_index_bar(2), create_index_bar(3)];
     catalog
-        .write_to_parquet(bars_b, None, None, Some(true))
+        .write_to_parquet(&bars_b, None, None, Some(true))
         .unwrap();
 
     let bar_type = bars_a[0].bar_type.to_string();
@@ -771,12 +763,10 @@ fn test_rust_get_missing_intervals() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1), create_bar(2)];
-    catalog
-        .write_to_parquet(bars1.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(5), create_bar(6)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bar_type = bars1[0].bar_type.to_string();
     let missing = catalog
@@ -790,9 +780,7 @@ fn test_rust_get_missing_intervals() {
 fn test_rust_reset_data_file_names() {
     let (_temp_dir, catalog) = create_temp_catalog();
     let bars = vec![create_bar(1), create_bar(2), create_bar(3)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Get intervals before reset
@@ -817,12 +805,10 @@ fn test_rust_extend_file_name() {
 
     // Write data with a gap
     let bars1 = vec![create_bar(1)];
-    catalog
-        .write_to_parquet(bars1.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(4)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bar_type = bars1[0].bar_type.to_string();
     // Extend the first file to include the missing timestamp range
@@ -847,7 +833,7 @@ fn test_rust_write_quote_ticks() {
 
     let quote_ticks = vec![create_quote_tick(1), create_quote_tick(2)];
     catalog
-        .write_to_parquet(quote_ticks, None, None, None)
+        .write_to_parquet(&quote_ticks, None, None, None)
         .unwrap();
 
     let files = catalog
@@ -867,7 +853,7 @@ fn test_rust_write_trade_ticks() {
 
     let trade_ticks = vec![create_trade_tick(1), create_trade_tick(2)];
     catalog
-        .write_to_parquet(trade_ticks, None, None, None)
+        .write_to_parquet(&trade_ticks, None, None, None)
         .unwrap();
 
     let files = catalog
@@ -897,7 +883,7 @@ fn test_query_round_trip_non_ascii_instrument_id() {
         UnixNanos::from(1),
     );
     catalog
-        .write_to_parquet(vec![trade], None, None, None)
+        .write_to_parquet(&[trade], None, None, None)
         .unwrap();
 
     let files = catalog.query_files("trades", None, None, None).unwrap();
@@ -934,7 +920,7 @@ fn test_filter_files_non_ascii_instrument_id() {
         UnixNanos::from(1),
     );
     catalog
-        .write_to_parquet(vec![trade], None, None, None)
+        .write_to_parquet(&[trade], None, None, None)
         .unwrap();
 
     let all_files = catalog.query_files("trades", None, None, None).unwrap();
@@ -1010,9 +996,7 @@ fn test_query_bars_non_ascii_instrument_id_partial_match() {
         UnixNanos::from(0),
         UnixNanos::from(1),
     );
-    catalog
-        .write_to_parquet(vec![bar], None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&[bar], None, None, None).unwrap();
 
     // Querying by the bare instrument id only matches via the bars partial-match
     // branch, since the directory name is the full bar-type string.
@@ -1038,7 +1022,7 @@ fn test_rust_write_order_book_deltas() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let deltas = vec![create_order_book_delta(1), create_order_book_delta(2)];
-    catalog.write_to_parquet(deltas, None, None, None).unwrap();
+    catalog.write_to_parquet(&deltas, None, None, None).unwrap();
 
     let files = catalog
         .query_files(
@@ -1056,7 +1040,7 @@ fn test_rust_write_order_book_depths() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let depths = vec![create_order_book_depth10(1), create_order_book_depth10(2)];
-    catalog.write_to_parquet(depths, None, None, None).unwrap();
+    catalog.write_to_parquet(&depths, None, None, None).unwrap();
 
     let files = catalog
         .query_files(
@@ -1075,7 +1059,7 @@ fn test_rust_write_mark_price_updates() {
 
     let mark_prices = vec![create_mark_price_update(1), create_mark_price_update(2)];
     catalog
-        .write_to_parquet(mark_prices, None, None, None)
+        .write_to_parquet(&mark_prices, None, None, None)
         .unwrap();
 
     let files = catalog
@@ -1095,7 +1079,7 @@ fn test_rust_write_index_price_updates() {
 
     let index_prices = vec![create_index_price_update(1), create_index_price_update(2)];
     catalog
-        .write_to_parquet(index_prices, None, None, None)
+        .write_to_parquet(&index_prices, None, None, None)
         .unwrap();
 
     let files = catalog
@@ -1114,10 +1098,10 @@ fn test_rust_query_files() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1), create_bar(2)];
-    catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(3), create_bar(4)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let files = catalog
         .query_files("bars", Some(vec!["AUD/USD.SIM".to_string()]), None, None)
@@ -1131,13 +1115,13 @@ fn test_rust_query_files_with_multiple_files() {
     let (_temp_dir, catalog) = create_temp_catalog();
 
     let bars1 = vec![create_bar(1), create_bar(2)];
-    catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     let bars2 = vec![create_bar(3), create_bar(4)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     let bars3 = vec![create_bar(5), create_bar(6)];
-    catalog.write_to_parquet(bars3, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars3, None, None, None).unwrap();
 
     let files = catalog
         .query_files("bars", Some(vec!["AUD/USD.SIM".to_string()]), None, None)
@@ -1171,7 +1155,7 @@ fn test_consolidate_data_by_period_basic() {
         create_bar(7_200_000_000_000), // 2 hours
         create_bar(7_201_000_000_000), // 2 hours + 1 second
     ];
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Consolidate by 1-hour periods
     catalog
@@ -1191,9 +1175,7 @@ fn test_consolidate_data_by_period_basic() {
         create_bar(7_200_000_000_000), // 2 hours
         create_bar(7_201_000_000_000), // 2 hours + 1 second
     ];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Consolidate by 1-hour periods
@@ -1227,9 +1209,7 @@ fn test_consolidate_data_by_period_with_time_range() {
         create_bar(4000),
         create_bar(5000),
     ];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Consolidate only middle range
@@ -1279,9 +1259,7 @@ fn test_consolidate_data_by_period_different_periods() {
         create_bar(180_000_000_000), // 3 minutes
         create_bar(240_000_000_000), // 4 minutes
     ];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Test different period sizes
@@ -1311,9 +1289,7 @@ fn test_consolidate_data_by_period_ensure_contiguous_files_false() {
 
     // Create some test data
     let bars = vec![create_bar(1000), create_bar(2000), create_bar(3000)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Consolidate with ensure_contiguous_files=false
@@ -1348,7 +1324,7 @@ fn test_consolidate_data_by_period_fragment_per_flush() {
         let bar = create_bar(i * hour_ns + 1);
         last_bar_type = Some(bar.bar_type.to_string());
         catalog
-            .write_to_parquet(vec![bar], None, None, Some(true))
+            .write_to_parquet(&[bar], None, None, Some(true))
             .unwrap();
     }
 
@@ -1382,12 +1358,10 @@ fn test_consolidate_catalog_by_period_basic() {
 
     // Create data for multiple data types
     let bars = vec![create_bar(1000), create_bar(2000)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let quotes = vec![create_quote_tick(1000), create_quote_tick(2000)];
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // Consolidate entire catalog
     catalog
@@ -1416,9 +1390,7 @@ fn test_consolidate_catalog_by_period_with_time_range() {
 
     // Create data spanning multiple periods
     let bars = vec![create_bar(1000), create_bar(5000), create_bar(10000)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Consolidate catalog with time range
     catalog
@@ -1458,7 +1430,7 @@ fn test_consolidate_catalog_by_period_default_parameters() {
 
     // Create some test data
     let bars = vec![create_bar(1000), create_bar(2000)];
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Consolidate with default parameters
     let result = catalog.consolidate_catalog_by_period(None, None, None, None);
@@ -1474,13 +1446,13 @@ fn test_consolidate_data_by_period_multiple_instruments() {
     // Create bars for AUD/USD
     let aud_bars = vec![create_bar(1000), create_bar(2000)];
     catalog
-        .write_to_parquet(aud_bars.clone(), None, None, None)
+        .write_to_parquet(&aud_bars, None, None, None)
         .unwrap();
 
     // Create quotes for ETH/USDT
     let eth_quotes = vec![create_quote_tick(1000), create_quote_tick(2000)];
     catalog
-        .write_to_parquet(eth_quotes, None, None, None)
+        .write_to_parquet(&eth_quotes, None, None, None)
         .unwrap();
 
     let bar_type = aud_bars[0].bar_type.to_string();
@@ -1563,7 +1535,7 @@ fn test_generic_query_typed_data_quotes() {
     let (_temp_dir, mut catalog) = create_temp_catalog();
     // Create test data
     let quotes = vec![create_quote_tick(1000), create_quote_tick(2000)];
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // query using generic typed data function
     let result = catalog
@@ -1590,7 +1562,7 @@ fn test_generic_query_typed_data_bars() {
 
     // Create test data
     let bars = vec![create_bar(1000), create_bar(2000)];
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // query using generic typed data function
     let result = catalog
@@ -1687,7 +1659,7 @@ fn test_generic_query_typed_data_with_where_clause() {
 
     // Create test data
     let quotes = vec![create_quote_tick(1000), create_quote_tick(2000)];
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // query with WHERE clause
     let result = catalog
@@ -1712,7 +1684,7 @@ fn test_generic_consolidate_data_by_period_quotes() {
     // Create multiple small files with contiguous timestamps
     for i in 0..3 {
         let quotes = vec![create_quote_tick(1000 + i)];
-        catalog.write_to_parquet(quotes, None, None, None).unwrap();
+        catalog.write_to_parquet(&quotes, None, None, None).unwrap();
     }
 
     // Verify we have multiple files initially
@@ -1749,7 +1721,7 @@ fn test_generic_consolidate_data_by_period_bars() {
     for i in 0..3 {
         let bars = vec![create_bar(1000 + i)];
         bars_list.push(bars[0]);
-        catalog.write_to_parquet(bars, None, None, None).unwrap();
+        catalog.write_to_parquet(&bars, None, None, None).unwrap();
     }
 
     let bar_type = bars_list[0].bar_type.to_string();
@@ -1787,7 +1759,7 @@ fn test_generic_consolidate_data_by_period_keeps_skipped_target() {
     for timestamps in [&file1_ts[..], &file2_ts[..], &file3_ts[..]] {
         let bars: Vec<Bar> = timestamps.iter().copied().map(create_bar).collect();
         catalog
-            .write_to_parquet(bars, None, None, Some(true))
+            .write_to_parquet(&bars, None, None, Some(true))
             .unwrap();
     }
 
@@ -1852,7 +1824,7 @@ fn test_generic_consolidate_data_by_period_with_time_range() {
 
     for quote in quotes {
         catalog
-            .write_to_parquet(vec![quote], None, None, None)
+            .write_to_parquet(&[quote], None, None, None)
             .unwrap();
     }
 
@@ -1884,7 +1856,7 @@ fn test_consolidation_workflow_end_to_end() {
     for i in 0..5 {
         let bars = vec![create_bar(1000 + i * 1000)];
         bars_list.push(bars[0]);
-        catalog.write_to_parquet(bars, None, None, None).unwrap();
+        catalog.write_to_parquet(&bars, None, None, None).unwrap();
     }
 
     let bar_type = bars_list[0].bar_type.to_string();
@@ -1913,9 +1885,7 @@ fn test_consolidation_preserves_data_integrity() {
 
     // Write each bar separately to create multiple files
     for bar in &original_bars {
-        catalog
-            .write_to_parquet(vec![*bar], None, None, None)
-            .unwrap();
+        catalog.write_to_parquet(&[*bar], None, None, None).unwrap();
     }
 
     let bar_type = original_bars[0].bar_type.to_string();
@@ -2464,7 +2434,7 @@ fn test_delete_data_range_complete_file_deletion() {
     ];
 
     // Write data
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // Verify initial state
     let initial_data = catalog
@@ -2501,7 +2471,7 @@ fn test_delete_data_range_partial_file_overlap_start() {
     ];
 
     // Write data
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete first part of the data
     catalog
@@ -2534,7 +2504,7 @@ fn test_delete_data_range_partial_file_overlap_end() {
     ];
 
     // Write data
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete last part of the data
     catalog
@@ -2568,7 +2538,7 @@ fn test_delete_data_range_partial_file_overlap_middle() {
     ];
 
     // Write data
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete middle part of the data
     catalog
@@ -2619,7 +2589,7 @@ fn test_delete_data_range_no_intersection() {
     let quotes = vec![create_quote_tick(2_000_000_000)];
 
     // Write data
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete data outside existing range
     catalog
@@ -2650,8 +2620,8 @@ fn test_delete_catalog_range_multiple_data_types() {
     ];
     let bars = vec![create_bar(1_500_000_000), create_bar(2_500_000_000)];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Verify initial state
     let initial_quotes = catalog
@@ -2696,8 +2666,8 @@ fn test_delete_catalog_range_complete_deletion() {
     let quotes = vec![create_quote_tick(1_000_000_000)];
     let bars = vec![create_bar(2_000_000_000)];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Verify initial state
     assert_eq!(
@@ -2784,8 +2754,8 @@ fn test_delete_catalog_range_open_boundaries() {
         create_bar(3_500_000_000),
     ];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // delete from beginning to middle (open start)
     catalog
@@ -2877,7 +2847,7 @@ fn test_delete_data_range_nanosecond_precision_boundaries() {
         create_quote_tick(1_000_000_003), // +3 nanoseconds
     ];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete exactly the middle two timestamps [1_000_000_001, 1_000_000_002]
     catalog
@@ -2911,7 +2881,7 @@ fn test_delete_data_range_single_file_double_split() {
         create_quote_tick(5_000_000_000),
     ];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete middle range [2_500_000_000, 3_500_000_000]
     // This should create both split_before and split_after operations
@@ -2948,7 +2918,7 @@ fn test_delete_data_range_saturating_arithmetic_edge_cases() {
         create_quote_tick(2),
     ];
 
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     // delete range [0, 1] which tests saturating_sub(1) on timestamp 0
     catalog
@@ -3205,13 +3175,13 @@ fn test_catalog_query_multiple_instruments_table_naming() {
 
     // Write data for all instruments
     catalog
-        .write_to_parquet(eurusd_quotes, None, None, None)
+        .write_to_parquet(&eurusd_quotes, None, None, None)
         .unwrap();
     catalog
-        .write_to_parquet(btcusd_quotes, None, None, None)
+        .write_to_parquet(&btcusd_quotes, None, None, None)
         .unwrap();
     catalog
-        .write_to_parquet(ethusdt_quotes, None, None, None)
+        .write_to_parquet(&ethusdt_quotes, None, None, None)
         .unwrap();
 
     // Query all instruments simultaneously
@@ -3267,9 +3237,9 @@ fn test_query_directory_based_registration() {
     let batch3 = create_quote_ticks_for_instrument(instrument_id, 20000, 3); // Large gap to ensure disjoint
 
     // Write each batch separately to create multiple files
-    catalog.write_to_parquet(batch1, None, None, None).unwrap();
-    catalog.write_to_parquet(batch2, None, None, None).unwrap();
-    catalog.write_to_parquet(batch3, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch1, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch2, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch3, None, None, None).unwrap();
 
     // Query with directory-based registration (default)
     let result = catalog.query::<QuoteTick>(
@@ -3303,7 +3273,7 @@ fn test_query_directory_based_registration_preserves_equal_timestamp_order() {
 
     catalog
         .write_to_parquet(
-            create_quote_ticks_for_instrument("ETH/USDT.BINANCE", 1000, 1),
+            &create_quote_ticks_for_instrument("ETH/USDT.BINANCE", 1000, 1),
             None,
             None,
             None,
@@ -3311,7 +3281,7 @@ fn test_query_directory_based_registration_preserves_equal_timestamp_order() {
         .unwrap();
     catalog
         .write_to_parquet(
-            create_quote_ticks_for_instrument("AUD/USD.SIM", 1000, 1),
+            &create_quote_ticks_for_instrument("AUD/USD.SIM", 1000, 1),
             None,
             None,
             None,
@@ -3344,9 +3314,9 @@ fn test_query_file_based_registration() {
     let batch3 = create_quote_ticks_for_instrument(instrument_id, 20000, 3); // Large gap to ensure disjoint
 
     // Write each batch separately to create multiple files
-    catalog.write_to_parquet(batch1, None, None, None).unwrap();
-    catalog.write_to_parquet(batch2, None, None, None).unwrap();
-    catalog.write_to_parquet(batch3, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch1, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch2, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch3, None, None, None).unwrap();
 
     // Get all files for this instrument
     let all_files = catalog
@@ -3389,8 +3359,8 @@ fn test_query_directory_based_vs_file_based() {
     let batch1 = create_quote_ticks_for_instrument(instrument_id, 1000, 2);
     let batch2 = create_quote_ticks_for_instrument(instrument_id, 10000, 2); // Large gap to ensure disjoint
 
-    catalog.write_to_parquet(batch1, None, None, None).unwrap();
-    catalog.write_to_parquet(batch2, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch1, None, None, None).unwrap();
+    catalog.write_to_parquet(&batch2, None, None, None).unwrap();
 
     // Get all files
     let all_files = catalog
@@ -4105,10 +4075,10 @@ fn test_query_directory_based_registration_with_cloud_uri() {
 
     // Write each batch separately to create multiple files
     local_catalog
-        .write_to_parquet(batch1, None, None, None)
+        .write_to_parquet(&batch1, None, None, None)
         .unwrap();
     local_catalog
-        .write_to_parquet(batch2, None, None, None)
+        .write_to_parquet(&batch2, None, None, None)
         .unwrap();
 
     // Verify that directory-based registration works with local paths
@@ -4163,7 +4133,7 @@ fn test_duplicate_table_registration() {
 fn test_query_typed_data_repeated_calls() {
     let (_temp_dir, mut catalog) = create_temp_catalog();
     let quotes = vec![create_quote_tick(1000), create_quote_tick(2000)];
-    catalog.write_to_parquet(quotes, None, None, None).unwrap();
+    catalog.write_to_parquet(&quotes, None, None, None).unwrap();
 
     let result1 = catalog
         .query_typed_data::<QuoteTick>(
@@ -4214,11 +4184,11 @@ fn test_write_skips_if_file_exists() {
 
     // Write initial data
     let bars1 = vec![create_bar(1), create_bar(2)];
-    let path1 = catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    let path1 = catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     // Attempt to write same interval again (same timestamps)
     let bars2 = vec![create_bar(1), create_bar(2)];
-    let path2 = catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    let path2 = catalog.write_to_parquet(&bars2, None, None, None).unwrap();
 
     // Should return the same path (file exists, write skipped)
     assert_eq!(path1, path2);
@@ -4235,11 +4205,11 @@ fn test_write_errors_on_overlapping_intervals() {
 
     // Write initial data with interval (1, 5)
     let bars1 = vec![create_bar(1), create_bar(5)];
-    catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     // Attempt to write overlapping interval (3, 7) - should fail
     let bars2 = vec![create_bar(3), create_bar(7)];
-    let result = catalog.write_to_parquet(bars2, None, None, None);
+    let result = catalog.write_to_parquet(&bars2, None, None, None);
 
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
@@ -4253,11 +4223,11 @@ fn test_write_succeeds_with_disjoint_intervals() {
     // Write first interval (1, 2)
     let bars1 = vec![create_bar(1), create_bar(2)];
     let bar_type = bars1[0].bar_type.to_string();
-    catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     // Write non-overlapping interval (5, 6) - should succeed
     let bars2 = vec![create_bar(5), create_bar(6)];
-    catalog.write_to_parquet(bars2, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars2, None, None, None).unwrap();
     let intervals = catalog.get_intervals("bars", Some(&bar_type)).unwrap();
     assert_eq!(intervals, vec![(1, 2), (5, 6)]);
 }
@@ -4268,11 +4238,11 @@ fn test_write_with_skip_disjoint_check() {
 
     // Write initial data with interval (1, 5)
     let bars1 = vec![create_bar(1), create_bar(5)];
-    catalog.write_to_parquet(bars1, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars1, None, None, None).unwrap();
 
     // Write overlapping interval with skip_disjoint_check=true - should succeed
     let bars2 = vec![create_bar(3), create_bar(7)];
-    let result = catalog.write_to_parquet(bars2, None, None, Some(true));
+    let result = catalog.write_to_parquet(&bars2, None, None, Some(true));
 
     // Should succeed because we skipped the check
     assert!(result.is_ok());
@@ -4284,9 +4254,7 @@ fn test_query_first_timestamp() {
 
     // Write some bars
     let bars = vec![create_bar(1000), create_bar(2000), create_bar(3000)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Query first timestamp
@@ -4317,9 +4285,7 @@ fn test_query_last_timestamp() {
 
     // Write some bars
     let bars = vec![create_bar(1000), create_bar(2000), create_bar(3000)];
-    catalog
-        .write_to_parquet(bars.clone(), None, None, None)
-        .unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     let bar_type = bars[0].bar_type.to_string();
     // Query last timestamp
@@ -4341,7 +4307,7 @@ fn test_list_data_types() {
 
     // Write some data
     let bars = vec![create_bar(1000)];
-    catalog.write_to_parquet(bars, None, None, None).unwrap();
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
 
     // Now should have bars
     let data_types = catalog.list_data_types().unwrap();

--- a/docs/how_to/run_rust_backtest.md
+++ b/docs/how_to/run_rust_backtest.md
@@ -141,7 +141,7 @@ let catalog = ParquetDataCatalog::new(
 );
 
 catalog.write_instruments(vec![instrument])?;
-catalog.write_to_parquet(quotes, None, None, None)?;
+catalog.write_to_parquet(&quotes, None, None, None)?;
 ```
 
 ### 2. Configure the run

--- a/patches/pyo3-stub-gen/Cargo.toml
+++ b/patches/pyo3-stub-gen/Cargo.toml
@@ -58,14 +58,8 @@ version = ">= 2.7.0"
 [dependencies.inventory]
 version = "0.3.22"
 
-[dependencies.itertools]
-version = "0.14.0"
-
 [dependencies.log]
 version = "0.4.29"
-
-[dependencies.maplit]
-version = "1.0.2"
 
 [dependencies.num-complex]
 version = "0.4.6"
@@ -88,14 +82,6 @@ version = "0.20.0"
 [dependencies.rust_decimal]
 version = "1.40"
 optional = true
-default-features = false
-
-[dependencies.rustpython-parser]
-version = "0.4"
-features = [
-    "location",
-    "num-bigint",
-]
 default-features = false
 
 [dependencies.serde]

--- a/patches/pyo3-stub-gen/src/generate/function.rs
+++ b/patches/pyo3-stub-gen/src/generate/function.rs
@@ -1,7 +1,6 @@
 use crate::generate::docstring::normalize_docstring;
 use crate::stub_type::ImportRef;
 use crate::{generate::*, rule_name::RuleName, type_info::*, TypeInfo};
-use itertools::Itertools;
 use std::fmt;
 
 /// Definition of a Python function.
@@ -86,8 +85,9 @@ impl fmt::Display for FunctionDef {
                             if let RuleName::Custom(custom) = &result {
                                 log::warn!("Unknown custom rule name '{custom}' used in type ignore. Ensure this is intended.");
                             }
-                            result
+                            result.to_string()
                         })
+                        .collect::<Vec<_>>()
                         .join(",");
                     Some(format!("  # type: ignore[{rules_str}]"))
                 }
@@ -176,8 +176,9 @@ impl FunctionDef {
                             if let RuleName::Custom(custom) = &result {
                                 log::warn!("Unknown custom rule name '{custom}' used in type ignore. Ensure this is intended.");
                             }
-                            result
+                            result.to_string()
                         })
+                        .collect::<Vec<_>>()
                         .join(",");
                     Some(format!("  # type: ignore[{rules_str}]"))
                 }

--- a/patches/pyo3-stub-gen/src/generate/method.rs
+++ b/patches/pyo3-stub-gen/src/generate/method.rs
@@ -1,7 +1,6 @@
 use crate::generate::docstring::normalize_docstring;
 use crate::stub_type::ImportRef;
 use crate::{generate::*, rule_name::RuleName, type_info::*, TypeInfo};
-use itertools::Itertools;
 use std::{collections::HashSet, fmt};
 
 pub use crate::type_info::MethodType;
@@ -101,8 +100,9 @@ impl fmt::Display for MethodDef {
                             if let RuleName::Custom(custom) = &result {
                                 log::warn!("Unknown custom rule name '{custom}' used in type ignore. Ensure this is intended.");
                             }
-                            result
+                            result.to_string()
                         })
+                        .collect::<Vec<_>>()
                         .join(",");
                     Some(format!("  # type: ignore[{rules_str}]"))
                 }
@@ -197,8 +197,9 @@ impl MethodDef {
                             if let RuleName::Custom(custom) = &result {
                                 log::warn!("Unknown custom rule name '{custom}' used in type ignore. Ensure this is intended.");
                             }
-                            result
+                            result.to_string()
                         })
+                        .collect::<Vec<_>>()
                         .join(",");
                     Some(format!("  # type: ignore[{rules_str}]"))
                 }

--- a/patches/pyo3-stub-gen/src/generate/module.rs
+++ b/patches/pyo3-stub-gen/src/generate/module.rs
@@ -1,6 +1,5 @@
 use crate::generate::*;
 use crate::stub_type::ImportRef;
-use itertools::Itertools;
 use std::{
     any::TypeId,
     collections::{BTreeMap, BTreeSet},
@@ -79,7 +78,9 @@ impl Module {
 
                 // Generate imports (same logic as Display impl)
                 let mut type_ref_grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
-                for import_ref in imports.into_iter().sorted() {
+                let mut sorted_imports = imports.into_iter().collect::<Vec<_>>();
+                sorted_imports.sort();
+                for import_ref in sorted_imports {
                     match import_ref {
                         ImportRef::Module(module_ref) => {
                             let name = module_ref.get().unwrap_or(&self.module.default_module_name);
@@ -173,12 +174,16 @@ impl Module {
                 }
 
                 // Generate classes
-                for class in self.module.class.values().sorted_by_key(|class| class.name) {
+                let mut classes = self.module.class.values().collect::<Vec<_>>();
+                classes.sort_by_key(|class| class.name);
+                for class in classes {
                     class.fmt_for_module(&self.module.name, f)?;
                 }
 
                 // Generate enums
-                for enum_ in self.module.enum_.values().sorted_by_key(|enum_| enum_.name) {
+                let mut enums = self.module.enum_.values().collect::<Vec<_>>();
+                enums.sort_by_key(|enum_| enum_.name);
+                for enum_ in enums {
                     enum_.fmt_for_module(&self.module.name, f)?;
                 }
 
@@ -322,7 +327,9 @@ impl fmt::Display for Module {
 
         // To gather `from submod import A, B, C` style imports
         let mut type_ref_grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for import_ref in imports.into_iter().sorted() {
+        let mut sorted_imports = imports.into_iter().collect::<Vec<_>>();
+        sorted_imports.sort();
+        for import_ref in sorted_imports {
             match import_ref {
                 ImportRef::Module(module_ref) => {
                     let name = module_ref.get().unwrap_or(&self.default_module_name);
@@ -411,10 +418,14 @@ impl fmt::Display for Module {
             var.fmt_for_module(&self.name, f)?;
             writeln!(f)?;
         }
-        for class in self.class.values().sorted_by_key(|class| class.name) {
+        let mut classes = self.class.values().collect::<Vec<_>>();
+        classes.sort_by_key(|class| class.name);
+        for class in classes {
             class.fmt_for_module(&self.name, f)?;
         }
-        for enum_ in self.enum_.values().sorted_by_key(|class| class.name) {
+        let mut enums = self.enum_.values().collect::<Vec<_>>();
+        enums.sort_by_key(|enum_| enum_.name);
+        for enum_ in enums {
             enum_.fmt_for_module(&self.name, f)?;
         }
         for functions in self.function.values() {

--- a/patches/pyo3-stub-gen/src/stub_type.rs
+++ b/patches/pyo3-stub-gen/src/stub_type.rs
@@ -11,7 +11,6 @@ mod either;
 #[cfg(feature = "rust_decimal")]
 mod rust_decimal;
 
-use maplit::hashset;
 use std::cmp::Ordering;
 use std::{
     collections::{HashMap, HashSet},
@@ -177,7 +176,7 @@ impl TypeInfo {
         Self {
             name: "typing.Any".to_string(),
             source_module: None,
-            import: hashset! { "typing".into() },
+            import: HashSet::from(["typing".into()]),
             type_refs: HashMap::new(),
         }
     }
@@ -303,7 +302,7 @@ impl TypeInfo {
         Self {
             name: format!("builtins.{name}"),
             source_module: None,
-            import: hashset! { "builtins".into() },
+            import: HashSet::from(["builtins".into()]),
             type_refs: HashMap::new(),
         }
     }
@@ -313,7 +312,7 @@ impl TypeInfo {
         Self {
             name: name.to_string(),
             source_module: None,
-            import: hashset! {},
+            import: HashSet::new(),
             type_refs: HashMap::new(),
         }
     }
@@ -600,23 +599,22 @@ pub trait PyStubType {
 #[cfg(test)]
 mod test {
     use super::*;
-    use maplit::hashset;
     use std::collections::HashMap;
     use test_case::test_case;
 
-    #[test_case(bool::type_input(), "builtins.bool", hashset! { "builtins".into() } ; "bool_input")]
-    #[test_case(<&str>::type_input(), "builtins.str", hashset! { "builtins".into() } ; "str_input")]
-    #[test_case(Vec::<u32>::type_input(), "typing.Sequence[builtins.int]", hashset! { "typing".into(), "builtins".into() } ; "Vec_u32_input")]
-    #[test_case(Vec::<u32>::type_output(), "builtins.list[builtins.int]", hashset! {  "builtins".into() } ; "Vec_u32_output")]
-    #[test_case(HashMap::<u32, String>::type_input(), "typing.Mapping[builtins.int, builtins.str]", hashset! { "typing".into(), "builtins".into() } ; "HashMap_u32_String_input")]
-    #[test_case(HashMap::<u32, String>::type_output(), "builtins.dict[builtins.int, builtins.str]", hashset! { "builtins".into() } ; "HashMap_u32_String_output")]
-    #[test_case(indexmap::IndexMap::<u32, String>::type_input(), "typing.Mapping[builtins.int, builtins.str]", hashset! { "typing".into(), "builtins".into() } ; "IndexMap_u32_String_input")]
-    #[test_case(indexmap::IndexMap::<u32, String>::type_output(), "builtins.dict[builtins.int, builtins.str]", hashset! { "builtins".into() } ; "IndexMap_u32_String_output")]
-    #[test_case(HashMap::<u32, Vec<u32>>::type_input(), "typing.Mapping[builtins.int, typing.Sequence[builtins.int]]", hashset! { "builtins".into(), "typing".into() } ; "HashMap_u32_Vec_u32_input")]
-    #[test_case(HashMap::<u32, Vec<u32>>::type_output(), "builtins.dict[builtins.int, builtins.list[builtins.int]]", hashset! { "builtins".into() } ; "HashMap_u32_Vec_u32_output")]
-    #[test_case(HashSet::<u32>::type_input(), "builtins.set[builtins.int]", hashset! { "builtins".into() } ; "HashSet_u32_input")]
-    #[test_case(indexmap::IndexSet::<u32>::type_input(), "builtins.set[builtins.int]", hashset! { "builtins".into() } ; "IndexSet_u32_input")]
-    #[test_case(TypeInfo::dict_of::<u32, String>(), "builtins.dict[builtins.int, builtins.str]", hashset! { "builtins".into() } ; "dict_of_u32_String")]
+    #[test_case(bool::type_input(), "builtins.bool", HashSet::from(["builtins".into()]) ; "bool_input")]
+    #[test_case(<&str>::type_input(), "builtins.str", HashSet::from(["builtins".into()]) ; "str_input")]
+    #[test_case(Vec::<u32>::type_input(), "typing.Sequence[builtins.int]", HashSet::from(["typing".into(), "builtins".into()]) ; "Vec_u32_input")]
+    #[test_case(Vec::<u32>::type_output(), "builtins.list[builtins.int]", HashSet::from(["builtins".into()]) ; "Vec_u32_output")]
+    #[test_case(HashMap::<u32, String>::type_input(), "typing.Mapping[builtins.int, builtins.str]", HashSet::from(["typing".into(), "builtins".into()]) ; "HashMap_u32_String_input")]
+    #[test_case(HashMap::<u32, String>::type_output(), "builtins.dict[builtins.int, builtins.str]", HashSet::from(["builtins".into()]) ; "HashMap_u32_String_output")]
+    #[test_case(indexmap::IndexMap::<u32, String>::type_input(), "typing.Mapping[builtins.int, builtins.str]", HashSet::from(["typing".into(), "builtins".into()]) ; "IndexMap_u32_String_input")]
+    #[test_case(indexmap::IndexMap::<u32, String>::type_output(), "builtins.dict[builtins.int, builtins.str]", HashSet::from(["builtins".into()]) ; "IndexMap_u32_String_output")]
+    #[test_case(HashMap::<u32, Vec<u32>>::type_input(), "typing.Mapping[builtins.int, typing.Sequence[builtins.int]]", HashSet::from(["builtins".into(), "typing".into()]) ; "HashMap_u32_Vec_u32_input")]
+    #[test_case(HashMap::<u32, Vec<u32>>::type_output(), "builtins.dict[builtins.int, builtins.list[builtins.int]]", HashSet::from(["builtins".into()]) ; "HashMap_u32_Vec_u32_output")]
+    #[test_case(HashSet::<u32>::type_input(), "builtins.set[builtins.int]", HashSet::from(["builtins".into()]) ; "HashSet_u32_input")]
+    #[test_case(indexmap::IndexSet::<u32>::type_input(), "builtins.set[builtins.int]", HashSet::from(["builtins".into()]) ; "IndexSet_u32_input")]
+    #[test_case(TypeInfo::dict_of::<u32, String>(), "builtins.dict[builtins.int, builtins.str]", HashSet::from(["builtins".into()]) ; "dict_of_u32_String")]
     fn test(tinfo: TypeInfo, name: &str, import: HashSet<ImportRef>) {
         assert_eq!(tinfo.name, name);
         if import.is_empty() {

--- a/patches/pyo3-stub-gen/src/stub_type/numpy.rs
+++ b/patches/pyo3-stub-gen/src/stub_type/numpy.rs
@@ -1,10 +1,9 @@
 use super::{PyStubType, TypeInfo};
-use maplit::hashset;
 use numpy::{
     ndarray::Dimension, Element, PyArray, PyArrayDescr, PyReadonlyArray, PyReadwriteArray,
     PyUntypedArray,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 trait NumPyScalar {
     fn type_() -> TypeInfo;
@@ -17,7 +16,7 @@ macro_rules! impl_numpy_scalar {
                 TypeInfo {
                     name: format!("numpy.{}", $name),
                     source_module: None,
-                    import: hashset!["numpy".into()],
+                    import: HashSet::from(["numpy".into()]),
                     type_refs: HashMap::new(),
                 }
             }
@@ -58,7 +57,7 @@ impl PyStubType for PyUntypedArray {
         TypeInfo {
             name: "numpy.typing.NDArray[typing.Any]".into(),
             source_module: None,
-            import: hashset!["numpy.typing".into(), "typing".into()],
+            import: HashSet::from(["numpy.typing".into(), "typing".into()]),
             type_refs: HashMap::new(),
         }
     }
@@ -89,7 +88,7 @@ impl PyStubType for PyArrayDescr {
         TypeInfo {
             name: "numpy.dtype".into(),
             source_module: None,
-            import: hashset!["numpy".into()],
+            import: HashSet::from(["numpy".into()]),
             type_refs: HashMap::new(),
         }
     }

--- a/patches/pyo3-stub-gen/src/stub_type/pyo3.rs
+++ b/patches/pyo3-stub-gen/src/stub_type/pyo3.rs
@@ -6,15 +6,14 @@ use ::pyo3::{
     types::*,
     Bound, Py, PyClass, PyRef, PyRefMut,
 };
-use maplit::hashset;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 impl PyStubType for PyAny {
     fn type_output() -> TypeInfo {
         TypeInfo {
             name: "typing.Any".to_string(),
             source_module: None,
-            import: hashset! { "typing".into() },
+            import: HashSet::from(["typing".into()]),
             type_refs: HashMap::new(),
         }
     }
@@ -95,7 +94,7 @@ macro_rules! impl_simple {
                 TypeInfo {
                     name: concat!($mod, ".", $pytype).to_string(),
                     source_module: None,
-                    import: hashset! { $mod.into() },
+                    import: HashSet::from([$mod.into()]),
                     type_refs: HashMap::new(),
                 }
             }


### PR DESCRIPTION
## Summary

Use borrowed slices for Parquet catalog write paths instead of taking owned `Vec<T>` values. This removes unused direct dependencies from persistence and the patched `pyo3-stub-gen`, and replaces those call sites with standard library equivalents.

## Type of change

- [x] Improvement (non-breaking for Python users)
- [x] Breaking change (Rust API signature change)
- [x] Maintenance / chore
- [x] Documentation update

## Breaking change details

Rust callers of `ParquetDataCatalog::write_to_parquet` and `data_to_record_batches` now pass borrowed slices instead of owned vectors:

```rust
catalog.write_to_parquet(&quotes, None, None, None)?;
```

The Python catalog API remains unchanged.

## Removed dependencies

Direct dependencies removed by this PR:

| Dependency | Removed from | Replacement |
| --- | --- | --- |
| `itertools` | Workspace root and `nautilus-persistence` | `slice::chunks`, `Vec::sort`, `Vec::join` |
| `itertools` | `patches/pyo3-stub-gen` | Standard iterator collection plus `Vec::sort` / `Vec::join` |
| `maplit` | `patches/pyo3-stub-gen` | `HashSet::from([...])` and `HashSet::new()` |
| `rustpython-parser` | `patches/pyo3-stub-gen` | Removed because the patched crate no longer uses it directly |

## Performance impact

| Area | Before | After | Expected impact |
| --- | --- | --- | --- |
| `data_to_record_batches` chunking | `itertools::chunks` plus per-chunk `collect_vec()` | Slice `chunks()` passed directly to encoders | Fewer temporary `Vec` allocations; expected improvement for large writes |
| Rust catalog write API | Takes ownership of `Vec<T>` | Borrows `&[T]` | Avoids unnecessary ownership transfer and caller clones |
| Test/catalog setup helpers | Temporary `Vec` literals | Temporary slice literals | Fewer test-only allocations |
| `pyo3-stub-gen` formatting joins | `itertools::join` | `collect::<Vec<_>>().join(",")` | Possible small regression in stub generation only; not runtime trading path |

No benchmark was run for this PR; the performance assessment is static allocation analysis.

## Documentation

- Updated the Rust backtest how-to snippet to pass borrowed catalog data.
