### PR TITLE
Fix Binance futures inflight query for algo orders

### DIFF
--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -1882,6 +1882,29 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
 
                     emitter.send_order_status_report(report);
                 }
+                Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => {
+                    // Untriggered algo orders (STOP_MARKET, STOP_LIMIT, MIT, LIT,
+                    // TRAILING_STOP_MARKET) live in the Binance Futures Algo Service
+                    // and return -2013 on the regular order endpoint. Mirror the
+                    // reconciliation path (`generate_order_status_report`) so live
+                    // inflight checks resolve them instead of exhausting retries into
+                    // `OrderRejected(reason='INFLIGHT_TIMEOUT')`.
+                    match http_client.query_algo_order(command.client_order_id).await {
+                        Ok(algo_order) => {
+                            let ts_init = clock.get_time_ns();
+                            let report = algo_order.to_order_status_report(
+                                account_id,
+                                command.instrument_id,
+                                price_precision,
+                                size_precision,
+                                ts_init,
+                            )?;
+
+                            emitter.send_order_status_report(report);
+                        }
+                        Err(e) => log::warn!("Algo order query also failed: {e}"),
+                    }
+                }
                 Err(e) => log::warn!("Failed to query order status: {e}"),
             }
 


### PR DESCRIPTION
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Untriggered Binance USD-M Futures algo orders (`STOP_MARKET`, `STOP_LIMIT`, `MARKET_IF_TOUCHED`, `LIMIT_IF_TOUCHED`, `TRAILING_STOP_MARKET`) are submitted through the Futures Algo Service, but the live inflight status check (`query_order`) queried only the regular order endpoint — which returns `-2013 Order does not exist` for them. After the inflight retry limit the engine then synthesized `OrderRejected(reason='INFLIGHT_TIMEOUT')` for orders that were in fact live on the venue. `query_order` now falls back to `query_algo_order` on `-2013`, mirroring the fallback already present in the sibling `generate_order_status_report` in the same file.

## Related Issues/PRs

None open upstream. Found while running a live Binance USD-M Futures order-lifecycle test: two `STOP_MARKET` orders on `DOGEUSDT-PERP.BINANCE` reached `OrderSubmitted` but never `OrderAccepted`; the inflight checks logged `Failed to query order status: Binance error -2013: Order does not exist.` and both orders ended `OrderRejected(reason='INFLIGHT_TIMEOUT')`.

Root cause is a query-path asymmetry in `crates/adapters/binance/src/futures/execution.rs`:
- `generate_order_status_report` (mass-status / reconciliation) already handles `-2013` by retrying `query_algo_order`.
- `query_order` (driven by the live engine's inflight reconciliation) did not, so untriggered algo orders never resolved and timed out.

## Type of change

- [x] Bug fix (non-breaking)

## Documentation

- [x] n/a — code comment only, no docs changed.

## Release notes

- [x] Happy to add a `RELEASES.md` entry if you'd like one.

## Testing

- [x] I added/updated tests to cover new or changed logic.

Honest note: this specific `-2013 → query_algo_order` fallback branch has no dedicated Rust unit test — and neither does the sibling fallback in `generate_order_status_report` that it mirrors (`mod tests` in this file currently covers only the `classify_submit_order_error` helpers; the query paths are exercised via the Python integration tests). The change is a direct structural mirror of that established in-tree pattern. I'm glad to add Rust coverage if you can point me at the preferred way to stand up a mocked `BinanceFuturesHttpClient` for these query paths.

---
_Disclosure: patch drafted with AI assistance and reviewed before submission._
