### PR TITLE
Fix catalog discovery for trades and quotes folders

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -65,6 +65,7 @@ from nautilus_trader.model.data import capsule_to_list
 from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.persistence.catalog.base import BaseDataCatalog
 from nautilus_trader.persistence.funcs import class_to_filename
+from nautilus_trader.persistence.funcs import class_to_filename_aliases
 from nautilus_trader.persistence.funcs import combine_filters
 from nautilus_trader.persistence.funcs import filename_to_class
 from nautilus_trader.persistence.funcs import urisafe_identifier
@@ -2223,12 +2224,15 @@ class ParquetDataCatalog(BaseDataCatalog):
             List of file paths matching the data class.
 
         """
-        file_prefix = class_to_filename(data_cls)
         base_path = self.path.rstrip("/")
-        glob_path = f"{base_path}/data/{file_prefix}/**/*.parquet"
-        file_paths: list[str] = self.fs.glob(glob_path)
+        file_prefixes = (class_to_filename(data_cls), *class_to_filename_aliases(data_cls))
+        file_paths: list[str] = []
 
-        return file_paths
+        for file_prefix in file_prefixes:
+            glob_path = f"{base_path}/data/{file_prefix}/**/*.parquet"
+            file_paths.extend(self.fs.glob(glob_path))
+
+        return sorted(dict.fromkeys(file_paths))
 
     def query_first_timestamp(
         self,

--- a/nautilus_trader/persistence/funcs.py
+++ b/nautilus_trader/persistence/funcs.py
@@ -36,6 +36,18 @@ from nautilus_trader.serialization.arrow.serializer import _RUST_CUSTOM_TYPE_REG
 CUSTOM_DATA_PREFIX = "custom_"
 
 
+def class_to_filename_aliases(cls: type) -> tuple[str, ...]:
+    """
+    Return additional catalog directory names which can contain the class.
+    """
+    filename_aliases = {
+        "QuoteTick": ("quotes",),
+        "TradeTick": ("trades",),
+    }
+
+    return filename_aliases.get(cls.__name__, ())
+
+
 def class_to_filename(cls: type) -> str:
     """
     Convert the given class to a filename.
@@ -59,7 +71,9 @@ def filename_to_class(filename: str) -> type | None:
     """
     builtin_filename_to_class = {
         "quote_tick": QuoteTick,
+        "quotes": QuoteTick,
         "trade_tick": TradeTick,
+        "trades": TradeTick,
         "bar": Bar,
         "order_book_deltas": OrderBookDelta,
         "order_book_depths": OrderBookDepth10,

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import datetime
+import os
 import sys
 import tempfile
 from typing import Any
@@ -277,6 +278,28 @@ def test_query_files_respects_empty_files_list(
     )
 
     assert result == []
+
+
+def test_get_file_list_from_data_cls_includes_folder_aliases(
+    catalog: ParquetDataCatalog,
+) -> None:
+    base_path = catalog.path.rstrip("/")
+    canonical_path = (
+        f"{base_path}/data/trade_tick/BINANCEBTCUSDT/"
+        "2024-01-01T00-00-00-000000000Z_2024-01-01T00-01-00-000000000Z.parquet"
+    )
+    alias_path = (
+        f"{base_path}/data/trades/BINANCEETHUSDT/"
+        "2024-01-01T00-00-00-000000000Z_2024-01-01T00-01-00-000000000Z.parquet"
+    )
+
+    for file_path in (canonical_path, alias_path):
+        catalog.fs.makedirs(os.path.dirname(file_path), exist_ok=True)
+        catalog.fs.touch(file_path)
+
+    assert catalog.get_file_list_from_data_cls(TradeTick) == sorted(
+        [canonical_path, alias_path],
+    )
 
 
 def test_write_data_empty_records_gap_extends_file(catalog: ParquetDataCatalog) -> None:

--- a/tests/unit_tests/persistence/test_funcs.py
+++ b/tests/unit_tests/persistence/test_funcs.py
@@ -41,9 +41,11 @@ def test_class_to_filename(s, expected):
     ("filename", "expected"),
     [
         ("trade_tick", TradeTick),
+        ("trades", TradeTick),
         ("order_book_deltas", OrderBookDelta),
         ("option_greeks", OptionGreeks),
         ("quote_tick", QuoteTick),
+        ("quotes", QuoteTick),
         ("nonexistent_filename", None),
     ],
 )


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I reviewed `CONTRIBUTING.md` and followed established practices

## Summary

Catalog file discovery now includes adapter-written `trades/` and `quotes/` directories when querying `TradeTick` and `QuoteTick` data, while preserving the canonical `trade_tick` and `quote_tick` write paths. This lets backtests discover parquet tick data written by adapters that use the plural directory names.

## Related Issues/PRs

Closes #4391

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` which follows existing conventions (when applicable)

Not added in this patch; the change is narrow compatibility behavior for existing catalog directories.

## Testing

**Ensure new or changed logic covered by tests.**

- [ ] Affected code paths already covered by test suite
- [x] I added/updated tests to cover new or changed logic

Added unit coverage for resolving `trades`/`quotes` aliases and for catalog file discovery across canonical and alias folders.

Local checks:
- `python -m py_compile nautilus_trader/persistence/funcs.py nautilus_trader/persistence/catalog/parquet.py tests/unit_tests/persistence/test_funcs.py tests/unit_tests/persistence/test_catalog.py`
- `git diff --check`

Could not run pytest locally because `pytest` is not installed in this shell and the local Nautilus extension build artifacts are unavailable for direct imports.
