### PR TITLE
Make common clock ref-count clones explicit

### DIFF
--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -15,6 +15,8 @@
 
 //! Real-time and static `Clock` implementations.
 
+#![warn(clippy::clone_on_ref_ptr)]
+
 use std::{any::Any, cell::RefCell, collections::BTreeMap, fmt::Debug, ops::Deref, time::Duration};
 
 use ahash::AHashMap;
@@ -2219,10 +2221,10 @@ mod tests {
         let cancellations = Arc::new(Mutex::new(Vec::new()));
         let cancel_all = Arc::new(Mutex::new(false));
 
-        let alerts_for_handler = alerts.clone();
-        let timers_for_handler = timers.clone();
-        let cancellations_for_handler = cancellations.clone();
-        let cancel_all_for_handler = cancel_all.clone();
+        let alerts_for_handler = Arc::clone(&alerts);
+        let timers_for_handler = Arc::clone(&timers);
+        let cancellations_for_handler = Arc::clone(&cancellations);
+        let cancel_all_for_handler = Arc::clone(&cancel_all);
         let api = ClockApi::from_handlers(
             || UnixNanos::from(1_700_000_000_123_456_789),
             move |name, alert_time_ns, _callback, allow_past| {

--- a/crates/common/src/python/clock.rs
+++ b/crates/common/src/python/clock.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+#![warn(clippy::clone_on_ref_ptr)]
+
 use std::{cell::RefCell, rc::Rc};
 
 use chrono::{DateTime, Duration, Utc};
@@ -255,7 +257,7 @@ impl PyClock {
     /// Gets the inner `Rc<RefCell<dyn Clock>>` for use in Rust code.
     #[must_use]
     pub fn clock_rc(&self) -> Rc<RefCell<dyn Clock>> {
-        self.0.clone()
+        Rc::clone(&self.0)
     }
 
     /// Creates a clock backed by [`TestClock`].


### PR DESCRIPTION
## Summary

- Enable `clippy::clone_on_ref_ptr` locally for the `crates/common` clock modules touched in this slice.
- Replace confirmed `Arc<Mutex<_>>` clock test handle clones with `Arc::clone`.
- Replace the Python clock wrapper's `Rc<RefCell<dyn Clock>>` handle clone with `Rc::clone`.

Refs #4300.

## Scope

This keeps the first contribution intentionally narrow, following the maintainer guidance in #4300 to avoid a big-bang cleanup and start with the `crates/common` clock module. Value/deep/custom clones remain unchanged, including `TimeEventCallback`, `TimeEvent`, `Vec`, and sender-like clones.

Package-wide `clone_on_ref_ptr` still reports existing warnings in other modules such as actor, component, msgbus, runner, timer, and core shared types; those are left for follow-up slices.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -p nautilus-common --lib -- -W clippy::clone_on_ref_ptr`
- `cargo clippy -p nautilus-common --tests --message-format=json -- -W clippy::clone_on_ref_ptr`
- `cargo clippy -p nautilus-common --lib --features python --message-format=json -- -W clippy::clone_on_ref_ptr`

The JSON diagnostic checks report zero `clone_on_ref_ptr` diagnostics in these clock-related paths:

- `crates/common/src/clock.rs`
- `crates/common/src/python/clock.rs`
- `crates/common/src/live/clock.rs`
- `crates/common/src/ffi/clock.rs`
