### PR TITLE
Sign Binance WS trading requests over key-sorted params

### DIFF
--- a/crates/adapters/binance/src/common/credential.rs
+++ b/crates/adapters/binance/src/common/credential.rs
@@ -386,6 +386,38 @@ fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.windows(needle.len()).any(|w| w == needle)
 }
 
+/// Builds the canonical query string that Binance's WebSocket API signs.
+///
+/// The WS API verifies a request's signature over its parameters **sorted by
+/// key**, so the signed query string must be key-sorted regardless of the order
+/// the parameters happen to iterate in. `serde_json`'s object backend is a
+/// sorted `BTreeMap` by default, but it silently becomes an insertion-ordered
+/// `IndexMap` if *any* crate anywhere in the build graph enables
+/// `serde_json/preserve_order` — a global Cargo feature-unification effect the
+/// adapter cannot control (e.g. a transitive `mongodb`/`bson` dependency).
+/// Signing the object in its raw iteration order therefore breaks intermittently
+/// with `-1022 Signature for this request is not valid` depending on unrelated
+/// dependencies. Sorting the keys here makes WS signing independent of that
+/// ambient feature.
+///
+/// This is not needed for the REST/HTTP path, which signs the exact query string
+/// it sends (Binance verifies REST signatures over the received order); only the
+/// WS API re-sorts before verifying.
+///
+/// See <https://github.com/nautechsystems/nautilus_trader/issues/4410>.
+pub(crate) fn canonical_ws_query_string<'a, I>(
+    params: I,
+) -> Result<String, serde_urlencoded::ser::Error>
+where
+    I: IntoIterator<Item = (&'a str, &'a serde_json::Value)>,
+{
+    // Collecting into a `BTreeMap` sorts by key regardless of the source order,
+    // and `serde_urlencoded` percent-encodes each value exactly as it would the
+    // original `serde_json::Value`.
+    let sorted: std::collections::BTreeMap<&str, &serde_json::Value> = params.into_iter().collect();
+    serde_urlencoded::to_string(sorted)
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -413,6 +445,34 @@ mod tests {
         let expected = "c8db56825ae71d6d79447849e617115f4a920fa2acdcab2b053c4b2838bd6b71";
 
         assert_eq!(cred.sign(message), expected);
+    }
+
+    #[rstest]
+    fn test_canonical_ws_query_string_is_key_sorted_regardless_of_input_order() {
+        // Parameters in a deliberately non-alphabetical order — exactly what a
+        // `serde_json/preserve_order` (IndexMap) build yields, and what broke WS
+        // signing with -1022 (issue #4410). Binance verifies the WS signature
+        // over the *sorted* parameters, so the query string must come out
+        // key-sorted whatever order the caller supplied them in.
+        let symbol = serde_json::json!("LTCBTC");
+        let side = serde_json::json!("BUY");
+        let quantity = serde_json::json!("1");
+        let timestamp = serde_json::json!(1_499_827_319_559i64);
+        let api_key = serde_json::json!("mykey");
+        let unsorted = [
+            ("symbol", &symbol),
+            ("side", &side),
+            ("quantity", &quantity),
+            ("timestamp", &timestamp),
+            ("apiKey", &api_key),
+        ];
+
+        let query = canonical_ws_query_string(unsorted).unwrap();
+
+        assert_eq!(
+            query,
+            "apiKey=mykey&quantity=1&side=BUY&symbol=LTCBTC&timestamp=1499827319559"
+        );
     }
 
     #[rstest]

--- a/crates/adapters/binance/src/futures/websocket/trading/handler.rs
+++ b/crates/adapters/binance/src/futures/websocket/trading/handler.rs
@@ -44,7 +44,7 @@ use super::{
     },
 };
 use crate::{
-    common::credential::SigningCredential,
+    common::credential::{SigningCredential, canonical_ws_query_string},
     futures::http::query::{
         BinanceCancelOrderParams, BinanceModifyOrderParams, BinanceNewOrderParams,
     },
@@ -255,8 +255,17 @@ impl BinanceFuturesWsTradingHandler {
             );
         }
 
-        let query_string = serde_urlencoded::to_string(&params)
-            .map_err(|e| BinanceFuturesWsApiError::ClientError(e.to_string()))?;
+        // Sign over a key-sorted query string: Binance's WS API verifies the
+        // signature against the parameters sorted by key, which must not depend
+        // on serde_json's Map iteration order (issue #4410).
+        let query_string = canonical_ws_query_string(
+            params
+                .as_object()
+                .into_iter()
+                .flatten()
+                .map(|(k, v)| (k.as_str(), v)),
+        )
+        .map_err(|e| BinanceFuturesWsApiError::ClientError(e.to_string()))?;
         let signature = self.credential.sign(&query_string);
 
         if let Some(obj) = params.as_object_mut() {

--- a/crates/adapters/binance/src/spot/websocket/trading/handler.rs
+++ b/crates/adapters/binance/src/spot/websocket/trading/handler.rs
@@ -47,7 +47,7 @@ use super::{
     },
 };
 use crate::{
-    common::credential::SigningCredential,
+    common::credential::{SigningCredential, canonical_ws_query_string},
     spot::{
         enums::BinanceSpotUserDataEventType,
         http::{models::BinanceCancelOrderResponse, parse},
@@ -344,8 +344,17 @@ impl BinanceSpotWsTradingHandler {
             );
         }
 
-        let query_string = serde_urlencoded::to_string(&params)
-            .map_err(|e| BinanceWsApiError::ClientError(e.to_string()))?;
+        // Sign over a key-sorted query string: Binance's WS API verifies the
+        // signature against the parameters sorted by key, which must not depend
+        // on serde_json's Map iteration order (issue #4410).
+        let query_string = canonical_ws_query_string(
+            params
+                .as_object()
+                .into_iter()
+                .flatten()
+                .map(|(k, v)| (k.as_str(), v)),
+        )
+        .map_err(|e| BinanceWsApiError::ClientError(e.to_string()))?;
         let signature = self.credential.sign(&query_string);
 
         if let Some(obj) = params.as_object_mut() {


### PR DESCRIPTION
## Summary

Binance's WebSocket trading API verifies a request's signature over its parameters **sorted by key**. Both `sign_params` implementations — `futures/websocket/trading/handler.rs` and `spot/websocket/trading/handler.rs` — build the signed query string with `serde_urlencoded::to_string(&params)`, i.e. in `serde_json::Map` iteration order.

That order is sorted only with serde_json's default `BTreeMap` backend. If **any** crate anywhere in the dependency graph enables `serde_json/preserve_order` — a global Cargo feature-unification effect, e.g. a transitive `mongodb`/`bson` dependency — the backend becomes an insertion-ordered `IndexMap`, the signed query string is no longer sorted, and every WS order fails with `-1022 Signature for this request is not valid`. A downstream crate cannot turn the feature back off.

Reported in #4410.

## Fix

Canonicalize the signed payload independently of the Map backend: sort the params into a `BTreeMap` before urlencoding, via a shared `common::credential::canonical_ws_query_string` helper used by both signers. `serde_urlencoded` percent-encodes each value exactly as before, so the only change is deterministic key ordering.

The REST/HTTP path is **unaffected** — it signs the exact query string it sends, and Binance verifies REST signatures over the received order — so this touches only the two WS trading signers.

## Test

`test_canonical_ws_query_string_is_key_sorted_regardless_of_input_order` feeds deliberately non-alphabetical params (the order a `preserve_order` build yields) and asserts the query string comes out sorted. It runs in the default build with no feature toggling — the helper takes the params as an ordered iterator, so the test reproduces the exact non-sorted order that broke signing and pins the invariant Binance verifies.

Locally green: `cargo test -p nautilus-binance --lib credential`, `cargo clippy -p nautilus-binance --all-targets -- -D warnings`, `cargo fmt --check`.

Closes #4410.