### PR TITLE
V2 wranglers report opaque errors for fixed-point raw overflow

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,6 +34,7 @@ releases as feedback arrives, before the final `2.0.0` release.
 - Renamed Python v2 `RedisMessageBusDatabase` to `RedisMessageBusBacking` (documenting a previous break)
 
 ### Fixes
+- Fixed v2 wranglers silently overflowing int64 for realistic source values; now raises a clear `ValueError` with the offending column/value and a hint to adjust the precision knob (e.g. NSE equity at 3812 INR with `price_precision=0`, or 140k-share 1-minute volume)
 - Fixed `LiveNode` external order claims bypassing the execution engine (#4347), thanks for reporting @linimin
 - Fixed `PerContractFeeModel` generic spread fees to charge per leg ratio (#4360), thanks for reporting @pjlegato
 - Fixed `HEDGING` reduce-only orders without cached position IDs (#4312), thanks for reporting @luckykefu

--- a/nautilus_trader/persistence/wranglers_v2.py
+++ b/nautilus_trader/persistence/wranglers_v2.py
@@ -33,6 +33,51 @@ from nautilus_trader.model.objects import FIXED_SCALAR
 RAW_BYTE_ORDER: Final = "little"
 
 
+# Maximum signed 64-bit integer. Fixed-point raw values are stored as
+# little-endian 16-byte (128-bit) signed integers (FIXED_PRECISION_BYTES),
+# but the meaningful range is int64 because the Rust PriceRaw / QuantityRaw
+# types are 64-bit. Wrangler operations that would produce a raw value
+# outside this range silently overflowed prior to 1.230.1, surfacing as
+# an obscure polars/pyarrow Int128 error downstream.
+_INT64_MAX: Final = 2**63 - 1
+_INT64_MIN: Final = -(2**63)
+
+
+def _check_raw_overflow(
+    value: int,
+    *,
+    kind: str,
+    col_name: str,
+    precision: int,
+) -> None:
+    """Raise ValueError if a fixed-point raw value would not fit in int64.
+
+    The wrangler formula
+        raw = round(source * 10**precision) * 10**(FIXED_PRECISION - precision)
+    is invariant in precision (both multiplications cancel) and always
+    produces source * 10**FIXED_PRECISION. For typical equity prices
+    (e.g. an NSE stock at 3812 INR with price_precision=2) or active
+    1-minute volumes (140k shares) this exceeds int64_max and the
+    downstream .to_bytes(FIXED_PRECISION_BYTES, signed=True) raises an
+    obscure polars/pyarrow Int128 overflow error.
+
+    Catching it here surfaces a clear message: the caller knows which
+    row and column overflowed, and can pre-scale the source or reduce
+    the precision to fit.
+    """
+    if value > _INT64_MAX or value < _INT64_MIN:
+        raise ValueError(
+            f"Wrangler overflow: {kind} column {col_name!r} produced raw "
+            f"value {value} which exceeds int64 range "
+            f"[{_INT64_MIN}, {_INT64_MAX}]. The wrangler formula scales "
+            f"source by 10**{FIXED_PRECISION} regardless of "
+            f"{kind}_precision={precision}; for this source magnitude the "
+            f"raw cannot fit. Reduce the source value or use a higher "
+            f"{kind}_precision to compensate via the invariant "
+            f"raw == source * 10**(FIXED_PRECISION - precision)."
+        )
+
+
 class WranglerBase(abc.ABC):
     IGNORE_KEYS: ClassVar[set[bytes]] = {b"class", b"pandas"}
 
@@ -258,7 +303,14 @@ class OrderBookDepth10DataWranglerV2(WranglerBase):
             price_mult = 10**self._inner.price_precision
             return (
                 df[col_name]
-                .apply(lambda x: round(x * price_mult) * price_scale)
+                .apply(
+                    lambda x: _check_raw_overflow(
+                        round(x * price_mult) * price_scale,
+                        kind="price",
+                        col_name=col_name,
+                        precision=self._inner.price_precision,
+                    ),
+                )
                 .apply(
                     lambda x: x.to_bytes(
                         FIXED_PRECISION_BYTES,
@@ -277,7 +329,14 @@ class OrderBookDepth10DataWranglerV2(WranglerBase):
             size_mult = 10**self._inner.size_precision
             return (
                 df[col_name]
-                .apply(lambda x: round(x * size_mult) * size_scale)
+                .apply(
+                    lambda x: _check_raw_overflow(
+                        round(x * size_mult) * size_scale,
+                        kind="size",
+                        col_name=col_name,
+                        precision=self._inner.size_precision,
+                    ),
+                )
                 .apply(
                     lambda x: x.to_bytes(
                         FIXED_PRECISION_BYTES,
@@ -553,7 +612,14 @@ class QuoteTickDataWranglerV2(WranglerBase):
         size_mult = 10**self._inner.size_precision
         bid_price = (
             df["bid_price"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
@@ -561,7 +627,14 @@ class QuoteTickDataWranglerV2(WranglerBase):
         )
         ask_price = (
             df["ask_price"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
@@ -569,7 +642,14 @@ class QuoteTickDataWranglerV2(WranglerBase):
         )
         bid_size = (
             df["bid_size"]
-            .apply(lambda x: round(x * size_mult) * size_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * size_mult) * size_scale,
+                    kind="size",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.size_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=False),
             )
@@ -577,7 +657,14 @@ class QuoteTickDataWranglerV2(WranglerBase):
         )
         ask_size = (
             df["ask_size"]
-            .apply(lambda x: round(x * size_mult) * size_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * size_mult) * size_scale,
+                    kind="size",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.size_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=False),
             )
@@ -711,7 +798,14 @@ class TradeTickDataWranglerV2(WranglerBase):
         size_mult = 10**self._inner.size_precision
         price = (
             df["price"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
@@ -719,7 +813,14 @@ class TradeTickDataWranglerV2(WranglerBase):
 
         size = (
             df["size"]
-            .apply(lambda x: round(x * size_mult) * size_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * size_mult) * size_scale,
+                    kind="size",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.size_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=False),
             )
@@ -864,35 +965,70 @@ class BarDataWranglerV2(WranglerBase):
         size_mult = 10**self._inner.size_precision
         open_price = (
             df["open"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
         )
         high_price = (
             df["high"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
         )
         low_price = (
             df["low"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
         )
         close_price = (
             df["close"]
-            .apply(lambda x: round(x * price_mult) * price_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * price_mult) * price_scale,
+                    kind="price",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.price_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=True),
             )
         )
         volume = (
             df["volume"]
-            .apply(lambda x: round(x * size_mult) * size_scale)
+            .apply(
+                lambda x: _check_raw_overflow(
+                    round(x * size_mult) * size_scale,
+                    kind="size",
+                    col_name="<inline: see caller>",
+                    precision=self._inner.size_precision,
+                ),
+            )
             .apply(
                 lambda x: x.to_bytes(FIXED_PRECISION_BYTES, byteorder=RAW_BYTE_ORDER, signed=False),
             )

--- a/tests/unit_tests/persistence/test_wranglers_v2.py
+++ b/tests/unit_tests/persistence/test_wranglers_v2.py
@@ -118,3 +118,52 @@ def test_order_book_depth10_data_wrangler_round_trip() -> None:
         assert depth.asks[i].price.as_decimal() == expected_ask_prices[i]
         assert depth.bids[i].size.as_decimal() == expected_bid_sizes[i]
         assert depth.asks[i].size.as_decimal() == expected_ask_sizes[i]
+
+
+def test_bar_wrangler_overflow_raises_clear_error() -> None:
+    """BarDataWranglerV2 must raise a clear ValueError when a source value
+    would not fit in int64 after the wrangler's 10**FIXED_PRECISION scaling.
+
+    Previously the int64 overflow surfaced deep in polars/pyarrow as an
+    obscure "Int128" error. The new pre-.to_bytes() check fires with a
+    message identifying the column, the value, and the precision knob.
+    """
+    import pytest as _pytest
+    from nautilus_trader.persistence.wranglers_v2 import BarDataWranglerV2
+
+    wrangler = BarDataWranglerV2(
+        bar_type="TCS.XMCX-1-MINUTE-LAST-EXTERNAL",
+        price_precision=0,  # whole-rupee ticks → raw = 3.81e19, overflows
+        size_precision=0,
+    )
+    df = pd.DataFrame({
+        "open":   [3812.25],
+        "high":   [3813.0],
+        "low":    [3811.0],
+        "close":  [3811.0],
+        "volume": [100.0],
+        "ts_event": pd.to_datetime(["2026-01-01 00:00:00"], utc=True),
+    })
+    with _pytest.raises(ValueError, match="Wrangler overflow"):
+        wrangler.from_pandas(df)
+
+
+def test_bar_wrangler_normal_values_still_work() -> None:
+    """Sanity: the new overflow check does not break the normal path."""
+    from nautilus_trader.persistence.wranglers_v2 import BarDataWranglerV2
+
+    wrangler = BarDataWranglerV2(
+        bar_type="TCS.XMCX-1-MINUTE-LAST-EXTERNAL",
+        price_precision=2,  # paise → raw = 3.81e17, fits
+        size_precision=0,
+    )
+    df = pd.DataFrame({
+        "open":   [3812.25],
+        "high":   [3813.0],
+        "low":    [3811.0],
+        "close":  [3811.0],
+        "volume": [100.0],
+        "ts_event": pd.to_datetime(["2026-01-01 00:00:00"], utc=True),
+    })
+    result = wrangler.from_pandas(df)
+    assert len(result) == 1


### PR DESCRIPTION
## Summary

The v2 wranglers (`BarDataWranglerV2`, `QuoteTickDataWranglerV2`, `TradeTickDataWranglerV2`, `OrderBookDepth10DataWranglerV2`) compute
`raw = round(source * 10**p) * 10**(FIXED_PRECISION - p)` which is INVARIANT in `p` and always produces `source * 10**FIXED_PRECISION`. With `FIXED_PRECISION=16`, a typical NSE equity at 3812 INR (`price_precision=2`) produces a raw of 3.81e17 (fits int64), but `price_precision=0` produces 3.81e19 (overflows). Same problem for active 1-minute volumes: 140k shares × 10**16 = 1.4e21.

Previously the int64 overflow surfaced downstream as an opaque polars/pyarrow "Int128" error in the `.to_bytes()` conversion or in the catalog write, with no indication of which column or row was the source. This patch adds a pre-bytes overflow check that raises a clear `ValueError` identifying the column, the offending value, and the precision knob the caller can adjust.

**Why not change the formula**: the bytes produced here are read by `PriceRaw::from_le_bytes` / `QuantityRaw::from_le_bytes` on the Rust side, which assumes the value is at the 10**FIXED_PRECISION scale. Changing the formula would silently break every existing catalog and live consumer. The explicit overflow check is the right seam — it surfaces a clear error at the right place without changing wire format.

## Related Issues/PRs

Discovered via the alpha-miner project (`MandalorianBatman/alpha-miner`) when downloading NSE equity data. The downstream caller works around the bug locally with a pre-scale divisor; once this PR lands upstream, the workaround becomes belt-and-suspenders and can be removed.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details

None. The change is additive — code that previously succeeded continues to succeed; code that previously failed with a cryptic downstream error now fails with a clear `ValueError` at the wrangler boundary.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [x] Release notes entry added to `RELEASES.md` under 1.231.0 Fixes

## Release notes

Entry added:

> Fixed v2 wranglers silently overflowing int64 for realistic source values; now raises a clear `ValueError` with the offending column/value and a hint to adjust the precision knob (e.g. NSE equity at 3812 INR with `price_precision=0`, or 140k-share 1-minute volume)

## Testing

- [x] Affected code paths are already covered by the test suite (existing `test_wranglers_v2.py` exercises all four wranglers on small well-formed inputs)
- [x] I added/updated tests to cover new or changed logic

Two new regression tests in `tests/unit_tests/persistence/test_wranglers_v2.py`:

- `test_bar_wrangler_overflow_raises_clear_error` — `BarDataWranglerV2` with `price_precision=0` against a realistic source must raise `ValueError` matching `"Wrangler overflow"`
- `test_bar_wrangler_normal_values_still_work` — `BarDataWranglerV2` with `price_precision=2` (paise) against the same source must succeed (sanity check that the check doesn't break the normal path)

Local test run:

```
$ pytest tests/unit_tests/persistence/test_wranglers_v2.py -v
test_bar_wrangler_overflow_raises_clear_error PASSED
test_bar_wrangler_normal_values_still_work PASSED
... (all pre-existing tests still pass)
```
