### PR TITLE
Expose websocket transport backend selection in Python/PyO3 configs

### DIFF
--- a/crates/adapters/architect_ax/src/python/config.rs
+++ b/crates/adapters/architect_ax/src/python/config.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -27,7 +28,7 @@ impl AxDataClientConfig {
     /// Configuration for the AX Exchange live data client.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_ws_public=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, update_instruments_interval_mins=None, funding_rate_poll_interval_mins=None))]
+    #[pyo3(signature = (api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_ws_public=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, update_instruments_interval_mins=None, funding_rate_poll_interval_mins=None, transport_backend=None))]
     fn py_new(
         api_key: Option<String>,
         api_secret: Option<String>,
@@ -44,6 +45,7 @@ impl AxDataClientConfig {
         recv_window_ms: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         funding_rate_poll_interval_mins: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -66,7 +68,7 @@ impl AxDataClientConfig {
                 .unwrap_or(default.update_instruments_interval_mins),
             funding_rate_poll_interval_mins: funding_rate_poll_interval_mins
                 .unwrap_or(default.funding_rate_poll_interval_mins),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 
@@ -85,7 +87,7 @@ impl AxExecClientConfig {
     /// Configuration for the AX Exchange live execution client.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (trader_id=None, account_id=None, api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_orders=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, cancel_on_disconnect=None))]
+    #[pyo3(signature = (trader_id=None, account_id=None, api_key=None, api_secret=None, environment=None, base_url_http=None, base_url_orders=None, base_url_ws_private=None, proxy_url=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, heartbeat_interval_secs=None, recv_window_ms=None, cancel_on_disconnect=None, transport_backend=None))]
     fn py_new(
         trader_id: Option<TraderId>,
         account_id: Option<AccountId>,
@@ -103,6 +105,7 @@ impl AxExecClientConfig {
         heartbeat_interval_secs: Option<u64>,
         recv_window_ms: Option<u64>,
         cancel_on_disconnect: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -124,7 +127,7 @@ impl AxExecClientConfig {
                 .unwrap_or(default.heartbeat_interval_secs),
             recv_window_ms: recv_window_ms.unwrap_or(default.recv_window_ms),
             cancel_on_disconnect: cancel_on_disconnect.unwrap_or(default.cancel_on_disconnect),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 

--- a/crates/adapters/binance/src/python/config.rs
+++ b/crates/adapters/binance/src/python/config.rs
@@ -21,6 +21,7 @@ use nautilus_model::{
     identifiers::{AccountId, TraderId},
     types::Currency,
 };
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
 
@@ -45,6 +46,7 @@ impl BinanceDataClientConfig {
         api_secret = None,
         spot_market_data_mode = None,
         instrument_status_poll_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -56,6 +58,7 @@ impl BinanceDataClientConfig {
         api_secret: Option<String>,
         spot_market_data_mode: Option<BinanceSpotMarketDataMode>,
         instrument_status_poll_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -68,7 +71,7 @@ impl BinanceDataClientConfig {
             spot_market_data_mode: spot_market_data_mode.unwrap_or(defaults.spot_market_data_mode),
             instrument_status_poll_secs: instrument_status_poll_secs
                 .unwrap_or(defaults.instrument_status_poll_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -104,6 +107,7 @@ impl BinanceExecClientConfig {
         treat_expired_as_canceled = false,
         use_trade_lite = false,
         bnfcr_currency = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -124,6 +128,7 @@ impl BinanceExecClientConfig {
         treat_expired_as_canceled: bool,
         use_trade_lite: bool,
         bnfcr_currency: Option<Currency>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -146,7 +151,7 @@ impl BinanceExecClientConfig {
             bnfcr_currency: bnfcr_currency.unwrap_or(defaults.bnfcr_currency),
             treat_expired_as_canceled,
             use_trade_lite,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -165,7 +170,7 @@ mod tests {
     #[rstest]
     fn test_data_client_py_new_uses_defaults_for_omitted_fields() {
         let config =
-            BinanceDataClientConfig::py_new(None, None, None, None, None, None, None, None);
+            BinanceDataClientConfig::py_new(None, None, None, None, None, None, None, None, None);
         let defaults = BinanceDataClientConfig::default();
 
         assert_eq!(config.product_type, defaults.product_type);
@@ -192,6 +197,7 @@ mod tests {
             Some("api-secret".to_string()),
             Some(BinanceSpotMarketDataMode::Json),
             Some(15),
+            None,
         );
 
         assert_eq!(config.product_type, BinanceProductType::UsdM);
@@ -216,7 +222,7 @@ mod tests {
         let account_id = AccountId::from("BINANCE-001");
         let config = BinanceExecClientConfig::py_new(
             trader_id, account_id, None, None, None, None, None, true, true, None, None, None,
-            None, None, false, false, None,
+            None, None, false, false, None, None,
         );
         let defaults = BinanceExecClientConfig::default();
 
@@ -267,6 +273,7 @@ mod tests {
             true,
             true,
             Some(Currency::USDC()),
+            None,
         );
 
         assert_eq!(config.product_type, BinanceProductType::UsdM);
@@ -312,6 +319,7 @@ mod tests {
             None,
             false,
             false,
+            None,
             None,
         );
 

--- a/crates/adapters/bitmex/src/python/config.rs
+++ b/crates/adapters/bitmex/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for BitMEX configuration.
 
 use nautilus_model::identifiers::AccountId;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -45,6 +46,7 @@ impl BitmexDataClientConfig {
         environment = None,
         max_requests_per_second = None,
         max_requests_per_minute = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -64,6 +66,7 @@ impl BitmexDataClientConfig {
         environment: Option<BitmexEnvironment>,
         max_requests_per_second: Option<u32>,
         max_requests_per_minute: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -86,7 +89,7 @@ impl BitmexDataClientConfig {
                 .unwrap_or(defaults.max_requests_per_second),
             max_requests_per_minute: max_requests_per_minute
                 .unwrap_or(defaults.max_requests_per_minute),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -122,6 +125,7 @@ impl BitmexExecClientConfig {
         submitter_proxy_urls = None,
         canceller_proxy_urls = None,
         deadmans_switch_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -146,6 +150,7 @@ impl BitmexExecClientConfig {
         submitter_proxy_urls: Option<Vec<String>>,
         canceller_proxy_urls: Option<Vec<String>>,
         deadmans_switch_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -174,7 +179,7 @@ impl BitmexExecClientConfig {
             submitter_proxy_urls,
             canceller_proxy_urls,
             deadmans_switch_timeout_secs,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/blockchain/src/python/config.rs
+++ b/crates/adapters/blockchain/src/python/config.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use nautilus_infrastructure::sql::pg::PostgresConnectOptions;
 use nautilus_model::defi::{Chain, DexType};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::config::{BlockchainDataClientConfig, DexPoolFilters};
@@ -42,7 +43,7 @@ impl BlockchainDataClientConfig {
     /// Configuration for blockchain data clients.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, multicall_calls_per_rpc_request=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None, proxy_url=None))]
+    #[pyo3(signature = (chain, dex_ids, http_rpc_url, rpc_requests_per_second=None, multicall_calls_per_rpc_request=None, wss_rpc_url=None, use_hypersync_for_live_data=true, from_block=None, pool_filters=None, postgres_cache_database_config=None, proxy_url=None, transport_backend=None))]
     fn py_new(
         #[gen_stub(
             override_type(
@@ -73,6 +74,7 @@ impl BlockchainDataClientConfig {
         )]
         postgres_cache_database_config: Option<PostgresConnectOptions>,
         proxy_url: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         Self::builder()
             .chain(Arc::new(chain.clone()))
@@ -86,6 +88,7 @@ impl BlockchainDataClientConfig {
             .maybe_pool_filters(pool_filters)
             .maybe_postgres_cache_database_config(postgres_cache_database_config)
             .maybe_proxy_url(proxy_url)
+            .transport_backend(transport_backend.unwrap_or_default())
             .build()
     }
 

--- a/crates/adapters/blockchain/tests/python.rs
+++ b/crates/adapters/blockchain/tests/python.rs
@@ -24,9 +24,16 @@ use nautilus_blockchain::{
 use nautilus_common::{
     cache::Cache, clock::TestClock, live::runner::replace_data_event_sender, messages::DataEvent,
 };
-use nautilus_model::{defi::chain::chains, identifiers::ClientId};
+use nautilus_model::{
+    defi::{DexType, chain::chains},
+    identifiers::ClientId,
+};
+use nautilus_network::{python as network_python, websocket::TransportBackend};
 use nautilus_system::get_global_pyo3_registry;
-use pyo3::{Py, Python, types::PyModule};
+use pyo3::{
+    Bound, Py, Python,
+    types::{PyAnyMethods, PyDict, PyDictMethods, PyModule},
+};
 use rstest::rstest;
 
 #[rstest]
@@ -40,14 +47,37 @@ fn test_blockchain_python_data_factory_extracts_from_registry() {
     });
 }
 
+#[rstest]
+fn test_blockchain_python_config_accepts_transport_backend() {
+    setup_data_event_sender();
+    Python::initialize();
+
+    Python::attach(|py| {
+        let blockchain_module = register_blockchain_python_module(py);
+        let network_module = register_network_python_module(py);
+        assert_data_config_extracts_transport_backend_from_python_constructor(
+            py,
+            &blockchain_module,
+            &network_module,
+        );
+    });
+}
+
 fn setup_data_event_sender() {
     let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
     replace_data_event_sender(sender);
 }
 
-fn register_blockchain_python_module(py: Python<'_>) {
+fn register_blockchain_python_module(py: Python<'_>) -> Bound<'_, PyModule> {
     let module = PyModule::new(py, "blockchain").expect("Blockchain module should be created");
     python::blockchain(py, &module).expect("Blockchain Python module should register");
+    module
+}
+
+fn register_network_python_module(py: Python<'_>) -> Bound<'_, PyModule> {
+    let module = PyModule::new(py, "network").expect("Network module should be created");
+    network_python::network(py, &module).expect("Network Python module should register");
+    module
 }
 
 fn assert_data_factory_extracts_from_python_object(py: Python<'_>) {
@@ -98,5 +128,47 @@ fn assert_data_factory_extracts_from_python_object(py: Python<'_>) {
     assert_eq!(
         client.client_id(),
         ClientId::from("BLOCKCHAIN-DATA-EXTRACTED")
+    );
+}
+
+fn assert_data_config_extracts_transport_backend_from_python_constructor(
+    py: Python<'_>,
+    blockchain_module: &Bound<'_, PyModule>,
+    network_module: &Bound<'_, PyModule>,
+) {
+    let config_type = blockchain_module
+        .getattr("BlockchainDataClientConfig")
+        .expect("BlockchainDataClientConfig should be available");
+    let transport_backend = network_module
+        .getattr("TransportBackend")
+        .expect("TransportBackend should be available")
+        .getattr("TUNGSTENITE")
+        .expect("TransportBackend.TUNGSTENITE should be available");
+    let kwargs = PyDict::new(py);
+    kwargs
+        .set_item("transport_backend", transport_backend)
+        .expect("transport_backend kwarg should be set");
+    let config = config_type
+        .call(
+            (
+                chains::ETHEREUM.clone(),
+                vec![DexType::UniswapV3],
+                "https://eth-mainnet.example.com",
+            ),
+            Some(&kwargs),
+        )
+        .expect("BlockchainDataClientConfig should construct from Python");
+    let registry = get_global_pyo3_registry();
+    let extracted_config = registry
+        .extract_config(py, config.into())
+        .expect("data config should extract");
+    let blockchain_config = extracted_config
+        .as_any()
+        .downcast_ref::<BlockchainDataClientConfig>()
+        .expect("data config should downcast");
+
+    assert_eq!(
+        blockchain_config.transport_backend,
+        TransportBackend::Tungstenite,
     );
 }

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Bybit configuration.
 
 use nautilus_model::identifiers::AccountId;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -44,7 +45,8 @@ impl BybitDataClientConfig {
         heartbeat_interval_secs = None,
         recv_window_ms = None,
         update_instruments_interval_mins = None,
-        instrument_poll_interval_secs = None,
+        instrument_status_poll_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -63,7 +65,8 @@ impl BybitDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         recv_window_ms: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
-        instrument_poll_interval_secs: Option<u64>,
+        instrument_status_poll_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -85,9 +88,9 @@ impl BybitDataClientConfig {
             recv_window_ms: recv_window_ms.unwrap_or(defaults.recv_window_ms),
             update_instruments_interval_mins: update_instruments_interval_mins
                 .or(defaults.update_instruments_interval_mins),
-            instrument_poll_interval_secs: instrument_poll_interval_secs
+            instrument_poll_interval_secs: instrument_status_poll_secs
                 .or(defaults.instrument_poll_interval_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -119,6 +122,7 @@ impl BybitExecClientConfig {
         account_id = None,
         use_spot_position_reports = None,
         margin_mode = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -139,6 +143,7 @@ impl BybitExecClientConfig {
         account_id: Option<AccountId>,
         use_spot_position_reports: Option<bool>,
         margin_mode: Option<BybitMarginMode>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -164,7 +169,7 @@ impl BybitExecClientConfig {
             futures_leverages: None,
             position_mode: None,
             margin_mode,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/coinbase/src/python/config.rs
+++ b/crates/adapters/coinbase/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Coinbase configuration.
 
 use nautilus_model::enums::AccountType;
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 use rust_decimal::Decimal;
 
@@ -40,6 +41,7 @@ impl CoinbaseDataClientConfig {
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
         derivatives_poll_interval_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -53,6 +55,7 @@ impl CoinbaseDataClientConfig {
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         derivatives_poll_interval_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -68,7 +71,7 @@ impl CoinbaseDataClientConfig {
                 .unwrap_or(defaults.update_instruments_interval_mins),
             derivatives_poll_interval_secs: derivatives_poll_interval_secs
                 .unwrap_or(defaults.derivatives_poll_interval_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -103,6 +106,7 @@ impl CoinbaseExecClientConfig {
         default_margin_type = None,
         default_leverage = None,
         retail_portfolio_id = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -120,6 +124,7 @@ impl CoinbaseExecClientConfig {
         default_margin_type: Option<CoinbaseMarginType>,
         default_leverage: Option<Decimal>,
         retail_portfolio_id: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -138,7 +143,7 @@ impl CoinbaseExecClientConfig {
             default_margin_type,
             default_leverage,
             retail_portfolio_id,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/deribit/src/python/config.rs
+++ b/crates/adapters/deribit/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Deribit configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -44,6 +45,7 @@ impl DeribitDataClientConfig {
         heartbeat_interval_secs = None,
         update_instruments_interval_mins = None,
         auto_load_missing_instruments = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -61,6 +63,7 @@ impl DeribitDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         auto_load_missing_instruments: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -82,7 +85,7 @@ impl DeribitDataClientConfig {
                 .unwrap_or(defaults.update_instruments_interval_mins),
             auto_load_missing_instruments: auto_load_missing_instruments
                 .unwrap_or(defaults.auto_load_missing_instruments),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -110,6 +113,7 @@ impl DeribitExecClientConfig {
         max_retries = None,
         retry_delay_initial_ms = None,
         retry_delay_max_ms = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -126,6 +130,7 @@ impl DeribitExecClientConfig {
         max_retries: Option<u32>,
         retry_delay_initial_ms: Option<u64>,
         retry_delay_max_ms: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -143,7 +148,7 @@ impl DeribitExecClientConfig {
             retry_delay_initial_ms: retry_delay_initial_ms
                 .unwrap_or(defaults.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(defaults.retry_delay_max_ms),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/derive/src/python/config.rs
+++ b/crates/adapters/derive/src/python/config.rs
@@ -15,6 +15,7 @@
 
 //! Python bindings for Derive configuration.
 
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 use rust_decimal::Decimal;
 
@@ -39,6 +40,7 @@ impl DeriveDataClientConfig {
         currencies = None,
         include_expired = None,
         auto_load_missing_instruments = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -52,6 +54,7 @@ impl DeriveDataClientConfig {
         currencies: Option<Vec<String>>,
         include_expired: Option<bool>,
         auto_load_missing_instruments: Option<bool>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -67,7 +70,7 @@ impl DeriveDataClientConfig {
             include_expired: include_expired.unwrap_or(defaults.include_expired),
             auto_load_missing_instruments: auto_load_missing_instruments
                 .unwrap_or(defaults.auto_load_missing_instruments),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -105,6 +108,7 @@ impl DeriveExecClientConfig {
         signature_expiry_secs = None,
         market_order_slippage_bps = None,
         max_matching_requests_per_second = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -126,6 +130,7 @@ impl DeriveExecClientConfig {
         signature_expiry_secs: Option<u64>,
         market_order_slippage_bps: Option<u32>,
         max_matching_requests_per_second: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -142,7 +147,7 @@ impl DeriveExecClientConfig {
                 .unwrap_or(defaults.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(defaults.retry_delay_max_ms),
             max_fee_per_contract,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             domain_separator,
             action_typehash,
             trade_module_address,

--- a/crates/adapters/hyperliquid/src/python/config.rs
+++ b/crates/adapters/hyperliquid/src/python/config.rs
@@ -15,6 +15,7 @@
 
 //! Python bindings for Hyperliquid configuration.
 
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -36,6 +37,7 @@ impl HyperliquidDataClientConfig {
         http_timeout_secs = None,
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -47,6 +49,7 @@ impl HyperliquidDataClientConfig {
         http_timeout_secs: Option<u64>,
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -59,7 +62,7 @@ impl HyperliquidDataClientConfig {
             ws_timeout_secs: ws_timeout_secs.unwrap_or(defaults.ws_timeout_secs),
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -90,6 +93,7 @@ impl HyperliquidExecClientConfig {
         market_order_slippage_bps = None,
         include_builder_attribution = None,
         ws_post_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -109,6 +113,7 @@ impl HyperliquidExecClientConfig {
         market_order_slippage_bps: Option<u32>,
         include_builder_attribution: Option<bool>,
         ws_post_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -131,7 +136,7 @@ impl HyperliquidExecClientConfig {
             include_builder_attribution: include_builder_attribution
                 .unwrap_or(defaults.include_builder_attribution),
             ws_post_timeout_secs: ws_post_timeout_secs.unwrap_or(defaults.ws_post_timeout_secs),
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             outcome_settlement_poll_secs: defaults.outcome_settlement_poll_secs,
         }
     }

--- a/crates/adapters/kraken/src/python/config.rs
+++ b/crates/adapters/kraken/src/python/config.rs
@@ -20,6 +20,7 @@ use nautilus_model::{
     enums::AccountType,
     identifiers::{AccountId, TraderId},
 };
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -47,6 +48,7 @@ impl KrakenDataClientConfig {
         heartbeat_interval_secs = None,
         ws_idle_timeout_ms = None,
         max_requests_per_second = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -64,6 +66,7 @@ impl KrakenDataClientConfig {
         heartbeat_interval_secs: Option<u64>,
         ws_idle_timeout_ms: Option<u64>,
         max_requests_per_second: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -82,7 +85,7 @@ impl KrakenDataClientConfig {
                 .unwrap_or(defaults.heartbeat_interval_secs),
             ws_idle_timeout_ms: ws_idle_timeout_ms.unwrap_or(defaults.ws_idle_timeout_ms),
             max_requests_per_second,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -116,6 +119,7 @@ impl KrakenExecClientConfig {
         margin_balance_asset = None,
         use_ws_trade = None,
         ws_request_timeout_secs = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -138,6 +142,7 @@ impl KrakenExecClientConfig {
         margin_balance_asset: Option<String>,
         use_ws_trade: Option<bool>,
         ws_request_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> PyResult<Self> {
         let defaults = Self::default();
         let spot_account_type = spot_account_type.unwrap_or(defaults.spot_account_type);
@@ -160,7 +165,7 @@ impl KrakenExecClientConfig {
             heartbeat_interval_secs: heartbeat_interval_secs
                 .unwrap_or(defaults.heartbeat_interval_secs),
             max_requests_per_second,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
             spot_account_type,
             default_leverage,
             use_spot_position_reports: use_spot_position_reports

--- a/crates/adapters/lighter/src/python/config.rs
+++ b/crates/adapters/lighter/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for Lighter configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -40,6 +41,7 @@ impl LighterDataClientConfig {
         ws_timeout_secs = None,
         update_instruments_interval_mins = None,
         rest_quota_per_min = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -54,6 +56,7 @@ impl LighterDataClientConfig {
         ws_timeout_secs: Option<u64>,
         update_instruments_interval_mins: Option<u64>,
         rest_quota_per_min: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -69,7 +72,7 @@ impl LighterDataClientConfig {
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
             rest_quota_per_min,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -103,6 +106,7 @@ impl LighterExecClientConfig {
         market_order_slippage_bps = None,
         rest_quota_per_min = None,
         sendtx_quota_per_min = None,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -120,6 +124,7 @@ impl LighterExecClientConfig {
         market_order_slippage_bps: Option<u32>,
         rest_quota_per_min: Option<u32>,
         sendtx_quota_per_min: Option<u32>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::builder()
             .trader_id(trader_id)
@@ -141,7 +146,7 @@ impl LighterExecClientConfig {
                 .unwrap_or(defaults.market_order_slippage_bps),
             rest_quota_per_min,
             sendtx_quota_per_min,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 

--- a/crates/adapters/okx/src/python/config.rs
+++ b/crates/adapters/okx/src/python/config.rs
@@ -16,6 +16,7 @@
 //! Python bindings for OKX configuration.
 
 use nautilus_model::identifiers::{AccountId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::prelude::*;
 
 use crate::{
@@ -46,6 +47,7 @@ impl OKXDataClientConfig {
         update_instruments_interval_mins = None,
         vip_level = None,
         load_spreads = false,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -66,6 +68,7 @@ impl OKXDataClientConfig {
         update_instruments_interval_mins: Option<u64>,
         vip_level: Option<OKXVipLevel>,
         load_spreads: bool,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -90,7 +93,7 @@ impl OKXDataClientConfig {
             update_instruments_interval_mins: update_instruments_interval_mins
                 .unwrap_or(defaults.update_instruments_interval_mins),
             vip_level,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -123,6 +126,7 @@ impl OKXExecClientConfig {
         retry_delay_max_ms = None,
         margin_mode = None,
         load_spreads = false,
+        transport_backend = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -144,6 +148,7 @@ impl OKXExecClientConfig {
         retry_delay_max_ms: Option<u64>,
         margin_mode: Option<OKXMarginMode>,
         load_spreads: bool,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -171,7 +176,7 @@ impl OKXExecClientConfig {
             margin_mode,
             load_spreads,
             use_spot_margin: defaults.use_spot_margin,
-            transport_backend: defaults.transport_backend,
+            transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
         }
     }
 
@@ -190,7 +195,7 @@ mod tests {
     fn test_data_config_py_new_load_spreads() {
         let config = OKXDataClientConfig::py_new(
             None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None, None, true,
+            None, None, true, None,
         );
 
         assert!(config.load_spreads);
@@ -217,6 +222,7 @@ mod tests {
             None,
             None,
             true,
+            None,
         );
 
         assert!(config.load_spreads);

--- a/crates/adapters/polymarket/src/python/config.rs
+++ b/crates/adapters/polymarket/src/python/config.rs
@@ -14,6 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_model::identifiers::{AccountId, InstrumentId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
 use crate::{
@@ -119,7 +120,7 @@ impl PolymarketDataClientConfig {
     /// and are skipped during serialization; they default to empty/`None` and must be
     /// installed programmatically after deserialization.
     #[new]
-    #[pyo3(signature = (instrument_config=None, base_url_http=None, base_url_ws=None, base_url_gamma=None, base_url_data_api=None, http_timeout_secs=None, ws_timeout_secs=None, ws_max_subscriptions=None, update_instruments_interval_mins=PY_OPTION_U64_MISSING_SENTINEL, subscribe_new_markets=None, auto_load_missing_instruments=None, auto_load_debounce_ms=None, auto_load_max_retries=None, auto_load_retry_delay_initial_secs=None, auto_load_retry_delay_max_secs=None, new_market_fetch_max_concurrency=None, resolve_poll_enabled=None, resolve_poll_interval_secs=None, resolve_poll_grace_secs=None, resolve_poll_max_wait_secs=None, base_url_rtds=None))]
+    #[pyo3(signature = (instrument_config=None, base_url_http=None, base_url_ws=None, base_url_gamma=None, base_url_data_api=None, http_timeout_secs=None, ws_timeout_secs=None, ws_max_subscriptions=None, update_instruments_interval_mins=PY_OPTION_U64_MISSING_SENTINEL, subscribe_new_markets=None, auto_load_missing_instruments=None, auto_load_debounce_ms=None, auto_load_max_retries=None, auto_load_retry_delay_initial_secs=None, auto_load_retry_delay_max_secs=None, new_market_fetch_max_concurrency=None, resolve_poll_enabled=None, resolve_poll_interval_secs=None, resolve_poll_grace_secs=None, resolve_poll_max_wait_secs=None, base_url_rtds=None, transport_backend=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
         instrument_config: Option<PolymarketInstrumentProviderConfig>,
@@ -143,6 +144,7 @@ impl PolymarketDataClientConfig {
         resolve_poll_grace_secs: Option<u64>,
         resolve_poll_max_wait_secs: Option<u64>,
         base_url_rtds: Option<String>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
 
@@ -180,7 +182,7 @@ impl PolymarketDataClientConfig {
                 .unwrap_or(default.resolve_poll_max_wait_secs),
             filters: Vec::new(),
             new_market_filter: None,
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 
@@ -202,7 +204,7 @@ impl PolymarketExecClientConfig {
     /// derive list.
     #[new]
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (trader_id=None, account_id=None, private_key=None, api_key=None, api_secret=None, passphrase=None, funder=None, signature_type=None, base_url_http=None, base_url_ws=None, base_url_data_api=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, ack_timeout_secs=None))]
+    #[pyo3(signature = (trader_id=None, account_id=None, private_key=None, api_key=None, api_secret=None, passphrase=None, funder=None, signature_type=None, base_url_http=None, base_url_ws=None, base_url_data_api=None, http_timeout_secs=None, max_retries=None, retry_delay_initial_ms=None, retry_delay_max_ms=None, ack_timeout_secs=None, transport_backend=None))]
     fn py_new(
         trader_id: Option<String>,
         account_id: Option<String>,
@@ -220,6 +222,7 @@ impl PolymarketExecClientConfig {
         retry_delay_initial_ms: Option<u64>,
         retry_delay_max_ms: Option<u64>,
         ack_timeout_secs: Option<u64>,
+        transport_backend: Option<TransportBackend>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -240,7 +243,7 @@ impl PolymarketExecClientConfig {
                 .unwrap_or(default.retry_delay_initial_ms),
             retry_delay_max_ms: retry_delay_max_ms.unwrap_or(default.retry_delay_max_ms),
             ack_timeout_secs: ack_timeout_secs.unwrap_or(default.ack_timeout_secs),
-            transport_backend: default.transport_backend,
+            transport_backend: transport_backend.unwrap_or(default.transport_backend),
         }
     }
 

--- a/crates/adapters/polymarket/src/python/mod.rs
+++ b/crates/adapters/polymarket/src/python/mod.rs
@@ -31,6 +31,7 @@ pub mod sort;
 use nautilus_common::factories::{ClientConfig, DataClientFactory, ExecutionClientFactory};
 use nautilus_core::python::{to_pyruntime_err, to_pyvalue_err};
 use nautilus_model::{data::ensure_rust_extractor_registered, identifiers::InstrumentId};
+use nautilus_network::websocket::TransportBackend;
 use nautilus_system::get_global_pyo3_registry;
 use pyo3::{prelude::*, types::PyDict};
 
@@ -272,6 +273,10 @@ fn extract_data_config_from_pyobject(
         .map(|value| value.extract::<u64>())
         .transpose()?
         .unwrap_or(default.resolve_poll_max_wait_secs);
+    let transport_backend = match getattr_optional(obj, "transport_backend")? {
+        Some(value) => value.extract::<TransportBackend>()?,
+        None => default.transport_backend,
+    };
     Ok(PolymarketDataClientConfig {
         instrument_config,
         base_url_http,
@@ -296,7 +301,7 @@ fn extract_data_config_from_pyobject(
         resolve_poll_max_wait_secs,
         filters: Vec::new(),
         new_market_filter: None,
-        transport_backend: default.transport_backend,
+        transport_backend,
     })
 }
 

--- a/crates/network/src/python/mod.rs
+++ b/crates/network/src/python/mod.rs
@@ -113,6 +113,7 @@ pub fn network(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::ratelimiter::quota::Quota>()?;
     m.add_class::<crate::websocket::WebSocketClient>()?;
     m.add_class::<crate::websocket::WebSocketConfig>()?;
+    m.add_class::<crate::websocket::TransportBackend>()?;
     m.add_class::<crate::socket::SocketClient>()?;
     m.add_class::<crate::socket::SocketConfig>()?;
 

--- a/crates/network/src/python/websocket.rs
+++ b/crates/network/src/python/websocket.rs
@@ -90,6 +90,7 @@ impl WebSocketConfig {
         reconnect_max_attempts=None,
         idle_timeout_ms=None,
         proxy_url=None,
+        backend=None,
     ))]
     fn py_new(
         url: String,
@@ -104,6 +105,7 @@ impl WebSocketConfig {
         reconnect_max_attempts: Option<u32>,
         idle_timeout_ms: Option<u64>,
         proxy_url: Option<String>,
+        backend: Option<TransportBackend>,
     ) -> PyResult<Self> {
         let config = Self {
             url,
@@ -117,7 +119,7 @@ impl WebSocketConfig {
             reconnect_jitter_ms,
             reconnect_max_attempts,
             idle_timeout_ms,
-            backend: TransportBackend::default(),
+            backend: backend.unwrap_or_default(),
             proxy_url,
         };
         config.validate().map_err(to_pyvalue_err)?;
@@ -476,6 +478,7 @@ mod py_new_tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(result.is_err());
@@ -666,6 +669,7 @@ counter = Counter()
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -749,6 +753,7 @@ counter = Counter()
             vec![(header_key, header_value)],
             Some(1),
             Some("heartbeat message".to_string()),
+            None,
             None,
             None,
             None,

--- a/crates/network/src/websocket/config.rs
+++ b/crates/network/src/websocket/config.rs
@@ -44,6 +44,23 @@ use crate::error::{NetworkConfigError, NetworkConfigResult};
 /// [`WebSocketConfig::headers`]).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(
+        module = "nautilus_trader.core.nautilus_pyo3.network",
+        eq,
+        from_py_object,
+        rename_all = "SCREAMING_SNAKE_CASE"
+    )
+)]
+#[cfg_attr(
+    feature = "python",
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum(module = "nautilus_trader.network")
+)]
+#[allow(
+    clippy::unsafe_derive_deserialize,
+    reason = "PyO3-backed enum still needs serde deserialization for strict config decoding"
+)]
 pub enum TransportBackend {
     /// `tokio-tungstenite` backed transport (default when `transport-sockudo` is disabled).
     #[cfg_attr(not(feature = "transport-sockudo"), default)]

--- a/nautilus_trader/adapters/architect_ax/config.py
+++ b/nautilus_trader/adapters/architect_ax/config.py
@@ -17,6 +17,7 @@ from nautilus_trader.common.config import PositiveInt
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.core.nautilus_pyo3 import AxEnvironment
+from nautilus_trader.network import TransportBackend
 
 
 class AxDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -62,6 +63,7 @@ class AxDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000
@@ -109,6 +111,7 @@ class AxExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000

--- a/nautilus_trader/adapters/binance/config.py
+++ b/nautilus_trader/adapters/binance/config.py
@@ -24,6 +24,7 @@ from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.config import PositiveInt
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.network import TransportBackend
 
 
 class BinanceInstrumentProviderConfig(InstrumentProviderConfig, frozen=True):
@@ -121,6 +122,7 @@ class BinanceDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     us: bool = False
     update_instruments_interval_mins: PositiveInt | None = 60
     use_agg_trade_ticks: bool = False
@@ -207,6 +209,7 @@ class BinanceExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_ws: str | None = None
     base_url_ws_stream: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     us: bool = False
     use_gtd: bool = True
     use_reduce_only: bool = True

--- a/nautilus_trader/adapters/bitmex/config.py
+++ b/nautilus_trader/adapters/bitmex/config.py
@@ -17,6 +17,7 @@ from nautilus_trader.common.config import PositiveInt
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.core.nautilus_pyo3 import BitmexEnvironment
+from nautilus_trader.network import TransportBackend
 
 
 class BitmexDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -74,6 +75,7 @@ class BitmexDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000
@@ -159,6 +161,7 @@ class BitmexExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000

--- a/nautilus_trader/adapters/bybit/config.py
+++ b/nautilus_trader/adapters/bybit/config.py
@@ -23,6 +23,7 @@ from nautilus_trader.core.nautilus_pyo3 import BybitEnvironment
 from nautilus_trader.core.nautilus_pyo3 import BybitMarginMode
 from nautilus_trader.core.nautilus_pyo3 import BybitPositionMode
 from nautilus_trader.core.nautilus_pyo3 import BybitProductType
+from nautilus_trader.network import TransportBackend
 
 
 def _resolve_environment(
@@ -81,6 +82,7 @@ class BybitDataClientConfig(LiveDataClientConfig, frozen=True):
     environment: BybitEnvironment | None = None
     base_url_http: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     update_instruments_interval_mins: PositiveInt | None = 60
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None
@@ -177,6 +179,7 @@ class BybitExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_ws_private: str | None = None
     base_url_ws_trade: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     use_gtd: bool = False  # Not supported on Bybit
     use_ws_execution_fast: bool = False
     use_http_batch_api: bool = False

--- a/nautilus_trader/adapters/deribit/config.py
+++ b/nautilus_trader/adapters/deribit/config.py
@@ -18,6 +18,7 @@ from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.core.nautilus_pyo3 import DeribitEnvironment
 from nautilus_trader.core.nautilus_pyo3 import DeribitProductType
+from nautilus_trader.network import TransportBackend
 
 
 class DeribitDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -71,6 +72,7 @@ class DeribitDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000
@@ -125,6 +127,7 @@ class DeribitExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000

--- a/nautilus_trader/adapters/hyperliquid/config.py
+++ b/nautilus_trader/adapters/hyperliquid/config.py
@@ -20,6 +20,7 @@ from nautilus_trader.common.config import PositiveInt
 from nautilus_trader.config import LiveDataClientConfig
 from nautilus_trader.config import LiveExecClientConfig
 from nautilus_trader.core.nautilus_pyo3 import HyperliquidEnvironment
+from nautilus_trader.network import TransportBackend
 
 
 class HyperliquidDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -47,6 +48,7 @@ class HyperliquidDataClientConfig(LiveDataClientConfig, frozen=True):
     environment: HyperliquidEnvironment | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt = 10
 
 
@@ -114,6 +116,7 @@ class HyperliquidExecClientConfig(LiveExecClientConfig, frozen=True):
     environment: HyperliquidEnvironment | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None
     retry_delay_max_ms: PositiveInt | None = None

--- a/nautilus_trader/adapters/kraken/config.py
+++ b/nautilus_trader/adapters/kraken/config.py
@@ -19,6 +19,7 @@ from nautilus_trader.config import PositiveInt
 from nautilus_trader.core.nautilus_pyo3 import KrakenEnvironment
 from nautilus_trader.core.nautilus_pyo3 import KrakenProductType
 from nautilus_trader.model.enums import AccountType
+from nautilus_trader.network import TransportBackend
 
 
 class KrakenDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -92,6 +93,7 @@ class KrakenDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_ws_futures: str | None = None
     base_url_ws_l3_spot: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     update_instruments_interval_mins: PositiveInt | None = 60
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None
@@ -221,6 +223,7 @@ class KrakenExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_ws_spot: str | None = None
     base_url_ws_futures: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None
     retry_delay_max_ms: PositiveInt | None = None

--- a/nautilus_trader/adapters/okx/config.py
+++ b/nautilus_trader/adapters/okx/config.py
@@ -22,6 +22,7 @@ from nautilus_trader.core.nautilus_pyo3 import OKXInstrumentType
 from nautilus_trader.core.nautilus_pyo3 import OKXMarginMode
 from nautilus_trader.core.nautilus_pyo3 import OKXRegion
 from nautilus_trader.core.nautilus_pyo3 import OKXVipLevel
+from nautilus_trader.network import TransportBackend
 
 
 class OKXDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -86,6 +87,7 @@ class OKXDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     http_timeout_secs: PositiveInt | None = 60
     max_retries: PositiveInt | None = 3
     retry_delay_initial_ms: PositiveInt | None = 1_000
@@ -182,6 +184,7 @@ class OKXExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     margin_mode: OKXMarginMode | None = None
     use_spot_margin: bool = False
     http_timeout_secs: PositiveInt | None = 60

--- a/nautilus_trader/adapters/polymarket/config.py
+++ b/nautilus_trader/adapters/polymarket/config.py
@@ -21,6 +21,7 @@ from nautilus_trader.config import NonNegativeInt
 from nautilus_trader.config import PositiveFloat
 from nautilus_trader.config import PositiveInt
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.network import TransportBackend
 
 
 class PolymarketDataClientConfig(LiveDataClientConfig, frozen=True):
@@ -112,6 +113,7 @@ class PolymarketDataClientConfig(LiveDataClientConfig, frozen=True):
     base_url_http: str | None = None
     base_url_ws: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     ws_connection_initial_delay_secs: PositiveFloat = 5
     ws_connection_delay_secs: PositiveFloat = 0.1
     ws_max_subscriptions_per_connection: PositiveInt = 200
@@ -201,6 +203,7 @@ class PolymarketExecClientConfig(LiveExecClientConfig, frozen=True):
     base_url_ws: str | None = None
     base_url_data_api: str | None = None
     proxy_url: str | None = None
+    transport_backend: TransportBackend | None = None
     ws_max_subscriptions_per_connection: PositiveInt = 200
     max_retries: PositiveInt | None = None
     retry_delay_initial_ms: PositiveInt | None = None

--- a/nautilus_trader/common/config.py
+++ b/nautilus_trader/common/config.py
@@ -100,11 +100,49 @@ def nautilus_schema_hook(type_: type[Any]) -> dict[str, Any]:
         return {"type": "string", "format": "date-time"}
     if type_ == pd.Timedelta:
         return {"type": "string"}
+    if _is_pyo3_enum_type(type_):
+        return {"type": "string"}
     if type_ in (Environment, TimeInForce):
         return {"type": "string"}
     if type_ is type:  # Handle <class 'type'>
         return {"type": "string"}  # Represent type objects as strings
     raise TypeError(f"Unsupported type for schema generation: {type_}")
+
+
+def _is_pyo3_enum_type(type_: type[Any]) -> bool:
+    module = getattr(type_, "__module__", "")
+    if "nautilus_pyo3" not in module:
+        return False
+
+    return _pyo3_enum_member_name_from_type(type_, None) is not None
+
+
+def _is_pyo3_enum_instance(obj: Any) -> bool:
+    return _pyo3_enum_member_name(obj) is not None
+
+
+def _pyo3_enum_member_name(obj: Any) -> str | None:
+    return _pyo3_enum_member_name_from_type(type(obj), obj)
+
+
+def _pyo3_enum_member_name_from_type(type_: type[Any], value: Any) -> str | None:
+    for attr in dir(type_):
+        if not attr.isupper():
+            continue
+
+        member = getattr(type_, attr, None)
+        if value is None or member is value:
+            return attr
+
+        try:
+            equals = member == value
+        except (NotImplementedError, TypeError, ValueError):
+            continue
+
+        if isinstance(equals, bool) and equals:
+            return attr
+
+    return None
 
 
 def msgspec_encoding_hook(obj: Any) -> Any:  # noqa: C901 (too complex)
@@ -129,6 +167,8 @@ def msgspec_encoding_hook(obj: Any) -> Any:  # noqa: C901 (too complex)
         return obj.isoformat()
     if isinstance(obj, Environment):
         return obj.value
+    if _is_pyo3_enum_instance(obj):
+        return _pyo3_enum_member_name(obj)
     if type(obj) in CUSTOM_ENCODINGS:
         func = CUSTOM_ENCODINGS[type(obj)]
         return func(obj)
@@ -171,6 +211,8 @@ def msgspec_decoding_hook(obj_type: type, obj: Any) -> Any:  # noqa: C901 (too c
         return TriggerType[obj]
     if obj_type == Environment:
         return obj_type(obj)
+    if _is_pyo3_enum_type(obj_type):
+        return getattr(obj_type, obj.split(".")[-1].upper())
     if obj_type in CUSTOM_DECODINGS:
         func = CUSTOM_DECODINGS[obj_type]
         return func(obj)
@@ -677,4 +719,4 @@ class ImportableConfig(NautilusConfig, frozen=True):
         assert ":" in self.path, "`path` variable should be of the form `path.to.module:class`"
         cls = resolve_path(self.path)
         cfg = msgspec.json.encode(self.config, enc_hook=msgspec_encoding_hook)
-        return msgspec.json.decode(cfg, type=cls)
+        return msgspec.json.decode(cfg, type=cls, dec_hook=msgspec_decoding_hook)

--- a/nautilus_trader/network/__init__.py
+++ b/nautilus_trader/network/__init__.py
@@ -1,0 +1,60 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+"""
+Network client and transport bindings exposed by the PyO3 runtime.
+"""
+
+from nautilus_trader.core.nautilus_pyo3.network import HttpClient
+from nautilus_trader.core.nautilus_pyo3.network import HttpClientBuildError
+from nautilus_trader.core.nautilus_pyo3.network import HttpError
+from nautilus_trader.core.nautilus_pyo3.network import HttpInvalidProxyError
+from nautilus_trader.core.nautilus_pyo3.network import HttpMethod
+from nautilus_trader.core.nautilus_pyo3.network import HttpResponse
+from nautilus_trader.core.nautilus_pyo3.network import HttpTimeoutError
+from nautilus_trader.core.nautilus_pyo3.network import Quota
+from nautilus_trader.core.nautilus_pyo3.network import SocketClient
+from nautilus_trader.core.nautilus_pyo3.network import SocketConfig
+from nautilus_trader.core.nautilus_pyo3.network import TransportBackend
+from nautilus_trader.core.nautilus_pyo3.network import WebSocketClient
+from nautilus_trader.core.nautilus_pyo3.network import WebSocketClientError
+from nautilus_trader.core.nautilus_pyo3.network import WebSocketConfig
+from nautilus_trader.core.nautilus_pyo3.network import http_delete
+from nautilus_trader.core.nautilus_pyo3.network import http_download
+from nautilus_trader.core.nautilus_pyo3.network import http_get
+from nautilus_trader.core.nautilus_pyo3.network import http_patch
+from nautilus_trader.core.nautilus_pyo3.network import http_post
+
+
+__all__ = [
+    "HttpClient",
+    "HttpClientBuildError",
+    "HttpError",
+    "HttpInvalidProxyError",
+    "HttpMethod",
+    "HttpResponse",
+    "HttpTimeoutError",
+    "Quota",
+    "SocketClient",
+    "SocketConfig",
+    "TransportBackend",
+    "WebSocketClient",
+    "WebSocketClientError",
+    "WebSocketConfig",
+    "http_delete",
+    "http_download",
+    "http_get",
+    "http_patch",
+    "http_post",
+]

--- a/python/nautilus_trader/adapters/architect_ax/__init__.pyi
+++ b/python/nautilus_trader/adapters/architect_ax/__init__.pyi
@@ -6,6 +6,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "AxCancelReason",
@@ -45,6 +46,7 @@ class AxDataClientConfig:
         recv_window_ms: int | None = None,
         update_instruments_interval_mins: int | None = None,
         funding_rate_poll_interval_mins: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -67,6 +69,7 @@ class AxExecClientConfig:
         heartbeat_interval_secs: int | None = None,
         recv_window_ms: int | None = None,
         cancel_on_disconnect: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/binance/__init__.pyi
+++ b/python/nautilus_trader/adapters/binance/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BinanceBar",
@@ -68,6 +69,7 @@ class BinanceDataClientConfig:
         api_secret: str | None = None,
         spot_market_data_mode: BinanceSpotMarketDataMode | None = None,
         instrument_status_poll_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -96,6 +98,7 @@ class BinanceExecClientConfig:
         treat_expired_as_canceled: bool = False,
         use_trade_lite: bool = False,
         bnfcr_currency: model.Currency | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/bitmex/__init__.pyi
+++ b/python/nautilus_trader/adapters/bitmex/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BITMEX_HTTP_URL",
@@ -48,6 +49,7 @@ class BitmexDataClientConfig:
         environment: BitmexEnvironment | None = None,
         max_requests_per_second: int | None = None,
         max_requests_per_minute: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -80,6 +82,7 @@ class BitmexExecClientConfig:
         submitter_proxy_urls: typing.Sequence[str] | None = None,
         canceller_proxy_urls: typing.Sequence[str] | None = None,
         deadmans_switch_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/blockchain/__init__.pyi
+++ b/python/nautilus_trader/adapters/blockchain/__init__.pyi
@@ -4,6 +4,7 @@ import typing
 
 from nautilus_trader import infrastructure
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BlockchainDataClientConfig",
@@ -28,6 +29,7 @@ class BlockchainDataClientConfig:
         pool_filters: DexPoolFilters | None = None,
         postgres_cache_database_config: infrastructure.PostgresConnectOptions | None = None,
         proxy_url: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def chain(self) -> model.Chain: ...

--- a/python/nautilus_trader/adapters/bybit/__init__.pyi
+++ b/python/nautilus_trader/adapters/bybit/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "BYBIT_NAUTILUS_BROKER_ID",
@@ -87,7 +88,8 @@ class BybitDataClientConfig:
         heartbeat_interval_secs: int | None = None,
         recv_window_ms: int | None = None,
         update_instruments_interval_mins: int | None = None,
-        instrument_poll_interval_secs: int | None = None,
+        instrument_status_poll_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -116,6 +118,7 @@ class BybitExecClientConfig:
         account_id: model.AccountId | None = None,
         use_spot_position_reports: bool | None = None,
         margin_mode: BybitMarginMode | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/coinbase/__init__.pyi
+++ b/python/nautilus_trader/adapters/coinbase/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "COINBASE",
@@ -34,6 +35,7 @@ class CoinbaseDataClientConfig:
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         derivatives_poll_interval_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -61,6 +63,7 @@ class CoinbaseExecClientConfig:
         default_margin_type: CoinbaseMarginType | None = None,
         default_leverage: decimal.Decimal | None = None,
         retail_portfolio_id: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/deribit/__init__.pyi
+++ b/python/nautilus_trader/adapters/deribit/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "DeribitCurrency",
@@ -40,6 +41,7 @@ class DeribitDataClientConfig:
         heartbeat_interval_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         auto_load_missing_instruments: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -64,6 +66,7 @@ class DeribitExecClientConfig:
         max_retries: int | None = None,
         retry_delay_initial_ms: int | None = None,
         retry_delay_max_ms: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/derive/__init__.pyi
+++ b/python/nautilus_trader/adapters/derive/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "DERIVE",
@@ -32,6 +33,7 @@ class DeriveDataClientConfig:
         currencies: typing.Sequence[str] | None = None,
         include_expired: bool | None = None,
         auto_load_missing_instruments: bool | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -63,6 +65,7 @@ class DeriveExecClientConfig:
         signature_expiry_secs: int | None = None,
         market_order_slippage_bps: int | None = None,
         max_matching_requests_per_second: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/hyperliquid/__init__.pyi
+++ b/python/nautilus_trader/adapters/hyperliquid/__init__.pyi
@@ -6,6 +6,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "HYPERLIQUID_POST_ONLY_WOULD_MATCH",
@@ -81,6 +82,7 @@ class HyperliquidDataClientConfig:
         http_timeout_secs: int | None = None,
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -108,6 +110,7 @@ class HyperliquidExecClientConfig:
         market_order_slippage_bps: int | None = None,
         include_builder_attribution: bool | None = None,
         ws_post_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/kraken/__init__.pyi
+++ b/python/nautilus_trader/adapters/kraken/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "KrakenApiResult",
@@ -58,6 +59,7 @@ class KrakenDataClientConfig:
         heartbeat_interval_secs: int | None = None,
         ws_idle_timeout_ms: int | None = None,
         max_requests_per_second: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -88,6 +90,7 @@ class KrakenExecClientConfig:
         margin_balance_asset: str | None = None,
         use_ws_trade: bool | None = None,
         ws_request_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/lighter/__init__.pyi
+++ b/python/nautilus_trader/adapters/lighter/__init__.pyi
@@ -4,6 +4,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "LIGHTER",
@@ -32,6 +33,7 @@ class LighterDataClientConfig:
         ws_timeout_secs: int | None = None,
         update_instruments_interval_mins: int | None = None,
         rest_quota_per_min: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...
@@ -59,6 +61,7 @@ class LighterExecClientConfig:
         market_order_slippage_bps: int | None = None,
         rest_quota_per_min: int | None = None,
         sendtx_quota_per_min: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
     @property
     def proxy_url(self) -> str | None: ...

--- a/python/nautilus_trader/adapters/okx/__init__.pyi
+++ b/python/nautilus_trader/adapters/okx/__init__.pyi
@@ -5,6 +5,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "OKX",
@@ -67,6 +68,7 @@ class OKXDataClientConfig:
         update_instruments_interval_mins: int | None = None,
         vip_level: OKXVipLevel | None = None,
         load_spreads: bool = False,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -96,6 +98,7 @@ class OKXExecClientConfig:
         retry_delay_max_ms: int | None = None,
         margin_mode: OKXMarginMode | None = None,
         load_spreads: bool = False,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/adapters/polymarket/__init__.pyi
+++ b/python/nautilus_trader/adapters/polymarket/__init__.pyi
@@ -4,6 +4,7 @@ import enum
 import typing
 
 from nautilus_trader import model
+from nautilus_trader import network
 
 __all__ = [
     "PolymarketDataClientConfig",
@@ -42,6 +43,7 @@ class PolymarketDataClientConfig:
         resolve_poll_grace_secs: int | None = None,
         resolve_poll_max_wait_secs: int | None = None,
         base_url_rtds: str | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -69,6 +71,7 @@ class PolymarketExecClientConfig:
         retry_delay_initial_ms: int | None = None,
         retry_delay_max_ms: int | None = None,
         ack_timeout_secs: int | None = None,
+        transport_backend: network.TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final

--- a/python/nautilus_trader/network/__init__.pyi
+++ b/python/nautilus_trader/network/__init__.pyi
@@ -10,6 +10,7 @@ __all__ = [
     "Quota",
     "SocketClient",
     "SocketConfig",
+    "TransportBackend",
     "WebSocketClient",
     "WebSocketConfig",
     "http_delete",
@@ -173,6 +174,7 @@ class WebSocketConfig:
         reconnect_max_attempts: int | None = None,
         idle_timeout_ms: int | None = None,
         proxy_url: str | None = None,
+        backend: TransportBackend | None = None,
     ) -> None: ...
 
 @typing.final
@@ -184,6 +186,11 @@ class HttpMethod(enum.Enum):
     PATCH = ...
 
     def __hash__(self) -> int: ...
+
+@typing.final
+class TransportBackend(enum.Enum):
+    TUNGSTENITE = ...
+    SOCKUDO = ...
 
 def http_delete(
     url: str,

--- a/tests/integration_tests/live/test_live_node_transport_backend.py
+++ b/tests/integration_tests/live/test_live_node_transport_backend.py
@@ -1,0 +1,322 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import msgspec
+import pytest
+
+from nautilus_trader.adapters.architect_ax import AxDataClientConfig
+from nautilus_trader.adapters.architect_ax import AxExecClientConfig
+from nautilus_trader.adapters.architect_ax import AxLiveDataClientFactory
+from nautilus_trader.adapters.architect_ax import AxLiveExecClientFactory
+from nautilus_trader.adapters.binance import BinanceDataClientConfig
+from nautilus_trader.adapters.binance import BinanceExecClientConfig
+from nautilus_trader.adapters.binance import BinanceLiveDataClientFactory
+from nautilus_trader.adapters.binance import BinanceLiveExecClientFactory
+from nautilus_trader.adapters.bitmex import BitmexDataClientConfig
+from nautilus_trader.adapters.bitmex import BitmexExecClientConfig
+from nautilus_trader.adapters.bitmex import BitmexLiveDataClientFactory
+from nautilus_trader.adapters.bitmex import BitmexLiveExecClientFactory
+from nautilus_trader.adapters.bybit import BybitDataClientConfig
+from nautilus_trader.adapters.bybit import BybitExecClientConfig
+from nautilus_trader.adapters.bybit import BybitLiveDataClientFactory
+from nautilus_trader.adapters.bybit import BybitLiveExecClientFactory
+from nautilus_trader.adapters.deribit import DeribitDataClientConfig
+from nautilus_trader.adapters.deribit import DeribitExecClientConfig
+from nautilus_trader.adapters.deribit import DeribitLiveDataClientFactory
+from nautilus_trader.adapters.deribit import DeribitLiveExecClientFactory
+from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidExecClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidLiveDataClientFactory
+from nautilus_trader.adapters.hyperliquid import HyperliquidLiveExecClientFactory
+from nautilus_trader.adapters.kraken import KrakenDataClientConfig
+from nautilus_trader.adapters.kraken import KrakenExecClientConfig
+from nautilus_trader.adapters.kraken import KrakenLiveDataClientFactory
+from nautilus_trader.adapters.kraken import KrakenLiveExecClientFactory
+from nautilus_trader.adapters.okx import OKXDataClientConfig
+from nautilus_trader.adapters.okx import OKXExecClientConfig
+from nautilus_trader.adapters.okx import OKXLiveDataClientFactory
+from nautilus_trader.adapters.okx import OKXLiveExecClientFactory
+from nautilus_trader.config import TradingNodeConfig
+from nautilus_trader.live.node import TradingNode
+from nautilus_trader.network import TransportBackend
+from nautilus_trader.test_kit.functions import ensure_all_tasks_completed
+from nautilus_trader.trading.strategy import Strategy
+
+
+RUNTIME_ADAPTER_CASES = [
+    (
+        "AX",
+        AxDataClientConfig,
+        AxExecClientConfig,
+        AxLiveDataClientFactory,
+        AxLiveExecClientFactory,
+    ),
+    (
+        "BINANCE",
+        BinanceDataClientConfig,
+        BinanceExecClientConfig,
+        BinanceLiveDataClientFactory,
+        BinanceLiveExecClientFactory,
+    ),
+    (
+        "BITMEX",
+        BitmexDataClientConfig,
+        BitmexExecClientConfig,
+        BitmexLiveDataClientFactory,
+        BitmexLiveExecClientFactory,
+    ),
+    (
+        "BYBIT",
+        BybitDataClientConfig,
+        BybitExecClientConfig,
+        BybitLiveDataClientFactory,
+        BybitLiveExecClientFactory,
+    ),
+    (
+        "DERIBIT",
+        DeribitDataClientConfig,
+        DeribitExecClientConfig,
+        DeribitLiveDataClientFactory,
+        DeribitLiveExecClientFactory,
+    ),
+    (
+        "HYPERLIQUID",
+        HyperliquidDataClientConfig,
+        HyperliquidExecClientConfig,
+        HyperliquidLiveDataClientFactory,
+        HyperliquidLiveExecClientFactory,
+    ),
+    (
+        "KRAKEN",
+        KrakenDataClientConfig,
+        KrakenExecClientConfig,
+        KrakenLiveDataClientFactory,
+        KrakenLiveExecClientFactory,
+    ),
+    (
+        "OKX",
+        OKXDataClientConfig,
+        OKXExecClientConfig,
+        OKXLiveDataClientFactory,
+        OKXLiveExecClientFactory,
+    ),
+]
+
+
+class SmokeStrategy(Strategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = False
+
+    def on_start(self) -> None:
+        self.started = True
+
+
+def _set_required_env_vars(monkeypatch) -> None:
+    for proxy_var in (
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(proxy_var, raising=False)
+
+    monkeypatch.setenv("BINANCE_API_KEY", "SOME_API_KEY")
+    monkeypatch.setenv("BINANCE_API_SECRET", "SOME_API_SECRET")
+    monkeypatch.setenv("DERIBIT_API_KEY", "SOME_API_KEY")
+    monkeypatch.setenv("DERIBIT_API_SECRET", "SOME_API_SECRET")
+    monkeypatch.setenv("OKX_API_KEY", "SOME_API_KEY")
+    monkeypatch.setenv("OKX_API_SECRET", "SOME_API_SECRET")
+    monkeypatch.setenv("OKX_API_PASSPHRASE", "SOME_API_PASSPHRASE")
+    monkeypatch.setenv("POLYMARKET_API_KEY", "SOME_API_KEY")
+    monkeypatch.setenv("POLYMARKET_API_SECRET", "SOME_API_SECRET")
+    monkeypatch.setenv("POLYMARKET_PASSPHRASE", "SOME_API_PASSPHRASE")
+    monkeypatch.setenv("POLYMARKET_FUNDER", "0x1111111111111111111111111111111111111111")
+    monkeypatch.setenv(
+        "POLYMARKET_PK",
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+    )
+
+
+def _raw_node_config(transport_backend: str) -> bytes:
+    return msgspec.json.encode(
+        {
+            "environment": "live",
+            "trader_id": "Test-111",
+            "data_clients": {
+                "BINANCE": {
+                    "path": "nautilus_trader.adapters.binance.config:BinanceDataClientConfig",
+                    "config": {
+                        "instrument_provider": {
+                            "load_all": False,
+                        },
+                        "transport_backend": transport_backend,
+                    },
+                },
+            },
+            "exec_clients": {
+                "BINANCE": {
+                    "path": "nautilus_trader.adapters.binance.config:BinanceExecClientConfig",
+                    "config": {
+                        "instrument_provider": {
+                            "load_all": False,
+                        },
+                        "transport_backend": transport_backend,
+                    },
+                },
+            },
+        },
+    )
+
+
+class TestTradingNodeTransportBackend:
+    def teardown(self):
+        ensure_all_tasks_completed()
+
+    @pytest.mark.parametrize(
+        ("transport_backend", "expected_backend"),
+        [
+            ("TUNGSTENITE", TransportBackend.TUNGSTENITE),
+            ("SOCKUDO", TransportBackend.SOCKUDO),
+        ],
+    )
+    def test_node_config_parse_accepts_transport_backend(
+        self,
+        transport_backend: str,
+        expected_backend: TransportBackend,
+    ) -> None:
+        config = TradingNodeConfig.parse(_raw_node_config(transport_backend))
+
+        data_config = config.data_clients["BINANCE"].create()
+        exec_config = config.exec_clients["BINANCE"].create()
+
+        assert data_config.transport_backend == expected_backend
+        assert exec_config.transport_backend == expected_backend
+
+    @pytest.mark.parametrize(
+        "transport_backend",
+        [TransportBackend.TUNGSTENITE, TransportBackend.SOCKUDO],
+    )
+    @pytest.mark.parametrize(
+        (
+            "client_name",
+            "data_config_cls",
+            "exec_config_cls",
+            "data_factory_cls",
+            "exec_factory_cls",
+        ),
+        RUNTIME_ADAPTER_CASES,
+    )
+    def test_node_build_accepts_transport_backend_for_runtime_adapters(
+        self,
+        monkeypatch,
+        event_loop_for_setup,
+        transport_backend: TransportBackend,
+        client_name: str,
+        data_config_cls,
+        exec_config_cls,
+        data_factory_cls,
+        exec_factory_cls,
+    ) -> None:
+        _set_required_env_vars(monkeypatch)
+
+        config = TradingNodeConfig(
+            trader_id="Test-111",
+            data_clients={
+                client_name: data_config_cls(transport_backend=transport_backend),
+            },
+            exec_clients={
+                client_name: exec_config_cls(transport_backend=transport_backend),
+            },
+        )
+
+        node = TradingNode(config=config, loop=event_loop_for_setup)
+        node.add_data_client_factory(client_name, data_factory_cls)
+        node.add_exec_client_factory(client_name, exec_factory_cls)
+        node.build()
+
+        assert node.is_built()
+
+    @pytest.mark.parametrize(
+        "transport_backend",
+        [TransportBackend.TUNGSTENITE, TransportBackend.SOCKUDO],
+    )
+    def test_node_build_accepts_transport_backend_for_polymarket(
+        self,
+        monkeypatch,
+        event_loop_for_setup,
+        transport_backend: TransportBackend,
+    ) -> None:
+        from nautilus_trader.adapters.polymarket import PolymarketDataClientConfig
+        from nautilus_trader.adapters.polymarket import PolymarketExecClientConfig
+        from nautilus_trader.adapters.polymarket import PolymarketLiveDataClientFactory
+        from nautilus_trader.adapters.polymarket import PolymarketLiveExecClientFactory
+
+        _set_required_env_vars(monkeypatch)
+
+        config = TradingNodeConfig(
+            trader_id="Test-111",
+            data_clients={
+                "POLYMARKET": PolymarketDataClientConfig(transport_backend=transport_backend),
+            },
+            exec_clients={
+                "POLYMARKET": PolymarketExecClientConfig(transport_backend=transport_backend),
+            },
+        )
+
+        node = TradingNode(config=config, loop=event_loop_for_setup)
+        node.add_data_client_factory("POLYMARKET", PolymarketLiveDataClientFactory)
+        node.add_exec_client_factory("POLYMARKET", PolymarketLiveExecClientFactory)
+        node.build()
+
+        assert node.is_built()
+
+    @pytest.mark.parametrize(
+        "transport_backend",
+        [TransportBackend.TUNGSTENITE, TransportBackend.SOCKUDO],
+    )
+    def test_python_strategy_can_be_added_to_trading_node(
+        self,
+        monkeypatch,
+        event_loop_for_setup,
+        transport_backend: TransportBackend,
+    ) -> None:
+        _set_required_env_vars(monkeypatch)
+
+        node = TradingNode(
+            config=TradingNodeConfig(
+                trader_id="Test-111",
+                data_clients={
+                    "BINANCE": BinanceDataClientConfig(transport_backend=transport_backend),
+                },
+                exec_clients={
+                    "BINANCE": BinanceExecClientConfig(transport_backend=transport_backend),
+                },
+            ),
+            loop=event_loop_for_setup,
+        )
+        node.add_data_client_factory("BINANCE", BinanceLiveDataClientFactory)
+        node.add_exec_client_factory("BINANCE", BinanceLiveExecClientFactory)
+        node.build()
+
+        strategy = SmokeStrategy()
+        node.trader.add_strategy(strategy)
+
+        assert node.is_built()
+        assert strategy in node.trader.strategies()

--- a/tests/unit_tests/config/test_common.py
+++ b/tests/unit_tests/config/test_common.py
@@ -525,6 +525,18 @@ def test_encoding_timedelta() -> None:
     assert result == obj.isoformat()
 
 
+def test_encoding_dataframe_uses_custom_encoder() -> None:
+    # Arrange
+    obj = pd.DataFrame({"LOCATION": ["LDN"], "VALUE": [1.23]})
+
+    # Act
+    result = msgspec_encoding_hook(obj)
+
+    # Assert
+    assert isinstance(result, str)
+    assert '"LOCATION":{"0":"LDN"}' in result
+
+
 def test_decoding_timedelta() -> None:
     # Arrange
     obj_type = pd.Timedelta

--- a/tests/unit_tests/config/test_transport_backend.py
+++ b/tests/unit_tests/config/test_transport_backend.py
@@ -1,0 +1,167 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import inspect
+
+import msgspec
+import pytest
+
+from nautilus_trader.adapters.architect_ax import AxDataClientConfig
+from nautilus_trader.adapters.architect_ax import AxExecClientConfig
+from nautilus_trader.adapters.binance import BinanceDataClientConfig
+from nautilus_trader.adapters.binance import BinanceExecClientConfig
+from nautilus_trader.adapters.bitmex import BitmexDataClientConfig
+from nautilus_trader.adapters.bitmex import BitmexExecClientConfig
+from nautilus_trader.adapters.bybit import BybitDataClientConfig
+from nautilus_trader.adapters.bybit import BybitExecClientConfig
+from nautilus_trader.adapters.deribit import DeribitDataClientConfig
+from nautilus_trader.adapters.deribit import DeribitExecClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidDataClientConfig
+from nautilus_trader.adapters.hyperliquid import HyperliquidExecClientConfig
+from nautilus_trader.adapters.kraken import KrakenDataClientConfig
+from nautilus_trader.adapters.kraken import KrakenExecClientConfig
+from nautilus_trader.adapters.okx import OKXDataClientConfig
+from nautilus_trader.adapters.okx import OKXExecClientConfig
+from nautilus_trader.common.config import pyo3_config_json
+from nautilus_trader.core import nautilus_pyo3
+from nautilus_trader.network import TransportBackend
+from nautilus_trader.network import WebSocketConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_proxy_env(monkeypatch):
+    for proxy_var in (
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(proxy_var, raising=False)
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        AxDataClientConfig,
+        AxExecClientConfig,
+        BinanceDataClientConfig,
+        BinanceExecClientConfig,
+        BitmexDataClientConfig,
+        BitmexExecClientConfig,
+        BybitDataClientConfig,
+        BybitExecClientConfig,
+        DeribitDataClientConfig,
+        DeribitExecClientConfig,
+        HyperliquidDataClientConfig,
+        HyperliquidExecClientConfig,
+        KrakenDataClientConfig,
+        KrakenExecClientConfig,
+        OKXDataClientConfig,
+        OKXExecClientConfig,
+    ],
+)
+def test_adapter_configs_round_trip_transport_backend(config_cls):
+    config = config_cls(transport_backend=TransportBackend.TUNGSTENITE)
+
+    assert config.transport_backend == TransportBackend.TUNGSTENITE
+
+    payload = msgspec.json.decode(pyo3_config_json(config))
+    assert payload["transport_backend"] == "TUNGSTENITE"
+
+    parsed = config_cls.parse(msgspec.json.encode(payload))
+    assert parsed.transport_backend == TransportBackend.TUNGSTENITE
+
+
+def test_polymarket_runtime_configs_round_trip_transport_backend() -> None:
+    from nautilus_trader.adapters.polymarket import PolymarketDataClientConfig
+    from nautilus_trader.adapters.polymarket import PolymarketExecClientConfig
+
+    for config_cls in (PolymarketDataClientConfig, PolymarketExecClientConfig):
+        config = config_cls(transport_backend=TransportBackend.TUNGSTENITE)
+
+        assert config.transport_backend == TransportBackend.TUNGSTENITE
+
+        payload = msgspec.json.decode(pyo3_config_json(config))
+        assert payload["transport_backend"] == "TUNGSTENITE"
+
+        parsed = config_cls.parse(msgspec.json.encode(payload))
+        assert parsed.transport_backend == TransportBackend.TUNGSTENITE
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "kwargs", "assert_in_repr"),
+    [
+        ("coinbase", "CoinbaseDataClientConfig", {}, True),
+        ("coinbase", "CoinbaseExecClientConfig", {}, True),
+        ("derive", "DeriveDataClientConfig", {}, True),
+        ("derive", "DeriveExecClientConfig", {}, True),
+        ("lighter", "LighterDataClientConfig", {}, True),
+        (
+            "lighter",
+            "LighterExecClientConfig",
+            {
+                "trader_id": nautilus_pyo3.TraderId("TESTER-001"),
+                "account_id": nautilus_pyo3.AccountId("LIGHTER-001"),
+            },
+            True,
+        ),
+        ("polymarket", "PolymarketDataClientConfig", {}, True),
+        ("polymarket", "PolymarketExecClientConfig", {}, False),
+    ],
+)
+def test_pyo3_configs_accept_transport_backend(
+    module_name,
+    class_name,
+    kwargs,
+    assert_in_repr,
+):
+    cls = getattr(getattr(nautilus_pyo3, module_name), class_name)
+    config = cls(transport_backend=TransportBackend.TUNGSTENITE, **kwargs)
+
+    assert "transport_backend" in inspect.signature(cls).parameters
+    if assert_in_repr:
+        assert "transport_backend: Tungstenite" in repr(config)
+
+
+def test_public_network_module_exposes_transport_backend() -> None:
+    assert TransportBackend.TUNGSTENITE != TransportBackend.SOCKUDO
+    assert inspect.signature(WebSocketConfig).parameters["backend"].default is None
+
+    config = WebSocketConfig(
+        "wss://example.invalid",
+        [],
+        backend=TransportBackend.TUNGSTENITE,
+    )
+
+    assert config is not None
+
+
+def test_transport_backend_none_preserves_wrapper_and_pyo3_defaults() -> None:
+    runtime_config = BinanceDataClientConfig()
+    parsed_runtime_config = BinanceDataClientConfig.parse(
+        msgspec.json.encode({"transport_backend": None}),
+    )
+    module_name = "binance"
+    class_name = "BinanceDataClientConfig"
+    pyo3_config = getattr(getattr(nautilus_pyo3, module_name), class_name)(transport_backend=None)
+
+    assert runtime_config.transport_backend is None
+    assert parsed_runtime_config.transport_backend is None
+    assert "transport_backend: Sockudo" in repr(pyo3_config)
+    assert WebSocketConfig("wss://example.invalid", [], backend=None) is not None


### PR DESCRIPTION
## What This PR Changes (##4339)
- adds a public Python/PyO3 `TransportBackend` surface so websocket clients can explicitly select `SOCKUDO` or `TUNGSTENITE`
- threads `transport_backend` through the Python adapter configs that already expose websocket settings
- updates Python config decoding so `TradingNodeConfig.parse(...).create()` preserves the selected backend
- fixes the Polymarket PyO3 extraction path so Python-side `transport_backend` is not dropped back to the default

## Why This Matters
Today the Rust websocket layer supports backend selection, but the Python/PyO3 config surface does not expose it consistently. That makes it impossible for Python strategies and `TradingNode` configs to opt into `TUNGSTENITE` even though the lower layers support it.

This PR closes that gap without changing adapter runtime behavior unless a Python caller explicitly sets `transport_backend`.

## Review Guide
The easiest way to review this PR is in four slices:
1. `crates/network/...`
   Exposes `TransportBackend` to PyO3 and adds the optional `backend` argument on `WebSocketConfig`.
2. `crates/adapters/*/src/python/config.rs`
   Adds optional `transport_backend` constructor arguments to the relevant adapter PyO3 config types.
3. `nautilus_trader/...` and `python/nautilus_trader/...`
   Keeps the Python wrapper layer and generated stubs aligned with the new config field.
4. Tests
   Verifies direct PyO3 construction, Python wrapper round-tripping, `TradingNode` parsing/building, and the blockchain/Polymarket extraction paths.

## Validation
- `PYO3_ONLY=1 BUILD_MODE=debug uv run --active --no-sync build.py`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy -u NO_PROXY -u no_proxy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -p pytest_asyncio.plugin tests/unit_tests/config/test_transport_backend.py -q`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy -u NO_PROXY -u no_proxy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -p pytest_asyncio.plugin tests/integration_tests/live/test_live_node_transport_backend.py -q`
- `cargo test -p nautilus-blockchain --test python test_blockchain_python_config_accepts_transport_backend --features python,hypersync -- --nocapture`
- `pre-commit run --files ...`
