### PR TITLE
Wire live client routing config into Rust nodes

### DIFF
--- a/crates/adapters/interactive_brokers/examples/node_data_tester.rs
+++ b/crates/adapters/interactive_brokers/examples/node_data_tester.rs
@@ -37,7 +37,7 @@ use nautilus_interactive_brokers::{
     },
     factories::InteractiveBrokersDataClientFactory,
 };
-use nautilus_live::node::LiveNode;
+use nautilus_live::{config::RoutingConfig, node::LiveNode};
 use nautilus_model::{
     data::bar::BarType,
     identifiers::{ClientId, InstrumentId, TraderId},
@@ -79,13 +79,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
+    let routing = RoutingConfig::builder().default(true).build();
+
     let mut node = LiveNode::builder(TraderId::from(TRADER_ID), Environment::Live)?
         .with_name(NODE_NAME.to_string())
         .with_delay_post_stop_secs(2)
-        .add_data_client(
+        .add_data_client_with_routing(
             None,
             Box::new(InteractiveBrokersDataClientFactory::new()),
             Box::new(data_config),
+            routing,
         )?
         .build()?;
 

--- a/crates/adapters/interactive_brokers/examples/node_exec_tester.rs
+++ b/crates/adapters/interactive_brokers/examples/node_exec_tester.rs
@@ -38,7 +38,10 @@ use nautilus_interactive_brokers::{
     },
     factories::{InteractiveBrokersDataClientFactory, InteractiveBrokersExecutionClientFactory},
 };
-use nautilus_live::{config::LiveExecEngineConfig, node::LiveNode};
+use nautilus_live::{
+    config::{LiveExecEngineConfig, RoutingConfig},
+    node::LiveNode,
+};
 use nautilus_model::{
     enums::{OrderType, TimeInForce},
     identifiers::{AccountId, ClientId, InstrumentId, StrategyId, TraderId},
@@ -80,6 +83,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let market_data_type = parse_market_data_type(MARKET_DATA_TYPE);
     let order_qty = Quantity::from(ORDER_QTY);
 
+    let routing = RoutingConfig::builder().default(true).build();
+
     let data_config = InteractiveBrokersDataClientConfig {
         host: HOST.to_string(),
         port: PORT,
@@ -108,17 +113,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_exec_engine_config(exec_engine_config)
         .with_delay_post_stop_secs(5)
         .with_reconciliation(true)
-        .add_data_client(
+        .add_data_client_with_routing(
             None,
             Box::new(InteractiveBrokersDataClientFactory::new()),
             Box::new(data_config),
+            routing.clone(),
         )?
-        .add_exec_client(
+        .add_exec_client_with_routing(
             None,
             Box::new(InteractiveBrokersExecutionClientFactory::new(
                 trader_id, account_id,
             )),
             Box::new(exec_config),
+            routing,
         )?
         .build()?;
 

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -90,9 +90,7 @@ use nautilus_common::{
 };
 use nautilus_core::{
     Params, UUID4, UnixNanos, WeakCell,
-    correctness::{
-        FAILED, check_key_in_map, check_key_not_in_map, check_predicate_false, check_predicate_true,
-    },
+    correctness::{FAILED, check_key_in_map, check_key_not_in_map, check_predicate_true},
     datetime::{NANOSECONDS_IN_DAY, millis_to_nanos_unchecked},
 };
 #[cfg(feature = "defi")]
@@ -152,7 +150,7 @@ pub struct DataEngine {
     pub(crate) cache: Rc<RefCell<Cache>>,
     pub(crate) external_clients: AHashSet<ClientId>,
     clients: IndexMap<ClientId, DataClientAdapter>,
-    default_client: Option<DataClientAdapter>,
+    default_client_id: Option<ClientId>,
     routing_map: IndexMap<Venue, ClientId>,
     book_intervals: AHashMap<NonZeroUsize, BookSnapshotInfos>,
     book_snapshot_counts: IndexMap<BookSnapshotKey, usize>,
@@ -235,7 +233,7 @@ impl DataEngine {
             cache,
             external_clients,
             clients: IndexMap::new(),
-            default_client: None,
+            default_client_id: None,
             routing_map: IndexMap::new(),
             book_intervals: AHashMap::new(),
             book_snapshot_counts: IndexMap::new(),
@@ -445,14 +443,6 @@ impl DataEngine {
     pub fn register_client(&mut self, client: DataClientAdapter, routing: Option<Venue>) {
         let client_id = client.client_id();
 
-        if let Some(default_client) = &self.default_client {
-            check_predicate_false(
-                default_client.client_id() == client.client_id(),
-                "client_id already registered as default client",
-            )
-            .expect(FAILED);
-        }
-
         check_key_not_in_map(&client_id, &self.clients, "client_id", "clients").expect(FAILED);
 
         if let Some(routing) = routing {
@@ -460,13 +450,13 @@ impl DataEngine {
             log::debug!("Set client {client_id} routing for {routing}");
         }
 
-        if client.venue.is_none() && self.default_client.is_none() {
-            self.default_client = Some(client);
+        if client.venue.is_none() && self.default_client_id.is_none() {
+            self.default_client_id = Some(client_id);
             log::debug!("Registered client {client_id} for default routing");
-        } else {
-            self.clients.insert(client_id, client);
-            log::debug!("Registered client {client_id}");
         }
+
+        self.clients.insert(client_id, client);
+        log::debug!("Registered client {client_id}");
     }
 
     /// Deregisters the client for the `client_id`.
@@ -477,6 +467,9 @@ impl DataEngine {
     pub fn deregister_client(&mut self, client_id: &ClientId) {
         check_key_in_map(client_id, &self.clients, "client_id", "clients").expect(FAILED);
 
+        if self.default_client_id.as_ref() == Some(client_id) {
+            self.default_client_id = None;
+        }
         self.clients.shift_remove(client_id);
         log::info!("Deregistered client {client_id}");
     }
@@ -494,15 +487,63 @@ impl DataEngine {
     /// Panics if a default client has already been registered.
     pub fn register_default_client(&mut self, client: DataClientAdapter) {
         check_predicate_true(
-            self.default_client.is_none(),
+            self.default_client_id.is_none(),
             "default client already registered",
         )
         .expect(FAILED);
 
         let client_id = client.client_id();
-
-        self.default_client = Some(client);
+        self.clients.insert(client_id, client);
+        self.default_client_id = Some(client_id);
         log::debug!("Registered default client {client_id}");
+    }
+
+    /// Marks an already-registered client as the default for fallback routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no client is registered with the given ID, or a different
+    /// client is already the default.
+    pub fn set_default_client(&mut self, client_id: ClientId) -> anyhow::Result<()> {
+        if self.default_client_id.is_some_and(|id| id != client_id) {
+            anyhow::bail!("default client already registered");
+        }
+
+        if !self.clients.contains_key(&client_id) {
+            anyhow::bail!("No client registered with ID {client_id}");
+        }
+        self.default_client_id = Some(client_id);
+        log::debug!("Set client {client_id} as default");
+        Ok(())
+    }
+
+    /// Sets routing for a specific venue to a given client ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client ID is not registered, or the venue is already routed to a
+    /// different client.
+    pub fn register_venue_routing(
+        &mut self,
+        client_id: ClientId,
+        venue: Venue,
+    ) -> anyhow::Result<()> {
+        if !self.clients.contains_key(&client_id) {
+            anyhow::bail!("No client registered with ID {client_id}");
+        }
+
+        if let Some(existing_client_id) = self.routing_map.get(&venue)
+            && *existing_client_id != client_id
+        {
+            anyhow::bail!(
+                "Venue {venue} already routed to {existing_client_id}, \
+                 cannot re-route to {client_id}"
+            );
+        }
+
+        self.routing_map.insert(venue, client_id);
+        log::debug!("Set client {client_id} routing for {venue}");
+        Ok(())
     }
 
     /// Starts all registered data clients and re-arms bar aggregator timers.
@@ -734,26 +775,12 @@ impl DataEngine {
 
     #[must_use]
     pub fn get_clients(&self) -> Vec<&DataClientAdapter> {
-        let (default_opt, clients_map) = (&self.default_client, &self.clients);
-        let mut clients: Vec<&DataClientAdapter> = clients_map.values().collect();
-
-        if let Some(default) = default_opt {
-            clients.push(default);
-        }
-
-        clients
+        self.clients.values().collect()
     }
 
     #[must_use]
     pub fn get_clients_mut(&mut self) -> Vec<&mut DataClientAdapter> {
-        let (default_opt, clients_map) = (&mut self.default_client, &mut self.clients);
-        let mut clients: Vec<&mut DataClientAdapter> = clients_map.values_mut().collect();
-
-        if let Some(default) = default_opt {
-            clients.push(default);
-        }
-
-        clients
+        self.clients.values_mut().collect()
     }
 
     pub fn get_client(
@@ -762,30 +789,15 @@ impl DataEngine {
         venue: Option<&Venue>,
     ) -> Option<&mut DataClientAdapter> {
         if let Some(client_id) = client_id {
-            // Explicit ID: first look in registered clients
-            if let Some(client) = self.clients.get_mut(client_id) {
-                return Some(client);
-            }
-
-            // Then check if it matches the default client
-            if let Some(default) = self.default_client.as_mut()
-                && default.client_id() == *client_id
-            {
-                return Some(default);
-            }
-
-            // Unknown explicit client
-            return None;
+            return self.clients.get_mut(client_id);
         }
 
-        if let Some(v) = venue {
-            // Route by venue if mapped client still registered
-            if let Some(client_id) = self.routing_map.get(v) {
-                return self.clients.get_mut(client_id);
-            }
+        if let Some(v) = venue
+            && let Some(client_id) = self.routing_map.get(v)
+        {
+            return self.clients.get_mut(client_id);
         }
 
-        // Fallback to default client
         self.get_default_client()
     }
 
@@ -799,23 +811,17 @@ impl DataEngine {
         venue: Option<&Venue>,
     ) -> Option<&mut DataClientAdapter> {
         let backtest_id = ClientId::new("BACKTEST");
-        // BACKTEST may live in `clients` or as the default (venue=None branch in
-        // `register_client`)
         if self.clients.contains_key(&backtest_id) {
             return self.clients.get_mut(&backtest_id);
-        }
-        let default_is_backtest = self
-            .default_client
-            .as_ref()
-            .is_some_and(|c| c.client_id() == backtest_id);
-        if default_is_backtest {
-            return self.default_client.as_mut();
         }
         self.get_client(client_id, venue)
     }
 
-    const fn get_default_client(&mut self) -> Option<&mut DataClientAdapter> {
-        self.default_client.as_mut()
+    fn get_default_client(&mut self) -> Option<&mut DataClientAdapter> {
+        match self.default_client_id {
+            Some(id) => self.clients.get_mut(&id),
+            None => None,
+        }
     }
 
     /// Returns all custom data types currently subscribed across all clients.

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -778,6 +778,153 @@ fn test_execute_subscribe_book_deltas(
 }
 
 #[rstest]
+fn test_execute_subscribe_routes_to_default_client_when_no_client_id(
+    audusd_sim: CurrencyPair,
+    data_engine: Rc<RefCell<DataEngine>>,
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+) {
+    let mut data_engine = data_engine.borrow_mut();
+
+    let broker_venue = Venue::new("IB");
+    let broker_client_id = ClientId::new("IB");
+    let recorder: Rc<RefCell<Vec<DataCommand>>> = Rc::new(RefCell::new(Vec::new()));
+    let client = MockDataClient::new_with_recorder(
+        clock,
+        cache,
+        broker_client_id,
+        Some(broker_venue),
+        Some(recorder.clone()),
+    );
+    let adapter = DataClientAdapter::new(
+        broker_client_id,
+        Some(broker_venue),
+        true,
+        true,
+        Box::new(client),
+    );
+    data_engine.register_default_client(adapter);
+
+    let sub_cmd = DataCommand::Subscribe(SubscribeCommand::BookDeltas(SubscribeBookDeltas::new(
+        audusd_sim.id,
+        BookType::L3_MBO,
+        None,
+        Some(audusd_sim.id.venue),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        true,
+        None,
+        None,
+    )));
+    data_engine.execute(sub_cmd.clone());
+
+    assert_eq!(recorder.borrow().as_slice(), std::slice::from_ref(&sub_cmd));
+}
+
+#[rstest]
+fn test_register_venue_routing_routes_exchange_venue_to_client(
+    data_engine: Rc<RefCell<DataEngine>>,
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+) {
+    let mut data_engine = data_engine.borrow_mut();
+
+    let broker_client_id = ClientId::new("IB");
+    let exchange_venue = Venue::new("IBIS");
+    let recorder: Rc<RefCell<Vec<DataCommand>>> = Rc::new(RefCell::new(Vec::new()));
+    let client = MockDataClient::new_with_recorder(
+        clock,
+        cache,
+        broker_client_id,
+        None,
+        Some(recorder.clone()),
+    );
+    let adapter = DataClientAdapter::new(broker_client_id, None, true, true, Box::new(client));
+    data_engine.register_client(adapter, None);
+    data_engine
+        .register_venue_routing(broker_client_id, exchange_venue)
+        .unwrap();
+
+    let instrument_id = InstrumentId::new(Symbol::new("VWCE"), exchange_venue);
+    let sub_cmd = DataCommand::Subscribe(SubscribeCommand::BookDeltas(SubscribeBookDeltas::new(
+        instrument_id,
+        BookType::L3_MBO,
+        None,
+        Some(exchange_venue),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        true,
+        None,
+        None,
+    )));
+    data_engine.execute(sub_cmd.clone());
+
+    assert_eq!(recorder.borrow().as_slice(), std::slice::from_ref(&sub_cmd));
+}
+
+#[rstest]
+fn test_default_and_venue_routing_apply_independently_for_venue_less_client(
+    data_engine: Rc<RefCell<DataEngine>>,
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+) {
+    let mut data_engine = data_engine.borrow_mut();
+
+    let broker_client_id = ClientId::new("IB");
+    let exchange_venue = Venue::new("IBIS");
+    let recorder: Rc<RefCell<Vec<DataCommand>>> = Rc::new(RefCell::new(Vec::new()));
+    let client = MockDataClient::new_with_recorder(
+        clock,
+        cache,
+        broker_client_id,
+        None,
+        Some(recorder.clone()),
+    );
+    let adapter = DataClientAdapter::new(broker_client_id, None, true, true, Box::new(client));
+    data_engine.register_client(adapter, None);
+    data_engine.set_default_client(broker_client_id).unwrap();
+    data_engine
+        .register_venue_routing(broker_client_id, exchange_venue)
+        .unwrap();
+
+    let routed_id = InstrumentId::new(Symbol::new("VWCE"), exchange_venue);
+    let routed_cmd =
+        DataCommand::Subscribe(SubscribeCommand::BookDeltas(SubscribeBookDeltas::new(
+            routed_id,
+            BookType::L3_MBO,
+            None,
+            Some(exchange_venue),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            true,
+            None,
+            None,
+        )));
+    data_engine.execute(routed_cmd.clone());
+
+    let unmapped_venue = Venue::new("UNKNOWN");
+    let default_cmd =
+        DataCommand::Subscribe(SubscribeCommand::BookDeltas(SubscribeBookDeltas::new(
+            InstrumentId::new(Symbol::new("XYZ"), unmapped_venue),
+            BookType::L3_MBO,
+            None,
+            Some(unmapped_venue),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            true,
+            None,
+            None,
+        )));
+    data_engine.execute(default_cmd.clone());
+
+    assert_eq!(recorder.borrow().as_slice(), &[routed_cmd, default_cmd]);
+}
+
+#[rstest]
 fn test_unsubscribe_book_deltas_removes_book_updater(
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -123,7 +123,7 @@ pub struct ExecutionEngine {
     clock: Rc<RefCell<dyn Clock>>,
     cache: Rc<RefCell<Cache>>,
     clients: IndexMap<ClientId, ExecutionClientAdapter>,
-    default_client: Option<ExecutionClientAdapter>,
+    default_client_id: Option<ClientId>,
     routing_map: HashMap<Venue, ClientId>,
     oms_overrides: HashMap<StrategyId, OmsType>,
     external_order_claims: HashMap<InstrumentId, StrategyId>,
@@ -157,7 +157,7 @@ impl ExecutionEngine {
             clock: clock.clone(),
             cache,
             clients: IndexMap::new(),
-            default_client: None,
+            default_client_id: None,
             routing_map: HashMap::new(),
             oms_overrides: HashMap::new(),
             external_order_claims: HashMap::new(),
@@ -310,39 +310,22 @@ impl ExecutionEngine {
     #[must_use]
     /// Returns true if all registered execution clients are connected.
     pub fn check_connected(&self) -> bool {
-        let clients_connected = self.clients.values().all(|c| c.is_connected());
-        let default_connected = self
-            .default_client
-            .as_ref()
-            .is_none_or(|c| c.is_connected());
-        clients_connected && default_connected
+        self.clients.values().all(|c| c.is_connected())
     }
 
     #[must_use]
     /// Returns true if all registered execution clients are disconnected.
     pub fn check_disconnected(&self) -> bool {
-        let clients_disconnected = self.clients.values().all(|c| !c.is_connected());
-        let default_disconnected = self
-            .default_client
-            .as_ref()
-            .is_none_or(|c| !c.is_connected());
-        clients_disconnected && default_disconnected
+        self.clients.values().all(|c| !c.is_connected())
     }
 
     /// Returns connection status for each registered client.
     #[must_use]
     pub fn client_connection_status(&self) -> Vec<(ClientId, bool)> {
-        let mut status: Vec<_> = self
-            .clients
+        self.clients
             .values()
             .map(|c| (c.client_id(), c.is_connected()))
-            .collect();
-
-        if let Some(default) = &self.default_client {
-            status.push((default.client_id(), default.is_connected()));
-        }
-
-        status
+            .collect()
     }
 
     #[must_use]
@@ -402,8 +385,28 @@ impl ExecutionEngine {
         let client_id = client.client_id();
         let adapter = ExecutionClientAdapter::new(client);
 
+        self.clients.insert(client_id, adapter);
+        self.default_client_id = Some(client_id);
         log::debug!("Registered default client {client_id}");
-        self.default_client = Some(adapter);
+    }
+
+    /// Marks an already-registered client as the default for fallback routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no client is registered with the given ID, or a default
+    /// client has already been set.
+    pub fn set_default_client(&mut self, client_id: ClientId) -> anyhow::Result<()> {
+        if self.default_client_id.is_some() {
+            anyhow::bail!("default client already registered");
+        }
+
+        if !self.clients.contains_key(&client_id) {
+            anyhow::bail!("No client registered with ID {client_id}");
+        }
+        self.default_client_id = Some(client_id);
+        log::debug!("Set client {client_id} as default");
+        Ok(())
     }
 
     #[must_use]
@@ -418,11 +421,6 @@ impl ExecutionEngine {
         &mut self,
         client_id: &ClientId,
     ) -> Option<&mut ExecutionClientAdapter> {
-        if let Some(default) = &self.default_client
-            && &default.client_id == client_id
-        {
-            return self.default_client.as_mut();
-        }
         self.clients.get_mut(client_id)
     }
 
@@ -456,18 +454,16 @@ impl ExecutionEngine {
         ts_init: UnixNanos,
     ) {
         let venue = instrument_id.venue;
-        if let Some(client_id) = self.routing_map.get(&venue) {
-            if let Some(client) = self.clients.get(client_id) {
-                client.register_external_order(
-                    client_order_id,
-                    venue_order_id,
-                    instrument_id,
-                    strategy_id,
-                    ts_init,
-                );
-            }
-        } else if let Some(default) = &self.default_client {
-            default.register_external_order(
+        let client_id = self
+            .routing_map
+            .get(&venue)
+            .copied()
+            .or(self.default_client_id);
+
+        if let Some(client_id) = client_id
+            && let Some(client) = self.clients.get(&client_id)
+        {
+            client.register_external_order(
                 client_order_id,
                 venue_order_id,
                 instrument_id,
@@ -480,36 +476,19 @@ impl ExecutionEngine {
     #[must_use]
     /// Returns all registered execution client IDs.
     pub fn client_ids(&self) -> Vec<ClientId> {
-        let mut ids: Vec<_> = self.clients.keys().copied().collect();
-
-        if let Some(default) = &self.default_client {
-            ids.push(default.client_id);
-        }
-        ids
+        self.clients.keys().copied().collect()
     }
 
     #[must_use]
     /// Returns mutable access to all registered execution clients.
     pub fn get_clients_mut(&mut self) -> Vec<&mut ExecutionClientAdapter> {
-        let mut adapters: Vec<_> = self.clients.values_mut().collect();
-
-        if let Some(default) = &mut self.default_client {
-            adapters.push(default);
-        }
-        adapters
+        self.clients.values_mut().collect()
     }
 
     /// Returns all registered execution clients.
     #[must_use]
     pub fn get_all_clients(&self) -> Vec<&dyn ExecutionClient> {
-        let mut clients: Vec<&dyn ExecutionClient> =
-            self.clients.values().map(|a| a.client.as_ref()).collect();
-
-        if let Some(default) = &self.default_client {
-            clients.push(default.client.as_ref());
-        }
-
-        clients
+        self.clients.values().map(|a| a.client.as_ref()).collect()
     }
 
     #[must_use]
@@ -542,13 +521,13 @@ impl ExecutionEngine {
 
         // Add clients for venue routing (for orders not in cache)
         for venue in &venues {
-            if let Some(client_id) = self.routing_map.get(venue) {
-                if let Some(adapter) = self.clients.get(client_id)
-                    && !clients.iter().any(|c| c.client_id() == adapter.client_id)
-                {
-                    clients.push(adapter.client.as_ref());
-                }
-            } else if let Some(adapter) = &self.default_client
+            let resolved_id = self
+                .routing_map
+                .get(venue)
+                .copied()
+                .or(self.default_client_id);
+
+            if let Some(adapter) = resolved_id.and_then(|id| self.clients.get(&id))
                 && !clients.iter().any(|c| c.client_id() == adapter.client_id)
             {
                 clients.push(adapter.client.as_ref());
@@ -2048,7 +2027,7 @@ impl ExecutionEngine {
             return Some(adapter);
         }
 
-        self.default_client.as_ref()
+        self.default_client_id.and_then(|id| self.clients.get(&id))
     }
 
     fn account_id_for_command(&self, command: &TradingCommand) -> Option<AccountId> {
@@ -2724,7 +2703,7 @@ impl ExecutionEngine {
             return client.oms_type;
         }
 
-        if let Some(client) = &self.default_client {
+        if let Some(client) = self.default_client_id.and_then(|id| self.clients.get(&id)) {
             return client.oms_type;
         }
 

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -3192,6 +3192,68 @@ fn test_submit_order_list_denies_when_client_does_not_handle_instrument_venue(
 }
 
 #[rstest]
+fn test_submit_order_routes_to_default_client_when_no_client_id(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = futures_contract_xcme();
+    let client = StubExecutionClient::new(
+        ClientId::from("IB"),
+        AccountId::from("IB-001"),
+        Venue::from("IB"),
+        OmsType::Netting,
+        None,
+    )
+    .with_handles_all_order_venues();
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_default_client(Box::new(client));
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-19700101-000000-001-001-1"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(10))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, None, true)
+        .unwrap();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        instrument_id: instrument.id,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        position_id: None,
+        params: None,
+        client_id: None,
+        exec_algorithm_id: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    };
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    assert_eq!(
+        submitted_order_ids.borrow().as_slice(),
+        &[order.client_order_id()],
+    );
+}
+
+#[rstest]
 fn test_submit_order_allows_routing_broker_for_exchange_mic_venue(
     mut execution_engine: ExecutionEngine,
 ) {

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -33,7 +33,7 @@ use nautilus_common::{
 use nautilus_core::UUID4;
 use nautilus_data::client::DataClientAdapter;
 use nautilus_execution::engine::ExecutionEngine;
-use nautilus_model::identifiers::TraderId;
+use nautilus_model::identifiers::{TraderId, Venue};
 use nautilus_portfolio::config::PortfolioConfig;
 #[cfg(feature = "python")]
 use nautilus_system::trader::Trader;
@@ -47,7 +47,10 @@ use nautilus_trading::ImportableControllerConfig;
 
 use super::{
     LiveNode,
-    config::{LiveDataEngineConfig, LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig},
+    config::{
+        LiveDataEngineConfig, LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig,
+        RoutingConfig,
+    },
 };
 use crate::{
     execution::{
@@ -88,6 +91,8 @@ pub struct LiveNodeBuilder {
     exec_client_factories: HashMap<String, ExecutionClientFactoryEntry>,
     data_client_configs: HashMap<String, Box<dyn ClientConfig>>,
     exec_client_configs: HashMap<String, Box<dyn ClientConfig>>,
+    data_client_routing: HashMap<String, RoutingConfig>,
+    exec_client_routing: HashMap<String, RoutingConfig>,
     event_store_factory: Option<EventStoreFactory>,
     clock_factory: Option<ClockFactory>,
     external_msgbus_factory: Option<Box<dyn MessageBusBackingFactory>>,
@@ -149,6 +154,8 @@ impl LiveNodeBuilder {
             exec_client_factories: HashMap::new(),
             data_client_configs: HashMap::new(),
             exec_client_configs: HashMap::new(),
+            data_client_routing: HashMap::new(),
+            exec_client_routing: HashMap::new(),
             event_store_factory: None,
             clock_factory: None,
             external_msgbus_factory: None,
@@ -177,6 +184,8 @@ impl LiveNodeBuilder {
             exec_client_factories: HashMap::new(),
             data_client_configs: HashMap::new(),
             exec_client_configs: HashMap::new(),
+            data_client_routing: HashMap::new(),
+            exec_client_routing: HashMap::new(),
             event_store_factory: None,
             clock_factory: None,
             external_msgbus_factory: None,
@@ -424,10 +433,25 @@ impl LiveNodeBuilder {
     ///
     /// Returns an error if a client with the same name is already registered.
     pub fn add_data_client(
+        self,
+        name: Option<String>,
+        factory: Box<dyn DataClientFactory>,
+        config: Box<dyn ClientConfig>,
+    ) -> anyhow::Result<Self> {
+        self.add_data_client_with_routing(name, factory, config, RoutingConfig::default())
+    }
+
+    /// Adds a data client factory with configuration and explicit routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a client with the same name is already registered.
+    pub fn add_data_client_with_routing(
         mut self,
         name: Option<String>,
         factory: Box<dyn DataClientFactory>,
         config: Box<dyn ClientConfig>,
+        routing: RoutingConfig,
     ) -> anyhow::Result<Self> {
         let name = name.unwrap_or_else(|| factory.name().to_string());
 
@@ -436,20 +460,39 @@ impl LiveNodeBuilder {
         }
 
         self.data_client_factories.insert(name.clone(), factory);
-        self.data_client_configs.insert(name, config);
+        self.data_client_configs.insert(name.clone(), config);
+        self.data_client_routing.insert(name, routing);
         Ok(self)
     }
 
     /// Adds an execution client factory with configuration.
     ///
+    /// Equivalent to [`Self::add_exec_client_with_routing`] with default (empty)
+    /// routing.
+    ///
     /// # Errors
     ///
     /// Returns an error if a client with the same name is already registered.
     pub fn add_exec_client(
+        self,
+        name: Option<String>,
+        factory: Box<dyn ExecutionClientFactory>,
+        config: Box<dyn ClientConfig>,
+    ) -> anyhow::Result<Self> {
+        self.add_exec_client_with_routing(name, factory, config, RoutingConfig::default())
+    }
+
+    /// Adds an execution client factory with configuration and explicit routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a client with the same name is already registered.
+    pub fn add_exec_client_with_routing(
         mut self,
         name: Option<String>,
         factory: Box<dyn ExecutionClientFactory>,
         config: Box<dyn ClientConfig>,
+        routing: RoutingConfig,
     ) -> anyhow::Result<Self> {
         let name = name.unwrap_or_else(|| factory.name().to_string());
 
@@ -459,7 +502,8 @@ impl LiveNodeBuilder {
 
         self.exec_client_factories
             .insert(name.clone(), ExecutionClientFactoryEntry::Adapter(factory));
-        self.exec_client_configs.insert(name, config);
+        self.exec_client_configs.insert(name.clone(), config);
+        self.exec_client_routing.insert(name, routing);
         Ok(self)
     }
 
@@ -575,10 +619,25 @@ impl LiveNodeBuilder {
                     client,
                 );
 
-                kernel
-                    .data_engine
-                    .borrow_mut()
-                    .register_client(adapter, venue);
+                let routing = self.data_client_routing.remove(&name).unwrap_or_default();
+
+                {
+                    let mut data_engine = kernel.data_engine.borrow_mut();
+                    data_engine.register_client(adapter, venue);
+
+                    if routing.default {
+                        data_engine.set_default_client(client_id)?;
+                    }
+
+                    if let Some(venues) = &routing.venues {
+                        for venue_str in venues {
+                            data_engine.register_venue_routing(
+                                client_id,
+                                Venue::new(venue_str.as_str()),
+                            )?;
+                        }
+                    }
+                }
 
                 log::info!("Registered DataClient-{client_id}");
             } else {
@@ -604,10 +663,25 @@ impl LiveNodeBuilder {
                 let client_id = client.client_id();
                 let venue = client.venue();
 
-                kernel
-                    .exec_engine
-                    .borrow_mut()
-                    .register_client(Box::new(client.clone()))?;
+                let routing = self.exec_client_routing.remove(&name).unwrap_or_default();
+
+                {
+                    let mut exec_engine = kernel.exec_engine.borrow_mut();
+                    exec_engine.register_client(Box::new(client.clone()))?;
+
+                    if routing.default {
+                        exec_engine.set_default_client(client_id)?;
+                    }
+
+                    if let Some(venues) = &routing.venues {
+                        for venue_str in venues {
+                            exec_engine.register_venue_routing(
+                                client_id,
+                                Venue::new(venue_str.as_str()),
+                            )?;
+                        }
+                    }
+                }
                 ExecutionEngine::subscribe_venue_instruments(&kernel.exec_engine, venue);
                 exec_clients.push(client);
 

--- a/crates/live/src/python/node.rs
+++ b/crates/live/src/python/node.rs
@@ -36,6 +36,8 @@ use nautilus_model::identifiers::{
 };
 use nautilus_portfolio::config::PortfolioConfig;
 use nautilus_system::get_global_pyo3_registry;
+
+use crate::node::config::RoutingConfig;
 #[cfg(feature = "examples")]
 use nautilus_testkit::{DataTester, DataTesterConfig, ExecTester, ExecTesterConfig};
 #[cfg(feature = "examples")]
@@ -1217,13 +1219,14 @@ impl LiveNodeBuilderPy {
         }
     }
 
-    #[pyo3(name = "add_data_client")]
+    #[pyo3(name = "add_data_client", signature = (name, factory, config, routing=None))]
     #[expect(clippy::needless_pass_by_value)]
     fn py_add_data_client(
         &self,
         name: Option<String>,
         factory: Py<PyAny>,
         config: Py<PyAny>,
+        routing: Option<RoutingConfig>,
     ) -> PyResult<Self> {
         let mut inner_ref = self.inner.borrow_mut();
         if let Some(builder) = inner_ref.take() {
@@ -1242,7 +1245,17 @@ impl LiveNodeBuilderPy {
                 let client_name = name.unwrap_or(factory_name);
 
                 // Add the data client to the builder using boxed trait objects
-                match builder.add_data_client(Some(client_name), boxed_factory, boxed_config) {
+                let result = match routing {
+                    Some(routing) => builder.add_data_client_with_routing(
+                        Some(client_name),
+                        boxed_factory,
+                        boxed_config,
+                        routing,
+                    ),
+                    None => builder.add_data_client(Some(client_name), boxed_factory, boxed_config),
+                };
+
+                match result {
                     Ok(updated_builder) => {
                         *inner_ref = Some(updated_builder);
                         Ok(Self {
@@ -1257,13 +1270,14 @@ impl LiveNodeBuilderPy {
         }
     }
 
-    #[pyo3(name = "add_exec_client")]
+    #[pyo3(name = "add_exec_client", signature = (name, factory, config, routing=None))]
     #[expect(clippy::needless_pass_by_value)]
     fn py_add_exec_client(
         &self,
         name: Option<String>,
         factory: Py<PyAny>,
         config: Py<PyAny>,
+        routing: Option<RoutingConfig>,
     ) -> PyResult<Self> {
         let mut inner_ref = self.inner.borrow_mut();
         if let Some(builder) = inner_ref.take() {
@@ -1279,7 +1293,17 @@ impl LiveNodeBuilderPy {
                     .extract::<String>(py)?;
                 let client_name = name.unwrap_or(factory_name);
 
-                match builder.add_exec_client(Some(client_name), boxed_factory, boxed_config) {
+                let result = match routing {
+                    Some(routing) => builder.add_exec_client_with_routing(
+                        Some(client_name),
+                        boxed_factory,
+                        boxed_config,
+                        routing,
+                    ),
+                    None => builder.add_exec_client(Some(client_name), boxed_factory, boxed_config),
+                };
+
+                match result {
                     Ok(updated_builder) => {
                         *inner_ref = Some(updated_builder);
                         Ok(Self {
@@ -1592,6 +1616,7 @@ mod tests {
     use rstest::rstest;
 
     use super::LiveNode;
+    use crate::node::config::RoutingConfig;
 
     #[derive(Clone, Copy, Debug)]
     enum ShutdownRunPath {
@@ -1637,7 +1662,6 @@ mod tests {
             Ok(())
         }
     }
-
     #[derive(Debug, Default)]
     struct TestDataClientConfig;
 
@@ -1795,6 +1819,82 @@ mod tests {
         async fn disconnect(&mut self) -> anyhow::Result<()> {
             self.connected.store(false, Ordering::Relaxed);
             anyhow::bail!("test disconnect failed")
+        }
+    }
+
+    struct VenueLessDataClient {
+        client_id: ClientId,
+    }
+
+    impl VenueLessDataClient {
+        fn new(client_id: ClientId) -> Self {
+            Self { client_id }
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl DataClient for VenueLessDataClient {
+        fn client_id(&self) -> ClientId {
+            self.client_id
+        }
+
+        fn venue(&self) -> Option<Venue> {
+            None
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn dispose(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn is_disconnected(&self) -> bool {
+            false
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct VenueLessDataClientFactory;
+
+    impl DataClientFactory for VenueLessDataClientFactory {
+        fn create(
+            &self,
+            name: &str,
+            _config: &dyn ClientConfig,
+            _cache: CacheView,
+            _clock: Rc<RefCell<dyn Clock>>,
+        ) -> anyhow::Result<Box<dyn DataClient>> {
+            Ok(Box::new(VenueLessDataClient::new(ClientId::from(name))))
+        }
+
+        fn name(&self) -> &'static str {
+            "VENUE_LESS"
+        }
+
+        fn config_type(&self) -> &'static str {
+            "TestDataClientConfig"
         }
     }
 
@@ -2314,6 +2414,53 @@ class ClaimsStrategy(Strategy):
             acquired_before_stop.load(Ordering::SeqCst),
             "worker thread should acquire the GIL while LiveNode::run is blocked"
         );
+    }
+
+    #[rstest]
+    fn test_build_routes_venue_less_data_client_with_venue_routing() {
+        Python::initialize();
+
+        let routing = RoutingConfig::builder()
+            .venues(vec!["IBIS".to_string()])
+            .build();
+        let node = LiveNode::builder(TraderId::from("TEST-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .with_timeout_connection(1)
+            .add_data_client_with_routing(
+                Some("IB".to_string()),
+                Box::new(VenueLessDataClientFactory),
+                Box::new(TestDataClientConfig),
+                routing,
+            )
+            .unwrap()
+            .build();
+
+        assert!(node.is_ok(), "build should succeed: {:?}", node.err());
+    }
+
+    #[rstest]
+    fn test_build_routes_venue_less_data_client_with_default_and_venues() {
+        Python::initialize();
+
+        let routing = RoutingConfig::builder()
+            .default(true)
+            .venues(vec!["IBIS".to_string()])
+            .build();
+        let node = LiveNode::builder(TraderId::from("TEST-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .with_timeout_connection(1)
+            .add_data_client_with_routing(
+                Some("IB".to_string()),
+                Box::new(VenueLessDataClientFactory),
+                Box::new(TestDataClientConfig),
+                routing,
+            )
+            .unwrap()
+            .build();
+
+        assert!(node.is_ok(), "build should succeed: {:?}", node.err());
     }
 
     #[rstest]

--- a/python/nautilus_trader/live/__init__.pyi
+++ b/python/nautilus_trader/live/__init__.pyi
@@ -189,10 +189,18 @@ class LiveNodeBuilder:
     def with_exec_engine_config(self, config: LiveExecEngineConfig) -> LiveNodeBuilder: ...
     def with_logging(self, logging: common.LoggerConfig) -> LiveNodeBuilder: ...
     def add_data_client(
-        self, name: str | None, factory: typing.Any, config: typing.Any
+        self,
+        name: str | None,
+        factory: typing.Any,
+        config: typing.Any,
+        routing: RoutingConfig | None = None,
     ) -> LiveNodeBuilder: ...
     def add_exec_client(
-        self, name: str | None, factory: typing.Any, config: typing.Any
+        self,
+        name: str | None,
+        factory: typing.Any,
+        config: typing.Any,
+        routing: RoutingConfig | None = None,
     ) -> LiveNodeBuilder: ...
     def add_simulated_exec_client(
         self, name: str | None, factory: typing.Any, config: typing.Any


### PR DESCRIPTION
Closes #4404.

## Problem

The engines resolved a client by exact `routing_map[venue]` match, then fell back to a single default. The IB client registers under the broker venue `IB` (`Some`), so it can never become the default, and there's no `routing_map` entry for the real exchange MICs (`IBIS`, `IDEALPRO`, …). Anything targeting an exchange-MIC instrument without an explicit `client_id` failed:

```
NO_EXECUTION_CLIENT: client_id=None, venue=IBIS
```

`RoutingConfig` (`default` / `venues`) existed on the live client configs and was exposed in Python, but the live builder never read it — dead config.

## Fix

Make the Rust/PyO3 live builder apply explicit routing config (mirrors the Cython live path):

- `add_data_client` / `add_exec_client` gain additive `*_with_routing` variants taking a `RoutingConfig` — live-node metadata beside the adapter config; factories still receive the plain IB config. At build the client is registered, then marked default (`routing.default`) or venue-routed (`routing.venues`).
- `DataEngine::register_venue_routing(client_id, venue)` — listed exchange MICs route to a registered client by id.
- `ExecutionEngine::set_default_client(client_id)` — marks an already-registered client default **without cloning a second instance** (default tracked by id, resolved through the `clients` map).

Routing order stays: explicit `client_id`, `routing.venues`, `routing.default`, then no route.

## Testing

Validated on a live IB gateway with `VWCE.IBIS`:
- Without `routing` → `NO_EXECUTION_CLIENT: client_id=None, venue=IBIS` (bug reproduced).
- With `routing=RoutingConfig(default=True)` → subscribe/bars, buy, fill, position — all route without `client_id`.

Engine unit tests added for both default-fallback and venue-routing paths; both suites + clippy clean.
