### PR TITLE
Fix LiveTimer task leak on clock drop and component teardown

### DIFF
--- a/crates/common/src/live/timer.rs
+++ b/crates/common/src/live/timer.rs
@@ -279,6 +279,14 @@ impl Timer for LiveTimer {
     }
 }
 
+impl Drop for LiveTimer {
+    fn drop(&mut self) {
+        if let Some(handle) = self.task_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{num::NonZeroU64, sync::Arc};

--- a/crates/system/src/trader.rs
+++ b/crates/system/src/trader.rs
@@ -846,6 +846,10 @@ impl Trader {
             msgbus::deregister_any(endpoint.into());
         }
 
+        for clock in self.clocks.values() {
+            clock.borrow_mut().cancel_timers();
+        }
+
         self.actor_ids.clear();
         self.strategy_ids.clear();
         self.strategy_stop_fns.clear();
@@ -866,6 +870,9 @@ impl Trader {
             log::debug!("Disposing strategy {strategy_id}");
             dispose_component(&strategy_id.inner())?;
             let component_id = ComponentId::new(strategy_id.inner().as_str());
+            if let Some(clock) = self.clocks.get(&component_id) {
+                clock.borrow_mut().cancel_timers();
+            }
             self.clocks.remove(&component_id);
 
             // Remove only this strategy's own msgbus handlers
@@ -902,6 +909,9 @@ impl Trader {
             let _ = stop_component(&actor_id.inner());
             dispose_component(&actor_id.inner())?;
             let component_id = ComponentId::new(actor_id.inner().as_str());
+            if let Some(clock) = self.clocks.get(&component_id) {
+                clock.borrow_mut().cancel_timers();
+            }
             self.clocks.remove(&component_id);
         }
 
@@ -922,6 +932,9 @@ impl Trader {
             let endpoint: Ustr = format!("{exec_algorithm_id}.execute").into();
             msgbus::deregister_any(endpoint.into());
             let component_id = ComponentId::new(exec_algorithm_id.inner().as_str());
+            if let Some(clock) = self.clocks.get(&component_id) {
+                clock.borrow_mut().cancel_timers();
+            }
             self.clocks.remove(&component_id);
         }
 
@@ -977,6 +990,9 @@ impl Trader {
 
         self.actor_ids.swap_remove(pos);
         let component_id = ComponentId::new(actor_id.inner().as_str());
+        if let Some(clock) = self.clocks.get(&component_id) {
+            clock.borrow_mut().cancel_timers();
+        }
         self.clocks.remove(&component_id);
 
         log::info!("Removed actor {actor_id} from trader {}", self.trader_id);
@@ -1100,6 +1116,9 @@ impl Trader {
         self.strategy_ids.swap_remove(pos);
         self.strategy_stop_fns.remove(strategy_id);
         let component_id = ComponentId::new(strategy_id.inner().as_str());
+        if let Some(clock) = self.clocks.get(&component_id) {
+            clock.borrow_mut().cancel_timers();
+        }
         self.clocks.remove(&component_id);
 
         log::info!(


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary


`LiveTimer::start` spawns a tokio task on the global runtime that forwards each tick through the `Arc<dyn TimeEventSender>` it captured at construction. The only thing that aborts that task is an explicit `LiveTimer::cancel()` (reached via `LiveClock::cancel_timer` / `cancel_timers`). Two paths today reliably end up with a `LiveTimer` dropped *without* `cancel` being called, leaving the tokio task alive after its receiver is gone:

1. **`LiveTimer` itself has no `Drop`.** Any caller that drops a `LiveClock` (test helper, panic during teardown, future API) leaks every armed timer the clock owned.
2. **Six `Trader` teardown sites — `dispose_components`, `clear_strategies`, `clear_actors`, `clear_exec_algorithms`, `remove_strategy`, `remove_actor` — clear or `remove()` `self.clocks` entries without first cancelling the timers each clock holds.** Each calls `dispose_component`, which sends a `Dispose` trigger, but the default `on_dispose` is a no-op and components routinely don't override it to call `clock.cancel_timers()`. The documented teardown paths therefore silently orphan any timer the component's `on_stop` didn't cancel by name.

Both manifest as the same downstream symptom: after the `AsyncRunner` is consumed and its `time_evt_rx` dropped, an orphaned timer task ticks against the closed channel and `AsyncTimeEventSender::send` logs:

```
[ERROR] nautilus_live::runner: Failed to send time event handler: channel closed
```

### Fix

Two complementary changes:

#### 1. Defensive `Drop` on `LiveTimer`

```rust
// crates/common/src/live/timer.rs
impl Drop for LiveTimer {
    fn drop(&mut self) {
        if let Some(handle) = self.task_handle.take() {
            handle.abort();
        }
    }
}
```

`JoinHandle::abort()` is idempotent with a prior explicit `cancel()` (abort on an already-finished task is a no-op), so this is purely additive. It catches any path — known or future — that drops a clock without explicit cancellation.

#### 2. Cancel timers in every `Trader` teardown helper

`dispose_components` gains a single walk before `self.clocks.clear()`:

```rust
// crates/system/src/trader.rs
for clock in self.clocks.values() {
    clock.borrow_mut().cancel_timers();
}
```

`clear_strategies`, `clear_actors`, `clear_exec_algorithms`, `remove_strategy`, and `remove_actor` each gain the same cancel inline before their `self.clocks.remove(&component_id)`, where the existing per-iteration cleanup already lives.

### Why both

They sit at different layers and reinforce each other rather than overlap:

- **`Drop` on `LiveTimer`** is the lowest-level safety net. It runs no matter who is unwinding the stack — test code, panic paths, third-party embedders, future APIs. It costs nothing when cleanup was already done correctly.
- **Cancel walks in `Trader`** make the documented lifecycle do what its name promises. Without them, `dispose_components` and the `clear_*` / `remove_*` helpers are silently misleading: they remove the clock entry but leave its timers running. Fixing this at the lifecycle layer means future component authors don't need to remember to override `on_dispose` to cancel timers — the framework already handles it.

It also matters that the `Drop` net doesn't fully cover the `remove_*` paths in practice: components live in a thread-local `COMPONENT_REGISTRY` that isn't cleaned up by `dispose_component`, so the component keeps an `Rc` to its `LiveClock` even after `Trader.clocks` drops its clone. The `LiveClock` (and its timers) doesn't drop until `HashMap::insert` overwrites the same `id` later or the process exits. The cancel walks make timer cancellation happen *at remove time*, regardless of when the component itself eventually drops.

### Behaviour change

- A `LiveTimer` dropped while its task is still running now aborts the task instead of leaving it alive on the runtime.
- `Trader::dispose_components`, `clear_strategies`, `clear_actors`, `clear_exec_algorithms`, `remove_strategy`, `remove_actor` now cancel timers on per-component clocks before clearing/removing them.
- No change to `cancel()` semantics, to the timer's tick behaviour while alive, to the `TimeEventSender` contract, or to any public API signature.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore