### PR TITLE
Fix Interactive Brokers over-reaction to data-farm flaps

### DIFF
--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -122,6 +122,14 @@ The adapter includes connection management features:
 - **Connection timeout**: Adjust the timeout with the `connection_timeout` parameter (default: 300 seconds).
 - **Connection watchdog**: Monitor connection health and trigger reconnection automatically when required.
 - **Graceful error handling**: Handle diverse connection scenarios with error classification.
+- **Transient data-farm tolerance**: Transient IB data-farm status notifications (codes 2103/2105 "broken" followed by 2104/2106 "OK", common during the nightly gateway restart) degrade only the affected data feeds and are recovered by resubscribing when the farm returns. They do **not** tear down the socket or the order/execution channel.
+
+#### Client ID allocation
+
+IB scopes open-order visibility by client id: a given client id only sees, and can manage, the orders it placed. Keep this in mind when allocating ids:
+
+- **Reserve a band per client.** On reconnect during a gateway restart the configured client id can still be held by the not-yet-released previous session (IB error 326). The adapter backs off and retries the *same* configured id first; only if the collision is consistent does it fall back to a nearby id within a bounded band (incremented deterministically, never randomly). Assign each client a contiguous band of ids (e.g. `1-5`, `6-10`, `11-15`) so a fallback stays within that client's range and never collides with a sibling process.
+- **Order isolation is not guaranteed at all times.** While running under a fallback id, order isolation by client id does not hold, and the adapter re-fetches all open orders in that case. Do not rely on client-id order isolation as a hard guarantee.
 
 ## Overview
 

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -172,7 +172,17 @@ class InteractiveBrokersClient(
         self._reconnect_jitter_secs: int = secrets.randbelow(4)
         self._had_ib_connection: bool = False
         self._last_disconnection_ns: int | None = None
-        self._randomize_client_id_on_next_connect: bool = False
+        self._client_id_collision_count: int = 0
+        # Reuse the configured client id for this many consecutive IB 326 collisions (back-off +
+        # retry) before falling back; then increment deterministically within a bounded band of
+        # `_max_client_id_offset` ids (configured_id .. configured_id + offset).
+        self._client_id_reuse_limit: int = 3
+        self._max_client_id_offset: int = 4
+        # Data-farm state (market-data farm 2103/2104, historical/HMDS farm 2105/2106). A
+        # transient farm "broken" degrades only the data feeds; the socket (and the
+        # order/execution channel) is kept alive and feeds resubscribe on the farm "OK".
+        self._data_farm_degraded_since_ns: int | None = None
+        self._data_farm_resubscription_task: asyncio.Task | None = None
 
         # MarketDataMixin
         self._bar_type_to_last_bar: dict[str, BarData | None] = {}
@@ -261,6 +271,9 @@ class InteractiveBrokersClient(
                 # which will set the `_is_ib_connected` event. This typically takes a few
                 # seconds, so we wait for it here.
                 await asyncio.wait_for(self._is_ib_connected.wait(), 15)
+                # Clean connect established; reset the client-id collision counter so a later
+                # reconnect starts again from the configured id.
+                self._client_id_collision_count = 0
                 self._start_connection_watchdog()
 
                 self._is_client_ready.set()

--- a/nautilus_trader/adapters/interactive_brokers/client/common.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/common.py
@@ -527,7 +527,9 @@ class BaseMixin:
     _port: int
     _configured_client_id: int
     _client_id: int
-    _randomize_client_id_on_next_connect: bool
+    _client_id_collision_count: int
+    _client_id_reuse_limit: int
+    _max_client_id_offset: int
     _fetch_all_open_orders: bool
     _request_timeout_secs: int
     _requests: Requests
@@ -562,6 +564,9 @@ class BaseMixin:
     _max_reconnect_attempts: int
     _indefinite_reconnect: bool
     _last_disconnection_ns: int | None
+    _next_client_id: Callable
+    _data_farm_degraded_since_ns: int | None
+    _data_farm_resubscription_task: Any  # asyncio.Task | None
 
     # MarketData
     _bar_type_to_last_bar: dict[str, BarData | None]

--- a/nautilus_trader/adapters/interactive_brokers/client/connection.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/connection.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import functools
-import secrets
 
 from ibapi import comm
 from ibapi import decoder
@@ -141,23 +140,50 @@ class InteractiveBrokersClientConnectionMixin(BaseMixin):
 
         """
         self._eclient.reset()
-        if self._randomize_client_id_on_next_connect:
-            self._client_id = self._generate_random_client_id()
-            self._randomize_client_id_on_next_connect = False
-        else:
-            self._client_id = self._configured_client_id
+        self._client_id = self._next_client_id()
+
+        if self._client_id != self._configured_client_id:
+            # A consistent client-id collision forced a fallback off the configured id. Because
+            # IB scopes open-order visibility by client id, order isolation is NOT active under
+            # the fallback id, so re-fetch all open orders on connect and warn the operator.
+            self._fetch_all_open_orders = True
+            self._log.warning(
+                f"Configured client id {self._configured_client_id} is consistently in use; "
+                f"falling back to client id {self._client_id}. Order isolation by client id is "
+                f"NOT active under the fallback id (open orders will be re-fetched).",
+            )
+
         self._eclient.host = self._host
         self._eclient.port = self._port
         self._eclient.clientId = self._client_id
 
-    def _generate_random_client_id(self) -> int:
-        reserved_client_ids = {self._configured_client_id, self._client_id}
-        client_id = self._client_id
+    def _next_client_id(self) -> int:
+        """
+        Return the client id to use for the next connection attempt.
 
-        while client_id in reserved_client_ids:
-            client_id = 1000 + secrets.randbelow(9000)
+        Three tiers of behaviour:
 
-        return client_id
+        - Normal (no collision): the configured client id.
+        - A single/occasional IB error 326 ("client id already in use"): the configured id is
+          reused, so a back-off then retry re-acquires it once the gateway releases the previous
+          session. This is the common case during a nightly gateway restart, and it preserves
+          order isolation (IB scopes open-order visibility by client id). The configured id is
+          retried for up to ``_client_id_reuse_limit`` consecutive collisions.
+        - A consistent collision (beyond that limit): the id is incremented deterministically
+          within a bounded band (``_max_client_id_offset``) - never randomly - so a fixed
+          client-id allocation policy is preserved and sibling processes are not clobbered.
+
+        The collision counter resets on a clean connection.
+
+        """
+        if self._client_id_collision_count <= self._client_id_reuse_limit:
+            return self._configured_client_id
+
+        offset = min(
+            self._client_id_collision_count - self._client_id_reuse_limit,
+            self._max_client_id_offset,
+        )
+        return self._configured_client_id + offset
 
     async def _connect_socket(self) -> None:
         """

--- a/nautilus_trader/adapters/interactive_brokers/client/error.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/error.py
@@ -35,9 +35,16 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
     """
 
     WARNING_CODES: Final[set[int]] = {1101, 1102, 110, 165, 202, 399, 404, 434, 492, 10167}
-    CLIENT_ERRORS: Final[set[int]] = {502, 503, 504, 10038, 10182, 1100, 2110}
-    CONNECTIVITY_LOST_CODES: Final[set[int]] = {326, 1100, 1300, 2103, 2110}
-    CONNECTIVITY_RESTORED_CODES: Final[set[int]] = {1101, 1102, 2104}
+    CLIENT_ERRORS: Final[set[int]] = {502, 503, 504, 10038, 1100, 2110}
+    CONNECTIVITY_LOST_CODES: Final[set[int]] = {326, 1100, 1300, 2110}
+    CONNECTIVITY_RESTORED_CODES: Final[set[int]] = {1101, 1102}
+    # Transient data-farm status notifications. A "broken" code degrades only the affected data
+    # feeds (market-data farm 2103, historical/HMDS farm 2105); the matching "OK" code resumes
+    # them (market-data farm 2104, HMDS farm 2106). Per IB these are expected during the nightly
+    # maintenance restart and must NOT be treated as full connectivity loss (which would tear
+    # down the whole socket, including the order/execution channel).
+    DATA_FARM_BROKEN_CODES: Final[set[int]] = {2103, 2105}
+    DATA_FARM_OK_CODES: Final[set[int]] = {2104, 2106}
     ORDER_REJECTION_CODES: Final[set[int]] = {201, 203, 321, 10289, 10293}
     SUPPRESS_ERROR_LOGGING_CODES: Final[set[int]] = {200}
 
@@ -111,12 +118,35 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
                 await self._handle_order_error(req_id, error_code, error_string)
             else:
                 self._log.warning(f"Unhandled error: {error_code} for req_id {req_id}")
+        else:
+            self._handle_connectivity_message(error_code)
+
+    def _handle_connectivity_message(self, error_code: int) -> None:
+        """
+        Handle a general (non request-specific) status or connectivity message.
+
+        Transient data-farm notifications degrade only the data feeds (keeping the socket, and
+        so the order/execution channel, alive); genuine connectivity-lost codes clear the
+        connection so the watchdog can reconnect; connectivity-restored codes set it again.
+
+        Parameters
+        ----------
+        error_code : int
+            The status or error code (dispatched with req_id == -1).
+
+        """
+        if error_code in self.DATA_FARM_BROKEN_CODES:
+            self._mark_data_farm_degraded(error_code)
+        elif error_code in self.DATA_FARM_OK_CODES:
+            self._handle_data_farm_ok(error_code)
         elif error_code in self.CLIENT_ERRORS or error_code in self.CONNECTIVITY_LOST_CODES:
             if error_code == 326:
-                self._randomize_client_id_on_next_connect = True
-                self._fetch_all_open_orders = True
+                self._client_id_collision_count += 1
                 self._log.warning(
-                    "Enabling `fetch_all_open_orders` for client ID fallback after IB error 326",
+                    f"IB error 326 (client id already in use), collision "
+                    f"#{self._client_id_collision_count}: backing off and retrying with the same "
+                    f"client id (falls back to a bounded id band after "
+                    f"{self._client_id_reuse_limit} consecutive collisions)",
                 )
 
             if self._is_ib_connected.is_set():
@@ -132,6 +162,63 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
             )
             self._is_ib_connected.set()
             self._had_ib_connection = True
+
+    def _mark_data_farm_degraded(self, error_code: int) -> None:
+        """
+        Flag the data feeds as degraded after a transient data-farm "broken"
+        notification.
+
+        Records the time of the first degradation (used to backfill bars missed during the
+        outage) and keeps the socket, including the order/execution channel, alive. The
+        connection watchdog is only tripped by genuine socket loss, never by a data-farm blip.
+
+        Parameters
+        ----------
+        error_code : int
+            The data-farm error code which triggered the degradation.
+
+        """
+        if self._data_farm_degraded_since_ns is None:
+            self._data_farm_degraded_since_ns = self._clock.timestamp_ns()
+
+        self._log.debug(
+            f"Data farm degraded by code {error_code}; feeds will resubscribe on farm-OK",
+            LogColor.BLUE,
+        )
+
+    def _handle_data_farm_ok(self, error_code: int) -> None:
+        """
+        Resume degraded data feeds after a data-farm "OK" notification.
+
+        Resubscribes the affected feeds without a socket teardown. Bars that completed during
+        the outage are recovered via the historical backfill (gated on the farm being OK, not
+        merely on the socket being up). A no-op when no degradation is outstanding.
+
+        Parameters
+        ----------
+        error_code : int
+            The data-farm error code which signalled recovery.
+
+        """
+        if self._data_farm_degraded_since_ns is None:
+            return
+
+        if (
+            self._data_farm_resubscription_task is not None
+            and not self._data_farm_resubscription_task.done()
+        ):
+            return
+
+        self._log.info(f"Data farm connection is OK (code {error_code}); resubscribing feeds")
+        self._data_farm_resubscription_task = self._create_task(
+            self._resubscribe_after_farm_recovery(),
+        )
+
+    async def _resubscribe_after_farm_recovery(self) -> None:
+        try:
+            await self._resubscribe_all()
+        finally:
+            self._data_farm_degraded_since_ns = None
 
     async def _handle_subscription_error(
         self,
@@ -169,14 +256,13 @@ class InteractiveBrokersClientErrorMixin(BaseMixin):
             else:
                 subscription.handle()
         elif error_code == 10182:
-            # Handle disconnection error
+            # "Failed to request live updates (disconnected)" - a data-farm level drop of this
+            # subscription, typically during a farm outage. Do NOT treat it as full connectivity
+            # loss (which would tear down the whole socket, including the order/execution
+            # channel); keep the socket alive and mark the data feeds degraded so they
+            # resubscribe once the farm recovers (2104/2106).
             self._log.warning(f"{error_code}: {error_string}")
-
-            if self._is_ib_connected.is_set():
-                self._log.info(
-                    f"`_is_ib_connected` unset by {subscription.name} in `_handle_subscription_error`",
-                )
-                self._is_ib_connected.clear()
+            self._mark_data_farm_degraded(error_code)
         else:
             # Log unknown subscription errors
             self._log.warning(

--- a/nautilus_trader/adapters/interactive_brokers/client/market_data.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/market_data.py
@@ -538,12 +538,20 @@ class InteractiveBrokersClientMarketDataMixin(BaseMixin):
             params=params,
         )
 
-        # In order to get missed bars after a disconnection
-        if (
-            self._last_disconnection_ns is not None
-            and self._last_disconnection_ns > params["first_start_ns"]
-        ):
-            start = self._last_disconnection_ns
+        # In order to get missed bars after a disconnection or a transient data-farm outage,
+        # move the bar filter cutoff back to the earliest point at which data was lost (a socket
+        # disconnection or a data-farm degradation). Bars from that point are recovered via the
+        # historical backfill on resubscription.
+        recovery_ns = self._last_disconnection_ns
+        if self._data_farm_degraded_since_ns is not None:
+            recovery_ns = (
+                self._data_farm_degraded_since_ns
+                if recovery_ns is None
+                else min(recovery_ns, self._data_farm_degraded_since_ns)
+            )
+
+        if recovery_ns is not None and recovery_ns > params["first_start_ns"]:
+            start = recovery_ns
 
         # Store start time separately for bar filtering (not part of resubscription handle)
         self._subscription_start_times[subscription.req_id] = start

--- a/nautilus_trader/adapters/interactive_brokers/config.py
+++ b/nautilus_trader/adapters/interactive_brokers/config.py
@@ -209,7 +209,13 @@ class InteractiveBrokersDataClientConfig(LiveDataClientConfig, frozen=True):
     ibg_port : int, default None
         The port for the gateway server. ("paper"/"live" defaults: IBG 4002/4001; TWS 7497/7496)
     ibg_client_id: int, default 1
-        The client_id to be passed into connect call.
+        The client_id passed to the IB connect call. IB scopes open-order visibility by client
+        id (each id only sees the orders it placed). On reconnect the configured id may still be
+        held by the not-yet-released previous session (IB error 326); the adapter backs off and
+        retries the same id first, and only falls back to a nearby id within a bounded band if the
+        collision is consistent. Reserve a contiguous band of client ids per client (e.g. 1-5,
+        6-10) so a fallback stays within that client's range. Note order isolation by client id is
+        not guaranteed while running under a fallback id.
     use_regular_trading_hours : bool
         If True, will request data for Regular Trading Hours only.
         Only applies to bar data - will have no effect on trade or tick data feeds.
@@ -257,7 +263,13 @@ class InteractiveBrokersExecClientConfig(LiveExecClientConfig, frozen=True):
     ibg_port : int
         The port for the gateway server. ("paper"/"live" defaults: IBG 4002/4001; TWS 7497/7496)
     ibg_client_id: int, default 1
-        The client_id to be passed into connect call.
+        The client_id passed to the IB connect call. IB scopes open-order visibility by client
+        id (each id only sees the orders it placed). On reconnect the configured id may still be
+        held by the not-yet-released previous session (IB error 326); the adapter backs off and
+        retries the same id first, and only falls back to a nearby id within a bounded band if the
+        collision is consistent. Reserve a contiguous band of client ids per client (e.g. 1-5,
+        6-10) so a fallback stays within that client's range. Note order isolation by client id is
+        not guaranteed while running under a fallback id.
     account_id : str
         Represents the account_id for the Interactive Brokers to which the TWS/Gateway is logged in.
         It's crucial that the account_id aligns with the account for which the TWS/Gateway is logged in.

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_connection.py
@@ -16,7 +16,6 @@
 import asyncio
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
-from unittest.mock import patch
 
 import pytest
 from ibapi.const import NO_VALID_ID
@@ -85,23 +84,62 @@ def test_initialize_connection_params_uses_configured_client_id(ib_client):
     assert ib_client._eclient.clientId == 0
 
 
-def test_initialize_connection_params_randomizes_client_id_after_326(ib_client):
+def test_initialize_connection_params_reuses_configured_id_within_reuse_limit(ib_client):
+    # A single/occasional collision (within the reuse limit) retries the SAME configured id,
+    # giving the gateway time to release it and preserving order isolation.
     # Arrange
     ib_client._configured_client_id = 4321
     ib_client._client_id = 8765
-    ib_client._randomize_client_id_on_next_connect = True
+    ib_client._client_id_reuse_limit = 3
+    ib_client._fetch_all_open_orders = False
 
-    # Act
-    with patch(
-        "nautilus_trader.adapters.interactive_brokers.client.connection.secrets.randbelow",
-        side_effect=[3321, 7765, 1357],
-    ):
+    for collision_count in (1, 3):  # single, and at the reuse limit
+        ib_client._client_id_collision_count = collision_count
+
+        # Act
         ib_client._initialize_connection_params()
 
-    # Assert
-    assert ib_client._client_id == 2357
-    assert ib_client._eclient.clientId == 2357
-    assert ib_client._randomize_client_id_on_next_connect is False
+        # Assert: configured id reused, no order re-fetch (isolation preserved)
+        assert ib_client._client_id == 4321
+        assert ib_client._eclient.clientId == 4321
+        assert ib_client._fetch_all_open_orders is False
+
+
+def test_initialize_connection_params_increments_after_consistent_326(ib_client):
+    # A consistent collision (beyond the reuse limit) falls back to a deterministic id within the
+    # band and re-fetches open orders (order isolation is lost under the fallback id).
+    # Arrange
+    ib_client._configured_client_id = 4321
+    ib_client._client_id = 8765
+    ib_client._client_id_reuse_limit = 3
+    ib_client._max_client_id_offset = 4
+    ib_client._client_id_collision_count = 5
+    ib_client._fetch_all_open_orders = False
+
+    # Act
+    ib_client._initialize_connection_params()
+
+    # Assert: offset = min(5 - 3, 4) = 2 -> 4321 + 2 = 4323 (deterministic, never random)
+    assert ib_client._client_id == 4323
+    assert ib_client._eclient.clientId == 4323
+    assert ib_client._fetch_all_open_orders is True
+
+
+def test_initialize_connection_params_bounds_client_id_offset(ib_client):
+    # The deterministic offset is capped so the fallback stays within the allocated band.
+    # Arrange
+    ib_client._configured_client_id = 100
+    ib_client._client_id = 8765
+    ib_client._client_id_reuse_limit = 3
+    ib_client._max_client_id_offset = 4
+    ib_client._client_id_collision_count = 50
+
+    # Act
+    ib_client._initialize_connection_params()
+
+    # Assert: offset capped at _max_client_id_offset (4) -> 100 + 4 = 104
+    assert ib_client._client_id == 104
+    assert ib_client._eclient.clientId == 104
 
 
 # Test for successful reconnection

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_error.py
@@ -14,7 +14,11 @@
 # -------------------------------------------------------------------------------------------------
 
 
+from unittest.mock import AsyncMock
+
 import pytest
+
+from nautilus_trader.test_kit.functions import eventually
 
 
 @pytest.mark.asyncio
@@ -54,11 +58,14 @@ async def test_ib_is_ready_by_notification_1102(ib_client):
 @pytest.mark.asyncio
 async def test_ib_is_not_ready_by_error_326(ib_client):
     """
-    Test that error 326 (client id already in use) clears the connection flag.
+    Test that a single error 326 (client id already in use) clears the connection flag
+    and increments the collision counter, but does NOT fetch all open orders or change
+    the client id (a back-off then retry with the same configured id preserves order
+    isolation).
     """
     # Arrange
     ib_client._is_ib_connected.set()
-    ib_client._randomize_client_id_on_next_connect = False
+    ib_client._client_id_collision_count = 0
     ib_client._fetch_all_open_orders = False
 
     # Act
@@ -71,15 +78,15 @@ async def test_ib_is_not_ready_by_error_326(ib_client):
 
     # Assert
     assert not ib_client._is_ib_connected.is_set()
-    assert ib_client._randomize_client_id_on_next_connect is True
-    assert ib_client._fetch_all_open_orders is True
+    assert ib_client._client_id_collision_count == 1
+    assert ib_client._fetch_all_open_orders is False
 
 
 @pytest.mark.asyncio
-async def test_error_326_arms_random_client_id_when_not_connected(ib_client):
+async def test_error_326_increments_collision_count_when_not_connected(ib_client):
     # Arrange
     ib_client._is_ib_connected.clear()
-    ib_client._randomize_client_id_on_next_connect = False
+    ib_client._client_id_collision_count = 0
     ib_client._fetch_all_open_orders = False
 
     # Act
@@ -92,15 +99,21 @@ async def test_error_326_arms_random_client_id_when_not_connected(ib_client):
 
     # Assert
     assert not ib_client._is_ib_connected.is_set()
-    assert ib_client._randomize_client_id_on_next_connect is True
-    assert ib_client._fetch_all_open_orders is True
+    assert ib_client._client_id_collision_count == 1
+    assert ib_client._fetch_all_open_orders is False
 
 
 @pytest.mark.asyncio
-async def test_ib_is_not_ready_by_error_10182(ib_client):
+async def test_subscription_disconnect_10182_keeps_connection_and_marks_farm_degraded(ib_client):
+    """
+    Test that a single subscription disconnect (10182) does NOT tear down the socket; it
+    keeps the connection (and the order/execution channel) alive and marks the data
+    feeds degraded so they resubscribe once the farm recovers.
+    """
     # Arrange
     req_id = 6
     ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = None
     ib_client._subscriptions.add(req_id, "EUR.USD", ib_client._eclient.reqHistoricalData, {})
 
     # Act
@@ -112,4 +125,176 @@ async def test_ib_is_not_ready_by_error_10182(ib_client):
     )
 
     # Assert
-    assert not ib_client._is_ib_connected.is_set()
+    assert ib_client._is_ib_connected.is_set()
+    assert ib_client._data_farm_degraded_since_ns is not None
+
+
+@pytest.mark.asyncio
+async def test_market_data_farm_broken_2103_keeps_connection(ib_client):
+    """
+    Test that a transient market-data farm "broken" (2103) does NOT tear down the
+    socket; it keeps the connection alive and only marks the data feeds degraded.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = None
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=2103,
+        error_string="Market data farm connection is broken:usfarm",
+    )
+
+    # Assert
+    assert ib_client._is_ib_connected.is_set()
+    assert ib_client._data_farm_degraded_since_ns is not None
+
+
+@pytest.mark.asyncio
+async def test_hmds_farm_broken_2105_keeps_connection(ib_client):
+    """
+    Test that a transient HMDS (historical) data farm "broken" (2105) does NOT tear down
+    the socket; it keeps the connection alive and only marks the data feeds degraded.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = None
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=2105,
+        error_string="HMDS data farm connection is broken:ushmds",
+    )
+
+    # Assert
+    assert ib_client._is_ib_connected.is_set()
+    assert ib_client._data_farm_degraded_since_ns is not None
+
+
+@pytest.mark.asyncio
+async def test_market_data_farm_ok_2104_resubscribes_when_degraded(ib_client):
+    """
+    Test that a market-data farm "OK" (2104) resubscribes the degraded feeds without a
+    socket teardown, then clears the degraded marker.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = 1
+    ib_client._resubscribe_all = AsyncMock()
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=2104,
+        error_string="Market data farm connection is OK:usfarm",
+    )
+    await eventually(lambda: ib_client._data_farm_degraded_since_ns is None)
+
+    # Assert
+    assert ib_client._is_ib_connected.is_set()
+    ib_client._resubscribe_all.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_hmds_farm_ok_2106_resubscribes_when_degraded(ib_client):
+    """
+    Test that an HMDS data farm "OK" (2106) resubscribes the degraded feeds without a
+    socket teardown, then clears the degraded marker.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = 1
+    ib_client._resubscribe_all = AsyncMock()
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=2106,
+        error_string="HMDS data farm connection is OK:ushmds",
+    )
+    await eventually(lambda: ib_client._data_farm_degraded_since_ns is None)
+
+    # Assert
+    assert ib_client._is_ib_connected.is_set()
+    ib_client._resubscribe_all.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_data_farm_ok_without_degradation_does_not_resubscribe(ib_client):
+    """
+    Test that a farm "OK" with no outstanding degradation is a no-op (no spurious
+    resubscribe).
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = None
+    ib_client._resubscribe_all = AsyncMock()
+
+    # Act
+    await ib_client.process_error(
+        req_id=-1,
+        error_time=0,
+        error_code=2104,
+        error_string="Market data farm connection is OK:usfarm",
+    )
+
+    # Assert
+    assert ib_client._is_ib_connected.is_set()
+    ib_client._resubscribe_all.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_data_farm_flap_sequence_keeps_socket_and_client_id(ib_client):
+    """
+    Model a nightly-maintenance data-farm flap (2105/2103 broken then 2104/2106 OK) and
+    assert the socket (order/execution channel) is never torn down and the client id is
+    never rotated; only the data feeds are resubscribed on recovery.
+    """
+    # Arrange
+    ib_client._is_ib_connected.set()
+    ib_client._data_farm_degraded_since_ns = None
+    ib_client._client_id = ib_client._configured_client_id
+    ib_client._client_id_collision_count = 0
+    ib_client._resubscribe_all = AsyncMock()
+
+    # Act - farm goes broken (market-data and HMDS)
+    for error_code, error_string in [
+        (2105, "HMDS data farm connection is broken:ushmds"),
+        (2103, "Market data farm connection is broken:usfarm"),
+    ]:
+        await ib_client.process_error(
+            req_id=-1,
+            error_time=0,
+            error_code=error_code,
+            error_string=error_string,
+        )
+
+    # Assert - socket stays up through the outage, no client-id churn
+    assert ib_client._is_ib_connected.is_set()
+    assert ib_client._client_id == ib_client._configured_client_id
+    assert ib_client._client_id_collision_count == 0
+    assert ib_client._data_farm_degraded_since_ns is not None
+
+    # Act - farm recovers
+    for error_code, error_string in [
+        (2104, "Market data farm connection is OK:usfarm"),
+        (2106, "HMDS data farm connection is OK:ushmds"),
+    ]:
+        await ib_client.process_error(
+            req_id=-1,
+            error_time=0,
+            error_code=error_code,
+            error_string=error_string,
+        )
+    await eventually(lambda: ib_client._data_farm_degraded_since_ns is None)
+
+    # Assert - feeds resubscribed, still connected, client id unchanged
+    assert ib_client._is_ib_connected.is_set()
+    assert ib_client._client_id == ib_client._configured_client_id
+    ib_client._resubscribe_all.assert_awaited()


### PR DESCRIPTION
## Problem

During IB Gateway's nightly maintenance restart, IB's data farms flap broken↔OK for several
minutes while the gateway re-establishes its upstream link. The adapter treats a transient
market-data farm "broken" (2103) and a single subscription disconnect (10182) as full
connectivity loss: it clears `_is_ib_connected`, so the connection watchdog tears down the
**entire** socket — including the order/execution channel — for what is only a market-data
notification. Each teardown then reconnects before IB releases the previous session, hitting
error 326 ("client id already in use"), and the adapter falls back to a **random** client id
whose flag resets on each connect — cycling configured→random→configured→random for the whole
farm-stabilization window.

Per IB's message-code documentation, 2103/2105 are transient/expected during daily maintenance
and should not trigger a socket teardown.

## Root cause

- `client/error.py`: `2103` was in `CONNECTIVITY_LOST_CODES` and `10182` cleared
  `_is_ib_connected`; both trip the `client.py` watchdog into a full `_stop_async` +
  `_start_async` reconnect of the whole socket. The market-data farm (2103/2104) and HMDS farm
  (2105/2106) were handled inconsistently — `2103` was "lost" but `2105` unhandled; `2104` was
  "restored" but `2106` missing.
- `client/connection.py`: error 326 armed a random client-id fallback whose flag reset each
  connect, so the fallback never "stuck" — producing the oscillation.

## Fix

1. **Decouple data-farm state from socket state.** New `DATA_FARM_BROKEN_CODES` {2103, 2105} and
   `DATA_FARM_OK_CODES` {2104, 2106} (resolving the asymmetry). A farm "broken" and a single
   10182 mark the data feeds degraded and record the degrade time **without** clearing
   `_is_ib_connected`, so the socket and the order/execution channel stay up. A farm "OK"
   resubscribes the degraded feeds without a socket teardown.
2. **Preserve bar-gap recovery.** `subscribe_historical_bars` moves the historical-bar backfill
   cutoff back to the earliest data-loss point (socket disconnect **or** farm degrade), so bars
   completed during a farm outage are still recovered via the backfill.
3. **Deterministic, tiered client-id handling** for any residual error 326 (removing the needless
   teardowns removes most collisions outright):
   - A single/occasional 326 backs off and retries the **same** configured id; IB scopes
     open-order visibility by client id, so reusing it preserves order isolation.
   - A consistent 326 (beyond a small reuse limit) increments the id **deterministically** within
     a bounded band — never randomly — and re-fetches all open orders, since order isolation does
     not hold under a fallback id.
   - The collision counter resets on a clean connect.
4. **Docs.** The config docstrings and the IB integration guide now recommend reserving a
   contiguous band of client ids per client (e.g. 1-5, 6-10) so a fallback stays within range,
   and note that client-id order isolation is not guaranteed while running under a fallback id.

## Tests

New/updated unit tests under `tests/integration_tests/adapters/interactive_brokers/client/`:

- 2103/2105 and 10182 keep the socket up and only mark feeds degraded.
- 2104/2106 resubscribe feeds without a teardown; a farm-OK with no outstanding degradation is a
  no-op.
- A full farm-flap sequence (2105/2103 broken → 2104/2106 OK) leaves the socket and the client id
  intact and resubscribes once.
- A single 326 keeps the configured id and does not fetch orders; a consistent 326 increments
  within the bounded band and re-fetches orders; the offset is capped.

All existing IB adapter tests pass (481 passed).

## Testing against a live gateway

Validated against a live IB Gateway over two consecutive nightly maintenance windows. A dedicated
client id ran the patched adapter, subscribed to 1-minute bars (the `reqHistoricalData`
keepUpToDate path) plus quotes on a liquid CME future, bracketing the ~03:59 UTC restart and the
farm-stabilization window each night:

| | Night 1 | Night 2 |
|---|---|---|
| Data-farm flaps (2103/2105 → 2104/2106) | 1 | 2 |
| …caused a socket teardown? | No — resubscribed | No — resubscribed |
| Farm-induced teardowns (the bug) | 0 | 0 |
| Genuine disconnects (gateway restart / IB code 1100) | 1 (restart) | 2 (restart + a real 1100) |
| Error 326 | 0 | yes — backed off, retried the **same** id |
| Client-id changes | 0 (stayed on the configured id) | 0 (stayed on the configured id) |
| Bar gaps / data loss | 0 | 0 |

Night 2 hit a rougher window: a genuine IB "connectivity lost" (code 1100) on top of the restart
forced a reconnect that raced IB's client-id release and produced error 326 — exactly the
scenario the old code turned into a `configured→random→configured` client-id churn. The patched
adapter instead backed off and retried on the **same** configured id, rode through every farm
flap without tearing down the socket, and lost no bars.

## References

- IB message codes (2103/2105 transient; 2104/2106 OK): https://interactivebrokers.github.io/tws-api/message_codes.html
- Error 326 / socket-release race: https://github.com/erdewit/ib_insync/issues/376
- Related: #3968 (farm reconnect events), #4210 (reconnect startup), #3733 (frozen subscriptions)
