### PR TITLE
Expose websocket backend selection in Python/PyO3 configs

### DIFF
--- a/crates/adapters/architect_ax/src/python/config.rs
+++ b/crates/adapters/architect_ax/src/python/config.rs
@@ -139,3 +139,59 @@ impl AxExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = AxDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = AxExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/architect_ax/src/python/config.rs
+++ b/crates/adapters/architect_ax/src/python/config.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -27,7 +28,7 @@ impl AxDataClientConfig {
     /// Configuration for the AX Exchange live data client.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_ws_public=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, update_instruments_interval_mins=None, funding_rate_poll_interval_mins=None))]
+    #[pyo3(signature = (api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_ws_public=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, update_instruments_interval_mins=None, funding_rate_poll_interval_mins=None, transport_backend=None))]
     fn py_new(
         api_key: Option<String>,
         api_secret: Option<String>,
@@ -44,6 +45,7 @@ impl AxDataClientConfig {
         recv_window_ms: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         funding_rate_poll_interval_mins: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -66,7 +68,7 @@ impl AxDataClientConfig {
                 .unwrap_or(default.update_instruments_interval_mins),
             funding_rate_poll_interval_mins: funding_rate_poll_interval_mins
                 .unwrap_or(default.funding_rate_poll_interval_mins),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 
@@ -85,7 +87,7 @@ impl AxExecClientConfig {
     /// Configuration for the AX Exchange live execution client.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (trader_id=None, account_id=None, api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_orders=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, cancel_on_disconnect=None))]
+    #[pyo3(signature = (trader_id=None, account_id=None, api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_orders=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, cancel_on_disconnect=None, transport_backend=None))]
     fn py_new(
         trader_id: Option<TraderId>,
         account_id: Option<AccountId>,
@@ -103,6 +105,7 @@ impl AxExecClientConfig {
         heartbeat_interval_secs: Option<u64>,
         recv_window_ms: Option<u64>,
         cancel_on_disconnect: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -124,7 +127,7 @@ impl AxExecClientConfig {
                 .unwrap_or(default.heartbeat_interval_secs),
             recv_window_ms: recv_window_ms.unwrap_or(default.recv_window_ms),
             cancel_on_disconnect: cancel_on_disconnect.unwrap_or(default.cancel_on_disconnect),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 

--- a/crates/adapters/binance/src/python/config.rs
+++ b/crates/adapters/binance/src/python/config.rs
@@ -21,6 +21,7 @@ use nautilus_model::{
     identifiers::{AccountId, TraderId},
     types::Currency,
 };
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
 
@@ -45,6 +46,7 @@ impl BinanceDataClientConfig {
         api_secret = None,
         spot_market_data_mode = None,
         instrument_status_poll_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -56,6 +58,7 @@ impl BinanceDataClientConfig {
         api_secret: Option<String>,
         spot_market_data_mode: Option<BinanceSpotMarketDataMode>,
         instrument_status_poll_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -68,7 +71,7 @@ impl BinanceDataClientConfig {
             spot_market_data_mode: spot_market_data_mode.unwrap_or(defaults.spot_market_data_mode),
             instrument_status_poll_secs: instrument_status_poll_secs
                 .unwrap_or(defaults.instrument_status_poll_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -104,6 +107,7 @@ impl BinanceExecClientConfig {
         treat_expired_as_canceled = false,
         use_trade_lite = false,
         bnfcr_currency = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -124,6 +128,7 @@ impl BinanceExecClientConfig {
         treat_expired_as_canceled: bool,
         use_trade_lite: bool,
         bnfcr_currency: Option<Currency>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -146,7 +151,7 @@ impl BinanceExecClientConfig {
             bnfcr_currency: bnfcr_currency.unwrap_or(defaults.bnfcr_currency),
             treat_expired_as_canceled,
             use_trade_lite,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -165,7 +170,7 @@ mod tests {
     #[rstest]
     fn test_data_client_py_new_uses_defaults_for_omitted_fields() {
         let config =
-            BinanceDataClientConfig::py_new(None, None, None, None, None, None, None, None);
+            BinanceDataClientConfig::py_new(None, None, None, None, None, None, None, None, None);
         let defaults = BinanceDataClientConfig::default();
 
         assert_eq!(config.product_type, defaults.product_type);
@@ -192,6 +197,7 @@ mod tests {
             Some("api-secret".to_string()),
             Some(BinanceSpotMarketDataMode::Json),
             Some(15),
+            Some(TransportBackend::Tungstenite),
         );
 
         assert_eq!(config.product_type, BinanceProductType::UsdM);
@@ -208,6 +214,7 @@ mod tests {
             BinanceSpotMarketDataMode::Json
         );
         assert_eq!(config.instrument_status_poll_secs, 15);
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
     }
 
     #[rstest]
@@ -216,7 +223,7 @@ mod tests {
         let account_id = AccountId::from("BINANCE-001");
         let config = BinanceExecClientConfig::py_new(
             trader_id, account_id, None, None, None, None, None, true, true, None, None, None,
-            None, None, false, false, None,
+            None, None, false, false, None, None,
         );
         let defaults = BinanceExecClientConfig::default();
 
@@ -267,6 +274,7 @@ mod tests {
             true,
             true,
             Some(Currency::USDC()),
+            Some(TransportBackend::Tungstenite),
         );
 
         assert_eq!(config.product_type, BinanceProductType::UsdM);
@@ -290,6 +298,7 @@ mod tests {
         assert_eq!(config.bnfcr_currency, Currency::USDC());
         assert!(config.treat_expired_as_canceled);
         assert!(config.use_trade_lite);
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
     }
 
     #[rstest]
@@ -312,6 +321,7 @@ mod tests {
             None,
             false,
             false,
+            None,
             None,
         );
 

--- a/crates/adapters/bitmex/src/python/config.rs
+++ b/crates/adapters/bitmex/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for BitMEX configuration.
 
 use nautilus_model::identifiers::AccountId;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -45,6 +46,7 @@ impl BitmexDataClientConfig {
         environment = None,
         max_requests_per_second = None,
         max_requests_per_minute = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -64,6 +66,7 @@ impl BitmexDataClientConfig {
         environment: Option<BitmexEnvironment>,
         max_requests_per_second: Option<u32>,
         max_requests_per_minute: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -86,7 +89,7 @@ impl BitmexDataClientConfig {
                 .unwrap_or(defaults.max_requests_per_second),
             max_requests_per_minute: max_requests_per_minute
                 .unwrap_or(defaults.max_requests_per_minute),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -122,6 +125,7 @@ impl BitmexExecClientConfig {
         submitter_proxy_urls = None,
         canceller_proxy_urls = None,
         deadmans_switch_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -146,6 +150,7 @@ impl BitmexExecClientConfig {
         submitter_proxy_urls: Option<Vec<String>>,
         canceller_proxy_urls: Option<Vec<String>>,
         deadmans_switch_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -174,7 +179,7 @@ impl BitmexExecClientConfig {
             submitter_proxy_urls,
             canceller_proxy_urls,
             deadmans_switch_timeout_secs,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/bitmex/src/python/config.rs
+++ b/crates/adapters/bitmex/src/python/config.rs
@@ -187,3 +187,65 @@ impl BitmexExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = BitmexDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = BitmexExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/blockchain/src/python/config.rs
+++ b/crates/adapters/blockchain/src/python/config.rs
@@ -153,3 +153,31 @@ impl BlockchainDataClientConfig {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use nautilus_model::defi::{DexType, chain::chains};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = BlockchainDataClientConfig::py_new(
+            &chains::ETHEREUM,
+            vec![DexType::UniswapV2],
+            "https://eth-mainnet.example.com".to_string(),
+            None,
+            None,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/blockchain/src/python/config.rs
+++ b/crates/adapters/blockchain/src/python/config.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use nautilus_infrastructure::sql::pg::PostgresConnectOptions;
 use nautilus_model::defi::{Chain, DexType};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::config::{BlockchainDataClientConfig, DexPoolFilters};
@@ -42,7 +43,7 @@ impl BlockchainDataClientConfig {
     /// Configuration for blockchain data clients.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, multicall_calls_per_rpc_request=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None, proxy_url=None))]
+    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, multicall_calls_per_rpc_request=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None, proxy_url=None, transport_backend=None))]
     fn py_new(
         #[gen_stub(
             override_type(
@@ -73,6 +74,7 @@ impl BlockchainDataClientConfig {
         )]
         postgres_cache_database_config: Option<PostgresConnectOptions>,
         proxy_url: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         Self::builder()
             .chain(Arc::new(chain.clone()))
@@ -86,6 +88,7 @@ impl BlockchainDataClientConfig {
             .maybe_pool_filters(pool_filters)
             .maybe_postgres_cache_database_config(postgres_cache_database_config)
             .maybe_proxy_url(proxy_url)
+            .transport_backend(transport_backend.unwrap_or_default())
             .build()
     }
 

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -177,3 +177,54 @@ impl BybitExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = BybitDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = BybitExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Bybit configuration.
 
 use nautilus_model::identifiers::AccountId;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -45,6 +46,7 @@ impl BybitDataClientConfig {
         recv_window_ms = None,
         update_instruments_interval_mins = None,
         instrument_poll_interval_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -64,6 +66,7 @@ impl BybitDataClientConfig {
         recv_window_ms: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         instrument_poll_interval_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -87,7 +90,7 @@ impl BybitDataClientConfig {
                 .or(defaults.update_instruments_interval_mins),
             instrument_poll_interval_secs: instrument_poll_interval_secs
                 .or(defaults.instrument_poll_interval_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -119,6 +122,7 @@ impl BybitExecClientConfig {
         account_id = None,
         use_spot_position_reports = None,
         margin_mode = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -139,6 +143,7 @@ impl BybitExecClientConfig {
         account_id: Option<AccountId>,
         use_spot_position_reports: Option<bool>,
         margin_mode: Option<BybitMarginMode>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -164,7 +169,7 @@ impl BybitExecClientConfig {
             futures_leverages: None,
             position_mode: None,
             margin_mode,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/coinbase/src/python/config.rs
+++ b/crates/adapters/coinbase/src/python/config.rs
@@ -157,3 +157,50 @@ impl CoinbaseExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = CoinbaseDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = CoinbaseExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/coinbase/src/python/config.rs
+++ b/crates/adapters/coinbase/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Coinbase configuration.
 
 use nautilus_model::enums::AccountType;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 use rust_decimal::Decimal;
 
@@ -40,6 +41,7 @@ impl CoinbaseDataClientConfig {
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
         derivatives_poll_interval_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -53,6 +55,7 @@ impl CoinbaseDataClientConfig {
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         derivatives_poll_interval_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -68,7 +71,7 @@ impl CoinbaseDataClientConfig {
                 .unwrap_or(defaults.update_instruments_interval_mins),
             derivatives_poll_interval_secs: derivatives_poll_interval_secs
                 .unwrap_or(defaults.derivatives_poll_interval_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -103,6 +106,7 @@ impl CoinbaseExecClientConfig {
         default_margin_type = None,
         default_leverage = None,
         retail_portfolio_id = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -120,6 +124,7 @@ impl CoinbaseExecClientConfig {
         default_margin_type: Option<CoinbaseMarginType>,
         default_leverage: Option<Decimal>,
         retail_portfolio_id: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -138,7 +143,7 @@ impl CoinbaseExecClientConfig {
             default_margin_type,
             default_leverage,
             retail_portfolio_id,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/deribit/src/python/config.rs
+++ b/crates/adapters/deribit/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Deribit configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -44,6 +45,7 @@ impl DeribitDataClientConfig {
         heartbeat_interval_secs = None,
         update_instruments_interval_mins = None,
         auto_load_missing_instruments = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -61,6 +63,7 @@ impl DeribitDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         auto_load_missing_instruments: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -82,7 +85,7 @@ impl DeribitDataClientConfig {
                 .unwrap_or(defaults.update_instruments_interval_mins),
             auto_load_missing_instruments: auto_load_missing_instruments
                 .unwrap_or(defaults.auto_load_missing_instruments),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -110,6 +113,7 @@ impl DeribitExecClientConfig {
         max_retries = None,
         retry_delay_initial_ms = None,
         retry_delay_max_ms = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -126,6 +130,7 @@ impl DeribitExecClientConfig {
         max_retries: Option<u32>,
         retry_delay_initial_ms: Option<u64>,
         retry_delay_max_ms: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -143,7 +148,7 @@ impl DeribitExecClientConfig {
             retry_delay_initial_ms: retry_delay_initial_ms
                 .unwrap_or(defaults.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(defaults.retry_delay_max_ms),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/deribit/src/python/config.rs
+++ b/crates/adapters/deribit/src/python/config.rs
@@ -156,3 +156,51 @@ impl DeribitExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = DeribitDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = DeribitExecClientConfig::py_new(
+            TraderId::from("TRADER-001"),
+            AccountId::from("DERIBIT-001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/derive/src/python/config.rs
+++ b/crates/adapters/derive/src/python/config.rs
@@ -15,6 +15,7 @@
 
 //! Python bindings for Derive configuration.
 
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 use rust_decimal::Decimal;
 
@@ -39,6 +40,7 @@ impl DeriveDataClientConfig {
         currencies = None,
         include_expired = None,
         auto_load_missing_instruments = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -52,6 +54,7 @@ impl DeriveDataClientConfig {
         currencies: Option<Vec<String>>,
         include_expired: Option<bool>,
         auto_load_missing_instruments: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -67,7 +70,7 @@ impl DeriveDataClientConfig {
             include_expired: include_expired.unwrap_or(defaults.include_expired),
             auto_load_missing_instruments: auto_load_missing_instruments
                 .unwrap_or(defaults.auto_load_missing_instruments),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -105,6 +108,7 @@ impl DeriveExecClientConfig {
         signature_expiry_secs = None,
         market_order_slippage_bps = None,
         max_matching_requests_per_second = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -126,6 +130,7 @@ impl DeriveExecClientConfig {
         signature_expiry_secs: Option<u64>,
         market_order_slippage_bps: Option<u32>,
         max_matching_requests_per_second: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -142,7 +147,7 @@ impl DeriveExecClientConfig {
                 .unwrap_or(defaults.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(defaults.retry_delay_max_ms),
             max_fee_per_contract,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             domain_separator,
             action_typehash,
             trade_module_address,

--- a/crates/adapters/derive/src/python/config.rs
+++ b/crates/adapters/derive/src/python/config.rs
@@ -167,3 +167,49 @@ impl DeriveExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = DeriveDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = DeriveExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/hyperliquid/src/python/config.rs
+++ b/crates/adapters/hyperliquid/src/python/config.rs
@@ -145,3 +145,49 @@ impl HyperliquidExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = HyperliquidDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = HyperliquidExecClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/hyperliquid/src/python/config.rs
+++ b/crates/adapters/hyperliquid/src/python/config.rs
@@ -15,6 +15,7 @@
 
 //! Python bindings for Hyperliquid configuration.
 
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -36,6 +37,7 @@ impl HyperliquidDataClientConfig {
         http_timeout_secs = None,
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -47,6 +49,7 @@ impl HyperliquidDataClientConfig {
         http_timeout_secs: Option<u64>,
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -59,7 +62,7 @@ impl HyperliquidDataClientConfig {
             ws_timeout_secs: ws_timeout_secs.unwrap_or(defaults.ws_timeout_secs),
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -90,6 +93,7 @@ impl HyperliquidExecClientConfig {
         market_order_slippage_bps = None,
         include_builder_attribution = None,
         ws_post_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -109,6 +113,7 @@ impl HyperliquidExecClientConfig {
         market_order_slippage_bps: Option<u32>,
         include_builder_attribution: Option<bool>,
         ws_post_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -131,7 +136,7 @@ impl HyperliquidExecClientConfig {
             include_builder_attribution: include_builder_attribution
                 .unwrap_or(defaults.include_builder_attribution),
             ws_post_timeout_secs: ws_post_timeout_secs.unwrap_or(defaults.ws_post_timeout_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             outcome_settlement_poll_secs: defaults.outcome_settlement_poll_secs,
         }
     }

--- a/crates/adapters/kraken/src/python/config.rs
+++ b/crates/adapters/kraken/src/python/config.rs
@@ -20,6 +20,7 @@ use nautilus_model::{
     enums::AccountType,
     identifiers::{AccountId, TraderId},
 };
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -47,6 +48,7 @@ impl KrakenDataClientConfig {
         heartbeat_interval_secs = None,
         ws_idle_timeout_ms = None,
         max_requests_per_second = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -64,6 +66,7 @@ impl KrakenDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         ws_idle_timeout_ms: Option<u64>,
         max_requests_per_second: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -82,7 +85,7 @@ impl KrakenDataClientConfig {
                 .unwrap_or(defaults.heartbeat_interval_secs),
             ws_idle_timeout_ms: ws_idle_timeout_ms.unwrap_or(defaults.ws_idle_timeout_ms),
             max_requests_per_second,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -116,6 +119,7 @@ impl KrakenExecClientConfig {
         margin_balance_asset = None,
         use_ws_trade = None,
         ws_request_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -138,6 +142,7 @@ impl KrakenExecClientConfig {
         margin_balance_asset: Option<String>,
         use_ws_trade: Option<bool>,
         ws_request_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> PyResult<Self> {
         let defaults = Self::default();
         let spot_account_type = spot_account_type.unwrap_or(defaults.spot_account_type);
@@ -160,7 +165,7 @@ impl KrakenExecClientConfig {
             heartbeat_interval_secs: heartbeat_interval_secs
                 .unwrap_or(defaults.heartbeat_interval_secs),
             max_requests_per_second,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             spot_account_type,
             default_leverage,
             use_spot_position_reports: use_spot_position_reports

--- a/crates/adapters/kraken/src/python/config.rs
+++ b/crates/adapters/kraken/src/python/config.rs
@@ -183,3 +183,57 @@ impl KrakenExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use nautilus_model::accounts::AccountType;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = KrakenDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = KrakenExecClientConfig::py_new(
+            TraderId::from("TRADER-001"),
+            AccountId::from("KRAKEN-001"),
+            "api-key".to_string(),
+            "api-secret".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(AccountType::Margin),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        )
+        .expect("config should build");
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/lighter/src/python/config.rs
+++ b/crates/adapters/lighter/src/python/config.rs
@@ -159,3 +159,48 @@ impl LighterExecClientConfig {
         format!("{self:?}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_data_client_py_new_sets_transport_backend() {
+        let config = LighterDataClientConfig::py_new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+
+    #[rstest]
+    fn test_exec_client_py_new_sets_transport_backend() {
+        let config = LighterExecClientConfig::py_new(
+            TraderId::from("TRADER-001"),
+            AccountId::from("LIGHTER-001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(TransportBackend::Tungstenite),
+        );
+
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    }
+}

--- a/crates/adapters/lighter/src/python/config.rs
+++ b/crates/adapters/lighter/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Lighter configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -40,6 +41,7 @@ impl LighterDataClientConfig {
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
         rest_quota_per_min = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -54,6 +56,7 @@ impl LighterDataClientConfig {
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         rest_quota_per_min: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -69,7 +72,7 @@ impl LighterDataClientConfig {
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
             rest_quota_per_min,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -103,6 +106,7 @@ impl LighterExecClientConfig {
         market_order_slippage_bps = None,
         rest_quota_per_min = None,
         sendtx_quota_per_min = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -120,6 +124,7 @@ impl LighterExecClientConfig {
         market_order_slippage_bps: Option<u32>,
         rest_quota_per_min: Option<u32>,
         sendtx_quota_per_min: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::builder()
             .trader_id(trader_id)
@@ -141,7 +146,7 @@ impl LighterExecClientConfig {
                 .unwrap_or(defaults.market_order_slippage_bps),
             rest_quota_per_min,
             sendtx_quota_per_min,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/okx/src/python/config.rs
+++ b/crates/adapters/okx/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for OKX configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -46,6 +47,7 @@ impl OKXDataClientConfig {
         update_instruments_interval_mins = None,
         vip_level = None,
         load_spreads = false,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -66,6 +68,7 @@ impl OKXDataClientConfig {
         update_instruments_interval_mins: Option<u64>,
         vip_level: Option<OKXVipLevel>,
         load_spreads: bool,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -90,7 +93,7 @@ impl OKXDataClientConfig {
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
             vip_level,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -123,6 +126,7 @@ impl OKXExecClientConfig {
         retry_delay_max_ms = None,
         margin_mode = None,
         load_spreads = false,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -144,6 +148,7 @@ impl OKXExecClientConfig {
         retry_delay_max_ms: Option<u64>,
         margin_mode: Option<OKXMarginMode>,
         load_spreads: bool,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -171,7 +176,7 @@ impl OKXExecClientConfig {
             margin_mode,
             load_spreads,
             use_spot_margin: defaults.use_spot_margin,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -190,7 +195,7 @@ mod tests {
     fn test_data_config_py_new_load_spreads() {
         let config = OKXDataClientConfig::py_new(
             None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None, None, true,
+            None, None, true, None,
         );
 
         assert!(config.load_spreads);
@@ -217,8 +222,10 @@ mod tests {
             None,
             None,
             true,
+            Some(TransportBackend::Tungstenite),
         );
 
         assert!(config.load_spreads);
+        assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
     }
 }

--- a/crates/adapters/polymarket/src/python/config.rs
+++ b/crates/adapters/polymarket/src/python/config.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_model::identifiers::{AccountId, InstrumentId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -119,7 +120,7 @@ impl PolymarketDataClientConfig {
     /// and are skipped during serialization; they default to empty/`None` and must be
     /// installed programmatically after deserialization.
     #[new]
-    #[pyo3(signature = (instrument_config=None, base_url_http=None, base_url_ws=None, base_url_gamma=None, base_url_data_api=None, http_timeout_secs=None, ws_timeout_secs=None, ws_max_subscriptions=None, update_instruments_interval_mins=PY_OPTION_U64_MISSING_SENTINEL, subscribe_new_markets=None, auto_load_missing_instruments=None, auto_load_debounce_ms=None, auto_load_max_retries=None, auto_load_retry_delay_initial_secs=None, auto_load_retry_delay_max_secs=None, new_market_fetch_max_concurrency=None, resolve_poll_enabled=None, resolve_poll_interval_secs=None, resolve_poll_grace_secs=None, resolve_poll_max_wait_secs=None, base_url_rtds=None))]
+    #[pyo3(signature = (instrument_config=None, base_url_http=None, base_url_ws=None, base_url_gamma=None, base_url_data_api=None, http_timeout_secs=None, ws_timeout_secs=None, ws_max_subscriptions=None, update_instruments_interval_mins=PY_OPTION_U64_MISSING_SENTINEL, subscribe_new_markets=None, auto_load_missing_instruments=None, auto_load_debounce_ms=None, auto_load_max_retries=None, auto_load_retry_delay_initial_secs=None, auto_load_retry_delay_max_secs=None, new_market_fetch_max_concurrency=None, resolve_poll_enabled=None, resolve_poll_interval_secs=None, resolve_poll_grace_secs=None, resolve_poll_max_wait_secs=None, base_url_rtds=None, transport_backend=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
         instrument_config: Option<PolymarketInstrumentProviderConfig>,
@@ -143,6 +144,7 @@ impl PolymarketDataClientConfig {
         resolve_poll_grace_secs: Option<u64>,
         resolve_poll_max_wait_secs: Option<u64>,
         base_url_rtds: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
 
@@ -180,7 +182,7 @@ impl PolymarketDataClientConfig {
                 .unwrap_or(default.resolve_poll_max_wait_secs),
             filters: Vec::new(),
             new_market_filter: None,
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 
@@ -202,7 +204,7 @@ impl PolymarketExecClientConfig {
     /// derive list.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (trader_id=None, account_id=None, private_key=None, api_key=None, api_secret=None, passphrase=None, funder=None, signature_type=None, base_url_http=None, base_url_ws=None, base_url_data_api=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, ack_timeout_secs=None))]
+    #[pyo3(signature = (trader_id=None, account_id=None, private_key=None, api_key=None, api_secret=None, passphrase=None, funder=None, signature_type=None, base_url_http=None, base_url_ws=None, base_url_data_api=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, ack_timeout_secs=None, transport_backend=None))]
     fn py_new(
         trader_id: Option<String>,
         account_id: Option<String>,
@@ -220,6 +222,7 @@ impl PolymarketExecClientConfig {
         retry_delay_initial_ms: Option<u64>,
         retry_delay_max_ms: Option<u64>,
         ack_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -240,7 +243,7 @@ impl PolymarketExecClientConfig {
                 .unwrap_or(default.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(default.retry_delay_max_ms),
             ack_timeout_secs: ack_timeout_secs.unwrap_or(default.ack_timeout_secs),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 

--- a/crates/adapters/polymarket/src/python/mod.rs
+++ b/crates/adapters/polymarket/src/python/mod.rs
@@ -273,10 +273,10 @@ fn extract_data_config_from_pyobject(
         .map(|value| value.extract::<u64>())
         .transpose()?
         .unwrap_or(default.resolve_poll_max_wait_secs);
-    let transport_backend = getattr_optional(obj, "transport_backend")?
-        .map(|value| value.extract::<TransportBackend>())
-        .transpose()?
-        .unwrap_or(default.transport_backend);
+    let transport_backend = match getattr_optional(obj, "transport_backend")? {
+        Some(value) => value.extract::<TransportBackend>()?,
+        None => default.transport_backend,
+    };
     Ok(PolymarketDataClientConfig {
         instrument_config,
         base_url_http,

--- a/crates/adapters/polymarket/src/python/mod.rs
+++ b/crates/adapters/polymarket/src/python/mod.rs
@@ -31,6 +31,7 @@ pub mod sort;
 use nautilus_common::factories::{ClientConfig, DataClientFactory, ExecutionClientFactory};
 use nautilus_core::python::{to_pyruntime_err, to_pyvalue_err};
 use nautilus_model::{data::ensure_rust_extractor_registered, identifiers::InstrumentId};
+use nautilus_network::websocket::TransportBackend;
 use nautilus_system::get_global_pyo3_registry;
 use pyo3::{prelude::*, types::PyDict};
 
@@ -272,6 +273,10 @@ fn extract_data_config_from_pyobject(
         .map(|value| value.extract::<u64>())
         .transpose()?
         .unwrap_or(default.resolve_poll_max_wait_secs);
+    let transport_backend = getattr_optional(obj, "transport_backend")?
+        .map(|value| value.extract::<TransportBackend>())
+        .transpose()?
+        .unwrap_or(default.transport_backend);
     Ok(PolymarketDataClientConfig {
         instrument_config,
         base_url_http,
@@ -296,7 +301,7 @@ fn extract_data_config_from_pyobject(
         resolve_poll_max_wait_secs,
         filters: Vec::new(),
         new_market_filter: None,
-        transport_backend: default.transport_backend,
+        transport_backend,
     })
 }
 

--- a/crates/network/src/python/mod.rs
+++ b/crates/network/src/python/mod.rs
@@ -113,6 +113,7 @@ pub fn network(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::ratelimiter::quota::Quota>()?;
     m.add_class::<crate::websocket::WebSocketClient>()?;
     m.add_class::<crate::websocket::WebSocketConfig>()?;
+    m.add_class::<crate::websocket::TransportBackend>()?;
     m.add_class::<crate::socket::SocketClient>()?;
     m.add_class::<crate::socket::SocketConfig>()?;
 

--- a/crates/network/src/python/websocket.rs
+++ b/crates/network/src/python/websocket.rs
@@ -90,6 +90,7 @@ impl WebSocketConfig {
         reconnect_max_attempts=None,
         idle_timeout_ms=None,
         proxy_url=None,
+        backend=None,
     ))]
     fn py_new(
         url: String,
@@ -104,6 +105,7 @@ impl WebSocketConfig {
         reconnect_max_attempts: Option<u32>,
         idle_timeout_ms: Option<u64>,
         proxy_url: Option<String>,
+        backend: Option<TransportBackend>,
     ) -> PyResult<Self> {
         let config = Self {
             url,
@@ -117,7 +119,7 @@ impl WebSocketConfig {
             reconnect_jitter_ms,
             reconnect_max_attempts,
             idle_timeout_ms,
-            backend: TransportBackend::default(),
+            backend: backend.unwrap_or_default(),
             proxy_url,
         };
         config.validate().map_err(to_pyvalue_err)?;
@@ -476,6 +478,7 @@ mod py_new_tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(result.is_err());
@@ -666,6 +669,7 @@ counter = Counter()
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -749,6 +753,7 @@ counter = Counter()
             vec![(header_key, header_value)],
             Some(1),
             Some("heartbeat message".to_string()),
+            None,
             None,
             None,
             None,

--- a/crates/network/src/websocket/config.rs
+++ b/crates/network/src/websocket/config.rs
@@ -44,6 +44,23 @@ use crate::error::{NetworkConfigError, NetworkConfigResult};
 /// [`WebSocketConfig::headers`]).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(
+        module = "nautilus_trader.core.nautilus_pyo3.network",
+        eq,
+        from_py_object,
+        rename_all = "SCREAMING_SNAKE_CASE"
+    )
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum(module = "nautilus_trader.network")
+)]
+#[allow(
+    clippy::unsafe_derive_deserialize,
+    reason = "PyO3-backed enum still needs serde deserialization for strict config decoding"
+)]
 pub enum TransportBackend {
     /// `tokio-tungstenite` backed transport (default when `transport-sockudo` is disabled).
     #[cfg_attr(not(feature = "transport-sockudo"), default)]

--- a/python/nautilus_trader/adapters/architect_ax/__init__.pyi
+++ b/python/nautilus_trader/adapters/architect_ax/__init__.pyi
@@ -6,6 +6,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "AxCancelReason",
@@ -45,6 +46,7 @@ class AxDataClientConfig:
         recv_window_ms: int | None = None,
         update_instruments_interval_mins: int | None = None,
         funding_rate_poll_interval_mins: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -67,6 +69,7 @@ class AxExecClientConfig:
         heartbeat_interval_secs: int | None = None,
         recv_window_ms: int | None = None,
         cancel_on_disconnect: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/binance/__init__.pyi
+++ b/python/nautilus_trader/adapters/binance/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BinanceBar",
@@ -68,6 +69,7 @@ class BinanceDataClientConfig:
         api_secret: str | None = None,
         spot_market_data_mode: BinanceSpotMarketDataMode | None = None,
         instrument_status_poll_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -96,6 +98,7 @@ class BinanceExecClientConfig:
         treat_expired_as_canceled: bool = False,
         use_trade_lite: bool = False,
         bnfcr_currency: model.Currency | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/bitmex/__init__.pyi
+++ b/python/nautilus_trader/adapters/bitmex/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BITMEX_HTTP_URL",
@@ -48,6 +49,7 @@ class BitmexDataClientConfig:
         environment: BitmexEnvironment | None = None,
         max_requests_per_second: int | None = None,
         max_requests_per_minute: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -80,6 +82,7 @@ class BitmexExecClientConfig:
         submitter_proxy_urls: typing.Sequence[str] | None = None,
         canceller_proxy_urls: typing.Sequence[str] | None = None,
         deadmans_switch_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/blockchain/__init__.pyi
+++ b/python/nautilus_trader/adapters/blockchain/__init__.pyi
@@ -4,6 +4,7 @@ import typing
 
 from nautilus_trader import infrastructure
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BlockchainDataClientConfig",
@@ -28,6 +29,7 @@ class BlockchainDataClientConfig:
         pool_filters: DexPoolFilters | None = None,
         postgres_cache_database_config: infrastructure.PostgresConnectOptions | None = None,
         proxy_url: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def chain(self) -> model.Chain: ...

--- a/python/nautilus_trader/adapters/bybit/__init__.pyi
+++ b/python/nautilus_trader/adapters/bybit/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BYBIT_NAUTILUS_BROKER_ID",
@@ -88,6 +89,7 @@ class BybitDataClientConfig:
         recv_window_ms: int | None = None,
         update_instruments_interval_mins: int | None = None,
         instrument_poll_interval_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -116,6 +118,7 @@ class BybitExecClientConfig:
         account_id: model.AccountId | None = None,
         use_spot_position_reports: bool | None = None,
         margin_mode: BybitMarginMode | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/coinbase/__init__.pyi
+++ b/python/nautilus_trader/adapters/coinbase/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "COINBASE",
@@ -34,6 +35,7 @@ class CoinbaseDataClientConfig:
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         derivatives_poll_interval_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -61,6 +63,7 @@ class CoinbaseExecClientConfig:
         default_margin_type: CoinbaseMarginType | None = None,
         default_leverage: decimal.Decimal | None = None,
         retail_portfolio_id: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/deribit/__init__.pyi
+++ b/python/nautilus_trader/adapters/deribit/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "DeribitCurrency",
@@ -40,6 +41,7 @@ class DeribitDataClientConfig:
         heartbeat_interval_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         auto_load_missing_instruments: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -64,6 +66,7 @@ class DeribitExecClientConfig:
         max_retries: int | None = None,
         retry_delay_initial_ms: int | None = None,
         retry_delay_max_ms: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/derive/__init__.pyi
+++ b/python/nautilus_trader/adapters/derive/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "DERIVE",
@@ -32,6 +33,7 @@ class DeriveDataClientConfig:
         currencies: typing.Sequence[str] | None = None,
         include_expired: bool | None = None,
         auto_load_missing_instruments: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -63,6 +65,7 @@ class DeriveExecClientConfig:
         signature_expiry_secs: int | None = None,
         market_order_slippage_bps: int | None = None,
         max_matching_requests_per_second: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/hyperliquid/__init__.pyi
+++ b/python/nautilus_trader/adapters/hyperliquid/__init__.pyi
@@ -6,6 +6,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "HYPERLIQUID_POST_ONLY_WOULD_MATCH",
@@ -81,6 +82,7 @@ class HyperliquidDataClientConfig:
         http_timeout_secs: int | None = None,
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -108,6 +110,7 @@ class HyperliquidExecClientConfig:
         market_order_slippage_bps: int | None = None,
         include_builder_attribution: bool | None = None,
         ws_post_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/kraken/__init__.pyi
+++ b/python/nautilus_trader/adapters/kraken/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "KrakenApiResult",
@@ -58,6 +59,7 @@ class KrakenDataClientConfig:
         heartbeat_interval_secs: int | None = None,
         ws_idle_timeout_ms: int | None = None,
         max_requests_per_second: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -88,6 +90,7 @@ class KrakenExecClientConfig:
         margin_balance_asset: str | None = None,
         use_ws_trade: bool | None = None,
         ws_request_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/lighter/__init__.pyi
+++ b/python/nautilus_trader/adapters/lighter/__init__.pyi
@@ -4,6 +4,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "LIGHTER",
@@ -32,6 +33,7 @@ class LighterDataClientConfig:
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         rest_quota_per_min: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -59,6 +61,7 @@ class LighterExecClientConfig:
         market_order_slippage_bps: int | None = None,
         rest_quota_per_min: int | None = None,
         sendtx_quota_per_min: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/okx/__init__.pyi
+++ b/python/nautilus_trader/adapters/okx/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "OKX",
@@ -67,6 +68,7 @@ class OKXDataClientConfig:
         update_instruments_interval_mins: int | None = None,
         vip_level: OKXVipLevel | None = None,
         load_spreads: bool = False,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -96,6 +98,7 @@ class OKXExecClientConfig:
         retry_delay_max_ms: int | None = None,
         margin_mode: OKXMarginMode | None = None,
         load_spreads: bool = False,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/polymarket/__init__.pyi
+++ b/python/nautilus_trader/adapters/polymarket/__init__.pyi
@@ -4,6 +4,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "PolymarketDataClientConfig",
@@ -42,6 +43,7 @@ class PolymarketDataClientConfig:
         resolve_poll_grace_secs: int | None = None,
         resolve_poll_max_wait_secs: int | None = None,
         base_url_rtds: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -69,6 +71,7 @@ class PolymarketExecClientConfig:
         retry_delay_initial_ms: int | None = None,
         retry_delay_max_ms: int | None = None,
         ack_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/network/__init__.pyi
+++ b/python/nautilus_trader/network/__init__.pyi
@@ -10,6 +10,7 @@ __all__ = [
     "Quota",
     "SocketClient",
     "SocketConfig",
+    "TransportBackend",
     "WebSocketClient",
     "WebSocketConfig",
     "http_delete",
@@ -173,7 +174,13 @@ class WebSocketConfig:
         reconnect_max_attempts: int | None = None,
         idle_timeout_ms: int | None = None,
         proxy_url: str | None = None,
+        backend: TransportBackend | None = None,
     ) -> None: ...
+
+@typing.final
+class TransportBackend(enum.Enum):
+    TUNGSTENITE = ...
+    SOCKUDO = ...
 
 @typing.final
 class HttpMethod(enum.Enum):


### PR DESCRIPTION
## What this fixes
Python/PyO3 websocket configs could not select the transport backend even though the Rust configs already supported it.

Before this PR:
- Rust configs could carry `TransportBackend`
- Python users could not set it on the shared `WebSocketConfig`
- several adapter config constructors silently fell back to the Rust default
- Polymarket's Python object extraction also dropped the field

After this PR:
- Python can explicitly choose `TransportBackend`
- adapter configs that already support the field in Rust now expose it in PyO3
- the Python typing surface matches the runtime surface

Closes #4339.

## Reviewer guide
Fastest review path:
1. [crates/network/src/websocket/config.rs](https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/network/src/websocket/config.rs)
   Adds the Python-visible `TransportBackend` enum.
2. [crates/network/src/python/websocket.rs](https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/network/src/python/websocket.rs)
   Exposes `backend=None` on `WebSocketConfig`.
3. Any one adapter config file, for example [crates/adapters/okx/src/python/config.rs](https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/adapters/okx/src/python/config.rs)
   Shows the repeated pattern used everywhere else: append `transport_backend=None` and pass it through to the existing Rust field.
4. [crates/adapters/polymarket/src/python/mod.rs](https://github.com/nautechsystems/nautilus_trader/blob/develop/crates/adapters/polymarket/src/python/mod.rs)
   Keeps Python object extraction aligned so the field is not lost on that path.
5. [python/nautilus_trader/network/__init__.pyi](https://github.com/nautechsystems/nautilus_trader/blob/develop/python/nautilus_trader/network/__init__.pyi)
   Confirms the public Python typing surface now exposes the enum and constructor arg.

## Why the diff touches many files
This is one cross-layer parity fix applied to every adapter config that already had a Rust-side `transport_backend` field.

The repeated changes are intentionally mechanical:
- add `transport_backend: Option<TransportBackend>` to the PyO3 constructor
- append `transport_backend=None` at the end of the Python signature
- pass it through with the existing Rust default preserved
- mirror that addition in the generated Python stub

No websocket runtime behavior, reconnect logic, or backend implementation was changed in this PR.

## Validation
- `cargo check` passed for all affected crates on Rust `1.96.0`
- `pre-commit` passed on the touched files with `RUSTUP_TOOLCHAIN=1.96.0-aarch64-apple-darwin`
