### PR TITLE
Add Bybit instrument subscriptions

### DIFF
--- a/crates/adapters/bybit/src/common/instruments.rs
+++ b/crates/adapters/bybit/src/common/instruments.rs
@@ -30,10 +30,20 @@ use nautilus_model::{
 fn economics_differ(a: &InstrumentAny, b: &InstrumentAny) -> bool {
     a.maker_fee() != b.maker_fee()
         || a.taker_fee() != b.taker_fee()
+        || a.margin_init() != b.margin_init()
+        || a.margin_maint() != b.margin_maint()
+        || a.price_precision() != b.price_precision()
+        || a.size_precision() != b.size_precision()
         || a.price_increment() != b.price_increment()
         || a.size_increment() != b.size_increment()
+        || a.multiplier() != b.multiplier()
+        || a.lot_size() != b.lot_size()
         || a.min_quantity() != b.min_quantity()
+        || a.max_quantity() != b.max_quantity()
         || a.min_notional() != b.min_notional()
+        || a.max_notional() != b.max_notional()
+        || a.min_price() != b.min_price()
+        || a.max_price() != b.max_price()
 }
 
 /// Compares a fresh instrument snapshot against cached definitions, emitting [`DataEvent::Instrument`]
@@ -75,6 +85,7 @@ mod tests {
         instruments::{CryptoPerpetual, InstrumentAny},
         types::{Currency, Money, Price, Quantity},
     };
+    use rstest::rstest;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
@@ -122,7 +133,7 @@ mod tests {
         perp(dec!(0.0001), dec!(0.00055), Quantity::from("0.001"), None)
     }
 
-    #[test]
+    #[rstest]
     fn test_emits_for_new_instrument() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let instrument = default_perp();
@@ -137,7 +148,7 @@ mod tests {
         assert!(cached.contains_key(&instrument.id()));
     }
 
-    #[test]
+    #[rstest]
     fn test_no_emit_when_unchanged() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let instrument = default_perp();
@@ -149,7 +160,7 @@ mod tests {
         assert!(rx.try_recv().is_err());
     }
 
-    #[test]
+    #[rstest]
     fn test_emits_on_fee_change() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let id = default_perp().id();
@@ -170,7 +181,7 @@ mod tests {
         assert_eq!(cached.get(&id).unwrap().taker_fee(), dec!(0.0008));
     }
 
-    #[test]
+    #[rstest]
     fn test_emits_on_size_increment_and_min_notional_change() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let id = default_perp().id();
@@ -195,7 +206,7 @@ mod tests {
         assert!(rx.try_recv().is_ok(), "min_notional change should emit");
     }
 
-    #[test]
+    #[rstest]
     fn test_subscription_gating_updates_cache_but_only_emits_for_subscribed() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let id = default_perp().id();

--- a/crates/adapters/bybit/src/common/instruments.rs
+++ b/crates/adapters/bybit/src/common/instruments.rs
@@ -1,0 +1,229 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Instrument definition diffing and emission for the Bybit adapter.
+
+use ahash::{AHashMap, AHashSet};
+use nautilus_common::messages::DataEvent;
+use nautilus_model::{
+    identifiers::InstrumentId,
+    instruments::{Instrument, InstrumentAny},
+};
+
+/// Returns `true` if the economically meaningful fields of two instruments differ.
+///
+/// [`InstrumentAny`]'s `PartialEq` compares only the instrument ID, and definitions carry
+/// per-fetch timestamps that always change — so neither is usable for detecting "real" updates.
+/// This compares the fields a strategy prices and sizes against, ignoring timestamps.
+fn economics_differ(a: &InstrumentAny, b: &InstrumentAny) -> bool {
+    a.maker_fee() != b.maker_fee()
+        || a.taker_fee() != b.taker_fee()
+        || a.price_increment() != b.price_increment()
+        || a.size_increment() != b.size_increment()
+        || a.min_quantity() != b.min_quantity()
+        || a.min_notional() != b.min_notional()
+}
+
+/// Compares a fresh instrument snapshot against cached definitions, emitting [`DataEvent::Instrument`]
+/// events for new and economically-changed instruments.
+///
+/// The cache is updated to reflect each meaningful change regardless of subscription, while emissions
+/// are gated by `subscriptions`: only subscribed instruments produce events. Pass `None` to emit for
+/// all changes (e.g. a venue-wide subscription).
+pub fn diff_and_emit_instruments(
+    new_instruments: &[InstrumentAny],
+    cached: &mut AHashMap<InstrumentId, InstrumentAny>,
+    subscriptions: Option<&AHashSet<InstrumentId>>,
+    sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
+) {
+    let is_subscribed = |id: &InstrumentId| subscriptions.is_none_or(|subs| subs.contains(id));
+
+    for instrument in new_instruments {
+        let id = instrument.id();
+        let changed = cached
+            .get(&id)
+            .is_none_or(|prev| economics_differ(prev, instrument));
+
+        if changed {
+            cached.insert(id, instrument.clone());
+            if is_subscribed(&id)
+                && let Err(e) = sender.send(DataEvent::Instrument(instrument.clone()))
+            {
+                log::error!("Failed to emit instrument event: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::UnixNanos;
+    use nautilus_model::{
+        identifiers::{InstrumentId, Symbol},
+        instruments::{CryptoPerpetual, InstrumentAny},
+        types::{Currency, Money, Price, Quantity},
+    };
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    /// Builds a BTCUSDT linear perp with the given economic fields; everything else is fixed so a
+    /// single varied field is what the diff sees.
+    fn perp(
+        maker_fee: Decimal,
+        taker_fee: Decimal,
+        size_increment: Quantity,
+        min_notional: Option<Money>,
+    ) -> InstrumentAny {
+        InstrumentAny::CryptoPerpetual(CryptoPerpetual::new(
+            InstrumentId::from("BTCUSDT-LINEAR.BYBIT"),
+            Symbol::from("BTCUSDT-LINEAR"),
+            Currency::BTC(),
+            Currency::USDT(),
+            Currency::USDT(),
+            false, // is_inverse
+            1,     // price_precision
+            3,     // size_precision
+            Price::from("0.1"),
+            size_increment,
+            None,                          // multiplier
+            None,                          // lot_size
+            None,                          // max_quantity
+            Some(Quantity::from("0.001")), // min_quantity
+            None,                          // max_notional
+            min_notional,
+            None, // max_price
+            None, // min_price
+            None, // margin_init
+            None, // margin_maint
+            Some(maker_fee),
+            Some(taker_fee),
+            None,                 // tick_scheme
+            None,                 // info
+            UnixNanos::default(), // ts_event
+            UnixNanos::default(), // ts_init
+        ))
+    }
+
+    fn default_perp() -> InstrumentAny {
+        perp(dec!(0.0001), dec!(0.00055), Quantity::from("0.001"), None)
+    }
+
+    #[test]
+    fn test_emits_for_new_instrument() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let instrument = default_perp();
+        let mut cached = AHashMap::new();
+
+        diff_and_emit_instruments(std::slice::from_ref(&instrument), &mut cached, None, &tx);
+
+        match rx.try_recv().expect("expected instrument event") {
+            DataEvent::Instrument(emitted) => assert_eq!(emitted.id(), instrument.id()),
+            _ => panic!("expected Instrument event"),
+        }
+        assert!(cached.contains_key(&instrument.id()));
+    }
+
+    #[test]
+    fn test_no_emit_when_unchanged() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let instrument = default_perp();
+        let mut cached = AHashMap::new();
+        cached.insert(instrument.id(), default_perp());
+
+        diff_and_emit_instruments(&[instrument], &mut cached, None, &tx);
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_emits_on_fee_change() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let id = default_perp().id();
+        let mut cached = AHashMap::new();
+        cached.insert(id, default_perp());
+
+        // Same instrument, higher taker fee.
+        let updated = perp(dec!(0.0001), dec!(0.0008), Quantity::from("0.001"), None);
+        diff_and_emit_instruments(&[updated], &mut cached, None, &tx);
+
+        match rx
+            .try_recv()
+            .expect("expected instrument event on fee change")
+        {
+            DataEvent::Instrument(emitted) => assert_eq!(emitted.taker_fee(), dec!(0.0008)),
+            _ => panic!("expected Instrument event"),
+        }
+        assert_eq!(cached.get(&id).unwrap().taker_fee(), dec!(0.0008));
+    }
+
+    #[test]
+    fn test_emits_on_size_increment_and_min_notional_change() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let id = default_perp().id();
+
+        // size_increment change
+        let mut cached = AHashMap::new();
+        cached.insert(id, default_perp());
+        let bigger_step = perp(dec!(0.0001), dec!(0.00055), Quantity::from("0.002"), None);
+        diff_and_emit_instruments(&[bigger_step], &mut cached, None, &tx);
+        assert!(rx.try_recv().is_ok(), "size_increment change should emit");
+
+        // min_notional change
+        let mut cached = AHashMap::new();
+        cached.insert(id, default_perp());
+        let with_min = perp(
+            dec!(0.0001),
+            dec!(0.00055),
+            Quantity::from("0.001"),
+            Some(Money::new(5.0, Currency::USDT())),
+        );
+        diff_and_emit_instruments(&[with_min], &mut cached, None, &tx);
+        assert!(rx.try_recv().is_ok(), "min_notional change should emit");
+    }
+
+    #[test]
+    fn test_subscription_gating_updates_cache_but_only_emits_for_subscribed() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let id = default_perp().id();
+
+        // Not subscribed: cache still updates, but no event.
+        let empty_subs = AHashSet::new();
+        let mut cached = AHashMap::new();
+        cached.insert(id, default_perp());
+        let updated = perp(dec!(0.0001), dec!(0.0008), Quantity::from("0.001"), None);
+
+        diff_and_emit_instruments(&[updated], &mut cached, Some(&empty_subs), &tx);
+
+        assert!(rx.try_recv().is_err(), "unsubscribed should not emit");
+        assert_eq!(
+            cached.get(&id).unwrap().taker_fee(),
+            dec!(0.0008),
+            "cache should update regardless of subscription"
+        );
+
+        // Subscribed: emits.
+        let mut subs = AHashSet::new();
+        subs.insert(id);
+        let mut cached = AHashMap::new();
+        cached.insert(id, default_perp());
+        let updated = perp(dec!(0.0001), dec!(0.0008), Quantity::from("0.001"), None);
+
+        diff_and_emit_instruments(&[updated], &mut cached, Some(&subs), &tx);
+
+        assert!(rx.try_recv().is_ok(), "subscribed should emit");
+    }
+}

--- a/crates/adapters/bybit/src/common/mod.rs
+++ b/crates/adapters/bybit/src/common/mod.rs
@@ -18,6 +18,7 @@
 pub mod consts;
 pub mod credential;
 pub mod enums;
+pub mod instruments;
 pub mod models;
 pub mod parse;
 pub mod status;

--- a/crates/adapters/bybit/src/common/status.rs
+++ b/crates/adapters/bybit/src/common/status.rs
@@ -89,7 +89,7 @@ pub fn diff_and_emit_statuses(
     }
 }
 
-fn emit_status(
+pub(crate) fn emit_status(
     sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     instrument_id: InstrumentId,
     action: MarketStatusAction,

--- a/crates/adapters/bybit/src/config.rs
+++ b/crates/adapters/bybit/src/config.rs
@@ -77,9 +77,9 @@ pub struct BybitDataClientConfig {
     /// Interval in minutes for instrument refresh from REST.
     /// When `None`, instrument refresh is disabled.
     pub update_instruments_interval_mins: Option<u64>,
-    /// Interval in seconds for polling instrument status changes.
-    /// When `None`, status polling is disabled.
-    pub instrument_status_poll_secs: Option<u64>,
+    /// Interval in seconds for polling instrument definitions and status changes from REST.
+    /// When `None`, instrument/status polling is disabled.
+    pub instrument_poll_interval_secs: Option<u64>,
     /// WebSocket transport backend (defaults to `Tungstenite`).
     #[builder(default)]
     pub transport_backend: TransportBackend,
@@ -89,7 +89,7 @@ impl Default for BybitDataClientConfig {
     fn default() -> Self {
         Self {
             update_instruments_interval_mins: Some(60),
-            instrument_status_poll_secs: Some(60),
+            instrument_poll_interval_secs: Some(60),
             ..Self::builder().build()
         }
     }

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -36,10 +36,11 @@ use nautilus_common::{
             InstrumentResponse, InstrumentsResponse, RequestBars, RequestBookSnapshot,
             RequestForwardPrices, RequestFundingRates, RequestInstrument, RequestInstruments,
             RequestTrades, SubscribeBars, SubscribeBookDeltas, SubscribeFundingRates,
-            SubscribeIndexPrices, SubscribeInstrumentStatus, SubscribeMarkPrices,
-            SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades, TradesResponse,
-            UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeFundingRates,
-            UnsubscribeIndexPrices, UnsubscribeInstrumentStatus, UnsubscribeMarkPrices,
+            SubscribeIndexPrices, SubscribeInstrument, SubscribeInstrumentStatus,
+            SubscribeInstruments, SubscribeMarkPrices, SubscribeOptionGreeks, SubscribeQuotes,
+            SubscribeTrades, TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas,
+            UnsubscribeFundingRates, UnsubscribeIndexPrices, UnsubscribeInstrument,
+            UnsubscribeInstrumentStatus, UnsubscribeInstruments, UnsubscribeMarkPrices,
             UnsubscribeOptionGreeks, UnsubscribeQuotes, UnsubscribeTrades,
         },
     },
@@ -65,8 +66,9 @@ use crate::{
     common::{
         consts::{BYBIT_DEFAULT_ORDERBOOK_DEPTH, BYBIT_VENUE},
         enums::BybitProductType,
+        instruments::diff_and_emit_instruments,
         parse::{extract_raw_symbol, make_bybit_symbol},
-        status::diff_and_emit_statuses,
+        status::{diff_and_emit_statuses, emit_status},
         symbol::BybitSymbol,
     },
     config::BybitDataClientConfig,
@@ -103,6 +105,9 @@ pub struct BybitDataClient {
     option_greeks_subs: Arc<AtomicSet<InstrumentId>>,
     instrument_status_subs: Arc<AtomicSet<InstrumentId>>,
     status_cache: Arc<AtomicMap<InstrumentId, MarketStatusAction>>,
+    instrument_subs: Arc<AtomicSet<InstrumentId>>,
+    /// Venue-wide subscription: when set, definition updates are emitted for all instruments.
+    subscribe_all_instruments: Arc<AtomicBool>,
     clock: &'static AtomicTime,
 }
 
@@ -180,6 +185,8 @@ impl BybitDataClient {
             option_greeks_subs: Arc::new(AtomicSet::new()),
             instrument_status_subs: Arc::new(AtomicSet::new()),
             status_cache: Arc::new(AtomicMap::new()),
+            instrument_subs: Arc::new(AtomicSet::new()),
+            subscribe_all_instruments: Arc::new(AtomicBool::new(false)),
             clock,
         })
     }
@@ -218,16 +225,14 @@ impl BybitDataClient {
         });
     }
 
-    fn spawn_instrument_status_polling(
-        &mut self,
-        product_types: &[BybitProductType],
-        poll_secs: u64,
-    ) {
+    fn spawn_instrument_polling(&mut self, product_types: &[BybitProductType], poll_secs: u64) {
         let http = self.http_client.clone();
         let sender = self.data_sender.clone();
         let instruments = self.instruments.clone();
         let status_cache = self.status_cache.clone();
         let status_subs = self.instrument_status_subs.clone();
+        let instrument_subs = self.instrument_subs.clone();
+        let subscribe_all_instruments = self.subscribe_all_instruments.clone();
         let cancel = self.cancellation_token.clone();
         let clock = self.clock;
         let product_types = product_types.to_vec();
@@ -239,46 +244,79 @@ impl BybitDataClient {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        if status_subs.is_empty() {
+                        let all_flag = subscribe_all_instruments.load(Ordering::Relaxed);
+                        let want_instruments = all_flag || !instrument_subs.is_empty();
+                        let want_statuses = !status_subs.is_empty();
+                        if !want_instruments && !want_statuses {
                             continue;
                         }
 
-                        // Accumulate statuses from all product types before diffing
                         let mut all_statuses = AHashMap::new();
 
-                        for &pt in &product_types {
-                            match http.request_instrument_statuses(pt).await {
-                                Ok(new_statuses) => {
-                                    let inst_guard = instruments.load();
-                                    for (id, action) in new_statuses {
-                                        if inst_guard.contains_key(&id) {
-                                            all_statuses.insert(id, action);
+                        if want_instruments {
+                            let subs: Option<AHashSet<InstrumentId>> = if all_flag {
+                                None
+                            } else {
+                                Some((**instrument_subs.load()).clone())
+                            };
+                            let mut inst_cache = (**instruments.load()).clone();
+
+                            for &pt in &product_types {
+                                match http.request_instruments_with_statuses(pt).await {
+                                    Ok((fetched, statuses)) => {
+                                        diff_and_emit_instruments(
+                                            &fetched, &mut inst_cache, subs.as_ref(), &sender,
+                                        );
+                                        for (id, action) in statuses {
+                                            if inst_cache.contains_key(&id) {
+                                                all_statuses.insert(id, action);
+                                            }
                                         }
                                     }
+                                    Err(e) => {
+                                        log::warn!("Bybit instrument poll failed for {pt:?}: {e}");
+                                    }
                                 }
-                                Err(e) => {
-                                    log::warn!("Bybit instrument status poll failed for {pt:?}: {e}");
+                            }
+
+                            instruments.store(inst_cache);
+                        } else {
+                            for &pt in &product_types {
+                                match http.request_instrument_statuses(pt).await {
+                                    Ok(new_statuses) => {
+                                        let inst_guard = instruments.load();
+                                        for (id, action) in new_statuses {
+                                            if inst_guard.contains_key(&id) {
+                                                all_statuses.insert(id, action);
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        log::warn!("Bybit instrument status poll failed for {pt:?}: {e}");
+                                    }
                                 }
                             }
                         }
 
-                        let ts = clock.get_time_ns();
-                        let mut cache = (**status_cache.load()).clone();
-                        let subs_guard = status_subs.load();
-                        diff_and_emit_statuses(
-                            &all_statuses, &mut cache, Some(&subs_guard), &sender, ts, ts,
-                        );
-                        status_cache.store(cache);
+                        if want_statuses {
+                            let ts = clock.get_time_ns();
+                            let mut cache = (**status_cache.load()).clone();
+                            let subs_guard = status_subs.load();
+                            diff_and_emit_statuses(
+                                &all_statuses, &mut cache, Some(&subs_guard), &sender, ts, ts,
+                            );
+                            status_cache.store(cache);
+                        }
                     }
                     () = cancel.cancelled() => {
-                        log::debug!("Bybit instrument status polling task cancelled");
+                        log::debug!("Bybit instrument polling task cancelled");
                         break;
                     }
                 }
             }
         });
         self.tasks.push(handle);
-        log::info!("Instrument status polling started: interval={poll_secs}s");
+        log::info!("Instrument polling started: interval={poll_secs}s");
     }
 }
 
@@ -653,7 +691,7 @@ impl DataClient for BybitDataClient {
         // Seed instrument status cache from initial fetch
         if self
             .config
-            .instrument_status_poll_secs
+            .instrument_poll_interval_secs
             .is_some_and(|s| s > 0)
         {
             // Collect all statuses first (without holding the lock across await)
@@ -765,11 +803,11 @@ impl DataClient for BybitDataClient {
             self.tasks.push(handle);
         }
 
-        // Spawn instrument status polling task
-        if let Some(poll_secs) = self.config.instrument_status_poll_secs
+        // Spawn the instrument/status polling task (serves both definition and status subs).
+        if let Some(poll_secs) = self.config.instrument_poll_interval_secs
             && poll_secs > 0
         {
-            self.spawn_instrument_status_polling(&product_types, poll_secs);
+            self.spawn_instrument_polling(&product_types, poll_secs);
         }
 
         self.is_connected.store(true, Ordering::Release);
@@ -1417,6 +1455,38 @@ impl DataClient for BybitDataClient {
         Ok(())
     }
 
+    fn subscribe_instruments(&mut self, cmd: SubscribeInstruments) -> anyhow::Result<()> {
+        log::debug!(
+            "subscribe_instruments: {venue} (definition updates detected via periodic instrument info polling)",
+            venue = cmd.venue,
+        );
+        self.subscribe_all_instruments
+            .store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn subscribe_instrument(&mut self, cmd: SubscribeInstrument) -> anyhow::Result<()> {
+        log::debug!(
+            "subscribe_instrument: {id} (definition updates detected via periodic instrument info polling)",
+            id = cmd.instrument_id,
+        );
+        self.instrument_subs.insert(cmd.instrument_id);
+        Ok(())
+    }
+
+    fn unsubscribe_instruments(&mut self, cmd: &UnsubscribeInstruments) -> anyhow::Result<()> {
+        log::debug!("unsubscribe_instruments: {venue}", venue = cmd.venue);
+        self.subscribe_all_instruments
+            .store(false, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn unsubscribe_instrument(&mut self, cmd: &UnsubscribeInstrument) -> anyhow::Result<()> {
+        log::debug!("unsubscribe_instrument: {id}", id = cmd.instrument_id);
+        self.instrument_subs.remove(&cmd.instrument_id);
+        Ok(())
+    }
+
     fn subscribe_instrument_status(
         &mut self,
         cmd: SubscribeInstrumentStatus,
@@ -1426,6 +1496,12 @@ impl DataClient for BybitDataClient {
             id = cmd.instrument_id,
         );
         self.instrument_status_subs.insert(cmd.instrument_id);
+
+        if let Some(action) = self.status_cache.load().get(&cmd.instrument_id).copied() {
+            let ts = self.clock.get_time_ns();
+            emit_status(&self.data_sender, cmd.instrument_id, action, ts, ts);
+        }
+
         Ok(())
     }
 

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -647,6 +647,9 @@ impl DataClient for BybitDataClient {
         self.option_greeks_subs.store(AHashSet::new());
         self.instrument_status_subs.store(AHashSet::new());
         self.status_cache.store(AHashMap::new());
+        self.instrument_subs.store(AHashSet::new());
+        self.subscribe_all_instruments
+            .store(false, Ordering::Relaxed);
         Ok(())
     }
 
@@ -848,6 +851,9 @@ impl DataClient for BybitDataClient {
         self.option_greeks_subs.store(AHashSet::new());
         self.instrument_status_subs.store(AHashSet::new());
         self.status_cache.store(AHashMap::new());
+        self.instrument_subs.store(AHashSet::new());
+        self.subscribe_all_instruments
+            .store(false, Ordering::Relaxed);
         self.is_connected.store(false, Ordering::Release);
         log::info!("Disconnected: client_id={}", self.client_id);
         Ok(())

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -267,6 +267,7 @@ impl BybitDataClient {
                                         diff_and_emit_instruments(
                                             &fetched, &mut inst_cache, subs.as_ref(), &sender,
                                         );
+
                                         for (id, action) in statuses {
                                             if inst_cache.contains_key(&id) {
                                                 all_statuses.insert(id, action);

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -3450,6 +3450,134 @@ impl BybitHttpClient {
         Ok(instruments)
     }
 
+    /// Requests full instrument definitions and their market statuses in a single endpoint pass.
+    ///
+    /// Both are parsed from the same `/v5/market/instruments-info` response, avoiding a second
+    /// round-trip when a caller needs definitions and statuses together (e.g. the polling loop
+    /// serving both instrument and status subscriptions).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or parsing fails.
+    pub async fn request_instruments_with_statuses(
+        &self,
+        product_type: BybitProductType,
+    ) -> anyhow::Result<(
+        Vec<InstrumentAny>,
+        AHashMap<InstrumentId, MarketStatusAction>,
+    )> {
+        let ts_init = self.generate_ts_init();
+        let mut statuses = AHashMap::new();
+
+        let default_fee_rate = |symbol: Ustr| BybitFeeRate {
+            symbol,
+            taker_fee_rate: "0.001".to_string(),
+            maker_fee_rate: "0.001".to_string(),
+            base_coin: None,
+        };
+
+        // A perp with a non-zero delivery time is scheduled for delisting.
+        let perp_status = |status: MarketStatusAction, is_scheduled_perp: bool| {
+            if status == MarketStatusAction::Trading && is_scheduled_perp {
+                MarketStatusAction::PreClose
+            } else {
+                status
+            }
+        };
+
+        let instruments = match product_type {
+            BybitProductType::Spot => {
+                let fee_map = self.fetch_fee_map(product_type, None).await?;
+                self.paginate_instruments::<BybitInstrumentSpot, _>(
+                    product_type,
+                    &None::<String>,
+                    None,
+                    |def| {
+                        let id = InstrumentId::new(
+                            Symbol::from(make_bybit_symbol(def.symbol, product_type)),
+                            *BYBIT_VENUE,
+                        );
+                        statuses.insert(id, MarketStatusAction::from(def.status));
+                        let fee = fee_map
+                            .get(&def.symbol)
+                            .cloned()
+                            .unwrap_or_else(|| default_fee_rate(def.symbol));
+                        parse_spot_instrument(def, &fee, ts_init, ts_init).ok()
+                    },
+                )
+                .await?
+            }
+            BybitProductType::Linear => {
+                let fee_map = self.fetch_fee_map(product_type, None).await?;
+                self.paginate_instruments::<BybitInstrumentLinear, _>(
+                    product_type,
+                    &None::<String>,
+                    None,
+                    |def| {
+                        let id = InstrumentId::new(
+                            Symbol::from(make_bybit_symbol(def.symbol, product_type)),
+                            *BYBIT_VENUE,
+                        );
+                        let scheduled = def.contract_type == BybitContractType::LinearPerpetual
+                            && def.delivery_time != "0";
+                        statuses.insert(id, perp_status(def.status.into(), scheduled));
+                        let fee = fee_map
+                            .get(&def.symbol)
+                            .cloned()
+                            .unwrap_or_else(|| default_fee_rate(def.symbol));
+                        parse_linear_instrument(def, &fee, ts_init, ts_init).ok()
+                    },
+                )
+                .await?
+            }
+            BybitProductType::Inverse => {
+                let fee_map = self.fetch_fee_map(product_type, None).await?;
+                self.paginate_instruments::<BybitInstrumentInverse, _>(
+                    product_type,
+                    &None::<String>,
+                    None,
+                    |def| {
+                        let id = InstrumentId::new(
+                            Symbol::from(make_bybit_symbol(def.symbol, product_type)),
+                            *BYBIT_VENUE,
+                        );
+                        let scheduled = def.contract_type == BybitContractType::InversePerpetual
+                            && def.delivery_time != "0";
+                        statuses.insert(id, perp_status(def.status.into(), scheduled));
+                        let fee = fee_map
+                            .get(&def.symbol)
+                            .cloned()
+                            .unwrap_or_else(|| default_fee_rate(def.symbol));
+                        parse_inverse_instrument(def, &fee, ts_init, ts_init).ok()
+                    },
+                )
+                .await?
+            }
+            BybitProductType::Option => {
+                let fee_map = self.fetch_option_fee_map(None).await?;
+                self.paginate_instruments::<BybitInstrumentOption, _>(
+                    product_type,
+                    &None::<String>,
+                    None,
+                    |def| {
+                        let id = InstrumentId::new(
+                            Symbol::from(make_bybit_symbol(def.symbol, product_type)),
+                            *BYBIT_VENUE,
+                        );
+                        statuses.insert(id, MarketStatusAction::from(def.status));
+                        let fee = fee_map.get(&def.base_coin);
+                        parse_option_instrument(def, fee, ts_init, ts_init).ok()
+                    },
+                )
+                .await?
+            }
+        };
+
+        self.cache_instruments(&instruments);
+
+        Ok((instruments, statuses))
+    }
+
     /// Request ticker information for market data.
     ///
     /// Fetches ticker data from Bybit's `/v5/market/tickers` endpoint and returns

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -44,7 +44,7 @@ impl BybitDataClientConfig {
         heartbeat_interval_secs = None,
         recv_window_ms = None,
         update_instruments_interval_mins = None,
-        instrument_status_poll_secs = None,
+        instrument_poll_interval_secs = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -63,7 +63,7 @@ impl BybitDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         recv_window_ms: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
-        instrument_status_poll_secs: Option<u64>,
+        instrument_poll_interval_secs: Option<u64>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -85,8 +85,8 @@ impl BybitDataClientConfig {
             recv_window_ms: recv_window_ms.unwrap_or(defaults.recv_window_ms),
             update_instruments_interval_mins: update_instruments_interval_mins
                 .or(defaults.update_instruments_interval_mins),
-            instrument_status_poll_secs: instrument_status_poll_secs
-                .or(defaults.instrument_status_poll_secs),
+            instrument_poll_interval_secs: instrument_poll_interval_secs
+                .or(defaults.instrument_poll_interval_secs),
             transport_backend: defaults.transport_backend,
         }
     }

--- a/crates/adapters/bybit/tests/data_client.rs
+++ b/crates/adapters/bybit/tests/data_client.rs
@@ -391,7 +391,7 @@ fn create_test_config(addr: SocketAddr) -> BybitDataClientConfig {
         heartbeat_interval_secs: 5,
         recv_window_ms: 5000,
         update_instruments_interval_mins: None,
-        instrument_status_poll_secs: None,
+        instrument_poll_interval_secs: None,
         transport_backend: Default::default(),
     }
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Add instrument subscription support for the Bybit adapter. Uses the same poll loop as the instrument statuses to avoid adding an extra parameter (now `insturment_poll_interval_secs`) and gets instrument definitions and statuses in one endpoint request. `on_instrument` is fired for every new instrument (if the subscription is venue-wide) and for changes to the economic fields of the instrument (e.g. fees).

Also emit instrument status on subscribe so the cache gets populated (not needed for instrument definitions since those are put into the cache on connect).

Currently economic difference is determined by a seperate`economics_differ()` function because an insturment is considered equal simply if it's id is equal (so fee changes and the like would be skipped). This helper function sits in the Bybit adapter but perhaps it would be better to move it into Instrument in the future if multiple adapters want to use it.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
