### PR TITLE
Fix remaining indicator rolling-window bugs

### DIFF
--- a/crates/indicators/src/ratio/efficiency_ratio.rs
+++ b/crates/indicators/src/ratio/efficiency_ratio.rs
@@ -79,6 +79,7 @@ impl Indicator for EfficiencyRatio {
     fn reset(&mut self) {
         self.value = 0.0;
         self.inputs.clear();
+        self.deltas.clear();
         self.initialized = false;
     }
 }
@@ -99,6 +100,13 @@ impl EfficiencyRatio {
 
     pub fn update_raw(&mut self, value: f64) {
         self.inputs.push(value);
+        // Bound the inputs window to `period`, matching the Cython
+        // `deque(maxlen=period)`; otherwise the net change below is measured from
+        // the all-time-first price instead of `period` bars back.
+        if self.inputs.len() > self.period {
+            self.inputs.remove(0);
+        }
+
         if self.inputs.len() < 2 {
             self.value = 0.0;
             return;
@@ -108,6 +116,11 @@ impl EfficiencyRatio {
         let last_diff =
             (self.inputs[self.inputs.len() - 1] - self.inputs[self.inputs.len() - 2]).abs();
         self.deltas.push(last_diff);
+        // Bound the deltas window to `period` as well, so the sum reflects only
+        // the last `period` absolute changes (Cython `deque(maxlen=period)`).
+        if self.deltas.len() > self.period {
+            self.deltas.remove(0);
+        }
         let sum_deltas = self.deltas.iter().sum::<f64>().abs();
         let net_diff = (self.inputs[self.inputs.len() - 1] - self.inputs[0]).abs();
         self.value = if sum_deltas == 0.0 {
@@ -201,6 +214,41 @@ mod tests {
         efficiency_ratio_10.update_raw(1.00005);
         efficiency_ratio_10.update_raw(1.00015);
         assert_eq!(efficiency_ratio_10.value, 0.428_571_428_572_153_63);
+    }
+
+    #[rstest]
+    fn test_value_bounded_to_period_after_warmup(mut efficiency_ratio_10: EfficiencyRatio) {
+        // Regression: with more than `period` inputs the rolling window must stay
+        // bounded to `period` (matching the Cython `deque(maxlen=period)`), so the
+        // net change and summed deltas use only the last `period` prices.
+        let prices = [
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0,
+        ];
+
+        for price in prices {
+            efficiency_ratio_10.update_raw(price);
+        }
+        // Window = last 10 prices: net_diff = |6 - 5| = 1, sum of the last 10 unit
+        // deltas = 10, so ER = 1 / 10 = 0.1. The old unbounded buffers instead gave
+        // |1 - 5| / 14 = 0.2857..., using the first-ever price and every delta.
+        assert_eq!(efficiency_ratio_10.inputs.len(), 10);
+        assert_eq!(efficiency_ratio_10.value, 0.1);
+    }
+
+    #[rstest]
+    fn test_reset_clears_deltas(mut efficiency_ratio_10: EfficiencyRatio) {
+        // Regression: reset must clear the deltas buffer too, otherwise stale
+        // deltas leak into the next run's sum (matching the Cython `_reset`).
+        for price in [1.0, 3.0, 6.0, 10.0, 15.0] {
+            efficiency_ratio_10.update_raw(price);
+        }
+        efficiency_ratio_10.reset();
+        assert!(efficiency_ratio_10.deltas.is_empty());
+
+        // Fresh run: two inputs of a single clean move give a ratio of 1.
+        efficiency_ratio_10.update_raw(100.0);
+        efficiency_ratio_10.update_raw(100.5);
+        assert_eq!(efficiency_ratio_10.value, 1.0);
     }
 
     #[rstest]

--- a/crates/indicators/src/ratio/spread_analyzer.rs
+++ b/crates/indicators/src/ratio/spread_analyzer.rs
@@ -96,9 +96,12 @@ impl Indicator for SpreadAnalyzer {
             self.spreads.remove(0);
         }
 
-        // Update average spread
-        self.average =
-            fast_mean_iterated(&self.spreads, spread, self.average, self.capacity, false).unwrap();
+        // Recompute the average over the bounded window. The Cython reference uses an
+        // incremental `fast_mean_iterated(..., drop_left=false)` update, but at capacity
+        // that subtracts `values[length - 1]` (the spread just pushed) rather than the
+        // evicted oldest value, so the average freezes for non-constant spreads.
+        // Recomputing from the bounded window is O(capacity) and always correct.
+        self.average = fast_mean(&self.spreads);
     }
 
     fn reset(&mut self) {
@@ -124,32 +127,6 @@ impl SpreadAnalyzer {
             spreads: Vec::with_capacity(capacity),
         }
     }
-}
-
-fn fast_mean_iterated(
-    values: &[f64],
-    next_value: f64,
-    current_value: f64,
-    expected_length: usize,
-    drop_left: bool,
-) -> Result<f64, &'static str> {
-    let length = values.len();
-
-    if length < expected_length {
-        return Ok(fast_mean(values));
-    }
-
-    if length != expected_length {
-        return Err("length of values must equal expected_length");
-    }
-
-    let value_to_drop = if drop_left {
-        values[0]
-    } else {
-        values[length - 1]
-    };
-
-    Ok(current_value + (next_value - value_to_drop) / length as f64)
 }
 
 fn fast_mean(values: &[f64]) -> f64 {
@@ -220,7 +197,7 @@ mod tests {
             spread_analyzer_10.handle_quote(&stub_quote(bid_price[i], ask_price[i]));
         }
 
-        assert_eq!(spread_analyzer_10.average, 0.050_000_000_000_001_9);
+        assert_eq!(spread_analyzer_10.average, 0.050_000_000_000_001_42);
     }
 
     #[rstest]
@@ -248,6 +225,27 @@ mod tests {
         assert!(spread_analyzer_10.initialized());
         assert_eq!(spread_analyzer_10.spreads.len(), 10);
         assert!((spread_analyzer_10.average - 0.05).abs() < 1e-9);
+    }
+
+    #[rstest]
+    fn test_average_tracks_varying_spreads_past_capacity(mut spread_analyzer_10: SpreadAnalyzer) {
+        // Regression: with non-constant spreads past `capacity`, the average must keep
+        // tracking the bounded window rather than freezing. Feeding 15 monotonically
+        // increasing spreads (0.01..=0.15) leaves the window holding the last 10
+        // (0.06..=0.15), whose mean is 0.105. The earlier incremental update froze the
+        // average at 0.055 (the mean of the first full window 0.01..=0.10).
+        let bid_price: [&str; 15] = ["100.00"; 15];
+        let ask_price: [&str; 15] = [
+            "100.01", "100.02", "100.03", "100.04", "100.05", "100.06", "100.07", "100.08",
+            "100.09", "100.10", "100.11", "100.12", "100.13", "100.14", "100.15",
+        ];
+
+        for i in 0..15 {
+            spread_analyzer_10.handle_quote(&stub_quote(bid_price[i], ask_price[i]));
+        }
+
+        assert_eq!(spread_analyzer_10.spreads.len(), 10);
+        assert!((spread_analyzer_10.average - 0.105).abs() < 1e-9);
     }
 
     #[rstest]

--- a/crates/indicators/src/ratio/spread_analyzer.rs
+++ b/crates/indicators/src/ratio/spread_analyzer.rs
@@ -88,6 +88,14 @@ impl Indicator for SpreadAnalyzer {
         self.current = spread;
         self.spreads.push(spread);
 
+        // Bound the rolling window to `capacity`, matching the Cython
+        // `deque(maxlen=capacity)`. Without this the buffer grows unbounded and
+        // `fast_mean_iterated` errors (panicking on `unwrap`) once the length
+        // exceeds `capacity`.
+        if self.spreads.len() > self.capacity {
+            self.spreads.remove(0);
+        }
+
         // Update average spread
         self.average =
             fast_mean_iterated(&self.spreads, spread, self.average, self.capacity, false).unwrap();
@@ -213,6 +221,33 @@ mod tests {
         }
 
         assert_eq!(spread_analyzer_10.average, 0.050_000_000_000_001_9);
+    }
+
+    #[rstest]
+    fn test_handles_more_inputs_than_capacity_without_panic(
+        mut spread_analyzer_10: SpreadAnalyzer,
+    ) {
+        // Regression: feeding more than `capacity` quotes must not panic, and the
+        // internal window must stay bounded to `capacity` (matching the Cython
+        // `deque(maxlen=capacity)`). Previously the unbounded buffer caused
+        // `fast_mean_iterated` to error and panic on the (capacity + 1)th quote.
+        let bid_price: [&str; 15] = [
+            "100.50", "100.45", "100.55", "100.60", "100.52", "100.48", "100.53", "100.57",
+            "100.49", "100.51", "100.54", "100.56", "100.58", "100.50", "100.52",
+        ];
+
+        let ask_price: [&str; 15] = [
+            "100.55", "100.50", "100.60", "100.65", "100.57", "100.53", "100.58", "100.62",
+            "100.54", "100.56", "100.59", "100.61", "100.63", "100.55", "100.57",
+        ];
+
+        for i in 0..15 {
+            spread_analyzer_10.handle_quote(&stub_quote(bid_price[i], ask_price[i]));
+        }
+
+        assert!(spread_analyzer_10.initialized());
+        assert_eq!(spread_analyzer_10.spreads.len(), 10);
+        assert!((spread_analyzer_10.average - 0.05).abs() < 1e-9);
     }
 
     #[rstest]

--- a/crates/indicators/src/volatility/fuzzy.rs
+++ b/crates/indicators/src/volatility/fuzzy.rs
@@ -324,6 +324,18 @@ impl FuzzyCandlesticks {
         self.last_low = low;
 
         let total = (high - low).abs();
+
+        // Bound the rolling windows to `period`, matching the Cython
+        // `deque(maxlen=period)`. Without this the fixed-capacity deques grow to
+        // their 1024 capacity, so the means (sum / period) and standard
+        // deviations are computed over far more than `period` candles.
+        if self.lengths.len() == self.period {
+            self.lengths.pop_front();
+            self.body_percents.pop_front();
+            self.upper_wick_percents.pop_front();
+            self.lower_wick_percents.pop_front();
+        }
+
         let _ = self.lengths.push_back(total);
 
         if total == 0.0 {
@@ -615,6 +627,42 @@ mod tests {
 
         let expected_vec = vec![-1, 1, 1, 3, 1];
         assert_eq!(fuzzy_candlesticks_10.vector, expected_vec);
+    }
+
+    #[rstest]
+    fn test_windows_bounded_to_period(mut fuzzy_candlesticks_10: FuzzyCandlesticks) {
+        // Regression: the four rolling windows must stay bounded to `period`
+        // (matching the Cython `deque(maxlen=period)`). Previously the
+        // fixed-capacity deques grew to their 1024 capacity, so the means
+        // (sum / period) and standard deviations were computed over far more than
+        // `period` candles.
+        let bars = [
+            (150.25, 153.4, 148.1, 152.75),
+            (152.8, 155.2, 151.3, 151.95),
+            (151.9, 152.85, 147.6, 148.2),
+            (148.3, 150.75, 146.9, 150.4),
+            (150.5, 154.3, 149.8, 153.9),
+            (153.95, 155.8, 152.2, 152.6),
+            (152.7, 153.4, 148.5, 149.1),
+            (149.2, 151.9, 147.3, 151.5),
+            (151.6, 156.4, 151.0, 155.8),
+            (155.9, 157.2, 153.7, 154.3),
+            (154.3, 158.0, 153.0, 157.2),
+            (157.2, 159.5, 155.1, 156.0),
+            (156.0, 156.9, 152.4, 153.1),
+            (153.1, 155.0, 150.2, 154.8),
+            (154.8, 157.7, 154.0, 156.9),
+        ];
+
+        for (open, high, low, close) in bars {
+            fuzzy_candlesticks_10.update_raw(open, high, low, close);
+        }
+
+        assert!(fuzzy_candlesticks_10.initialized());
+        assert_eq!(fuzzy_candlesticks_10.lengths.len(), 10);
+        assert_eq!(fuzzy_candlesticks_10.body_percents.len(), 10);
+        assert_eq!(fuzzy_candlesticks_10.upper_wick_percents.len(), 10);
+        assert_eq!(fuzzy_candlesticks_10.lower_wick_percents.len(), 10);
     }
 
     #[rstest]

--- a/crates/indicators/src/volatility/rvi.rs
+++ b/crates/indicators/src/volatility/rvi.rs
@@ -131,6 +131,14 @@ impl RelativeVolatilityIndex {
     }
 
     pub fn update_raw(&mut self, close: f64) {
+        // Bound the price window to `period`, matching the Cython
+        // `deque(maxlen=period)`. The fixed-capacity deque otherwise retains up
+        // to 1024 prices, so the standard deviation below is computed over far
+        // more than `period` observations while using a `period`-window mean.
+        if self.prices.len() == self.period {
+            self.prices.pop_front();
+        }
+
         self.prices.push_back(close);
         self.ma.update_raw(close);
 
@@ -220,6 +228,21 @@ mod tests {
         }
 
         assert!(rvi_10.initialized());
+        assert_eq!(rvi_10.value, 10.0);
+    }
+
+    #[rstest]
+    fn test_prices_window_bounded_to_period(mut rvi_10: RelativeVolatilityIndex) {
+        // Regression: the price window must stay bounded to `period` (matching the
+        // Cython `deque(maxlen=period)`). Previously the fixed-capacity deque grew
+        // to its 1024 capacity, so the standard deviation was computed over far
+        // more than `period` prices while using a `period`-window mean.
+        for i in 0..50 {
+            rvi_10.update_raw(100.0 + f64::from(i));
+        }
+
+        assert!(rvi_10.initialized());
+        assert_eq!(rvi_10.prices.len(), 10);
         assert_eq!(rvi_10.value, 10.0);
     }
 


### PR DESCRIPTION
## Summary

Extends the indicator rolling-window bug-fix lineage (#4239 `DonchianChannel` →
#4326 `RateOfChange` → #4333 `VerticalHorizontalFilter` / `OnBalanceVolume`) with
the remaining members of the family. Each indicator stored its rolling window in an
unbounded `Vec` or a fixed-1024-capacity `ArrayDeque` instead of bounding it to
`period` / `capacity` like the Cython reference's `deque(maxlen=...)`, so each
diverged from Cython once more than the window size of observations was processed.

One commit per indicator:

- **SpreadAnalyzer** — the unbounded `Vec` of spreads made `fast_mean_iterated`
  receive a slice longer than its expected length, return `Err`, and panic on
  `.unwrap()` at the `(capacity + 1)`th quote (a live-trading crash). Bound the
  window to `capacity`.
- **EfficiencyRatio** — unbounded `inputs` and `deltas` made `net_diff` use the
  all-time-first price and `sum_deltas` sum every delta ever seen; `reset()` also
  left `deltas` populated. Bound both to `period` and clear `deltas` on reset.
  Since `AdaptiveMovingAverage` embeds this indicator, its Kaufman efficiency input
  is corrected too.
- **RelativeVolatilityIndex** — the standard deviation was computed over up to 1024
  prices while the mean came from the `period`-window SMA. Bound the price window to
  `period`.
- **FuzzyCandlesticks** — four buffers (candle lengths, body/upper-wick/lower-wick
  percents) grew to 1024, inflating the `sum / period` means and the std
  denominators. Bound all four to `period`.

All now match the Cython `deque(maxlen=period)` (or `maxlen=capacity`) semantics.

## Tests

Each fix adds a regression test feeding more than `period` / `capacity`
observations — the gap the existing per-indicator tests missed by stopping at
exactly the window size.

- `cargo nextest run -p nautilus-indicators` — all pass (including `AdaptiveMovingAverage` / AMAT unchanged).
- `cargo clippy -p nautilus-indicators --all-targets --all-features -- -D warnings`
  clean; nightly `cargo fmt`.
