### PR TITLE
Exit startup early when execution reconciliation fails in Rust

### DIFF
--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -1164,7 +1164,14 @@ impl ExecutionClient for SandboxExecutionClient {
         &self,
         _lookback_mins: Option<u64>,
     ) -> anyhow::Result<Option<ExecutionMassStatus>> {
-        // Sandbox doesn't need reconciliation
-        Ok(None)
+        let core = self.core.borrow();
+        let ts_init = self.clock.borrow().timestamp_ns();
+        Ok(Some(ExecutionMassStatus::new(
+            core.client_id,
+            core.account_id,
+            core.venue,
+            ts_init,
+            None,
+        )))
     }
 }

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -2418,6 +2418,28 @@ fn test_account_id(execution_client: SandboxExecutionClient, account_id: Account
 }
 
 #[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_returns_empty_report(
+    execution_client: SandboxExecutionClient,
+    client_id: ClientId,
+    account_id: AccountId,
+    venue: Venue,
+) {
+    let mass_status = execution_client
+        .generate_mass_status(None)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(mass_status.client_id, client_id);
+    assert_eq!(mass_status.account_id, account_id);
+    assert_eq!(mass_status.venue, venue);
+    assert!(mass_status.order_reports().is_empty());
+    assert!(mass_status.fill_reports().is_empty());
+    assert!(mass_status.position_reports().is_empty());
+}
+
+#[rstest]
 fn test_config_accessor(execution_client: SandboxExecutionClient, venue: Venue) {
     let config = execution_client.config();
 

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -79,6 +79,7 @@
 
 use std::{collections::HashSet, fmt::Debug, future::Future, pin::Pin, time::Duration};
 
+use anyhow::Context;
 use indexmap::IndexSet;
 use nautilus_common::{
     actor::{Actor, DataActor, DataActorNative},
@@ -611,8 +612,7 @@ impl LiveNode {
 
         for client_id in client_ids {
             if start.elapsed() > timeout {
-                log::warn!("Reconciliation timeout reached, stopping early");
-                break;
+                anyhow::bail!("Startup reconciliation timeout reached");
             }
 
             log_info!(
@@ -673,13 +673,13 @@ impl LiveNode {
                     }
                 }
                 Ok(None) => {
-                    log::warn!(
+                    anyhow::bail!(
                         "No mass status available from {client_id} \
                          (likely adapter error when generating reports)"
                     );
                 }
                 Err(e) => {
-                    log::warn!("Failed to get mass status from {client_id}: {e}");
+                    return Err(e).context(format!("Failed to get mass status from {client_id}"));
                 }
             }
         }

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -423,7 +423,15 @@ impl LiveNode {
             }
         }
 
-        self.perform_startup_reconciliation().await?;
+        if let Err(e) = self.perform_startup_reconciliation().await {
+            if let Err(finalize_err) = self.abort_startup("Startup reconciliation failed").await {
+                anyhow::bail!(
+                    "startup reconciliation failed: {e}; failed to finalize startup abort: {finalize_err}"
+                );
+            }
+
+            return Err(e);
+        }
 
         self.kernel.start_trader();
         #[cfg(feature = "plugin")]
@@ -611,9 +619,11 @@ impl LiveNode {
         let client_ids = self.kernel.exec_engine.borrow().client_ids();
 
         for client_id in client_ids {
-            if start.elapsed() > timeout {
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
                 anyhow::bail!("Startup reconciliation timeout reached");
             }
+            let remaining = timeout - elapsed;
 
             log_info!(
                 "Requesting mass status from {}...",
@@ -621,12 +631,19 @@ impl LiveNode {
                 color = LogColor::Blue
             );
 
-            let mass_status_result = self
-                .kernel
-                .exec_engine
-                .borrow_mut()
-                .generate_mass_status(&client_id, lookback_mins)
-                .await;
+            let mass_status_result = tokio::time::timeout(remaining, async {
+                self.kernel
+                    .exec_engine
+                    .borrow_mut()
+                    .generate_mass_status(&client_id, lookback_mins)
+                    .await
+            })
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "Startup reconciliation timeout reached while requesting mass status from {client_id}"
+                )
+            })?;
 
             match mass_status_result {
                 Ok(Some(mass_status)) => {
@@ -852,7 +869,25 @@ impl LiveNode {
 
         if engine_connection_status == EngineConnectionStatus::Connected {
             // Run reconciliation now that instruments are in cache and start trader
-            self.perform_startup_reconciliation().await?;
+            if let Err(e) = self.perform_startup_reconciliation().await {
+                let result = self.abort_startup("Startup reconciliation failed").await;
+                Self::drain_channels(
+                    &mut time_evt_rx,
+                    &mut data_evt_rx,
+                    &mut data_cmd_rx,
+                    &mut exec_evt_rx,
+                    &mut exec_cmd_rx,
+                );
+                log::info!("Event loop stopped");
+
+                if let Err(finalize_err) = result {
+                    anyhow::bail!(
+                        "startup reconciliation failed: {e}; failed to finalize startup abort: {finalize_err}"
+                    );
+                }
+
+                return Err(e);
+            }
             self.kernel.start_trader();
             #[cfg(feature = "plugin")]
             if let Err(e) = self.plugins.start_controllers() {

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -623,7 +623,9 @@ impl LiveNode {
             if elapsed >= timeout {
                 anyhow::bail!("Startup reconciliation timeout reached");
             }
-            let remaining = timeout - elapsed;
+            let remaining = timeout
+                .checked_sub(elapsed)
+                .expect("elapsed checked against reconciliation timeout");
 
             log_info!(
                 "Requesting mass status from {}...",

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -58,7 +58,7 @@ use nautilus_model::{
     },
     instruments::{Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt},
     orders::{OrderAny, OrderTestBuilder, stubs::TestOrderEventStubs},
-    reports::{OrderStatusReport, PositionStatusReport},
+    reports::{ExecutionMassStatus, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, MarginBalance, Price, Quantity},
 };
 use nautilus_trading::{
@@ -229,6 +229,170 @@ fn test_builder_accepts_live() {
 
 mod serial_tests {
     use super::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct StartupMassStatusClientState {
+        connected: Arc<AtomicBool>,
+        mass_status_requested: Arc<AtomicBool>,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum StartupMassStatusBehavior {
+        Unavailable,
+        Error,
+        Pending,
+    }
+
+    struct StartupMassStatusExecutionClient {
+        state: StartupMassStatusClientState,
+        behavior: StartupMassStatusBehavior,
+    }
+
+    impl StartupMassStatusExecutionClient {
+        const CLIENT_ID: &'static str = "STARTUP-MASS-STATUS";
+
+        fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
+            Self { state, behavior }
+        }
+    }
+
+    #[derive(Debug)]
+    struct StartupMassStatusExecutionClientConfig;
+
+    impl ClientConfig for StartupMassStatusExecutionClientConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct StartupMassStatusExecutionClientFactory {
+        state: StartupMassStatusClientState,
+        behavior: StartupMassStatusBehavior,
+    }
+
+    impl StartupMassStatusExecutionClientFactory {
+        fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
+            Self { state, behavior }
+        }
+    }
+
+    impl ExecutionClientFactory for StartupMassStatusExecutionClientFactory {
+        fn create(
+            &self,
+            _name: &str,
+            _config: &dyn ClientConfig,
+            _cache: CacheView,
+        ) -> anyhow::Result<Box<dyn ExecutionClient>> {
+            Ok(Box::new(StartupMassStatusExecutionClient::new(
+                self.state.clone(),
+                self.behavior,
+            )))
+        }
+
+        fn name(&self) -> &'static str {
+            "startup-mass-status"
+        }
+
+        fn config_type(&self) -> &'static str {
+            stringify!(StartupMassStatusExecutionClientConfig)
+        }
+    }
+
+    fn live_node_with_startup_mass_status_client(
+        name: &str,
+        config: LiveNodeConfig,
+        behavior: StartupMassStatusBehavior,
+    ) -> (LiveNode, StartupMassStatusClientState) {
+        let state = StartupMassStatusClientState::default();
+        let factory = StartupMassStatusExecutionClientFactory::new(state.clone(), behavior);
+
+        let node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name(name)
+            .add_exec_client(
+                Some("startup-mass-status".to_string()),
+                Box::new(factory),
+                Box::new(StartupMassStatusExecutionClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        (node, state)
+    }
+
+    #[async_trait(?Send)]
+    impl ExecutionClient for StartupMassStatusExecutionClient {
+        fn is_connected(&self) -> bool {
+            self.state.connected.load(Ordering::Relaxed)
+        }
+
+        fn client_id(&self) -> ClientId {
+            ClientId::from(Self::CLIENT_ID)
+        }
+
+        fn account_id(&self) -> AccountId {
+            AccountId::from("STARTUP-MASS-STATUS-001")
+        }
+
+        fn venue(&self) -> Venue {
+            crypto_perpetual_ethusdt().id().venue
+        }
+
+        fn oms_type(&self) -> OmsType {
+            OmsType::Hedging
+        }
+
+        fn get_account(&self) -> Option<AccountAny> {
+            None
+        }
+
+        fn generate_account_state(
+            &self,
+            _balances: Vec<AccountBalance>,
+            _margins: Vec<MarginBalance>,
+            _reported: bool,
+            _ts_event: UnixNanos,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            self.state.connected.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> anyhow::Result<()> {
+            self.state.connected.store(false, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn generate_mass_status(
+            &self,
+            _lookback_mins: Option<u64>,
+        ) -> anyhow::Result<Option<ExecutionMassStatus>> {
+            self.state
+                .mass_status_requested
+                .store(true, Ordering::Relaxed);
+
+            match self.behavior {
+                StartupMassStatusBehavior::Unavailable => Ok(None),
+                StartupMassStatusBehavior::Error => Err(anyhow::anyhow!("mass status failed")),
+                StartupMassStatusBehavior::Pending => {
+                    std::future::pending::<anyhow::Result<Option<ExecutionMassStatus>>>().await
+                }
+            }
+        }
+    }
 
     struct BlockingReportExecutionClient {
         connected: Cell<bool>,
@@ -794,6 +958,162 @@ mod serial_tests {
             "run() should complete within 5 seconds after stop"
         );
         assert_eq!(handle.state(), NodeState::Stopped);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_start_aborts_startup_when_mass_status_unavailable() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut node, state) = live_node_with_startup_mass_status_client(
+            "StartupMassStatusUnavailableNode",
+            config,
+            StartupMassStatusBehavior::Unavailable,
+        );
+        let handle = node.handle();
+
+        let err = node.start().await.expect_err("start should fail");
+
+        assert!(
+            err.to_string().contains("No mass status available"),
+            "unexpected error: {err:#}"
+        );
+        assert!(state.mass_status_requested.load(Ordering::Relaxed));
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!state.connected.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_aborts_startup_when_mass_status_unavailable() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut node, state) = live_node_with_startup_mass_status_client(
+            "RunStartupMassStatusUnavailableNode",
+            config,
+            StartupMassStatusBehavior::Unavailable,
+        );
+        let handle = node.handle();
+
+        let err = node.run().await.expect_err("run should fail");
+
+        assert!(
+            err.to_string().contains("No mass status available"),
+            "unexpected error: {err:#}"
+        );
+        assert!(state.mass_status_requested.load(Ordering::Relaxed));
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!state.connected.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_start_aborts_startup_when_mass_status_errors() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut node, state) = live_node_with_startup_mass_status_client(
+            "StartStartupMassStatusErrorNode",
+            config,
+            StartupMassStatusBehavior::Error,
+        );
+        let handle = node.handle();
+
+        let err = node.start().await.expect_err("start should fail");
+        let err = format!("{err:#}");
+
+        assert!(
+            err.contains("Failed to get mass status from") && err.contains("mass status failed"),
+            "unexpected error: {err}"
+        );
+        assert!(state.mass_status_requested.load(Ordering::Relaxed));
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!state.connected.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_aborts_startup_when_mass_status_errors() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut node, state) = live_node_with_startup_mass_status_client(
+            "StartupMassStatusErrorNode",
+            config,
+            StartupMassStatusBehavior::Error,
+        );
+        let handle = node.handle();
+
+        let err = node.run().await.expect_err("run should fail");
+        let err = format!("{err:#}");
+
+        assert!(
+            err.contains("Failed to get mass status from") && err.contains("mass status failed"),
+            "unexpected error: {err}"
+        );
+        assert!(state.mass_status_requested.load(Ordering::Relaxed));
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!state.connected.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_startup_reconciliation_times_out_waiting_for_mass_status() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            timeout_reconciliation: Duration::from_millis(50),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut node, state) = live_node_with_startup_mass_status_client(
+            "StartupMassStatusTimeoutNode",
+            config,
+            StartupMassStatusBehavior::Pending,
+        );
+        let handle = node.handle();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), node.run()).await;
+
+        assert!(
+            result.is_ok(),
+            "startup reconciliation timeout should fire before the test timeout"
+        );
+        let err = result
+            .unwrap()
+            .expect_err("run should fail on startup reconciliation timeout");
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("Startup reconciliation timeout reached"),
+            "unexpected error: {err}"
+        );
+        assert!(state.mass_status_requested.load(Ordering::Relaxed));
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!state.connected.load(Ordering::Relaxed));
     }
 
     // The maintenance dispatcher is a single `select!` arm in `LiveNode::run`


### PR DESCRIPTION
Return an error from Rust LiveNode startup reconciliation when mass status generation times out, returns None, or fails, instead of warning and continuing.

# Pull Request

## Summary

This prevents ignoring initial reconciliation failures/timeouts and blindly starting the trading node.

## Related Issues/PRs

Relates to https://github.com/nautechsystems/nautilus_trader/issues/4405

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [X] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Will [error out](https://github.com/nautechsystems/nautilus_trader/blob/8160730c7c550480b0a439fb11086a4c4de15f0b/crates/live/src/node/mod.rs#L415) the node in case of failure instead of just logging and starting.

## Testing

Did not see specific tests for this scenario but some could be added
We could also create an error enum to identify timeouts, missing mass status or failures during generation, but wanted to keep things simple
