### PR TITLE
Fix HTTP response body size cap to prevent unbounded allocation

### DIFF
--- a/crates/network/src/http/client.rs
+++ b/crates/network/src/http/client.rs
@@ -37,6 +37,13 @@ const DEFAULT_POOL_IDLE_TIMEOUT_SECS: u64 = 60;
 /// Default HTTP/2 keep-alive interval in seconds.
 const DEFAULT_HTTP2_KEEP_ALIVE_SECS: u64 = 30;
 
+/// Default maximum HTTP response body size in bytes (100 MiB).
+///
+/// Bounds peak memory per response so a hostile or malfunctioning endpoint
+/// cannot exhaust memory by streaming an arbitrarily large body. Mirrors the
+/// caps already enforced on the WebSocket and raw-socket paths.
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 100 * 1024 * 1024;
+
 /// An HTTP client that supports rate limiting and timeouts.
 ///
 /// Built on `reqwest` for async I/O. Allows per-endpoint and default quotas
@@ -161,6 +168,7 @@ impl HttpClient {
             client,
             header_keys: Arc::from(valid_keys),
             header_names: Arc::from(header_names),
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
         };
 
         Ok(Self {
@@ -348,6 +356,8 @@ pub struct InnerHttpClient {
     pub(crate) client: reqwest::Client,
     pub(crate) header_keys: Arc<[String]>,
     pub(crate) header_names: Arc<[HeaderName]>,
+    /// Maximum response body size in bytes; bodies exceeding this are rejected.
+    pub(crate) max_response_bytes: usize,
 }
 
 impl InnerHttpClient {
@@ -485,13 +495,52 @@ impl InnerHttpClient {
         }
 
         let status = HttpStatus::new(response.status());
-        let body = response.bytes().await.map_err(HttpClientError::from)?;
+        let body = self.read_body_capped(response).await?;
 
         Ok(HttpResponse {
             status,
             headers,
             body,
         })
+    }
+
+    /// Reads the response body, rejecting any body that exceeds `max_response_bytes`.
+    ///
+    /// A `Content-Length` larger than the cap is rejected up front; otherwise the
+    /// body is streamed chunk-by-chunk and aborted as soon as the accumulated size
+    /// would exceed the cap, so an oversized or unbounded (chunked) body is never
+    /// fully buffered into memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the body exceeds the configured maximum size, or if
+    /// reading a chunk fails.
+    async fn read_body_capped(
+        &self,
+        mut response: Response,
+    ) -> Result<bytes::Bytes, HttpClientError> {
+        let max = self.max_response_bytes;
+
+        // Fast path: reject up front when the advertised length already exceeds the cap.
+        if let Some(len) = response.content_length()
+            && len > max as u64
+        {
+            return Err(HttpClientError::Error(format!(
+                "HTTP response body of {len} bytes exceeds maximum of {max} bytes",
+            )));
+        }
+
+        let mut buf = bytes::BytesMut::new();
+        while let Some(chunk) = response.chunk().await.map_err(HttpClientError::from)? {
+            if buf.len() + chunk.len() > max {
+                return Err(HttpClientError::Error(format!(
+                    "HTTP response body exceeds maximum of {max} bytes",
+                )));
+            }
+            buf.extend_from_slice(&chunk);
+        }
+
+        Ok(buf.freeze())
     }
 }
 
@@ -506,6 +555,7 @@ impl Default for InnerHttpClient {
             client,
             header_keys: Arc::default(),
             header_names: Arc::default(),
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
         }
     }
 }
@@ -572,6 +622,11 @@ mod tests {
                     "Eventually responded"
                 }),
             )
+            .route(
+                "/large",
+                // Returns a 1 MiB body to exercise the response size cap.
+                get(|| async { "x".repeat(1024 * 1024) }),
+            )
     }
 
     async fn start_test_server() -> Result<SocketAddr, Box<dyn std::error::Error + Send + Sync>> {
@@ -605,6 +660,58 @@ mod tests {
 
         assert!(response.status.is_success());
         assert_eq!(String::from_utf8_lossy(&response.body), "hello-world!");
+    }
+
+    #[tokio::test]
+    async fn test_response_body_within_cap_is_returned() {
+        let addr = start_test_server().await.unwrap();
+        let url = format!("http://{addr}");
+
+        // Cap above the 1 MiB payload: body should be returned intact.
+        let mut client = InnerHttpClient::default();
+        client.max_response_bytes = 4 * 1024 * 1024;
+
+        let response = client
+            .send_request(
+                reqwest::Method::GET,
+                format!("{url}/large"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(response.status.is_success());
+        assert_eq!(response.body.len(), 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn test_response_body_exceeding_cap_is_rejected() {
+        let addr = start_test_server().await.unwrap();
+        let url = format!("http://{addr}");
+
+        // Cap below the 1 MiB payload: the request must fail rather than buffer it.
+        let mut client = InnerHttpClient::default();
+        client.max_response_bytes = 16 * 1024;
+
+        let result = client
+            .send_request(
+                reqwest::Method::GET,
+                format!("{url}/large"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        let err = result.expect_err("oversized response body should be rejected");
+        assert!(
+            err.to_string().contains("exceeds maximum"),
+            "unexpected error: {err}",
+        );
     }
 
     #[tokio::test]

--- a/crates/network/src/http/client.rs
+++ b/crates/network/src/http/client.rs
@@ -668,8 +668,10 @@ mod tests {
         let url = format!("http://{addr}");
 
         // Cap above the 1 MiB payload: body should be returned intact.
-        let mut client = InnerHttpClient::default();
-        client.max_response_bytes = 4 * 1024 * 1024;
+        let client = InnerHttpClient {
+            max_response_bytes: 4 * 1024 * 1024,
+            ..Default::default()
+        };
 
         let response = client
             .send_request(
@@ -693,8 +695,10 @@ mod tests {
         let url = format!("http://{addr}");
 
         // Cap below the 1 MiB payload: the request must fail rather than buffer it.
-        let mut client = InnerHttpClient::default();
-        client.max_response_bytes = 16 * 1024;
+        let client = InnerHttpClient {
+            max_response_bytes: 16 * 1024,
+            ..Default::default()
+        };
 
         let result = client
             .send_request(


### PR DESCRIPTION
Closes #4308

## Summary

The shared `HttpClient` read the full response body via `response.bytes()` with no size limit, so a hostile or malfunctioning endpoint could exhaust memory by streaming an arbitrarily large (or chunked, unbounded) body. This mirrors the caps already enforced on the WebSocket and raw-socket paths.

As discussed in #4308, this implements the `Content-Length` precheck plus chunked body accounting with a default cap on full-body materialization.

## Changes

- Add `DEFAULT_MAX_RESPONSE_BYTES` (100 MiB) and a `max_response_bytes` field on `InnerHttpClient` (set in both the constructor and `Default`).
- Replace `response.bytes()` in `to_response` with a new `read_body_capped` that:
  - rejects up front when `Content-Length` already exceeds the cap, and
  - otherwise streams the body chunk-by-chunk, aborting as soon as the accumulated size would exceed the cap — so an oversized or unbounded body is never fully buffered into memory.

The cap is enforced internally; the public client API and the 16 adapter call sites are unchanged.

## Test plan

- [x] Added a `/large` test route serving a 1 MiB body.
- [x] `test_response_body_within_cap_is_returned` — body under the cap is returned intact.
- [x] `test_response_body_exceeding_cap_is_rejected` — body over the cap fails with an "exceeds maximum" error rather than being buffered.
- [x] `cargo fmt` clean.

> Note: I'm on a local toolchain (1.88) below the pinned 1.96, so I relied on CI to run the full `cargo check`/`nextest` for the workspace. The change is confined to `crates/network/src/http/client.rs` and depends only on existing `reqwest`/`HttpClientError` APIs.