### PR TITLE
Set quote anchor before grid order submission

### DIFF
--- a/nautilus_trader/examples/strategies/grid_market_maker.py
+++ b/nautilus_trader/examples/strategies/grid_market_maker.py
@@ -114,6 +114,7 @@ class GridMarketMaker(Strategy):
         self._trade_size: Quantity | None = config.trade_size
         self._price_precision: int | None = None
         self._last_quoted_mid: Price | None = None
+        self._pending_grid_signature: tuple[tuple[OrderSide, Price], ...] | None = None
         self._pending_self_cancels: set[ClientOrderId] = set()
 
     def on_start(self) -> None:
@@ -190,12 +191,19 @@ class GridMarketMaker(Strategy):
         if not grid:
             return
 
+        grid_signature = tuple(grid)
+        if not has_resting and self._pending_grid_signature == grid_signature:
+            return
+
         expire_time = None
         tif = TimeInForce.GTC
 
         if self.config.expire_time_secs is not None:
             expire_time = self.clock.utc_now() + timedelta(seconds=self.config.expire_time_secs)
             tif = TimeInForce.GTD
+
+        self._last_quoted_mid = mid
+        self._pending_grid_signature = grid_signature
 
         for side, price in grid:
             order = self.order_factory.limit(
@@ -209,8 +217,6 @@ class GridMarketMaker(Strategy):
             )
             self.submit_order(order)
 
-        self._last_quoted_mid = mid
-
     def on_order_filled(self, event: OrderFilled) -> None:
         """
         Actions to be performed when an order is filled.
@@ -220,6 +226,7 @@ class GridMarketMaker(Strategy):
         order = self.cache.order(event.client_order_id)
         if order is not None and order.is_closed:
             self._pending_self_cancels.discard(event.client_order_id)
+            self._pending_grid_signature = None
 
     def on_order_rejected(self, event: OrderRejected) -> None:
         """
@@ -228,6 +235,7 @@ class GridMarketMaker(Strategy):
         self._pending_self_cancels.discard(event.client_order_id)
         # Reset so the next quote tick can retry placing the full grid
         self._last_quoted_mid = None
+        self._pending_grid_signature = None
 
     def on_order_expired(self, event: OrderExpired) -> None:
         """
@@ -236,6 +244,7 @@ class GridMarketMaker(Strategy):
         self._pending_self_cancels.discard(event.client_order_id)
         # GTD expiry means the grid is gone; reset so re-quoting is not suppressed
         self._last_quoted_mid = None
+        self._pending_grid_signature = None
 
     def on_order_canceled(self, event: OrderCanceled) -> None:
         """
@@ -248,6 +257,7 @@ class GridMarketMaker(Strategy):
         if self.config.on_cancel_resubmit:
             # Reset so the next quote tick triggers a full grid resubmission
             self._last_quoted_mid = None
+            self._pending_grid_signature = None
 
     def on_reset(self) -> None:
         """
@@ -257,6 +267,7 @@ class GridMarketMaker(Strategy):
         self._trade_size = self.config.trade_size
         self._price_precision = None
         self._last_quoted_mid = None
+        self._pending_grid_signature = None
         self._pending_self_cancels.clear()
 
     def _should_requote(self, mid: Price) -> bool:

--- a/tests/unit_tests/examples/strategies/test_grid_market_maker.py
+++ b/tests/unit_tests/examples/strategies/test_grid_market_maker.py
@@ -321,6 +321,62 @@ def test_anchor_set_after_first_quote(env):
     assert strategy._last_quoted_mid == Price(0.65000, env.instrument.price_precision)
 
 
+def test_anchor_set_before_first_order_submit(env, monkeypatch):
+    # Arrange
+    strategy = _make_strategy(env)
+    strategy.start()
+    original_submit_order = strategy.submit_order
+    observed_anchor = []
+
+    def submit_order_spy(order, *args, **kwargs):
+        observed_anchor.append(strategy._last_quoted_mid)
+        return original_submit_order(order, *args, **kwargs)
+
+    monkeypatch.setattr(strategy, "submit_order", submit_order_spy)
+
+    # Act
+    _process_quote(env, bid_price=0.64990, ask_price=0.65010)
+
+    # Assert
+    assert observed_anchor
+    assert all(anchor == Price(0.65000, env.instrument.price_precision) for anchor in observed_anchor)
+
+
+def test_duplicate_quote_during_first_submit_does_not_double_submit_grid(env, monkeypatch):
+    # Arrange
+    strategy = _make_strategy(env)
+    strategy.start()
+    original_submit_order = strategy.submit_order
+    reentered = False
+
+    ts = env.clock.timestamp_ns()
+    tick = TestDataStubs.quote_tick(
+        instrument=env.instrument,
+        bid_price=0.64990,
+        ask_price=0.65010,
+        ts_event=ts,
+        ts_init=ts,
+    )
+
+    def submit_order_with_reentrant_quote(order, *args, **kwargs):
+        nonlocal reentered
+        if not reentered:
+            reentered = True
+            strategy.on_quote_tick(tick)
+        return original_submit_order(order, *args, **kwargs)
+
+    monkeypatch.setattr(strategy, "submit_order", submit_order_with_reentrant_quote)
+
+    # Act
+    env.data_engine.process(tick)
+    env.exchange.process_quote_tick(tick)
+    env.exchange.process(ts)
+
+    # Assert
+    assert reentered
+    assert len(env.cache.orders_open(instrument_id=env.instrument.id)) == 6
+
+
 def test_requote_suppressed_below_threshold(env):
     # Arrange — requote_threshold_bps=5, first quote sets the anchor at mid=0.65000
     strategy = _make_strategy(env, requote_threshold_bps=5)


### PR DESCRIPTION
## Summary
- set the grid requote anchor before submitting the first order in a new grid
- track the pending grid signature so a reentrant quote callback cannot submit the same empty-cache grid twice
- clear pending grid state on terminal order events and reset
- add regression coverage for pre-submit anchor state and reentrant quote handling

## Verification
- git diff --check
- python3 -m py_compile nautilus_trader/examples/strategies/grid_market_maker.py tests/unit_tests/examples/strategies/test_grid_market_maker.py

Note: full pytest was not run because pytest/uv are not available in this environment.