### PR TITLE
Fix Interactive Brokers v2 crypto market data

### DIFF
--- a/.supply-chain/config.toml
+++ b/.supply-chain/config.toml
@@ -1436,7 +1436,7 @@ version = "0.1.65"
 criteria = "safe-to-deploy"
 
 [[exemptions.ibapi]]
-version = "3.0.1"
+version = "3.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_collections]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "ibapi"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab7f26e4336d0cb94be12bc6c0779cced423c3aceda01f5fd23cbcb0446a43e"
+checksum = "61cfb4b8eefd8dda23e2e327187a6ae837018c15d7ca6a79199c6cd475e5f169"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ dydx-proto = "0.4.0"
 fallible-streaming-iterator = "0.1.9"
 flate2 = "1.1.9"
 hypersync-client = { version = "1.4.0" }
-ibapi = "=3.0.1"
+ibapi = "=3.2.0"
 itoa = "1.0.18"
 ryu = "1.0.23"
 serde_repr = "0.1.20"

--- a/crates/adapters/interactive_brokers/src/common/parse.rs
+++ b/crates/adapters/interactive_brokers/src/common/parse.rs
@@ -73,7 +73,7 @@ pub fn ib_contract_to_instrument_id_simplified(
                 }
             }
             SecurityType::ForexPair => Venue::from("IDEALPRO"),
-            SecurityType::Crypto => Venue::from("PAXOS"),
+            SecurityType::Crypto => derive_crypto_venue(contract),
             SecurityType::Stock => Venue::from("SMART"),
             SecurityType::Option | SecurityType::FuturesOption => {
                 if !contract.exchange.as_str().is_empty() && contract.exchange.as_str() != "SMART" {
@@ -234,7 +234,7 @@ pub fn ib_contract_to_instrument_id_raw(
 ) -> anyhow::Result<InstrumentId> {
     let venue = venue.unwrap_or_else(|| match contract.security_type {
         SecurityType::ForexPair => Venue::from("IDEALPRO"),
-        SecurityType::Crypto => Venue::from("PAXOS"),
+        SecurityType::Crypto => derive_crypto_venue(contract),
         SecurityType::Stock => Venue::from("SMART"),
         SecurityType::Option => Venue::from("SMART"),
         SecurityType::FuturesOption => Venue::from("SMART"),
@@ -357,6 +357,30 @@ pub static VENUE_MEMBERS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
         map
     });
 
+/// Returns `true` if the contract is a cryptocurrency contract.
+///
+/// Centralizes the crypto check used to gate crypto-specific request handling
+/// (e.g. the `AGGTRADES` `whatToShow` rule — see
+/// [`crate::data::convert::price_type_to_ib_what_to_show_for_security`]).
+#[must_use]
+pub fn is_crypto_contract(contract: &Contract) -> bool {
+    matches!(contract.security_type, SecurityType::Crypto)
+}
+
+/// Derives the venue for a crypto contract.
+///
+/// IB routes crypto to multiple venues; both PAXOS and ZEROHASH are live (which one
+/// applies depends on the account/region). Uses the contract's actual exchange when
+/// set (e.g. ZEROHASH or PAXOS), falling back to PAXOS when it is unspecified.
+#[must_use]
+pub fn derive_crypto_venue(contract: &Contract) -> Venue {
+    if !contract.exchange.as_str().is_empty() && contract.exchange.as_str() != "SMART" {
+        Venue::from(contract.exchange.as_str())
+    } else {
+        Venue::from("PAXOS")
+    }
+}
+
 #[must_use]
 pub fn possible_exchanges_for_venue(venue: &str) -> Vec<String> {
     if let Some(exchanges) = VENUE_MEMBERS.get(venue) {
@@ -371,7 +395,9 @@ pub fn possible_exchanges_for_venue(venue: &str) -> Vec<String> {
 
 /// Venue lists for different asset classes
 const VENUES_CASH: &[&str] = &["IDEALPRO"];
-const VENUES_CRYPTO: &[&str] = &["PAXOS"];
+// IB routes crypto to both PAXOS and ZEROHASH (which one applies depends on the
+// account/region); accept both.
+const VENUES_CRYPTO: &[&str] = &["PAXOS", "ZEROHASH"];
 const VENUES_OPT: &[&str] = &["SMART", "EUREX"];
 const VENUES_FUT: &[&str] = &[
     "BELFOX",
@@ -1363,6 +1389,86 @@ mod tests {
         assert_eq!(contract.symbol.as_str(), "DOGE");
         assert_eq!(contract.currency.as_str(), "USD");
         assert_eq!(contract.local_symbol.as_str(), "DOGE.USD");
+    }
+
+    #[rstest]
+    fn test_instrument_id_to_ib_contract_parses_zerohash_crypto_symbol() {
+        // ZEROHASH is one of IB's crypto venues (alongside PAXOS).
+        let instrument_id = InstrumentId::from("BTC/USD.ZEROHASH");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Crypto);
+        assert_eq!(contract.exchange.as_str(), "ZEROHASH");
+        assert_eq!(contract.symbol.as_str(), "BTC");
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "BTC.USD");
+    }
+
+    #[rstest]
+    fn test_ib_contract_to_instrument_id_simplified_derives_zerohash_crypto_venue() {
+        // Contract -> InstrumentId derives the venue from the ZEROHASH exchange.
+        let contract = Contract {
+            symbol: Symbol::from("BTC"),
+            security_type: SecurityType::Crypto,
+            exchange: Exchange::from("ZEROHASH"),
+            currency: Currency::from("USD"),
+            local_symbol: "BTC.USD".to_string(),
+            ..Default::default()
+        };
+
+        let instrument_id = ib_contract_to_instrument_id_simplified(&contract, None).unwrap();
+
+        assert_eq!(instrument_id, InstrumentId::from("BTC/USD.ZEROHASH"));
+    }
+
+    #[rstest]
+    fn test_ib_contract_to_instrument_id_simplified_falls_back_to_paxos_crypto_venue() {
+        // Contract -> InstrumentId falls back to PAXOS when no exchange is set,
+        // preserving backwards compatibility.
+        let contract = Contract {
+            symbol: Symbol::from("DOGE"),
+            security_type: SecurityType::Crypto,
+            currency: Currency::from("USD"),
+            local_symbol: "DOGE.USD".to_string(),
+            ..Default::default()
+        };
+
+        let instrument_id = ib_contract_to_instrument_id_simplified(&contract, None).unwrap();
+
+        assert_eq!(instrument_id, InstrumentId::from("DOGE/USD.PAXOS"));
+    }
+
+    #[rstest]
+    fn test_instrument_id_to_ib_contract_parses_paxos_crypto_symbol() {
+        // PAXOS remains a live IB crypto venue alongside ZEROHASH.
+        let instrument_id = InstrumentId::from("BTC/USD.PAXOS");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Crypto);
+        assert_eq!(contract.exchange.as_str(), "PAXOS");
+        assert_eq!(contract.symbol.as_str(), "BTC");
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "BTC.USD");
+    }
+
+    #[rstest]
+    fn test_ib_contract_to_instrument_id_simplified_derives_paxos_crypto_venue() {
+        // A PAXOS contract derives the PAXOS venue from its exchange (not via the
+        // fallback), proving both venues are honored when explicitly set.
+        let contract = Contract {
+            symbol: Symbol::from("BTC"),
+            security_type: SecurityType::Crypto,
+            exchange: Exchange::from("PAXOS"),
+            currency: Currency::from("USD"),
+            local_symbol: "BTC.USD".to_string(),
+            ..Default::default()
+        };
+
+        let instrument_id = ib_contract_to_instrument_id_simplified(&contract, None).unwrap();
+
+        assert_eq!(instrument_id, InstrumentId::from("BTC/USD.PAXOS"));
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/data/convert.rs
+++ b/crates/adapters/interactive_brokers/src/data/convert.rs
@@ -16,9 +16,12 @@
 //! Conversion utilities for Interactive Brokers data types.
 
 use chrono::{DateTime, Utc};
-use ibapi::market_data::historical::{
-    BarSize as HistoricalBarSize, BarTimestamp, Duration as IBDuration, ToDuration,
-    WhatToShow as HistoricalWhatToShow,
+use ibapi::market_data::{
+    historical::{
+        BarSize as HistoricalBarSize, BarTimestamp, Duration as IBDuration, ToDuration,
+        WhatToShow as HistoricalWhatToShow,
+    },
+    realtime::WhatToShow as RealtimeWhatToShow,
 };
 use nautilus_core::UnixNanos;
 use nautilus_model::{
@@ -83,6 +86,57 @@ pub fn price_type_to_ib_what_to_show(price_type: PriceType) -> HistoricalWhatToS
         PriceType::Mid => HistoricalWhatToShow::MidPoint,
         _ => HistoricalWhatToShow::Trades, // Default to trades
     }
+}
+
+/// Whether IB requires `AGGTRADES` (not `TRADES`) for this request.
+///
+/// TWS rejects `TRADES` for crypto contracts (ZEROHASH/PAXOS) with error 10299 on
+/// both `reqHistoricalData` and `reqRealTimeBars`; crypto trade-price data is served
+/// only under `AGGTRADES`. Non-crypto contracts and non-trade price types are
+/// unaffected. Mirrors the Java engine's `LiveOneMinBarIngestionService.whatToShowFor`.
+#[must_use]
+fn uses_agg_trades(is_crypto: bool, price_type: PriceType) -> bool {
+    is_crypto && price_type == PriceType::Last
+}
+
+/// Convert Nautilus PriceType to IB WhatToShow for historical bars, mapping crypto
+/// trade-price (`PriceType::Last`) to `AGGTRADES` (see `uses_agg_trades`).
+#[must_use]
+pub fn price_type_to_ib_what_to_show_for_security(
+    price_type: PriceType,
+    is_crypto: bool,
+) -> HistoricalWhatToShow {
+    if uses_agg_trades(is_crypto, price_type) {
+        return HistoricalWhatToShow::AggTrades;
+    }
+    price_type_to_ib_what_to_show(price_type)
+}
+
+/// Convert Nautilus PriceType to IB WhatToShow for real-time (5-second) bars.
+///
+/// Unmapped price types default to [`RealtimeWhatToShow::Trades`].
+#[must_use]
+pub fn price_type_to_ib_realtime_what_to_show(price_type: PriceType) -> RealtimeWhatToShow {
+    match price_type {
+        PriceType::Last => RealtimeWhatToShow::Trades,
+        PriceType::Bid => RealtimeWhatToShow::Bid,
+        PriceType::Ask => RealtimeWhatToShow::Ask,
+        PriceType::Mid => RealtimeWhatToShow::MidPoint,
+        _ => RealtimeWhatToShow::Trades, // Default to trades
+    }
+}
+
+/// Convert Nautilus PriceType to IB WhatToShow for real-time (5-second) bars, mapping
+/// crypto trade-price (`PriceType::Last`) to `AGGTRADES` (see `uses_agg_trades`).
+#[must_use]
+pub fn price_type_to_ib_realtime_what_to_show_for_security(
+    price_type: PriceType,
+    is_crypto: bool,
+) -> RealtimeWhatToShow {
+    if uses_agg_trades(is_crypto, price_type) {
+        return RealtimeWhatToShow::AggTrades;
+    }
+    price_type_to_ib_realtime_what_to_show(price_type)
 }
 
 #[must_use]
@@ -400,6 +454,102 @@ mod tests {
             price_type_to_ib_what_to_show(PriceType::Mid),
             HistoricalWhatToShow::MidPoint
         );
+    }
+
+    #[rstest]
+    fn test_price_type_to_ib_what_to_show_for_security_crypto() {
+        // Crypto trade-price (Last) must map to AGGTRADES, not TRADES — TWS rejects
+        // TRADES for crypto (error 10299). Mirrors the Java whatToShowFor rule.
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Last, true),
+            HistoricalWhatToShow::AggTrades
+        );
+        // Non-trade price types are unaffected by the crypto special case.
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Bid, true),
+            HistoricalWhatToShow::Bid
+        );
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Ask, true),
+            HistoricalWhatToShow::Ask
+        );
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Mid, true),
+            HistoricalWhatToShow::MidPoint
+        );
+    }
+
+    #[rstest]
+    fn test_price_type_to_ib_what_to_show_for_security_non_crypto() {
+        // Non-crypto: trade-price stays TRADES (equities/futures), everything else
+        // identical to the plain mapping.
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Last, false),
+            HistoricalWhatToShow::Trades
+        );
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Bid, false),
+            HistoricalWhatToShow::Bid
+        );
+        assert_eq!(
+            price_type_to_ib_what_to_show_for_security(PriceType::Mid, false),
+            HistoricalWhatToShow::MidPoint
+        );
+    }
+
+    #[rstest]
+    fn test_aggtrades_wire_string() {
+        // The vendored ibapi patch must serialize AggTrades as the exact IB wire
+        // token "AGGTRADES" on BOTH the historical and realtime enums.
+        assert_eq!(HistoricalWhatToShow::AggTrades.to_string(), "AGGTRADES");
+        assert_eq!(RealtimeWhatToShow::AggTrades.to_string(), "AGGTRADES");
+    }
+
+    #[rstest]
+    fn test_price_type_to_ib_realtime_what_to_show() {
+        // `RealtimeWhatToShow` does not derive `PartialEq`, so match on the variants.
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show(PriceType::Last),
+            RealtimeWhatToShow::Trades
+        ));
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show(PriceType::Bid),
+            RealtimeWhatToShow::Bid
+        ));
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show(PriceType::Ask),
+            RealtimeWhatToShow::Ask
+        ));
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show(PriceType::Mid),
+            RealtimeWhatToShow::MidPoint
+        ));
+    }
+
+    #[rstest]
+    fn test_price_type_to_ib_realtime_what_to_show_for_security_crypto() {
+        // Crypto trade-price (Last) 5-second bars must request AGGTRADES on the
+        // realtime path too — TWS rejects TRADES for crypto (error 10299) on
+        // reqRealTimeBars, exactly as on the historical path. Mirrors the Java
+        // engine passing whatToShowFor(CRYPTO)="AGGTRADES" to subscribeRealTimeBars.
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show_for_security(PriceType::Last, true),
+            RealtimeWhatToShow::AggTrades
+        ));
+        // Non-trade price types unaffected by the crypto special case.
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show_for_security(PriceType::Mid, true),
+            RealtimeWhatToShow::MidPoint
+        ));
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show_for_security(PriceType::Bid, true),
+            RealtimeWhatToShow::Bid
+        ));
+        // Non-crypto trade-price stays TRADES.
+        assert!(matches!(
+            price_type_to_ib_realtime_what_to_show_for_security(PriceType::Last, false),
+            RealtimeWhatToShow::Trades
+        ));
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -32,6 +32,7 @@ use anyhow::Context;
 use ibapi::{
     contracts::{Contract, Currency as IBCurrency, Exchange as IBExchange, SecurityType, Symbol},
     market_data::{IgnoreSize, historical::ToDuration},
+    prelude::{StreamExt, SubscriptionItemStreamExt},
 };
 use nautilus_common::{
     clients::DataClient,
@@ -71,7 +72,8 @@ use super::{
     convert::{
         apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
         calculate_duration, calculate_duration_segments, chrono_to_ib_datetime,
-        ib_bar_to_nautilus_bar, price_type_to_ib_what_to_show,
+        ib_bar_to_nautilus_bar, price_type_to_ib_realtime_what_to_show_for_security,
+        price_type_to_ib_what_to_show_for_security,
     },
 };
 use crate::{
@@ -308,10 +310,6 @@ impl InteractiveBrokersDataClient {
             last_bars: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             bar_timeout_tasks: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
         })
-    }
-
-    fn venue_id(&self) -> Venue {
-        *IB_VENUE
     }
 
     fn cancel_active_subscriptions(&self) -> anyhow::Result<()> {
@@ -568,7 +566,12 @@ impl DataClient for InteractiveBrokersDataClient {
     }
 
     fn venue(&self) -> Option<Venue> {
-        Some(self.venue_id())
+        // Interactive Brokers is a multi-venue adapter (SMART, IDEALPRO, ZEROHASH, CME, etc.),
+        // so the data client must register for default routing rather than a single venue:
+        // subscriptions and requests are routed by the command's venue (derived from the
+        // instrument ID), which would otherwise never match and be dropped by the data engine.
+        // Mirrors the other multi-venue adapters (Tardis, Databento).
+        None
     }
 
     fn start(&mut self) -> anyhow::Result<()> {
@@ -1260,6 +1263,12 @@ impl DataClient for InteractiveBrokersDataClient {
         let handle_revised_bars = self.config.handle_revised_bars;
         let use_rth = self.config.use_regular_trading_hours;
         let start_ns = parse_start_ns(cmd.params.as_ref());
+        // Crypto (ZEROHASH/PAXOS) trade-price bars must request AGGTRADES, not
+        // TRADES (TWS rejects TRADES for crypto, error 10299) — on BOTH the
+        // realtime (reqRealTimeBars) and historical (reqHistoricalData) paths, per
+        // the Java engine's whatToShowFor rule. Capture the flag before `contract`
+        // is moved into the subscription task below.
+        let is_crypto = crate::common::parse::is_crypto_contract(&contract);
 
         // Create subscription-specific cancellation token
         let subscription_token = self.cancellation_token.child_token();
@@ -1276,6 +1285,10 @@ impl DataClient for InteractiveBrokersDataClient {
                     bar_type,
                     bar_type_str,
                     instrument_id,
+                    price_type_to_ib_realtime_what_to_show_for_security(
+                        bar_type.spec().price_type,
+                        is_crypto,
+                    ),
                     price_precision,
                     size_precision,
                     data_sender,
@@ -1292,7 +1305,10 @@ impl DataClient for InteractiveBrokersDataClient {
                     client_clone,
                     contract,
                     bar_type,
-                    price_type_to_ib_what_to_show(bar_type.spec().price_type),
+                    price_type_to_ib_what_to_show_for_security(
+                        bar_type.spec().price_type,
+                        is_crypto,
+                    ),
                     price_precision,
                     size_precision,
                     use_rth,
@@ -1853,10 +1869,18 @@ impl DataClient for InteractiveBrokersDataClient {
                 }
 
                 match builder.bid_ask(IgnoreSize::No).await {
-                    Ok(mut subscription) => {
+                    Ok(subscription) => {
+                        let mut subscription = subscription.filter_data();
                         let mut batch_quotes = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(tick) => tick,
+                                Err(e) => {
+                                    tracing::warn!("Historical quote ticks stream error: {e:?}");
+                                    continue;
+                                }
+                            };
                             let ts_event =
                                 super::convert::ib_timestamp_to_unix_nanos(&tick.timestamp);
                             let ts_init = clock.get_time_ns();
@@ -2034,10 +2058,18 @@ impl DataClient for InteractiveBrokersDataClient {
                 }
 
                 match builder.trade().await {
-                    Ok(mut subscription) => {
+                    Ok(subscription) => {
+                        let mut subscription = subscription.filter_data();
                         let mut batch_trades = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(tick) => tick,
+                                Err(e) => {
+                                    tracing::warn!("Historical trade ticks stream error: {e:?}");
+                                    continue;
+                                }
+                            };
                             let ts_event =
                                 super::convert::ib_timestamp_to_unix_nanos(&tick.timestamp);
                             let ts_init = clock.get_time_ns();
@@ -2162,7 +2194,11 @@ impl DataClient for InteractiveBrokersDataClient {
         // Convert bar type to IB formats
         let ib_bar_size = bar_type_to_ib_bar_size(&cmd.bar_type)
             .context("Failed to convert bar type to IB bar size")?;
-        let ib_what_to_show = price_type_to_ib_what_to_show(cmd.bar_type.spec().price_type);
+        // Crypto trade-price bars require AGGTRADES (TWS rejects TRADES for crypto,
+        // error 10299); mirror the Java engine's whatToShowFor rule.
+        let is_crypto = crate::common::parse::is_crypto_contract(&contract);
+        let ib_what_to_show =
+            price_type_to_ib_what_to_show_for_security(cmd.bar_type.spec().price_type, is_crypto);
 
         // Calculate segments to break down the request if needed
         let segments = if let (Some(start), Some(end)) = (cmd.start, cmd.end) {
@@ -2368,6 +2404,23 @@ mod tests {
         let dt = chrono::DateTime::from_timestamp(1, 2).unwrap();
 
         assert_eq!(datetime_to_unix_nanos(dt), UnixNanos::from(1_000_000_002));
+    }
+
+    #[rstest]
+    fn test_venue_is_none_for_default_routing() {
+        // IB is a multi-venue adapter: `venue()` must be `None` so the data engine registers
+        // the client for default routing. A `Some(venue)` here means venue-routed subscribe
+        // commands (e.g. `BTC/USD.ZEROHASH` bars, `AAPL.NASDAQ` quotes) never reach the client.
+        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        nautilus_common::live::runner::replace_data_event_sender(sender);
+
+        let config = InteractiveBrokersDataClientConfig::default();
+        let provider = Arc::new(InteractiveBrokersInstrumentProvider::new(
+            config.instrument_provider.clone(),
+        ));
+        let client = InteractiveBrokersDataClient::new(*IB_CLIENT_ID, config, provider).unwrap();
+
+        assert_eq!(client.venue(), None);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -580,6 +580,7 @@ pub(super) async fn handle_realtime_bars_subscription(
     bar_type: BarType,
     bar_type_str: String,
     _instrument_id: InstrumentId,
+    what_to_show: RealtimeWhatToShow,
     price_precision: u8,
     size_precision: u8,
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
@@ -599,7 +600,7 @@ pub(super) async fn handle_realtime_bars_subscription(
 
     let mut subscription = client
         .realtime_bars(&contract)
-        .what_to_show(RealtimeWhatToShow::Trades)
+        .what_to_show(what_to_show)
         .trading_hours(trading_hours)
         .subscribe()
         .await

--- a/crates/adapters/interactive_brokers/src/historical/client.rs
+++ b/crates/adapters/interactive_brokers/src/historical/client.rs
@@ -23,6 +23,7 @@ use ibapi::{
     client::Client,
     contracts::Contract,
     market_data::{IgnoreSize, TradingHours, historical},
+    prelude::{StreamExt, SubscriptionItemStreamExt},
 };
 use nautilus_core::UnixNanos;
 use nautilus_model::{
@@ -42,7 +43,7 @@ use crate::{
     data::convert::{
         apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
         chrono_to_ib_datetime, ib_bar_to_nautilus_bar, ib_timestamp_to_unix_nanos,
-        price_type_to_ib_what_to_show,
+        price_type_to_ib_what_to_show_for_security,
     },
     providers::instruments::InteractiveBrokersInstrumentProvider,
 };
@@ -357,9 +358,13 @@ impl HistoricalInteractiveBrokersClient {
                 let bar_type_with_id =
                     BarType::new(instrument_id, bar_spec, AggregationSource::External);
 
-                // Convert bar type to IB parameters
+                // Convert bar type to IB parameters. Crypto trade-price bars must
+                // request AGGTRADES, not TRADES (TWS rejects TRADES for crypto,
+                // error 10299) — same rule as the live data client's historical path.
                 let ib_bar_size = bar_type_to_ib_bar_size(&bar_type_with_id)?;
-                let ib_what_to_show = price_type_to_ib_what_to_show(bar_spec.price_type);
+                let is_crypto = crate::common::parse::is_crypto_contract(&contract);
+                let ib_what_to_show =
+                    price_type_to_ib_what_to_show_for_security(bar_spec.price_type, is_crypto);
 
                 // Calculate duration segments
                 let segments =
@@ -564,7 +569,7 @@ impl HistoricalInteractiveBrokersClient {
                 IbHistoricalTickType::Trades => {
                     loop {
                         // Make request for this batch
-                        let mut subscription = tokio::time::timeout(
+                        let subscription = tokio::time::timeout(
                             std::time::Duration::from_secs(timeout),
                             self.ib_client
                                 .historical_ticks(&contract, 1000)
@@ -579,9 +584,17 @@ impl HistoricalInteractiveBrokersClient {
                             timeout
                         ))??;
 
+                        let mut subscription = subscription.filter_data();
                         let mut batch_ticks = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(tick) => tick,
+                                Err(e) => {
+                                    tracing::warn!("Historical trade ticks stream error: {e:?}");
+                                    continue;
+                                }
+                            };
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
                             if ts_event < start_date_time_ns || ts_event > end_date_time_ns {
@@ -665,7 +678,7 @@ impl HistoricalInteractiveBrokersClient {
                 IbHistoricalTickType::BidAsk => {
                     loop {
                         // Make request for this batch
-                        let mut subscription = tokio::time::timeout(
+                        let subscription = tokio::time::timeout(
                             std::time::Duration::from_secs(timeout),
                             self.ib_client
                                 .historical_ticks(&contract, 1000)
@@ -680,9 +693,17 @@ impl HistoricalInteractiveBrokersClient {
                             timeout
                         ))??;
 
+                        let mut subscription = subscription.filter_data();
                         let mut batch_ticks = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(tick) => tick,
+                                Err(e) => {
+                                    tracing::warn!("Historical bid/ask ticks stream error: {e:?}");
+                                    continue;
+                                }
+                            };
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
                             if ts_event < start_date_time_ns || ts_event > end_date_time_ns {


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Makes the v2 Interactive Brokers adapter work with **both** of IBKR's crypto
venues — PAXOS and ZeroHash (which one applies depends on the account/region,
see IBKR's crypto trading-permissions docs). The adapter previously hardcoded
PAXOS, so ZeroHash-routed instruments like `BTC/USD.ZEROHASH` failed contract
resolution, and several stacked defects broke crypto market data. This PR
derives the crypto venue from the contract's exchange (falling back to PAXOS),
registers the client for default multi-venue routing, honors the bar's price
type on real-time bars, and maps crypto trade-price bars to `AGGTRADES` (TWS
rejects `TRADES` for crypto with error 10299 on both venues). PAXOS continues
to work unchanged.

## Related Issues/PRs

- `AGGTRADES` requires a `WhatToShow::AggTrades` variant, added upstream in
  wboayue/rust-ibapi#693 and shipped in **`ibapi` 3.2.0**. This PR bumps `ibapi`
  to `=3.2.0` from crates.io (no `[patch.crates-io]`, no fork).
- 3.2.0 also restructured `TickSubscription` from an inherent
  `next() -> Option<T>` into a `Stream` of `Result<SubscriptionItem<T>, Error>`.
  The four historical-tick call sites (`data/core.rs` quotes + trades,
  `historical/client.rs` trades + bid/ask) were migrated to
  `subscription.filter_data()` with explicit `Ok`/`Err` handling, matching the
  idiom already used on the execution paths.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

None. Both PAXOS and ZeroHash are supported concurrently — PAXOS is retained as
the fallback and in `VENUES_CRYPTO`, so existing PAXOS routing is unchanged.
`venue()` now returns `None` (default routing), matching the other multi-venue
adapters (Tardis, Databento).

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] I added/updated tests to cover new or changed logic

Rust unit tests added in `parse.rs` (ZeroHash **and** PAXOS symbol parse +
contract→instrument venue derivation, explicit and fallback), `convert.rs`
(crypto→AGGTRADES on historical and realtime paths, non-crypto unaffected,
wire-string check), and `core.rs` (`venue()` is `None` for default routing);
the standalone `HistoricalInteractiveBrokersClient` bar path now applies the
same crypto AGGTRADES rule. Live-verified against an IB paper gateway (2026-07-05):
`BTC/USD.ZEROHASH` 5-second bars flow post-fix (3/3 bars in ~19s), cross-checked
against a direct TWS-API `reqRealTimeBars`
(`secType=CRYPTO, exchange=ZEROHASH, whatToShow=AGGTRADES`).
