### PR TITLE
Add caller-supplied clock factory seam for live/sandbox nodes

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -1928,6 +1928,7 @@ mod tests {
             config,
             None,
             Some(Box::new(event_store_factory)),
+            None,
         )
         .unwrap();
         engine.instance_id = engine.kernel.instance_id;

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -36,6 +36,7 @@ use nautilus_execution::engine::ExecutionEngine;
 use nautilus_model::identifiers::TraderId;
 use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_system::{
+    clock_factory::ClockFactory,
     config::StreamingConfig,
     event_store::{EventStoreFactory, KernelEventStore},
     kernel::NautilusKernel,
@@ -85,6 +86,7 @@ pub struct LiveNodeBuilder {
     data_client_configs: HashMap<String, Box<dyn ClientConfig>>,
     exec_client_configs: HashMap<String, Box<dyn ClientConfig>>,
     event_store_factory: Option<EventStoreFactory>,
+    clock_factory: Option<ClockFactory>,
     external_msgbus_factory: Option<Box<dyn MessageBusBackingFactory>>,
     external_msgbus_egress: Option<Box<dyn MessageBusExternalEgress>>,
     external_msgbus_ingress: Option<ExternalMessageBusIngress>,
@@ -100,6 +102,7 @@ impl Debug for LiveNodeBuilder {
             .field("data_client_configs", &self.data_client_configs.keys())
             .field("exec_client_configs", &self.exec_client_configs.keys())
             .field("event_store_factory", &self.event_store_factory.is_some())
+            .field("clock_factory", &self.clock_factory.is_some())
             .field(
                 "external_msgbus_factory",
                 &self.external_msgbus_factory.is_some(),
@@ -144,6 +147,7 @@ impl LiveNodeBuilder {
             data_client_configs: HashMap::new(),
             exec_client_configs: HashMap::new(),
             event_store_factory: None,
+            clock_factory: None,
             external_msgbus_factory: None,
             external_msgbus_egress: None,
             external_msgbus_ingress: None,
@@ -171,6 +175,7 @@ impl LiveNodeBuilder {
             data_client_configs: HashMap::new(),
             exec_client_configs: HashMap::new(),
             event_store_factory: None,
+            clock_factory: None,
             external_msgbus_factory: None,
             external_msgbus_egress: None,
             external_msgbus_ingress: None,
@@ -349,6 +354,16 @@ impl LiveNodeBuilder {
         self
     }
 
+    /// Inject a caller-supplied clock factory for the kernel and component clocks.
+    #[must_use]
+    pub fn with_clock_factory<F>(mut self, factory: F) -> Self
+    where
+        F: Fn() -> Rc<RefCell<dyn Clock>> + 'static,
+    {
+        self.clock_factory = Some(Rc::new(factory));
+        self
+    }
+
     /// Inject external message bus egress for serialized message bus publications.
     #[must_use]
     pub fn with_external_msgbus_egress(
@@ -501,6 +516,7 @@ impl LiveNodeBuilder {
             self.config.clone(),
             None,
             self.event_store_factory.take(),
+            self.clock_factory.take(),
         )?;
 
         self.install_external_msgbus_factory(&kernel)?;

--- a/crates/system/README.md
+++ b/crates/system/README.md
@@ -14,7 +14,7 @@ and system-level factories for creating components:
 
 - `NautilusKernel` - Core system orchestrator managing engines and components.
 - `NautilusKernelConfig` - Configuration for kernel initialization.
-- System builders and factories for component creation.
+- System builders and factories for component creation, including caller-supplied clock construction for live/sandbox systems.
 
 ## NautilusTrader
 

--- a/crates/system/src/builder.rs
+++ b/crates/system/src/builder.rs
@@ -33,6 +33,7 @@ use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_risk::engine::config::RiskEngineConfig;
 
 use crate::{
+    clock_factory::ClockFactory,
     config::KernelConfig,
     event_store::{EventStoreFactory, KernelEventStore},
     kernel::NautilusKernel,
@@ -65,6 +66,7 @@ pub struct NautilusKernelBuilder {
     portfolio: Option<PortfolioConfig>,
     msgbus: Option<MessageBusConfig>,
     event_store_factory: Option<EventStoreFactory>,
+    clock_factory: Option<ClockFactory>,
     external_msgbus_factory: Option<Box<dyn MessageBusBackingFactory>>,
     external_msgbus_egress: Option<Box<dyn MessageBusExternalEgress>>,
 }
@@ -94,6 +96,7 @@ impl Debug for NautilusKernelBuilder {
             .field("portfolio", &self.portfolio)
             .field("msgbus", &self.msgbus)
             .field("event_store_factory", &self.event_store_factory.is_some())
+            .field("clock_factory", &self.clock_factory.is_some())
             .field(
                 "external_msgbus_factory",
                 &self.external_msgbus_factory.is_some(),
@@ -133,6 +136,7 @@ impl NautilusKernelBuilder {
             portfolio: None,
             msgbus: None,
             event_store_factory: None,
+            clock_factory: None,
             external_msgbus_factory: None,
             external_msgbus_egress: None,
         }
@@ -289,6 +293,20 @@ impl NautilusKernelBuilder {
         self
     }
 
+    /// Inject a caller-supplied clock factory for the kernel and component clocks.
+    ///
+    /// The factory is invoked for the kernel clock and once per registered component. Each
+    /// invocation should return a fresh instance. Without a factory, live/sandbox systems use
+    /// `LiveClock::default()`.
+    #[must_use]
+    pub fn with_clock_factory<F>(mut self, factory: F) -> Self
+    where
+        F: Fn() -> Rc<RefCell<dyn Clock>> + 'static,
+    {
+        self.clock_factory = Some(Rc::new(factory));
+        self
+    }
+
     /// Inject external message bus egress for serialized message bus publications.
     #[must_use]
     pub fn with_external_msgbus_egress(
@@ -360,6 +378,7 @@ impl NautilusKernelBuilder {
             config,
             self.cache_database,
             self.event_store_factory,
+            self.clock_factory,
         )?;
 
         let config = kernel.config.msgbus().unwrap_or_default();
@@ -645,6 +664,82 @@ mod tests {
         assert!(
             Rc::ptr_eq(&received_clock, &kernel.clock()),
             "factory must receive the kernel's clock Rc, not a fresh allocation",
+        );
+    }
+
+    #[cfg(feature = "live")]
+    #[rstest]
+    fn test_builder_with_clock_factory_drives_kernel_and_component_clocks() {
+        use nautilus_common::clock::TestClock;
+
+        let calls = Rc::new(Cell::new(0usize));
+        let calls_in_closure = calls.clone();
+
+        let kernel = NautilusKernelBuilder::new(
+            "ClockFactoryKernel".to_string(),
+            TraderId::from("TRADER-CF"),
+            Environment::Live,
+        )
+        .with_clock_factory(move || {
+            calls_in_closure.set(calls_in_closure.get() + 1);
+            Rc::new(RefCell::new(TestClock::new())) as Rc<RefCell<dyn Clock>>
+        })
+        .build()
+        .expect("kernel builds with clock factory");
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "kernel clock must consume exactly one factory call"
+        );
+        assert!(
+            (*kernel.clock().borrow()).as_any().is::<TestClock>(),
+            "kernel clock must be the factory-produced TestClock"
+        );
+
+        let c1 = kernel
+            .trader()
+            .borrow_mut()
+            .create_component_clock(ComponentId::new("COMP-1"));
+        let c2 = kernel
+            .trader()
+            .borrow_mut()
+            .create_component_clock(ComponentId::new("COMP-2"));
+
+        assert_eq!(
+            calls.get(),
+            3,
+            "factory must back kernel clock and each component clock"
+        );
+        assert!((*c1.borrow()).as_any().is::<TestClock>());
+        assert!((*c2.borrow()).as_any().is::<TestClock>());
+    }
+
+    #[cfg(feature = "live")]
+    #[rstest]
+    fn test_builder_without_clock_factory_uses_live_clock_default() {
+        use nautilus_common::live::clock::LiveClock; // nautilus-import-ok
+
+        let kernel = NautilusKernelBuilder::new(
+            "DefaultClockKernel".to_string(),
+            TraderId::from("TRADER-DC"),
+            Environment::Live,
+        )
+        .build()
+        .expect("kernel builds without a clock factory");
+
+        assert!(
+            (*kernel.clock().borrow()).as_any().is::<LiveClock>(),
+            "no factory uses LiveClock::default for the kernel clock"
+        );
+
+        let comp = kernel
+            .trader()
+            .borrow_mut()
+            .create_component_clock(ComponentId::new("COMP-D"));
+        assert!(
+            (*comp.borrow()).as_any().is::<LiveClock>(),
+            "no factory uses LiveClock::default for component clocks"
         );
     }
 

--- a/crates/system/src/clock_factory.rs
+++ b/crates/system/src/clock_factory.rs
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Caller-supplied clock construction seam for live/sandbox systems.
+//!
+//! The kernel builds its kernel clock and every per-component clock through this factory when one
+//! is injected (see [`crate::builder::NautilusKernelBuilder::with_clock_factory`]). When no factory
+//! is supplied the kernel falls back to `LiveClock::default()`, preserving today's behavior.
+
+use std::{cell::RefCell, rc::Rc};
+
+use nautilus_common::clock::Clock;
+
+/// Cloneable factory closure invoked to construct a fresh [`Clock`] instance.
+///
+/// Invoked once for the kernel clock and once per registered component, so it is `Fn`
+/// (re-invokable) and wrapped in [`Rc`] (the same factory is shared by the kernel and the
+/// [`Trader`](crate::trader::Trader)). Each invocation must return a brand-new clock instance to
+/// preserve the per-component-instance invariant.
+pub type ClockFactory = Rc<dyn Fn() -> Rc<RefCell<dyn Clock>>>;

--- a/crates/system/src/clock_factory.rs
+++ b/crates/system/src/clock_factory.rs
@@ -26,7 +26,7 @@ use nautilus_common::clock::Clock;
 /// Cloneable factory closure invoked to construct a fresh [`Clock`] instance.
 ///
 /// Invoked once for the kernel clock and once per registered component, so it is `Fn`
-/// (re-invokable) and wrapped in [`Rc`] (the same factory is shared by the kernel and the
+/// (re-invocable) and wrapped in [`Rc`] (the same factory is shared by the kernel and the
 /// [`Trader`](crate::trader::Trader)). Each invocation must return a brand-new clock instance to
 /// preserve the per-component-instance invariant.
 pub type ClockFactory = Rc<dyn Fn() -> Rc<RefCell<dyn Clock>>>;

--- a/crates/system/src/controller.rs
+++ b/crates/system/src/controller.rs
@@ -537,6 +537,7 @@ mod tests {
             clock as Rc<RefCell<dyn Clock>>,
             cache,
             portfolio,
+            None,
         )));
         trader.borrow_mut().initialize().unwrap();
 

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -48,6 +48,7 @@ use ustr::Ustr;
 
 use crate::{
     builder::NautilusKernelBuilder,
+    clock_factory::ClockFactory,
     config::NautilusKernelConfig,
     event_store::{EventStoreFactory, KernelEventStore, RegisteredComponents},
     trader::Trader,
@@ -112,7 +113,7 @@ impl NautilusKernel {
     ///
     /// Returns an error if the kernel fails to initialize.
     pub fn new<T: NautilusKernelConfig + 'static>(name: String, config: T) -> anyhow::Result<Self> {
-        Self::new_with(name, config, None, None)
+        Self::new_with(name, config, None, None, None)
     }
 
     /// Create a new [`NautilusKernel`] instance with an injected cache database adapter.
@@ -130,7 +131,7 @@ impl NautilusKernel {
         config: T,
         cache_database: Option<Box<dyn CacheDatabaseAdapter>>,
     ) -> anyhow::Result<Self> {
-        Self::new_with(name, config, cache_database, None)
+        Self::new_with(name, config, cache_database, None, None)
     }
 
     /// Create a new [`NautilusKernel`] instance with optional cache database and event store
@@ -149,6 +150,7 @@ impl NautilusKernel {
         config: T,
         cache_database: Option<Box<dyn CacheDatabaseAdapter>>,
         event_store_factory: Option<EventStoreFactory>,
+        clock_factory: Option<ClockFactory>,
     ) -> anyhow::Result<Self> {
         let instance_id = config.instance_id().unwrap_or_default();
         let machine_id = Self::determine_machine_id()?;
@@ -164,7 +166,7 @@ impl NautilusKernel {
 
         log::info!("Building system kernel");
 
-        let clock = Self::initialize_clock(config.environment());
+        let clock = Self::initialize_clock(config.environment(), clock_factory.as_ref());
         let event_store = match event_store_factory {
             Some(factory) => Some(factory(instance_id, clock.clone())?),
             None => None,
@@ -222,6 +224,7 @@ impl NautilusKernel {
             clock.clone(),
             cache.clone(),
             portfolio.clone(),
+            clock_factory,
         )));
 
         let ts_created = clock.borrow().timestamp_ns();
@@ -312,7 +315,10 @@ impl NautilusKernel {
         Ok(log_guard)
     }
 
-    fn initialize_clock(environment: Environment) -> Rc<RefCell<dyn Clock>> {
+    fn initialize_clock(
+        environment: Environment,
+        clock_factory: Option<&ClockFactory>,
+    ) -> Rc<RefCell<dyn Clock>> {
         match environment {
             Environment::Backtest => {
                 let test_clock = TestClock::new();
@@ -320,15 +326,24 @@ impl NautilusKernel {
             }
             #[cfg(feature = "live")]
             Environment::Live | Environment::Sandbox => {
-                let live_clock = nautilus_common::live::clock::LiveClock::default(); // nautilus-import-ok
-                Rc::new(RefCell::new(live_clock))
+                if let Some(factory) = clock_factory {
+                    factory()
+                } else {
+                    let live_clock = nautilus_common::live::clock::LiveClock::default(); // nautilus-import-ok
+                    Rc::new(RefCell::new(live_clock))
+                }
             }
             #[cfg(not(feature = "live"))]
             Environment::Live | Environment::Sandbox => {
-                panic!(
-                    "Live/Sandbox environment requires the 'live' feature to be enabled. \
-                     Build with `--features live` or add `features = [\"live\"]` to your dependency."
-                );
+                if let Some(factory) = clock_factory {
+                    factory()
+                } else {
+                    panic!(
+                        "Live/Sandbox environment requires the 'live' feature to be enabled. \
+                         Build with `--features live` or supply a clock factory via \
+                         NautilusKernelBuilder::with_clock_factory / LiveNodeBuilder::with_clock_factory."
+                    );
+                }
             }
         }
     }

--- a/crates/system/src/lib.rs
+++ b/crates/system/src/lib.rs
@@ -56,6 +56,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod builder;
+pub mod clock_factory;
 pub mod config;
 pub mod controller;
 pub mod event_store;
@@ -70,6 +71,7 @@ pub mod python;
 
 // Re-exports
 pub use builder::NautilusKernelBuilder;
+pub use clock_factory::ClockFactory;
 pub use config::{NautilusKernelConfig, RotationConfig, StreamingConfig};
 pub use controller::Controller;
 pub use event_store::{EventStoreFactory, KernelEventStore, RegisteredComponents};

--- a/crates/system/src/trader.rs
+++ b/crates/system/src/trader.rs
@@ -53,9 +53,12 @@ use nautilus_trading::{
 };
 use ustr::Ustr;
 
-use crate::registration::{
-    base_strategy_id, ensure_unique_order_id_tag, strategy_control_endpoint,
-    strategy_registration_id,
+use crate::{
+    clock_factory::ClockFactory,
+    registration::{
+        base_strategy_id, ensure_unique_order_id_tag, strategy_control_endpoint,
+        strategy_registration_id,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,6 +96,8 @@ pub struct Trader {
     cache: Rc<RefCell<Cache>>,
     /// Portfolio reference for strategy registration.
     portfolio: Rc<RefCell<Portfolio>>,
+    /// Optional caller-supplied factory for per-component clocks in live/sandbox.
+    clock_factory: Option<ClockFactory>,
     /// Registered actor IDs (actors stored in global registry).
     actor_ids: Vec<ActorId>,
     /// Registered strategy IDs (strategies stored in global registry).
@@ -129,6 +134,7 @@ impl Trader {
         clock: Rc<RefCell<dyn Clock>>,
         cache: Rc<RefCell<Cache>>,
         portfolio: Rc<RefCell<Portfolio>>,
+        clock_factory: Option<ClockFactory>,
     ) -> Self {
         let ts_created = clock.borrow().timestamp_ns();
 
@@ -140,6 +146,7 @@ impl Trader {
             clock,
             cache,
             portfolio,
+            clock_factory,
             actor_ids: Vec::new(),
             strategy_ids: Vec::new(),
             strategy_stop_fns: AHashMap::new(),
@@ -250,7 +257,10 @@ impl Trader {
     pub fn create_component_clock(&mut self, component_id: ComponentId) -> Rc<RefCell<dyn Clock>> {
         let clock: Rc<RefCell<dyn Clock>> = match self.environment {
             Environment::Backtest => Rc::new(RefCell::new(TestClock::new())),
-            Environment::Live | Environment::Sandbox => Self::create_live_clock(),
+            Environment::Live | Environment::Sandbox => match &self.clock_factory {
+                Some(factory) => factory(),
+                None => Self::create_live_clock(),
+            },
         };
         self.clocks.insert(component_id, clock.clone());
         clock
@@ -1205,7 +1215,10 @@ impl Component for Trader {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+    };
 
     use nautilus_common::{
         actor::{
@@ -1376,6 +1389,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         assert_eq!(trader.trader_id(), trader_id);
@@ -1408,6 +1422,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         assert_eq!(
@@ -1430,6 +1445,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let actor = TestDataActor::new(DataActorConfig::default());
@@ -1456,6 +1472,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = DataActorConfig {
@@ -1495,6 +1512,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -1528,6 +1546,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let strategy_id = StrategyId::from("ExampleStrategy-XNAS");
@@ -1568,6 +1587,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let strategy_id = StrategyId::from("ExampleStrategy-XNAS");
@@ -1612,6 +1632,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let strategy1 = TestStrategy::new(StrategyConfig::default());
@@ -1642,6 +1663,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let mut strategy = TestStrategy::new(StrategyConfig::default());
@@ -1674,6 +1696,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -1714,6 +1737,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         assert!(
@@ -1749,6 +1773,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -1779,6 +1804,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = ExecutionAlgorithmConfig {
@@ -1809,6 +1835,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
         trader.state = ComponentState::Running;
 
@@ -1841,6 +1868,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         // Add components
@@ -1892,6 +1920,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         // Initially pre-initialized
@@ -1944,6 +1973,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -1992,6 +2022,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -2034,6 +2065,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         // Simulate running state
@@ -2059,6 +2091,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         // Simulate disposed state
@@ -2084,6 +2117,7 @@ mod tests {
             clock.clone(),
             cache,
             portfolio,
+            None,
         );
 
         let component_a = ComponentId::new("ACTOR-A");
@@ -2094,6 +2128,37 @@ mod tests {
         // Each component gets its own clock instance
         assert_ne!(clock_a.as_ptr() as *const _, clock.as_ptr() as *const _);
         assert_ne!(clock_a.as_ptr() as *const _, clock_b.as_ptr() as *const _);
+    }
+
+    #[rstest]
+    fn test_create_component_clock_live_uses_factory_with_distinct_instances() {
+        let (_msgbus, cache, portfolio, _data_engine, _risk_engine, _exec_engine, clock) =
+            create_trader_components();
+        let calls = Rc::new(Cell::new(0usize));
+        let calls_in_closure = calls.clone();
+        let factory: ClockFactory = Rc::new(move || {
+            calls_in_closure.set(calls_in_closure.get() + 1);
+            Rc::new(RefCell::new(TestClock::new())) as Rc<RefCell<dyn Clock>>
+        });
+
+        let mut trader = Trader::new(
+            TraderId::test_default(),
+            UUID4::new(),
+            Environment::Sandbox,
+            clock,
+            cache,
+            portfolio,
+            Some(factory),
+        );
+
+        let a = trader.create_component_clock(ComponentId::new("ACTOR-A"));
+        let b = trader.create_component_clock(ComponentId::new("ACTOR-B"));
+
+        assert_eq!(calls.get(), 2, "factory invoked once per component");
+        assert!(
+            !Rc::ptr_eq(&a, &b),
+            "each component must get its own clock instance"
+        );
     }
 
     #[rstest]
@@ -2110,6 +2175,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let config = StrategyConfig {
@@ -2166,6 +2232,7 @@ mod tests {
             clock,
             cache,
             portfolio,
+            None,
         );
 
         let actor_a = TestDataActor::new(DataActorConfig {


### PR DESCRIPTION
## Summary

Lets a Live/Sandbox node be built with a caller-supplied clock factory instead
of the hardwired `LiveClock::default()`, used for both the kernel clock and
every per-component clock. When no factory is supplied, behavior is identical
to today.

Implements the closure-factory option (the RFC's first-listed approach) from
#4304. Closes #4304.

## Approach

A cloneable, re-invokable closure alias, mirroring the existing
`EventStoreFactory` precedent in this crate:

    pub type ClockFactory = Rc<dyn Fn() -> Rc<RefCell<dyn Clock>>>;

The key difference from `EventStoreFactory` (which is single-use, `FnOnce`):
the clock factory is invoked many times — once for the kernel clock and once
per component — so it is `Fn` and cloneable, and each component still receives
its own distinct clock instance.

## What changed

- New `ClockFactory` alias in `crates/system/src/clock_factory.rs`, re-exported
  from the crate.
- Threaded through `NautilusKernel::new_with`, `Trader::new`, and both
  `initialize_clock` / `create_component_clock`.
- A `with_clock_factory` builder method on both `NautilusKernelBuilder` and
  `LiveNodeBuilder`, mirroring `with_event_store`.
- All constructor call sites updated, including the backtest engine and test
  helpers.

## Compatibility

No factory supplied → byte-identical to today (`LiveClock::default()`). The
backtest path is unchanged (`TestClock`). The constructors `Trader::new` and
`NautilusKernel::new_with` gain a trailing parameter — a source-level signature
change, consistent with the precedent set by `EventStoreFactory`.

## Scope

In: the construction seam only. Out: any `LiveTimer`/runner change (the `Clock`
trait is already a sufficient control surface), the Sandbox
`OrderMatchingEngine`, and the Python builder surface (a clock factory is a
Rust closure not expressible from Python).

## Testing

Three new `nautilus-system` tests covering: the factory applied to the kernel
clock and every component clock; the default path unchanged when no factory is
supplied; and distinct per-component clock instances under a factory.
`cargo fmt`, `clippy -D warnings`, and the `--features live` test suite pass.
