### PR TITLE
Fix Tardis replay inconsistent trades folder name

### DIFF
--- a/crates/adapters/tardis/src/replay.rs
+++ b/crates/adapters/tardis/src/replay.rs
@@ -475,7 +475,7 @@ fn batch_and_write_deltas(
     match book_deltas_to_arrow_record_batch_bytes(deltas) {
         Ok(batch) => write_batch(
             &batch,
-            "order_book_deltas",
+            OrderBookDelta::path_prefix(),
             instrument_id,
             date,
             path,
@@ -497,7 +497,7 @@ fn batch_and_write_depths(
     match book_depth10_to_arrow_record_batch_bytes(depths) {
         Ok(batch) => write_batch(
             &batch,
-            "order_book_depths",
+            OrderBookDepth10::path_prefix(),
             instrument_id,
             date,
             path,
@@ -539,7 +539,14 @@ fn batch_and_write_trades(
     compression: Compression,
 ) {
     match trades_to_arrow_record_batch_bytes(trades) {
-        Ok(batch) => write_batch(&batch, "trade_tick", instrument_id, date, path, compression),
+        Ok(batch) => write_batch(
+            &batch,
+            TradeTick::path_prefix(),
+            instrument_id,
+            date,
+            path,
+            compression,
+        ),
         Err(e) => {
             log::error!("Error converting TradeTick to Arrow: {e:?}");
         }
@@ -723,7 +730,7 @@ mod tests {
         common::{enums::TardisExchange, testing::load_test_json},
         config::BookSnapshotOutput,
         machine::{
-            message::{BookSnapshotMsg, OptionSummaryMsg, WsMessage},
+            message::{BookSnapshotMsg, OptionSummaryMsg, TradeMsg, WsMessage},
             parse::parse_tardis_ws_message,
             types::TardisInstrumentMiniInfo,
         },
@@ -862,5 +869,65 @@ mod tests {
         assert_eq!(quotes_out, vec![quote_1, quote_2]);
         assert_eq!(quotes_out[0].instrument_id, instrument_id);
         assert!(quotes_out[0].ts_init < quotes_out[1].ts_init);
+    }
+
+    #[rstest]
+    fn test_trades_replay_catalog_round_trip() {
+        let instrument_id = InstrumentId::from("XBTUSD.BITMEX");
+        let compression = ParquetCompression::Zstd.as_parquet_compression();
+        let info = Arc::new(TardisInstrumentMiniInfo::new(
+            instrument_id,
+            None,
+            TardisExchange::Bitmex,
+            1,
+            0,
+        ));
+
+        let trade_msg: TradeMsg = serde_json::from_str(&load_test_json("trade.json")).unwrap();
+        let Some(Data::Trade(trade_1)) = parse_tardis_ws_message(
+            WsMessage::Trade(trade_msg),
+            &info,
+            &BookSnapshotOutput::Deltas,
+        ) else {
+            panic!("Expected trade message to route to Data::Trade");
+        };
+
+        let mut trade_2 = trade_1;
+        trade_2.ts_event = trade_1.ts_event + 1_000_000_000;
+        trade_2.ts_init = trade_1.ts_init + 1_000_000_000;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_path = temp_dir.path().join("data");
+
+        let mut trades_map: AHashMap<InstrumentId, Vec<TradeTick>> = AHashMap::new();
+        let mut trades_cursors: AHashMap<InstrumentId, DateCursor> = AHashMap::new();
+
+        for trade in [trade_1, trade_2] {
+            handle_trade_msg(
+                trade,
+                &mut trades_map,
+                &mut trades_cursors,
+                &data_path,
+                compression,
+            );
+        }
+
+        for (id, trades) in &trades_map {
+            let cursor = trades_cursors.get(id).expect("Expected cursor");
+            batch_and_write_trades(trades, id, cursor.date_utc, &data_path, compression);
+        }
+
+        // Trades must be written under the catalog convention path ("trades")
+        assert!(data_path.join(TradeTick::path_prefix()).exists());
+        assert!(!data_path.join("trade_tick").exists());
+
+        let mut catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
+        let trades_out = catalog
+            .trade_ticks(Some(vec![instrument_id.to_string()]), None, None)
+            .unwrap();
+
+        assert_eq!(trades_out, vec![trade_1, trade_2]);
+        assert_eq!(trades_out[0].instrument_id, instrument_id);
+        assert!(trades_out[0].ts_init < trades_out[1].ts_init);
     }
 }


### PR DESCRIPTION
## Summary

Closes #4371

Tardis replay wrote quotes to `quotes/` (via `QuoteTick::path_prefix()`) but trades to a hardcoded `"trade_tick"` folder, producing inconsistent output directories:

```
/data/tardis/data/quotes
/data/tardis/data/trade_tick
```

Trades written to `trade_tick/` are also not discoverable by `ParquetDataCatalog`, which queries trade data via `TradeTick::path_prefix()` (`trades/`).

## Changes

- `batch_and_write_trades` now uses `TradeTick::path_prefix()` (`"trades"`) instead of the hardcoded `"trade_tick"`.
- `batch_and_write_deltas` / `batch_and_write_depths` switched from hardcoded strings (`"order_book_deltas"` / `"order_book_depths"`) to `OrderBookDelta::path_prefix()` / `OrderBookDepth10::path_prefix()` — same values, removes remaining hardcoding so writers can't drift from catalog conventions.
- Added `test_trades_replay_catalog_round_trip`: parses the `trade.json` fixture, writes trades via the replay path, asserts output lands under `trades/` (not `trade_tick/`), and round-trips through `ParquetDataCatalog::trade_ticks()`.

## Test plan

- [x] `cargo build -p nautilus-tardis --bins --tests` passes
- [x] `rustfmt --check` clean on the changed file
- [ ] `cargo test -p nautilus-tardis replay` (reviewer/CI to confirm)