### PR TITLE
Replace bincode in event_store with a positional codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,26 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bip32"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,7 +4534,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "arrow 57.3.1",
- "bincode 1.3.3",
+ "bincode",
  "capnp 0.23.2",
  "faster-hex",
  "fastrange-rs",
@@ -5247,7 +5227,7 @@ dependencies = [
  "async-channel",
  "async-stream",
  "async-task",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "downcast-rs",
  "errno",
@@ -6067,7 +6047,6 @@ dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "async-trait",
- "bincode 2.0.1",
  "blake3",
  "bytes",
  "criterion",
@@ -10482,12 +10461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10561,12 +10534,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,6 @@ aws-lc-rs = { version = "1.17.0", default-features = false, features = [
   "non-fips", # FIPS 140-3 mode blocked: aws-lc-fips-sys requires Go toolchain
 ] }
 base64 = "0.22.1"
-bincode = { version = "2.0.1", features = ["serde"] }
 blake3 = { version = "1.8.5", default-features = false, features = ["std"] }
 bon = "3.9.3"
 bytes = { version = "1.12.0", features = ["serde"] }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Released on TBD (UTC).
 - Added Unix SIGTERM handling to the v2 `LiveNode` shutdown path (Rust)
 
 ### Breaking Changes
+- **Breaking:** the `event_store` on-disk envelope format changed (bincode replaced by a hardened positional codec). Beta stores written by v1.227-v1.229 are rejected with a clear `Corrupted` error and must be regenerated; there is no migrator.
 - Renamed Bybit data config `instrument_status_poll_secs` to `instrument_poll_interval_secs`
 - Changed `Throttler` rate limit fields to non-zero accessors instead of public fields (Rust)
 

--- a/crates/event_store/Cargo.toml
+++ b/crates/event_store/Cargo.toml
@@ -41,7 +41,6 @@ nautilus-persistence = { workspace = true, optional = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
-bincode = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/event_store/benches/codec.rs
+++ b/crates/event_store/benches/codec.rs
@@ -15,17 +15,23 @@
 
 //! Benchmarks for the on-disk envelope codec.
 //!
-//! Every captured entry is bincode-serialized before the redb commit and bincode-deserialized
-//! on every read. The writer batches up to 100 entries per commit, so per-entry codec cost
-//! multiplies into the commit-latency budget the SPEC's storage benchmark allocates (5 ms p50
-//! at the default batch size). These benches keep that cost visible.
+//! Every captured entry is codec-serialized before the redb commit and codec-deserialized on
+//! every read. The writer batches up to 100 entries per commit, so per-entry codec cost multiplies
+//! into the commit-latency budget the SPEC's storage benchmark allocates (5 ms p50 at the default
+//! batch size). These benches keep that cost visible.
+//!
+//! One-time bincode 2.0.1 baseline captured before removing the dependency with a release-mode
+//! scratch harness on 2026-06-26 (50,000 iterations per operation, payload sizes below):
+//! 256 bytes: bincode 349 B, codec 378 B; encode 126.3 ns vs 178.0 ns; decode 153.5 ns vs 218.3 ns.
+//! 1024 bytes: bincode 1117 B, codec 1146 B; encode 196.2 ns vs 261.9 ns; decode 163.4 ns vs 216.0 ns.
+//! 4096 bytes: bincode 4189 B, codec 4218 B; encode 205.3 ns vs 256.0 ns; decode 201.1 ns vs 250.9 ns.
 
 use std::hint::black_box;
 
 use bytes::Bytes;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use nautilus_core::UnixNanos;
-use nautilus_event_store::{EventStoreEntry, Headers, Topic, compute_entry_hash};
+use nautilus_event_store::{EventStoreEntry, Headers, Topic, codec, compute_entry_hash};
 use ustr::Ustr;
 
 const PAYLOAD_SIZES: &[usize] = &[256, 1024, 4096];
@@ -59,16 +65,14 @@ fn entry_with_payload(size: usize) -> EventStoreEntry {
 }
 
 fn bench_serialize(c: &mut Criterion) {
-    let mut group = c.benchmark_group("bincode_serialize_entry");
-    let config = bincode::config::standard();
+    let mut group = c.benchmark_group("codec_serialize_entry");
 
     for &size in PAYLOAD_SIZES {
         let entry = entry_with_payload(size);
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &entry, |b, entry| {
             b.iter(|| {
-                let bytes =
-                    bincode::serde::encode_to_vec(black_box(entry), config).expect("serialize");
+                let bytes = codec::encode_to_vec(black_box(entry)).expect("serialize");
                 black_box(bytes)
             });
         });
@@ -78,20 +82,16 @@ fn bench_serialize(c: &mut Criterion) {
 }
 
 fn bench_deserialize(c: &mut Criterion) {
-    let mut group = c.benchmark_group("bincode_deserialize_entry");
-    let config = bincode::config::standard();
+    let mut group = c.benchmark_group("codec_deserialize_entry");
 
     for &size in PAYLOAD_SIZES {
         let entry = entry_with_payload(size);
-        let encoded = bincode::serde::encode_to_vec(&entry, config).expect("serialize");
+        let encoded = codec::encode_to_vec(&entry).expect("serialize");
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
             b.iter(|| {
-                let (decoded, _) = bincode::serde::decode_from_slice::<EventStoreEntry, _>(
-                    black_box(encoded),
-                    config,
-                )
-                .expect("deserialize");
+                let decoded = codec::decode_from_slice::<EventStoreEntry>(black_box(encoded))
+                    .expect("deserialize");
                 black_box(decoded)
             });
         });

--- a/crates/event_store/src/backend/redb.rs
+++ b/crates/event_store/src/backend/redb.rs
@@ -26,7 +26,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bincode::config::{Configuration, standard};
 use nautilus_core::UnixNanos;
 use redb::{
     CommitError, Database, DatabaseError, Durability, ReadOnlyDatabase, ReadTransaction,
@@ -36,8 +35,10 @@ use redb::{
 
 use crate::{
     backend::{AppendEntry, EventStore, IndexKey, IndexKind, ScanDirection},
+    codec,
     entry::EventStoreEntry,
     error::EventStoreError,
+    format,
     manifest::{RunManifest, RunStatus},
     snapshot::{SnapshotAnchor, validate_new_anchor},
 };
@@ -50,8 +51,6 @@ const SNAPSHOT_ANCHOR_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new
 
 const MANIFEST_KEY: &str = "current";
 const SNAPSHOT_ANCHOR_KEY: &str = "latest";
-
-const BINCODE_CONFIG: Configuration = standard();
 
 /// On-disk [`EventStore`] backed by a per-run [`redb`] file.
 ///
@@ -212,6 +211,7 @@ impl RedbBackend {
         }
 
         let db = ReadOnlyDatabase::open(&path).map_err(map_read_only_database_err)?;
+        format::verify_store_format(&db)?;
         let manifest = Self::read_manifest(&db)?.ok_or_else(|| {
             EventStoreError::Corrupted(format!(
                 "missing manifest in run file at {}",
@@ -299,7 +299,10 @@ impl RedbBackend {
 
     fn read_run_manifest(path: &Path) -> Result<RunManifest, EventStoreError> {
         let manifest = match ReadOnlyDatabase::open(path) {
-            Ok(db) => Self::read_manifest(&db)?,
+            Ok(db) => {
+                format::verify_store_format(&db)?;
+                Self::read_manifest(&db)?
+            }
             // Each durable commit deletes redb's allocator-state table and only a clean
             // `Database::drop` rewrites it, so a hard-killed process leaves a file the
             // read-only open refuses. A writable open repairs it for future opens.
@@ -309,6 +312,7 @@ impl RedbBackend {
                     path.display()
                 );
                 let db = Database::open(path).map_err(map_database_err)?;
+                format::verify_store_format(&db)?;
                 Self::read_manifest(&db)?
             }
             Err(e) => return Err(map_read_only_database_err(e)),
@@ -342,6 +346,7 @@ impl RedbBackend {
             txn.open_table(SNAPSHOT_ANCHOR_TABLE)
                 .map_err(map_table_err)?;
         }
+        format::write_store_format(&txn)?;
         insert_run_manifest(&txn, manifest)?;
         txn.commit().map_err(map_commit_err)?;
         Ok(())
@@ -363,9 +368,8 @@ impl RedbBackend {
             return Ok(None);
         };
         let bytes = value.value();
-        let (manifest, _) =
-            bincode::serde::decode_from_slice::<RunManifest, _>(bytes, BINCODE_CONFIG)
-                .map_err(|e| EventStoreError::Corrupted(format!("decode manifest: {e}")))?;
+        let manifest = codec::decode_from_slice::<RunManifest>(bytes)
+            .map_err(|e| EventStoreError::Corrupted(format!("decode manifest: {e}")))?;
         Ok(Some(manifest))
     }
 
@@ -382,9 +386,8 @@ impl RedbBackend {
             return Ok(None);
         };
         let bytes = value.value();
-        let (anchor, _) =
-            bincode::serde::decode_from_slice::<SnapshotAnchor, _>(bytes, BINCODE_CONFIG)
-                .map_err(|e| EventStoreError::Corrupted(format!("decode snapshot anchor: {e}")))?;
+        let anchor = codec::decode_from_slice::<SnapshotAnchor>(bytes)
+            .map_err(|e| EventStoreError::Corrupted(format!("decode snapshot anchor: {e}")))?;
         Ok(Some(anchor))
     }
 
@@ -411,8 +414,8 @@ impl RedbBackend {
             let (key, value) = row.map_err(map_storage_err)?;
             let bytes = value.value();
 
-            match bincode::serde::decode_from_slice::<EventStoreEntry, _>(bytes, BINCODE_CONFIG) {
-                Ok((entry, _)) => {
+            match codec::decode_from_slice::<EventStoreEntry>(bytes) {
+                Ok(entry) => {
                     if entry.ts_init > max_ts {
                         max_ts = entry.ts_init;
                     }
@@ -455,6 +458,7 @@ impl EventStore for RedbBackend {
         let db = Database::create(&path).map_err(map_database_err)?;
 
         if path_existed {
+            format::verify_store_format(&db)?;
             let on_disk = Self::read_manifest(&db)?.ok_or_else(|| {
                 EventStoreError::Corrupted(format!(
                     "missing manifest in existing run file at {}",
@@ -524,7 +528,7 @@ impl EventStore for RedbBackend {
         let encoded: Vec<Vec<u8>> = entries
             .iter()
             .map(|append| {
-                bincode::serde::encode_to_vec(&append.entry, BINCODE_CONFIG).map_err(|e| {
+                codec::encode_to_vec(&append.entry).map_err(|e| {
                     EventStoreError::Backend(format!("encode entry seq={}: {e}", append.entry.seq))
                 })
             })
@@ -617,11 +621,8 @@ impl EventStore for RedbBackend {
                 });
             }
             let bytes = v.value();
-            let (entry, _) =
-                bincode::serde::decode_from_slice::<EventStoreEntry, _>(bytes, BINCODE_CONFIG)
-                    .map_err(|e| {
-                        EventStoreError::Corrupted(format!("decode entry seq={seq}: {e}"))
-                    })?;
+            let entry = codec::decode_from_slice::<EventStoreEntry>(bytes)
+                .map_err(|e| EventStoreError::Corrupted(format!("decode entry seq={seq}: {e}")))?;
 
             if entry.recompute_hash() != entry.entry_hash {
                 return Err(EventStoreError::HashMismatch { seq });
@@ -664,9 +665,8 @@ impl EventStore for RedbBackend {
         };
 
         let bytes = value.value();
-        let (entry, _) =
-            bincode::serde::decode_from_slice::<EventStoreEntry, _>(bytes, BINCODE_CONFIG)
-                .map_err(|e| EventStoreError::Corrupted(format!("decode entry seq={seq}: {e}")))?;
+        let entry = codec::decode_from_slice::<EventStoreEntry>(bytes)
+            .map_err(|e| EventStoreError::Corrupted(format!("decode entry seq={seq}: {e}")))?;
 
         if entry.recompute_hash() != entry.entry_hash {
             return Err(EventStoreError::HashMismatch { seq });
@@ -714,7 +714,7 @@ impl EventStore for RedbBackend {
         let latest = Self::read_snapshot_anchor(state.db.readable())?;
         validate_new_anchor(&anchor, state.high_watermark, latest.as_ref())?;
 
-        let bytes = bincode::serde::encode_to_vec(&anchor, BINCODE_CONFIG)
+        let bytes = codec::encode_to_vec(&anchor)
             .map_err(|e| EventStoreError::Backend(format!("encode snapshot anchor: {e}")))?;
         let db = state.db.read_write()?;
         let txn = begin_immediate_write(db)?;
@@ -782,7 +782,7 @@ fn insert_run_manifest(
     txn: &WriteTransaction,
     manifest: &RunManifest,
 ) -> Result<(), EventStoreError> {
-    let bytes = bincode::serde::encode_to_vec(manifest, BINCODE_CONFIG)
+    let bytes = codec::encode_to_vec(manifest)
         .map_err(|e| EventStoreError::Backend(format!("encode manifest: {e}")))?;
     let mut table = txn.open_table(MANIFEST_TABLE).map_err(map_table_err)?;
     table
@@ -879,8 +879,46 @@ fn map_transaction_err(err: TransactionError) -> EventStoreError {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use tempfile::TempDir;
 
     use super::*;
+
+    fn raw_run_path(base: &Path, run_id: &str) -> PathBuf {
+        let dir = base.join("trader-001");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir.join(format!("{run_id}.redb"))
+    }
+
+    fn create_pre_codec_run_file(path: &Path) {
+        let entries: TableDefinition<u64, &[u8]> = TableDefinition::new("entries");
+        let manifest: TableDefinition<&str, &[u8]> = TableDefinition::new("manifest");
+        let db = Database::create(path).expect("create redb");
+        let txn = db.begin_write().expect("begin write");
+        {
+            txn.open_table(entries).expect("open entries");
+            let mut table = txn.open_table(manifest).expect("open manifest");
+            table
+                .insert("current", b"old-format".as_slice())
+                .expect("insert");
+        }
+        txn.commit().expect("commit");
+    }
+
+    #[rstest]
+    fn read_run_manifest_rejects_store_without_format_marker() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = raw_run_path(tmp.path(), "run-old-format");
+        create_pre_codec_run_file(&path);
+
+        let err = RedbBackend::read_run_manifest(&path).expect_err("must reject old format");
+
+        match err {
+            EventStoreError::Corrupted(msg) => {
+                assert!(msg.contains("regenerated"), "msg was: {msg}");
+            }
+            other => panic!("expected Corrupted, was {other:?}"),
+        }
+    }
 
     #[rstest]
     #[case::file_too_large(ErrorKind::FileTooLarge, true)]

--- a/crates/event_store/src/capture/builtins.rs
+++ b/crates/event_store/src/capture/builtins.rs
@@ -28,9 +28,9 @@
 //! tag so forensics scans see entries identical to the bare-type capture path.
 //!
 //! The payload serialization format is MessagePack via `rmp-serde`. The on-disk envelope
-//! codec stays bincode (positional, non-self-describing); MessagePack inside the payload
-//! handles the upstream Nautilus types that carry `#[serde(tag = "type")]` internal
-//! tagging, which a non-self-describing format like bincode cannot round-trip.
+//! uses the positional codec; MessagePack inside the payload handles the upstream Nautilus
+//! types that carry `#[serde(tag = "type")]` internal tagging, which a non-self-describing
+//! format cannot round-trip.
 
 use std::collections::HashSet;
 

--- a/crates/event_store/src/codec.rs
+++ b/crates/event_store/src/codec.rs
@@ -1326,11 +1326,12 @@ mod tests {
 
     #[rstest]
     fn decodes_a_bincode_blob_as_bad_magic() {
-        let cfg = bincode::config::standard();
-        let bytes = bincode::serde::encode_to_vec("old-format".to_string(), cfg).unwrap();
+        // bincode standard() encoding of String "old-format", frozen so the test needs
+        // no bincode dependency: varint len 10 (0x0A) ++ b"old-format".
+        const OLD_BINCODE_STRING: &[u8] = b"\x0aold-format";
 
         assert!(matches!(
-            decode_from_slice::<String>(&bytes),
+            decode_from_slice::<String>(OLD_BINCODE_STRING),
             Err(CodecError::BadMagic)
         ));
     }

--- a/crates/event_store/src/codec.rs
+++ b/crates/event_store/src/codec.rs
@@ -1,0 +1,1566 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Hardened positional serde codec for event-store records.
+
+use std::{char, fmt::Display, str};
+
+use serde::{
+    Serialize,
+    de::{
+        self, DeserializeOwned, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess,
+        SeqAccess, VariantAccess, Visitor,
+    },
+    ser::{
+        self, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    },
+};
+use thiserror::Error;
+
+const MAGIC: [u8; 4] = *b"NESC";
+const VERSION: u8 = 1;
+const HEADER_LEN: usize = MAGIC.len() + 1;
+
+/// Serializes `value` into a freshly allocated, framed codec buffer.
+///
+/// The output is `MAGIC ++ VERSION ++ body`. Deterministic: equal values produce
+/// byte-identical output.
+///
+/// # Errors
+///
+/// Returns [`CodecError`] if `value`'s [`Serialize`] impl drives the format outside the
+/// supported positional model, such as an unbounded sequence whose length is not known up front.
+pub fn encode_to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    let mut encoder = Encoder { out: Vec::new() };
+    encoder.out.extend_from_slice(&MAGIC);
+    encoder.out.push(VERSION);
+    value.serialize(&mut encoder)?;
+    Ok(encoder.out)
+}
+
+/// Decodes a `T` from a complete framed codec buffer.
+///
+/// Validates the frame header, decodes the body positionally, then requires the input to be fully
+/// consumed.
+///
+/// # Errors
+///
+/// Returns [`CodecError`] on a bad or short header, malformed body, a self-describing deserialize
+/// request, or unconsumed trailing bytes.
+pub fn decode_from_slice<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
+    let mut decoder = Decoder {
+        input: bytes,
+        pos: 0,
+    };
+    decoder.read_header()?;
+    let value = T::deserialize(&mut decoder)?;
+    if decoder.pos != decoder.input.len() {
+        return Err(CodecError::TrailingBytes(decoder.input.len() - decoder.pos));
+    }
+    Ok(value)
+}
+
+/// Errors returned by the event-store positional codec.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CodecError {
+    /// The input ended before the requested bytes could be read.
+    #[error("unexpected end of codec input: needed {needed} more byte(s)")]
+    UnexpectedEof {
+        /// Number of bytes the decoder attempted to read.
+        needed: usize,
+    },
+    /// The frame did not start with the event-store codec magic.
+    #[error("bad codec magic: input is not a nautilus event-store codec frame")]
+    BadMagic,
+    /// The frame version is not supported by this decoder.
+    #[error("unsupported codec version: {0}")]
+    UnsupportedVersion(u8),
+    /// An encoded length would exceed the remaining input.
+    #[error("encoded length {claimed} exceeds remaining input {remaining}")]
+    LengthOverflow {
+        /// Claimed encoded length or collection count, as the raw on-wire `u64`.
+        ///
+        /// Kept as `u64` (not `usize`) so the reported value is exact on every
+        /// target, including a length that overflows `usize` on a sub-64-bit
+        /// build — the case that would otherwise be reported with a lossy
+        /// sentinel.
+        claimed: u64,
+        /// Bytes remaining in the input when the length was checked.
+        remaining: usize,
+    },
+    /// A string was not valid UTF-8.
+    #[error("invalid utf-8 in encoded string")]
+    InvalidUtf8,
+    /// A bool discriminant was not `0x00` or `0x01`.
+    #[error("invalid bool discriminant: {0:#04x}")]
+    InvalidBool(u8),
+    /// An option discriminant was not `0x00` or `0x01`.
+    #[error("invalid option discriminant: {0:#04x}")]
+    InvalidOption(u8),
+    /// A decoded char value was not a valid Unicode scalar value.
+    #[error("invalid char scalar value: {0:#010x}")]
+    InvalidChar(u32),
+    /// An enum variant index was outside the type's variant set.
+    #[error("unknown enum variant index: {0}")]
+    UnknownVariant(u32),
+    /// Serde did not provide a sequence or map length.
+    #[error("sequence length was not provided by the serializer")]
+    MissingLen,
+    /// The input had bytes remaining after a complete value was decoded.
+    #[error("{0} unconsumed trailing byte(s) after decode")]
+    TrailingBytes(usize),
+    /// The caller attempted self-describing deserialization.
+    #[error("self-describing deserialization is not supported by this format")]
+    SelfDescribing,
+    /// Serde-generated error message.
+    #[error("{0}")]
+    Message(String),
+}
+
+impl ser::Error for CodecError {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+impl de::Error for CodecError {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+#[derive(Debug)]
+struct Encoder {
+    out: Vec<u8>,
+}
+
+impl Encoder {
+    fn write_len(&mut self, len: usize) {
+        self.out.extend_from_slice(&(len as u64).to_le_bytes());
+    }
+
+    fn write_variant(&mut self, variant_index: u32) {
+        self.out.extend_from_slice(&variant_index.to_le_bytes());
+    }
+}
+
+impl ser::Serializer for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.out.push(u8::from(v));
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.out.push(v);
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.out.extend_from_slice(&(v as u32).to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.write_len(v.len());
+        self.out.extend_from_slice(v.as_bytes());
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.write_len(v.len());
+        self.out.extend_from_slice(v);
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.out.push(0);
+        Ok(())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.out.push(1);
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.write_variant(variant_index);
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.write_variant(variant_index);
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let len = len.ok_or(CodecError::MissingLen)?;
+        self.write_len(len);
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.write_variant(variant_index);
+        Ok(self)
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let len = len.ok_or(CodecError::MissingLen)?;
+        self.write_len(len);
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.write_variant(variant_index);
+        Ok(self)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+impl SerializeSeq for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeTuple for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeTupleStruct for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeTupleVariant for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeMap for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        key.serialize(&mut **self)
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeStruct for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl SerializeStructVariant for &mut Encoder {
+    type Ok = ();
+    type Error = CodecError;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Decoder<'de> {
+    input: &'de [u8],
+    pos: usize,
+}
+
+impl<'de> Decoder<'de> {
+    fn read_header(&mut self) -> Result<(), CodecError> {
+        if self.input.len() < HEADER_LEN {
+            return Err(CodecError::UnexpectedEof { needed: HEADER_LEN });
+        }
+
+        let magic = self.take(MAGIC.len())?;
+        if magic != MAGIC {
+            return Err(CodecError::BadMagic);
+        }
+
+        let version = self.take(1)?[0];
+        if version != VERSION {
+            return Err(CodecError::UnsupportedVersion(version));
+        }
+
+        Ok(())
+    }
+
+    fn remaining(&self) -> usize {
+        self.input.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'de [u8], CodecError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(CodecError::UnexpectedEof { needed: n })?;
+        let slice = self
+            .input
+            .get(self.pos..end)
+            .ok_or(CodecError::UnexpectedEof { needed: n })?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn read_len(&mut self) -> Result<usize, CodecError> {
+        let raw = self.read_u64()?;
+        let remaining = self.remaining();
+        // A length is valid only if it both fits `usize` and is within the
+        // remaining input. Any failure reports the exact `u64` wire value via
+        // `claimed`, so the overflow case needs no lossy `usize` sentinel.
+        match usize::try_from(raw) {
+            Ok(claimed) if claimed <= remaining => Ok(claimed),
+            _ => Err(CodecError::LengthOverflow {
+                claimed: raw,
+                remaining,
+            }),
+        }
+    }
+
+    fn read_u16(&mut self) -> Result<u16, CodecError> {
+        let bytes: [u8; 2] = self
+            .take(2)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        Ok(u16::from_le_bytes(bytes))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, CodecError> {
+        let bytes: [u8; 4] = self
+            .take(4)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, CodecError> {
+        let bytes: [u8; 8] = self
+            .take(8)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        Ok(u64::from_le_bytes(bytes))
+    }
+}
+
+macro_rules! deserialize_integer {
+    ($method:ident, $visit:ident, $ty:ty, $width:literal) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            let bytes: [u8; $width] = self
+                .take($width)?
+                .try_into()
+                .expect("take returned the exact requested width");
+            visitor.$visit(<$ty>::from_le_bytes(bytes))
+        }
+    };
+}
+
+impl<'de> de::Deserializer<'de> for &mut Decoder<'de> {
+    type Error = CodecError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(CodecError::SelfDescribing)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.take(1)?[0] {
+            0 => visitor.visit_bool(false),
+            1 => visitor.visit_bool(true),
+            other => Err(CodecError::InvalidBool(other)),
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let bytes: [u8; 1] = self
+            .take(1)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        visitor.visit_i8(i8::from_le_bytes(bytes))
+    }
+
+    deserialize_integer!(deserialize_i16, visit_i16, i16, 2);
+    deserialize_integer!(deserialize_i32, visit_i32, i32, 4);
+    deserialize_integer!(deserialize_i64, visit_i64, i64, 8);
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(self.take(1)?[0])
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(self.read_u16()?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(self.read_u32()?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.read_u64()?)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let bytes: [u8; 4] = self
+            .take(4)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        visitor.visit_f32(f32::from_le_bytes(bytes))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let bytes: [u8; 8] = self
+            .take(8)?
+            .try_into()
+            .expect("take returned the exact requested width");
+        visitor.visit_f64(f64::from_le_bytes(bytes))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let raw = self.read_u32()?;
+        let value = char::from_u32(raw).ok_or(CodecError::InvalidChar(raw))?;
+        visitor.visit_char(value)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let len = self.read_len()?;
+        let bytes = self.take(len)?;
+        let value = str::from_utf8(bytes).map_err(|_| CodecError::InvalidUtf8)?;
+        visitor.visit_borrowed_str(value)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let len = self.read_len()?;
+        let bytes = self.take(len)?;
+        visitor.visit_borrowed_bytes(bytes)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.take(1)?[0] {
+            0 => visitor.visit_none(),
+            1 => visitor.visit_some(self),
+            other => Err(CodecError::InvalidOption(other)),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let remaining = self.read_len()?;
+        visitor.visit_seq(SeqReader {
+            dec: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(SeqReader {
+            dec: self,
+            remaining: len,
+        })
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let remaining = self.read_len()?;
+        visitor.visit_map(MapReader {
+            dec: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(SeqReader {
+            dec: self,
+            remaining: fields.len(),
+        })
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let index = self.read_u32()?;
+        if index as usize >= variants.len() {
+            return Err(CodecError::UnknownVariant(index));
+        }
+        visitor.visit_enum(EnumReader { dec: self, index })
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u32(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(CodecError::SelfDescribing)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
+struct SeqReader<'a, 'de> {
+    dec: &'a mut Decoder<'de>,
+    remaining: usize,
+}
+
+impl<'de> SeqAccess<'de> for SeqReader<'_, 'de> {
+    type Error = CodecError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+
+        self.remaining -= 1;
+        seed.deserialize(&mut *self.dec).map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining)
+    }
+}
+
+#[derive(Debug)]
+struct MapReader<'a, 'de> {
+    dec: &'a mut Decoder<'de>,
+    remaining: usize,
+}
+
+impl<'de> MapAccess<'de> for MapReader<'_, 'de> {
+    type Error = CodecError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+
+        self.remaining -= 1;
+        seed.deserialize(&mut *self.dec).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.dec)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining)
+    }
+}
+
+#[derive(Debug)]
+struct EnumReader<'a, 'de> {
+    dec: &'a mut Decoder<'de>,
+    index: u32,
+}
+
+impl<'de> EnumAccess<'de> for EnumReader<'_, 'de> {
+    type Error = CodecError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = seed.deserialize(self.index.into_deserializer())?;
+        Ok((value, self))
+    }
+}
+
+impl<'de> VariantAccess<'de> for EnumReader<'_, 'de> {
+    type Error = CodecError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.dec)
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(SeqReader {
+            dec: self.dec,
+            remaining: len,
+        })
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(SeqReader {
+            dec: self.dec,
+            remaining: fields.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::array;
+
+    use bytes::Bytes;
+    use indexmap::IndexMap;
+    use nautilus_core::{UUID4, UnixNanos};
+    use nautilus_system::RegisteredComponents;
+    use proptest::{prelude::*, test_runner::Config as ProptestConfig};
+    use rstest::rstest;
+    use serde::Deserialize;
+    use ustr::Ustr;
+
+    use super::*;
+    use crate::{
+        EventStoreEntry, Headers, RunManifest, RunStatus, SnapshotAnchor,
+        hash::{EntryHash, compute_entry_hash},
+        markers::{
+            DataClass, DataCursorSnapshot, HiFiMarker, MarkerGap, MarkerGapReason, StreamCursor,
+            StreamDictEntry,
+        },
+    };
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ScalarProbe {
+        b: bool,
+        i8s: [i8; 3],
+        i16s: [i16; 3],
+        i32s: [i32; 3],
+        i64s: [i64; 3],
+        u16: u16,
+        f32s: [f32; 3],
+        f64s: [f64; 3],
+        ch: char,
+    }
+
+    impl PartialEq for ScalarProbe {
+        fn eq(&self, other: &Self) -> bool {
+            self.b == other.b
+                && self.i8s == other.i8s
+                && self.i16s == other.i16s
+                && self.i32s == other.i32s
+                && self.i64s == other.i64s
+                && self.u16 == other.u16
+                && self
+                    .f32s
+                    .iter()
+                    .zip(other.f32s)
+                    .all(|(left, right)| left.to_bits() == right.to_bits())
+                && self
+                    .f64s
+                    .iter()
+                    .zip(other.f64s)
+                    .all(|(left, right)| left.to_bits() == right.to_bits())
+                && self.ch == other.ch
+        }
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct BoolProbe {
+        b: bool,
+    }
+
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        decode_from_slice(&encode_to_vec(value).expect("encode")).expect("decode")
+    }
+
+    fn headers_populated() -> Headers {
+        Headers {
+            correlation_id: Some(UUID4::from_bytes([1; 16])),
+            causation_id: Some(UUID4::from_bytes([2; 16])),
+        }
+    }
+
+    fn entry(headers: Headers) -> EventStoreEntry {
+        let topic = "exec.command".into();
+        let payload_type = Ustr::from("SubmitOrder");
+        let payload = Bytes::from_static(b"\x01\x02\x03\x04");
+        let seq = 42;
+        let ts_init = UnixNanos::from(1_700_000_000_000_000_000);
+        let ts_publish = UnixNanos::from(1_700_000_000_000_000_001);
+        let entry_hash = compute_entry_hash(
+            seq,
+            ts_init,
+            ts_publish,
+            "exec.command",
+            payload_type.as_str(),
+            &payload,
+            &headers,
+        );
+
+        EventStoreEntry::new(
+            entry_hash,
+            seq,
+            headers,
+            topic,
+            payload_type,
+            payload,
+            ts_init,
+            ts_publish,
+        )
+    }
+
+    fn registered_components() -> RegisteredComponents {
+        let mut components = RegisteredComponents::default();
+        components
+            .actors
+            .insert("actor-1".to_string(), "hash-a".to_string());
+        components
+            .strategies
+            .insert("strategy-1".to_string(), "hash-s".to_string());
+        components
+            .algorithms
+            .insert("algo-1".to_string(), "hash-g".to_string());
+        components.subscriptions.push("data.quotes".to_string());
+        components.endpoints.push("exec.command".to_string());
+        components
+    }
+
+    fn running_manifest() -> RunManifest {
+        RunManifest {
+            run_id: "1700000000-abcd1234".to_string(),
+            parent_run_id: None,
+            instance_id: "trader-001".to_string(),
+            binary_hash: "deadbeef".to_string(),
+            schema_version: 1,
+            crate_versions: "feedface".to_string(),
+            feature_flags: Vec::new(),
+            adapter_versions: IndexMap::new(),
+            config_hash: "cafebabe".to_string(),
+            registered_components: RegisteredComponents::default(),
+            seed: None,
+            start_ts_init: UnixNanos::from(10),
+            end_ts_init: None,
+            high_watermark: 0,
+            status: RunStatus::Running,
+        }
+    }
+
+    fn sealed_manifest() -> RunManifest {
+        let mut adapter_versions = IndexMap::new();
+        adapter_versions.insert("binance".to_string(), "1.2.3".to_string());
+        adapter_versions.insert("okx".to_string(), "2.3.4".to_string());
+
+        RunManifest {
+            run_id: "1700000010-cafe1234".to_string(),
+            parent_run_id: Some("1700000000-abcd1234".to_string()),
+            instance_id: "trader-001".to_string(),
+            binary_hash: "deadbeef".to_string(),
+            schema_version: 2,
+            crate_versions: "feedface".to_string(),
+            feature_flags: vec!["live".to_string(), "persistence".to_string()],
+            adapter_versions,
+            config_hash: "cafebabe".to_string(),
+            registered_components: registered_components(),
+            seed: Some(7),
+            start_ts_init: UnixNanos::from(10),
+            end_ts_init: Some(UnixNanos::from(20)),
+            high_watermark: 99,
+            status: RunStatus::Ended,
+        }
+    }
+
+    fn snapshot_with_cursors() -> DataCursorSnapshot {
+        DataCursorSnapshot {
+            marker_seq: 7,
+            event_seq_before: 42,
+            ts_init: UnixNanos::from(100),
+            advanced: vec![
+                StreamCursor {
+                    slot: 1,
+                    ts_init_hi: UnixNanos::from(101),
+                    count: 10,
+                },
+                StreamCursor {
+                    slot: 2,
+                    ts_init_hi: UnixNanos::from(102),
+                    count: 11,
+                },
+            ],
+        }
+    }
+
+    fn hifi_marker() -> HiFiMarker {
+        HiFiMarker {
+            marker_seq: 1,
+            event_seq_before: 42,
+            slot: 3,
+            ts_event: UnixNanos::from(1000),
+            ts_init: UnixNanos::from(1001),
+            same_ts_ordinal: 2,
+            record_fingerprint: array::from_fn(|idx| {
+                u8::try_from(idx).expect("fingerprint index is in 0..32")
+            }),
+        }
+    }
+
+    #[rstest]
+    #[case::empty(Headers::empty())]
+    #[case::populated(headers_populated())]
+    fn roundtrip_event_store_entry(#[case] headers: Headers) {
+        let decoded = roundtrip(&entry(headers));
+
+        assert_eq!(decoded.recompute_hash(), decoded.entry_hash);
+    }
+
+    #[rstest]
+    #[case::running(running_manifest())]
+    #[case::sealed(sealed_manifest())]
+    fn roundtrip_run_manifest(#[case] manifest: RunManifest) {
+        assert_eq!(roundtrip(&manifest), manifest);
+    }
+
+    #[rstest]
+    fn roundtrip_registered_components() {
+        let components = registered_components();
+
+        assert_eq!(roundtrip(&components), components);
+    }
+
+    #[rstest]
+    fn roundtrip_snapshot_anchor() {
+        let anchor = SnapshotAnchor::new(10, "cache://run/10", "blake3:abcd");
+
+        assert_eq!(roundtrip(&anchor), anchor);
+    }
+
+    #[rstest]
+    #[case::advanced(snapshot_with_cursors())]
+    #[case::empty(DataCursorSnapshot {
+        marker_seq: 8,
+        event_seq_before: 43,
+        ts_init: UnixNanos::from(101),
+        advanced: Vec::new(),
+    })]
+    fn roundtrip_data_cursor_snapshot(#[case] snapshot: DataCursorSnapshot) {
+        assert_eq!(roundtrip(&snapshot), snapshot);
+    }
+
+    #[rstest]
+    fn roundtrip_hifi_marker() {
+        let marker = hifi_marker();
+
+        assert_eq!(roundtrip(&marker), marker);
+    }
+
+    #[rstest]
+    #[case(MarkerGapReason::Overflow)]
+    #[case(MarkerGapReason::WriterClosed)]
+    fn roundtrip_marker_gap(#[case] reason: MarkerGapReason) {
+        let gap = MarkerGap {
+            from_marker_seq: 1,
+            to_marker_seq: 2,
+            reason,
+        };
+
+        assert_eq!(roundtrip(&gap), gap);
+    }
+
+    #[rstest]
+    fn roundtrip_stream_dict_entry() {
+        let entry = StreamDictEntry {
+            slot: 3,
+            data_cls: DataClass::Quote,
+            identifier: "ETHUSDT.BINANCE".to_string(),
+        };
+
+        assert_eq!(roundtrip(&entry), entry);
+    }
+
+    #[rstest]
+    #[case(RunStatus::Running)]
+    #[case(RunStatus::Ended)]
+    #[case(RunStatus::CrashedRecovered)]
+    #[case(RunStatus::Quarantined)]
+    fn roundtrip_run_status_all_variants(#[case] status: RunStatus) {
+        assert_eq!(roundtrip(&status), status);
+    }
+
+    #[rstest]
+    #[case(DataClass::BookDeltas)]
+    #[case(DataClass::BookDepth10)]
+    #[case(DataClass::Quote)]
+    #[case(DataClass::Trade)]
+    #[case(DataClass::Bar)]
+    fn roundtrip_data_class_all_variants(#[case] data_class: DataClass) {
+        assert_eq!(roundtrip(&data_class), data_class);
+    }
+
+    #[rstest]
+    #[case(MarkerGapReason::Overflow)]
+    #[case(MarkerGapReason::WriterClosed)]
+    fn roundtrip_marker_gap_reason_all_variants(#[case] reason: MarkerGapReason) {
+        assert_eq!(roundtrip(&reason), reason);
+    }
+
+    #[rstest]
+    #[case::false_value(false)]
+    #[case::true_value(true)]
+    fn roundtrip_scalars(#[case] value: bool) {
+        let probe = ScalarProbe {
+            b: value,
+            i8s: [i8::MIN, -1, i8::MAX],
+            i16s: [i16::MIN, -2, i16::MAX],
+            i32s: [i32::MIN, -3, i32::MAX],
+            i64s: [i64::MIN, -4, i64::MAX],
+            u16: u16::MAX,
+            f32s: [0.0, 1.25, f32::NAN],
+            f64s: [0.0, f64::INFINITY, f64::NAN],
+            ch: '∞',
+        };
+
+        assert_eq!(roundtrip(&probe), probe);
+    }
+
+    #[rstest]
+    fn encode_is_deterministic() {
+        let entry = entry(headers_populated());
+        let manifest = sealed_manifest();
+
+        assert_eq!(
+            encode_to_vec(&entry).unwrap(),
+            encode_to_vec(&entry).unwrap()
+        );
+        assert_eq!(
+            encode_to_vec(&manifest).unwrap(),
+            encode_to_vec(&manifest).unwrap()
+        );
+    }
+
+    #[rstest]
+    fn header_present_and_correct() {
+        let bytes = encode_to_vec(&RunStatus::Running).unwrap();
+
+        assert_eq!(&bytes[..4], b"NESC");
+        assert_eq!(bytes[4], 1);
+    }
+
+    #[rstest]
+    fn header_bad_magic_rejected() {
+        let mut bytes = encode_to_vec(&entry(Headers::empty())).unwrap();
+        bytes[0] ^= 0xFF;
+
+        assert!(matches!(
+            decode_from_slice::<EventStoreEntry>(&bytes),
+            Err(CodecError::BadMagic)
+        ));
+    }
+
+    #[rstest]
+    fn header_unsupported_version_rejected() {
+        let mut bytes = encode_to_vec(&entry(Headers::empty())).unwrap();
+        bytes[4] = 2;
+
+        assert!(matches!(
+            decode_from_slice::<EventStoreEntry>(&bytes),
+            Err(CodecError::UnsupportedVersion(2))
+        ));
+    }
+
+    #[rstest]
+    fn header_truncated_rejected() {
+        let bytes = encode_to_vec(&entry(Headers::empty())).unwrap();
+
+        assert!(matches!(
+            decode_from_slice::<EventStoreEntry>(&bytes[..3]),
+            Err(CodecError::UnexpectedEof { .. })
+        ));
+    }
+
+    #[rstest]
+    fn decodes_a_bincode_blob_as_bad_magic() {
+        let cfg = bincode::config::standard();
+        let bytes = bincode::serde::encode_to_vec("old-format".to_string(), cfg).unwrap();
+
+        assert!(matches!(
+            decode_from_slice::<String>(&bytes),
+            Err(CodecError::BadMagic)
+        ));
+    }
+
+    #[rstest]
+    fn truncated_body_rejected() {
+        let bytes = encode_to_vec(&entry(Headers::empty())).unwrap();
+
+        assert!(decode_from_slice::<EventStoreEntry>(&bytes[..bytes.len() - 1]).is_err());
+    }
+
+    #[rstest]
+    fn forged_length_prefix_rejected() {
+        let mut bytes = encode_to_vec(&"ok".to_string()).unwrap();
+        bytes[HEADER_LEN..HEADER_LEN + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        assert!(matches!(
+            decode_from_slice::<String>(&bytes),
+            Err(CodecError::LengthOverflow { .. })
+        ));
+    }
+
+    #[rstest]
+    fn length_overflow_rejected() {
+        let mut bytes = encode_to_vec(&vec![1_u8, 2, 3]).unwrap();
+        bytes[HEADER_LEN..HEADER_LEN + 8].copy_from_slice(&99_u64.to_le_bytes());
+
+        assert!(matches!(
+            decode_from_slice::<Vec<u8>>(&bytes),
+            Err(CodecError::LengthOverflow { claimed: 99, .. })
+        ));
+    }
+
+    #[rstest]
+    fn bad_bool_discriminant_rejected() {
+        let mut bytes = encode_to_vec(&BoolProbe { b: false }).unwrap();
+        bytes[HEADER_LEN] = 2;
+
+        assert!(matches!(
+            decode_from_slice::<BoolProbe>(&bytes),
+            Err(CodecError::InvalidBool(2))
+        ));
+    }
+
+    #[rstest]
+    fn bad_option_discriminant_rejected() {
+        let mut bytes = encode_to_vec(&Headers::empty()).unwrap();
+        bytes[HEADER_LEN] = 2;
+
+        assert!(matches!(
+            decode_from_slice::<Headers>(&bytes),
+            Err(CodecError::InvalidOption(2))
+        ));
+    }
+
+    #[rstest]
+    fn invalid_utf8_rejected() {
+        let mut bytes = encode_to_vec(&"ok".to_string()).unwrap();
+        bytes[HEADER_LEN + 8] = 0xFF;
+
+        assert!(matches!(
+            decode_from_slice::<String>(&bytes),
+            Err(CodecError::InvalidUtf8)
+        ));
+    }
+
+    #[rstest]
+    fn unknown_enum_variant_rejected() {
+        let mut bytes = encode_to_vec(&RunStatus::Running).unwrap();
+        bytes[HEADER_LEN..HEADER_LEN + 4].copy_from_slice(&99_u32.to_le_bytes());
+
+        assert!(matches!(
+            decode_from_slice::<RunStatus>(&bytes),
+            Err(CodecError::UnknownVariant(99))
+        ));
+    }
+
+    #[rstest]
+    fn trailing_bytes_rejected() {
+        let mut bytes = encode_to_vec(&RunStatus::Running).unwrap();
+        bytes.push(0xFF);
+
+        assert!(matches!(
+            decode_from_slice::<RunStatus>(&bytes),
+            Err(CodecError::TrailingBytes(1))
+        ));
+    }
+
+    #[rstest]
+    fn rejects_self_describing() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(untagged)]
+        enum Probe {
+            A(u64),
+            B(String),
+        }
+
+        let bytes = encode_to_vec(&1_u64).unwrap();
+        let err = decode_from_slice::<Probe>(&bytes).expect_err("untagged enum must reject any");
+        assert!(matches!(err, CodecError::SelfDescribing));
+    }
+
+    #[rstest]
+    fn serialize_without_known_len_is_rejected() {
+        let mut encoder = Encoder { out: Vec::new() };
+        assert!(matches!(
+            ser::Serializer::serialize_seq(&mut encoder, None),
+            Err(CodecError::MissingLen)
+        ));
+
+        let mut encoder = Encoder { out: Vec::new() };
+        assert!(matches!(
+            ser::Serializer::serialize_map(&mut encoder, None),
+            Err(CodecError::MissingLen)
+        ));
+    }
+
+    struct U32Visitor;
+
+    impl Visitor<'_> for U32Visitor {
+        type Value = u32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a little-endian u32 identifier")
+        }
+
+        fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+    }
+
+    #[rstest]
+    fn deserialize_identifier_reads_u32() {
+        // `deserialize_identifier` is implemented for totality only (struct
+        // fields decode positionally and variant indices flow through serde's
+        // `U32Deserializer`, so the derive never reaches it). Drive it directly
+        // to prove the laid brick: it forwards to the little-endian `u32` reader.
+        let body = 7_u32.to_le_bytes();
+        let mut decoder = Decoder {
+            input: &body,
+            pos: 0,
+        };
+
+        let value = de::Deserializer::deserialize_identifier(&mut decoder, U32Visitor)
+            .expect("identifier decodes as a u32");
+
+        assert_eq!(value, 7);
+        assert_eq!(decoder.pos, body.len());
+    }
+
+    #[rstest]
+    fn deserialize_ignored_any_rejected() {
+        // `deserialize_ignored_any` is implemented for totality only and is hard
+        // to reach via the positional model, but it carries the same
+        // self-describing-rejection load as `deserialize_any` (the `wire.rs`
+        // invariant). `IgnoredAny::deserialize` drives it directly; assert it
+        // rejects rather than silently skipping.
+        let mut decoder = Decoder { input: &[], pos: 0 };
+
+        let err = de::IgnoredAny::deserialize(&mut decoder)
+            .expect_err("ignored_any must reject as self-describing");
+
+        assert!(matches!(err, CodecError::SelfDescribing));
+    }
+
+    #[rstest]
+    fn entry_hash_newtype_roundtrips() {
+        let hash = EntryHash(array::from_fn(|idx| {
+            u8::try_from(idx).expect("hash index is in 0..32")
+        }));
+
+        assert_eq!(roundtrip(&hash), hash);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        #[rstest]
+        fn prop_roundtrip_data_cursor_snapshot(
+            marker_seq in any::<u64>(),
+            event_seq_before in any::<u64>(),
+            ts_init in any::<u64>(),
+            cursors in proptest::collection::vec((any::<u32>(), any::<u64>(), any::<u64>()), 0..8),
+        ) {
+            let snap = DataCursorSnapshot {
+                marker_seq,
+                event_seq_before,
+                ts_init: UnixNanos::from(ts_init),
+                advanced: cursors
+                    .into_iter()
+                    .map(|(slot, hi, count)| StreamCursor {
+                        slot,
+                        ts_init_hi: UnixNanos::from(hi),
+                        count,
+                    })
+                    .collect(),
+            };
+
+            let bytes = encode_to_vec(&snap).expect("encode");
+            let decoded: DataCursorSnapshot = decode_from_slice(&bytes).expect("decode");
+            prop_assert_eq!(snap, decoded);
+        }
+
+        #[rstest]
+        fn prop_roundtrip_hifi_marker(
+            marker_seq in any::<u64>(),
+            event_seq_before in any::<u64>(),
+            slot in any::<u32>(),
+            ts_event in any::<u64>(),
+            ts_init in any::<u64>(),
+            same_ts_ordinal in any::<u32>(),
+            fingerprint in proptest::array::uniform32(any::<u8>()),
+        ) {
+            let marker = HiFiMarker {
+                marker_seq,
+                event_seq_before,
+                slot,
+                ts_event: UnixNanos::from(ts_event),
+                ts_init: UnixNanos::from(ts_init),
+                same_ts_ordinal,
+                record_fingerprint: fingerprint,
+            };
+
+            let bytes = encode_to_vec(&marker).expect("encode");
+            let decoded: HiFiMarker = decode_from_slice(&bytes).expect("decode");
+            prop_assert_eq!(marker, decoded);
+        }
+    }
+}

--- a/crates/event_store/src/format.rs
+++ b/crates/event_store/src/format.rs
@@ -1,0 +1,109 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Store-level on-disk format marker.
+//!
+//! Written into every redb run file at creation and verified at every open before any record is
+//! decoded, so a store written by a pre-codec beta build is rejected with a clear error rather than
+//! surfacing as a confusing per-record decode failure.
+
+use std::io::ErrorKind;
+
+use redb::{
+    ReadableDatabase, StorageError, TableDefinition, TableError, TransactionError, WriteTransaction,
+};
+
+use crate::error::EventStoreError;
+
+/// On-disk store format. Bump only on a hard envelope-format break.
+pub(crate) const STORE_FORMAT_VERSION: u32 = 1;
+
+pub(crate) const BETA_REGEN_MSG: &str = "event store written by an unsupported on-disk format \
+     (pre-codec beta v1.227-1.229); the format changed and these stores \
+     must be regenerated";
+
+const FORMAT_TABLE: TableDefinition<&str, u32> = TableDefinition::new("store_format");
+const FORMAT_KEY: &str = "codec";
+
+/// Writes the current format marker.
+pub(crate) fn write_store_format(txn: &WriteTransaction) -> Result<(), EventStoreError> {
+    let mut table = txn.open_table(FORMAT_TABLE).map_err(map_table_err)?;
+    table
+        .insert(FORMAT_KEY, STORE_FORMAT_VERSION)
+        .map_err(map_storage_err)?;
+    Ok(())
+}
+
+/// Verifies the store carries the supported format marker.
+pub(crate) fn verify_store_format<D: ReadableDatabase + ?Sized>(
+    db: &D,
+) -> Result<(), EventStoreError> {
+    let txn = db.begin_read().map_err(map_transaction_err)?;
+    let table = match txn.open_table(FORMAT_TABLE) {
+        Ok(table) => table,
+        Err(TableError::TableDoesNotExist(_)) => {
+            return Err(EventStoreError::Corrupted(BETA_REGEN_MSG.to_string()));
+        }
+        Err(e) => return Err(map_table_err(e)),
+    };
+    let Some(value) = table.get(FORMAT_KEY).map_err(map_storage_err)? else {
+        return Err(EventStoreError::Corrupted(BETA_REGEN_MSG.to_string()));
+    };
+    let version = value.value();
+
+    if version == STORE_FORMAT_VERSION {
+        Ok(())
+    } else {
+        Err(EventStoreError::Corrupted(format!(
+            "unsupported event store on-disk format version {version}; supported version is {STORE_FORMAT_VERSION}",
+        )))
+    }
+}
+
+fn map_storage_err(err: StorageError) -> EventStoreError {
+    match err {
+        StorageError::Io(io_err) if is_disk_pressure(io_err.kind()) => {
+            EventStoreError::Disk(io_err.to_string())
+        }
+        StorageError::Corrupted(msg) => EventStoreError::Corrupted(msg),
+        other => EventStoreError::Backend(other.to_string()),
+    }
+}
+
+fn is_disk_pressure(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::FileTooLarge | ErrorKind::StorageFull | ErrorKind::QuotaExceeded
+    )
+}
+
+fn map_table_err(err: TableError) -> EventStoreError {
+    match err {
+        TableError::Storage(storage) => map_storage_err(storage),
+        TableError::TableDoesNotExist(_)
+        | TableError::TableTypeMismatch { .. }
+        | TableError::TableIsMultimap(_)
+        | TableError::TableIsNotMultimap(_)
+        | TableError::TypeDefinitionChanged { .. } => EventStoreError::Corrupted(err.to_string()),
+        other => EventStoreError::Backend(other.to_string()),
+    }
+}
+
+fn map_transaction_err(err: TransactionError) -> EventStoreError {
+    match err {
+        TransactionError::Storage(storage) => map_storage_err(storage),
+        other => EventStoreError::Backend(other.to_string()),
+    }
+}

--- a/crates/event_store/src/kernel.rs
+++ b/crates/event_store/src/kernel.rs
@@ -1199,10 +1199,10 @@ pub(crate) fn submit_run_started_blocking(
 }
 
 fn encode_run_started(components: &RegisteredComponents) -> Bytes {
-    // bincode keeps the payload compact and matches the manifest encoding the backend
-    // already uses; replay's RunStarted decoder pairs with this representation.
-    let bytes = bincode::serde::encode_to_vec(components, bincode::config::standard())
-        .expect("RegisteredComponents serializes via serde, must not fail under standard config");
+    // The payload uses the same positional codec as the event-store envelope.
+    let bytes = crate::codec::encode_to_vec(components).expect(
+        "RegisteredComponents serializes via serde, must not fail under the positional codec",
+    );
     Bytes::from(bytes)
 }
 

--- a/crates/event_store/src/lib.rs
+++ b/crates/event_store/src/lib.rs
@@ -42,6 +42,7 @@
 
 pub mod backend;
 pub mod capture;
+pub mod codec;
 pub mod entry;
 pub mod error;
 pub mod hash;

--- a/crates/event_store/src/lib.rs
+++ b/crates/event_store/src/lib.rs
@@ -57,6 +57,7 @@ pub mod snapshot;
 pub mod verifier;
 pub mod writer;
 
+mod format;
 mod wire;
 
 pub use backend::{

--- a/crates/event_store/src/markers/marker.rs
+++ b/crates/event_store/src/markers/marker.rs
@@ -389,20 +389,18 @@ mod tests {
     }
 
     #[rstest]
-    fn marker_record_bincode_roundtrip() {
-        let cfg = bincode::config::standard();
-
+    fn marker_record_codec_roundtrip() {
         // DataCursorSnapshot
         let snap = baseline_snapshot();
-        let bytes = bincode::serde::encode_to_vec(&snap, cfg).unwrap();
-        let (decoded, _): (DataCursorSnapshot, _) =
-            bincode::serde::decode_from_slice(&bytes, cfg).unwrap();
+        let bytes = crate::codec::encode_to_vec(&snap).expect("encode");
+        let decoded =
+            crate::codec::decode_from_slice::<DataCursorSnapshot>(&bytes).expect("decode");
         assert_eq!(snap, decoded);
 
         // HiFiMarker
         let hifi = baseline_hifi();
-        let bytes = bincode::serde::encode_to_vec(&hifi, cfg).unwrap();
-        let (decoded, _): (HiFiMarker, _) = bincode::serde::decode_from_slice(&bytes, cfg).unwrap();
+        let bytes = crate::codec::encode_to_vec(&hifi).expect("encode");
+        let decoded = crate::codec::decode_from_slice::<HiFiMarker>(&bytes).expect("decode");
         assert_eq!(hifi, decoded);
 
         // MarkerGap
@@ -411,8 +409,8 @@ mod tests {
             to_marker_seq: 10,
             reason: MarkerGapReason::Overflow,
         };
-        let bytes = bincode::serde::encode_to_vec(&gap, cfg).unwrap();
-        let (decoded, _): (MarkerGap, _) = bincode::serde::decode_from_slice(&bytes, cfg).unwrap();
+        let bytes = crate::codec::encode_to_vec(&gap).expect("encode");
+        let decoded = crate::codec::decode_from_slice::<MarkerGap>(&bytes).expect("decode");
         assert_eq!(gap, decoded);
 
         // StreamDictEntry
@@ -421,9 +419,8 @@ mod tests {
             data_cls: DataClass::Bar,
             identifier: "BTCUSDT-PERP.BINANCE".to_string(),
         };
-        let bytes = bincode::serde::encode_to_vec(&dict, cfg).unwrap();
-        let (decoded, _): (StreamDictEntry, _) =
-            bincode::serde::decode_from_slice(&bytes, cfg).unwrap();
+        let bytes = crate::codec::encode_to_vec(&dict).expect("encode");
+        let decoded = crate::codec::decode_from_slice::<StreamDictEntry>(&bytes).expect("decode");
         assert_eq!(dict, decoded);
     }
 
@@ -517,15 +514,14 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
 
-        // Any cursor snapshot survives a bincode encode/decode unchanged
+        // Any cursor snapshot survives a codec encode/decode unchanged
         #[rstest]
-        fn prop_marker_snapshot_bincode_roundtrip(
+        fn prop_marker_snapshot_codec_roundtrip(
             marker_seq in any::<u64>(),
             event_seq_before in any::<u64>(),
             ts_init in any::<u64>(),
             cursors in proptest::collection::vec((any::<u32>(), any::<u64>(), any::<u64>()), 0..8),
         ) {
-            let cfg = bincode::config::standard();
             let snap = DataCursorSnapshot {
                 marker_seq,
                 event_seq_before,
@@ -540,15 +536,14 @@ mod tests {
                     .collect(),
             };
 
-            let bytes = bincode::serde::encode_to_vec(&snap, cfg).expect("encode");
-            let (decoded, _): (DataCursorSnapshot, _) =
-                bincode::serde::decode_from_slice(&bytes, cfg).expect("decode");
+            let bytes = crate::codec::encode_to_vec(&snap).expect("encode");
+            let decoded = crate::codec::decode_from_slice::<DataCursorSnapshot>(&bytes).expect("decode");
             prop_assert_eq!(snap, decoded);
         }
 
-        // Any high-fidelity marker survives a bincode encode/decode unchanged
+        // Any high-fidelity marker survives a codec encode/decode unchanged
         #[rstest]
-        fn prop_hifi_marker_bincode_roundtrip(
+        fn prop_hifi_marker_codec_roundtrip(
             marker_seq in any::<u64>(),
             event_seq_before in any::<u64>(),
             slot in any::<u32>(),
@@ -557,7 +552,6 @@ mod tests {
             same_ts_ordinal in any::<u32>(),
             fingerprint in proptest::array::uniform32(any::<u8>()),
         ) {
-            let cfg = bincode::config::standard();
             let marker = HiFiMarker {
                 marker_seq,
                 event_seq_before,
@@ -568,9 +562,8 @@ mod tests {
                 record_fingerprint: fingerprint,
             };
 
-            let bytes = bincode::serde::encode_to_vec(&marker, cfg).expect("encode");
-            let (decoded, _): (HiFiMarker, _) =
-                bincode::serde::decode_from_slice(&bytes, cfg).expect("decode");
+            let bytes = crate::codec::encode_to_vec(&marker).expect("encode");
+            let decoded = crate::codec::decode_from_slice::<HiFiMarker>(&bytes).expect("decode");
             prop_assert_eq!(marker, decoded);
         }
     }

--- a/crates/event_store/src/markers/redb.rs
+++ b/crates/event_store/src/markers/redb.rs
@@ -22,7 +22,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bincode::config::{Configuration, standard};
 use redb::{
     CommitError, Database, DatabaseError, Durability, ReadOnlyDatabase, ReadTransaction,
     ReadableDatabase, ReadableTable, StorageError, TableDefinition, TableError, TransactionError,
@@ -31,7 +30,9 @@ use redb::{
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
+    codec,
     error::EventStoreError,
+    format,
     manifest::RunStatus,
     markers::{
         DataCursorSnapshot, HiFiMarker, MarkerBackend, MarkerGap, MarkerManifest,
@@ -47,8 +48,6 @@ const STREAM_DICT_TABLE: TableDefinition<u32, &[u8]> = TableDefinition::new("str
 const MARKER_MANIFEST_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("marker_manifest");
 
 const MANIFEST_KEY: &str = "current";
-
-const BINCODE_CONFIG: Configuration = standard();
 
 /// On-disk [`MarkerBackend`] backed by a per-run [`redb`] marker sidecar file.
 ///
@@ -143,6 +142,7 @@ impl RedbMarkerBackend {
         }
 
         let db = ReadOnlyDatabase::open(&path).map_err(map_database_err)?;
+        format::verify_store_format(&db)?;
         let manifest = Self::read_manifest(&db)?.ok_or_else(|| {
             EventStoreError::Corrupted(format!(
                 "missing marker manifest in run file at {}",
@@ -190,6 +190,7 @@ impl RedbMarkerBackend {
             txn.open_table(MARKER_GAPS_TABLE).map_err(map_table_err)?;
             txn.open_table(STREAM_DICT_TABLE).map_err(map_table_err)?;
         }
+        format::write_store_format(&txn)?;
         insert_marker_manifest(&txn, manifest)?;
         txn.commit().map_err(map_commit_err)?;
         Ok(())
@@ -242,6 +243,7 @@ impl MarkerBackend for RedbMarkerBackend {
         let db = Database::create(&path).map_err(map_database_err)?;
 
         if path_existed {
+            format::verify_store_format(&db)?;
             let on_disk = Self::read_manifest(&db)?.ok_or_else(|| {
                 EventStoreError::Corrupted(format!(
                     "missing marker manifest in existing run file at {}",
@@ -572,14 +574,13 @@ fn insert_marker_manifest(
 }
 
 fn encode_value<T: Serialize>(label: &str, value: &T) -> Result<Vec<u8>, EventStoreError> {
-    bincode::serde::encode_to_vec(value, BINCODE_CONFIG)
+    codec::encode_to_vec(value)
         .map_err(|e| EventStoreError::Backend(format!("encode {label}: {e}")))
 }
 
 fn decode_value<T: DeserializeOwned>(label: &str, bytes: &[u8]) -> Result<T, EventStoreError> {
-    let (value, _) = bincode::serde::decode_from_slice::<T, _>(bytes, BINCODE_CONFIG)
-        .map_err(|e| EventStoreError::Corrupted(format!("decode {label}: {e}")))?;
-    Ok(value)
+    codec::decode_from_slice::<T>(bytes)
+        .map_err(|e| EventStoreError::Corrupted(format!("decode {label}: {e}")))
 }
 
 fn map_storage_err(err: StorageError) -> EventStoreError {
@@ -652,6 +653,7 @@ mod tests {
     use super::RedbMarkerBackend;
     use crate::{
         error::EventStoreError,
+        format,
         manifest::RunStatus,
         markers::{
             DataClass, DataCursorSnapshot, HiFiMarker, MarkerBackend, MarkerGap, MarkerGapReason,
@@ -736,6 +738,80 @@ mod tests {
     #[fixture]
     fn temp_dir() -> TempDir {
         TempDir::new().expect("create temp dir")
+    }
+
+    fn create_pre_codec_marker_file(path: &Path) {
+        let manifest: redb::TableDefinition<&str, &[u8]> =
+            redb::TableDefinition::new("marker_manifest");
+        let db = redb::Database::create(path).expect("create redb");
+        let txn = db.begin_write().expect("begin write");
+        {
+            let mut table = txn.open_table(manifest).expect("open marker manifest");
+            table
+                .insert("current", b"old-format".as_slice())
+                .expect("insert");
+        }
+        txn.commit().expect("commit");
+    }
+
+    fn create_future_marker_file(path: &Path) {
+        let manifest: redb::TableDefinition<&str, &[u8]> =
+            redb::TableDefinition::new("marker_manifest");
+        let store_format: redb::TableDefinition<&str, u32> =
+            redb::TableDefinition::new("store_format");
+        let db = redb::Database::create(path).expect("create redb");
+        let txn = db.begin_write().expect("begin write");
+        {
+            let mut format_table = txn.open_table(store_format).expect("open store format");
+            format_table
+                .insert("codec", format::STORE_FORMAT_VERSION + 1)
+                .expect("insert format");
+            let mut manifest_table = txn.open_table(manifest).expect("open marker manifest");
+            manifest_table
+                .insert("current", b"future-format".as_slice())
+                .expect("insert manifest");
+        }
+        txn.commit().expect("commit");
+    }
+
+    fn assert_corrupted_regenerated<T: Debug>(result: Result<T, EventStoreError>) {
+        match result {
+            Err(EventStoreError::Corrupted(msg)) => {
+                assert!(msg.contains("regenerated"), "msg was: {msg}");
+            }
+            other => panic!("expected Corrupted regeneration error, was {other:?}"),
+        }
+    }
+
+    fn assert_corrupted<T: Debug>(result: Result<T, EventStoreError>) {
+        match result {
+            Err(EventStoreError::Corrupted(_)) => {}
+            other => panic!("expected Corrupted error, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn open_rejects_marker_store_without_format_marker(temp_dir: TempDir) {
+        let run_id = "1700000000-redb-old-format";
+        let path = marker_path(temp_dir.path(), "trader-001", run_id);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        create_pre_codec_marker_file(&path);
+
+        let mut backend = RedbMarkerBackend::new(&path);
+        assert_corrupted_regenerated(backend.open_run(manifest(run_id)));
+        assert_corrupted_regenerated(RedbMarkerBackend::open_read_only_file(&path));
+    }
+
+    #[rstest]
+    fn open_rejects_marker_store_with_future_format_marker(temp_dir: TempDir) {
+        let run_id = "1700000000-redb-future-format";
+        let path = marker_path(temp_dir.path(), "trader-001", run_id);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        create_future_marker_file(&path);
+
+        let mut backend = RedbMarkerBackend::new(&path);
+        assert_corrupted(backend.open_run(manifest(run_id)));
+        assert_corrupted(RedbMarkerBackend::open_read_only_file(&path));
     }
 
     #[rstest]

--- a/crates/event_store/src/wire.rs
+++ b/crates/event_store/src/wire.rs
@@ -15,11 +15,11 @@
 
 //! Wire-format adapters for the on-disk event store envelope.
 //!
-//! `UnixNanos` deserializes through `deserialize_any`, which non-self-describing formats
-//! such as bincode reject. The on-disk envelope therefore serializes timestamp fields as
-//! raw `u64` and reconstructs the strong type on read.
+//! `UnixNanos` deserializes through `deserialize_any`, which the non-self-describing positional
+//! codec rejects. The on-disk envelope therefore serializes timestamp fields as raw `u64` and
+//! reconstructs the strong type on read.
 
-/// Serializes [`nautilus_core::UnixNanos`] as a raw `u64` so bincode can round-trip it.
+/// Serializes [`nautilus_core::UnixNanos`] as a raw `u64` so the positional codec can round-trip it.
 pub(crate) mod nanos_as_u64 {
     use nautilus_core::UnixNanos;
     use serde::{Deserialize, Deserializer, Serializer};

--- a/crates/event_store/tests/envelope.rs
+++ b/crates/event_store/tests/envelope.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! On-disk envelope contract: bincode round-trips for `EventStoreEntry` and `RunManifest`
+//! On-disk envelope contract: codec round-trips for `EventStoreEntry` and `RunManifest`
 //! must preserve every field, and the recomputed hash on a decoded entry must still match
 //! the stored hash.
 
@@ -21,7 +21,7 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_event_store::{
-    EventStoreEntry, Headers, RegisteredComponents, RunManifest, RunStatus, Topic,
+    EventStoreEntry, Headers, RegisteredComponents, RunManifest, RunStatus, Topic, codec,
     compute_entry_hash,
 };
 use rstest::rstest;
@@ -79,11 +79,8 @@ fn round_trip<T>(value: &T) -> T
 where
     T: serde::Serialize + serde::de::DeserializeOwned,
 {
-    let config = bincode::config::standard();
-    let encoded = bincode::serde::encode_to_vec(value, config).expect("serialize");
-    let (decoded, _) =
-        bincode::serde::decode_from_slice::<T, _>(&encoded, config).expect("deserialize");
-    decoded
+    let encoded = codec::encode_to_vec(value).expect("serialize");
+    codec::decode_from_slice::<T>(&encoded).expect("deserialize")
 }
 
 #[rstest]
@@ -97,7 +94,7 @@ fn entry_round_trip_empty_headers() {
 
 #[rstest]
 fn entry_round_trip_populated_headers() {
-    // All three header fields must round-trip through bincode and the hash must
+    // All three header fields must round-trip through the codec and the hash must
     // still validate; catches regressions in `wire::nanos_as_u64` and in
     // `Option<UUID4>` serde coupling under non-self-describing formats.
     let headers = Headers {

--- a/crates/event_store/tests/reader.rs
+++ b/crates/event_store/tests/reader.rs
@@ -421,7 +421,7 @@ fn list_runs_repairs_hard_crashed_run_file_and_recovery_seals_it() {
 fn reader_round_trip_preserves_payload_and_hash() {
     // Walk every entry through the reader and re-validate: the writer-stamped
     // entry_hash must still match a fresh recompute after the round-trip through
-    // bincode + redb + reader iteration.
+    // codec + redb + reader iteration.
     let tmp = TempDir::new().expect("tempdir");
     let drafts: Vec<EntryDraft> = (10_u64..14_u64)
         .map(|ts| EntryDraft {

--- a/crates/event_store/tests/redb.rs
+++ b/crates/event_store/tests/redb.rs
@@ -72,6 +72,61 @@ fn manifest(run_id: &str) -> RunManifest {
     }
 }
 
+fn raw_run_path(base: &std::path::Path, run_id: &str) -> std::path::PathBuf {
+    let dir = base.join(INSTANCE_ID);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir.join(format!("{run_id}.redb"))
+}
+
+fn create_pre_codec_run_file(path: &std::path::Path) {
+    let entries: redb::TableDefinition<u64, &[u8]> = redb::TableDefinition::new("entries");
+    let manifest: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new("manifest");
+    let db = redb::Database::create(path).expect("create redb");
+    let txn = db.begin_write().expect("begin write");
+    {
+        txn.open_table(entries).expect("open entries");
+        let mut manifest_table = txn.open_table(manifest).expect("open manifest");
+        manifest_table
+            .insert("current", b"old-format".as_slice())
+            .expect("insert manifest");
+    }
+    txn.commit().expect("commit");
+}
+
+fn create_future_format_run_file(path: &std::path::Path) {
+    let entries: redb::TableDefinition<u64, &[u8]> = redb::TableDefinition::new("entries");
+    let manifest: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new("manifest");
+    let store_format: redb::TableDefinition<&str, u32> = redb::TableDefinition::new("store_format");
+    let db = redb::Database::create(path).expect("create redb");
+    let txn = db.begin_write().expect("begin write");
+    {
+        txn.open_table(entries).expect("open entries");
+        let mut format_table = txn.open_table(store_format).expect("open store format");
+        format_table.insert("codec", 2_u32).expect("insert format");
+        let mut manifest_table = txn.open_table(manifest).expect("open manifest");
+        manifest_table
+            .insert("current", b"future-format".as_slice())
+            .expect("insert manifest");
+    }
+    txn.commit().expect("commit");
+}
+
+fn assert_corrupted_regenerated<T: std::fmt::Debug>(result: Result<T, EventStoreError>) {
+    match result {
+        Err(EventStoreError::Corrupted(msg)) => {
+            assert!(msg.contains("regenerated"), "msg was: {msg}");
+        }
+        other => panic!("expected Corrupted regeneration error, was {other:?}"),
+    }
+}
+
+fn assert_corrupted<T: std::fmt::Debug>(result: Result<T, EventStoreError>) {
+    match result {
+        Err(EventStoreError::Corrupted(_)) => {}
+        other => panic!("expected Corrupted error, was {other:?}"),
+    }
+}
+
 fn build_entry(seq: u64, headers: Headers, ts_init: u64) -> EventStoreEntry {
     let topic: Topic = "exec.command.SubmitOrder".into();
     let payload_type = Ustr::from("SubmitOrder");
@@ -98,6 +153,28 @@ fn build_entry(seq: u64, headers: Headers, ts_init: u64) -> EventStoreEntry {
         ts_init,
         ts_publish,
     )
+}
+
+#[rstest]
+fn open_rejects_store_without_format_marker() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = raw_run_path(tmp.path(), "run-old-format");
+    create_pre_codec_run_file(&path);
+
+    let mut backend = RedbBackend::new(tmp.path());
+    assert_corrupted_regenerated(backend.open_run(manifest("run-old-format")));
+    assert_corrupted_regenerated(RedbBackend::open_sealed_file(&path));
+}
+
+#[rstest]
+fn open_rejects_store_with_future_format_marker() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = raw_run_path(tmp.path(), "run-future-format");
+    create_future_format_run_file(&path);
+
+    let mut backend = RedbBackend::new(tmp.path());
+    assert_corrupted(backend.open_run(manifest("run-future-format")));
+    assert_corrupted(RedbBackend::open_sealed_file(&path));
 }
 
 fn append_with(seq: u64, ts_init: u64, index_keys: Vec<IndexKey>) -> AppendEntry {
@@ -949,7 +1026,7 @@ fn parity_with_memory_backend_for_indices() {
 
 #[rstest]
 fn scan_returns_corrupted_when_entry_bytes_are_garbled() {
-    // Garbled bincode payload at a known seq must surface as Corrupted, not Backend
+    // Garbled codec payload at a known seq must surface as Corrupted, not Backend
     // or Gap. Drives the decode->Corrupted classification on both scan paths.
     let tmp = TempDir::new().expect("tempdir");
     let path = {
@@ -971,7 +1048,7 @@ fn scan_returns_corrupted_when_entry_bytes_are_garbled() {
         let txn = db.begin_write().expect("begin write");
         {
             let mut table = txn.open_table(entries).expect("open table");
-            // Replace seq=2's bytes with something that is not a valid bincode envelope.
+            // Replace seq=2's bytes with something that is not a valid codec envelope.
             table
                 .insert(2_u64, b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".as_slice())
                 .expect("overwrite seq 2");
@@ -1060,9 +1137,13 @@ fn open_run_returns_corrupted_for_table_type_mismatch() {
     {
         let manifest_wrong: redb::TableDefinition<&str, u64> =
             redb::TableDefinition::new("manifest");
+        let store_format: redb::TableDefinition<&str, u32> =
+            redb::TableDefinition::new("store_format");
         let db = redb::Database::create(&path).expect("create redb");
         let txn = db.begin_write().expect("begin write");
         {
+            let mut format_table = txn.open_table(store_format).expect("open store format");
+            format_table.insert("codec", 1_u32).expect("insert format");
             let mut table = txn.open_table(manifest_wrong).expect("open table");
             table.insert("current", 42_u64).expect("insert");
         }

--- a/crates/event_store/tests/verifier.rs
+++ b/crates/event_store/tests/verifier.rs
@@ -28,7 +28,6 @@ use std::{
     process::Command,
 };
 
-use bincode::config::standard;
 use bytes::Bytes;
 use indexmap::IndexMap;
 use nautilus_core::UnixNanos;
@@ -36,7 +35,7 @@ use nautilus_event_store::{
     AppendEntry, DataClass, DataCursorSnapshot, EventStore, EventStoreEntry, GapRange, Headers,
     IndexKey, IndexKind, MarkerBackend, MarkerManifest, RedbBackend, RedbMarkerBackend,
     RegisteredComponents, RunManifest, RunStatus, SnapshotAnchor, StreamCursor, Topic, Verifier,
-    VerifyFinding, compute_entry_hash, compute_marker_hash,
+    VerifyFinding, codec, compute_entry_hash, compute_marker_hash,
 };
 use redb::ReadableTable;
 use rstest::rstest;
@@ -340,7 +339,7 @@ fn binary_hash_mismatch_exits_corrupt_without_quarantine() {
     let path = run_path(&tmp, run_id);
     let mut tampered = build_entry(2, 11);
     tampered.payload = Bytes::from_static(b"\xFF");
-    let bytes = bincode::serde::encode_to_vec(&tampered, standard()).expect("encode");
+    let bytes = codec::encode_to_vec(&tampered).expect("encode");
     {
         let db = redb::Database::create(&path).expect("open redb");
         let txn = db.begin_write().expect("begin write");
@@ -577,7 +576,7 @@ fn open_redb_rejects_missing_run() {
 #[rstest]
 fn manufactured_seq_swap_surfaces_as_finding() {
     // Build a sealed run, then overwrite the bytes at table key=2 with the
-    // bincode-encoded entry whose embedded seq is 99. The hash recomputes
+    // codec-encoded entry whose embedded seq is 99. The hash recomputes
     // correctly because the hash hashes entry.seq=99, so scan_seq returns
     // Ok(Some(entry)) without raising HashMismatch. The verifier must catch
     // the key/embedded-seq divergence.
@@ -588,7 +587,7 @@ fn manufactured_seq_swap_surfaces_as_finding() {
     let path = tmp.path().join(INSTANCE_ID).join(format!("{run_id}.redb"));
     let entries: redb::TableDefinition<u64, &[u8]> = redb::TableDefinition::new("entries");
     let substitute = build_entry(99, 11);
-    let bytes = bincode::serde::encode_to_vec(&substitute, standard()).expect("encode");
+    let bytes = codec::encode_to_vec(&substitute).expect("encode");
     {
         let db = redb::Database::create(&path).expect("open redb");
         let txn = db.begin_write().expect("begin write");

--- a/crates/event_store/tests/writer.rs
+++ b/crates/event_store/tests/writer.rs
@@ -35,7 +35,7 @@ use nautilus_core::{
 use nautilus_event_store::{
     AppendEntry, EntryDraft, EventStore, EventStoreEntry, EventStoreWriter, HaltCallback,
     HaltReason, Headers, IndexKey, IndexKind, MemoryBackend, RedbBackend, RegisteredComponents,
-    RunManifest, RunStatus, ScanDirection, SubmitError, Topic, WriterConfig,
+    RunManifest, RunStatus, ScanDirection, SubmitError, Topic, WriterConfig, codec,
 };
 use redb::{ReadableDatabase, ReadableTable};
 use rstest::rstest;
@@ -427,11 +427,8 @@ fn writer_seals_manifest_with_max_observed_ts_init() {
         .get("current")
         .expect("get manifest")
         .expect("manifest exists");
-    let (decoded_manifest, _) = bincode::serde::decode_from_slice::<RunManifest, _>(
-        bytes.value(),
-        bincode::config::standard(),
-    )
-    .expect("decode manifest");
+    let decoded_manifest =
+        codec::decode_from_slice::<RunManifest>(bytes.value()).expect("decode manifest");
     assert_eq!(decoded_manifest.status, RunStatus::Ended);
     assert_eq!(decoded_manifest.high_watermark, 4);
     assert_eq!(decoded_manifest.end_ts_init, Some(UnixNanos::from(9_999)));
@@ -595,11 +592,8 @@ fn writer_preserves_payload_and_hash_round_trip() {
         let (k, v) = row.expect("row");
         let seq = k.value();
         let bytes = v.value();
-        let (entry, _) = bincode::serde::decode_from_slice::<
-            nautilus_event_store::EventStoreEntry,
-            _,
-        >(bytes, bincode::config::standard())
-        .expect("decode");
+        let entry = codec::decode_from_slice::<nautilus_event_store::EventStoreEntry>(bytes)
+            .expect("decode");
         assert_eq!(entry.seq, seq);
         assert_eq!(entry.recompute_hash(), entry.entry_hash);
     }
@@ -686,11 +680,8 @@ fn writer_stamps_ts_publish_from_clock_at_submit() {
 
     for row in entries.iter().expect("iter") {
         let (_, v) = row.expect("row");
-        let (entry, _) = bincode::serde::decode_from_slice::<
-            nautilus_event_store::EventStoreEntry,
-            _,
-        >(v.value(), bincode::config::standard())
-        .expect("decode");
+        let entry = codec::decode_from_slice::<nautilus_event_store::EventStoreEntry>(v.value())
+            .expect("decode");
         decoded.push(entry);
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -158,10 +158,6 @@ skip = [
   { crate = "syn" },
   { crate = "strsim" },
 
-  # bincode 1.3.3 (transitive via madsim dev-dep and hypersync-client) vs
-  # 2.0.1 (event_store envelope codec)
-  { crate = "bincode" },
-
   # Enum derive macros - strum 0.27 (alloy, hypersync) vs 0.28 (nautilus)
   { crate = "strum" },
   { crate = "strum_macros" },


### PR DESCRIPTION
## Summary

`bincode` is unmaintained (RUSTSEC-2025-0141). This replaces it in the
`event_store` on-disk envelope with a hand-rolled, non-self-describing
positional serde codec, and adds a store-level format marker so pre-change
beta stores are rejected with a clear error rather than silently mis-decoded.

Closes #4316.

## Format break (beta only)

This is a hard, intentional on-disk format change with no migrator. Event
stores written by beta versions **v1.227–1.229** are no longer readable and
must be regenerated. Opening such a store now fails fast with a clear
`Corrupted`-class error ("...must be regenerated") instead of mis-decoding.

## What changed

Two commits:

1. **Codec module** (`crates/event_store/src/codec.rs`) — a non-self-describing,
   positional serde `Serializer`/`Deserializer` framed with a `NESC` magic +
   version header over a fixed-width little-endian byte layer. Decoding is
   bounds-checked (forged-prefix and length-overflow rejection), requires full
   buffer consumption, and rejects `deserialize_any` to preserve the `wire.rs`
   invariant. Decode failures feed the existing `EventStoreError::Corrupted`
   path.

2. **Cutover** — swap every production call site (`backend/redb.rs`,
   `markers/redb.rs`, `kernel.rs`) to the codec; add the store-level format
   marker (`format.rs`) — a native-redb `store_format` table written at store
   init and verified before any record decode; migrate the test corpus; rework
   `benches/codec.rs` to a one-time captured baseline; remove the `bincode`
   2.0.1 dependency.

## On the choice of a hand-rolled codec

We rolled our own rather than adopting another crate, since the encoded data
model is small and fully positional-safe (all enums are unit-only), which keeps
the codec bounded and adds no new dependency — ending the codec-churn exposure
(bincode → postcard → bincode) permanently.

That said, if you'd prefer the more conservative route of depending on
[`wincode`](https://crates.io/crates/wincode) instead of maintaining a
bespoke codec, we're happy to accommodate — say the word and we'll rework the
PR to use it.

## Dependency note

Only `event_store`'s direct `bincode 2.0.1` dependency (and the workspace
entry + lockfile nodes) is removed. The transitive `bincode 1.3.3` pulled via
`hypersync-client`/`madsim` is unaffected, so the existing RUSTSEC-2025-0141
ignore in `deny.toml` is retained; only the now-redundant duplicate-version
`bans` skip is dropped.

## Scope

In: the `event_store` envelope codec only. Untouched: MessagePack inside
payloads (used there deliberately), the redb storage layer, and the BLAKE3
hash framing.

## Testing

- Round-trip, corrupt-input, forged-prefix, and property tests for the codec
- Old-format and unsupported-version rejection tests for both the event and
  marker backends
- `cargo fmt`, `clippy -D warnings`, the full feature-expanded crate test
  suite, and `cargo deny check advisories bans` all pass
