### PR TITLE
Disable spread quote vega pricing after missing greeks

### DIFF
--- a/crates/data/src/aggregation.rs
+++ b/crates/data/src/aggregation.rs
@@ -2209,8 +2209,12 @@ pub struct SpreadQuoteAggregator {
     quote_build_delay: u64,
     has_update: bool,
     timer_name: String,
+    vega_pricing_timeout_timer_name: String,
     historical_event_at_ts_init: Option<TimeEvent>,
     vega_provider: Option<Box<dyn VegaProvider>>,
+    disable_vega_pricing: bool,
+    vega_pricing_temporarily_disabled: bool,
+    vega_pricing_timeout_seconds: u64,
     price_rounder: Option<Box<dyn SpreadPriceRounder>>,
     is_running: bool,
     aggregator_weak: Option<Weak<RefCell<Self>>>,
@@ -2245,6 +2249,8 @@ impl SpreadQuoteAggregator {
         historical_mode: bool,
         update_interval_seconds: Option<u64>,
         quote_build_delay: u64,
+        disable_vega_pricing: bool,
+        vega_pricing_timeout_seconds: u64,
         vega_provider: Option<Box<dyn VegaProvider>>,
         price_rounder: Option<Box<dyn SpreadPriceRounder>>,
     ) -> Self {
@@ -2256,6 +2262,8 @@ impl SpreadQuoteAggregator {
             assert!(r != 0, "Ratio cannot be zero");
         }
         let timer_name = format!("SPREAD_QUOTE_{spread_instrument_id}");
+        let vega_pricing_timeout_timer_name =
+            format!("VEGA_PRICING_TIMEOUT_{spread_instrument_id}");
         Self {
             spread_instrument_id,
             leg_ids,
@@ -2279,8 +2287,12 @@ impl SpreadQuoteAggregator {
             quote_build_delay,
             has_update: false,
             timer_name,
+            vega_pricing_timeout_timer_name,
             historical_event_at_ts_init: None,
             vega_provider,
+            disable_vega_pricing,
+            vega_pricing_temporarily_disabled: false,
+            vega_pricing_timeout_seconds,
             price_rounder,
             is_running: false,
             aggregator_weak: None,
@@ -2333,20 +2345,18 @@ impl SpreadQuoteAggregator {
     ///
     /// Panics if called with `None` in timer mode without a prior [`Self::prepare_for_timer_mode`] call.
     pub fn start_timer(&mut self, aggregator_rc: Option<Rc<RefCell<Self>>>) {
+        if let Some(rc) = aggregator_rc {
+            self.aggregator_weak = Some(Rc::downgrade(&rc));
+        }
+
         let Some(interval_secs) = self.update_interval_seconds else {
             return;
         };
-        let aggregator_weak = if let Some(rc) = aggregator_rc {
-            let weak = Rc::downgrade(&rc);
-            self.aggregator_weak = Some(weak.clone());
-            weak
-        } else {
-            self.aggregator_weak.clone().expect(
-                "SpreadQuoteAggregator: timer mode requires prepare_for_timer_mode(rc) to be \
+        let aggregator_weak = self.aggregator_weak.clone().expect(
+            "SpreadQuoteAggregator: timer mode requires prepare_for_timer_mode(rc) to be \
                  called first with the Rc that wraps this aggregator (before feeding quotes in \
                  historical mode or before start_timer(None)).",
-            )
-        };
+        );
 
         let callback = TimeEventCallback::RustLocal(Rc::new(move |event: TimeEvent| {
             if let Some(agg) = aggregator_weak.upgrade() {
@@ -2383,17 +2393,25 @@ impl SpreadQuoteAggregator {
 
     /// Stops the timer when in timer-driven mode.
     pub fn stop_timer(&mut self) {
-        if self.update_interval_seconds.is_none() {
-            return;
+        if self.update_interval_seconds.is_some()
+            && self
+                .clock
+                .borrow()
+                .timer_names()
+                .contains(&self.timer_name.as_str())
+        {
+            self.clock.borrow_mut().cancel_timer(&self.timer_name);
         }
 
         if self
             .clock
             .borrow()
             .timer_names()
-            .contains(&self.timer_name.as_str())
+            .contains(&self.vega_pricing_timeout_timer_name.as_str())
         {
-            self.clock.borrow_mut().cancel_timer(&self.timer_name);
+            self.clock
+                .borrow_mut()
+                .cancel_timer(&self.vega_pricing_timeout_timer_name);
         }
     }
 
@@ -2481,6 +2499,9 @@ impl SpreadQuoteAggregator {
             return;
         }
 
+        let use_vega_pricing =
+            !(self.disable_vega_pricing || self.vega_pricing_temporarily_disabled);
+
         for (idx, &leg_id) in self.leg_ids.iter().enumerate() {
             let Some(tick) = self.last_quotes.get(&leg_id) else {
                 log::error!(
@@ -2501,7 +2522,8 @@ impl SpreadQuoteAggregator {
                 self.mid_prices[idx] = f64::midpoint(ask_price, bid_price);
                 self.bid_ask_spreads[idx] = ask_price - bid_price;
 
-                if let Some(ref vp) = self.vega_provider
+                if use_vega_pricing
+                    && let Some(ref vp) = self.vega_provider
                     && let Some(vega) = vp.vega_for_leg(leg_id)
                 {
                     self.vegas[idx] = vega;
@@ -2518,7 +2540,11 @@ impl SpreadQuoteAggregator {
         (self.handler)(spread_quote);
     }
 
-    fn create_option_spread_prices(&self) -> (f64, f64) {
+    fn create_option_spread_prices(&mut self) -> (f64, f64) {
+        if self.disable_vega_pricing || self.vega_pricing_temporarily_disabled {
+            return self.create_futures_spread_prices();
+        }
+
         let vega_multipliers: Vec<f64> = (0..self.n_legs)
             .map(|i| {
                 if self.vegas[i] == 0.0 {
@@ -2536,9 +2562,11 @@ impl SpreadQuoteAggregator {
 
         if non_zero.is_empty() {
             log::warn!(
-                "No vega information available for the components of {}. Will generate spread quote using component quotes only",
-                self.spread_instrument_id
+                "No vega information available for the components of {}; will generate spread quote using component quotes only, vega pricing is disabled for {} seconds, subscribe to some underlying price information for more precise quotes",
+                self.spread_instrument_id,
+                self.vega_pricing_timeout_seconds
             );
+            self.start_vega_pricing_timeout();
             return self.create_futures_spread_prices();
         }
         let vega_multiplier = non_zero.iter().map(|x| x.abs()).sum::<f64>() / non_zero.len() as f64;
@@ -2559,6 +2587,44 @@ impl SpreadQuoteAggregator {
         let raw_bid = spread_mid_price - bid_ask_spread * 0.5;
         let raw_ask = spread_mid_price + bid_ask_spread * 0.5;
         (raw_bid, raw_ask)
+    }
+
+    fn clear_vega_pricing_timeout(&mut self) {
+        self.vega_pricing_temporarily_disabled = false;
+    }
+
+    fn start_vega_pricing_timeout(&mut self) {
+        self.vega_pricing_temporarily_disabled = true;
+
+        if self
+            .clock
+            .borrow()
+            .timer_names()
+            .contains(&self.vega_pricing_timeout_timer_name.as_str())
+        {
+            return;
+        }
+
+        let Some(aggregator_weak) = self.aggregator_weak.clone() else {
+            return;
+        };
+        let callback = TimeEventCallback::RustLocal(Rc::new(move |_event: TimeEvent| {
+            if let Some(agg) = aggregator_weak.upgrade() {
+                agg.borrow_mut().clear_vega_pricing_timeout();
+            }
+        }));
+        let alert_time =
+            self.clock.borrow().timestamp_ns() + self.vega_pricing_timeout_seconds * 1_000_000_000;
+
+        self.clock
+            .borrow_mut()
+            .set_time_alert_ns(
+                &self.vega_pricing_timeout_timer_name,
+                alert_time,
+                Some(callback),
+                Some(true),
+            )
+            .expect("Failed to set spread quote vega pricing timeout");
     }
 
     fn create_futures_spread_prices(&self) -> (f64, f64) {
@@ -6103,6 +6169,8 @@ mod tests {
             false,
             None,
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6158,6 +6226,8 @@ mod tests {
             false,
             None,
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6213,6 +6283,8 @@ mod tests {
             false,
             None,
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6268,6 +6340,8 @@ mod tests {
             false,
             Some(1),
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6345,6 +6419,8 @@ mod tests {
             true,
             Some(1),
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6419,6 +6495,8 @@ mod tests {
             true,
             Some(1),
             0,
+            false,
+            60,
             None,
             None,
         );
@@ -6488,6 +6566,8 @@ mod tests {
             false,
             None,
             0,
+            false,
+            60,
             Some(Box::new(vega_provider)),
             None,
         );
@@ -6533,7 +6613,7 @@ mod tests {
         vega_provider.insert(leg1, 0.0);
         vega_provider.insert(leg2, 0.0);
 
-        let mut agg = SpreadQuoteAggregator::new(
+        let agg = SpreadQuoteAggregator::new(
             spread_id,
             &legs,
             false,
@@ -6542,16 +6622,20 @@ mod tests {
             Box::new(move |q: QuoteTick| {
                 handler_clone.lock().expect(MUTEX_POISONED).push(q);
             }),
-            clock,
+            clock.clone(),
             false,
             None,
             0,
+            false,
+            1,
             Some(Box::new(vega_provider)),
             None,
         );
+        let rc = Rc::new(RefCell::new(agg));
+        rc.borrow_mut().start_timer(Some(Rc::clone(&rc)));
 
         let ts = UnixNanos::from(1_000_000_000);
-        agg.handle_quote_tick(QuoteTick::new(
+        rc.borrow_mut().handle_quote_tick(QuoteTick::new(
             leg1,
             Price::from("10.00"),
             Price::from("10.10"),
@@ -6560,7 +6644,7 @@ mod tests {
             ts,
             ts,
         ));
-        agg.handle_quote_tick(QuoteTick::new(
+        rc.borrow_mut().handle_quote_tick(QuoteTick::new(
             leg2,
             Price::from("20.00"),
             Price::from("20.10"),
@@ -6569,11 +6653,144 @@ mod tests {
             ts,
             ts,
         ));
-        let quotes = handler.lock().expect(MUTEX_POISONED);
-        assert_eq!(quotes.len(), 1);
-        let q = &quotes[0];
-        assert_eq!(q.bid_price, Price::from("-10.10"));
-        assert_eq!(q.ask_price, Price::from("-9.90"));
+        {
+            let quotes = handler.lock().expect(MUTEX_POISONED);
+            assert_eq!(quotes.len(), 1);
+            let q = &quotes[0];
+            assert_eq!(q.bid_price, Price::from("-10.10"));
+            assert_eq!(q.ask_price, Price::from("-9.90"));
+        }
+        assert!(rc.borrow().vega_pricing_temporarily_disabled);
+
+        let timeout_name = rc.borrow().vega_pricing_timeout_timer_name.clone();
+        assert!(
+            clock
+                .borrow()
+                .timer_names()
+                .contains(&timeout_name.as_str())
+        );
+
+        let events = clock
+            .borrow_mut()
+            .advance_time(UnixNanos::from(2_000_000_000), true);
+
+        for handler in clock.borrow().match_handlers(events) {
+            handler.run();
+        }
+
+        assert!(!rc.borrow().vega_pricing_temporarily_disabled);
+
+        let cancel_handler = Arc::new(Mutex::new(Vec::new()));
+        let cancel_handler_clone = Arc::clone(&cancel_handler);
+        let mut cancel_vega_provider = MapVegaProvider::new();
+        cancel_vega_provider.insert(leg1, 0.0);
+        cancel_vega_provider.insert(leg2, 0.0);
+        let cancel_agg = SpreadQuoteAggregator::new(
+            spread_id,
+            &legs,
+            false,
+            instrument.price_precision(),
+            0,
+            Box::new(move |q: QuoteTick| {
+                cancel_handler_clone.lock().expect(MUTEX_POISONED).push(q);
+            }),
+            clock.clone(),
+            false,
+            None,
+            0,
+            false,
+            10,
+            Some(Box::new(cancel_vega_provider)),
+            None,
+        );
+        let cancel_rc = Rc::new(RefCell::new(cancel_agg));
+        cancel_rc
+            .borrow_mut()
+            .start_timer(Some(Rc::clone(&cancel_rc)));
+        cancel_rc.borrow_mut().handle_quote_tick(QuoteTick::new(
+            leg1,
+            Price::from("10.00"),
+            Price::from("10.10"),
+            Quantity::from(100),
+            Quantity::from(100),
+            ts,
+            ts,
+        ));
+        cancel_rc.borrow_mut().handle_quote_tick(QuoteTick::new(
+            leg2,
+            Price::from("20.00"),
+            Price::from("20.10"),
+            Quantity::from(100),
+            Quantity::from(100),
+            ts,
+            ts,
+        ));
+        let cancel_timeout_name = cancel_rc.borrow().vega_pricing_timeout_timer_name.clone();
+        assert!(
+            clock
+                .borrow()
+                .timer_names()
+                .contains(&cancel_timeout_name.as_str())
+        );
+        cancel_rc.borrow_mut().stop_timer();
+        assert!(
+            !clock
+                .borrow()
+                .timer_names()
+                .contains(&cancel_timeout_name.as_str())
+        );
+
+        let permanent_handler = Arc::new(Mutex::new(Vec::new()));
+        let permanent_handler_clone = Arc::clone(&permanent_handler);
+        let mut permanent_vega_provider = MapVegaProvider::new();
+        permanent_vega_provider.insert(leg1, 0.15);
+        permanent_vega_provider.insert(leg2, 0.12);
+        let mut permanent_agg = SpreadQuoteAggregator::new(
+            spread_id,
+            &legs,
+            false,
+            instrument.price_precision(),
+            0,
+            Box::new(move |q: QuoteTick| {
+                permanent_handler_clone
+                    .lock()
+                    .expect(MUTEX_POISONED)
+                    .push(q);
+            }),
+            Rc::new(RefCell::new(TestClock::new())),
+            false,
+            None,
+            0,
+            true,
+            1,
+            Some(Box::new(permanent_vega_provider)),
+            None,
+        );
+
+        permanent_agg.handle_quote_tick(QuoteTick::new(
+            leg1,
+            Price::from("10.00"),
+            Price::from("10.10"),
+            Quantity::from(100),
+            Quantity::from(100),
+            ts,
+            ts,
+        ));
+        permanent_agg.handle_quote_tick(QuoteTick::new(
+            leg2,
+            Price::from("20.00"),
+            Price::from("20.10"),
+            Quantity::from(100),
+            Quantity::from(100),
+            ts,
+            ts,
+        ));
+
+        let permanent_quotes = permanent_handler.lock().expect(MUTEX_POISONED);
+        assert_eq!(permanent_quotes.len(), 1);
+        assert_eq!(permanent_quotes[0].bid_price, Price::from("-10.10"));
+        assert_eq!(permanent_quotes[0].ask_price, Price::from("-9.90"));
+        assert!(!permanent_agg.vega_pricing_temporarily_disabled);
     }
 
     #[rstest]
@@ -6601,6 +6818,8 @@ mod tests {
             false,
             None,
             0,
+            false,
+            60,
             None,
             Some(Box::new(rounder)),
         );

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -3171,6 +3171,14 @@ impl DataEngine {
                 .as_ref()
                 .and_then(|params| params.get_u64("quote_build_delay"))
                 .unwrap_or(0),
+            cmd.params
+                .as_ref()
+                .and_then(|params| params.get_bool("disable_vega_pricing"))
+                .unwrap_or(false),
+            cmd.params
+                .as_ref()
+                .and_then(|params| params.get_u64("vega_pricing_timeout_seconds"))
+                .unwrap_or(60),
             None,
             None,
         )));

--- a/nautilus_trader/data/aggregation.pxd
+++ b/nautilus_trader/data/aggregation.pxd
@@ -206,6 +206,10 @@ cdef class SpreadQuoteAggregator:
     cdef readonly object _ask_sizes
     cdef readonly Instrument _spread_instrument
     cdef readonly bint _is_futures_spread
+    cdef readonly bint _disable_vega_pricing
+    cdef readonly bint _vega_pricing_temporarily_disabled
+    cdef readonly int _vega_pricing_timeout_seconds
+    cdef readonly str _vega_pricing_timeout_timer_name
     cdef readonly bint _has_update
 
     # Component tracking
@@ -217,6 +221,9 @@ cdef class SpreadQuoteAggregator:
 
     # Historical mode support (similar to TimeBarAggregator)
     cdef list _historical_events
+
+    cdef void _clear_vega_pricing_timeout(self, TimeEvent event)
+    cdef void _start_vega_pricing_timeout(self)
 
     cpdef void start_timer(self)
     cpdef void stop_timer(self)

--- a/nautilus_trader/data/aggregation.pyx
+++ b/nautilus_trader/data/aggregation.pyx
@@ -1857,6 +1857,8 @@ cdef class SpreadQuoteAggregator:
         bint historical,
         object update_interval_seconds = None,
         int quote_build_delay = 0,
+        bint disable_vega_pricing = False,
+        int vega_pricing_timeout_seconds = 60,
     ):
         self._handler = handler
         self._clock = clock
@@ -1888,12 +1890,16 @@ cdef class SpreadQuoteAggregator:
         self.historical_mode = historical
         self._update_interval_seconds = update_interval_seconds
         self._quote_build_delay = quote_build_delay
+        self._disable_vega_pricing = disable_vega_pricing
+        self._vega_pricing_temporarily_disabled = False
+        self._vega_pricing_timeout_seconds = vega_pricing_timeout_seconds
         self.is_running = False
         self._historical_events = []
 
         # Timers on a same clock execute first based on their timer name
         # "SPREAD_QUOTE_..." < "TIME_BAR_..."
         self._timer_name = f"SPREAD_QUOTE_{self._spread_instrument_id}"
+        self._vega_pricing_timeout_timer_name = f"VEGA_PRICING_TIMEOUT_{self._spread_instrument_id}"
         self._has_update = False
 
     cpdef void set_historical_mode(self, bint historical_mode, handler: Callable[[QuoteTick], None], GreeksCalculator greeks_calculator):
@@ -1932,11 +1938,14 @@ cdef class SpreadQuoteAggregator:
         )
 
     cpdef void stop_timer(self):
-        if self._update_interval_seconds is None:
-            return
-
-        if self._timer_name in self._clock.timer_names:
+        if (
+            self._update_interval_seconds is not None
+            and self._timer_name in self._clock.timer_names
+        ):
             self._clock.cancel_timer(self._timer_name)
+
+        if self._vega_pricing_timeout_timer_name in self._clock.timer_names:
+            self._clock.cancel_timer(self._vega_pricing_timeout_timer_name)
 
     cpdef void handle_quote_tick(self, QuoteTick tick):
         if self._update_interval_seconds is not None and self.historical_mode:
@@ -2010,6 +2019,11 @@ cdef class SpreadQuoteAggregator:
         if not self._has_update:
             return
 
+        cdef bint use_vega_pricing = not (
+            self._disable_vega_pricing
+            or self._vega_pricing_temporarily_disabled
+        )
+
         for idx, leg_id in enumerate(self._leg_ids):
             tick = self._last_quotes.get(leg_id)
             if tick is None:
@@ -2029,14 +2043,15 @@ cdef class SpreadQuoteAggregator:
             if not self._is_futures_spread:
                 self._mid_prices[idx] = (ask_price + bid_price) * 0.5
                 self._bid_ask_spreads[idx] = ask_price - bid_price
-                greeks_data = self._greeks_calculator.instrument_greeks(
-                    leg_id,
-                    percent_greeks=True,
-                    use_cached_greeks=True,
-                    vega_time_weight_base=30,
-                )
-                if greeks_data is not None:
-                    self._vegas[idx] = greeks_data.vega
+                if use_vega_pricing:
+                    greeks_data = self._greeks_calculator.instrument_greeks(
+                        leg_id,
+                        percent_greeks=True,
+                        use_cached_greeks=True,
+                        vega_time_weight_base=30,
+                    )
+                    if greeks_data is not None:
+                        self._vegas[idx] = greeks_data.vega
 
         cdef tuple raw_bid_ask_prices
         if self._is_futures_spread:
@@ -2050,6 +2065,12 @@ cdef class SpreadQuoteAggregator:
         self._handler(spread_quote)
 
     cdef tuple _create_option_spread_prices(self):
+        if (
+            self._disable_vega_pricing
+            or self._vega_pricing_temporarily_disabled
+        ):
+            return self._create_futures_spread_prices()
+
         vega_multipliers = np.divide(
             self._bid_ask_spreads,
             self._vegas,
@@ -2063,8 +2084,10 @@ cdef class SpreadQuoteAggregator:
             self._log.warning(
                 f"No vega information available for the components of {self._spread_instrument_id}. "
                 f"Will generate spread quote using component quotes only. "
+                f"Vega pricing is disabled for {self._vega_pricing_timeout_seconds} seconds. "
                 f"Subscribe to some underlying price information for more precise quotes."
             )
+            self._start_vega_pricing_timeout()
             return self._create_futures_spread_prices()
 
         vega_multiplier = np.abs(non_zero_multipliers).mean()
@@ -2079,6 +2102,20 @@ cdef class SpreadQuoteAggregator:
         raw_ask_price = spread_mid_price + bid_ask_spread * 0.5
 
         return (raw_bid_price, raw_ask_price)
+
+    cdef void _clear_vega_pricing_timeout(self, TimeEvent event):
+        self._vega_pricing_temporarily_disabled = False
+
+    cdef void _start_vega_pricing_timeout(self):
+        self._vega_pricing_temporarily_disabled = True
+        if self._vega_pricing_timeout_timer_name in self._clock.timer_names:
+            return
+
+        self._clock.set_time_alert_ns(
+            name=self._vega_pricing_timeout_timer_name,
+            alert_time_ns=self._clock.timestamp_ns() + secs_to_nanos(self._vega_pricing_timeout_seconds),
+            callback=self._clear_vega_pricing_timeout,
+        )
 
     cdef tuple _create_futures_spread_prices(self):
         # Calculate spread ask: for positive ratios use ask, for negative ratios use bid

--- a/nautilus_trader/data/engine.pyx
+++ b/nautilus_trader/data/engine.pyx
@@ -4091,6 +4091,8 @@ cdef class DataEngine(Component):
 
         update_interval_seconds = params.get("update_interval_seconds", 1)
         quote_build_delay = params.get("quote_build_delay", 0)
+        disable_vega_pricing = params.get("disable_vega_pricing", False)
+        vega_pricing_timeout_seconds = params.get("vega_pricing_timeout_seconds", 60)
         greeks_calculator = GreeksCalculator(self._cache, self._clock)
         self._spread_quote_aggregators[key] = SpreadQuoteAggregator(
             spread_instrument=instrument,
@@ -4100,6 +4102,8 @@ cdef class DataEngine(Component):
             historical=False,
             update_interval_seconds=update_interval_seconds,
             quote_build_delay=quote_build_delay,
+            disable_vega_pricing=disable_vega_pricing,
+            vega_pricing_timeout_seconds=vega_pricing_timeout_seconds,
         )
         self._log.debug(f"Created aggregator for {key=}")
 

--- a/tests/unit_tests/data/test_aggregation.py
+++ b/tests/unit_tests/data/test_aggregation.py
@@ -6117,6 +6117,7 @@ class TestSpreadQuoteAggregator:
             clock=self.clock,
             historical=False,
             update_interval_seconds=None,
+            vega_pricing_timeout_seconds=1,
         )
 
         option1_quote = QuoteTick(
@@ -6152,6 +6153,54 @@ class TestSpreadQuoteAggregator:
         # Ask = 1.10 - 2.00 = -0.90
         assert spread_quote.bid_price.as_double() == -1.10
         assert spread_quote.ask_price.as_double() == -0.90
+        assert aggregator._vega_pricing_temporarily_disabled
+
+        assert aggregator._vega_pricing_timeout_timer_name in self.clock.timer_names
+
+        events = self.clock.advance_time(self.clock.timestamp_ns() + 2 * NANOSECONDS_IN_SECOND)
+        for event in events:
+            event.handle()
+
+        assert not aggregator._vega_pricing_temporarily_disabled
+
+        cancel_handler = []
+        cancel_aggregator = SpreadQuoteAggregator(
+            spread_instrument=self.spread_instrument,
+            handler=cancel_handler.append,
+            greeks_calculator=greeks_calculator,
+            clock=self.clock,
+            historical=False,
+            update_interval_seconds=None,
+            vega_pricing_timeout_seconds=10,
+        )
+
+        cancel_aggregator.handle_quote_tick(option1_quote)
+        cancel_aggregator.handle_quote_tick(option2_quote)
+
+        assert cancel_aggregator._vega_pricing_timeout_timer_name in self.clock.timer_names
+        cancel_aggregator.stop_timer()
+        assert cancel_aggregator._vega_pricing_timeout_timer_name not in self.clock.timer_names
+
+        permanent_handler = []
+        permanent_aggregator = SpreadQuoteAggregator(
+            spread_instrument=self.spread_instrument,
+            handler=permanent_handler.append,
+            greeks_calculator=greeks_calculator,
+            clock=self.clock,
+            historical=False,
+            update_interval_seconds=None,
+            disable_vega_pricing=True,
+            vega_pricing_timeout_seconds=1,
+        )
+        permanent_aggregator._vegas[:] = [0.15, 0.12]
+
+        permanent_aggregator.handle_quote_tick(option1_quote)
+        permanent_aggregator.handle_quote_tick(option2_quote)
+
+        assert len(permanent_handler) == 1
+        assert permanent_handler[0].bid_price.as_double() == -1.10
+        assert permanent_handler[0].ask_price.as_double() == -0.90
+        assert not permanent_aggregator._vega_pricing_temporarily_disabled
 
 
 class TestSpreadQuoteAggregatorHistoricalMode:


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Adds `disable_vega_pricing` and `vega_pricing_timeout_seconds` parameters to spread quote aggregation in both Cython and Rust.
- Uses `disable_vega_pricing` as a permanent bypass for option spread vega pricing.
- Temporarily disables vega pricing after missing or zero vega data, then re-enables it with a one-shot timer after `vega_pricing_timeout_seconds`, defaulting to 60 seconds.
- Updates the missing-vega warning to state that vega pricing is disabled for the configured timeout window.
- Passes the new params from the data engine into the spread quote aggregator for request and subscription paths.

### Design decisions

- Temporary disable state is local to each spread quote aggregator instance because each aggregator handles one spread instrument.
- No shared disabled-instrument map is used.
- Permanent disable and temporary disable are separate flags so explicit user configuration does not schedule timeout state.
- The existing futures-spread pricing path is reused as the fallback when vega pricing is unavailable or disabled.
- The Rust implementation mirrors the Cython behavior for parity between v1 and v2 paths.

### Implementation

- `nautilus_trader/data/aggregation.pyx` and `.pxd` add the new constructor params, internal state, warning text, and timeout callbacks.
- `nautilus_trader/data/engine.pyx` reads `disable_vega_pricing` and `vega_pricing_timeout_seconds` from spread quote params and forwards them to `SpreadQuoteAggregator`.
- `crates/data/src/aggregation.rs` adds the same permanent and temporary vega pricing controls, plus a `VEGA_PRICING_TIMEOUT_*` time alert.
- `crates/data/src/engine/mod.rs` reads the same params from request and subscription params.
- `tests/unit_tests/data/test_aggregation.py` and the Rust aggregation tests cover temporary timeout clearing and permanent disable behavior.

### Flow

```mermaid
flowchart TD
    A[Spread quote build] --> B{Permanent or temporary vega disable?}
    B -- Yes --> C[Use component quote pricing]
    B -- No --> D[Load leg vegas]
    D --> E{Any non-zero vega multiplier?}
    E -- Yes --> F[Use vega-weighted option spread pricing]
    E -- No --> G[Warn and temporarily disable vega pricing]
    G --> H[Start timeout timer]
    H --> C
    H --> I[Timer fires after configured seconds]
    I --> J[Re-enable vega pricing]
```

### Verification

- Passed `cargo fmt --package nautilus-data`.
- Passed `cargo test -p nautilus-data test_spread_quote_all_zero_vega_fallback --lib`.
- Passed `uv run --no-sync python -m cython nautilus_trader/data/aggregation.pyx -3`.
- `make build-debug` is blocked by unrelated duplicate `request_book_depth` and `request_book_deltas` definitions in `crates/adapters/databento/src/data.rs`.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4323

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
