### PR TITLE
Move live reconciliation real-time gates to the monotonic clock

### DIFF
--- a/crates/live/Cargo.toml
+++ b/crates/live/Cargo.toml
@@ -123,6 +123,7 @@ criterion = { workspace = true }
 madsim = { workspace = true }
 rstest = { workspace = true }
 rust_decimal_macros = { workspace = true }
+tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
 toml = { workspace = true }
 ustr = { workspace = true }
 

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -39,10 +39,7 @@ use nautilus_common::{
 };
 use nautilus_core::{
     UUID4, UnixNanos,
-    datetime::{
-        NANOSECONDS_IN_MILLISECOND, NANOSECONDS_IN_SECOND, mins_to_nanos, mins_to_secs,
-        nanos_to_millis,
-    },
+    datetime::{mins_to_nanos, mins_to_secs},
 };
 use nautilus_execution::{
     engine::ExecutionEngine,
@@ -234,9 +231,11 @@ impl ExecutionManagerConfig {
 struct InflightCheck {
     #[allow(dead_code)]
     pub client_order_id: ClientOrderId,
-    pub ts_submitted: UnixNanos,
+    pub ts_submitted: dst::time::Instant,
     pub retry_count: u32,
-    pub last_query_ts: Option<UnixNanos>,
+    // `Instant` debug output is runtime-specific and intentionally only useful
+    // as an opaque monotonic offset.
+    pub last_query_ts: Option<dst::time::Instant>,
 }
 
 /// Manager for execution state.
@@ -270,12 +269,12 @@ pub struct ExecutionManager {
     external_order_claims: IndexMap<InstrumentId, StrategyId>,
     processed_fills: IndexMap<TradeId, ClientOrderId>,
     recon_check_retries: IndexMap<ClientOrderId, u32>,
-    ts_last_query: IndexMap<ClientOrderId, UnixNanos>,
-    order_local_activity_ns: IndexMap<ClientOrderId, UnixNanos>,
+    ts_last_query: IndexMap<ClientOrderId, dst::time::Instant>,
+    order_local_activity: IndexMap<ClientOrderId, dst::time::Instant>,
     // Monotonic (`dst::time`) instants, not `self.clock`; see `record_position_activity`.
     position_local_activity: IndexMap<InstrumentAccountKey, dst::time::Instant>,
     position_recon_retries: IndexMap<InstrumentAccountKey, u32>,
-    recent_fills_cache: IndexMap<TradeId, UnixNanos>,
+    recent_fills_cache: IndexMap<TradeId, dst::time::Instant>,
 }
 
 impl Debug for ExecutionManager {
@@ -306,17 +305,11 @@ impl ExecutionManager {
             processed_fills: IndexMap::new(),
             recon_check_retries: IndexMap::new(),
             ts_last_query: IndexMap::new(),
-            order_local_activity_ns: IndexMap::new(),
+            order_local_activity: IndexMap::new(),
             position_local_activity: IndexMap::new(),
             position_recon_retries: IndexMap::new(),
             recent_fills_cache: IndexMap::new(),
         }
-    }
-
-    /// Returns the current clock timestamp in nanoseconds.
-    #[must_use]
-    pub fn generate_timestamp_ns(&self) -> UnixNanos {
-        self.clock.borrow().timestamp_ns()
     }
 
     /// Reconciles orders and fills from a mass status report.
@@ -802,13 +795,16 @@ impl ExecutionManager {
     /// (rejection or cancellation) based on the order's status.
     pub fn check_inflight_orders(&mut self) -> InflightCheckResult {
         let mut result = InflightCheckResult::default();
-        let current_time = self.clock.borrow().timestamp_ns();
-        let threshold_ns = self.config.inflight_threshold_ms * NANOSECONDS_IN_MILLISECOND;
+        let now = dst::time::Instant::now();
+        let threshold = Duration::from_millis(self.config.inflight_threshold_ms);
 
         let mut to_check = Vec::new();
 
         for (client_order_id, check) in &self.inflight_checks {
-            if current_time - check.ts_submitted > threshold_ns {
+            if now
+                .checked_duration_since(check.ts_submitted)
+                .is_some_and(|elapsed| elapsed > threshold)
+            {
                 to_check.push(*client_order_id);
             }
         }
@@ -824,14 +820,16 @@ impl ExecutionManager {
 
             if let Some(check) = self.inflight_checks.get_mut(&client_order_id) {
                 if let Some(last_query_ts) = check.last_query_ts
-                    && current_time - last_query_ts < threshold_ns
+                    && now
+                        .checked_duration_since(last_query_ts)
+                        .is_none_or(|elapsed| elapsed < threshold)
                 {
                     continue;
                 }
 
                 check.retry_count += 1;
-                check.last_query_ts = Some(current_time);
-                self.ts_last_query.insert(client_order_id, current_time);
+                check.last_query_ts = Some(now);
+                self.ts_last_query.insert(client_order_id, now);
                 self.recon_check_retries
                     .insert(client_order_id, check.retry_count);
 
@@ -875,6 +873,7 @@ impl ExecutionManager {
                     self.clear_recon_tracking(&client_order_id, true);
                 } else if let Some(order) = self.get_order(client_order_id) {
                     // Intermediate retry: query the venue for current order status
+                    let ts_now = self.clock.borrow().timestamp_ns();
                     let client_id = self.cache.borrow().client_id(&client_order_id).copied();
                     let query = TradingCommand::QueryOrder(QueryOrder::new(
                         order.trader_id(),
@@ -884,7 +883,7 @@ impl ExecutionManager {
                         order.client_order_id(),
                         order.venue_order_id(),
                         UUID4::new(),
-                        current_time,
+                        ts_now,
                         None,
                         None, // correlation_id
                     ));
@@ -988,9 +987,8 @@ impl ExecutionManager {
         &mut self,
         client_ids: Option<&IndexSet<ClientId>>,
     ) -> Vec<TradingCommand> {
-        let current_time = self.clock.borrow().timestamp_ns();
-        let query_delay_ns =
-            u64::from(self.config.single_order_query_delay_ms) * NANOSECONDS_IN_MILLISECOND;
+        let now = dst::time::Instant::now();
+        let query_delay = Duration::from_millis(u64::from(self.config.single_order_query_delay_ms));
         let query_limit = self.config.max_single_order_queries_per_cycle as usize;
 
         if query_limit == 0 {
@@ -1030,12 +1028,13 @@ impl ExecutionManager {
                 continue;
             }
 
-            if let Some(&last_activity) = self.order_local_activity_ns.get(&client_order_id) {
-                let elapsed_ns = current_time.duration_since(&last_activity).unwrap_or(0);
+            if let Some(&last_activity) = self.order_local_activity.get(&client_order_id) {
+                let elapsed = last_activity.elapsed();
+                let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
 
-                if elapsed_ns < self.config.open_check_threshold_ns {
-                    let elapsed_ms = nanos_to_millis(elapsed_ns);
-                    let threshold_ms = nanos_to_millis(self.config.open_check_threshold_ns);
+                if elapsed < threshold {
+                    let elapsed_ms = elapsed.as_millis();
+                    let threshold_ms = threshold.as_millis();
                     log::debug!(
                         "Deferring open order query for {client_order_id}: recent local activity \
                          ({elapsed_ms}ms < threshold={threshold_ms}ms)",
@@ -1045,14 +1044,15 @@ impl ExecutionManager {
             }
 
             if let Some(last_query_ts) = self.ts_last_query.get(&client_order_id)
-                && current_time
-                    .duration_since(last_query_ts)
-                    .is_none_or(|elapsed_ns| elapsed_ns < query_delay_ns)
+                && now
+                    .checked_duration_since(*last_query_ts)
+                    .is_none_or(|elapsed| elapsed < query_delay)
             {
                 continue;
             }
 
-            self.ts_last_query.insert(client_order_id, current_time);
+            self.ts_last_query.insert(client_order_id, now);
+            let ts_now = self.clock.borrow().timestamp_ns();
 
             let cmd = TradingCommand::QueryOrder(QueryOrder::new(
                 order.trader_id(),
@@ -1062,7 +1062,7 @@ impl ExecutionManager {
                 client_order_id,
                 order.venue_order_id(),
                 UUID4::new(),
-                current_time,
+                ts_now,
                 None,
                 None,
             ));
@@ -1121,7 +1121,6 @@ impl ExecutionManager {
             }
         }
 
-        let ts_now = self.clock.borrow().timestamp_ns();
         let mut events = Vec::new();
 
         for report in all_reports {
@@ -1129,12 +1128,13 @@ impl ExecutionManager {
                 && let Some(order) = self.get_order(*client_order_id)
             {
                 // Check for recent local activity to avoid race conditions with in-flight fills
-                if let Some(&last_activity) = self.order_local_activity_ns.get(client_order_id) {
-                    let elapsed_ns = ts_now.duration_since(&last_activity).unwrap_or(0);
+                if let Some(&last_activity) = self.order_local_activity.get(client_order_id) {
+                    let elapsed = last_activity.elapsed();
+                    let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
 
-                    if elapsed_ns < self.config.open_check_threshold_ns {
-                        let elapsed_ms = nanos_to_millis(elapsed_ns);
-                        let threshold_ms = nanos_to_millis(self.config.open_check_threshold_ns);
+                    if elapsed < threshold {
+                        let elapsed_ms = elapsed.as_millis();
+                        let threshold_ms = threshold.as_millis();
                         log::debug!(
                             "Deferring reconciliation for {client_order_id}: recent local activity ({elapsed_ms}ms < threshold={threshold_ms}ms)",
                         );
@@ -1379,7 +1379,7 @@ impl ExecutionManager {
 
     /// Registers an order as inflight for tracking.
     pub fn register_inflight(&mut self, client_order_id: ClientOrderId) {
-        let ts_submitted = self.clock.borrow().timestamp_ns();
+        let ts_submitted = dst::time::Instant::now();
         self.inflight_checks.insert(
             client_order_id,
             InflightCheck {
@@ -1391,17 +1391,18 @@ impl ExecutionManager {
         );
         self.recon_check_retries.insert(client_order_id, 0);
         self.ts_last_query.shift_remove(&client_order_id);
-        self.order_local_activity_ns.shift_remove(&client_order_id);
+        self.order_local_activity.shift_remove(&client_order_id);
     }
 
     /// Records local activity for the specified order.
     ///
-    /// Uses the current clock time (receipt time) instead of venue time to accurately
-    /// track when we last processed activity for this order. This avoids race conditions
-    /// where network/queue latency makes events appear "old" even though they just arrived.
+    /// Uses a monotonic receipt instant, not venue or domain time, to accurately
+    /// track when we last processed activity for this order. This avoids race
+    /// conditions where network/queue latency makes events appear "old" even
+    /// though they just arrived.
     pub fn record_local_activity(&mut self, client_order_id: ClientOrderId) {
-        let ts_now = self.clock.borrow().timestamp_ns();
-        self.order_local_activity_ns.insert(client_order_id, ts_now);
+        self.order_local_activity
+            .insert(client_order_id, dst::time::Instant::now());
     }
 
     /// Clears reconciliation tracking state for an order.
@@ -1412,7 +1413,7 @@ impl ExecutionManager {
         if drop_last_query {
             self.ts_last_query.shift_remove(client_order_id);
         }
-        self.order_local_activity_ns.shift_remove(client_order_id);
+        self.order_local_activity.shift_remove(client_order_id);
     }
 
     /// Returns any external order claim for the given instrument ID.
@@ -1548,27 +1549,31 @@ impl ExecutionManager {
         self.recent_fills_cache.contains_key(trade_id)
     }
 
-    /// Marks a fill as recently processed with current timestamp.
+    /// Marks a fill as recently processed with the current monotonic instant.
     pub fn mark_fill_processed(&mut self, trade_id: TradeId) {
-        let ts_now = self.clock.borrow().timestamp_ns();
-        self.recent_fills_cache.insert(trade_id, ts_now);
+        self.recent_fills_cache
+            .insert(trade_id, dst::time::Instant::now());
     }
 
     /// Prunes expired fills from the recent fills cache.
     ///
     /// Default TTL is 60 seconds.
-    #[expect(
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        reason = "TTL is a small positive seconds value; the nanosecond product fits u64"
-    )]
     pub fn prune_recent_fills_cache(&mut self, ttl_secs: f64) {
-        let ts_now = self.clock.borrow().timestamp_ns();
-        let ttl_ns = (ttl_secs * NANOSECONDS_IN_SECOND as f64) as u64;
+        // Map the f64 TTL to a Duration, reproducing the old
+        // (ttl_secs * NANOSECONDS_IN_SECOND) as u64 cast at the boundaries
+        // rather than panicking on this pub fn. The as cast saturated:
+        //   - negative / NaN            -> 0        (prune everything)
+        //   - positive overflow / +inf  -> u64::MAX (keep everything)
+        // try_from_secs_f64 returns Err for all three, so branch on the sign
+        // to keep the two behaviors distinct.
+        let ttl = match Duration::try_from_secs_f64(ttl_secs) {
+            Ok(ttl) => ttl,
+            Err(_) if ttl_secs > 0.0 => Duration::MAX,
+            Err(_) => Duration::ZERO,
+        };
 
         self.recent_fills_cache
-            .retain(|_, &mut ts_cached| ts_now - ts_cached <= ttl_ns);
+            .retain(|_, &mut cached_at| cached_at.elapsed() <= ttl);
     }
 
     /// Purges closed orders from the cache that are older than the configured buffer.
@@ -1675,14 +1680,31 @@ impl ExecutionManager {
         let ts_now = self.clock.borrow().timestamp_ns();
         let ts_last = order.ts_last();
 
-        // Check if order is too recent
-        if (ts_now - ts_last) < self.config.open_check_threshold_ns {
-            return events;
+        // Domain-time recency gate: ts_last and ts_now are both domain
+        // timestamps, so this stays on self.clock (it is not a real-time
+        // settling window).
+        match ts_now.duration_since(&ts_last) {
+            // Within the recency threshold: order is genuinely too recent, defer.
+            Some(elapsed_ns) if elapsed_ns < self.config.open_check_threshold_ns => {
+                return events;
+            }
+            // Old enough: fall through to the reconciliation checks below.
+            Some(_) => {}
+            // ts_last is ahead of ts_now - impossible under a sane clock.
+            // A corrupted far-future ts_last (for example a double-scaled
+            // timestamp) would otherwise stall this order's reconciliation
+            // forever with no signal, so warn before deferring.
+            None => {
+                log::warn!(
+                    "Order {client_order_id} has venue ts_last {ts_last} ahead of local ts_now {ts_now}; deferring reconciliation"
+                );
+                return events;
+            }
         }
 
         // Check local activity threshold
-        if let Some(&last_activity) = self.order_local_activity_ns.get(&client_order_id)
-            && (ts_now - last_activity) < self.config.open_check_threshold_ns
+        if let Some(&last_activity) = self.order_local_activity.get(&client_order_id)
+            && last_activity.elapsed() < Duration::from_nanos(self.config.open_check_threshold_ns)
         {
             return events;
         }
@@ -2986,6 +3008,7 @@ impl ExecutionManager {
 #[cfg(test)]
 mod tests {
     use nautilus_common::clock::TestClock;
+    use nautilus_core::datetime::NANOSECONDS_IN_SECOND;
     use nautilus_model::{
         enums::OmsType,
         instruments::{

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -96,7 +96,7 @@ use nautilus_common::{
     timer::TimeEventHandler,
 };
 use nautilus_core::{
-    UUID4, UnixNanos,
+    UUID4,
     datetime::{NANOSECONDS_IN_MILLISECOND, mins_to_secs, secs_to_nanos_unchecked},
 };
 use nautilus_model::{
@@ -913,7 +913,7 @@ impl LiveNode {
 
         let recon_start = dst::time::Instant::now() + startup_delay;
 
-        let mut ts_last_inflight = self.exec_manager.generate_timestamp_ns();
+        let mut ts_last_inflight = dst::time::Instant::now();
         let mut ts_last_open = ts_last_inflight;
         let mut ts_last_position = ts_last_inflight;
 
@@ -1079,9 +1079,9 @@ impl LiveNode {
 
                     if recon_enabled && now >= recon_next {
                         let recon_intervals = ReconciliationCheckIntervals {
-                            inflight: inflight_interval_ns,
-                            open: open_interval_ns,
-                            position: position_interval_ns,
+                            inflight: Duration::from_nanos(inflight_interval_ns),
+                            open: Duration::from_nanos(open_interval_ns),
+                            position: Duration::from_nanos(position_interval_ns),
                         };
                         let mut recon_state = ReconciliationCheckState {
                             ts_last_inflight: &mut ts_last_inflight,
@@ -1092,6 +1092,7 @@ impl LiveNode {
                         };
 
                         self.run_reconciliation_checks(
+                            now,
                             recon_intervals,
                             &mut recon_state,
                         );
@@ -1774,12 +1775,11 @@ impl LiveNode {
     // in the event loop.
     fn run_reconciliation_checks(
         &mut self,
+        now: dst::time::Instant,
         intervals: ReconciliationCheckIntervals,
         state: &mut ReconciliationCheckState<'_>,
     ) {
-        let ts_now = self.exec_manager.generate_timestamp_ns();
-
-        if reconciliation_check_due(ts_now, *state.ts_last_inflight, intervals.inflight) {
+        if reconciliation_check_due(now, *state.ts_last_inflight, intervals.inflight) {
             if self.state() == NodeState::ShuttingDown {
                 return;
             }
@@ -1788,12 +1788,12 @@ impl LiveNode {
             for cmd in result.queries {
                 AsyncRunner::handle_exec_command(cmd);
             }
-            *state.ts_last_inflight = ts_now;
+            *state.ts_last_inflight = now;
         }
 
-        let open_due = reconciliation_check_due(ts_now, *state.ts_last_open, intervals.open);
+        let open_due = reconciliation_check_due(now, *state.ts_last_open, intervals.open);
         let position_due =
-            reconciliation_check_due(ts_now, *state.ts_last_position, intervals.position);
+            reconciliation_check_due(now, *state.ts_last_position, intervals.position);
 
         if (open_due || position_due) && self.state() == NodeState::ShuttingDown {
             return;
@@ -1802,7 +1802,7 @@ impl LiveNode {
         if state.open_order_report_task.is_some() {
             if open_due {
                 log::debug!("Open-order reconciliation already in progress");
-                *state.ts_last_open = ts_now;
+                *state.ts_last_open = now;
             }
 
             if position_due {
@@ -1817,7 +1817,7 @@ impl LiveNode {
         if state.position_report_task.is_some() {
             if position_due {
                 log::debug!("Position reconciliation already in progress");
-                *state.ts_last_position = ts_now;
+                *state.ts_last_position = now;
             }
 
             if open_due {
@@ -1831,10 +1831,10 @@ impl LiveNode {
 
         if position_due && (!open_due || *state.ts_last_position < *state.ts_last_open) {
             *state.position_report_task = self.start_position_report_check();
-            *state.ts_last_position = ts_now;
+            *state.ts_last_position = now;
         } else if open_due {
             *state.open_order_report_task = self.start_open_order_report_check();
-            *state.ts_last_open = ts_now;
+            *state.ts_last_open = now;
         }
     }
 
@@ -1982,24 +1982,28 @@ async fn request_position_reports(
     }
 }
 
-fn reconciliation_check_due(ts_now: UnixNanos, ts_last: UnixNanos, interval_ns: u64) -> bool {
-    interval_ns > 0
-        && ts_now
-            .duration_since(&ts_last)
-            .is_some_and(|elapsed_ns| elapsed_ns >= interval_ns)
+fn reconciliation_check_due(
+    now: dst::time::Instant,
+    last: dst::time::Instant,
+    interval: Duration,
+) -> bool {
+    interval > Duration::ZERO
+        && now
+            .checked_duration_since(last)
+            .is_some_and(|elapsed| elapsed >= interval)
 }
 
 #[derive(Clone, Copy)]
 struct ReconciliationCheckIntervals {
-    inflight: u64,
-    open: u64,
-    position: u64,
+    inflight: Duration,
+    open: Duration,
+    position: Duration,
 }
 
 struct ReconciliationCheckState<'a> {
-    ts_last_inflight: &'a mut UnixNanos,
-    ts_last_open: &'a mut UnixNanos,
-    ts_last_position: &'a mut UnixNanos,
+    ts_last_inflight: &'a mut dst::time::Instant,
+    ts_last_open: &'a mut dst::time::Instant,
+    ts_last_position: &'a mut dst::time::Instant,
     open_order_report_task: &'a mut Option<OpenOrderReportTask>,
     position_report_task: &'a mut Option<PositionReportTask>,
 }
@@ -2666,8 +2670,46 @@ mod tests {
         assert_eq!(cached_order.status(), OrderStatus::Initialized);
     }
 
-    #[rstest]
-    fn test_run_reconciliation_checks_does_not_publish_open_order_queries() {
+    #[cfg(all(feature = "simulation", madsim))]
+    async fn advance_clock(d: Duration) {
+        madsim::time::advance(d);
+        madsim::task::yield_now().await;
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    async fn advance_clock(d: Duration) {
+        tokio::time::advance(d).await;
+    }
+
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_reconciliation_check_due_uses_monotonic_elapsed_time() {
+        let last = dst::time::Instant::now();
+        let interval = Duration::from_millis(100);
+
+        assert!(!reconciliation_check_due(last, last, Duration::ZERO));
+        assert!(!reconciliation_check_due(last, last, interval));
+
+        advance_clock(Duration::from_millis(99)).await;
+        let before_interval = dst::time::Instant::now();
+        assert!(!reconciliation_check_due(before_interval, last, interval));
+
+        advance_clock(Duration::from_millis(1)).await;
+        let at_interval = dst::time::Instant::now();
+        assert!(reconciliation_check_due(at_interval, last, interval));
+
+        assert!(!reconciliation_check_due(last, at_interval, interval));
+    }
+
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_run_reconciliation_checks_does_not_publish_open_order_queries() {
         let config = LiveNodeConfig {
             exec_engine: crate::config::LiveExecEngineConfig {
                 reconciliation: true,
@@ -2713,17 +2755,21 @@ mod tests {
             venue_order_id,
         );
 
-        let mut ts_last_inflight = UnixNanos::default();
-        let mut ts_last_open = UnixNanos::default();
-        let mut ts_last_position = UnixNanos::default();
+        let last = dst::time::Instant::now();
+        advance_clock(Duration::from_nanos(1)).await;
+        let now = dst::time::Instant::now();
+        let mut ts_last_inflight = last;
+        let mut ts_last_open = last;
+        let mut ts_last_position = last;
         let mut open_order_report_task = None;
         let mut position_report_task = None;
 
         node.run_reconciliation_checks(
+            now,
             ReconciliationCheckIntervals {
-                inflight: 0,
-                open: 1,
-                position: 0,
+                inflight: Duration::ZERO,
+                open: Duration::from_nanos(1),
+                position: Duration::ZERO,
             },
             &mut ReconciliationCheckState {
                 ts_last_inflight: &mut ts_last_inflight,

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -25,7 +25,8 @@ use indexmap::IndexSet;
 use nautilus_common::{
     cache::Cache,
     clients::ExecutionClient,
-    clock::TestClock,
+    clock::{Clock, TestClock},
+    live::dst,
     messages::{
         ExecutionReport,
         execution::{
@@ -56,7 +57,7 @@ use nautilus_model::{
     events::{
         OrderEventAny, OrderFilled,
         account::state::AccountState,
-        order::spec::{OrderPendingCancelSpec, OrderPendingUpdateSpec},
+        order::spec::{OrderAcceptedSpec, OrderPendingCancelSpec, OrderPendingUpdateSpec},
     },
     identifiers::{
         AccountId, ClientId, ClientOrderId, ExecAlgorithmId, InstrumentId, PositionId, StrategyId,
@@ -73,6 +74,17 @@ use nautilus_model::{
 };
 use rstest::rstest;
 use rust_decimal_macros::dec;
+
+#[cfg(all(feature = "simulation", madsim))]
+async fn advance_clock(d: dst::time::Duration) {
+    madsim::time::advance(d);
+    madsim::task::yield_now().await;
+}
+
+#[cfg(not(all(feature = "simulation", madsim)))]
+async fn advance_clock(d: dst::time::Duration) {
+    tokio::time::advance(d).await;
+}
 
 struct TestContext {
     clock: Rc<RefCell<TestClock>>,
@@ -129,6 +141,12 @@ impl TestContext {
         self.clock
             .borrow_mut()
             .advance_time(UnixNanos::from(current.as_u64() + delta_nanos), true);
+    }
+
+    async fn advance_both(&self, d: dst::time::Duration) {
+        let delta_nanos = u64::try_from(d.as_nanos()).expect("test duration fits in u64 nanos");
+        self.advance_time(delta_nanos);
+        advance_clock(d).await;
     }
 
     fn add_instrument(&self, instrument: InstrumentAny) {
@@ -287,14 +305,18 @@ fn test_fill_deduplication_tracks_processed_fill() {
     assert!(ctx.manager.is_fill_recently_processed(&trade_id));
 }
 
-#[rstest]
-fn test_fill_deduplication_prune_removes_expired() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_fill_deduplication_prune_removes_expired() {
     let mut ctx = TestContext::new();
     let old_trade = TradeId::from("T-OLD");
     let new_trade = TradeId::from("T-NEW");
 
     ctx.manager.mark_fill_processed(old_trade);
-    ctx.advance_time(120_000_000_000); // 120 seconds
+    ctx.advance_both(dst::time::Duration::from_secs(120)).await;
     ctx.manager.mark_fill_processed(new_trade);
 
     ctx.manager.prune_recent_fills_cache(60.0); // 60 second TTL
@@ -303,8 +325,82 @@ fn test_fill_deduplication_prune_removes_expired() {
     assert!(ctx.manager.is_fill_recently_processed(&new_trade));
 }
 
-#[rstest]
-fn test_observe_order_report_clears_inflight_tracking() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_fill_deduplication_prune_uses_monotonic_ttl() {
+    let mut ctx = TestContext::new();
+    let trade_id = TradeId::from("T-MONOTONIC");
+
+    ctx.manager.mark_fill_processed(trade_id);
+    ctx.advance_time(120_000_000_000);
+    ctx.manager.prune_recent_fills_cache(60.0);
+    assert!(ctx.manager.is_fill_recently_processed(&trade_id));
+
+    advance_clock(dst::time::Duration::from_secs(61)).await;
+    ctx.manager.prune_recent_fills_cache(60.0);
+    assert!(!ctx.manager.is_fill_recently_processed(&trade_id));
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_prune_recent_fills_cache_keeps_all_on_overflow_ttl() {
+    // Positive-overflow and infinity TTLs must saturate to keep-all.
+    let mut ctx = TestContext::new();
+    let trade_id = TradeId::from("T-KEEP");
+    ctx.manager.mark_fill_processed(trade_id);
+    advance_clock(dst::time::Duration::from_nanos(1)).await;
+
+    ctx.manager.prune_recent_fills_cache(1.0e30);
+    assert!(
+        ctx.manager.is_fill_recently_processed(&trade_id),
+        "overflowing TTL must keep entries, not prune them",
+    );
+
+    ctx.manager.prune_recent_fills_cache(f64::INFINITY);
+    assert!(
+        ctx.manager.is_fill_recently_processed(&trade_id),
+        "infinite TTL must keep entries",
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_prune_recent_fills_cache_prunes_all_on_negative_or_nan_ttl() {
+    // Negative and NaN TTLs fall back to a zero TTL, matching the old cast.
+    let mut ctx = TestContext::new();
+
+    ctx.manager.mark_fill_processed(TradeId::from("T-NEG"));
+    advance_clock(dst::time::Duration::from_nanos(1)).await;
+    ctx.manager.prune_recent_fills_cache(-1.0);
+    assert!(
+        !ctx.manager
+            .is_fill_recently_processed(&TradeId::from("T-NEG"))
+    );
+
+    ctx.manager.mark_fill_processed(TradeId::from("T-NAN"));
+    advance_clock(dst::time::Duration::from_nanos(1)).await;
+    ctx.manager.prune_recent_fills_cache(f64::NAN);
+    assert!(
+        !ctx.manager
+            .is_fill_recently_processed(&TradeId::from("T-NAN"))
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_observe_order_report_clears_inflight_tracking() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 5,
@@ -335,15 +431,20 @@ fn test_observe_order_report_clears_inflight_tracking() {
     ctx.manager.observe_execution_report(&report);
 
     // Advance time past threshold so inflight check would trigger if still tracked
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     // Inflight check should return empty — tracking was cleared by observation
     let result = ctx.manager.check_inflight_orders();
     assert!(result.events.is_empty());
 }
 
-#[rstest]
-fn test_observe_pending_order_report_keeps_inflight_tracking() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_observe_pending_order_report_keeps_inflight_tracking() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 3,
@@ -374,7 +475,8 @@ fn test_observe_pending_order_report_keeps_inflight_tracking() {
     ctx.manager.observe_execution_report(&report);
 
     // Inflight tracking should still be active
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result = ctx.manager.check_inflight_orders();
 
     // Order is still tracked: should generate a query (retry 1 < max 3)
@@ -1586,8 +1688,12 @@ async fn test_reconcile_mass_status_sorts_events_chronologically() {
     assert!(result.events[0].ts_event() < result.events[1].ts_event());
 }
 
-#[rstest]
-fn test_inflight_order_generates_rejection_after_max_retries() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_order_generates_rejection_after_max_retries() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -1604,7 +1710,8 @@ fn test_inflight_order_generates_rejection_after_max_retries() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000); // 200ms, past threshold
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await; // 200ms, past threshold
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -1617,8 +1724,41 @@ fn test_inflight_order_generates_rejection_after_max_retries() {
     }
 }
 
-#[rstest]
-fn test_inflight_check_skips_filtered_order_ids() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_timeout_uses_monotonic_gate_and_domain_event_timestamp() {
+    let config = ExecutionManagerConfig {
+        inflight_threshold_ms: 100,
+        inflight_max_retries: 1,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-SPLIT");
+
+    ctx.add_instrument(test_instrument());
+    let order = create_submitted_order("O-SPLIT", instrument_id, OrderSide::Buy, "1.0", "3000.00");
+    ctx.add_order(order);
+
+    ctx.manager.register_inflight(client_order_id);
+    let domain_ts = ctx.clock.borrow().timestamp_ns();
+    advance_clock(dst::time::Duration::from_millis(200)).await;
+
+    let result = ctx.manager.check_inflight_orders();
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].ts_event(), domain_ts);
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_check_skips_filtered_order_ids() {
     let filtered_id = ClientOrderId::from("O-FILTERED");
     let mut config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
@@ -1642,7 +1782,8 @@ fn test_inflight_check_skips_filtered_order_ids() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(filtered_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -1784,8 +1925,12 @@ async fn test_reconcile_mass_status_accepted_order_expired_at_venue() {
     assert!(matches!(result.events[0], OrderEventAny::Expired(_)));
 }
 
-#[rstest]
-fn test_inflight_increments_retry_count_before_max() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_increments_retry_count_before_max() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 3,
@@ -1802,27 +1947,34 @@ fn test_inflight_increments_retry_count_before_max() {
     ctx.manager.register_inflight(client_order_id);
 
     // First check - past threshold, retry count becomes 1, generates QueryOrder
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result1 = ctx.manager.check_inflight_orders();
     assert!(result1.events.is_empty()); // Not at max yet
     assert_eq!(result1.queries.len(), 1);
 
     // Second check - retry count becomes 2, generates QueryOrder
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result2 = ctx.manager.check_inflight_orders();
     assert!(result2.events.is_empty()); // Still not at max
     assert_eq!(result2.queries.len(), 1);
 
     // Third check - retry count becomes 3, equals max, generates rejection
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result3 = ctx.manager.check_inflight_orders();
     assert_eq!(result3.events.len(), 1);
     assert!(matches!(result3.events[0], OrderEventAny::Rejected(_)));
     assert!(result3.queries.is_empty());
 }
 
-#[rstest]
-fn test_inflight_pending_update_generates_canceled() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_pending_update_generates_canceled() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -1846,7 +1998,8 @@ fn test_inflight_pending_update_generates_canceled() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000); // 200ms, past threshold
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await; // 200ms, past threshold
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -1862,8 +2015,12 @@ fn test_inflight_pending_update_generates_canceled() {
     }
 }
 
-#[rstest]
-fn test_inflight_pending_cancel_generates_canceled() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_pending_cancel_generates_canceled() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -1887,7 +2044,8 @@ fn test_inflight_pending_cancel_generates_canceled() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -1903,8 +2061,12 @@ fn test_inflight_pending_cancel_generates_canceled() {
     }
 }
 
-#[rstest]
-fn test_inflight_generates_query_before_max_retries() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_generates_query_before_max_retries() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 3,
@@ -1921,7 +2083,8 @@ fn test_inflight_generates_query_before_max_retries() {
     ctx.manager.register_inflight(client_order_id);
 
     // First check - past threshold, retry 1 < max 3 -> generates QueryOrder
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result = ctx.manager.check_inflight_orders();
 
     assert!(
@@ -1937,8 +2100,12 @@ fn test_inflight_generates_query_before_max_retries() {
     }
 }
 
-#[rstest]
-fn test_inflight_no_query_at_max_retries() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_no_query_at_max_retries() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 2,
@@ -1955,13 +2122,15 @@ fn test_inflight_no_query_at_max_retries() {
     ctx.manager.register_inflight(client_order_id);
 
     // First check - intermediate, generates query
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result1 = ctx.manager.check_inflight_orders();
     assert!(result1.events.is_empty());
     assert_eq!(result1.queries.len(), 1);
 
     // Second check - at max retries, generates terminal event only
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result2 = ctx.manager.check_inflight_orders();
 
     assert_eq!(
@@ -1976,8 +2145,12 @@ fn test_inflight_no_query_at_max_retries() {
     assert!(matches!(result2.events[0], OrderEventAny::Rejected(_)));
 }
 
-#[rstest]
-fn test_inflight_query_preserves_client_id_routing() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_query_preserves_client_id_routing() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 3,
@@ -1993,7 +2166,8 @@ fn test_inflight_query_preserves_client_id_routing() {
     ctx.add_order_with_client_id(order, client_id);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     let result = ctx.manager.check_inflight_orders();
     assert_eq!(result.queries.len(), 1);
@@ -2010,8 +2184,12 @@ fn test_inflight_query_preserves_client_id_routing() {
     }
 }
 
-#[rstest]
-fn test_inflight_query_throttled_within_threshold() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_query_throttled_within_threshold() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 5,
@@ -2034,7 +2212,8 @@ fn test_inflight_query_throttled_within_threshold() {
     ctx.manager.register_inflight(client_order_id);
 
     // First check past threshold generates a query
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result1 = ctx.manager.check_inflight_orders();
     assert_eq!(result1.queries.len(), 1);
 
@@ -2044,13 +2223,18 @@ fn test_inflight_query_throttled_within_threshold() {
     assert!(result2.events.is_empty());
 
     // Advance past threshold again, query should fire
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result3 = ctx.manager.check_inflight_orders();
     assert_eq!(result3.queries.len(), 1);
 }
 
-#[rstest]
-fn test_inflight_accepted_order_at_max_retries_no_event() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_accepted_order_at_max_retries_no_event() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -2073,7 +2257,8 @@ fn test_inflight_accepted_order_at_max_retries_no_event() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -2082,13 +2267,18 @@ fn test_inflight_accepted_order_at_max_retries_no_event() {
     assert!(result.queries.is_empty());
 
     // Tracking should be cleared, subsequent check also empty
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result2 = ctx.manager.check_inflight_orders();
     assert!(result2.events.is_empty());
 }
 
-#[rstest]
-fn test_inflight_order_not_in_cache_at_max_retries_no_event() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_order_not_in_cache_at_max_retries_no_event() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -2099,7 +2289,8 @@ fn test_inflight_order_not_in_cache_at_max_retries_no_event() {
 
     // Register inflight without adding order to cache
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     let result = ctx.manager.check_inflight_orders();
 
@@ -2107,13 +2298,18 @@ fn test_inflight_order_not_in_cache_at_max_retries_no_event() {
     assert!(result.queries.is_empty());
 
     // Tracking cleared, subsequent check also empty
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result2 = ctx.manager.check_inflight_orders();
     assert!(result2.events.is_empty());
 }
 
-#[rstest]
-fn test_inflight_terminal_event_clears_tracking() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inflight_terminal_event_clears_tracking() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 1,
@@ -2128,7 +2324,8 @@ fn test_inflight_terminal_event_clears_tracking() {
     ctx.add_order(order);
 
     ctx.manager.register_inflight(client_order_id);
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     // First check generates terminal rejection
     let result1 = ctx.manager.check_inflight_orders();
@@ -2136,7 +2333,8 @@ fn test_inflight_terminal_event_clears_tracking() {
     assert!(matches!(result1.events[0], OrderEventAny::Rejected(_)));
 
     // Second check should return empty (tracking was cleared)
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
     let result2 = ctx.manager.check_inflight_orders();
     assert!(result2.events.is_empty());
     assert!(result2.queries.is_empty());
@@ -2281,8 +2479,12 @@ async fn test_reconcile_mass_status_order_already_in_sync() {
     assert!(result.events.is_empty());
 }
 
-#[rstest]
-fn test_clear_recon_tracking_removes_inflight() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_clear_recon_tracking_removes_inflight() {
     let config = ExecutionManagerConfig {
         inflight_threshold_ms: 100,
         inflight_max_retries: 5,
@@ -2297,7 +2499,8 @@ fn test_clear_recon_tracking_removes_inflight() {
     ctx.manager.clear_recon_tracking(&client_order_id, true);
 
     // Advance time past threshold
-    ctx.advance_time(200_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
 
     // Check should not generate events since order was cleared
     let result = ctx.manager.check_inflight_orders();
@@ -7034,8 +7237,12 @@ fn test_check_open_order_queries_returns_empty_when_cycle_limit_is_zero() {
     assert!(queries.is_empty());
 }
 
-#[rstest]
-fn test_check_open_order_queries_respects_query_delay() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_order_queries_respects_query_delay() {
     let mut ctx = TestContext::with_config(ExecutionManagerConfig {
         max_single_order_queries_per_cycle: 5,
         single_order_query_delay_ms: 100,
@@ -7052,13 +7259,23 @@ fn test_check_open_order_queries_respects_query_delay() {
 
     let first_queries = ctx.manager.check_open_order_queries();
     let delayed_queries = ctx.manager.check_open_order_queries();
+    ctx.advance_time(200_000_000);
+    let domain_advanced_queries = ctx.manager.check_open_order_queries();
+    advance_clock(dst::time::Duration::from_millis(100)).await;
+    let monotonic_advanced_queries = ctx.manager.check_open_order_queries();
 
     assert_eq!(first_queries.len(), 1);
     assert!(delayed_queries.is_empty());
+    assert!(domain_advanced_queries.is_empty());
+    assert_eq!(monotonic_advanced_queries.len(), 1);
 }
 
-#[rstest]
-fn test_check_open_order_queries_defers_with_recent_local_activity() {
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_order_queries_defers_with_recent_local_activity() {
     let mut ctx = TestContext::with_config(ExecutionManagerConfig {
         max_single_order_queries_per_cycle: 5,
         open_check_threshold_ns: 5_000_000_000,
@@ -7076,8 +7293,14 @@ fn test_check_open_order_queries_defers_with_recent_local_activity() {
     ctx.manager.record_local_activity(client_order_id);
 
     let queries = ctx.manager.check_open_order_queries();
+    ctx.advance_time(6_000_000_000);
+    let domain_advanced_queries = ctx.manager.check_open_order_queries();
+    advance_clock(dst::time::Duration::from_secs(5)).await;
+    let monotonic_advanced_queries = ctx.manager.check_open_order_queries();
 
     assert!(queries.is_empty());
+    assert!(domain_advanced_queries.is_empty());
+    assert_eq!(monotonic_advanced_queries.len(), 1);
 }
 
 #[rstest]
@@ -7175,8 +7398,11 @@ fn insert_accepted_limit_order_for_instrument(
     ctx.cache.borrow_mut().update_order(&accepted).unwrap();
 }
 
-#[rstest]
-#[tokio::test]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
 async fn test_check_open_orders_defers_with_recent_local_activity() {
     // Test that reconciliation is deferred when there's recent local activity
     // within the threshold, to avoid race conditions with in-flight fills.
@@ -7230,8 +7456,11 @@ async fn test_check_open_orders_defers_with_recent_local_activity() {
     assert_eq!(cached_order.filled_qty(), Quantity::from("0.0"));
 }
 
-#[rstest]
-#[tokio::test]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
 async fn test_check_open_orders_proceeds_after_threshold_exceeded() {
     // Test that reconciliation proceeds when the local activity is older than
     // the configured threshold.
@@ -7259,7 +7488,8 @@ async fn test_check_open_orders_proceeds_after_threshold_exceeded() {
     ctx.add_order(order.clone());
 
     ctx.manager.record_local_activity(client_order_id);
-    ctx.advance_time(500_000_000);
+    ctx.advance_both(dst::time::Duration::from_millis(500))
+        .await;
 
     let report = create_order_status_report(
         Some(client_order_id),
@@ -7385,6 +7615,57 @@ async fn test_check_open_orders_submitted_missing_at_venue_generates_rejected() 
     } else {
         panic!("Expected OrderRejected event, was {:?}", events[0]);
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_check_open_orders_defers_when_venue_ts_last_is_ahead() {
+    // A corrupted far-future ts_last must defer reconciliation without
+    // rejecting or panicking.
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let mut order = create_limit_order(
+        "O-AHEAD",
+        test_instrument_id(),
+        OrderSide::Buy,
+        "10.0",
+        "100.0",
+    );
+    let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
+    order.apply(submitted).unwrap();
+
+    let future_ts = UnixNanos::from(10_000_000_000);
+    let accepted = OrderEventAny::Accepted(
+        OrderAcceptedSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(VenueOrderId::from("V-AHEAD"))
+            .account_id(test_account_id())
+            .ts_event(future_ts)
+            .ts_init(future_ts)
+            .build(),
+    );
+    order.apply(accepted).unwrap();
+    ctx.add_order(order);
+
+    let mock_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(
+        events.is_empty(),
+        "a far-future venue ts_last must defer reconciliation, not reject or panic",
+    );
 }
 
 #[tokio::test]
@@ -8203,7 +8484,7 @@ async fn test_position_check_grace_survives_accelerated_trading_clock() {
     assert!(
         events.is_empty(),
         "grace must survive an accelerated trading clock (it is measured on the \
-         monotonic clock); got {} reconciliation event(s), the grace regressed \
+         monotonic clock); was {} reconciliation event(s), the grace regressed \
          to self.clock",
         events.len(),
     );
@@ -8212,6 +8493,71 @@ async fn test_position_check_grace_survives_accelerated_trading_clock() {
             .position_recon_retry_count(&(instrument_id, account)),
         0,
         "grace path must return before the retry counter is touched",
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_grace_expires_on_monotonic_clock() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 60_000_000_000,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account = AccountId::from("BINANCE-A");
+
+    ctx.add_instrument(instrument);
+    ctx.add_margin_account(account);
+
+    let ts_event = UnixNanos::from(1_000_000_000);
+    let fill_report = FillReport::new(
+        account,
+        instrument_id,
+        VenueOrderId::from("V-EXPIRY"),
+        TradeId::from("T-EXPIRY"),
+        OrderSide::Buy,
+        Quantity::from("0.06"),
+        Price::from("3000.00"),
+        Money::new(0.0, Currency::USDT()),
+        LiquiditySide::Taker,
+        Some(ClientOrderId::from("O-EXPIRY")),
+        None,
+        ts_event,
+        ts_event,
+        None,
+    );
+    ctx.manager
+        .observe_execution_report(&ExecutionReport::Fill(Box::new(fill_report)));
+
+    advance_clock(dst::time::Duration::from_secs(61)).await;
+
+    let venue_report = PositionStatusReport::new(
+        account,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("0.06"),
+        ts_event,
+        ts_event,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Filled(_))),
+        "position discrepancy should fire after the monotonic grace expires",
     );
 }
 


### PR DESCRIPTION
### The bug

#4366 fixed the *position* reconciliation grace - a real-time settling window measured on `self.clock`, which a clock factory can drive fast, sit on a foreign epoch, or stall. As @cjdsellers noted in that review, the order-side siblings still have it. This is the rest of the family.

Worth being precise about the runner loop, because there are two gates and only one was already right. The outer maintenance loop (`LiveNode::run`) wakes on the monotonic `dst::time` clock - but the inner per-check cadence inside `run_reconciliation_checks` gates on `self.clock` via `generate_timestamp_ns()`. So even after #4366, a **stalled** `self.clock` never marks the inflight/open/position checks due; they silently stop running, and the position grace #4366 fixed guards a check that never fires. An **accelerated** clock collapses the cadence to the outer minimum and burns inflight retries at clock speed. Same root cause.

### The fix

Everything measuring a real-time settling window moves onto monotonic `dst::time::Instant`:

- open-order local-activity grace (`order_local_activity`)
- inflight submit/query timeout (`InflightCheck`)
- recent-fills dedup TTL (`recent_fills_cache`)
- shared open/inflight query cadence (`ts_last_query`) - one map written by both paths, so converting only one axis would compare across clocks
- inner reconciliation sub-check cadence gate (`reconciliation_check_due`)

`self.clock` stays for every *domain* timestamp: generated event/command `ts_event`/`ts_init`, and venue lookback/purge cutoffs. The two query-emitting functions are split accordingly - monotonic for the gate, `self.clock` for the `QueryOrder` `ts_init`. The old plain `UnixNanos` subtractions in these windows panicked on underflow (a venue clock slightly ahead of local time was enough); `Instant` durations remove that class outright.

### One hunk that isn't a pure clock swap

`handle_missing_order` has a second gate comparing the order's *venue* `ts_last` against local time - genuinely mixed-axis, no monotonic instant to move to, so it stays on `self.clock`. Its subtraction had the same underflow foot-gun, so it's hardened from a panicking `-` to a checked `duration_since`: where a venue timestamp runs ahead of the local clock the old code panicked, the new code logs a warning and defers reconciliation, so a corrupted far-future `ts_last` (for example a double-scaled timestamp) is visible to operators rather than silently stalling that order's reconciliation forever. Flagging it as the one behavior fix rather than a pure refactor.

### Choices worth flagging

- `prune_recent_fills_cache` is `pub`, so it must preserve the old `f64`-to-`u64` cast's saturation exactly: negative/NaN saturated to `0` (prune all), and positive overflow / `+inf` saturated to `u64::MAX` (keep all). `try_from_secs_f64` returns `Err` for both, so the fallback branches on the sign - `Err(_) if ttl_secs > 0.0 => Duration::MAX`, else `Duration::ZERO` - rather than collapsing every `Err` to zero.
- Removed `ExecutionManager::generate_timestamp_ns`; the cadence-gate change was its last caller.
- Query-cadence sites use `checked_duration_since(...).is_none_or(...)`, mirroring each original site rather than `elapsed()`.
- The stalled-clock regression is pinned by a pure-function unit test on `reconciliation_check_due` (it no longer references `self.clock`), not a full integration harness.

### Tests

Affected inflight / open-order / recent-fills tests migrate to tokio paused virtual time (`tokio` `test-util` dev-dependency, matching `crates/data`), plus a position-grace expiry regression. The key cases are **differential** - advancing one clock axis at a time: monotonic-only to prove the gate fires on real time, `self.clock`-only to prove a regression back to it would be caught, so "advance both" can't mask a wrong-clock implementation.

### Follow-ups (deliberately not in this PR)

- **Consolidate the recency-map pattern.** This change leaves four `IndexMap<_, dst::time::Instant>` gates with identical "mark now / within window? / prune older than TTL" semantics (`ts_last_query`, `order_local_activity`, `position_local_activity`, `recent_fills_cache`). A small `RecencyMap<K>` that owns `Instant::now()` internally would make the monotonic-clock choice structural rather than a per-call-site discipline, so a future call site could not reach for the trading clock again. It is also the destination the wider sweep below migrates onto.
- **A wider sweep for the same class.** "Real-time window measured on the trading clock" is a pattern, not a one-off. This PR closes the live-reconciliation instances, but one remains open even here: `handle_missing_order`'s venue-`ts_last` recency gate - hardened against underflow in this PR, but still a cross-axis compare. A follow-up could re-base that on local receipt time (landing it on the `RecencyMap` above) and audit the other timers/throttles (data-engine cadences, the order emulator, cache-purge intervals) for the same shape, moving the genuinely real-time ones onto `dst::time`.

> Separately from this change: `cargo test -p nautilus-live` hangs in `tests/node.rs` on `develop` under a nightly toolchain - I believe in `serial_tests::test_error_log_triggers_graceful_shutdown`, though I've not nailed it down yet (that test passes in isolation, so it may be a cross-test interaction). Not reproduced on the pinned stable 1.96.0, which is presumably why CI stays green. Worth a look if it shows up in a CI-adjacent setup.
