### PR TITLE
Coalesce backtest expiry timers and speed up test clock advancement

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -333,6 +333,8 @@ impl BacktestEngine {
     pub fn add_instrument(&mut self, instrument: &InstrumentAny) -> anyhow::Result<()> {
         let instrument_id = instrument.id();
         if let Some(exchange) = self.venues.get(&instrument.id().venue) {
+            let previous_expiration_ns = exchange.borrow().instrument_expiration(instrument_id);
+
             if matches!(
                 instrument,
                 InstrumentAny::CurrencyPair(_) | InstrumentAny::TokenizedAsset(_)
@@ -346,6 +348,19 @@ impl BacktestEngine {
             exchange.borrow_mut().add_instrument(instrument.clone())?;
             if let Some(expiration_ns) = instrument.expiration_ns() {
                 self.set_instrument_expiration_timer(exchange, instrument_id, expiration_ns)?;
+            }
+
+            if let Some(previous_expiration_ns) = previous_expiration_ns
+                && instrument.expiration_ns() != Some(previous_expiration_ns)
+                && !exchange
+                    .borrow()
+                    .has_unprocessed_instrument_expiration(previous_expiration_ns)
+            {
+                let timer_name = Self::instrument_expiration_timer_name(
+                    instrument_id.venue,
+                    previous_expiration_ns,
+                );
+                self.kernel.clock.borrow_mut().cancel_timer(&timer_name);
             }
         } else {
             anyhow::bail!(
@@ -1356,7 +1371,12 @@ impl BacktestEngine {
             return Ok(());
         }
 
-        let timer_name = Self::instrument_expiration_timer_name(instrument_id);
+        let timer_name = Self::instrument_expiration_timer_name(instrument_id.venue, expiration_ns);
+        let timer_key = ustr::Ustr::from(timer_name.as_str());
+        if self.kernel.clock.borrow().timer_exists(&timer_key) {
+            return Ok(());
+        }
+
         let exchange: Weak<RefCell<SimulatedExchange>> = Rc::downgrade(exchange);
         let callback: Rc<dyn Fn(TimeEvent)> = Rc::new(move |event: TimeEvent| {
             if let Some(exchange) = exchange.upgrade() {
@@ -1365,7 +1385,6 @@ impl BacktestEngine {
                     .process_instrument_expirations(event.ts_event);
             }
         });
-        let timer_key = ustr::Ustr::from(timer_name.as_str());
         let mut clock = self.kernel.clock.borrow_mut();
         if clock.timer_exists(&timer_key) {
             clock.cancel_timer(&timer_name);
@@ -1381,8 +1400,8 @@ impl BacktestEngine {
         Ok(())
     }
 
-    fn instrument_expiration_timer_name(instrument_id: InstrumentId) -> String {
-        format!("INSTRUMENT-EXPIRATION:{instrument_id}")
+    fn instrument_expiration_timer_name(venue: Venue, expiration_ns: UnixNanos) -> String {
+        format!("INSTRUMENT-EXPIRATION:{venue}:{expiration_ns}")
     }
 
     fn schedule_funding_settlement_if_required(
@@ -1415,11 +1434,7 @@ impl BacktestEngine {
                     .process_funding_settlement(instrument_id, event.ts_event);
             }
         });
-        let timer_key = ustr::Ustr::from(timer_name.as_str());
         let mut clock = self.kernel.clock.borrow_mut();
-        if clock.timer_exists(&timer_key) {
-            clock.cancel_timer(&timer_name);
-        }
 
         clock.set_time_alert_ns(
             &timer_name,

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -307,6 +307,23 @@ impl SimulatedExchange {
         self.instruments.keys()
     }
 
+    /// Returns the expiration timestamp for the given instrument, if present.
+    #[must_use]
+    pub fn instrument_expiration(&self, instrument_id: InstrumentId) -> Option<UnixNanos> {
+        self.matching_engines
+            .get(&instrument_id)
+            .and_then(|matching_engine| matching_engine.instrument.expiration_ns())
+    }
+
+    /// Returns whether an unprocessed instrument remains for the given expiration.
+    #[must_use]
+    pub fn has_unprocessed_instrument_expiration(&self, expiration_ns: UnixNanos) -> bool {
+        self.matching_engines.values().any(|matching_engine| {
+            !matching_engine.is_expiration_processed()
+                && matching_engine.instrument.expiration_ns() == Some(expiration_ns)
+        })
+    }
+
     pub fn initialize_account(&mut self) {
         self.generate_fresh_account_state();
     }

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -3763,6 +3763,51 @@ fn test_option_expiry_timer_runs_when_end_equals_expiration() {
     );
 }
 
+#[rstest]
+fn test_instruments_with_same_expiration_share_expiry_timer() {
+    let venue = Venue::from("OPRA");
+    let expiration_ns = UnixNanos::from(2_000_000_000u64);
+    let mut engine = BacktestEngine::new(BacktestEngineConfig::default()).unwrap();
+    engine
+        .add_venue(
+            SimulatedVenueConfig::builder()
+                .venue(venue)
+                .oms_type(OmsType::Netting)
+                .account_type(AccountType::Margin)
+                .book_type(BookType::L1_MBP)
+                .starting_balances(vec![Money::from("1_000_000 USD")])
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+    let option = option_contract(venue, expiration_ns);
+    let mut other_option = option_contract(venue, expiration_ns);
+    if let InstrumentAny::OptionContract(option) = &mut other_option {
+        option.id = InstrumentId::from(format!("AAPL240315C00155000.{venue}").as_str());
+        option.raw_symbol = Symbol::from("AAPL240315C00155000");
+        option.strike_price = Price::from("155.00");
+    }
+
+    engine.add_instrument(&option).unwrap();
+    engine.add_instrument(&other_option).unwrap();
+
+    let expiry_timer_names: Vec<String> = engine
+        .kernel()
+        .clock
+        .borrow()
+        .timer_names()
+        .into_iter()
+        .filter(|name| name.starts_with("INSTRUMENT-EXPIRATION:"))
+        .map(ToString::to_string)
+        .collect();
+
+    assert_eq!(
+        expiry_timer_names,
+        vec![format!("INSTRUMENT-EXPIRATION:{venue}:{expiration_ns}")],
+    );
+}
+
 fn run_call_option_expiry_timer(
     underlying_price: &str,
     end_ns: UnixNanos,

--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -17,12 +17,19 @@
 
 #![warn(clippy::clone_on_ref_ptr)]
 
-use std::{any::Any, cell::RefCell, collections::BTreeMap, fmt::Debug, ops::Deref, time::Duration};
+use std::{
+    any::Any,
+    cell::RefCell,
+    collections::{BTreeMap, BinaryHeap},
+    fmt::Debug,
+    ops::Deref,
+    time::Duration,
+};
 
 use ahash::AHashMap;
 use chrono::{DateTime, Utc};
 use nautilus_core::{
-    AtomicTime, UnixNanos,
+    AtomicTime, UUID4, UnixNanos,
     correctness::{check_positive_u64, check_predicate_true, check_valid_string_utf8},
     datetime::NANOSECONDS_IN_SECOND,
     string::formatting::Separable,
@@ -30,7 +37,8 @@ use nautilus_core::{
 use ustr::Ustr;
 
 use crate::timer::{
-    TestTimer, TimeEvent, TimeEventCallback, TimeEventHandler, Timer, create_valid_interval,
+    ScheduledTimeEvent, TestTimer, TimeEvent, TimeEventCallback, TimeEventHandler, Timer,
+    create_valid_interval,
 };
 
 /// Represents a type of clock.
@@ -837,8 +845,8 @@ pub fn validate_and_prepare_timer(
 #[derive(Debug)]
 pub struct TestClock {
     time: AtomicTime,
-    // Use btree map to ensure stable ordering when scanning for timers in `advance_time`
     timers: BTreeMap<Ustr, TestTimer>,
+    timer_queue: BinaryHeap<ScheduledTimeEvent>,
     callbacks: CallbackRegistry,
 }
 
@@ -849,6 +857,7 @@ impl TestClock {
         Self {
             time: AtomicTime::new(false, UnixNanos::default()),
             timers: BTreeMap::new(),
+            timer_queue: BinaryHeap::new(),
             callbacks: CallbackRegistry::new(),
         }
     }
@@ -889,15 +898,29 @@ impl TestClock {
             self.time.set_time(to_time_ns);
         }
 
-        // Iterate and advance timers and collect events, only retain alive timers
         let mut events: Vec<TimeEvent> = Vec::new();
-        self.timers.retain(|_, timer| {
-            timer.advance(to_time_ns).for_each(|event| {
-                events.push(event);
-            });
 
-            !timer.is_expired()
-        });
+        while self
+            .timer_queue
+            .peek()
+            .is_some_and(|entry| entry.0.ts_event <= to_time_ns)
+        {
+            let entry = self
+                .timer_queue
+                .pop()
+                .expect("timer queue peeked Some but pop returned None");
+
+            let Some((event, next_event)) = self.advance_timer_from_entry(&entry.0) else {
+                continue;
+            };
+
+            events.push(event);
+            if let Some(next_event) = next_event {
+                self.timer_queue.push(next_event);
+            }
+        }
+
+        self.compact_timer_queue_if_needed();
 
         if events.len() >= WARN_TIME_EVENTS_THRESHOLD {
             log::warn!(
@@ -909,7 +932,11 @@ impl TestClock {
             );
         }
 
-        events.sort_by_key(|a| a.ts_event);
+        events.sort_by(|a, b| {
+            a.ts_event
+                .cmp(&b.ts_event)
+                .then_with(|| a.name.cmp(&b.name))
+        });
         events
     }
 
@@ -932,6 +959,56 @@ impl TestClock {
 
     fn replace_existing_timer_if_needed(&mut self, name: &Ustr) {
         replace_existing_timer(&mut self.timers, name);
+        self.compact_timer_queue_if_needed();
+    }
+
+    fn insert_timer(&mut self, timer: TestTimer) {
+        self.timer_queue.push(Self::scheduled_event(&timer));
+        self.timers.insert(timer.name, timer);
+        self.compact_timer_queue_if_needed();
+    }
+
+    fn advance_timer_from_entry(
+        &mut self,
+        entry: &TimeEvent,
+    ) -> Option<(TimeEvent, Option<ScheduledTimeEvent>)> {
+        let timer = self.timers.get_mut(&entry.name)?;
+        if timer.next_time_ns() != entry.ts_event {
+            return None;
+        }
+
+        let Some((event, _)) = timer.next() else {
+            self.timers.remove(&entry.name);
+            return None;
+        };
+
+        let next_entry = if timer.is_expired() {
+            self.timers.remove(&entry.name);
+            None
+        } else {
+            Some(Self::scheduled_event(timer))
+        };
+
+        Some((event, next_entry))
+    }
+
+    fn compact_timer_queue_if_needed(&mut self) {
+        if self.timer_queue.len() > self.timers.len().saturating_mul(2) {
+            self.compact_timer_queue();
+        }
+    }
+
+    fn compact_timer_queue(&mut self) {
+        self.timer_queue = self.timers.values().map(Self::scheduled_event).collect();
+    }
+
+    fn scheduled_event(timer: &TestTimer) -> ScheduledTimeEvent {
+        ScheduledTimeEvent::new(TimeEvent::new(
+            timer.name,
+            UUID4::new(),
+            timer.next_time_ns(),
+            timer.next_time_ns(),
+        ))
     }
 }
 
@@ -1040,7 +1117,7 @@ impl Clock for TestClock {
             Some(alert_time_ns),
             fire_immediately,
         );
-        self.timers.insert(name, timer);
+        self.insert_timer(timer);
 
         Ok(())
     }
@@ -1087,7 +1164,7 @@ impl Clock for TestClock {
             stop_time_ns,
             fire_immediately,
         );
-        self.timers.insert(name, timer);
+        self.insert_timer(timer);
 
         Ok(())
     }
@@ -1103,6 +1180,7 @@ impl Clock for TestClock {
         if let Some(mut timer) = timer {
             timer.cancel();
         }
+        self.compact_timer_queue_if_needed();
     }
 
     fn cancel_timers(&mut self) {
@@ -1111,11 +1189,13 @@ impl Clock for TestClock {
         }
 
         self.timers.clear();
+        self.timer_queue.clear();
     }
 
     fn reset(&mut self) {
         self.time = AtomicTime::new(false, UnixNanos::default());
         self.timers = BTreeMap::new();
+        self.timer_queue = BinaryHeap::new();
         self.callbacks.clear();
     }
 }
@@ -1820,6 +1900,50 @@ mod tests {
         // Advance time - should get no events from cancelled timer
         let events = test_clock.advance_time(start_time + 2000, true);
         assert_eq!(events.len(), 0);
+    }
+
+    #[rstest]
+    fn test_cancelled_timer_queue_entry_is_skipped(mut test_clock: TestClock) {
+        let start_time = test_clock.timestamp_ns();
+        test_clock
+            .set_time_alert_ns("cancelled", start_time + 1000, None, None)
+            .unwrap();
+        test_clock
+            .set_time_alert_ns("active", start_time + 2000, None, None)
+            .unwrap();
+
+        test_clock.cancel_timer("cancelled");
+        assert_eq!(test_clock.timer_count(), 1);
+        assert_eq!(test_clock.timer_queue.len(), 2);
+
+        let events = test_clock.advance_time(start_time + 1000, true);
+        assert!(events.is_empty());
+        assert_eq!(test_clock.timer_names(), vec!["active"]);
+
+        let events = test_clock.advance_time(start_time + 2000, true);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name.as_str(), "active");
+    }
+
+    #[rstest]
+    fn test_timer_queue_compacts_stale_entries(mut test_clock: TestClock) {
+        let start_time = test_clock.timestamp_ns();
+        test_clock
+            .set_time_alert_ns("active", start_time + 1000, None, None)
+            .unwrap();
+        test_clock
+            .set_time_alert_ns("cancelled-1", start_time + 2000, None, None)
+            .unwrap();
+        test_clock
+            .set_time_alert_ns("cancelled-2", start_time + 3000, None, None)
+            .unwrap();
+
+        test_clock.cancel_timer("cancelled-1");
+        assert_eq!(test_clock.timer_queue.len(), 3);
+
+        test_clock.cancel_timer("cancelled-2");
+        assert_eq!(test_clock.timer_count(), 1);
+        assert_eq!(test_clock.timer_queue.len(), 1);
     }
 
     #[rstest]

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -331,7 +331,7 @@ cdef class SimulatedExchange:
     cdef void _update_next_instrument_expiration(self, OrderMatchingEngine matching_engine)
     cdef void _set_instrument_expiration_timer(self, OrderMatchingEngine matching_engine)
     cdef void _set_instrument_expiration_timers(self)
-    cdef str _instrument_expiration_timer_name(self, InstrumentId instrument_id)
+    cdef str _instrument_expiration_timer_name(self, Venue venue, uint64_t expiration_ns)
 
     cdef void _process_trading_command(self, TradingCommand command)
     cdef void _process_modify_submitted_order(self, ModifyOrder command)

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -3711,9 +3711,12 @@ cdef class SimulatedExchange:
         if expiration_ns == 0:
             return
 
-        cdef str timer_name = self._instrument_expiration_timer_name(matching_engine.instrument.id)
+        cdef str timer_name = self._instrument_expiration_timer_name(
+            matching_engine.instrument.id.venue,
+            expiration_ns,
+        )
         if timer_name in self._clock.timer_names:
-            self._clock.cancel_timer(timer_name)
+            return
 
         self._clock.set_time_alert_ns(
             name=timer_name,
@@ -3726,8 +3729,8 @@ cdef class SimulatedExchange:
         for matching_engine in self._matching_engines.values():
             self._set_instrument_expiration_timer(matching_engine)
 
-    cdef str _instrument_expiration_timer_name(self, InstrumentId instrument_id):
-        return f"INSTRUMENT-EXPIRATION:{instrument_id.value}"
+    cdef str _instrument_expiration_timer_name(self, Venue venue, uint64_t expiration_ns):
+        return f"INSTRUMENT-EXPIRATION:{venue.value}:{expiration_ns}"
 
     cpdef void reset(self):
         """

--- a/tests/integration_tests/test_option_exercise_flow.py
+++ b/tests/integration_tests/test_option_exercise_flow.py
@@ -526,6 +526,39 @@ def test_option_expiry_timer_reschedules_after_instrument_update():
     engine.dispose()
 
 
+def test_instruments_with_same_expiration_share_expiry_timer():
+    venue = Venue("NASDAQ")
+    expiry_ns = dt_to_unix_nanos(pd.Timestamp("2024-03-15 16:00:00", tz="UTC"))
+    engine = BacktestEngine(config=BacktestEngineConfig())
+    engine.add_venue(
+        venue=venue,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.MARGIN,
+        base_currency=USD,
+        starting_balances=[Money(1_000_000, USD)],
+    )
+
+    engine.add_instrument(_timer_underlying_equity())
+    engine.add_instrument(_timer_call_option(expiration_ns=expiry_ns))
+    engine.add_instrument(
+        _timer_call_option(
+            expiration_ns=expiry_ns,
+            instrument_id="AAPL240315C00155000.NASDAQ",
+            raw_symbol="AAPL240315C00155000",
+            strike_price=155.0,
+        ),
+    )
+
+    expiry_timer_names = [
+        name
+        for name in engine.kernel.clock.timer_names
+        if name.startswith("INSTRUMENT-EXPIRATION:")
+    ]
+    assert expiry_timer_names == [f"INSTRUMENT-EXPIRATION:{venue.value}:{expiry_ns}"]
+
+    engine.dispose()
+
+
 def _build_timer_engine_with_call_option(
     underlying_price: float,
     expiry_ns: int,
@@ -594,14 +627,17 @@ def _timer_call_option(
     expiration_ns: int,
     ts_event: int = 0,
     ts_init: int = 0,
+    instrument_id: str = "AAPL240315C00150000.NASDAQ",
+    raw_symbol: str = "AAPL240315C00150000",
+    strike_price: float = 150.0,
 ) -> OptionContract:
     return OptionContract(
-        instrument_id=InstrumentId.from_str("AAPL240315C00150000.NASDAQ"),
-        raw_symbol=Symbol("AAPL240315C00150000"),
+        instrument_id=InstrumentId.from_str(instrument_id),
+        raw_symbol=Symbol(raw_symbol),
         asset_class=AssetClass.EQUITY,
         underlying="AAPL",
         option_kind=OptionKind.CALL,
-        strike_price=Price(150.0, 2),
+        strike_price=Price(strike_price, 2),
         currency=USD,
         activation_ns=dt_to_unix_nanos(pd.Timestamp("2024-03-01", tz="UTC")),
         expiration_ns=expiration_ns,


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Schedules one instrument expiration timer per `(venue, expiration_ns)` instead of one timer per instrument.
- Applies the same timer naming rule in Rust backtests and Cython/Python v1 backtests.
- Keeps `TestClock` timers stored in the existing `BTreeMap` and adds a lazy `BinaryHeap` index for next-due timer lookup.
- Leaves `LiveClock` unchanged.

### Problem

Backtests with many expiring instruments can create many equivalent expiration timers for the same venue and expiration timestamp. Each timer points at logic that already processes all matching engines due at that timestamp, so per-instrument timer registration is redundant.

`TestClock::advance_time` also scanned every stored timer on every advancement, even when most timers were not due.

### Design

The authoritative timer state stays in the existing name-indexed `BTreeMap`. `TestClock` now keeps a heap of scheduled next events as an index. Canceling or replacing a timer removes it from the map and leaves the heap entry to be skipped later. The heap is compacted when stale entries grow beyond twice the live timer count.

```mermaid
flowchart LR
    Heap[BinaryHeap next due entries] --> Pop[Pop due entry]
    Pop --> Lookup[Lookup timer by name in BTreeMap]
    Lookup --> Missing[Missing or changed next time: skip]
    Lookup --> Valid[Valid timer: call next]
    Valid --> Requeue[Requeue next due entry]
    Valid --> Remove[Expired: remove from BTreeMap]
    Map[BTreeMap authoritative timers] --> Lookup
```

Backtest expiration timers are now keyed by venue and expiration timestamp. A second instrument with the same key reuses the existing timer.

```mermaid
flowchart LR
    A[Instrument A OPRA expiry T] --> C[Timer INSTRUMENT-EXPIRATION:OPRA:T]
    B[Instrument B OPRA expiry T] --> C
    C --> D[process_instrument_expirations T]
    D --> E[Check all matching engines due at T]
```

The Rust backtest path additionally cancels the old timer for an updated instrument when no unprocessed instrument still uses that previous expiration.

```mermaid
sequenceDiagram
    participant Engine
    participant Exchange
    participant Clock

    Engine->>Exchange: read previous expiration
    Engine->>Exchange: add or update instrument
    Engine->>Clock: ensure timer for venue:new_expiration
    alt no remaining instrument uses previous expiration
        Engine->>Clock: cancel venue:previous_expiration
    end
```

### Implementation notes

- Rust backtest timer names changed from `INSTRUMENT-EXPIRATION:{instrument_id}` to `INSTRUMENT-EXPIRATION:{venue}:{expiration_ns}`.
- Cython backtest timer names now use the same shape and return early if the shared timer already exists.
- `ScheduledTimeEvent` ordering was left unchanged; `BinaryHeap<ScheduledTimeEvent>` already pops earlier timestamps first.
- Events emitted from `TestClock::advance_time` are sorted by timestamp and name to stay close to the old `BTreeMap` scan behavior for same-timestamp timers.

### Tests

- `make build-debug`.
- `make format`.
- `cargo test -p nautilus-common clock::tests`.
- `cargo test -p nautilus-common --features live test_live`.
- `cargo test -p nautilus-backtest --test backtest_engine test_instruments_with_same_expiration_share_expiry_timer -- --exact`.
- `cargo test -p nautilus-backtest --test backtest_engine option_expiry_timer`.
- `uv run --no-sync python -X faulthandler -m pytest tests/integration_tests/test_option_exercise_flow.py::test_instruments_with_same_expiration_share_expiry_timer -q`.
- `uv run --no-sync python -X faulthandler -m pytest tests/integration_tests/test_option_exercise_flow.py::test_option_expiry_timer_reschedules_after_instrument_update -q`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4306

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
