### PR TITLE
Fix VerticalHorizontalFilter and OnBalanceVolume period windows

### DIFF
--- a/crates/indicators/src/momentum/obv.rs
+++ b/crates/indicators/src/momentum/obv.rs
@@ -107,14 +107,22 @@ impl OnBalanceVolume {
             0.0
         };
 
-        let _ = self.obv.push_back(delta);
-
-        self.value = self.obv.iter().sum();
+        if self.period == 0 {
+            // Unbounded cumulative OBV (matches the Cython `deque(maxlen=None)` reference).
+            self.value += delta;
+        } else {
+            // Rolling sum over the last `period` deltas (Cython `deque(maxlen=period)`).
+            if self.obv.len() == self.period {
+                let _ = self.obv.pop_front();
+            }
+            let _ = self.obv.push_back(delta);
+            self.value = self.obv.iter().sum();
+        }
 
         if !self.initialized {
             self.has_inputs = true;
 
-            if (self.period == 0 && !self.obv.is_empty()) || self.obv.len() >= self.period {
+            if self.period == 0 || self.obv.len() >= self.period {
                 self.initialized = true;
             }
         }
@@ -170,7 +178,7 @@ mod tests {
         }
 
         assert!(obv_10.initialized());
-        assert_eq!(obv_10.value, 41200.0);
+        assert_eq!(obv_10.value, 33700.0);
     }
 
     #[rstest]
@@ -186,5 +194,35 @@ mod tests {
         assert_eq!(obv_10.obv.len(), 0);
         assert!(!obv_10.has_inputs);
         assert!(!obv_10.initialized);
+    }
+
+    #[rstest]
+    fn test_value_respects_period_window() {
+        let mut obv = OnBalanceVolume::new(3);
+
+        // Each bar closes up, so delta = +volume; the early large volume must
+        // leave the 3-period window.
+        obv.update_raw(1.0, 2.0, 1000.0); // delta +1000 (early spike)
+        obv.update_raw(1.0, 2.0, 1.0);
+        obv.update_raw(1.0, 2.0, 2.0);
+        obv.update_raw(1.0, 2.0, 3.0);
+
+        // Window is now [1, 2, 3]: the 1000 spike has been evicted, so value = 6.
+        assert_eq!(obv.value, 6.0);
+    }
+
+    #[rstest]
+    fn test_period_zero_is_unbounded_cumulative() {
+        let mut obv = OnBalanceVolume::new(0);
+
+        // Feed more than MAX_PERIOD up-closes of +1; a fixed 1024-wide deque
+        // would cap the sum, but period == 0 is an unbounded cumulative total.
+        let count = MAX_PERIOD + 100;
+        for _ in 0..count {
+            obv.update_raw(1.0, 2.0, 1.0);
+        }
+
+        assert!(obv.initialized());
+        assert_eq!(obv.value, count as f64);
     }
 }

--- a/crates/indicators/src/momentum/vhf.rs
+++ b/crates/indicators/src/momentum/vhf.rs
@@ -113,6 +113,10 @@ impl VerticalHorizontalFilter {
             self.previous_close = close;
         }
 
+        if self.prices.len() == self.period {
+            let _ = self.prices.pop_front();
+        }
+
         let _ = self.prices.push_back(close);
 
         let max_price = self
@@ -217,5 +221,20 @@ mod tests {
         assert_eq!(vhf_10.prices.len(), 0);
         assert!(!vhf_10.has_inputs);
         assert!(!vhf_10.initialized);
+    }
+
+    #[rstest]
+    fn test_value_respects_period_window() {
+        let mut vhf = VerticalHorizontalFilter::new(3, None);
+
+        vhf.update_raw(100.0); // Early spike must leave the 3-period window
+        vhf.update_raw(1.0);
+        vhf.update_raw(2.0);
+        vhf.update_raw(3.0);
+        vhf.update_raw(4.0);
+
+        // Window is now [2, 3, 4]: |max - min| = 2, and the SMA(3) of the last
+        // three absolute price changes (1, 1, 1) is 1, so value = 2 / 3 / 1.
+        assert_eq!(vhf.value, 2.0 / 3.0);
     }
 }


### PR DESCRIPTION
## Summary

Fix `VerticalHorizontalFilter` to respect its `period` window.

The `prices` deque is declared with a fixed `MAX_PERIOD` (1024) capacity, but the
window was never bounded to `period`. As a result the `max`/`min` used in the VHF
calculation folded over every retained price (up to 1024) instead of the last
`period` bars, so the value diverged once more than `period` inputs were seen.

This mirrors the fix applied to `DonchianChannel` in #4239: evict the oldest price
once the window reaches `period` before pushing, matching the Cython reference
which uses `deque(maxlen=period)`.

## Tests

- Added `test_value_respects_period_window` (an early spike must leave the window;
  buggy result = 33.0, fixed = 2/3).
- Existing tests pass unchanged. `test_value_with_ten_inputs` did not catch the bug
  because its min value appeared at both an evicted and a retained position.

```
cargo nextest run -p nautilus-indicators vhf   # 8 passed
```
