### PR TITLE
Fix Tardis replay inconsistent bars folder name

### DIFF
--- a/crates/adapters/tardis/src/replay.rs
+++ b/crates/adapters/tardis/src/replay.rs
@@ -678,7 +678,10 @@ fn parquet_filepath_bars(bar_type: &BarType, date: NaiveDate) -> PathBuf {
         UnixNanos::from(end_nanos as u64),
     );
 
-    PathBuf::new().join("bar").join(bar_type_str).join(filename)
+    PathBuf::new()
+        .join(Bar::path_prefix())
+        .join(bar_type_str)
+        .join(filename)
 }
 
 fn write_batch(
@@ -929,5 +932,75 @@ mod tests {
         assert_eq!(trades_out, vec![trade_1, trade_2]);
         assert_eq!(trades_out[0].instrument_id, instrument_id);
         assert!(trades_out[0].ts_init < trades_out[1].ts_init);
+    }
+
+    #[rstest]
+    fn test_bars_replay_catalog_round_trip() {
+        use nautilus_model::types::{Price, Quantity};
+
+        let compression = ParquetCompression::Zstd.as_parquet_compression();
+        let bar_type = BarType::from("BTCUSDT-PERP.BINANCE-1-MINUTE-LAST-EXTERNAL");
+
+        let ts_1 = UnixNanos::from(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0)
+                .unwrap()
+                .timestamp_nanos_opt()
+                .unwrap() as u64,
+        );
+        let ts_2 = ts_1 + 1_000_000_000;
+
+        let bar_1 = Bar::new(
+            bar_type,
+            Price::from("100.00"),
+            Price::from("110.00"),
+            Price::from("90.00"),
+            Price::from("105.00"),
+            Quantity::from("1000"),
+            ts_1,
+            ts_1,
+        );
+        let bar_2 = Bar::new(
+            bar_type,
+            Price::from("105.00"),
+            Price::from("115.00"),
+            Price::from("95.00"),
+            Price::from("110.00"),
+            Quantity::from("1000"),
+            ts_2,
+            ts_2,
+        );
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_path = temp_dir.path().join("data");
+
+        let mut bars_map: AHashMap<BarType, Vec<Bar>> = AHashMap::new();
+        let mut bars_cursors: AHashMap<BarType, DateCursor> = AHashMap::new();
+
+        for bar in [bar_1, bar_2] {
+            handle_bar_msg(
+                bar,
+                &mut bars_map,
+                &mut bars_cursors,
+                &data_path,
+                compression,
+            );
+        }
+
+        for (bar_type, bars) in &bars_map {
+            let cursor = bars_cursors.get(bar_type).expect("Expected cursor");
+            batch_and_write_bars(bars, bar_type, cursor.date_utc, &data_path, compression);
+        }
+
+        // Bars must be written under the catalog convention path ("bars"), consistent
+        // with the other data types so they are discoverable by `ParquetDataCatalog`.
+        assert!(data_path.join(Bar::path_prefix()).exists());
+        assert!(!data_path.join("bar").exists());
+
+        let mut catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
+        let bars_out = catalog.bars(None, None, None).unwrap();
+
+        assert_eq!(bars_out, vec![bar_1, bar_2]);
+        assert_eq!(bars_out[0].bar_type, bar_type);
+        assert!(bars_out[0].ts_init < bars_out[1].ts_init);
     }
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Tardis replay wrote bars to a hardcoded `"bar"` folder while `ParquetDataCatalog` reads bar data using `Bar::path_prefix()` (`"bars"`), so replayed bars were written to a directory the catalog never queries and were not discoverable using `ParquetDataCatalog::bars()`. This switches `parquet_filepath_bars` to `Bar::path_prefix()`, making the replay writers consistent with the catalog convention (the same drift fixed for trades in #4371).


## Related Issues/PRs

Follow-up to #4371, addressing the bars path drift (`bar/` vs `bars/`) @cjdsellers flagged in that review thread.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A, existing datasets are unaffected. This only changes the output directory for newly replayed bars to match the catalog convention.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added `test_bars_replay_catalog_round_trip` in `crates/adapters/tardis/src/replay.rs`: writes bars via the replay path, asserts output lands under `bars/` (not `bar/`), and round-trips through `ParquetDataCatalog::bars()`. Verified locally with `cargo test -p nautilus-tardis replay` and `cargo fmt --all -- --check`.
