### PR TITLE
Make timer_exists consistent with timer_names and timer_count on expired timers

### DIFF
--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -70,7 +70,7 @@ pub trait Clock: Debug + Any {
     /// Returns the count of active timers in the clock.
     fn timer_count(&self) -> usize;
 
-    /// If a timer with the `name` exists.
+    /// If an active (not expired) timer with the `name` exists.
     fn timer_exists(&self, name: &Ustr) -> bool;
 
     /// Register a default event handler for the clock. If a timer
@@ -608,7 +608,7 @@ impl<'a> ClockApi<'a> {
         }
     }
 
-    /// Returns whether the timer `name` exists.
+    /// Returns whether an active (not expired) timer `name` exists.
     ///
     /// # Panics
     ///
@@ -1060,7 +1060,9 @@ impl Clock for TestClock {
     }
 
     fn timer_exists(&self, name: &Ustr) -> bool {
-        self.timers.contains_key(name)
+        self.timers
+            .get(name)
+            .is_some_and(|timer| !timer.is_expired())
     }
 
     fn register_default_handler(&mut self, callback: TimeEventCallback) {
@@ -1695,6 +1697,34 @@ mod tests {
             .unwrap();
 
         assert!(test_clock.timer_exists(&name));
+    }
+
+    #[rstest]
+    fn test_timer_exists_consistent_with_names_and_count_after_expiry(mut test_clock: TestClock) {
+        let name = Ustr::from("expiring_timer");
+        let start_time = test_clock.timestamp_ns();
+
+        test_clock
+            .set_timer_ns(
+                name.as_str(),
+                1_000,
+                Some(start_time),
+                Some(start_time + 2_500),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert!(test_clock.timer_exists(&name));
+        assert_eq!(test_clock.timer_count(), 1);
+
+        test_clock.advance_time(start_time + 10_000, true);
+
+        // All three introspection surfaces must agree the timer is gone
+        assert!(!test_clock.timer_exists(&name));
+        assert_eq!(test_clock.timer_count(), 0);
+        assert!(test_clock.timer_names().is_empty());
     }
 
     #[rstest]

--- a/crates/common/src/live/clock.rs
+++ b/crates/common/src/live/clock.rs
@@ -123,7 +123,9 @@ impl Clock for LiveClock {
     }
 
     fn timer_exists(&self, name: &Ustr) -> bool {
-        self.timers.contains_key(name)
+        self.timers
+            .get(name)
+            .is_some_and(|timer| !timer.is_expired())
     }
 
     fn register_default_handler(&mut self, handler: TimeEventCallback) {
@@ -435,6 +437,45 @@ mod tests {
             Duration::from_secs(2),
         );
         assert!(events.lock().expect(MUTEX_POISONED).is_empty());
+    }
+
+    #[rstest]
+    fn test_live_clock_timer_exists_consistent_after_expiry() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender = Arc::new(CollectingSender::new(Arc::clone(&events)));
+
+        let mut clock = LiveClock::new(Some(sender));
+        clock.register_default_handler(TimeEventCallback::from(|_| {}));
+
+        let name = Ustr::from("expiring");
+        let now = clock.timestamp_ns();
+        let interval_ns = Duration::from_millis(5).as_nanos() as u64;
+        let stop_time = UnixNanos::from(*now + Duration::from_millis(12).as_nanos() as u64);
+
+        clock
+            .set_timer_ns(
+                name.as_str(),
+                interval_ns,
+                None,
+                Some(stop_time),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert!(clock.timer_exists(&name));
+
+        // Wait for the timer task to run past its stop time and finish
+        wait_until(|| clock.timer_count() == 0, Duration::from_secs(2));
+
+        // An expired timer is purged only lazily on the next set/cancel call,
+        // so the entry still sits in the map; the three introspection surfaces
+        // must nevertheless agree it is gone
+        assert!(clock.timers.contains_key(&name));
+        assert!(!clock.timer_exists(&name));
+        assert_eq!(clock.timer_count(), 0);
+        assert!(clock.timer_names().is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
The `Clock` trait has three introspection surfaces for timers, and they disagreed with each other. `timer_names` and `timer_count` both filter on `!timer.is_expired()` - they report only *active* timers. But `timer_exists` was a bare `contains_key`, so it counted expired timers too.

Expired entries are not removed the instant a timer fires; they are purged lazily. `LiveClock` clears them only on the next `set_time_alert_ns` / `set_timer_ns` / cancel call. So there is an unbounded window where a fired-and-done timer still sits in the map - and during that window `timer_exists(name)` returns `true` while `timer_count()` and `timer_names()` behave as though it is gone.

`TestClock` removes one-shot timers eagerly as they fire, so the disagreement is only reachable on the live clock in practice - but both impls carried the identical bare `contains_key`, so both are fixed here to keep the trait contract uniform across clocks.

### The fix

Filter `timer_exists` on `!is_expired()` in both `LiveClock` and `TestClock`, so all three surfaces answer from the same active-timer view. The trait method's doc and the `Clock` API wrapper are updated to say they report an *active (not expired)* timer.

### Consumers are unaffected

Every caller either already tolerates the new answer or improves under it:

- The cancel-before-set callers (`throttler`, option-chain `manager`, data `engine`) do `if timer_exists { cancel_timer }`. With the fix they skip cancelling an already-expired lingering entry - which the immediately following `set_*` overwrites via `replace_existing_timer` anyway, so the outcome is identical.
- The backtest instrument-expiration guard (`if timer_exists { return }`) runs on `TestClock`, which never leaves an expired timer in the map, so its behavior does not change.

### Tests

- `TestClock`: a repeating timer with a stop time is advanced past expiry; the test asserts all three surfaces agree it is gone (`timer_exists` false, `timer_count` 0, `timer_names` empty).
- `LiveClock`: a timer is run past its stop time on the real Tokio runtime; once it has finished, the test asserts the entry is *still physically in the map* (`timers.contains_key` true - lazy purge has not run) yet `timer_exists` reports false, matching `timer_count`/`timer_names`. This is the exact expired-but-present state the fix targets.