### PR TITLE
Consolidate reconciliation recency maps into RecencyMap<K>

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -67,6 +67,8 @@ use nautilus_model::{
 use rust_decimal::{Decimal, prelude::ToPrimitive};
 use ustr::Ustr;
 
+use super::recency::RecencyMap;
+
 /// Tag for orders originating from venue (external orders).
 static TAG_VENUE: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("VENUE"));
 
@@ -231,11 +233,11 @@ impl ExecutionManagerConfig {
 struct InflightCheck {
     #[allow(dead_code)]
     pub client_order_id: ClientOrderId,
-    pub ts_submitted: dst::time::Instant,
+    pub submitted_at: dst::time::Instant,
     pub retry_count: u32,
     // `Instant` debug output is runtime-specific and intentionally only useful
     // as an opaque monotonic offset.
-    pub last_query_ts: Option<dst::time::Instant>,
+    pub last_query_at: Option<dst::time::Instant>,
 }
 
 /// Manager for execution state.
@@ -269,12 +271,12 @@ pub struct ExecutionManager {
     external_order_claims: IndexMap<InstrumentId, StrategyId>,
     processed_fills: IndexMap<TradeId, ClientOrderId>,
     recon_check_retries: IndexMap<ClientOrderId, u32>,
-    ts_last_query: IndexMap<ClientOrderId, dst::time::Instant>,
-    order_local_activity: IndexMap<ClientOrderId, dst::time::Instant>,
+    order_query_recency: RecencyMap<ClientOrderId>,
+    order_local_activity: RecencyMap<ClientOrderId>,
     // Monotonic (`dst::time`) instants, not `self.clock`; see `record_position_activity`.
-    position_local_activity: IndexMap<InstrumentAccountKey, dst::time::Instant>,
+    position_local_activity: RecencyMap<InstrumentAccountKey>,
     position_recon_retries: IndexMap<InstrumentAccountKey, u32>,
-    recent_fills_cache: IndexMap<TradeId, dst::time::Instant>,
+    recent_fills_cache: RecencyMap<TradeId>,
 }
 
 impl Debug for ExecutionManager {
@@ -304,11 +306,11 @@ impl ExecutionManager {
             external_order_claims: IndexMap::new(),
             processed_fills: IndexMap::new(),
             recon_check_retries: IndexMap::new(),
-            ts_last_query: IndexMap::new(),
-            order_local_activity: IndexMap::new(),
-            position_local_activity: IndexMap::new(),
+            order_query_recency: RecencyMap::default(),
+            order_local_activity: RecencyMap::default(),
+            position_local_activity: RecencyMap::default(),
             position_recon_retries: IndexMap::new(),
-            recent_fills_cache: IndexMap::new(),
+            recent_fills_cache: RecencyMap::default(),
         }
     }
 
@@ -802,7 +804,7 @@ impl ExecutionManager {
 
         for (client_order_id, check) in &self.inflight_checks {
             if now
-                .checked_duration_since(check.ts_submitted)
+                .checked_duration_since(check.submitted_at)
                 .is_some_and(|elapsed| elapsed > threshold)
             {
                 to_check.push(*client_order_id);
@@ -819,17 +821,17 @@ impl ExecutionManager {
             }
 
             if let Some(check) = self.inflight_checks.get_mut(&client_order_id) {
-                if let Some(last_query_ts) = check.last_query_ts
+                if let Some(last_query_at) = check.last_query_at
                     && now
-                        .checked_duration_since(last_query_ts)
+                        .checked_duration_since(last_query_at)
                         .is_none_or(|elapsed| elapsed < threshold)
                 {
                     continue;
                 }
 
                 check.retry_count += 1;
-                check.last_query_ts = Some(now);
-                self.ts_last_query.insert(client_order_id, now);
+                check.last_query_at = Some(now);
+                self.order_query_recency.mark(client_order_id);
                 self.recon_check_retries
                     .insert(client_order_id, check.retry_count);
 
@@ -999,7 +1001,7 @@ impl ExecutionManager {
         filtered_orders.sort_by_key(|order| {
             let client_order_id = order.client_order_id();
             (
-                self.ts_last_query.get(&client_order_id).copied(),
+                self.order_query_recency.last_marked(&client_order_id),
                 client_order_id,
             )
         });
@@ -1028,30 +1030,27 @@ impl ExecutionManager {
                 continue;
             }
 
-            if let Some(&last_activity) = self.order_local_activity.get(&client_order_id) {
-                let elapsed = last_activity.elapsed();
-                let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
-
-                if elapsed < threshold {
-                    let elapsed_ms = elapsed.as_millis();
-                    let threshold_ms = threshold.as_millis();
-                    log::debug!(
-                        "Deferring open order query for {client_order_id}: recent local activity \
-                         ({elapsed_ms}ms < threshold={threshold_ms}ms)",
-                    );
-                    continue;
-                }
+            let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
+            if let Some(elapsed) = self.order_local_activity.elapsed_at(&client_order_id, now)
+                && elapsed < threshold
+            {
+                let elapsed_ms = elapsed.as_millis();
+                let threshold_ms = threshold.as_millis();
+                log::debug!(
+                    "Deferring open order query for {client_order_id}: recent local activity \
+                     ({elapsed_ms}ms < threshold={threshold_ms}ms)",
+                );
+                continue;
             }
 
-            if let Some(last_query_ts) = self.ts_last_query.get(&client_order_id)
-                && now
-                    .checked_duration_since(*last_query_ts)
-                    .is_none_or(|elapsed| elapsed < query_delay)
+            if self
+                .order_query_recency
+                .within_at(&client_order_id, now, query_delay)
             {
                 continue;
             }
 
-            self.ts_last_query.insert(client_order_id, now);
+            self.order_query_recency.mark(client_order_id);
             let ts_now = self.clock.borrow().timestamp_ns();
 
             let cmd = TradingCommand::QueryOrder(QueryOrder::new(
@@ -1128,18 +1127,16 @@ impl ExecutionManager {
                 && let Some(order) = self.get_order(*client_order_id)
             {
                 // Check for recent local activity to avoid race conditions with in-flight fills
-                if let Some(&last_activity) = self.order_local_activity.get(client_order_id) {
-                    let elapsed = last_activity.elapsed();
-                    let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
-
-                    if elapsed < threshold {
-                        let elapsed_ms = elapsed.as_millis();
-                        let threshold_ms = threshold.as_millis();
-                        log::debug!(
-                            "Deferring reconciliation for {client_order_id}: recent local activity ({elapsed_ms}ms < threshold={threshold_ms}ms)",
-                        );
-                        continue;
-                    }
+                let threshold = Duration::from_nanos(self.config.open_check_threshold_ns);
+                if let Some(elapsed) = self.order_local_activity.elapsed(client_order_id)
+                    && elapsed < threshold
+                {
+                    let elapsed_ms = elapsed.as_millis();
+                    let threshold_ms = threshold.as_millis();
+                    log::debug!(
+                        "Deferring reconciliation for {client_order_id}: recent local activity ({elapsed_ms}ms < threshold={threshold_ms}ms)",
+                    );
+                    continue;
                 }
 
                 let instrument = self.get_instrument(&report.instrument_id);
@@ -1379,19 +1376,18 @@ impl ExecutionManager {
 
     /// Registers an order as inflight for tracking.
     pub fn register_inflight(&mut self, client_order_id: ClientOrderId) {
-        let ts_submitted = dst::time::Instant::now();
         self.inflight_checks.insert(
             client_order_id,
             InflightCheck {
                 client_order_id,
-                ts_submitted,
+                submitted_at: dst::time::Instant::now(),
                 retry_count: 0,
-                last_query_ts: None,
+                last_query_at: None,
             },
         );
         self.recon_check_retries.insert(client_order_id, 0);
-        self.ts_last_query.shift_remove(&client_order_id);
-        self.order_local_activity.shift_remove(&client_order_id);
+        self.order_query_recency.remove(&client_order_id);
+        self.order_local_activity.remove(&client_order_id);
     }
 
     /// Records local activity for the specified order.
@@ -1401,8 +1397,7 @@ impl ExecutionManager {
     /// conditions where network/queue latency makes events appear "old" even
     /// though they just arrived.
     pub fn record_local_activity(&mut self, client_order_id: ClientOrderId) {
-        self.order_local_activity
-            .insert(client_order_id, dst::time::Instant::now());
+        self.order_local_activity.mark(client_order_id);
     }
 
     /// Clears reconciliation tracking state for an order.
@@ -1411,9 +1406,9 @@ impl ExecutionManager {
         self.recon_check_retries.shift_remove(client_order_id);
 
         if drop_last_query {
-            self.ts_last_query.shift_remove(client_order_id);
+            self.order_query_recency.remove(client_order_id);
         }
-        self.order_local_activity.shift_remove(client_order_id);
+        self.order_local_activity.remove(client_order_id);
     }
 
     /// Returns any external order claim for the given instrument ID.
@@ -1456,7 +1451,7 @@ impl ExecutionManager {
     /// See `check_position_discrepancy`.
     pub fn record_position_activity(&mut self, instrument_id: InstrumentId, account_id: AccountId) {
         self.position_local_activity
-            .insert((instrument_id, account_id), dst::time::Instant::now());
+            .mark((instrument_id, account_id));
     }
 
     /// Returns the current position-reconciliation retry count for the given
@@ -1551,8 +1546,7 @@ impl ExecutionManager {
 
     /// Marks a fill as recently processed with the current monotonic instant.
     pub fn mark_fill_processed(&mut self, trade_id: TradeId) {
-        self.recent_fills_cache
-            .insert(trade_id, dst::time::Instant::now());
+        self.recent_fills_cache.mark(trade_id);
     }
 
     /// Prunes expired fills from the recent fills cache.
@@ -1572,8 +1566,7 @@ impl ExecutionManager {
             Err(_) => Duration::ZERO,
         };
 
-        self.recent_fills_cache
-            .retain(|_, &mut cached_at| cached_at.elapsed() <= ttl);
+        self.recent_fills_cache.prune_older_than(ttl);
     }
 
     /// Purges closed orders from the cache that are older than the configured buffer.
@@ -1703,9 +1696,10 @@ impl ExecutionManager {
         }
 
         // Check local activity threshold
-        if let Some(&last_activity) = self.order_local_activity.get(&client_order_id)
-            && last_activity.elapsed() < Duration::from_nanos(self.config.open_check_threshold_ns)
-        {
+        if self.order_local_activity.within(
+            &client_order_id,
+            Duration::from_nanos(self.config.open_check_threshold_ns),
+        ) {
             return events;
         }
 
@@ -1763,10 +1757,10 @@ impl ExecutionManager {
         let ts_now = self.clock.borrow().timestamp_ns();
 
         // Grace window measured on the monotonic `dst::time` clock; see `record_position_activity`.
-        if let Some(&last_activity) = self.position_local_activity.get(&key)
-            && last_activity.elapsed()
-                < Duration::from_nanos(self.config.position_check_threshold_ns)
-        {
+        if self.position_local_activity.within(
+            &key,
+            Duration::from_nanos(self.config.position_check_threshold_ns),
+        ) {
             log::debug!(
                 "Skipping position reconciliation for {instrument_id}: recent activity within threshold"
             );

--- a/crates/live/src/execution/mod.rs
+++ b/crates/live/src/execution/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod emitter;
 pub mod manager;
+pub(crate) mod recency;
 
 #[cfg(feature = "node")]
 pub(crate) mod client;

--- a/crates/live/src/execution/recency.rs
+++ b/crates/live/src/execution/recency.rs
@@ -1,0 +1,165 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{hash::Hash, time::Duration};
+
+use indexmap::IndexMap;
+use nautilus_common::live::dst;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecencyMap<K> {
+    inner: IndexMap<K, dst::time::Instant>,
+}
+
+impl<K> Default for RecencyMap<K> {
+    fn default() -> Self {
+        Self {
+            inner: IndexMap::new(),
+        }
+    }
+}
+
+impl<K> RecencyMap<K>
+where
+    K: Eq + Hash,
+{
+    pub(crate) fn mark(&mut self, key: K) {
+        self.inner.insert(key, dst::time::Instant::now());
+    }
+
+    #[must_use]
+    pub(crate) fn contains_key(&self, key: &K) -> bool {
+        self.inner.contains_key(key)
+    }
+
+    pub(crate) fn remove(&mut self, key: &K) {
+        self.inner.shift_remove(key);
+    }
+
+    #[must_use]
+    pub(crate) fn last_marked(&self, key: &K) -> Option<dst::time::Instant> {
+        self.inner.get(key).copied()
+    }
+
+    #[must_use]
+    pub(crate) fn within(&self, key: &K, window: Duration) -> bool {
+        self.elapsed(key).is_some_and(|elapsed| elapsed < window)
+    }
+
+    #[must_use]
+    pub(crate) fn within_at(&self, key: &K, now: dst::time::Instant, window: Duration) -> bool {
+        self.elapsed_at(key, now)
+            .is_some_and(|elapsed| elapsed < window)
+    }
+
+    #[must_use]
+    pub(crate) fn elapsed(&self, key: &K) -> Option<Duration> {
+        self.elapsed_at(key, dst::time::Instant::now())
+    }
+
+    #[must_use]
+    pub(crate) fn elapsed_at(&self, key: &K, now: dst::time::Instant) -> Option<Duration> {
+        self.inner
+            .get(key)
+            .map(|marked_at| now.checked_duration_since(*marked_at).unwrap_or_default())
+    }
+
+    pub(crate) fn prune_older_than(&mut self, ttl: Duration) {
+        let now = dst::time::Instant::now();
+        self.inner.retain(|_, marked_at| {
+            now.checked_duration_since(*marked_at)
+                .is_none_or(|elapsed| elapsed <= ttl)
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use nautilus_common::live::dst;
+    use rstest::rstest;
+
+    use super::RecencyMap;
+
+    #[cfg(all(feature = "simulation", madsim))]
+    async fn advance_clock(d: Duration) {
+        madsim::time::advance(d);
+        madsim::task::yield_now().await;
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    async fn advance_clock(d: Duration) {
+        tokio::time::advance(d).await;
+    }
+
+    #[rstest]
+    fn test_mark_contains_and_remove() {
+        let mut recency = RecencyMap::default();
+
+        recency.mark("A");
+
+        assert!(recency.contains_key(&"A"));
+
+        recency.remove(&"A");
+
+        assert!(!recency.contains_key(&"A"));
+    }
+
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_within_uses_monotonic_elapsed_time() {
+        let mut recency = RecencyMap::default();
+
+        recency.mark("A");
+
+        assert!(recency.within(&"A", Duration::from_millis(100)));
+
+        advance_clock(Duration::from_millis(100)).await;
+
+        assert!(!recency.within(&"A", Duration::from_millis(100)));
+    }
+
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_prune_older_than_removes_expired_entries() {
+        let mut recency = RecencyMap::default();
+
+        recency.mark("OLD");
+        advance_clock(Duration::from_mins(2)).await;
+        recency.mark("NEW");
+
+        recency.prune_older_than(Duration::from_mins(1));
+
+        assert!(!recency.contains_key(&"OLD"));
+        assert!(recency.contains_key(&"NEW"));
+    }
+
+    #[rstest]
+    fn test_future_mark_counts_as_within_window() {
+        let mut recency = RecencyMap::default();
+        let now = dst::time::Instant::now();
+
+        recency.inner.insert("A", now + Duration::from_secs(1));
+
+        assert!(recency.within_at(&"A", now, Duration::from_millis(1)));
+    }
+}

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -913,9 +913,9 @@ impl LiveNode {
 
         let recon_start = dst::time::Instant::now() + startup_delay;
 
-        let mut ts_last_inflight = dst::time::Instant::now();
-        let mut ts_last_open = ts_last_inflight;
-        let mut ts_last_position = ts_last_inflight;
+        let mut last_inflight_check = dst::time::Instant::now();
+        let mut last_open_check = last_inflight_check;
+        let mut last_position_check = last_inflight_check;
 
         // Per-task `(interval, next_fire)` schedules dispatched by the
         // shared `maintenance_timer` below. See module docs for rationale.
@@ -1084,9 +1084,9 @@ impl LiveNode {
                             position: Duration::from_nanos(position_interval_ns),
                         };
                         let mut recon_state = ReconciliationCheckState {
-                            ts_last_inflight: &mut ts_last_inflight,
-                            ts_last_open: &mut ts_last_open,
-                            ts_last_position: &mut ts_last_position,
+                            last_inflight_check: &mut last_inflight_check,
+                            last_open_check: &mut last_open_check,
+                            last_position_check: &mut last_position_check,
                             open_order_report_task: &mut open_order_report_task,
                             position_report_task: &mut position_report_task,
                         };
@@ -1779,7 +1779,7 @@ impl LiveNode {
         intervals: ReconciliationCheckIntervals,
         state: &mut ReconciliationCheckState<'_>,
     ) {
-        if reconciliation_check_due(now, *state.ts_last_inflight, intervals.inflight) {
+        if reconciliation_check_due(now, *state.last_inflight_check, intervals.inflight) {
             if self.state() == NodeState::ShuttingDown {
                 return;
             }
@@ -1788,12 +1788,12 @@ impl LiveNode {
             for cmd in result.queries {
                 AsyncRunner::handle_exec_command(cmd);
             }
-            *state.ts_last_inflight = now;
+            *state.last_inflight_check = now;
         }
 
-        let open_due = reconciliation_check_due(now, *state.ts_last_open, intervals.open);
+        let open_due = reconciliation_check_due(now, *state.last_open_check, intervals.open);
         let position_due =
-            reconciliation_check_due(now, *state.ts_last_position, intervals.position);
+            reconciliation_check_due(now, *state.last_position_check, intervals.position);
 
         if (open_due || position_due) && self.state() == NodeState::ShuttingDown {
             return;
@@ -1802,7 +1802,7 @@ impl LiveNode {
         if state.open_order_report_task.is_some() {
             if open_due {
                 log::debug!("Open-order reconciliation already in progress");
-                *state.ts_last_open = now;
+                *state.last_open_check = now;
             }
 
             if position_due {
@@ -1817,7 +1817,7 @@ impl LiveNode {
         if state.position_report_task.is_some() {
             if position_due {
                 log::debug!("Position reconciliation already in progress");
-                *state.ts_last_position = now;
+                *state.last_position_check = now;
             }
 
             if open_due {
@@ -1829,12 +1829,12 @@ impl LiveNode {
             return;
         }
 
-        if position_due && (!open_due || *state.ts_last_position < *state.ts_last_open) {
+        if position_due && (!open_due || *state.last_position_check < *state.last_open_check) {
             *state.position_report_task = self.start_position_report_check();
-            *state.ts_last_position = now;
+            *state.last_position_check = now;
         } else if open_due {
             *state.open_order_report_task = self.start_open_order_report_check();
-            *state.ts_last_open = now;
+            *state.last_open_check = now;
         }
     }
 
@@ -2001,9 +2001,9 @@ struct ReconciliationCheckIntervals {
 }
 
 struct ReconciliationCheckState<'a> {
-    ts_last_inflight: &'a mut dst::time::Instant,
-    ts_last_open: &'a mut dst::time::Instant,
-    ts_last_position: &'a mut dst::time::Instant,
+    last_inflight_check: &'a mut dst::time::Instant,
+    last_open_check: &'a mut dst::time::Instant,
+    last_position_check: &'a mut dst::time::Instant,
     open_order_report_task: &'a mut Option<OpenOrderReportTask>,
     position_report_task: &'a mut Option<PositionReportTask>,
 }
@@ -2758,9 +2758,9 @@ mod tests {
         let last = dst::time::Instant::now();
         advance_clock(Duration::from_nanos(1)).await;
         let now = dst::time::Instant::now();
-        let mut ts_last_inflight = last;
-        let mut ts_last_open = last;
-        let mut ts_last_position = last;
+        let mut last_inflight_check = last;
+        let mut last_open_check = last;
+        let mut last_position_check = last;
         let mut open_order_report_task = None;
         let mut position_report_task = None;
 
@@ -2772,9 +2772,9 @@ mod tests {
                 position: Duration::ZERO,
             },
             &mut ReconciliationCheckState {
-                ts_last_inflight: &mut ts_last_inflight,
-                ts_last_open: &mut ts_last_open,
-                ts_last_position: &mut ts_last_position,
+                last_inflight_check: &mut last_inflight_check,
+                last_open_check: &mut last_open_check,
+                last_position_check: &mut last_position_check,
                 open_order_report_task: &mut open_order_report_task,
                 position_report_task: &mut position_report_task,
             },


### PR DESCRIPTION
Right now the monotonic-clock choice is a discipline, not a rule. Every one of
those four sites - `ts_last_query`, `order_local_activity`,
`position_local_activity`, `recent_fills_cache` - has to remember to stamp from
`dst::time::Instant::now()` and not `self.clock`, and to handle a future-marked
instant in the safe direction by hand.

So make it structural. `RecencyMap<K>` owns `Instant::now()` internally - you
`mark(key)`, ask `within(key, window)`, `prune_older_than(ttl)`, and there is no
seam left to thread the wrong clock through.

### The shape

```
struct RecencyMap<K> { inner: IndexMap<K, dst::time::Instant> }
mark / contains_key / remove / last_marked
within / within_at / elapsed / elapsed_at    // _at variants take the pass's `now`
prune_older_than
```

The `_at` variants exist so the reconciliation loop passes its loop-top `now`
once instead of resampling `Instant::now()` per order - the second half of that
same review note. Every `checked_duration_since` resolves a `None`
(marked-in-the-future) to the safe direction, matching what each original site
did by hand, so a garbage future instant reads as "0 elapsed, within window"
rather than panicking.

### Renames

The `ts_*`-named fields you flagged in #4376 - `ts_*` repo-wide means a domain
`UnixNanos`, but these hold monotonic `Instant`s, so the names lie:

- `InflightCheck::ts_submitted` -> `submitted_at`
- `InflightCheck::last_query_ts` -> `last_query_at`
- the node scheduler's `ts_last_*` locals and `ReconciliationCheckState` fields
  -> `last_*_check`
- `ts_last_query` -> `order_query_recency` (keyed on `ClientOrderId`, parallels
  `order_local_activity`; the other three map fields self-document under
  `RecencyMap<K>`, but this one's `ts_` prefix did not survive the type change
  gracefully, so it got a real name too)

### Tests

Focused `RecencyMap` unit tests: mark/contains/remove, monotonic expiry under
paused virtual time, pruning older-than-TTL, and the future-marked-instant safe
direction.

### Still to come

The second promised follow-up - close the class: `handle_missing_order`'s
venue-`ts_last` gate onto receipt time, plus the wider timer/throttle audit.
