### PR TITLE
Fix IB market order update price normalization

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1409,6 +1409,101 @@ async fn test_process_order_update_stream_emits_accepted_then_canceled() {
 }
 
 #[tokio::test]
+async fn test_process_order_update_stream_clears_market_order_update_prices() {
+    let instrument_provider = create_test_instrument_provider();
+    let equity = equity_aapl();
+    let order_id = 7005;
+    let contract_id = 12347;
+    let client_order_id = ClientOrderId::from("O-STREAM-MKT-UPDATE");
+    let venue_order_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let instrument_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let trader_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let strategy_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let order_avg_prices = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fills = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fill_avgs = Arc::new(Mutex::new(AHashMap::new()));
+    let order_fill_progress = Arc::new(Mutex::new(AHashMap::new()));
+    let accepted_orders = Arc::new(Mutex::new(ahash::AHashSet::new()));
+    let pending_cancel_orders = Arc::new(Mutex::new(ahash::AHashSet::new()));
+    let spread_fill_tracking = Arc::new(Mutex::new(AHashMap::new()));
+    let commission_cache = Arc::new(Mutex::new(AHashMap::new()));
+    let order_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let (exec_sender, mut exec_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (update_sender, update_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut subscription = Subscription::new(update_receiver);
+
+    let instrument_id = equity.id();
+    instrument_provider.insert_test_instrument(InstrumentAny::from(equity), contract_id, 1);
+    venue_order_id_map
+        .lock()
+        .unwrap()
+        .insert(order_id, client_order_id);
+    instrument_id_map
+        .lock()
+        .unwrap()
+        .insert(order_id, instrument_id);
+    trader_id_map
+        .lock()
+        .unwrap()
+        .insert(order_id, TraderId::from("TRADER-001"));
+    strategy_id_map
+        .lock()
+        .unwrap()
+        .insert(order_id, StrategyId::from("STRATEGY-001"));
+
+    let mut open_order = create_test_open_order(order_id, "Submitted", "");
+    open_order.contract.contract_id = contract_id;
+    open_order.order.total_quantity = 10.0;
+    open_order.order.order_type = "MKT".to_string();
+    open_order.order.limit_price = Some(150.25);
+    open_order.order.aux_price = Some(149.75);
+
+    update_sender
+        .send(Ok(OrderUpdate::OpenOrder(open_order)))
+        .unwrap();
+    drop(update_sender);
+
+    InteractiveBrokersExecutionClient::process_order_update_stream(
+        &mut subscription,
+        &order_id_map,
+        &venue_order_id_map,
+        &instrument_provider,
+        &exec_sender,
+        nautilus_core::time::get_atomic_clock_realtime(),
+        AccountId::from("IB-001"),
+        &commission_cache,
+        &instrument_id_map,
+        &trader_id_map,
+        &strategy_id_map,
+        &spread_fill_tracking,
+        &order_avg_prices,
+        &pending_combo_fills,
+        &pending_combo_fill_avgs,
+        &order_fill_progress,
+        &accepted_orders,
+        &pending_cancel_orders,
+    )
+    .await;
+
+    let accepted_event = exec_receiver.try_recv().unwrap();
+    assert!(matches!(
+        accepted_event,
+        ExecutionEvent::Order(OrderEventAny::Accepted(_))
+    ));
+
+    let updated_event = exec_receiver.try_recv().unwrap();
+    match updated_event {
+        ExecutionEvent::Order(OrderEventAny::Updated(event)) => {
+            assert_eq!(event.client_order_id, client_order_id);
+            assert_eq!(event.quantity, Quantity::from(10));
+            assert_eq!(event.price, None);
+            assert_eq!(event.trigger_price, None);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_process_order_update_stream_emits_fill_after_commission_report() {
     let instrument_provider = create_test_instrument_provider();
     let equity = equity_aapl();

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -11,7 +11,7 @@ use ibapi::subscriptions::SubscriptionItem;
 
 use super::*;
 use crate::{
-    common::enums::{IbAction, IbOrderStatus},
+    common::enums::{IbAction, IbOrderStatus, IbOrderType},
     execution::parse,
 };
 
@@ -447,14 +447,11 @@ impl InteractiveBrokersExecutionClient {
             strategy_id_map,
         )?;
         let price_magnifier = instrument_provider.get_price_magnifier(&instrument_id) as f64;
-        let price = order_data
-            .order
-            .limit_price
-            .map(|price| Price::new(price * price_magnifier, instrument.price_precision()));
-        let trigger_price = order_data
-            .order
-            .aux_price
-            .map(|price| Price::new(price * price_magnifier, instrument.price_precision()));
+        let (price, trigger_price) = Self::open_order_price_fields(
+            order_data,
+            price_magnifier,
+            instrument.price_precision(),
+        );
         let quantity = Quantity::new(order_data.order.total_quantity, instrument.size_precision());
         let venue_order_id =
             parse::ib_venue_order_id(order_data.order_id, order_data.order.perm_id);
@@ -479,6 +476,32 @@ impl InteractiveBrokersExecutionClient {
         exec_sender
             .send(ExecutionEvent::Order(OrderEventAny::Updated(event)))
             .map_err(|e| anyhow::anyhow!("Failed to send order updated event: {e}"))
+    }
+
+    fn open_order_price_fields(
+        order_data: &ibapi::orders::OrderData,
+        price_magnifier: f64,
+        price_precision: u8,
+    ) -> (Option<Price>, Option<Price>) {
+        let order_type = IbOrderType::from_str(order_data.order.order_type.as_str())
+            .map_or(OrderType::Market, IbOrderType::nautilus_order_type);
+        let price = order_data
+            .order
+            .limit_price
+            .map(|price| Price::new(price * price_magnifier, price_precision));
+        let trigger_price = order_data
+            .order
+            .aux_price
+            .map(|price| Price::new(price * price_magnifier, price_precision));
+
+        match order_type {
+            OrderType::Market | OrderType::MarketToLimit | OrderType::TrailingStopMarket => {
+                (None, None)
+            }
+            OrderType::Limit | OrderType::TrailingStopLimit => (price, None),
+            OrderType::StopMarket | OrderType::MarketIfTouched => (None, trigger_price),
+            OrderType::StopLimit | OrderType::LimitIfTouched => (price, trigger_price),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Normalizes Interactive Brokers `OpenOrder` price fields before emitting `OrderUpdated` events.
- Prevents IB echoed `limit_price` and `aux_price` values from reaching market-style Nautilus orders, avoiding the `MarketOrder::update()` invalid-event assertion reported in issue #4375.
- Preserves valid price fields for limit and stop-style order updates by mapping the IB order type back to the Nautilus order type before constructing the event.

### Design decisions
- Kept the fix at the adapter boundary in `crates/adapters/interactive_brokers/src/execution/core_updates.rs` so malformed venue echoes are cleaned before model order invariants are applied.
- Reused the existing `IbOrderType` to Nautilus `OrderType` mapping rather than adding string checks for only `MKT`.
- Left the order model assertions unchanged because they correctly protect order-type invariants.

### Verification
- `cargo test -p nautilus-interactive-brokers test_process_order_update_stream_clears_market_order_update_prices --lib`
- `cargo test -p nautilus-interactive-brokers --lib`
- `make build-debug`
- `make format`
- `make pre-commit`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4375

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
