### PR TITLE
Fix per-contract fees for option spreads

### DIFF
--- a/crates/execution/src/models/fee.rs
+++ b/crates/execution/src/models/fee.rs
@@ -309,11 +309,39 @@ impl FeeModel for PerContractFeeModel {
         _order: &OrderAny,
         fill_quantity: Quantity,
         _fill_px: Price,
-        _instrument: &InstrumentAny,
+        instrument: &InstrumentAny,
     ) -> anyhow::Result<Money> {
-        let total = self.commission.as_decimal() * fill_quantity.as_decimal();
+        let total = self.commission.as_decimal()
+            * fill_quantity.as_decimal()
+            * spread_contract_count(instrument);
         Money::from_decimal(total, self.commission.currency).map_err(Into::into)
     }
+}
+
+fn spread_contract_count(instrument: &InstrumentAny) -> Decimal {
+    let symbol = instrument.id().symbol.to_string();
+    if !symbol.contains("___") {
+        return Decimal::ONE;
+    }
+
+    symbol
+        .split("___")
+        .filter_map(spread_leg_ratio)
+        .sum::<i64>()
+        .max(1)
+        .into()
+}
+
+fn spread_leg_ratio(component: &str) -> Option<i64> {
+    let ratio = component
+        .strip_prefix("((")
+        .and_then(|rest| rest.split_once("))").map(|(ratio, _)| ratio))
+        .or_else(|| {
+            component
+                .strip_prefix('(')
+                .and_then(|rest| rest.split_once(')').map(|(ratio, _)| ratio))
+        })?;
+    ratio.parse::<i64>().ok()
 }
 
 #[derive(Debug, Clone)]
@@ -605,9 +633,13 @@ mod tests {
 
     use nautilus_model::{
         enums::{LiquiditySide, OrderSide, OrderType},
+        identifiers::InstrumentId,
         instruments::{
             BinaryOption, CryptoOption, Instrument, InstrumentAny, OptionContract,
-            stubs::{audusd_sim, binary_option, crypto_option_btc_deribit, option_contract_appl},
+            stubs::{
+                audusd_sim, binary_option, crypto_option_btc_deribit, option_contract_appl,
+                option_spread,
+            },
         },
         orders::{
             Order, OrderAny,
@@ -783,6 +815,33 @@ mod tests {
             )
             .unwrap();
         assert_eq!(commission, Money::new(50.0, Currency::USD()));
+    }
+
+    #[rstest]
+    fn test_per_contract_fee_model_option_spread_charges_each_contract() {
+        let commission_per_contract = Money::from("1.25 USD");
+        let fee_model = PerContractFeeModel::new(commission_per_contract).unwrap();
+        let spread_id = InstrumentId::from("((2))SPY C410___(1)SPY C400.SMART");
+        let mut option_spread = option_spread();
+        option_spread.id = spread_id;
+        let instrument = InstrumentAny::OptionSpread(option_spread);
+        let market_order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from(2))
+            .build();
+        let accepted_order = TestOrderStubs::make_accepted_order(&market_order);
+
+        let commission = fee_model
+            .get_commission(
+                &accepted_order,
+                Quantity::from(2),
+                Price::from("1.0"),
+                &instrument,
+            )
+            .unwrap();
+
+        assert_eq!(commission, Money::from("7.50 USD"));
     }
 
     #[rstest]

--- a/nautilus_trader/backtest/models/fee.pyx
+++ b/nautilus_trader/backtest/models/fee.pyx
@@ -22,6 +22,7 @@ from nautilus_trader.core.rust.core cimport NANOSECONDS_IN_MILLISECOND
 from nautilus_trader.core.rust.model cimport LiquiditySide
 from nautilus_trader.model.book cimport OrderBook
 from nautilus_trader.model.functions cimport liquidity_side_to_str
+from nautilus_trader.model.identifiers cimport generic_spread_id_n_legs
 from nautilus_trader.model.instruments.base cimport Instrument
 from nautilus_trader.model.objects cimport Money
 from nautilus_trader.model.objects cimport Price
@@ -205,4 +206,7 @@ cdef class PerContractFeeModel(FeeModel):
         Price fill_px,
         Instrument instrument,
     ):
-        return Money(self._commission * fill_qty, self._commission.currency)
+        return Money(
+            self._commission * fill_qty * generic_spread_id_n_legs(instrument.id),
+            self._commission.currency,
+        )

--- a/tests/unit_tests/backtest/test_commission_model.py
+++ b/tests/unit_tests/backtest/test_commission_model.py
@@ -19,15 +19,19 @@ import pytest
 
 from nautilus_trader.backtest.models import FixedFeeModel
 from nautilus_trader.backtest.models import MakerTakerFeeModel
+from nautilus_trader.backtest.models import PerContractFeeModel
 from nautilus_trader.model.currencies import BTC
 from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OptionKind
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.identifiers import Symbol
 from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import new_generic_spread_id
 from nautilus_trader.model.instruments import CryptoOption
 from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.instruments import OptionSpread
 from nautilus_trader.model.objects import Money
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
@@ -108,6 +112,49 @@ def test_fixed_commission_multiple_fills(
     # Assert
     assert commission_first_fill == expected_first_fill
     assert commission_next_fill == expected_next_fill
+
+
+def test_per_contract_commission_option_spread_charges_each_contract():
+    # Arrange
+    spread_id = new_generic_spread_id(
+        [
+            (InstrumentId.from_str("SPY C400.SMART"), 1),
+            (InstrumentId.from_str("SPY C410.SMART"), -2),
+        ],
+    )
+    instrument = OptionSpread(
+        instrument_id=spread_id,
+        raw_symbol=spread_id.symbol,
+        asset_class=AssetClass.EQUITY,
+        currency=USD,
+        price_precision=2,
+        price_increment=Price.from_str("0.01"),
+        multiplier=Quantity.from_int(100),
+        lot_size=Quantity.from_int(1),
+        underlying="SPY",
+        strategy_type="SPREAD",
+        activation_ns=0,
+        expiration_ns=0,
+        ts_event=0,
+        ts_init=0,
+    )
+    fee_model = PerContractFeeModel(Money(Decimal("1.25"), USD))
+    order = TestExecStubs.make_accepted_order(
+        instrument=instrument,
+        order_side=OrderSide.BUY,
+        quantity=Quantity.from_int(2),
+    )
+
+    # Act
+    commission = fee_model.get_commission(
+        order,
+        Quantity.from_int(2),
+        Price.from_str("1.00"),
+        instrument,
+    )
+
+    # Assert
+    assert commission == Money(Decimal("7.50"), USD)
 
 
 def test_instrument_percent_commission_maker(instrument):


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes `PerContractFeeModel` so option spreads charge per underlying contract leg, not once for the whole spread fill.
- Applies the same behavior in legacy Cython backtests and Rust v2 execution fee models.
- Uses ratio-weighted leg counts, so a 1/-2 spread charges three fee units per spread unit.
- Confirms generated spread leg fills also carry their leg-level fees; these are the fills consumed by portfolio accounting.
- Leaves `FixedFeeModel` unchanged because fixed fees are intentionally charged once per fill or order.

### Design decisions

- Reuses the existing Cython `generic_spread_id_n_legs` helper instead of duplicating spread parsing in the fee model.
- Uses a small guarded Rust parser for the existing generic spread ID format because this branch does not expose a Rust spread-ID helper.
- Falls back to one contract for non-generic IDs so regular instruments and non-generic spread IDs keep existing behavior.
- Counts the absolute value of each leg ratio because brokers charge per traded contract, not per distinct leg row.
- Keeps the parent spread `OrderFilled` commission populated for order history while preserving leg-fill commissions for accounting. Portfolio/accounting skips spread-instrument balance updates and consumes the generated leg fills, so the accounting-relevant fees remain on the leg events.

### Implementation

- `nautilus_trader/backtest/models/fee.pyx` multiplies per-contract commission by `generic_spread_id_n_legs(instrument.id)`.
- `crates/execution/src/models/fee.rs` adds `spread_contract_count` and `spread_leg_ratio`, then uses them in `PerContractFeeModel`.
- `tests/unit_tests/backtest/test_commission_model.py` adds a 1/-2 option spread fee test.
- `tests/unit_tests/backtest/test_matching_engine.py` asserts a 1/-2 spread fill emits the total parent fee and leg-level fees of 2.50 USD and 5.00 USD.
- `crates/execution/src/models/fee.rs` adds the matching Rust unit test.

### Flow

```mermaid
flowchart LR
    Fill["Spread fill quantity"] --> Legs["Generic spread leg ratios"]
    Legs --> Count["Sum absolute ratios"]
    Count --> Fee["commission * fill_qty * contract_count"]
```

### Verification

- Passed `cargo fmt --check --manifest-path crates/execution/Cargo.toml`.
- Passed `cargo test -p nautilus-execution test_per_contract_fee_model_option_spread_charges_each_contract --lib`.
- Passed `cargo test -p nautilus-execution test_per_contract_fee_model --lib`.
- Passed `make build-debug`.
- Passed `uv run --no-sync pytest tests/unit_tests/backtest/test_commission_model.py::test_per_contract_commission_option_spread_charges_each_contract`.
- Passed `uv run --no-sync pytest tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_spread_order_and_leg_fills_have_per_contract_commission`.
- Passed `uv run --no-sync pytest tests/unit_tests/backtest/test_commission_model.py::test_per_contract_commission_option_spread_charges_each_contract tests/unit_tests/backtest/test_matching_engine.py::TestOrderMatchingEngine::test_spread_order_and_leg_fills_have_per_contract_commission`.
- Passed `uv run --no-sync ruff check tests/unit_tests/backtest/test_commission_model.py`.
- Passed `uv run --no-sync ruff format --check tests/unit_tests/backtest/test_commission_model.py`.
- Passed `uv run --no-sync ruff check tests/unit_tests/backtest/test_commission_model.py tests/unit_tests/backtest/test_matching_engine.py`.
- Passed `uv run --no-sync ruff format --check tests/unit_tests/backtest/test_commission_model.py tests/unit_tests/backtest/test_matching_engine.py`.
- Passed `git diff --check`.




## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4360

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
